### PR TITLE
chore(analytics): diagnose PostHog tracking gap

### DIFF
--- a/tests/services/posthog.test.ts
+++ b/tests/services/posthog.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Smoke tests for services/posthog.ts
+ *
+ * Context: A HogQL query showed PostHog events starting only from 2026-04-12.
+ * Root cause: PostHog was added to the codebase on 2026-04-12 (commit 4f4b74049).
+ * The gap is expected — it's the tracking baseline, not a bug.
+ *
+ * These tests protect against regressions:
+ * - PostHog initializes on app boot (non-blocking, async)
+ * - Uses the first-party reverse proxy (ad-blocker resilience)
+ * - `$pageview` events are captured via capturePageView
+ * - Consent is silent (no popup / banner) — analytics granted by default
+ *
+ * The global mock in tests/setup.tsx stubs @/services/posthog, so we unmock
+ * and dynamically import the real module. posthog-js itself is mocked at the
+ * module level to capture init/capture calls without touching the network.
+ */
+
+import { vi, describe, it, expect, beforeEach, beforeAll } from 'vitest';
+
+// Pull in the real implementations (global mock replaces them by default).
+vi.unmock('@/services/posthog');
+vi.unmock('@/services/consentService');
+
+// Per-test-file mock of posthog-js so we can observe init/capture.
+const posthogMock = {
+  init: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+};
+
+vi.mock('posthog-js', () => ({
+  default: posthogMock,
+}));
+
+let posthogModule: typeof import('@/services/posthog');
+let consentModule: typeof import('@/services/consentService');
+
+beforeAll(async () => {
+  posthogModule = await import('@/services/posthog');
+  consentModule = await import('@/services/consentService');
+});
+
+beforeEach(() => {
+  posthogMock.init.mockClear();
+  posthogMock.capture.mockClear();
+  posthogMock.identify.mockClear();
+  // Ensure clean localStorage between tests
+  try { localStorage.clear(); } catch { /* jsdom quota ignored */ }
+});
+
+describe('PostHog smoke tests', () => {
+  it('initPostHog() calls posthog.init with the EU reverse proxy host', async () => {
+    posthogModule.initPostHog();
+
+    // ensurePostHog() performs a dynamic import + async IIFE; poll for resolution.
+    for (let i = 0; i < 20 && posthogMock.init.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    // Module-level singleton may short-circuit in later tests; assert at least once.
+    expect(posthogMock.init).toHaveBeenCalled();
+    const [key, opts] = posthogMock.init.mock.calls[0];
+
+    // Key must be present (baseline — not a secret, already public in client bundle).
+    expect(typeof key).toBe('string');
+    expect(key.length).toBeGreaterThan(0);
+
+    // First-party proxy — critical for ad-blocker resilience.
+    // Hardcoding 't.frontaliereticino.ch' protects against regression to eu.i.posthog.com.
+    expect(opts.api_host).toBe('https://t.frontaliereticino.ch');
+
+    // Pageviews handled manually via analytics.ts (avoid double-capture in SPA).
+    expect(opts.capture_pageview).toBe(false);
+
+    // Autocapture disabled — explicit events only.
+    expect(opts.autocapture).toBe(false);
+  });
+
+  it('capturePageView() emits a $pageview event with $current_url + title', async () => {
+    // First init so the internal singleton is populated.
+    posthogModule.initPostHog();
+    for (let i = 0; i < 20 && posthogMock.init.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    posthogModule.capturePageView('/test-path', 'Test Title');
+    for (let i = 0; i < 20 && posthogMock.capture.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const pageviewCalls = posthogMock.capture.mock.calls.filter(
+      ([eventName]) => eventName === '$pageview',
+    );
+    expect(pageviewCalls.length).toBeGreaterThanOrEqual(1);
+
+    const [, props] = pageviewCalls[0];
+    expect(props.$current_url).toContain('/test-path');
+    expect(props.title).toBe('Test Title');
+  });
+
+  it('captureEvent() forwards arbitrary events with properties', async () => {
+    posthogModule.initPostHog();
+    for (let i = 0; i < 20 && posthogMock.init.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    posthogModule.captureEvent('job_alert_created', { surface: 'inline_cta' });
+    for (let i = 0; i < 20 && posthogMock.capture.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const match = posthogMock.capture.mock.calls.find(
+      ([name]) => name === 'job_alert_created',
+    );
+    expect(match).toBeDefined();
+    expect(match?.[1]).toMatchObject({ surface: 'inline_cta' });
+  });
+});
+
+describe('Silent consent guarantee', () => {
+  it('setDefaultConsent() grants analytics without any banner / popup', () => {
+    // No stored preference → defaults to granted.
+    consentModule.setDefaultConsent();
+
+    const state = consentModule.getConsent();
+    expect(state).not.toBeNull();
+    expect(state?.analytics).toBe(true);
+    expect(state?.advertising).toBe(true);
+
+    // Nothing in the DOM should reference a consent banner component
+    // (CookieBanner was removed in the silent-consent migration).
+    expect(document.querySelector('[data-testid="cookie-banner"]')).toBeNull();
+    expect(document.querySelector('[data-testid="consent-popup"]')).toBeNull();
+  });
+
+  it('isAnalyticsGranted() returns true after silent default', () => {
+    consentModule.setDefaultConsent();
+    expect(consentModule.isAnalyticsGranted()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Root cause — Hypothesis A (no gap, new baseline)

The HogQL query `SELECT toStartOfDay(timestamp) ... WHERE event='$pageview' ... INTERVAL 28 DAY` returning only 9 days (2026-04-12 → 2026-04-20) is **not** a tracking gap. PostHog was first added to the codebase on **2026-04-12**, so 2026-04-12 is the earliest possible day with any data.

### Evidence

| # | Finding | Source |
|---|---------|--------|
| 1 | `services/posthog.ts` first commit | `4f4b74049` on 2026-04-12 18:46 +0200 — `feat: PostHog analytics, /go/ affiliate redirects, newsletter partner section` |
| 2 | First-party reverse proxy already in place | `bf8d15de5` on 2026-04-12 19:45 +0200 — `feat: PostHog reverse proxy + FAQ schema for striking distance pages` |
| 3 | Proxy host hardcoded | `services/posthog.ts` → `api_host: 'https://t.frontaliereticino.ch'` |
| 4 | Silent consent, no gate | `services/consentService.ts` `setDefaultConsent()` defaults `analytics: true`, no banner. |
| 5 | Init is unconditional | `App.tsx` module scope: `setDefaultConsent(); initPostHog();` — runs on every page load. |
| 6 | `$pageview` captured for every SPA nav | `services/analytics.ts` line 246 calls `posthogPageView()` on every `page_view` |
| 7 | Static pages also track | `build-plugins/constants.ts` emits `POSTHOG_SNIPPET` with `capture_pageview: true` into OG landing pages, /go/ redirects, salary-hub landings |
| 8 | No pre-2026-04-12 commits mentioning posthog | `git log -- services/posthog.ts services/analytics.ts services/consentService.ts` in the 2026-04-08 → 2026-04-14 window shows nothing earlier |

All four hypotheses ranked:
- **A — Just new tracking (winner):** commit date == data start date. Explains everything.
- B — Consent gate removed on 04-12: disproven. Consent default was already silent before posthog ever existed (silent-consent migration is older; `consentService` pre-dates posthog).
- C — Ad blocker: mitigated. Reverse proxy `t.frontaliereticino.ch` is active from day one. Still expect ~10–15% blocking loss, but that would cause volume drop, not a hard cutoff at 04-12.
- D — Config change on 04-12: same as A — the "config change" was the *addition* of the service.

## Action taken

**No code fix** — root cause is expected behavior, not a bug. Added smoke test `tests/services/posthog.test.ts` (5 tests) to guard against regressions:

- `initPostHog()` is called with the EU reverse proxy host (`t.frontaliereticino.ch`) — protects first-party routing
- `capture_pageview: false` and `autocapture: false` — protects SPA manual-capture contract
- `capturePageView('/path', 'title')` emits `$pageview` with correct `$current_url` + `title`
- `captureEvent('job_alert_created', { surface })` forwards arbitrary events
- `setDefaultConsent()` grants analytics silently — no `[data-testid="cookie-banner"]` or `[data-testid="consent-popup"]` element created

The tests use `vi.unmock('@/services/posthog')` + `vi.unmock('@/services/consentService')` to bypass the global stubs in `tests/setup.tsx`, then mock `posthog-js` at the module level to observe `init` / `capture` calls without network traffic.

## Test plan

- [x] `npx vitest run tests/services/posthog.test.ts` — 5/5 passing
- [x] `npx tsc --noEmit` — zero errors from the new file (unrelated pre-existing errors in `tests/hooks/useNewsletterState.test.ts` and `tests/hooks/useSimulationState.test.ts` are present on `main` too)
- [x] `NODE_OPTIONS='--max-old-space-size=8192' npx vite build` — exits 0
- [x] `npx vitest run` — 24,843 passing. One pre-existing failure in `tests/job-cross-locale-guard.test.ts` reproduces on `main` before this change (it depends on `data/jobs.json` which is gitignored and lacks `canonicalContent.byLocale` entries in this worktree) — not caused by this PR.

## Follow-ups (not in this PR)

- Document the PostHog baseline date (2026-04-12) in whichever doc tracks analytics coverage — candidates: `docs/CI-CD-PIPELINE.md` analytics section, or a new note in the SEO ROI measurement playbook.
- If the ~10–15% ad-blocker loss ever matters for reporting, consider adding `posthog.capture('$pageview', {...})` fallback via a noscript pixel. Not needed now — GA4 already covers the blocker-resilient baseline.