### PR TITLE
feat(audit): orphan-pages-in-sitemaps audit script + baseline

### DIFF
--- a/data/orphan-pages-audit.json
+++ b/data/orphan-pages-audit.json
@@ -1,0 +1,460 @@
+{
+  "version": 1,
+  "generatedAt": "2026-04-28T07:06:15.811Z",
+  "mode": "source",
+  "totalSitemapUrls": 7538,
+  "totalOrphans": 6031,
+  "perSitemap": {
+    "sitemap-annual-report.xml": {
+      "total": 4,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-blog.xml": {
+      "total": 1072,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-border-wait-map.xml": {
+      "total": 4,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-border-wait.xml": {
+      "total": 108,
+      "orphans": 104,
+      "examples": [
+        "https://frontaliereticino.ch/traffico-dogane/ticino-como/",
+        "https://frontaliereticino.ch/traffico-dogane/ticino-varese/",
+        "https://frontaliereticino.ch/traffico-dogane/chiasso-centro/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/chiasso-brogeda/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/chiasso-strada/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/maslianico-pizzamiglio/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/maslianico-roggiana/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/bizzarone-novazzano/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/ronago-novazzano/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/crociale-dei-mulini/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/drezzo-pedrinate/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/lanzo-d-intelvi-arogno/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/campione-d-italia-bissone/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/oria-gandria/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/gaggiolo/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/san-pietro/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/clivio-ligornetto/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/rodero-stabio/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/saltrio-arzo/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/ponte-tresa/oggi/"
+      ]
+    },
+    "sitemap-career-landings.xml": {
+      "total": 4,
+      "orphans": 2,
+      "examples": [
+        "https://frontaliereticino.ch/agenzie-del-lavoro-lugano/",
+        "https://frontaliereticino.ch/stage-lugano/"
+      ]
+    },
+    "sitemap-comparisons.xml": {
+      "total": 1,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-cost-of-living.xml": {
+      "total": 6,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-faq-hub.xml": {
+      "total": 1,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-fr-salaire-net.xml": {
+      "total": 1,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-fuel-daily.xml": {
+      "total": 48,
+      "orphans": 40,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/locarno/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/chiasso/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/mendrisio/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/lugano/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/bellinzona/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/locarno/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/chiasso/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/mendrisio/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/lugano/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/bellinzona/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/locarno/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/chiasso/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/mendrisio/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/lugano/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/bellinzona/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/locarno/aujourd-hui/"
+      ]
+    },
+    "sitemap-fuel-italian-cities.xml": {
+      "total": 88,
+      "orphans": 88,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-diesel/italia/como/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/italy/como/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/italien/como/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/italie/como/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/oggi/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/italy/como/today/",
+        "https://frontaliereticino.ch/de/benzinpreis-schweiz/italien/como/heute/",
+        "https://frontaliereticino.ch/fr/prix-essence-suisse/italie/como/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-diesel/italia/varese/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/italy/varese/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/italien/varese/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/italie/varese/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/oggi/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/italy/varese/today/",
+        "https://frontaliereticino.ch/de/benzinpreis-schweiz/italien/varese/heute/",
+        "https://frontaliereticino.ch/fr/prix-essence-suisse/italie/varese/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-diesel/italia/luino/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/italy/luino/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/italien/luino/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/italie/luino/aujourd-hui/"
+      ]
+    },
+    "sitemap-fuel-italian-stations.xml": {
+      "total": 424,
+      "orphans": 424,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/carrefour-via-cristoforo-colombo/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/q8-via-pasquale-paoli-s-n/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/q8-loc-tavernola-via-per-cernobbio-35/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-camerlata-1/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-cavour-30/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-ambrosoli-11/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-viale-fratelli-rosselli-19/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-cecilio-1/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-canturina-85/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-del-dos-14/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-ninguarda-sp-28/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-varesina-128/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-franklin-delano-roosevelt-2/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-statale-per-lecco-60/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-oltrecolle-31/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-asiago-15/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/esso-viale-europa-82/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/retitalia-viale-europa/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/agip-eni-viale-aguggiari-235/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/agip-eni-via-lungolago-di-capolago-sp-1/"
+      ]
+    },
+    "sitemap-fuel-stations.xml": {
+      "total": 488,
+      "orphans": 488,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/station-via-francesco-borromini/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/pemoil-corso-san-gottardo/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/piccadilly-via-franco-zorzi/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/orcam-via-carlo-maderno/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/eni-via-gaggiolo/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/ecsa-via-colombera/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/texon-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-colombera/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/bp-via-san-gottardo/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-del-breggia/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/gioia-str-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/anfra-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia-2/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-maestri-comacini/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-strada-per-gandria/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale-2/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale/"
+      ]
+    },
+    "sitemap-glossario.xml": {
+      "total": 42,
+      "orphans": 29,
+      "examples": [
+        "https://frontaliereticino.ch/glossario-frontaliere/doppiaimposizione/",
+        "https://frontaliereticino.ch/glossario-frontaliere/addizionale-regionale/",
+        "https://frontaliereticino.ch/glossario-frontaliere/addizionale-comunale/",
+        "https://frontaliereticino.ch/glossario-frontaliere/deduzioni/",
+        "https://frontaliereticino.ch/glossario-frontaliere/lohnausweis/",
+        "https://frontaliereticino.ch/glossario-frontaliere/cu/",
+        "https://frontaliereticino.ch/glossario-frontaliere/ral/",
+        "https://frontaliereticino.ch/glossario-frontaliere/modello-730/",
+        "https://frontaliereticino.ch/glossario-frontaliere/redditi-pf/",
+        "https://frontaliereticino.ch/glossario-frontaliere/rendita/",
+        "https://frontaliereticino.ch/glossario-frontaliere/capitale-lpp/",
+        "https://frontaliereticino.ch/glossario-frontaliere/prestazione-libero-passaggio/",
+        "https://frontaliereticino.ch/glossario-frontaliere/ssn/",
+        "https://frontaliereticino.ch/glossario-frontaliere/franchigia-assicurativa/",
+        "https://frontaliereticino.ch/glossario-frontaliere/modelli-assicurativi/",
+        "https://frontaliereticino.ch/glossario-frontaliere/ainp/",
+        "https://frontaliereticino.ch/glossario-frontaliere/permesso-c/",
+        "https://frontaliereticino.ch/glossario-frontaliere/permesso-l/",
+        "https://frontaliereticino.ch/glossario-frontaliere/accordo-frontalieri/",
+        "https://frontaliereticino.ch/glossario-frontaliere/nuovo-accordo-2024/"
+      ]
+    },
+    "sitemap-guides.xml": {
+      "total": 8,
+      "orphans": 8,
+      "examples": [
+        "https://frontaliereticino.ch/guides/guida-completa-frontaliere-2026/",
+        "https://frontaliereticino.ch/guides/guida-completa-frontaliere-2026.pdf",
+        "https://frontaliereticino.ch/guides/permesso-g-vantaggi-svantaggi/",
+        "https://frontaliereticino.ch/guides/permesso-g-vantaggi-svantaggi.pdf",
+        "https://frontaliereticino.ch/guides/lamal-vs-ssn-frontalieri/",
+        "https://frontaliereticino.ch/guides/lamal-vs-ssn-frontalieri.pdf",
+        "https://frontaliereticino.ch/guides/trovare-lavoro-ticino-frontaliere/",
+        "https://frontaliereticino.ch/guides/trovare-lavoro-ticino-frontaliere.pdf"
+      ]
+    },
+    "sitemap-health-premiums.xml": {
+      "total": 183,
+      "orphans": 181,
+      "examples": [
+        "https://frontaliereticino.ch/premi-cassa-malati/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/bambini-0-18/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/giovani-adulti-19-25/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-26-30/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-46-55/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-56-piu/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/bambini-0-18/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/giovani-adulti-19-25/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-26-30/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-31-45/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-46-55/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-56-piu/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/bambini-0-18/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/giovani-adulti-19-25/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-26-30/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-31-45/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-46-55/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-56-piu/"
+      ]
+    },
+    "sitemap-job-market.xml": {
+      "total": 21,
+      "orphans": 20,
+      "examples": [
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-13-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-14-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-15-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-16-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-17-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/marzo-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/infermieri/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/educatori/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/case-anziani/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/sanita/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/amministrativo/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/vendite/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/finanza/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/informatica/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/retail/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/meccanica/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/edilizia/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/ristorazione/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/logistica/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/ingegneria/"
+      ]
+    },
+    "sitemap-jobs.xml": {
+      "total": 2434,
+      "orphans": 2426,
+      "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-tally-weijl/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-grand-hotel-kronenhof/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-kulm-hotel-st-moritz/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-mtic-group/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-afry/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-kantonale-verwaltung-graubunden/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-board-international/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hubers-landhendl-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hugli-nahrmittel-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-bell-schweiz-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hugli-nahrmittel-erzeugung-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-bell-deutschland-gmbh-co-kg/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hugli-nahrungsmittel-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-suddeutsche-truthahn-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hilcona-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hilcona-feinkost-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-eisberg-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-bell-schwarzwalder-schinken-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-eisberg-osterreich-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-geiser-ag/"
+      ]
+    },
+    "sitemap-market-report.xml": {
+      "total": 4,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-news.xml": {
+      "total": 187,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-nursing.xml": {
+      "total": 3,
+      "orphans": 2,
+      "examples": [
+        "https://frontaliereticino.ch/lavoro-oss-svizzera/",
+        "https://frontaliereticino.ch/lavoro-sanitario-ticino/"
+      ]
+    },
+    "sitemap-orphan-landings.xml": {
+      "total": 18,
+      "orphans": 18,
+      "examples": [
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-svizzera/",
+        "https://frontaliereticino.ch/ricerca/lavoro-in-svizzera/",
+        "https://frontaliereticino.ch/ricerca/lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-ticino-negli-ultimi-3-giorni/",
+        "https://frontaliereticino.ch/ricerca/cerco-lavoro-in-svizzera/",
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-ticino-da-ieri/",
+        "https://frontaliereticino.ch/de/suche/chauffeur-jobs/",
+        "https://frontaliereticino.ch/ricerca/posti-di-lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/lavoro-ticino-da-ieri/",
+        "https://frontaliereticino.ch/fr/recherche/groupe-mutuel-emploi/",
+        "https://frontaliereticino.ch/de/suche/chauffeur-schweiz/",
+        "https://frontaliereticino.ch/ricerca/coop-lavora-con-noi/",
+        "https://frontaliereticino.ch/de/suche/job-etudiant-denner/",
+        "https://frontaliereticino.ch/ricerca/cerco-lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/lavori-ticino/",
+        "https://frontaliereticino.ch/ricerca/lavori-in-svizzera/",
+        "https://frontaliereticino.ch/ricerca/lavoro-ticino-negli-ultimi-3-giorni/"
+      ]
+    },
+    "sitemap-pages.xml": {
+      "total": 144,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-professions.xml": {
+      "total": 10,
+      "orphans": 10,
+      "examples": [
+        "https://frontaliereticino.ch/lavoro-ticino-infermiere/",
+        "https://frontaliereticino.ch/lavoro-ticino-operaio/",
+        "https://frontaliereticino.ch/lavoro-ticino-impiegato/",
+        "https://frontaliereticino.ch/lavoro-ticino-ingegnere/",
+        "https://frontaliereticino.ch/lavoro-ticino-educatore/",
+        "https://frontaliereticino.ch/lavoro-ticino-autista/",
+        "https://frontaliereticino.ch/lavoro-ticino-muratore/",
+        "https://frontaliereticino.ch/lavoro-ticino-cuoco/",
+        "https://frontaliereticino.ch/lavoro-ticino-cameriere/",
+        "https://frontaliereticino.ch/lavoro-ticino-elettricista/"
+      ]
+    },
+    "sitemap-recency.xml": {
+      "total": 2,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-salary-hub.xml": {
+      "total": 1732,
+      "orphans": 1699,
+      "examples": [
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-nuovo-frontaliere-oltre-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-new-crossborder-over-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-neuer-grenzgaenger-ueber-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-nouveau-frontalier-plus-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-1-figlio-entro-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-1-child-within-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-1-kind-innerhalb-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-1-enfant-moins-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-1-figlio-nuovo-frontaliere-oltre-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-1-child-new-crossborder-over-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-1-kind-neuer-grenzgaenger-ueber-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-1-enfant-nouveau-frontalier-plus-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-entro-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-2-children-within-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-2-kinder-innerhalb-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-2-enfants-moins-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-nuovo-frontaliere-oltre-20km/"
+      ]
+    },
+    "sitemap-sector.xml": {
+      "total": 10,
+      "orphans": 8,
+      "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/educatori/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/ingegneri/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/autisti/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/sviluppatori/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/ristorazione/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/operatori-socio-sanitari/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/logistica/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/apprendistato/"
+      ]
+    },
+    "sitemap-seo-hubs.xml": {
+      "total": 303,
+      "orphans": 299,
+      "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-2/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-3/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-4/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-5/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-6/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-7/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-8/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-9/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-10/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-11/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-12/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-13/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-14/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-15/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-16/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-17/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-18/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-19/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-20/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-21/"
+      ]
+    },
+    "sitemap-weekly-employers.xml": {
+      "total": 188,
+      "orphans": 185,
+      "examples": [
+        "https://frontaliereticino.ch/aziende-che-assumono/lugano/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/mendrisio/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/chiasso/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/stabio/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/bellinzona/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/locarno/settimana-corrente/",
+        "https://frontaliereticino.ch/en/companies-hiring/lugano/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/mendrisio/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/chiasso/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/stabio/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/bellinzona/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/locarno/current-week/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/lugano/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/mendrisio/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/chiasso/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/stabio/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/bellinzona/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/locarno/aktuelle-woche/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/ticino/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/lugano/semaine-courante/"
+      ]
+    }
+  }
+}

