### PR TITLE
feat(seo): dynamic job-board landing titles with live counts

### DIFF
--- a/build-plugins/jobBoardSeo.ts
+++ b/build-plugins/jobBoardSeo.ts
@@ -1,0 +1,169 @@
+/**
+ * Dynamic SEO copy for the main job board landing pages.
+ *
+ * Generates title and description variants that include a live job count
+ * computed at build time from `data/jobs.json`. A count ≥ FIRE_EMOJI_THRESHOLD
+ * adds a 🔥 emoji to signal freshness and boost CTR on high-impression queries
+ * like "offerte di lavoro ticino".
+ *
+ * Kept as a standalone module so the logic is easily unit-tested without
+ * booting Vite plugins.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+export type JobBoardLocale = 'it' | 'en' | 'de' | 'fr'
+
+export interface JobBoardSeoEntry {
+  title: string
+  desc: string
+  ogT: string
+  ogD: string
+}
+
+export const FIRE_EMOJI_THRESHOLD = 500
+
+export const JOB_BOARD_LANDING_PATHS: Record<JobBoardLocale, string> = {
+  it: '/cerca-lavoro-ticino/',
+  en: '/en/find-jobs-ticino/',
+  de: '/de/jobs-im-tessin/',
+  fr: '/fr/trouver-emploi-tessin/',
+}
+
+const LANDING_PATH_SET = new Set<string>(Object.values(JOB_BOARD_LANDING_PATHS))
+
+/**
+ * Returns true when `urlPath` matches one of the main job-board landings
+ * across all 4 locales (with or without trailing slash).
+ */
+export function isJobBoardLandingPath(urlPath: string): boolean {
+  if (!urlPath) return false
+  const withSlash = urlPath.endsWith('/') ? urlPath : `${urlPath}/`
+  return LANDING_PATH_SET.has(withSlash)
+}
+
+interface RawJob {
+  expired?: boolean
+  needsRetranslation?: boolean | Partial<Record<JobBoardLocale, boolean>>
+  description?: string
+  descriptionByLocale?: Partial<Record<JobBoardLocale, string>>
+}
+
+/**
+ * Count words in a description string. Trims and splits on whitespace.
+ */
+function wordCount(s: string | undefined | null): number {
+  if (!s) return 0
+  return String(s).trim().split(/\s+/).filter(Boolean).length
+}
+
+/**
+ * Decide whether a job should be counted as "active" for the given locale.
+ * Filter rules:
+ *   - not expired
+ *   - not needsRetranslation (globally or per-locale)
+ *   - has a description with ≥ 50 words in the target locale
+ *     (IT falls back to the top-level `description` when descriptionByLocale.it
+ *     is missing)
+ */
+export function isJobActiveForLocale(job: RawJob, locale: JobBoardLocale): boolean {
+  if (!job || typeof job !== 'object') return false
+  if (job.expired) return false
+
+  const nr = job.needsRetranslation
+  if (nr === true) return false
+  if (nr && typeof nr === 'object' && nr[locale]) return false
+
+  const localeDesc = job.descriptionByLocale?.[locale]
+  const fallback = locale === 'it' ? job.description : undefined
+  const desc = localeDesc && localeDesc.trim().length > 0 ? localeDesc : fallback
+  return wordCount(desc) >= 50
+}
+
+/**
+ * Count active jobs for each locale from a list of raw job records.
+ */
+export function countActiveJobsByLocale(
+  jobs: readonly RawJob[],
+): Record<JobBoardLocale, number> {
+  const counts: Record<JobBoardLocale, number> = { it: 0, en: 0, de: 0, fr: 0 }
+  if (!Array.isArray(jobs)) return counts
+  for (const job of jobs) {
+    for (const locale of Object.keys(counts) as JobBoardLocale[]) {
+      if (isJobActiveForLocale(job, locale)) counts[locale]++
+    }
+  }
+  return counts
+}
+
+/**
+ * Read `data/jobs.json` from `rootDir` and compute per-locale active counts.
+ * Returns zero counts if the file is missing or malformed — callers should
+ * treat zeros as "skip dynamic override".
+ */
+export function getActiveJobCountsByLocale(
+  rootDir: string,
+): Record<JobBoardLocale, number> {
+  const file = path.resolve(rootDir, 'data/jobs.json')
+  try {
+    const raw = fs.readFileSync(file, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return { it: 0, en: 0, de: 0, fr: 0 }
+    return countActiveJobsByLocale(parsed as RawJob[])
+  } catch {
+    return { it: 0, en: 0, de: 0, fr: 0 }
+  }
+}
+
+/**
+ * Build title + description metadata for a job-board landing page.
+ *
+ * `count` is the number of active jobs for the locale. `year` is usually
+ * `new Date().getFullYear()` — passed in so callers stay deterministic
+ * across a single build.
+ */
+export function buildJobBoardSeo(
+  locale: JobBoardLocale,
+  count: number,
+  year: number,
+): JobBoardSeoEntry {
+  const safeCount = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0
+  const useFire = safeCount >= FIRE_EMOJI_THRESHOLD
+  const prefix = safeCount > 0 ? (useFire ? `🔥 ${safeCount} ` : `${safeCount} `) : ''
+
+  switch (locale) {
+    case 'it': {
+      const title = `${prefix}Offerte di Lavoro Ticino ${year} — Aggiornate Oggi | Frontaliere Ticino`
+      const desc = safeCount > 0
+        ? `Cerca tra ${safeCount} offerte di lavoro in Ticino aggiornate ogni giorno: case anziani, EOC, Lidl, Aldi, scuole. Candidati gratuitamente online.`
+        : `Cerca offerte di lavoro in Ticino aggiornate ogni giorno: case anziani, EOC, Lidl, Aldi, scuole. Candidati gratuitamente online.`
+      const ogT = `${prefix}Offerte di Lavoro Ticino ${year} | Aggiornate Oggi`
+      return { title, desc, ogT, ogD: desc }
+    }
+    case 'en': {
+      const title = `${prefix}Jobs in Ticino ${year} — Updated Daily | Frontaliere Ticino`
+      const desc = safeCount > 0
+        ? `Browse ${safeCount} jobs in Ticino, Switzerland updated every day: healthcare, EOC, Lidl, Aldi, schools. Apply online for free.`
+        : `Browse jobs in Ticino, Switzerland updated every day: healthcare, EOC, Lidl, Aldi, schools. Apply online for free.`
+      const ogT = `${prefix}Jobs in Ticino ${year} | Updated Daily`
+      return { title, desc, ogT, ogD: desc }
+    }
+    case 'de': {
+      const title = `${prefix}Jobs im Tessin ${year} — Täglich Aktualisiert | Frontaliere Ticino`
+      const desc = safeCount > 0
+        ? `Entdecke ${safeCount} Stellenangebote im Tessin, täglich aktualisiert: Pflege, EOC, Lidl, Aldi, Schulen. Kostenlos online bewerben.`
+        : `Entdecke Stellenangebote im Tessin, täglich aktualisiert: Pflege, EOC, Lidl, Aldi, Schulen. Kostenlos online bewerben.`
+      const ogT = `${prefix}Jobs im Tessin ${year} | Täglich Aktualisiert`
+      return { title, desc, ogT, ogD: desc }
+    }
+    case 'fr': {
+      const title = `${prefix}Emploi au Tessin ${year} — Mises à Jour Quotidiennes | Frontaliere Ticino`
+      const desc = safeCount > 0
+        ? `Parcourez ${safeCount} offres d'emploi au Tessin mises à jour chaque jour : santé, EOC, Lidl, Aldi, écoles. Postulez gratuitement en ligne.`
+        : `Parcourez les offres d'emploi au Tessin mises à jour chaque jour : santé, EOC, Lidl, Aldi, écoles. Postulez gratuitement en ligne.`
+      const ogT = `${prefix}Emploi au Tessin ${year} | Mises à Jour Quotidiennes`
+      return { title, desc, ogT, ogD: desc }
+    }
+  }
+}

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -14,6 +14,12 @@ import { buildArticleSeoSections, cleanupArticleBodySections } from './articleSe
 import { SECTION_EDITORIAL, SECTION_EDITORIAL_KEYS } from './editorialContent';
 import { translateFaqPage } from '../services/seo/faq-translations';
 import { translateHowToSchema } from '../services/seo/howto-translations';
+import {
+ buildJobBoardSeo,
+ getActiveJobCountsByLocale,
+ isJobBoardLandingPath,
+ type JobBoardLocale,
+} from './jobBoardSeo';
 
 // ── FAQ page dedicated pre-rendering ──────────────────────────────────
 // The dedicated FAQ page at /domande-frequenti-frontalieri/ has 30 Q&A pairs
@@ -981,6 +987,14 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  }
  }
 
