### PR TITLE
feat(ci): self-trigger generate-article chain to bypass cron unreliability

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -13,6 +13,11 @@ on:
         description: 'Optional: specific article URL to generate from (leave empty for auto-scan)'
         required: false
         type: string
+      retry_count:
+        description: 'Internal: retry counter for self-trigger chain (do not set manually)'
+        required: false
+        type: string
+        default: '0'
 
 concurrency:
   # Shared group: only 1 run active at a time, next run queues (not skipped).
@@ -503,3 +508,93 @@ jobs:
               echo "> **🔁 Retry**: trigger \`workflow_dispatch\` with URL: \`$SOURCE_URL\`" >> "$GITHUB_STEP_SUMMARY"
             fi
           fi
+
+      # ── Self-trigger chain ────────────────────────────────────────────
+      # GitHub Actions silently skips ~66% of cron slots (measured 34%
+      # utilization on this 30-min cron). At end of every run we dispatch
+      # the next via workflow_dispatch + PAT to bypass cron unreliability.
+      # The concurrency group `article-generation` already prevents overlap.
+      # The cron schedule remains as a fallback safety net.
+      - name: Determine self-trigger decision
+        id: decide_trigger
+        if: always()
+        env:
+          HAS_CHANGES: ${{ steps.changes.outputs.has_changes }}
+          COMMITTED: ${{ steps.commit.outputs.committed }}
+          VERIFIED: ${{ steps.verify_article.outputs.exists }}
+          GENERATE_OUTCOME: ${{ steps.generate.outcome }}
+          # Retry counter passed via workflow_dispatch input (default 0 for cron-triggered runs)
+          RETRY_COUNT: ${{ github.event.inputs.retry_count || '0' }}
+        run: |
+          # Outcome decision tree:
+          # ✅ verified=true → self-trigger immediately, retry_count=0
+          # ⚪ has_changes=false (no source / all duplicates) → self-trigger after 600s, retry_count=0
+          # 🟠 committed=false (rebase/push race) → self-trigger after 60s, retry_count=0
+          # 🟠 verified=false (committed but not in dist) → RETRY with backoff
+          # 🔴 generate step failure → RETRY with backoff
+          # Backoff schedule: 60s → 300s → 1800s, max 3 retries, then give up (cron resumes)
+
+          SHOULD_TRIGGER="false"
+          DELAY="0"
+          REASON="unknown"
+          NEXT_RETRY="0"
+
+          if [ "$VERIFIED" = "true" ]; then
+            SHOULD_TRIGGER="true"
+            DELAY="0"
+            REASON="success"
+            NEXT_RETRY="0"
+          elif [ "$HAS_CHANGES" = "false" ]; then
+            SHOULD_TRIGGER="true"
+            DELAY="600"
+            REASON="no_changes"
+            NEXT_RETRY="0"
+          elif [ "$COMMITTED" = "false" ] && [ "$HAS_CHANGES" = "true" ]; then
+            SHOULD_TRIGGER="true"
+            DELAY="60"
+            REASON="rebase_failed"
+            NEXT_RETRY="0"
+          else
+            # Failure path: verify_failed OR generate_failed OR build_failed
+            CUR_RETRY="${RETRY_COUNT:-0}"
+            if [ "$CUR_RETRY" -lt 3 ]; then
+              NEXT_RETRY=$((CUR_RETRY + 1))
+              case "$NEXT_RETRY" in
+                1) DELAY=60 ;;
+                2) DELAY=300 ;;
+                3) DELAY=1800 ;;
+              esac
+              SHOULD_TRIGGER="true"
+              REASON="retry_${NEXT_RETRY}_of_3"
+            else
+              SHOULD_TRIGGER="false"
+              REASON="retry_exhausted"
+            fi
+          fi
+
+          echo "should_trigger=$SHOULD_TRIGGER" >> "$GITHUB_OUTPUT"
+          echo "delay=$DELAY" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          echo "next_retry=$NEXT_RETRY" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## 🔁 Self-trigger decision"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Should trigger | \`$SHOULD_TRIGGER\` |"
+            echo "| Reason | \`$REASON\` |"
+            echo "| Delay (s) | \`$DELAY\` |"
+            echo "| Retry count (next) | \`$NEXT_RETRY\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Self-trigger next run
+        if: steps.decide_trigger.outputs.should_trigger == 'true'
+        continue-on-error: true
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          WORKFLOW_FILE: generate-article.yml
+          DELAY_SECONDS: ${{ steps.decide_trigger.outputs.delay }}
+          SELF_TRIGGER_REASON: ${{ steps.decide_trigger.outputs.reason }}
+          RETRY_COUNT: ${{ steps.decide_trigger.outputs.next_retry }}
+        run: bash scripts/lib/trigger-self.sh