--- a/data/orphan-pages-baseline.json
+++ b/data/orphan-pages-baseline.json
@@ -1,0 +1,460 @@
+{
+  "version": 1,
+  "generatedAt": "2026-04-28T07:06:15.811Z",
+  "mode": "source",
+  "totalSitemapUrls": 7538,
+  "totalOrphans": 6031,
+  "perSitemap": {
+    "sitemap-annual-report.xml": {
+      "total": 4,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-blog.xml": {
+      "total": 1072,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-border-wait-map.xml": {
+      "total": 4,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-border-wait.xml": {
+      "total": 108,
+      "orphans": 104,
+      "examples": [
+        "https://frontaliereticino.ch/traffico-dogane/ticino-como/",
+        "https://frontaliereticino.ch/traffico-dogane/ticino-varese/",
+        "https://frontaliereticino.ch/traffico-dogane/chiasso-centro/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/chiasso-brogeda/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/chiasso-strada/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/maslianico-pizzamiglio/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/maslianico-roggiana/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/bizzarone-novazzano/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/ronago-novazzano/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/crociale-dei-mulini/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/drezzo-pedrinate/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/lanzo-d-intelvi-arogno/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/campione-d-italia-bissone/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/oria-gandria/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/gaggiolo/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/san-pietro/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/clivio-ligornetto/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/rodero-stabio/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/saltrio-arzo/oggi/",
+        "https://frontaliereticino.ch/traffico-dogane/ponte-tresa/oggi/"
+      ]
+    },
+    "sitemap-career-landings.xml": {
+      "total": 4,
+      "orphans": 2,
+      "examples": [
+        "https://frontaliereticino.ch/agenzie-del-lavoro-lugano/",
+        "https://frontaliereticino.ch/stage-lugano/"
+      ]
+    },
+    "sitemap-comparisons.xml": {
+      "total": 1,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-cost-of-living.xml": {
+      "total": 6,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-faq-hub.xml": {
+      "total": 1,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-fr-salaire-net.xml": {
+      "total": 1,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-fuel-daily.xml": {
+      "total": 48,
+      "orphans": 40,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/oggi/",
+        "https://frontaliereticino.ch/prezzi-diesel/locarno/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/chiasso/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/mendrisio/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/lugano/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/bellinzona/today/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/locarno/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/chiasso/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/mendrisio/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/lugano/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/bellinzona/heute/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/locarno/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/chiasso/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/mendrisio/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/lugano/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/bellinzona/aujourd-hui/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/locarno/aujourd-hui/"
+      ]
+    },
+    "sitemap-fuel-italian-cities.xml": {
+      "total": 88,
+      "orphans": 88,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-diesel/italia/como/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/italy/como/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/italien/como/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/italie/como/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/oggi/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/italy/como/today/",
+        "https://frontaliereticino.ch/de/benzinpreis-schweiz/italien/como/heute/",
+        "https://frontaliereticino.ch/fr/prix-essence-suisse/italie/como/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-diesel/italia/varese/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/italy/varese/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/italien/varese/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/italie/varese/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/oggi/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/italy/varese/today/",
+        "https://frontaliereticino.ch/de/benzinpreis-schweiz/italien/varese/heute/",
+        "https://frontaliereticino.ch/fr/prix-essence-suisse/italie/varese/aujourd-hui/",
+        "https://frontaliereticino.ch/prezzi-diesel/italia/luino/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/italy/luino/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/italien/luino/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/italie/luino/aujourd-hui/"
+      ]
+    },
+    "sitemap-fuel-italian-stations.xml": {
+      "total": 424,
+      "orphans": 424,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/carrefour-via-cristoforo-colombo/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/q8-via-pasquale-paoli-s-n/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/q8-loc-tavernola-via-per-cernobbio-35/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-camerlata-1/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-cavour-30/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-ambrosoli-11/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-viale-fratelli-rosselli-19/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-cecilio-1/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-via-canturina-85/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-del-dos-14/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/agip-eni-ninguarda-sp-28/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-varesina-128/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-franklin-delano-roosevelt-2/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-statale-per-lecco-60/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-oltrecolle-31/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/como/stazioni/api-ip-via-asiago-15/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/esso-viale-europa-82/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/retitalia-viale-europa/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/agip-eni-viale-aguggiari-235/",
+        "https://frontaliereticino.ch/prezzi-benzina/italia/varese/stazioni/agip-eni-via-lungolago-di-capolago-sp-1/"
+      ]
+    },
+    "sitemap-fuel-stations.xml": {
+      "total": 488,
+      "orphans": 488,
+      "examples": [
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/station-via-francesco-borromini/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/pemoil-corso-san-gottardo/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/piccadilly-via-franco-zorzi/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/orcam-via-carlo-maderno/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/eni-via-gaggiolo/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/ecsa-via-colombera/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/texon-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-colombera/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/bp-via-san-gottardo/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-del-breggia/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/gioia-str-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/anfra-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia-2/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-maestri-comacini/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-strada-per-gandria/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale-2/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale/"
+      ]
+    },
+    "sitemap-glossario.xml": {
+      "total": 42,
+      "orphans": 29,
+      "examples": [
+        "https://frontaliereticino.ch/glossario-frontaliere/doppiaimposizione/",
+        "https://frontaliereticino.ch/glossario-frontaliere/addizionale-regionale/",
+        "https://frontaliereticino.ch/glossario-frontaliere/addizionale-comunale/",
+        "https://frontaliereticino.ch/glossario-frontaliere/deduzioni/",
+        "https://frontaliereticino.ch/glossario-frontaliere/lohnausweis/",
+        "https://frontaliereticino.ch/glossario-frontaliere/cu/",
+        "https://frontaliereticino.ch/glossario-frontaliere/ral/",
+        "https://frontaliereticino.ch/glossario-frontaliere/modello-730/",
+        "https://frontaliereticino.ch/glossario-frontaliere/redditi-pf/",
+        "https://frontaliereticino.ch/glossario-frontaliere/rendita/",
+        "https://frontaliereticino.ch/glossario-frontaliere/capitale-lpp/",
+        "https://frontaliereticino.ch/glossario-frontaliere/prestazione-libero-passaggio/",
+        "https://frontaliereticino.ch/glossario-frontaliere/ssn/",
+        "https://frontaliereticino.ch/glossario-frontaliere/franchigia-assicurativa/",
+        "https://frontaliereticino.ch/glossario-frontaliere/modelli-assicurativi/",
+        "https://frontaliereticino.ch/glossario-frontaliere/ainp/",
+        "https://frontaliereticino.ch/glossario-frontaliere/permesso-c/",
+        "https://frontaliereticino.ch/glossario-frontaliere/permesso-l/",
+        "https://frontaliereticino.ch/glossario-frontaliere/accordo-frontalieri/",
+        "https://frontaliereticino.ch/glossario-frontaliere/nuovo-accordo-2024/"
+      ]
+    },
+    "sitemap-guides.xml": {
+      "total": 8,
+      "orphans": 8,
+      "examples": [
+        "https://frontaliereticino.ch/guides/guida-completa-frontaliere-2026/",
+        "https://frontaliereticino.ch/guides/guida-completa-frontaliere-2026.pdf",
+        "https://frontaliereticino.ch/guides/permesso-g-vantaggi-svantaggi/",
+        "https://frontaliereticino.ch/guides/permesso-g-vantaggi-svantaggi.pdf",
+        "https://frontaliereticino.ch/guides/lamal-vs-ssn-frontalieri/",
+        "https://frontaliereticino.ch/guides/lamal-vs-ssn-frontalieri.pdf",
+        "https://frontaliereticino.ch/guides/trovare-lavoro-ticino-frontaliere/",
+        "https://frontaliereticino.ch/guides/trovare-lavoro-ticino-frontaliere.pdf"
+      ]
+    },
+    "sitemap-health-premiums.xml": {
+      "total": 183,
+      "orphans": 181,
+      "examples": [
+        "https://frontaliereticino.ch/premi-cassa-malati/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/bambini-0-18/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/giovani-adulti-19-25/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-26-30/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-46-55/",
+        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-56-piu/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/bambini-0-18/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/giovani-adulti-19-25/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-26-30/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-31-45/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-46-55/",
+        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-56-piu/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/bambini-0-18/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/giovani-adulti-19-25/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-26-30/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-31-45/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-46-55/",
+        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-56-piu/"
+      ]
+    },
+    "sitemap-job-market.xml": {
+      "total": 21,
+      "orphans": 20,
+      "examples": [
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-13-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-14-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-15-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-16-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-17-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/marzo-2026/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/infermieri/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/educatori/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/case-anziani/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/sanita/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/amministrativo/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/vendite/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/finanza/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/informatica/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/retail/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/meccanica/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/edilizia/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/ristorazione/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/logistica/",
+        "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/ingegneria/"
+      ]
+    },
+    "sitemap-jobs.xml": {
+      "total": 2434,
+      "orphans": 2426,
+      "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-tally-weijl/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-grand-hotel-kronenhof/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-kulm-hotel-st-moritz/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-mtic-group/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-afry/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-kantonale-verwaltung-graubunden/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-board-international/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hubers-landhendl-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hugli-nahrmittel-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-bell-schweiz-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hugli-nahrmittel-erzeugung-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-bell-deutschland-gmbh-co-kg/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hugli-nahrungsmittel-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-suddeutsche-truthahn-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hilcona-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-hilcona-feinkost-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-eisberg-ag/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-bell-schwarzwalder-schinken-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-eisberg-osterreich-gmbh/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-geiser-ag/"
+      ]
+    },
+    "sitemap-market-report.xml": {
+      "total": 4,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-news.xml": {
+      "total": 187,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-nursing.xml": {
+      "total": 3,
+      "orphans": 2,
+      "examples": [
+        "https://frontaliereticino.ch/lavoro-oss-svizzera/",
+        "https://frontaliereticino.ch/lavoro-sanitario-ticino/"
+      ]
+    },
+    "sitemap-orphan-landings.xml": {
+      "total": 18,
+      "orphans": 18,
+      "examples": [
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-svizzera/",
+        "https://frontaliereticino.ch/ricerca/lavoro-in-svizzera/",
+        "https://frontaliereticino.ch/ricerca/lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-ticino-negli-ultimi-3-giorni/",
+        "https://frontaliereticino.ch/ricerca/cerco-lavoro-in-svizzera/",
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-ticino-da-ieri/",
+        "https://frontaliereticino.ch/de/suche/chauffeur-jobs/",
+        "https://frontaliereticino.ch/ricerca/posti-di-lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/offerte-di-lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/lavoro-ticino-da-ieri/",
+        "https://frontaliereticino.ch/fr/recherche/groupe-mutuel-emploi/",
+        "https://frontaliereticino.ch/de/suche/chauffeur-schweiz/",
+        "https://frontaliereticino.ch/ricerca/coop-lavora-con-noi/",
+        "https://frontaliereticino.ch/de/suche/job-etudiant-denner/",
+        "https://frontaliereticino.ch/ricerca/cerco-lavoro-ticino/",
+        "https://frontaliereticino.ch/ricerca/lavori-ticino/",
+        "https://frontaliereticino.ch/ricerca/lavori-in-svizzera/",
+        "https://frontaliereticino.ch/ricerca/lavoro-ticino-negli-ultimi-3-giorni/"
+      ]
+    },
+    "sitemap-pages.xml": {
+      "total": 144,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-professions.xml": {
+      "total": 10,
+      "orphans": 10,
+      "examples": [
+        "https://frontaliereticino.ch/lavoro-ticino-infermiere/",
+        "https://frontaliereticino.ch/lavoro-ticino-operaio/",
+        "https://frontaliereticino.ch/lavoro-ticino-impiegato/",
+        "https://frontaliereticino.ch/lavoro-ticino-ingegnere/",
+        "https://frontaliereticino.ch/lavoro-ticino-educatore/",
+        "https://frontaliereticino.ch/lavoro-ticino-autista/",
+        "https://frontaliereticino.ch/lavoro-ticino-muratore/",
+        "https://frontaliereticino.ch/lavoro-ticino-cuoco/",
+        "https://frontaliereticino.ch/lavoro-ticino-cameriere/",
+        "https://frontaliereticino.ch/lavoro-ticino-elettricista/"
+      ]
+    },
+    "sitemap-recency.xml": {
+      "total": 2,
+      "orphans": 0,
+      "examples": []
+    },
+    "sitemap-salary-hub.xml": {
+      "total": 1732,
+      "orphans": 1699,
+      "examples": [
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-nuovo-frontaliere-oltre-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-new-crossborder-over-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-neuer-grenzgaenger-ueber-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-nouveau-frontalier-plus-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-1-figlio-entro-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-1-child-within-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-1-kind-innerhalb-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-1-enfant-moins-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-1-figlio-nuovo-frontaliere-oltre-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-1-child-new-crossborder-over-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-1-kind-neuer-grenzgaenger-ueber-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-1-enfant-nouveau-frontalier-plus-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-entro-20km/",
+        "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-2-children-within-20km/",
+        "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-2-kinder-innerhalb-20km/",
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-2-enfants-moins-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-nuovo-frontaliere-oltre-20km/"
+      ]
+    },
+    "sitemap-sector.xml": {
+      "total": 10,
+      "orphans": 8,
+      "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/educatori/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/ingegneri/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/autisti/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/sviluppatori/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/ristorazione/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/operatori-socio-sanitari/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/logistica/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/apprendistato/"
+      ]
+    },
+    "sitemap-seo-hubs.xml": {
+      "total": 303,
+      "orphans": 299,
+      "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-2/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-3/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-4/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-5/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-6/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-7/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-8/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-9/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-10/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-11/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-12/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-13/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-14/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-15/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-16/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-17/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-18/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-19/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-20/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-21/"
+      ]
+    },
+    "sitemap-weekly-employers.xml": {
+      "total": 188,
+      "orphans": 185,
+      "examples": [
+        "https://frontaliereticino.ch/aziende-che-assumono/lugano/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/mendrisio/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/chiasso/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/stabio/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/bellinzona/settimana-corrente/",
+        "https://frontaliereticino.ch/aziende-che-assumono/locarno/settimana-corrente/",
+        "https://frontaliereticino.ch/en/companies-hiring/lugano/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/mendrisio/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/chiasso/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/stabio/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/bellinzona/current-week/",
+        "https://frontaliereticino.ch/en/companies-hiring/locarno/current-week/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/lugano/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/mendrisio/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/chiasso/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/stabio/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/bellinzona/aktuelle-woche/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/locarno/aktuelle-woche/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/ticino/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/lugano/semaine-courante/"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -239,6 +239,8 @@
     "audit:h1-title-duplicates:rebaseline": "node scripts/audit-h1-title-duplicates.mjs --write-baseline=data/h1-title-duplicates-baseline.json",
     "audit:title-length": "node scripts/audit-title-length.mjs --threshold=90 --baseline=data/title-length-baseline.json",
     "audit:title-length:rebaseline": "node scripts/audit-title-length.mjs --threshold=90 --write-baseline=data/title-length-baseline.json",
+    "audit:orphan-sitemap-pages": "node scripts/audit-orphan-pages-in-sitemaps.mjs",
+    "audit:orphan-sitemap-pages:rebaseline": "node scripts/audit-orphan-pages-in-sitemaps.mjs --rebaseline",
     "probe:5xx": "node scripts/probe-5xx.mjs",
     "prepush": "node scripts/assemble-jobs-dataset.mjs --stats && npm run validate:blog-meta-placeholders && npm run validate:crawler-summaries && npm run validate:third-party-secrets && npm run validate:jobs-crawler-keys && npm test && npm run build:ci && cp dist/index.html dist/404.html && npm run test:post-build && npm run validate:structured-data && npm run validate:jobs-rich-results && npm run validate:jobs-quality && npm run validate:sitemap-links && npm run validate:sitemap && npm run validate:hreflang && npm run validate:internal-links && npm run validate:thin-pages && node scripts/validate-soft404.mjs && node scripts/validate-canonical.mjs && node scripts/validate-content-quality.mjs"
   },

--- a/scripts/audit-orphan-pages-in-sitemaps.mjs
+++ b/scripts/audit-orphan-pages-in-sitemaps.mjs
@@ -1,0 +1,554 @@
+#!/usr/bin/env node
+/**
+ * audit-orphan-pages-in-sitemaps.mjs
+ *
+ * Detect "orphaned pages in sitemaps" — URLs listed in any of the live
+ * sitemap-*.xml files but with NO internal link pointing to them anywhere
+ * in the site graph. Semrush flags these (currently 4,936 on
+ * frontaliereticino.ch) because they consume crawl budget without site-
+ * structure support and tend to rank worse.
+ *
+ * Phase 1 deliverable: this is a REPORTING script. It always exits 0 on
+ * orphans (the regression gate comes in Phase 3 via a `--gate=baseline`
+ * flag — see `compareAgainstBaseline()` below).
+ *
+ * --------------------------------------------------------------------------
+ * Pipeline
+ * --------------------------------------------------------------------------
+ * 1. Fetch sitemap.xml index from https://frontaliereticino.ch/sitemap.xml
+ *    and follow every <sitemap><loc> child it lists. 30s timeout per fetch;
+ *    failures are LOUD (no silent skips — a missing sitemap is a real bug).
+ * 2. Parse <loc> entries from each child sitemap into:
+ *      sitemapsToUrls: Map<sitemapName, Set<canonicalPath>>
+ *    where canonicalPath strips the host, fragments, and normalises
+ *    trailing slashes consistently.
+ * 3. Build the "linked" set from the LOCAL worktree:
+ *      Mode A (preferred): scan dist/**\/*.html for <a href="…">
+ *      Mode B (fallback):  scan source files (App.tsx, components/,
+ *                          services/, build-plugins/, scripts/) for
+ *                          string/template literals shaped like internal
+ *                          paths ('/foo/bar' or `/foo/${slug}`).
+ *    Mode A is used automatically when dist/ has ≥ 10 HTML files. Force
+ *    Mode B with --source-mode (faster local iteration).
+ * 4. Diff: orphans = sitemapUrls \ linkedUrls.
+ * 5. Output:
+ *      - Stdout table (Sitemap | Total | Orphans | %).
+ *      - Top N orphan example URLs per sitemap.
+ *      - JSON report at data/orphan-pages-audit.json.
+ *      - Baseline at data/orphan-pages-baseline.json (only if missing,
+ *        unless --rebaseline).
+ *
+ * --------------------------------------------------------------------------
+ * Caveats
+ * --------------------------------------------------------------------------
+ * - Mode B is approximate: dynamic href values built at runtime
+ *   (e.g. `/${locale}/articles/${slug}`) may underestimate the linked set,
+ *   inflating the orphan count. The ratchet baseline shipped from this run
+ *   is therefore a Mode-B baseline; once CI runs Mode A on a real dist/,
+ *   regenerate via --rebaseline.
+ * - Trailing slashes: both `/foo/` and `/foo` are normalised to the
+ *   no-trailing-slash form on BOTH sides before set-diffing (so we never
+ *   classify a page as orphan due to a slash mismatch).
+ *
+ * --------------------------------------------------------------------------
+ * CLI flags
+ * --------------------------------------------------------------------------
+ *   --feature=<name>    Limit output to one sitemap (e.g. --feature=blog
+ *                       matches sitemap-blog.xml).
+ *   --limit=<n>         Examples per sitemap in stdout (default 20).
+ *   --source-mode       Force Mode B even when dist/ is populated.
+ *   --out=<path>        Override the JSON report path (default
+ *                       data/orphan-pages-audit.json).
+ *   --rebaseline        Overwrite data/orphan-pages-baseline.json from this
+ *                       run. Use after a deliberate improvement.
+ */
+
+import { readdir, readFile, stat, writeFile, access } from 'node:fs/promises';
+import { join, relative, isAbsolute, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import https from 'node:https';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const DIST = join(ROOT, 'dist');
+const DATA_DIR = join(ROOT, 'data');
+const HOST = 'https://frontaliereticino.ch';
+
+const argv = process.argv.slice(2);
+const args = new Map();
+for (const a of argv) {
+  if (a.startsWith('--')) {
+    const [k, v] = a.slice(2).split('=');
+    args.set(k, v ?? true);
+  }
+}
+
+const FEATURE_FILTER = typeof args.get('feature') === 'string' ? args.get('feature') : null;
+const LIMIT = Number(args.get('limit') ?? 20);
+const FORCE_SOURCE_MODE = args.has('source-mode');
+const OUT_PATH = args.get('out')
+  ? resolvePath(String(args.get('out')))
+  : join(DATA_DIR, 'orphan-pages-audit.json');
+const REBASELINE = args.has('rebaseline');
+const BASELINE_PATH = join(DATA_DIR, 'orphan-pages-baseline.json');
+
+function resolvePath(p) {
+  return isAbsolute(p) ? p : join(ROOT, p);
+}
+
+// ---------------------------------------------------------------------------
+// HTTPS fetch with timeout (no extra deps — node stdlib only).
+// ---------------------------------------------------------------------------
+
+function fetchText(url, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers: { 'User-Agent': 'orphan-pages-audit/1.0' } }, (res) => {
+      // Follow one redirect if present.
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume();
+        const next = new URL(res.headers.location, url).toString();
+        fetchText(next, timeoutMs).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+        return;
+      }
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`Timeout after ${timeoutMs}ms fetching ${url}`));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sitemap parsing — extracts every <loc> via a non-validating regex. The
+// live sitemaps are well-formed XML, so the regex is sufficient and avoids
+// adding a parser dependency.
+// ---------------------------------------------------------------------------
+
+function extractLocs(xml) {
+  const out = [];
+  const re = /<loc>\s*([^<\s][^<]*?)\s*<\/loc>/gi;
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    out.push(m[1].trim());
+  }
+  return out;
+}
+
+function urlToCanonicalPath(url) {
+  try {
+    const u = new URL(url);
+    let p = u.pathname || '/';
+    // Strip trailing slash from non-root paths.
+    if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+    return p;
+  } catch {
+    return null;
+  }
+}
+
+function sitemapNameFromUrl(url) {
+  const last = url.split('/').filter(Boolean).pop();
+  return last || url;
+}
+
+async function fetchAllSitemaps() {
+  const indexUrl = `${HOST}/sitemap.xml`;
+  process.stderr.write(`[audit] Fetching index ${indexUrl}\n`);
+  const indexXml = await fetchText(indexUrl);
+  const childUrls = extractLocs(indexXml).filter((u) => /\.xml(\?|$)/i.test(u));
+
+  if (childUrls.length === 0) {
+    throw new Error('Sitemap index returned zero <loc> entries — refusing to continue.');
+  }
+
+  process.stderr.write(`[audit] Index lists ${childUrls.length} child sitemaps\n`);
+
+  /** @type {Map<string, Set<string>>} */
+  const sitemapsToUrls = new Map();
+  /** @type {Map<string, string>} */
+  const canonicalToOriginal = new Map();
+
+  // Sequential to be polite to the host.
+  for (const childUrl of childUrls) {
+    const name = sitemapNameFromUrl(childUrl);
+    process.stderr.write(`[audit]   Fetching ${name} ...\n`);
+    let xml;
+    try {
+      xml = await fetchText(childUrl);
+    } catch (e) {
+      throw new Error(`Failed to fetch child sitemap ${childUrl}: ${e.message}`);
+    }
+    const locs = extractLocs(xml).filter((u) => !/\.xml(\?|$)/i.test(u)); // exclude nested sitemap entries
+    const set = new Set();
+    for (const u of locs) {
+      const p = urlToCanonicalPath(u);
+      if (!p) continue;
+      set.add(p);
+      if (!canonicalToOriginal.has(p)) canonicalToOriginal.set(p, u);
+    }
+    sitemapsToUrls.set(name, set);
+  }
+
+  return { sitemapsToUrls, canonicalToOriginal };
+}
+
+// ---------------------------------------------------------------------------
+// Mode A: dist/**\/*.html scan.
+// ---------------------------------------------------------------------------
+
+async function* walkFiles(dir, predicate) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(full, predicate);
+    } else if (entry.isFile() && predicate(full, entry.name)) {
+      yield full;
+    }
+  }
+}
+
+async function distHasEnoughHtml() {
+  try {
+    await access(DIST);
+  } catch {
+    return false;
+  }
+  let count = 0;
+  for await (const _ of walkFiles(DIST, (_, name) => name.endsWith('.html'))) {
+    count += 1;
+    if (count >= 10) return true;
+  }
+  return false;
+}
+
+function normaliseInternalPath(href) {
+  if (!href) return null;
+  let h = href.trim();
+  if (!h) return null;
+  // Strip fragments and queries — the sitemap canonical paths don't carry them.
+  const hash = h.indexOf('#');
+  if (hash >= 0) h = h.slice(0, hash);
+  const q = h.indexOf('?');
+  if (q >= 0) h = h.slice(0, q);
+  if (!h) return null;
+  // Absolute URLs to the canonical host.
+  if (/^https?:\/\//i.test(h)) {
+    try {
+      const u = new URL(h);
+      const allowedHosts = new Set(['frontaliereticino.ch', 'www.frontaliereticino.ch']);
+      if (!allowedHosts.has(u.host.toLowerCase())) return null;
+      let p = u.pathname || '/';
+      if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+      return p;
+    } catch {
+      return null;
+    }
+  }
+  // Bare leading-slash internal path.
+  if (h.startsWith('/')) {
+    let p = h;
+    if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+    return p;
+  }
+  return null;
+}
+
+async function collectLinkedUrlsModeA() {
+  /** @type {Set<string>} */
+  const linked = new Set();
+  const hrefRe = /href\s*=\s*"([^"]+)"|href\s*=\s*'([^']+)'/gi;
+  for await (const file of walkFiles(DIST, (_, name) => name.endsWith('.html'))) {
+    let html;
+    try {
+      html = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+    let m;
+    while ((m = hrefRe.exec(html)) !== null) {
+      const href = m[1] ?? m[2];
+      const p = normaliseInternalPath(href);
+      if (p) linked.add(p);
+    }
+    hrefRe.lastIndex = 0;
+  }
+  return linked;
+}
+
+// ---------------------------------------------------------------------------
+// Mode B: source-tree scan for path-shaped string/template literals.
+// ---------------------------------------------------------------------------
+
+const SOURCE_ROOTS = ['App.tsx', 'components', 'services', 'build-plugins', 'scripts'];
+const SOURCE_EXTS = new Set(['.ts', '.tsx', '.mjs', '.js', '.jsx', '.cjs']);
+
+function looksLikeInternalSlugLiteral(s) {
+  // Must start with `/` and not be a protocol-relative URL or filesystem path
+  // marker like `/* */` (which won't appear inside a string anyway).
+  if (!s.startsWith('/')) return false;
+  if (s.startsWith('//')) return false;
+  // Reject obvious non-URL paths.
+  if (/^\/(?:Users|home|tmp|var|opt|usr|etc)(?:\/|$)/.test(s)) return false;
+  // Reject regex-like or escape-heavy literals.
+  if (s.includes('\\')) return false;
+  // Allowed slug characters: letters, digits, hyphen, underscore, slash, dot,
+  // plus `${...}` template placeholders (which we'll fold to a wildcard match
+  // — but for the purposes of computing "is this path internally linked?"
+  // we keep the literal prefix).
+  if (!/^\/[A-Za-z0-9._\-/${}]*$/.test(s)) return false;
+  // Length sanity — sitemap paths are realistically 1..200 chars.
+  if (s.length > 200) return false;
+  return true;
+}
+
+async function collectLinkedUrlsModeB() {
+  /** @type {Set<string>} */
+  const linked = new Set();
+  /** @type {Set<string>} */
+  const linkedPrefixes = new Set();
+
+  const stringRe = /(['"`])((?:\\\1|(?!\1).)*?)\1/g; // single, double, backtick
+  for (const root of SOURCE_ROOTS) {
+    const full = join(ROOT, root);
+    let s;
+    try {
+      s = await stat(full);
+    } catch {
+      continue;
+    }
+    if (s.isFile()) {
+      await scanSourceFile(full, linked, linkedPrefixes, stringRe);
+    } else if (s.isDirectory()) {
+      for await (const file of walkFiles(full, (_, name) => {
+        const dot = name.lastIndexOf('.');
+        if (dot < 0) return false;
+        return SOURCE_EXTS.has(name.slice(dot));
+      })) {
+        await scanSourceFile(file, linked, linkedPrefixes, stringRe);
+      }
+    }
+  }
+
+  return { linked, linkedPrefixes };
+}
+
+async function scanSourceFile(file, linked, linkedPrefixes, stringRe) {
+  let src;
+  try {
+    src = await readFile(file, 'utf8');
+  } catch {
+    return;
+  }
+  let m;
+  stringRe.lastIndex = 0;
+  while ((m = stringRe.exec(src)) !== null) {
+    const lit = m[2];
+    if (!lit) continue;
+    if (!looksLikeInternalSlugLiteral(lit)) continue;
+
+    const dollar = lit.indexOf('${');
+    if (dollar < 0) {
+      // Pure literal path: register both the form and its trailing-slash-stripped form.
+      let p = lit;
+      if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+      linked.add(p);
+    } else {
+      // Template path with at least one ${...} placeholder. Take the prefix
+      // up to the first placeholder as a prefix-match key. This treats any
+      // sitemap path beginning with that prefix (and at least one extra
+      // segment) as "potentially linked dynamically".
+      const prefix = lit.slice(0, dollar);
+      // Strip trailing slash to keep the prefix consistent with linked-path normalisation.
+      let pre = prefix;
+      if (pre.length > 1 && pre.endsWith('/')) pre = pre.slice(0, -1);
+      // Require the prefix to contain at least one slash beyond the leading one
+      // — `/${slug}` alone is too generic and would match every URL on the site.
+      const slashCount = (pre.match(/\//g) || []).length;
+      if (slashCount >= 2) {
+        linkedPrefixes.add(pre);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orphan computation.
+// ---------------------------------------------------------------------------
+
+function isLinked(path, linked, linkedPrefixes) {
+  if (linked.has(path)) return true;
+  if (!linkedPrefixes || linkedPrefixes.size === 0) return false;
+  for (const pre of linkedPrefixes) {
+    // path is "linked dynamically" if it starts with `${pre}/` AND has at
+    // least one more segment beyond the prefix.
+    if (path === pre) return true;
+    if (path.startsWith(pre + '/')) return true;
+  }
+  return false;
+}
+
+function computeOrphans(sitemapsToUrls, linked, linkedPrefixes, canonicalToOriginal) {
+  /** @type {Record<string, { total: number; orphans: number; examples: string[] }>} */
+  const perSitemap = {};
+  let totalSitemapUrls = 0;
+  let totalOrphans = 0;
+
+  const sortedSitemaps = [...sitemapsToUrls.keys()].sort();
+  for (const name of sortedSitemaps) {
+    const urls = sitemapsToUrls.get(name);
+    const orphans = [];
+    for (const p of urls) {
+      if (!isLinked(p, linked, linkedPrefixes)) {
+        orphans.push(p);
+      }
+    }
+    perSitemap[name] = {
+      total: urls.size,
+      orphans: orphans.length,
+      examples: orphans.slice(0, LIMIT).map((p) => canonicalToOriginal.get(p) || p),
+    };
+    totalSitemapUrls += urls.size;
+    totalOrphans += orphans.length;
+  }
+
+  return { perSitemap, totalSitemapUrls, totalOrphans };
+}
+
+// ---------------------------------------------------------------------------
+// Output.
+// ---------------------------------------------------------------------------
+
+function printTable(report, mode) {
+  const lines = [];
+  lines.push(`Mode: ${mode}`);
+  lines.push('');
+  const header = `${'Sitemap'.padEnd(40)} ${'Total'.padStart(7)} ${'Orphans'.padStart(8)} ${'%'.padStart(7)}`;
+  lines.push(header);
+  lines.push('-'.repeat(header.length));
+
+  const rows = Object.entries(report.perSitemap).filter(([name]) => {
+    if (!FEATURE_FILTER) return true;
+    return name.includes(String(FEATURE_FILTER));
+  });
+
+  for (const [name, row] of rows) {
+    const pct = row.total === 0 ? 0 : (row.orphans / row.total) * 100;
+    lines.push(
+      `${name.padEnd(40)} ${String(row.total).padStart(7)} ${String(row.orphans).padStart(8)} ${pct.toFixed(1).padStart(6)}%`,
+    );
+  }
+  lines.push('-'.repeat(header.length));
+  const totalPct = report.totalSitemapUrls === 0 ? 0 : (report.totalOrphans / report.totalSitemapUrls) * 100;
+  lines.push(
+    `${'TOTAL'.padEnd(40)} ${String(report.totalSitemapUrls).padStart(7)} ${String(report.totalOrphans).padStart(8)} ${totalPct.toFixed(1).padStart(6)}%`,
+  );
+
+  // Examples per sitemap (only those with ≥1 orphan).
+  for (const [name, row] of rows) {
+    if (row.orphans === 0) continue;
+    lines.push('');
+    lines.push(`# ${name} — top ${Math.min(LIMIT, row.examples.length)} orphan examples`);
+    for (const ex of row.examples) lines.push(`  ${ex}`);
+  }
+
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Baseline / ratchet plumbing — wired but not enforced (Phase 3).
+// ---------------------------------------------------------------------------
+
+async function readBaseline() {
+  try {
+    const txt = await readFile(BASELINE_PATH, 'utf8');
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+// Phase 3 will wire `--gate=baseline` to call this. Returning a result
+// object now keeps the structure stable.
+// eslint-disable-next-line no-unused-vars
+function compareAgainstBaseline(current, baseline) {
+  if (!baseline) return { regressed: false, regressions: [] };
+  const regressions = [];
+  for (const [name, row] of Object.entries(current.perSitemap)) {
+    const prev = baseline.perSitemap?.[name];
+    if (!prev) continue;
+    if (row.orphans > prev.orphans) {
+      regressions.push({ sitemap: name, prev: prev.orphans, current: row.orphans });
+    }
+  }
+  return { regressed: regressions.length > 0, regressions };
+}
+
+// ---------------------------------------------------------------------------
+// Main.
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const { sitemapsToUrls, canonicalToOriginal } = await fetchAllSitemaps();
+
+  const useModeA = !FORCE_SOURCE_MODE && (await distHasEnoughHtml());
+  const mode = useModeA ? 'html' : 'source';
+  process.stderr.write(`[audit] Using Mode ${useModeA ? 'A (dist HTML scan)' : 'B (source scan)'}\n`);
+
+  let linked;
+  let linkedPrefixes;
+  if (useModeA) {
+    linked = await collectLinkedUrlsModeA();
+    linkedPrefixes = new Set();
+  } else {
+    const r = await collectLinkedUrlsModeB();
+    linked = r.linked;
+    linkedPrefixes = r.linkedPrefixes;
+  }
+
+  process.stderr.write(`[audit] Linked set: ${linked.size} exact paths, ${linkedPrefixes.size} dynamic prefixes\n`);
+
+  const report = computeOrphans(sitemapsToUrls, linked, linkedPrefixes, canonicalToOriginal);
+
+  const json = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    mode,
+    totalSitemapUrls: report.totalSitemapUrls,
+    totalOrphans: report.totalOrphans,
+    perSitemap: report.perSitemap,
+  };
+
+  await writeFile(OUT_PATH, JSON.stringify(json, null, 2) + '\n', 'utf8');
+  process.stderr.write(`[audit] Wrote report → ${relative(ROOT, OUT_PATH)}\n`);
+
+  // Baseline handling.
+  const existing = await readBaseline();
+  if (REBASELINE || !existing) {
+    await writeFile(BASELINE_PATH, JSON.stringify(json, null, 2) + '\n', 'utf8');
+    process.stderr.write(
+      `[audit] ${REBASELINE ? 'Rebaselined' : 'Seeded baseline'} → ${relative(ROOT, BASELINE_PATH)}\n`,
+    );
+  }
+
+  printTable(report, mode);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[audit] FATAL: ${err.stack || err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Phase 1 of the orphan-pages-in-sitemaps cleanup. Adds `scripts/audit-orphan-pages-in-sitemaps.mjs` — a standalone Node ESM audit that fetches all 29 live `sitemap-*.xml` files, builds the internally-linked URL set from the local worktree (Mode A: `dist/**/*.html` scan, or Mode B: source-tree scan when `dist/` is empty), and reports per-sitemap orphan counts.

- New script + `npm run audit:orphan-sitemap-pages` / `:rebaseline` aliases.
- Seeded `data/orphan-pages-audit.json` and `data/orphan-pages-baseline.json` from a Mode B run (dist/ was empty in this worktree).
- Phase 3 will wire `--gate=baseline` to make this a blocking deploy gate. Code structure (`compareAgainstBaseline()`) is in place — only the CLI flag needs adding.

## Audit summary (Mode B — source-tree scan)

```
Mode: source

Sitemap                                    Total  Orphans       %
-----------------------------------------------------------------
sitemap-annual-report.xml                      4        0    0.0%
sitemap-blog.xml                            1072        0    0.0%
sitemap-border-wait-map.xml                    4        0    0.0%
sitemap-border-wait.xml                      108      104   96.3%
sitemap-career-landings.xml                    4        2   50.0%
sitemap-comparisons.xml                        1        0    0.0%
sitemap-cost-of-living.xml                     6        0    0.0%
sitemap-faq-hub.xml                            1        0    0.0%
sitemap-fr-salaire-net.xml                     1        0    0.0%
sitemap-fuel-daily.xml                        48       40   83.3%
sitemap-fuel-italian-cities.xml               88       88  100.0%
sitemap-fuel-italian-stations.xml            424      424  100.0%
sitemap-fuel-stations.xml                    488      488  100.0%
sitemap-glossario.xml                         42       29   69.0%
sitemap-guides.xml                             8        8  100.0%
sitemap-health-premiums.xml                  183      181   98.9%
sitemap-job-market.xml                        21       20   95.2%
sitemap-jobs.xml                            2434     2426   99.7%
sitemap-market-report.xml                      4        0    0.0%
sitemap-news.xml                             187        0    0.0%
sitemap-nursing.xml                            3        2   66.7%
sitemap-orphan-landings.xml                   18       18  100.0%
sitemap-pages.xml                            144        0    0.0%
sitemap-professions.xml                       10       10  100.0%
sitemap-recency.xml                            2        0    0.0%
sitemap-salary-hub.xml                      1732     1699   98.1%
sitemap-sector.xml                            10        8   80.0%
sitemap-seo-hubs.xml                         303      299   98.7%
sitemap-weekly-employers.xml                 188      185   98.4%
-----------------------------------------------------------------
TOTAL                                       7538     6031   80.0%
```

## Notes for Phase 2 dispatch

- `sitemap-jobs.xml` (2,426 orphans, 99.7%) and `sitemap-salary-hub.xml` (1,699, 98.1%) dominate the count — these are the biggest-impact targets.
- `sitemap-fuel-stations.xml`, `sitemap-fuel-italian-cities.xml`, `sitemap-fuel-italian-stations.xml`, `sitemap-orphan-landings.xml`, `sitemap-professions.xml`, `sitemap-guides.xml` are flagged 100% orphan in Mode B — almost certainly a Mode B undercount on dynamically-built `<a>` hrefs (e.g. `/${locale}/${slug}` patterns), but worth verifying in Mode A on a real CI build.
- Mode B caveat: Semrush reports `sitemap-blog.xml` entries (e.g. `comprare-casa-italia-confine-ticino`) as orphans in production, but Mode B reports 0 here because dynamic prefixes catch them. The Mode B baseline is therefore **looser** than reality — the first Mode A run from CI will produce the authoritative ratchet floor.

## Test plan

- [ ] Reviewer: `npm run audit:orphan-sitemap-pages` runs to completion locally
- [ ] Reviewer: spot-check a few of the listed orphans against live frontaliereticino.ch
- [ ] Phase 2 agents: use this report to dispatch per-sitemap fix branches
- [ ] Phase 3: wire `--gate=baseline` flag and add CI step in `.github/workflows/deploy.yml`
