### PR TITLE
fix(seo): reduce CLS — disable AdSense in-page auto ads on root layout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1496,7 +1496,22 @@ const App: React.FC = () => {
  <ErrorBoundary>
  <TabContentContext.Provider value={tabContentValue}>
  <NavigationContext.Provider value={navContextValue}>
- <div className={`min-h-screen relative flex flex-col font-sans text-strong transition-colors duration-300 overflow-hidden`}>
+ {/* AUTO ADS POLICY (CLS fix — FRO-CLS).
+  * Google AdSense Auto Ads is enabled at the account level. In-page auto ads
+  * inject content into the DOM AFTER first paint, which causes severe CLS
+  * (measured mobile p75 0.51, target <0.1). We opt the ENTIRE app out of
+  * in-page auto ads by setting `data-no-auto-ads="inside"` on the root
+  * layout container. This still allows:
+  *   - Anchor / overlay auto ads (position:fixed, no CLS — `data-overlays=bottom`
+  *     is set on the AdSense script in AdSenseBanner.tsx).
+  *   - Manual AdSenseBanner slots (explicit `<ins class="adsbygoogle">` with
+  *     reserved placeholder height in components/shared/AdSenseBanner.tsx —
+  *     these are honored regardless of the no-auto-ads directive).
+  * Revenue impact: loses in-page auto-ads (~€10/day RPM per adsenseSlots.ts
+  * header comment). Anchor auto ads (~€16/day) remain. Manual slots remain.
+  * SEO impact: removes the biggest CLS contributor, unblocking ranking
+  * improvements on job/blog pages. */}
+ <div data-no-auto-ads="inside" className={`min-h-screen relative flex flex-col font-sans text-strong transition-colors duration-300 overflow-hidden`}>
  <div className="absolute inset-0 bg-surface-alt -z-20" style={{ contain: 'strict' }}></div>
 
  {/* LinkedIn OAuth2 callback processing overlay */}


### PR DESCRIPTION
## Summary
- PostHog `web_vitals` 14d shows CLS p75 mobile **0.51** (Google "Poor" threshold 0.25 — 5x over), desktop **0.34**, tablet **0.51** — the single biggest Core Web Vitals blocker for SEO rankings on job pages (currently pos 2-3).
- Root cause: AdSense Auto Ads is enabled at the account level; in-page auto ads inject into the DOM after first paint causing severe layout shift.
- Fix: set `data-no-auto-ads="inside"` on the root layout `<div>` in `App.tsx`. Google-documented directive that disables automatic in-page ad injection app-wide.

## Auto Ads Policy (documented in code comment)
- **Disabled**: in-page auto ads (CLS cause) — loses ~€10/day RPM.
- **Kept**: anchor/overlay auto ads (`data-overlays=bottom` on AdSense script → position:fixed, no CLS) — ~€16/day RPM unaffected.
- **Kept**: all manual `AdSenseBanner` slots — they render explicit `<ins class="adsbygoogle">` with `placeholderMinHeight` reserved space, honored regardless of the no-auto-ads directive.

## Investigation findings
Full audit done in worktree; all other potential CLS contributors are already clean:
- **Images**: all 35 `<img>` tags in `components/` already have explicit `width` + `height` (0 violations).
- **Recharts**: every `ResponsiveContainer` call either passes explicit `height` prop or is inside a parent with a fixed height (0 violations).
- **Fonts**: Inter preloaded with `font-display: swap` + `size-adjust`/`ascent-override` metrics that compensate for fallback font (minimal FOUT CLS). Space Grotesk from Google Fonts also preloaded.
- **Modals / popups** (NewsletterPopup, WhatsNewModal, AiChatbot): all `position: fixed`, no flow-level CLS.
- **Cookie banner**: already removed (silent consent, see `consentService.ts`).

## Impact
Target: CLS p75 mobile < 0.1 within 7 days post-deploy. Expected SEO uplift: +15-25% organic traffic on job/blog pages, which more than offsets the lost in-page auto-ads RPM.

## Test plan
- [x] `npx tsc --noEmit` — no new errors on `App.tsx` (pre-existing failures in `tests/hooks/*.test.ts` unrelated to this change).
- [x] `npx vite build` — exit 0 (872 static pages, 3016 OG pages, all SEO artifacts generated).
- [x] `npx vitest run` — 21 626 / 21 626 test assertions pass; 4 test files skip due to local `data/jobs.json` being gitignored (pre-existing, unrelated).
- [ ] Post-deploy: verify AdSense still renders (anchor ads + manual slots) on production.
- [ ] Post-deploy +7d: verify PostHog `web_vitals` shows CLS p75 mobile < 0.1.
- [ ] Post-deploy +7d: verify AdSense revenue (expect anchor + manual slots unaffected, in-page drops to zero).

## Files changed
- `App.tsx` — single edit on root layout `<div>` + 15-line policy comment.