--- a/docs/CI-CD-PIPELINE.md
+++ b/docs/CI-CD-PIPELINE.md
@@ -151,3 +151,26 @@ jobs:
 Some AI providers return extreme `Retry-After` values (e.g. Cerebras: `Retry-After: 86399` = 24h). Without a cap, the entire translate-pending pipeline freezes for a full day, causing a massive translation backlog.
 
 **Rule**: Always cap `Retry-After` header values to a maximum of **2 minutes** (`MAX_RETRY_AFTER_MS = 2 * 60 * 1000`) in `scripts/lib/ai-models.mjs`. The model fallback chain will naturally move to the next available provider.
+
+## Article generation self-trigger chain
+
+**Why.** `generate-article.yml` runs every 30 min via cron, but GitHub Actions silently skips ~66% of cron slots (measured 34% utilization over 5 days; avg gap 88 min vs 30 expected). At ~22 min real generation time per article, the theoretical max is 65/day; we were getting ~16/day.
+
+**How.** At the end of every run, the workflow self-dispatches the next via `workflow_dispatch` API using the `GITHUB_PAT` secret (same pattern as `scripts/lib/trigger-deploy.sh`). The shared concurrency group `article-generation` prevents overlap. The `7,37 * * * *` cron stays as a fallback safety net.
+
+**Outcome matrix** (computed by step `decide_trigger`, dispatched by step `Self-trigger next run`):
+
+| Outcome | Delay | Retry counter |
+|---|---|---|
+| `success` (committed + verified in dist) | 0s | reset to 0 |
+| `no_changes` (no source / all duplicates) | 600s | reset to 0 |
+| `rebase_failed` (push race deferred article) | 60s | reset to 0 |
+| `verify_failed` / `generate_failed` / `build_failed` | 60s → 300s → 1800s | exponential, max 3 retries |
+| `retry_exhausted` | n/a — no dispatch | cron resumes |
+
+**Kill instructions.** Two options:
+
+1. **Soft kill (per-run skip)**: clear the `GITHUB_PAT` repo secret. The script logs "skip, no token" and exits 0 — the cron schedule keeps the workflow alive.
+2. **Hard kill (chain off)**: comment out the `Self-trigger next run` step in `.github/workflows/generate-article.yml` and push. Cron continues at 30-min intervals.
+
+Source: `scripts/lib/trigger-self.sh`, tests at `tests/lib/trigger-self.test.ts`.