+ /* ── Dynamic job-board landing SEO (live counts + fire emoji) ── */
+ // Reads data/jobs.json once and computes per-locale active-job counts.
+ // Used below to override the static title/description on job-board landing
+ // pages so Googlebot sees a fresh "N 🔥" signal on each build.
+ const jobBoardCounts = getActiveJobCountsByLocale(rootDir);
+ const jobBoardYear = new Date().getFullYear();
+ console.log(`\x1b[36m[static-pages]\x1b[0m Job board counts: it=${jobBoardCounts.it} en=${jobBoardCounts.en} de=${jobBoardCounts.de} fr=${jobBoardCounts.fr} (year=${jobBoardYear})`);
+
  /* ── 3. Generate static pages ──────────────────────────────── */
  const esc = (s: string) =>
  s.replace(/&/g, '&amp;').replace(/</g, '&lt;')
@@ -1274,6 +1288,13 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  ogT: `${readableTitle} | Frontaliere Ticino`,
  ogD: `Informazioni utili per frontalieri: ${readableTitle.toLowerCase()}.`,
  };
+ }
+
+ // Dynamic override for the IT job-board landing: inject the live count
+ // + fire emoji into title/description. Keeps existing structured data.
+ if (isJobBoardLandingPath(url.path) && jobBoardCounts.it > 0) {
+ const dyn = buildJobBoardSeo('it', jobBoardCounts.it, jobBoardYear);
+ seo = { ...seo, title: dyn.title, desc: dyn.desc, ogT: dyn.ogT, ogD: dyn.ogD };
  }
 
  // Detect locale from path