--- a/scripts/lib/trigger-self.sh
+++ b/scripts/lib/trigger-self.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# scripts/lib/trigger-self.sh — Self-trigger a workflow_dispatch event
+#
+# Used at the end of a workflow run to chain into the next run, bypassing
+# GitHub Actions' unreliable cron scheduler (measured ~34% utilization on
+# generate-article.yml's 30-min cron). Concurrency groups already prevent
+# overlap, so it's safe to fire-and-forget.
+#
+# Modeled on scripts/lib/trigger-deploy.sh — same auth + payload + dispatch
+# + best-effort error handling pattern.
+#
+# Required env vars:
+#   GITHUB_PAT or GH_TOKEN  — Personal Access Token with workflow scope
+#   GITHUB_REPOSITORY       — owner/repo (set automatically in Actions)
+#   WORKFLOW_FILE           — workflow filename to dispatch (e.g. generate-article.yml)
+# Optional env vars:
+#   DELAY_SECONDS           — sleep N seconds before dispatch (default 0)
+#   DISPATCH_REF            — branch/tag (default: main)
+#   SELF_TRIGGER_REASON     — reason string for observability (e.g. "success",
+#                             "no_changes", "rebase_failed", "retry_1_of_3")
+#   RETRY_COUNT             — retry counter passed to the dispatched run
+#                             (omitted from payload when empty or "0")
+#
+# Exit codes:
+#   0  — dispatch sent OR skipped (no token) OR API error (best-effort)
+#   1  — only when WORKFLOW_FILE is missing (caller misconfiguration)
+#
+# This script is best-effort: an HTTP failure must NEVER fail the parent
+# job. The cron schedule remains the safety-net fallback.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+write_output() {
+  local key="$1"
+  local value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+REASON="${SELF_TRIGGER_REASON:-unspecified}"
+write_output "self_trigger_reason" "$REASON"
+
+# Validate WORKFLOW_FILE — this is a hard caller-side error
+if [ -z "${WORKFLOW_FILE:-}" ]; then
+  echo "❌ trigger-self.sh: WORKFLOW_FILE env var is required" >&2
+  write_output "dispatch_sent" "false"
+  exit 1
+fi
+
+# Resolve a token — prefer GITHUB_PAT, fall back to GH_TOKEN
+TOKEN="${GITHUB_PAT:-${GH_TOKEN:-}}"
+
+if [ -z "$TOKEN" ]; then
+  echo "ℹ️ trigger-self.sh: no GITHUB_PAT or GH_TOKEN — skip self-trigger (cron fallback applies)"
+  write_output "dispatch_sent" "false"
+  exit 0
+fi
+
+REPO="${GITHUB_REPOSITORY:-valerielinc-ops/frontaliere-si-o-no}"
+REF="${DISPATCH_REF:-main}"
+DELAY="${DELAY_SECONDS:-0}"
+RETRY_COUNT="${RETRY_COUNT:-}"
+
+# Optional pre-dispatch sleep (lets the runner unwind, gives the queue room)
+if [ -n "$DELAY" ] && [ "$DELAY" != "0" ]; then
+  echo "⏳ trigger-self.sh: sleeping ${DELAY}s before dispatch (reason=${REASON})..."
+  sleep "$DELAY"
+fi
+
+echo "🔁 trigger-self.sh: dispatching ${WORKFLOW_FILE} on ${REF} (reason=${REASON}, retry_count=${RETRY_COUNT:-0})"
+
+PAYLOAD="$(
+  DISPATCH_REF_JSON="$REF" \
+  RETRY_COUNT_JSON="$RETRY_COUNT" \
+  node <<'NODE'
+const trim = (v) => String(v || '').trim();
+const payload = { ref: trim(process.env.DISPATCH_REF_JSON) || 'main' };
+const retry = trim(process.env.RETRY_COUNT_JSON);
+if (retry && retry !== '0') {
+  payload.inputs = { retry_count: retry };
+}
+process.stdout.write(JSON.stringify(payload));
+NODE
+)"
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  "https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/dispatches" \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -d "$PAYLOAD" || echo "000")
+
+if [ "$HTTP_CODE" = "204" ]; then
+  echo "✅ trigger-self.sh: ${WORKFLOW_FILE} dispatched successfully (reason=${REASON})"
+  write_output "dispatch_sent" "true"
+  exit 0
+else
+  echo "⚠️ trigger-self.sh: dispatch returned HTTP ${HTTP_CODE} (expected 204) — best-effort, not failing parent job"
+  write_output "dispatch_sent" "false"
+  exit 0
+fi

--- a/tests/lib/trigger-self.test.ts
+++ b/tests/lib/trigger-self.test.ts
@@ -1,0 +1,87 @@
+// Tests for scripts/lib/trigger-self.sh — best-effort self-dispatch helper.
+// We exercise the SKIP path (no token) and the misconfiguration path
+// (no WORKFLOW_FILE). We never hit the real GitHub API: success requires
+// a real PAT + WORKFLOW_FILE, so the curl branch is intentionally not
+// covered here.
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SCRIPT = resolve('scripts/lib/trigger-self.sh');
+
+function run(env = {}, opts = {}) {
+  // Use a per-call GITHUB_OUTPUT file so we can assert the key=value writes
+  const tmp = mkdtempSync(join(tmpdir(), 'trigger-self-'));
+  const outFile = join(tmp, 'output');
+  // Touch the file (the script appends, doesn't create)
+  execFileSync('bash', ['-c', `: > "${outFile}"`]);
+  try {
+    const stdout = execFileSync('bash', [SCRIPT], {
+      env: {
+        PATH: process.env.PATH,
+        GITHUB_OUTPUT: outFile,
+        ...env,
+      },
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...opts,
+    });
+    const githubOutput = readFileSync(outFile, 'utf8');
+    return { code: 0, stdout, stderr: '', githubOutput };
+  } catch (e) {
+    const githubOutput = (() => {
+      try {
+        return readFileSync(outFile, 'utf8');
+      } catch {
+        return '';
+      }
+    })();
+    return {
+      code: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+      githubOutput,
+    };
+  }
+}
+
+describe('scripts/lib/trigger-self.sh', () => {
+  it('skips silently when no GITHUB_PAT and no GH_TOKEN are set', () => {
+    const { code, stdout, githubOutput } = run({
+      WORKFLOW_FILE: 'generate-article.yml',
+    });
+    expect(code).toBe(0);
+    expect(stdout.toLowerCase()).toMatch(/skip/);
+    expect(githubOutput).toMatch(/dispatch_sent=false/);
+  });
+
+  it('exits 1 with a clear error when WORKFLOW_FILE is missing', () => {
+    const { code, stdout, stderr, githubOutput } = run({
+      GITHUB_PAT: 'fake-token',
+    });
+    expect(code).toBe(1);
+    expect(stdout + stderr).toMatch(/WORKFLOW_FILE/);
+    expect(githubOutput).toMatch(/dispatch_sent=false/);
+  });
+
+  it('respects DELAY_SECONDS=0 (no observable sleep on the fast path)', () => {
+    const start = Date.now();
+    run({
+      WORKFLOW_FILE: 'generate-article.yml',
+      DELAY_SECONDS: '0',
+    });
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it('writes self_trigger_reason to GITHUB_OUTPUT for observability', () => {
+    const { githubOutput } = run({
+      WORKFLOW_FILE: 'generate-article.yml',
+      SELF_TRIGGER_REASON: 'no_changes',
+    });
+    expect(githubOutput).toMatch(/self_trigger_reason=no_changes/);
+  });
+});


### PR DESCRIPTION
## Why

GitHub Actions cron silently drops ~66% of scheduled slots (measured 34% utilization over 80 runs / 5 days on this 30-min cron). Real generation time is 22 min, theoretical max 65 articles/day, current actual ~16/day.

## What

Adds a `workflow_dispatch` chain at the end of every run, dispatched via the existing `GITHUB_PAT` secret (same pattern as `trigger-deploy.sh`). The 30-min cron stays as a safety-net fallback. The `article-generation` concurrency group already prevents overlap.

**Outcome → next-trigger matrix:**
| Outcome | Self-trigger | Delay |
|---|---|---|
| ✅ verified=true | yes | 0s |
| ⚪ no_changes (no source / dup) | yes | 600s |
| 🟠 rebase_failed | yes | 60s |
| 🔴 failure | yes (max 3 retries) | 60/300/1800s |
| 🔴 retry_exhausted | no | — (cron resumes) |

## Files

- `scripts/lib/trigger-self.sh` (new, executable, ~100 LOC) — best-effort dispatch helper modeled on `trigger-deploy.sh`
- `.github/workflows/generate-article.yml` — adds `retry_count` input, `decide_trigger` step, `Self-trigger next run` step (purely additive, no existing steps modified)
- `tests/lib/trigger-self.test.ts` — 4 unit tests (skip-no-token, missing-WORKFLOW_FILE, no-sleep, reason-output)
- `docs/CI-CD-PIPELINE.md` — short section explaining the chain + kill switches

## Test plan

- [x] `bash -n scripts/lib/trigger-self.sh` clean
- [x] `npx js-yaml .github/workflows/generate-article.yml` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/lib/trigger-self.test.ts` — 4/4 pass
- [x] Fast `npx vite build` (with SKIP_* gates) — exit 0
- [x] Full `npx vitest run` — same flakiness profile as pristine origin/main (no regressions added)
- [ ] Live E2E: dispatch workflow manually, verify next run auto-dispatched within 60s of completion (orchestrator does post-merge)

## Kill switches

- Soft: clear `GITHUB_PAT` secret → script exits 0 silently, cron continues at 30-min cadence
- Hard: comment out the `Self-trigger next run` step

## Pre-existing test failures (NOT introduced)

Full test suite shows 20 failures on this branch and 38 on pristine origin/main — flaky tests due to `isolate: false` + shared VM context. Different runs produce different counts. Not in scope for this PR.