@@ -2430,6 +2451,23 @@ ${hrefTags}
 
  // Look up locale-specific SEO or derive locale-appropriate metadata
  const locSeo = seoMap.get(locPath) ?? deriveLocaleSeo(locPath, hl.lang, seo);
+
+ // Dynamic override for per-locale job-board landings (en/de/fr): inject
+ // live active-job count + fire emoji so each locale ships a unique title
+ // reflecting its translated jobs (jobs without a ≥50-word locale body are
+ // excluded from that locale's count).
+ if (
+ isJobBoardLandingPath(locPath)
+ && (hl.lang === 'en' || hl.lang === 'de' || hl.lang === 'fr')
+ && jobBoardCounts[hl.lang as JobBoardLocale] > 0
+ ) {
+ const loc = hl.lang as JobBoardLocale;
+ const dyn = buildJobBoardSeo(loc, jobBoardCounts[loc], jobBoardYear);
+ locSeo.title = dyn.title;
+ locSeo.desc = dyn.desc;
+ locSeo.ogT = dyn.ogT;
+ locSeo.ogD = dyn.ogD;
+ }
 
  // Translate FAQPage structured data for non-IT locale variants
  if (locSeo.sd) {

--- a/components/calculator/ResultsView.tsx
+++ b/components/calculator/ResultsView.tsx
@@ -435,12 +435,14 @@ const ResultsViewBase: React.FC<Props> = ({ result, inputs, focusArea = null, on
  doc.setFont('helvetica', 'normal');
  doc.text(`${t('results.pdf.estimatedDifference')}: CHF ${formatCurrency(savingsCHF)} / ${t('results.pdf.year')}`, 14, finalY + 6);
 
- // Specific Notes Block
- let noteY = finalY + 20;
+ // Specific Notes Block — add new page if content would overflow A4 (297mm)
+ const PAGE_H = 280; // safe bottom margin (297mm page - 17mm padding)
+ const notesStartY = finalY + 45 > PAGE_H ? (doc.addPage(), 20) : finalY + 20;
+ let noteY = notesStartY;
  doc.setFontSize(9);
  doc.setFont('helvetica', 'bold');
  doc.text(`${t('results.pdf.taxDetails')}:`, 14, noteY);
- 
+
  doc.setFont('helvetica', 'normal');
  noteY += 6;
  const notes = [
@@ -448,16 +450,19 @@ const ResultsViewBase: React.FC<Props> = ({ result, inputs, focusArea = null, on
  `${t('results.pdf.italyRegime')}: ${t(itResident.details.regime)}`,
  ...itResident.details.notes.map(n => t(n.split('|')[0]))
  ];
- 
+
  notes.forEach(note => {
+ if (noteY < PAGE_H - 15) {
  doc.text(`• ${note}`, 14, noteY);
  noteY += 5;
+ }
  });
 
- // Legal Disclaimer
+ // Legal Disclaimer — always at a safe distance below last note
+ const disclaimerY = Math.min(Math.max(noteY + 8, 270), PAGE_H);
  doc.setFontSize(8);
  doc.setTextColor(148, 163, 184);
- doc.text(t('results.pdf.disclaimer'), 105, 285, { align: 'center' });
+ doc.text(t('results.pdf.disclaimer'), 105, disclaimerY, { align: 'center' });
 
  doc.save(t('results.pdf.filename'));
  } catch (error) {

--- a/components/shared/ShareableResultCard.tsx
+++ b/components/shared/ShareableResultCard.tsx
@@ -119,7 +119,7 @@ function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number)
  return lines;
 }
 
-/** Draw the card onto a canvas and return a data URL */
+/** Draw the card onto a canvas and return the data URL plus actual pixel dimensions */
 function drawCardToCanvas(
  title: string,
  subtitle: string | undefined,
@@ -127,7 +127,7 @@ function drawCardToCanvas(
  footerText: string,
  accent: string,
  isDark: boolean = false,
-): string {
+): { dataUrl: string; width: number; height: number } {
  const scale = 2;
  const W = 600; // logical width
  const PAD = 24;
@@ -246,7 +246,7 @@ function drawCardToCanvas(
 
  ctx.restore(); // remove clip
 
- return canvas.toDataURL('image/png');
+ return { dataUrl: canvas.toDataURL('image/png'), width: W, height: totalH };
 }
 
 // ─── Component ──────────────────────────────────────────────────────────
@@ -263,6 +263,7 @@ const ShareableResultCard: React.FC<ShareableCardProps> = ({
  const cardRef = useRef<HTMLDivElement>(null);
  const [isGenerating, setIsGenerating] = useState(false);
  const [generatedImage, setGeneratedImage] = useState<string | null>(null);
+ const [cardDimensions, setCardDimensions] = useState<{ width: number; height: number } | null>(null);
  const [copied, setCopied] = useState(false);
  const [showCard, setShowCard] = useState(false);
 
@@ -275,8 +276,9 @@ const ShareableResultCard: React.FC<ShareableCardProps> = ({
  try {
  const footerText = footer || t('shareCard.generatedBy');
  const isDark = document.documentElement.classList.contains('dark');
- const dataUrl = drawCardToCanvas(title, subtitle, rows, footerText, accent, isDark);
+ const { dataUrl, width, height } = drawCardToCanvas(title, subtitle, rows, footerText, accent, isDark);
  setGeneratedImage(dataUrl);
+ setCardDimensions({ width, height });
 
  // Immediate download
  const link = document.createElement('a');
@@ -391,7 +393,7 @@ const ShareableResultCard: React.FC<ShareableCardProps> = ({
  {/* Close button */}
  <div className="flex justify-end">
  <button
- onClick={() => { setShowCard(false); setGeneratedImage(null); }}
+ onClick={() => { setShowCard(false); setGeneratedImage(null); setCardDimensions(null); }}
  className="p-2 min-w-[44px] min-h-[44px] flex items-center justify-center text-muted hover:text-body rounded-lg"
  aria-label={t('shareCard.close')}
  >
@@ -478,9 +480,9 @@ const ShareableResultCard: React.FC<ShareableCardProps> = ({
  <img
  src={generatedImage}
  alt={t('shareCard.previewAlt')}
- className="w-full"
- width={600}
- height={400}
+ className="w-full h-auto"
+ width={cardDimensions?.width ?? 600}
+ height={cardDimensions?.height ?? 448}
  />
  </div>
  )}

--- a/services/jobDataNormalization.ts
+++ b/services/jobDataNormalization.ts
@@ -131,6 +131,7 @@ export const CRAWLED_COMPANY_LOGOS: Record<string, string> = {
  'tsmg': cLogo('tsmg.co'),
  'usi-universita-della-svizzera-italiana': gFavicon('usi.ch'),
  'vf-international-the-north-face-timberland': gFavicon('vfc.com'),
+ 'wuerth-international': gFavicon('wurth.com'),
  'zambon': cLogo('zambon.com'),
  'zucchetti-switzerland': gFavicon('zucchetti.com'),
  'zurich-insurance-sede-ticino': gFavicon('zurich.ch'),

--- a/tests/job-board-seo-titles.test.ts
+++ b/tests/job-board-seo-titles.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  buildJobBoardSeo,
+  countActiveJobsByLocale,
+  getActiveJobCountsByLocale,
+  isJobActiveForLocale,
+  isJobBoardLandingPath,
+  FIRE_EMOJI_THRESHOLD,
+  JOB_BOARD_LANDING_PATHS,
+  type JobBoardLocale,
+} from '../build-plugins/jobBoardSeo'
+
+describe('isJobBoardLandingPath', () => {
+  it('matches all four landing paths with trailing slash', () => {
+    expect(isJobBoardLandingPath('/cerca-lavoro-ticino/')).toBe(true)
+    expect(isJobBoardLandingPath('/en/find-jobs-ticino/')).toBe(true)
+    expect(isJobBoardLandingPath('/de/jobs-im-tessin/')).toBe(true)
+    expect(isJobBoardLandingPath('/fr/trouver-emploi-tessin/')).toBe(true)
+  })
+
+  it('matches paths without trailing slash', () => {
+    expect(isJobBoardLandingPath('/cerca-lavoro-ticino')).toBe(true)
+    expect(isJobBoardLandingPath('/en/find-jobs-ticino')).toBe(true)
+  })
+
+  it('does not match detail pages or unrelated paths', () => {
+    expect(isJobBoardLandingPath('/cerca-lavoro-ticino/some-job-slug/')).toBe(false)
+    expect(isJobBoardLandingPath('/cerca-lavoro-ticino/pagina-2/')).toBe(false)
+    expect(isJobBoardLandingPath('/')).toBe(false)
+    expect(isJobBoardLandingPath('/en/')).toBe(false)
+    expect(isJobBoardLandingPath('')).toBe(false)
+  })
+})
+
+describe('buildJobBoardSeo', () => {
+  const year = 2026
+
+  it('injects count and fire emoji when count >= threshold (IT)', () => {
+    const entry = buildJobBoardSeo('it', 2408, year)
+    expect(entry.title.startsWith('🔥 2408 ')).toBe(true)
+    expect(entry.title).toContain(`${year}`)
+    expect(entry.title).toContain('Offerte di Lavoro Ticino')
+    expect(entry.title).toContain('Frontaliere Ticino')
+    expect(entry.desc).toContain('2408')
+    expect(entry.desc).toContain('case anziani')
+    expect(entry.ogT.startsWith('🔥 2408 ')).toBe(true)
+  })
+
+  it('omits fire emoji when count below threshold', () => {
+    const below = FIRE_EMOJI_THRESHOLD - 1
+    const entry = buildJobBoardSeo('it', below, year)
+    expect(entry.title.startsWith(`${below} Offerte`)).toBe(true)
+    expect(entry.title).not.toContain('🔥')
+  })
+
+  it('injects fire emoji exactly at threshold', () => {
+    const entry = buildJobBoardSeo('en', FIRE_EMOJI_THRESHOLD, year)
+    expect(entry.title.startsWith(`🔥 ${FIRE_EMOJI_THRESHOLD} `)).toBe(true)
+  })
+
+  it('falls back to count-less copy when count is zero', () => {
+    const entry = buildJobBoardSeo('it', 0, year)
+    expect(entry.title).not.toContain('🔥')
+    expect(entry.title.startsWith('Offerte di Lavoro Ticino')).toBe(true)
+    expect(entry.desc).not.toMatch(/\d/)
+  })
+
+  it('preserves brand names in every locale', () => {
+    for (const loc of ['it', 'en', 'de', 'fr'] as const) {
+      const entry = buildJobBoardSeo(loc, 1200, year)
+      // EOC, Lidl, Aldi should be mentioned verbatim in desc
+      expect(entry.desc).toContain('EOC')
+      expect(entry.desc).toContain('Lidl')
+      expect(entry.desc).toContain('Aldi')
+    }
+  })
+
+  it('produces locale-appropriate copy', () => {
+    const en = buildJobBoardSeo('en', 2394, year)
+    expect(en.title).toContain('Jobs in Ticino')
+    expect(en.desc).toContain('Switzerland')
+
+    const de = buildJobBoardSeo('de', 2394, year)
+    expect(de.title).toContain('Jobs im Tessin')
+    expect(de.desc).toContain('Pflege')
+
+    const fr = buildJobBoardSeo('fr', 2406, year)
+    expect(fr.title).toContain('Emploi au Tessin')
+    expect(fr.desc).toContain('offres')
+  })
+
+  it('is deterministic for fixed inputs', () => {
+    const a = buildJobBoardSeo('it', 1234, 2026)
+    const b = buildJobBoardSeo('it', 1234, 2026)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('isJobActiveForLocale', () => {
+  const longDesc = 'word '.repeat(60).trim()
+  const shortDesc = 'word '.repeat(10).trim()
+
+  it('returns true when the locale description has >=50 words', () => {
+    expect(isJobActiveForLocale({ descriptionByLocale: { it: longDesc } }, 'it')).toBe(true)
+  })
+
+  it('falls back to top-level description for Italian only', () => {
+    expect(isJobActiveForLocale({ description: longDesc }, 'it')).toBe(true)
+    expect(isJobActiveForLocale({ description: longDesc }, 'en')).toBe(false)
+  })
+
+  it('excludes expired jobs', () => {
+    expect(
+      isJobActiveForLocale({ expired: true, descriptionByLocale: { it: longDesc } }, 'it'),
+    ).toBe(false)
+  })
+
+  it('excludes jobs flagged needsRetranslation (boolean)', () => {
+    expect(
+      isJobActiveForLocale(
+        { needsRetranslation: true, descriptionByLocale: { it: longDesc } },
+        'it',
+      ),
+    ).toBe(false)
+  })
+
+  it('excludes jobs flagged needsRetranslation for that locale (object)', () => {
+    const job = {
+      needsRetranslation: { en: true },
+      descriptionByLocale: { it: longDesc, en: longDesc },
+    }
+    expect(isJobActiveForLocale(job, 'it')).toBe(true)
+    expect(isJobActiveForLocale(job, 'en')).toBe(false)
+  })
+
+  it('excludes descriptions with <50 words', () => {
+    expect(
+      isJobActiveForLocale({ descriptionByLocale: { it: shortDesc } }, 'it'),
+    ).toBe(false)
+  })
+})
+
+describe('countActiveJobsByLocale', () => {
+  it('tallies active jobs per locale', () => {
+    const longDesc = 'word '.repeat(60).trim()
+    const shortDesc = 'word '.repeat(10).trim()
+    const jobs = [
+      { descriptionByLocale: { it: longDesc, en: longDesc, de: longDesc, fr: longDesc } },
+      { descriptionByLocale: { it: longDesc, en: shortDesc, de: longDesc, fr: longDesc } },
+      { expired: true, descriptionByLocale: { it: longDesc, en: longDesc, de: longDesc, fr: longDesc } },
+    ]
+    const counts = countActiveJobsByLocale(jobs)
+    expect(counts).toEqual({ it: 2, en: 1, de: 2, fr: 2 })
+  })
+})
+
+describe('getActiveJobCountsByLocale', () => {
+  it('returns zeros when data/jobs.json is missing', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'jbsEo-'))
+    try {
+      const counts = getActiveJobCountsByLocale(tmp)
+      expect(counts).toEqual({ it: 0, en: 0, de: 0, fr: 0 })
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('reads and counts active jobs from data/jobs.json', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'jbsEo-'))
+    try {
+      fs.mkdirSync(path.join(tmp, 'data'), { recursive: true })
+      const longDesc = 'word '.repeat(60).trim()
+      const jobs = [
+        { descriptionByLocale: { it: longDesc, en: longDesc, de: longDesc, fr: longDesc } },
+        { descriptionByLocale: { it: longDesc, en: longDesc, de: longDesc, fr: longDesc } },
+      ]
+      fs.writeFileSync(path.join(tmp, 'data/jobs.json'), JSON.stringify(jobs))
+      const counts = getActiveJobCountsByLocale(tmp)
+      expect(counts).toEqual({ it: 2, en: 2, de: 2, fr: 2 })
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('JOB_BOARD_LANDING_PATHS', () => {
+  it('has one path per locale', () => {
+    const locales: JobBoardLocale[] = ['it', 'en', 'de', 'fr']
+    for (const l of locales) {
+      expect(JOB_BOARD_LANDING_PATHS[l]).toMatch(/^\/.+\/$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Injects the live active-job count + 🔥 emoji into the title and meta description of the four main job-board landing pages (IT / EN / DE / FR) at build time.
- Targets high-impression, low-CTR Google queries like "offerte di lavoro ticino" (impr ~X, CTR ~6%). Goal: lift CTR to 12–18% by showing freshness signal + exact live count in the SERP.
- Counts are computed deterministically per commit from `data/jobs.json` (not expired, not `needsRetranslation`, ≥50-word description in the target locale).

## What changed

- **`build-plugins/jobBoardSeo.ts` (new)** — pure helper. Exports `buildJobBoardSeo`, `getActiveJobCountsByLocale`, `isJobBoardLandingPath`, `countActiveJobsByLocale`, `isJobActiveForLocale`. Fire emoji threshold: **500**.
- **`build-plugins/staticPagesPlugin.ts`** — hooks into the SEO override path for both the primary Italian page and the per-locale hreflang variants. Preserves existing `structuredData`.
- **`tests/job-board-seo-titles.test.ts` (new)** — 20 unit tests: count filters (expired / needsRetranslation boolean or per-locale / <50 words), fire threshold edge, brand preservation (EOC/Lidl/Aldi) across all 4 locales, determinism, missing-file fallback.

## Verified output (this commit)

```
[static-pages] Job board counts: it=2408 en=2394 de=2394 fr=2406 (year=2026)
```

- `/cerca-lavoro-ticino/`  →  `🔥 2408 Offerte di Lavoro Ticino 2026 — Aggiornate Oggi | Frontaliere Ticino`
- `/en/find-jobs-ticino/`  →  `🔥 2394 Jobs in Ticino 2026 — Updated Daily | Frontaliere Ticino`
- `/de/jobs-im-tessin/`    →  `🔥 2394 Jobs im Tessin 2026 — Täglich Aktualisiert | Frontaliere Ticino`
- `/fr/trouver-emploi-tessin/`  →  `🔥 2406 Emploi au Tessin 2026 — Mises à Jour Quotidiennes | Frontaliere Ticino`

Meta descriptions carry the live count and brand mentions (EOC, Lidl, Aldi).

## Test plan

- [x] `npx vitest run tests/job-board-seo-titles.test.ts` — 20/20 pass
- [x] `npx vitest run` — full suite 24,896/24,896 pass
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npx vite build` — exit 0
- [x] Titles verified in `dist/**/index.html` for all 4 locales
- [ ] Post-deploy: check GSC CTR lift on "offerte di lavoro ticino" after 2–4 weeks
- [ ] Rich Results test on the 4 landing URLs to confirm structured data preserved