### PR TITLE
feat(audit): BFS reachability + --gate=baseline for orphan-sitemap-pages

### DIFF
--- a/data/orphan-pages-audit.json
+++ b/data/orphan-pages-audit.json
@@ -1,57 +1,90 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-28T07:06:15.811Z",
-  "mode": "source",
-  "totalSitemapUrls": 7538,
-  "totalOrphans": 6031,
+  "generatedAt": "2026-04-28T09:03:15.754Z",
+  "mode": "html",
+  "totalSitemapUrls": 7536,
+  "totalOrphans": 6933,
   "perSitemap": {
     "sitemap-annual-report.xml": {
       "total": 4,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/report/frontalieri-2026/",
+        "https://frontaliereticino.ch/en/report/cross-border-workers-2026/",
+        "https://frontaliereticino.ch/de/report/grenzgaenger-2026/",
+        "https://frontaliereticino.ch/fr/report/frontaliers-2026/"
+      ]
     },
     "sitemap-blog.xml": {
-      "total": 1072,
-      "orphans": 0,
-      "examples": []
+      "total": 1080,
+      "orphans": 983,
+      "examples": [
+        "https://frontaliereticino.ch/articoli-frontaliere/stipendio-netto-frontaliere-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/lamal-vs-cmi-frontaliere/",
+        "https://frontaliereticino.ch/articoli-frontaliere/primo-giorno-lavoro-svizzera/",
+        "https://frontaliereticino.ch/articoli-frontaliere/tredicesima-netta-frontaliere/",
+        "https://frontaliereticino.ch/articoli-frontaliere/terzo-pilastro-3a-frontaliere/",
+        "https://frontaliereticino.ch/articoli-frontaliere/migliori-comuni-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/costo-vita-ticino-vs-lombardia/",
+        "https://frontaliereticino.ch/articoli-frontaliere/tassa-salute-aumentano-tensioni-ticino/",
+        "https://frontaliereticino.ch/articoli-frontaliere/comprare-casa-italia-confine-ticino/",
+        "https://frontaliereticino.ch/articoli-frontaliere/franco-forte-effetti-stipendio-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/cu-2026-scadenze-telelavoro-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/telelavoro-italia-svizzera-ratifica/",
+        "https://frontaliereticino.ch/articoli-frontaliere/telelavoro-frontalieri-accordo-italia-svizzera-ratifica-definitiva/",
+        "https://frontaliereticino.ch/articoli-frontaliere/tassa-salute-ticino-chiede-stop-ristorni-italia/",
+        "https://frontaliereticino.ch/articoli-frontaliere/frontalieri-cu-2026-telelavoro-45-giorni-regole-definitive/",
+        "https://frontaliereticino.ch/articoli-frontaliere/smood-chiude-attivita-ticino-impatto-lavoro-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/disoccupazione-svizzera-gennaio-2026-dati-ticino-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/riscaldamento-casa-ticino-norme-energetiche-risparmio/",
+        "https://frontaliereticino.ch/articoli-frontaliere/sostituzione-caldaia-ticino-norme-2026-risparmio/",
+        "https://frontaliereticino.ch/articoli-frontaliere/mostra-hic-sunt-leones-confini-svizzera-frontalieri/"
+      ]
     },
     "sitemap-border-wait-map.xml": {
       "total": 4,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/guida-frontaliere/mappa-live-valichi/",
+        "https://frontaliereticino.ch/en/cross-border-guide/live-border-crossings-map/",
+        "https://frontaliereticino.ch/de/grenzgaenger-ratgeber/live-grenzuebergaenge-karte/",
+        "https://frontaliereticino.ch/fr/guide-frontalier/carte-live-passages-frontaliers/"
+      ]
     },
     "sitemap-border-wait.xml": {
       "total": 108,
-      "orphans": 104,
+      "orphans": 81,
       "examples": [
-        "https://frontaliereticino.ch/traffico-dogane/ticino-como/",
-        "https://frontaliereticino.ch/traffico-dogane/ticino-varese/",
-        "https://frontaliereticino.ch/traffico-dogane/chiasso-centro/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/chiasso-brogeda/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/chiasso-strada/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/maslianico-pizzamiglio/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/maslianico-roggiana/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/bizzarone-novazzano/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/ronago-novazzano/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/crociale-dei-mulini/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/drezzo-pedrinate/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/lanzo-d-intelvi-arogno/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/campione-d-italia-bissone/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/oria-gandria/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/gaggiolo/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/san-pietro/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/clivio-ligornetto/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/rodero-stabio/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/saltrio-arzo/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/ponte-tresa/oggi/"
+        "https://frontaliereticino.ch/en/border-wait/",
+        "https://frontaliereticino.ch/en/border-wait/ticino-como/",
+        "https://frontaliereticino.ch/en/border-wait/ticino-varese/",
+        "https://frontaliereticino.ch/en/border-wait/chiasso-centro/today/",
+        "https://frontaliereticino.ch/en/border-wait/chiasso-brogeda/today/",
+        "https://frontaliereticino.ch/en/border-wait/chiasso-strada/today/",
+        "https://frontaliereticino.ch/en/border-wait/maslianico-pizzamiglio/today/",
+        "https://frontaliereticino.ch/en/border-wait/maslianico-roggiana/today/",
+        "https://frontaliereticino.ch/en/border-wait/bizzarone-novazzano/today/",
+        "https://frontaliereticino.ch/en/border-wait/ronago-novazzano/today/",
+        "https://frontaliereticino.ch/en/border-wait/crociale-dei-mulini/today/",
+        "https://frontaliereticino.ch/en/border-wait/drezzo-pedrinate/today/",
+        "https://frontaliereticino.ch/en/border-wait/lanzo-d-intelvi-arogno/today/",
+        "https://frontaliereticino.ch/en/border-wait/campione-d-italia-bissone/today/",
+        "https://frontaliereticino.ch/en/border-wait/oria-gandria/today/",
+        "https://frontaliereticino.ch/en/border-wait/gaggiolo/today/",
+        "https://frontaliereticino.ch/en/border-wait/san-pietro/today/",
+        "https://frontaliereticino.ch/en/border-wait/clivio-ligornetto/today/",
+        "https://frontaliereticino.ch/en/border-wait/rodero-stabio/today/",
+        "https://frontaliereticino.ch/en/border-wait/saltrio-arzo/today/"
       ]
     },
     "sitemap-career-landings.xml": {
       "total": 4,
-      "orphans": 2,
+      "orphans": 4,
       "examples": [
         "https://frontaliereticino.ch/agenzie-del-lavoro-lugano/",
-        "https://frontaliereticino.ch/stage-lugano/"
+        "https://frontaliereticino.ch/concorsi-pubblici-lugano/",
+        "https://frontaliereticino.ch/stage-lugano/",
+        "https://frontaliereticino.ch/contratti-lavoro-frontalieri/"
       ]
     },
     "sitemap-comparisons.xml": {
@@ -61,8 +94,13 @@
     },
     "sitemap-cost-of-living.xml": {
       "total": 6,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/costo-vita-lugano-ticino/",
+        "https://frontaliereticino.ch/costo-vita-mendrisio-ticino/",
+        "https://frontaliereticino.ch/costo-vita-bellinzona-ticino/",
+        "https://frontaliereticino.ch/costo-vita-locarno-ticino/"
+      ]
     },
     "sitemap-faq-hub.xml": {
       "total": 1,
@@ -71,33 +109,35 @@
     },
     "sitemap-fr-salaire-net.xml": {
       "total": 1,
-      "orphans": 0,
-      "examples": []
+      "orphans": 1,
+      "examples": [
+        "https://frontaliereticino.ch/fr/calculer-salaire/calcul-salaire-net-frontalier-suisse/"
+      ]
     },
     "sitemap-fuel-daily.xml": {
       "total": 48,
-      "orphans": 40,
+      "orphans": 36,
       "examples": [
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/locarno/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/chiasso/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/mendrisio/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/lugano/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/bellinzona/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/locarno/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/chiasso/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/mendrisio/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/lugano/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/bellinzona/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/locarno/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/chiasso/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/mendrisio/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/lugano/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/bellinzona/aujourd-hui/",
-        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/locarno/aujourd-hui/"
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/locarno/aujourd-hui/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/today/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/chiasso/today/"
       ]
     },
     "sitemap-fuel-italian-cities.xml": {
@@ -154,34 +194,35 @@
     },
     "sitemap-fuel-stations.xml": {
       "total": 488,
-      "orphans": 488,
+      "orphans": 415,
       "examples": [
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/station-via-francesco-borromini/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/pemoil-corso-san-gottardo/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/piccadilly-via-franco-zorzi/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/orcam-via-carlo-maderno/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/eni-via-gaggiolo/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/ecsa-via-colombera/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/texon-via-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-colombera/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/bp-via-san-gottardo/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-del-breggia/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/gioia-str-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/anfra-via-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia-2/",
         "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-maestri-comacini/",
         "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-strada-per-gandria/",
         "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale-2/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale/"
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/garage-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-strada-regina/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/pk-via-piodella/",
+        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/stazioni/euro-via-monte-ceneri/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/coop-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/stazioni/coop-via-san-gottardo/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/tamoil-via-passeggiata/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/avia-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-cantonale-2/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/europetroli-via-gaggiolo/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/eni-via-gaggiolo-3/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/avia-via-gaggiolo/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-al-confine/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale-3/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale-2/"
       ]
     },
     "sitemap-glossario.xml": {
       "total": 42,
-      "orphans": 29,
+      "orphans": 30,
       "examples": [
+        "https://frontaliereticino.ch/glossario-frontaliere/permesso-b/",
         "https://frontaliereticino.ch/glossario-frontaliere/doppiaimposizione/",
         "https://frontaliereticino.ch/glossario-frontaliere/addizionale-regionale/",
         "https://frontaliereticino.ch/glossario-frontaliere/addizionale-comunale/",
@@ -200,8 +241,7 @@
         "https://frontaliereticino.ch/glossario-frontaliere/ainp/",
         "https://frontaliereticino.ch/glossario-frontaliere/permesso-c/",
         "https://frontaliereticino.ch/glossario-frontaliere/permesso-l/",
-        "https://frontaliereticino.ch/glossario-frontaliere/accordo-frontalieri/",
-        "https://frontaliereticino.ch/glossario-frontaliere/nuovo-accordo-2024/"
+        "https://frontaliereticino.ch/glossario-frontaliere/accordo-frontalieri/"
       ]
     },
     "sitemap-guides.xml": {
@@ -220,40 +260,14 @@
     },
     "sitemap-health-premiums.xml": {
       "total": 183,
-      "orphans": 181,
-      "examples": [
-        "https://frontaliereticino.ch/premi-cassa-malati/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/bambini-0-18/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/giovani-adulti-19-25/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-26-30/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-46-55/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-56-piu/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/bambini-0-18/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/giovani-adulti-19-25/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-26-30/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-31-45/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-46-55/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-56-piu/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/bambini-0-18/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/giovani-adulti-19-25/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-26-30/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-31-45/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-46-55/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-56-piu/"
-      ]
+      "orphans": 0,
+      "examples": []
     },
     "sitemap-job-market.xml": {
       "total": 21,
-      "orphans": 20,
+      "orphans": 15,
       "examples": [
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-13-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-14-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-15-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-16-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-17-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/marzo-2026/",
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/infermieri/",
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/educatori/",
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/case-anziani/",
@@ -271,8 +285,8 @@
       ]
     },
     "sitemap-jobs.xml": {
-      "total": 2434,
-      "orphans": 2426,
+      "total": 2416,
+      "orphans": 2415,
       "examples": [
         "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-tally-weijl/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-grand-hotel-kronenhof/",
@@ -298,18 +312,45 @@
     },
     "sitemap-market-report.xml": {
       "total": 4,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/reports/mercato-lavoro-frontalieri-ticino-2026/",
+        "https://frontaliereticino.ch/en/reports/ticino-cross-border-job-market-2026/",
+        "https://frontaliereticino.ch/de/reports/tessiner-grenzgaenger-arbeitsmarkt-2026/",
+        "https://frontaliereticino.ch/fr/reports/marche-emploi-frontaliers-tessin-2026/"
+      ]
     },
     "sitemap-news.xml": {
-      "total": 187,
-      "orphans": 0,
-      "examples": []
+      "total": 195,
+      "orphans": 98,
+      "examples": [
+        "https://frontaliereticino.ch/articoli-frontaliere/medici-senza-permesso-svizzera-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/crans-montana-spese-cura-italiani-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/lombardia-aumenta-stipendi-sanitari-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/petizione-gioventu-comunista-tassa-esenzione-militare/",
+        "https://frontaliereticino.ch/articoli-frontaliere/petizione-tassa-esenzione-militare-ticino/",
+        "https://frontaliereticino.ch/articoli-frontaliere/immigrazione-svizzera-60-anni-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/supermercati-ticino-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/latte-ticino-crisi-politica-ritardo/",
+        "https://frontaliereticino.ch/articoli-frontaliere/maria-timofeeva-trionfa-chiasso-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/crans-montana-cure-italiani-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/costi-salute-svizzera-frontalieri-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/imposta-ocse-multinazionali-obiettivi-lontani/",
+        "https://frontaliereticino.ch/articoli-frontaliere/settimana-corta-svizzera-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/adulti-genitori-sostegno-finanziario-ticino-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/swiss-lufthansa-economy-basic-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/twint-account-frode-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/costi-sanitari-ticino-2024-4-percento/",
+        "https://frontaliereticino.ch/articoli-frontaliere/cybersicurezza-industriale-ticino-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/redditi-varesotti-2024-luvinate/",
+        "https://frontaliereticino.ch/articoli-frontaliere/chiusure-autostrade-ticino-2026/"
+      ]
     },
     "sitemap-nursing.xml": {
       "total": 3,
-      "orphans": 2,
+      "orphans": 3,
       "examples": [
+        "https://frontaliereticino.ch/lavoro-infermieri-svizzera/",
         "https://frontaliereticino.ch/lavoro-oss-svizzera/",
         "https://frontaliereticino.ch/lavoro-sanitario-ticino/"
       ]
@@ -340,24 +381,34 @@
     },
     "sitemap-pages.xml": {
       "total": 144,
-      "orphans": 0,
-      "examples": []
+      "orphans": 72,
+      "examples": [
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-vecchio-frontaliere/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-nuovo-frontaliere-2026/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-vecchio-frontaliere/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-nuovo-frontaliere-2026/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-vecchio-frontaliere/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-nuovo-frontaliere-2026/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-sposato-2-figli/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-sposato-2-figli/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-sposato-2-figli/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-residenza-oltre-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-residenza-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-residenza-oltre-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/nuovi-frontalieri-oltre-20-km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-residenza-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-residenza-oltre-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-residenza-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/confronto-netto-2025-2026-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/confronto-netto-2025-2026-oltre-20km/"
+      ]
     },
     "sitemap-professions.xml": {
       "total": 10,
-      "orphans": 10,
-      "examples": [
-        "https://frontaliereticino.ch/lavoro-ticino-infermiere/",
-        "https://frontaliereticino.ch/lavoro-ticino-operaio/",
-        "https://frontaliereticino.ch/lavoro-ticino-impiegato/",
-        "https://frontaliereticino.ch/lavoro-ticino-ingegnere/",
-        "https://frontaliereticino.ch/lavoro-ticino-educatore/",
-        "https://frontaliereticino.ch/lavoro-ticino-autista/",
-        "https://frontaliereticino.ch/lavoro-ticino-muratore/",
-        "https://frontaliereticino.ch/lavoro-ticino-cuoco/",
-        "https://frontaliereticino.ch/lavoro-ticino-cameriere/",
-        "https://frontaliereticino.ch/lavoro-ticino-elettricista/"
-      ]
+      "orphans": 0,
+      "examples": []
     },
     "sitemap-recency.xml": {
       "total": 2,
@@ -366,8 +417,9 @@
     },
     "sitemap-salary-hub.xml": {
       "total": 1732,
-      "orphans": 1699,
+      "orphans": 1732,
       "examples": [
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf/",
         "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf/",
         "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf/",
         "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf/",
@@ -386,14 +438,15 @@
         "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-entro-20km/",
         "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-2-children-within-20km/",
         "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-2-kinder-innerhalb-20km/",
-        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-2-enfants-moins-20km/",
-        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-nuovo-frontaliere-oltre-20km/"
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-2-enfants-moins-20km/"
       ]
     },
     "sitemap-sector.xml": {
       "total": 10,
-      "orphans": 8,
+      "orphans": 10,
       "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/infermieri/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/case-anziani/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/educatori/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/ingegneri/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/autisti/",
@@ -406,8 +459,9 @@
     },
     "sitemap-seo-hubs.xml": {
       "total": 303,
-      "orphans": 299,
+      "orphans": 303,
       "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-2/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-3/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-4/",
@@ -426,26 +480,21 @@
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-17/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-18/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-19/",
-        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-20/",
-        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-21/"
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-20/"
       ]
     },
     "sitemap-weekly-employers.xml": {
       "total": 188,
-      "orphans": 185,
+      "orphans": 181,
       "examples": [
-        "https://frontaliereticino.ch/aziende-che-assumono/lugano/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/mendrisio/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/chiasso/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/stabio/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/bellinzona/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/locarno/settimana-corrente/",
+        "https://frontaliereticino.ch/en/companies-hiring/ticino/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/lugano/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/mendrisio/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/chiasso/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/stabio/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/bellinzona/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/locarno/current-week/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/ticino/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/lugano/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/mendrisio/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/chiasso/aktuelle-woche/",
@@ -453,7 +502,11 @@
         "https://frontaliereticino.ch/de/unternehmen-einstellen/bellinzona/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/locarno/aktuelle-woche/",
         "https://frontaliereticino.ch/fr/entreprises-recrutent/ticino/semaine-courante/",
-        "https://frontaliereticino.ch/fr/entreprises-recrutent/lugano/semaine-courante/"
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/lugano/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/mendrisio/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/chiasso/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/stabio/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/bellinzona/semaine-courante/"
       ]
     }
   }

--- a/data/orphan-pages-baseline.json
+++ b/data/orphan-pages-baseline.json
@@ -1,57 +1,90 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-28T07:06:15.811Z",
-  "mode": "source",
-  "totalSitemapUrls": 7538,
-  "totalOrphans": 6031,
+  "generatedAt": "2026-04-28T09:03:15.754Z",
+  "mode": "html",
+  "totalSitemapUrls": 7536,
+  "totalOrphans": 6933,
   "perSitemap": {
     "sitemap-annual-report.xml": {
       "total": 4,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/report/frontalieri-2026/",
+        "https://frontaliereticino.ch/en/report/cross-border-workers-2026/",
+        "https://frontaliereticino.ch/de/report/grenzgaenger-2026/",
+        "https://frontaliereticino.ch/fr/report/frontaliers-2026/"
+      ]
     },
     "sitemap-blog.xml": {
-      "total": 1072,
-      "orphans": 0,
-      "examples": []
+      "total": 1080,
+      "orphans": 983,
+      "examples": [
+        "https://frontaliereticino.ch/articoli-frontaliere/stipendio-netto-frontaliere-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/lamal-vs-cmi-frontaliere/",
+        "https://frontaliereticino.ch/articoli-frontaliere/primo-giorno-lavoro-svizzera/",
+        "https://frontaliereticino.ch/articoli-frontaliere/tredicesima-netta-frontaliere/",
+        "https://frontaliereticino.ch/articoli-frontaliere/terzo-pilastro-3a-frontaliere/",
+        "https://frontaliereticino.ch/articoli-frontaliere/migliori-comuni-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/costo-vita-ticino-vs-lombardia/",
+        "https://frontaliereticino.ch/articoli-frontaliere/tassa-salute-aumentano-tensioni-ticino/",
+        "https://frontaliereticino.ch/articoli-frontaliere/comprare-casa-italia-confine-ticino/",
+        "https://frontaliereticino.ch/articoli-frontaliere/franco-forte-effetti-stipendio-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/cu-2026-scadenze-telelavoro-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/telelavoro-italia-svizzera-ratifica/",
+        "https://frontaliereticino.ch/articoli-frontaliere/telelavoro-frontalieri-accordo-italia-svizzera-ratifica-definitiva/",
+        "https://frontaliereticino.ch/articoli-frontaliere/tassa-salute-ticino-chiede-stop-ristorni-italia/",
+        "https://frontaliereticino.ch/articoli-frontaliere/frontalieri-cu-2026-telelavoro-45-giorni-regole-definitive/",
+        "https://frontaliereticino.ch/articoli-frontaliere/smood-chiude-attivita-ticino-impatto-lavoro-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/disoccupazione-svizzera-gennaio-2026-dati-ticino-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/riscaldamento-casa-ticino-norme-energetiche-risparmio/",
+        "https://frontaliereticino.ch/articoli-frontaliere/sostituzione-caldaia-ticino-norme-2026-risparmio/",
+        "https://frontaliereticino.ch/articoli-frontaliere/mostra-hic-sunt-leones-confini-svizzera-frontalieri/"
+      ]
     },
     "sitemap-border-wait-map.xml": {
       "total": 4,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/guida-frontaliere/mappa-live-valichi/",
+        "https://frontaliereticino.ch/en/cross-border-guide/live-border-crossings-map/",
+        "https://frontaliereticino.ch/de/grenzgaenger-ratgeber/live-grenzuebergaenge-karte/",
+        "https://frontaliereticino.ch/fr/guide-frontalier/carte-live-passages-frontaliers/"
+      ]
     },
     "sitemap-border-wait.xml": {
       "total": 108,
-      "orphans": 104,
+      "orphans": 81,
       "examples": [
-        "https://frontaliereticino.ch/traffico-dogane/ticino-como/",
-        "https://frontaliereticino.ch/traffico-dogane/ticino-varese/",
-        "https://frontaliereticino.ch/traffico-dogane/chiasso-centro/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/chiasso-brogeda/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/chiasso-strada/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/maslianico-pizzamiglio/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/maslianico-roggiana/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/bizzarone-novazzano/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/ronago-novazzano/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/crociale-dei-mulini/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/drezzo-pedrinate/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/lanzo-d-intelvi-arogno/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/campione-d-italia-bissone/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/oria-gandria/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/gaggiolo/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/san-pietro/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/clivio-ligornetto/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/rodero-stabio/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/saltrio-arzo/oggi/",
-        "https://frontaliereticino.ch/traffico-dogane/ponte-tresa/oggi/"
+        "https://frontaliereticino.ch/en/border-wait/",
+        "https://frontaliereticino.ch/en/border-wait/ticino-como/",
+        "https://frontaliereticino.ch/en/border-wait/ticino-varese/",
+        "https://frontaliereticino.ch/en/border-wait/chiasso-centro/today/",
+        "https://frontaliereticino.ch/en/border-wait/chiasso-brogeda/today/",
+        "https://frontaliereticino.ch/en/border-wait/chiasso-strada/today/",
+        "https://frontaliereticino.ch/en/border-wait/maslianico-pizzamiglio/today/",
+        "https://frontaliereticino.ch/en/border-wait/maslianico-roggiana/today/",
+        "https://frontaliereticino.ch/en/border-wait/bizzarone-novazzano/today/",
+        "https://frontaliereticino.ch/en/border-wait/ronago-novazzano/today/",
+        "https://frontaliereticino.ch/en/border-wait/crociale-dei-mulini/today/",
+        "https://frontaliereticino.ch/en/border-wait/drezzo-pedrinate/today/",
+        "https://frontaliereticino.ch/en/border-wait/lanzo-d-intelvi-arogno/today/",
+        "https://frontaliereticino.ch/en/border-wait/campione-d-italia-bissone/today/",
+        "https://frontaliereticino.ch/en/border-wait/oria-gandria/today/",
+        "https://frontaliereticino.ch/en/border-wait/gaggiolo/today/",
+        "https://frontaliereticino.ch/en/border-wait/san-pietro/today/",
+        "https://frontaliereticino.ch/en/border-wait/clivio-ligornetto/today/",
+        "https://frontaliereticino.ch/en/border-wait/rodero-stabio/today/",
+        "https://frontaliereticino.ch/en/border-wait/saltrio-arzo/today/"
       ]
     },
     "sitemap-career-landings.xml": {
       "total": 4,
-      "orphans": 2,
+      "orphans": 4,
       "examples": [
         "https://frontaliereticino.ch/agenzie-del-lavoro-lugano/",
-        "https://frontaliereticino.ch/stage-lugano/"
+        "https://frontaliereticino.ch/concorsi-pubblici-lugano/",
+        "https://frontaliereticino.ch/stage-lugano/",
+        "https://frontaliereticino.ch/contratti-lavoro-frontalieri/"
       ]
     },
     "sitemap-comparisons.xml": {
@@ -61,8 +94,13 @@
     },
     "sitemap-cost-of-living.xml": {
       "total": 6,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/costo-vita-lugano-ticino/",
+        "https://frontaliereticino.ch/costo-vita-mendrisio-ticino/",
+        "https://frontaliereticino.ch/costo-vita-bellinzona-ticino/",
+        "https://frontaliereticino.ch/costo-vita-locarno-ticino/"
+      ]
     },
     "sitemap-faq-hub.xml": {
       "total": 1,
@@ -71,33 +109,35 @@
     },
     "sitemap-fr-salaire-net.xml": {
       "total": 1,
-      "orphans": 0,
-      "examples": []
+      "orphans": 1,
+      "examples": [
+        "https://frontaliereticino.ch/fr/calculer-salaire/calcul-salaire-net-frontalier-suisse/"
+      ]
     },
     "sitemap-fuel-daily.xml": {
       "total": 48,
-      "orphans": 40,
+      "orphans": 36,
       "examples": [
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/oggi/",
-        "https://frontaliereticino.ch/prezzi-diesel/locarno/oggi/",
+        "https://frontaliereticino.ch/en/diesel-price-switzerland/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/chiasso/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/mendrisio/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/lugano/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/bellinzona/today/",
         "https://frontaliereticino.ch/en/diesel-price-switzerland/locarno/today/",
+        "https://frontaliereticino.ch/de/dieselpreis-schweiz/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/chiasso/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/mendrisio/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/lugano/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/bellinzona/heute/",
         "https://frontaliereticino.ch/de/dieselpreis-schweiz/locarno/heute/",
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/chiasso/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/mendrisio/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/lugano/aujourd-hui/",
         "https://frontaliereticino.ch/fr/prix-gasoil-suisse/bellinzona/aujourd-hui/",
-        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/locarno/aujourd-hui/"
+        "https://frontaliereticino.ch/fr/prix-gasoil-suisse/locarno/aujourd-hui/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/today/",
+        "https://frontaliereticino.ch/en/gasoline-price-switzerland/chiasso/today/"
       ]
     },
     "sitemap-fuel-italian-cities.xml": {
@@ -154,34 +194,35 @@
     },
     "sitemap-fuel-stations.xml": {
       "total": 488,
-      "orphans": 488,
+      "orphans": 415,
       "examples": [
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/station-via-francesco-borromini/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/pemoil-corso-san-gottardo/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/piccadilly-via-franco-zorzi/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/orcam-via-carlo-maderno/",
-        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/eni-via-gaggiolo/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/ecsa-via-colombera/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/texon-via-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-colombera/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/bp-via-san-gottardo/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-del-breggia/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/gioia-str-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/anfra-via-cantonale/",
-        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/eni-via-del-breggia-2/",
         "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/socar-via-maestri-comacini/",
         "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-strada-per-gandria/",
         "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale-2/",
-        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale/"
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/garage-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-strada-regina/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/pk-via-piodella/",
+        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/stazioni/euro-via-monte-ceneri/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/coop-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/bellinzona/stazioni/coop-via-san-gottardo/",
+        "https://frontaliereticino.ch/prezzi-diesel/chiasso/stazioni/tamoil-via-passeggiata/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/avia-via-cantonale/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/euro-via-cantonale-2/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/europetroli-via-gaggiolo/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/eni-via-gaggiolo-3/",
+        "https://frontaliereticino.ch/prezzi-diesel/mendrisio/stazioni/avia-via-gaggiolo/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-al-confine/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/eni-via-cantonale-3/",
+        "https://frontaliereticino.ch/prezzi-diesel/lugano/stazioni/piccadilly-via-cantonale-2/"
       ]
     },
     "sitemap-glossario.xml": {
       "total": 42,
-      "orphans": 29,
+      "orphans": 30,
       "examples": [
+        "https://frontaliereticino.ch/glossario-frontaliere/permesso-b/",
         "https://frontaliereticino.ch/glossario-frontaliere/doppiaimposizione/",
         "https://frontaliereticino.ch/glossario-frontaliere/addizionale-regionale/",
         "https://frontaliereticino.ch/glossario-frontaliere/addizionale-comunale/",
@@ -200,8 +241,7 @@
         "https://frontaliereticino.ch/glossario-frontaliere/ainp/",
         "https://frontaliereticino.ch/glossario-frontaliere/permesso-c/",
         "https://frontaliereticino.ch/glossario-frontaliere/permesso-l/",
-        "https://frontaliereticino.ch/glossario-frontaliere/accordo-frontalieri/",
-        "https://frontaliereticino.ch/glossario-frontaliere/nuovo-accordo-2024/"
+        "https://frontaliereticino.ch/glossario-frontaliere/accordo-frontalieri/"
       ]
     },
     "sitemap-guides.xml": {
@@ -220,40 +260,14 @@
     },
     "sitemap-health-premiums.xml": {
       "total": 183,
-      "orphans": 181,
-      "examples": [
-        "https://frontaliereticino.ch/premi-cassa-malati/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/bambini-0-18/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/giovani-adulti-19-25/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-26-30/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-46-55/",
-        "https://frontaliereticino.ch/premi-cassa-malati/ticino/adulto-56-piu/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/bambini-0-18/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/giovani-adulti-19-25/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-26-30/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-31-45/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-46-55/",
-        "https://frontaliereticino.ch/premi-cassa-malati/grigioni/adulto-56-piu/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/bambini-0-18/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/giovani-adulti-19-25/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-26-30/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-31-45/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-46-55/",
-        "https://frontaliereticino.ch/premi-cassa-malati/uri/adulto-56-piu/"
-      ]
+      "orphans": 0,
+      "examples": []
     },
     "sitemap-job-market.xml": {
       "total": 21,
-      "orphans": 20,
+      "orphans": 15,
       "examples": [
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-13-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-14-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-15-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-16-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/settimana-17-2026/",
-        "https://frontaliereticino.ch/mercato-lavoro-ticino/marzo-2026/",
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/infermieri/",
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/educatori/",
         "https://frontaliereticino.ch/mercato-lavoro-ticino/settore/case-anziani/",
@@ -271,8 +285,8 @@
       ]
     },
     "sitemap-jobs.xml": {
-      "total": 2434,
-      "orphans": 2426,
+      "total": 2416,
+      "orphans": 2415,
       "examples": [
         "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-tally-weijl/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/azienda-grand-hotel-kronenhof/",
@@ -298,18 +312,45 @@
     },
     "sitemap-market-report.xml": {
       "total": 4,
-      "orphans": 0,
-      "examples": []
+      "orphans": 4,
+      "examples": [
+        "https://frontaliereticino.ch/reports/mercato-lavoro-frontalieri-ticino-2026/",
+        "https://frontaliereticino.ch/en/reports/ticino-cross-border-job-market-2026/",
+        "https://frontaliereticino.ch/de/reports/tessiner-grenzgaenger-arbeitsmarkt-2026/",
+        "https://frontaliereticino.ch/fr/reports/marche-emploi-frontaliers-tessin-2026/"
+      ]
     },
     "sitemap-news.xml": {
-      "total": 187,
-      "orphans": 0,
-      "examples": []
+      "total": 195,
+      "orphans": 98,
+      "examples": [
+        "https://frontaliereticino.ch/articoli-frontaliere/medici-senza-permesso-svizzera-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/crans-montana-spese-cura-italiani-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/lombardia-aumenta-stipendi-sanitari-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/petizione-gioventu-comunista-tassa-esenzione-militare/",
+        "https://frontaliereticino.ch/articoli-frontaliere/petizione-tassa-esenzione-militare-ticino/",
+        "https://frontaliereticino.ch/articoli-frontaliere/immigrazione-svizzera-60-anni-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/supermercati-ticino-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/latte-ticino-crisi-politica-ritardo/",
+        "https://frontaliereticino.ch/articoli-frontaliere/maria-timofeeva-trionfa-chiasso-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/crans-montana-cure-italiani-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/costi-salute-svizzera-frontalieri-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/imposta-ocse-multinazionali-obiettivi-lontani/",
+        "https://frontaliereticino.ch/articoli-frontaliere/settimana-corta-svizzera-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/adulti-genitori-sostegno-finanziario-ticino-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/swiss-lufthansa-economy-basic-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/twint-account-frode-frontalieri/",
+        "https://frontaliereticino.ch/articoli-frontaliere/costi-sanitari-ticino-2024-4-percento/",
+        "https://frontaliereticino.ch/articoli-frontaliere/cybersicurezza-industriale-ticino-2026/",
+        "https://frontaliereticino.ch/articoli-frontaliere/redditi-varesotti-2024-luvinate/",
+        "https://frontaliereticino.ch/articoli-frontaliere/chiusure-autostrade-ticino-2026/"
+      ]
     },
     "sitemap-nursing.xml": {
       "total": 3,
-      "orphans": 2,
+      "orphans": 3,
       "examples": [
+        "https://frontaliereticino.ch/lavoro-infermieri-svizzera/",
         "https://frontaliereticino.ch/lavoro-oss-svizzera/",
         "https://frontaliereticino.ch/lavoro-sanitario-ticino/"
       ]
@@ -340,24 +381,34 @@
     },
     "sitemap-pages.xml": {
       "total": 144,
-      "orphans": 0,
-      "examples": []
+      "orphans": 72,
+      "examples": [
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-vecchio-frontaliere/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-nuovo-frontaliere-2026/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-vecchio-frontaliere/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-nuovo-frontaliere-2026/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-vecchio-frontaliere/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-nuovo-frontaliere-2026/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-sposato-2-figli/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-sposato-2-figli/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-sposato-2-figli/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-residenza-oltre-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-80000-chf-residenza-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-residenza-oltre-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/nuovi-frontalieri-oltre-20-km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf-residenza-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-residenza-oltre-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-100000-chf-residenza-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/confronto-netto-2025-2026-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km/",
+        "https://frontaliereticino.ch/calcola-stipendio/confronto-netto-2025-2026-oltre-20km/"
+      ]
     },
     "sitemap-professions.xml": {
       "total": 10,
-      "orphans": 10,
-      "examples": [
-        "https://frontaliereticino.ch/lavoro-ticino-infermiere/",
-        "https://frontaliereticino.ch/lavoro-ticino-operaio/",
-        "https://frontaliereticino.ch/lavoro-ticino-impiegato/",
-        "https://frontaliereticino.ch/lavoro-ticino-ingegnere/",
-        "https://frontaliereticino.ch/lavoro-ticino-educatore/",
-        "https://frontaliereticino.ch/lavoro-ticino-autista/",
-        "https://frontaliereticino.ch/lavoro-ticino-muratore/",
-        "https://frontaliereticino.ch/lavoro-ticino-cuoco/",
-        "https://frontaliereticino.ch/lavoro-ticino-cameriere/",
-        "https://frontaliereticino.ch/lavoro-ticino-elettricista/"
-      ]
+      "orphans": 0,
+      "examples": []
     },
     "sitemap-recency.xml": {
       "total": 2,
@@ -366,8 +417,9 @@
     },
     "sitemap-salary-hub.xml": {
       "total": 1732,
-      "orphans": 1699,
+      "orphans": 1732,
       "examples": [
+        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf/",
         "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf/",
         "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf/",
         "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf/",
@@ -386,14 +438,15 @@
         "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-entro-20km/",
         "https://frontaliereticino.ch/en/calculate-salary/net-salary-40000-chf-2-children-within-20km/",
         "https://frontaliereticino.ch/de/gehalt-berechnen/nettogehalt-40000-chf-2-kinder-innerhalb-20km/",
-        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-2-enfants-moins-20km/",
-        "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-40000-chf-2-figli-nuovo-frontaliere-oltre-20km/"
+        "https://frontaliereticino.ch/fr/calculer-salaire/salaire-net-40000-chf-2-enfants-moins-20km/"
       ]
     },
     "sitemap-sector.xml": {
       "total": 10,
-      "orphans": 8,
+      "orphans": 10,
       "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/infermieri/",
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/case-anziani/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/educatori/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/ingegneri/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/autisti/",
@@ -406,8 +459,9 @@
     },
     "sitemap-seo-hubs.xml": {
       "total": 303,
-      "orphans": 299,
+      "orphans": 303,
       "examples": [
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-2/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-3/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-4/",
@@ -426,26 +480,21 @@
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-17/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-18/",
         "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-19/",
-        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-20/",
-        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-21/"
+        "https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-20/"
       ]
     },
     "sitemap-weekly-employers.xml": {
       "total": 188,
-      "orphans": 185,
+      "orphans": 181,
       "examples": [
-        "https://frontaliereticino.ch/aziende-che-assumono/lugano/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/mendrisio/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/chiasso/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/stabio/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/bellinzona/settimana-corrente/",
-        "https://frontaliereticino.ch/aziende-che-assumono/locarno/settimana-corrente/",
+        "https://frontaliereticino.ch/en/companies-hiring/ticino/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/lugano/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/mendrisio/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/chiasso/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/stabio/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/bellinzona/current-week/",
         "https://frontaliereticino.ch/en/companies-hiring/locarno/current-week/",
+        "https://frontaliereticino.ch/de/unternehmen-einstellen/ticino/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/lugano/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/mendrisio/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/chiasso/aktuelle-woche/",
@@ -453,7 +502,11 @@
         "https://frontaliereticino.ch/de/unternehmen-einstellen/bellinzona/aktuelle-woche/",
         "https://frontaliereticino.ch/de/unternehmen-einstellen/locarno/aktuelle-woche/",
         "https://frontaliereticino.ch/fr/entreprises-recrutent/ticino/semaine-courante/",
-        "https://frontaliereticino.ch/fr/entreprises-recrutent/lugano/semaine-courante/"
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/lugano/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/mendrisio/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/chiasso/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/stabio/semaine-courante/",
+        "https://frontaliereticino.ch/fr/entreprises-recrutent/bellinzona/semaine-courante/"
       ]
     }
   }

--- a/scripts/audit-orphan-pages-in-sitemaps.mjs
+++ b/scripts/audit-orphan-pages-in-sitemaps.mjs
@@ -3,14 +3,10 @@
  * audit-orphan-pages-in-sitemaps.mjs
  *
  * Detect "orphaned pages in sitemaps" — URLs listed in any of the live
- * sitemap-*.xml files but with NO internal link pointing to them anywhere
- * in the site graph. Semrush flags these (currently 4,936 on
+ * sitemap-*.xml files but not reachable via internal-link traversal from
+ * the homepage `/`. Semrush flags these (currently ~4,936 on
  * frontaliereticino.ch) because they consume crawl budget without site-
  * structure support and tend to rank worse.
- *
- * Phase 1 deliverable: this is a REPORTING script. It always exits 0 on
- * orphans (the regression gate comes in Phase 3 via a `--gate=baseline`
- * flag — see `compareAgainstBaseline()` below).
  *
  * --------------------------------------------------------------------------
  * Pipeline
@@ -23,11 +19,17 @@
  *    where canonicalPath strips the host, fragments, and normalises
  *    trailing slashes consistently.
  * 3. Build the "linked" set from the LOCAL worktree:
- *      Mode A (preferred): scan dist/**\/*.html for <a href="…">
+ *      Mode A (preferred): BFS reachability from `/` over dist/**\/*.html.
+ *                          Start at dist/index.html, follow every <a href>,
+ *                          stop at noindex pages (don't extract their
+ *                          outgoing links — they're crawl-graph dead-ends),
+ *                          stop at files that don't exist in dist/. The
+ *                          returned set is the reachable subgraph.
  *      Mode B (fallback):  scan source files (App.tsx, components/,
  *                          services/, build-plugins/, scripts/) for
  *                          string/template literals shaped like internal
- *                          paths ('/foo/bar' or `/foo/${slug}`).
+ *                          paths ('/foo/bar' or `/foo/${slug}`). Approximate;
+ *                          used only when dist/ is empty.
  *    Mode A is used automatically when dist/ has ≥ 10 HTML files. Force
  *    Mode B with --source-mode (faster local iteration).
  * 4. Diff: orphans = sitemapUrls \ linkedUrls.
@@ -43,12 +45,16 @@
  * --------------------------------------------------------------------------
  * - Mode B is approximate: dynamic href values built at runtime
  *   (e.g. `/${locale}/articles/${slug}`) may underestimate the linked set,
- *   inflating the orphan count. The ratchet baseline shipped from this run
- *   is therefore a Mode-B baseline; once CI runs Mode A on a real dist/,
+ *   inflating the orphan count. The ratchet baseline shipped from a Mode-B
+ *   run is therefore only a stop-gap; once CI runs Mode A on a real dist/,
  *   regenerate via --rebaseline.
  * - Trailing slashes: both `/foo/` and `/foo` are normalised to the
  *   no-trailing-slash form on BOTH sides before set-diffing (so we never
  *   classify a page as orphan due to a slash mismatch).
+ * - The `--gate=baseline` ratchet only makes sense in Mode A. The two modes
+ *   measure fundamentally different things (graph reachability vs source-
+ *   string membership), so cross-mode comparison is meaningless. Invoking
+ *   the gate in Mode B exits 1 with a clear error.
  *
  * --------------------------------------------------------------------------
  * CLI flags
@@ -61,6 +67,9 @@
  *                       data/orphan-pages-audit.json).
  *   --rebaseline        Overwrite data/orphan-pages-baseline.json from this
  *                       run. Use after a deliberate improvement.
+ *   --gate=baseline     Compare current run to baseline; exit 1 if any
+ *                       sitemap orphan count is HIGHER than baseline. Mode A
+ *                       only.
  */
 
 import { readdir, readFile, stat, writeFile, access } from 'node:fs/promises';
@@ -90,6 +99,8 @@ const OUT_PATH = args.get('out')
   ? resolvePath(String(args.get('out')))
   : join(DATA_DIR, 'orphan-pages-audit.json');
 const REBASELINE = args.has('rebaseline');
+const GATE = args.get('gate'); // string | true | undefined
+const GATE_BASELINE = GATE === 'baseline';
 const BASELINE_PATH = join(DATA_DIR, 'orphan-pages-baseline.json');
 
 function resolvePath(p) {
@@ -202,7 +213,7 @@ async function fetchAllSitemaps() {
 }
 
 // ---------------------------------------------------------------------------
-// Mode A: dist/**\/*.html scan.
+// File-walking helpers.
 // ---------------------------------------------------------------------------
 
 async function* walkFiles(dir, predicate) {
@@ -222,19 +233,24 @@ async function* walkFiles(dir, predicate) {
   }
 }
 
-async function distHasEnoughHtml() {
+async function distHasEnoughHtml(distRoot = DIST) {
   try {
-    await access(DIST);
+    await access(distRoot);
   } catch {
     return false;
   }
   let count = 0;
-  for await (const _ of walkFiles(DIST, (_, name) => name.endsWith('.html'))) {
+  for await (const _ of walkFiles(distRoot, (_, name) => name.endsWith('.html'))) {
     count += 1;
     if (count >= 10) return true;
   }
   return false;
 }
+
+// ---------------------------------------------------------------------------
+// Path normalisation — used both when extracting hrefs from HTML and when
+// matching against sitemap canonical paths.
+// ---------------------------------------------------------------------------
 
 function normaliseInternalPath(href) {
   if (!href) return null;
@@ -261,6 +277,8 @@ function normaliseInternalPath(href) {
   }
   // Bare leading-slash internal path.
   if (h.startsWith('/')) {
+    // Reject protocol-relative ('//foo') and scheme-like prefixes.
+    if (h.startsWith('//')) return null;
     let p = h;
     if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
     return p;
@@ -268,50 +286,150 @@ function normaliseInternalPath(href) {
   return null;
 }
 
-async function collectLinkedUrlsModeA() {
+// ---------------------------------------------------------------------------
+// Mode A: BFS reachability from `/` over dist/.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a normalised internal path to a dist HTML file path.
+ * Returns null if neither candidate exists.
+ *   `/foo/bar` → dist/foo/bar/index.html OR dist/foo/bar.html
+ *   `/`        → dist/index.html
+ */
+async function resolvePathToDistFile(distRoot, path) {
+  if (path === '/' || path === '') {
+    const indexFile = join(distRoot, 'index.html');
+    try {
+      await access(indexFile);
+      return indexFile;
+    } catch {
+      return null;
+    }
+  }
+  // Strip leading slash for join.
+  const rel = path.replace(/^\/+/, '');
+  const candidateA = join(distRoot, rel, 'index.html');
+  try {
+    await access(candidateA);
+    return candidateA;
+  } catch {
+    /* fall through */
+  }
+  const candidateB = join(distRoot, `${rel}.html`);
+  try {
+    await access(candidateB);
+    return candidateB;
+  } catch {
+    return null;
+  }
+}
+
+const ROBOTS_NOINDEX_RE =
+  /<meta\s+[^>]*name\s*=\s*["']robots["'][^>]*content\s*=\s*["'][^"']*\bnoindex\b[^"']*["'][^>]*>/i;
+
+function htmlHasNoindex(html) {
+  return ROBOTS_NOINDEX_RE.test(html);
+}
+
+/**
+ * Extract every <a href="..."> from an HTML string. Deliberately ignores
+ * <link rel="alternate"> and <link rel="canonical"> — Semrush-style BFS
+ * reachability follows only <a> tags (those are the navigable graph).
+ */
+function extractAnchorHrefs(html) {
+  const out = [];
+  // Match <a ...> (NOT <link ...>) and capture its href value.
+  const tagRe = /<a\b[^>]*\shref\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>/gi;
+  let m;
+  while ((m = tagRe.exec(html)) !== null) {
+    const href = m[2] ?? m[3] ?? m[4];
+    if (typeof href === 'string') out.push(href);
+  }
+  return out;
+}
+
+/**
+ * BFS reachability from `/` across dist/.
+ * Returns { linked, stats }:
+ *   linked:        Set of normalised paths visited (i.e. files that exist
+ *                  AND were reached via the link graph from `/`).
+ *   stats.visited: linked.size
+ *   stats.noindex: count of pages reached but not crawled-through
+ *                  (their outgoing links were skipped)
+ *   stats.dead:    count of frontier paths whose target file did not exist
+ *                  in dist/ (i.e. dangling links — interesting for separate
+ *                  diagnostics but not part of the reachable set)
+ */
+async function bfsReachableFromHome(distRoot) {
+  const startFile = await resolvePathToDistFile(distRoot, '/');
+  if (!startFile) {
+    throw new Error(`BFS start node missing: ${join(distRoot, 'index.html')} does not exist.`);
+  }
+
   /** @type {Set<string>} */
-  const linked = new Set();
-  const hrefRe = /href\s*=\s*"([^"]+)"|href\s*=\s*'([^']+)'/gi;
-  for await (const file of walkFiles(DIST, (_, name) => name.endsWith('.html'))) {
+  const visited = new Set();
+  /** @type {Set<string>} */
+  const enqueued = new Set();
+  /** @type {string[]} */
+  const frontier = ['/'];
+  enqueued.add('/');
+
+  let noindexCount = 0;
+  let deadCount = 0;
+
+  while (frontier.length > 0) {
+    const current = frontier.shift();
+    const file = await resolvePathToDistFile(distRoot, current);
+    if (!file) {
+      // Dangling internal link — counts as unreachable (nothing to crawl).
+      deadCount += 1;
+      continue;
+    }
     let html;
     try {
       html = await readFile(file, 'utf8');
     } catch {
+      deadCount += 1;
       continue;
     }
-    let m;
-    while ((m = hrefRe.exec(html)) !== null) {
-      const href = m[1] ?? m[2];
-      const p = normaliseInternalPath(href);
-      if (p) linked.add(p);
+    // The page exists, so it IS reachable. Record it.
+    visited.add(current);
+    // If noindex, treat as a bridge: don't extract outgoing links (Semrush
+    // wouldn't propagate equity through a noindex page).
+    if (htmlHasNoindex(html)) {
+      noindexCount += 1;
+      continue;
     }
-    hrefRe.lastIndex = 0;
+    const hrefs = extractAnchorHrefs(html);
+    for (const href of hrefs) {
+      const p = normaliseInternalPath(href);
+      if (!p) continue;
+      if (enqueued.has(p)) continue;
+      enqueued.add(p);
+      frontier.push(p);
+    }
   }
-  return linked;
+
+  return {
+    linked: visited,
+    stats: { visited: visited.size, noindex: noindexCount, dead: deadCount },
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Mode B: source-tree scan for path-shaped string/template literals.
+// (Unchanged from prior implementation — kept as a fallback when no dist/.)
 // ---------------------------------------------------------------------------
 
 const SOURCE_ROOTS = ['App.tsx', 'components', 'services', 'build-plugins', 'scripts'];
 const SOURCE_EXTS = new Set(['.ts', '.tsx', '.mjs', '.js', '.jsx', '.cjs']);
 
 function looksLikeInternalSlugLiteral(s) {
-  // Must start with `/` and not be a protocol-relative URL or filesystem path
-  // marker like `/* */` (which won't appear inside a string anyway).
   if (!s.startsWith('/')) return false;
   if (s.startsWith('//')) return false;
-  // Reject obvious non-URL paths.
   if (/^\/(?:Users|home|tmp|var|opt|usr|etc)(?:\/|$)/.test(s)) return false;
-  // Reject regex-like or escape-heavy literals.
   if (s.includes('\\')) return false;
-  // Allowed slug characters: letters, digits, hyphen, underscore, slash, dot,
-  // plus `${...}` template placeholders (which we'll fold to a wildcard match
-  // — but for the purposes of computing "is this path internally linked?"
-  // we keep the literal prefix).
   if (!/^\/[A-Za-z0-9._\-/${}]*$/.test(s)) return false;
-  // Length sanity — sitemap paths are realistically 1..200 chars.
   if (s.length > 200) return false;
   return true;
 }
@@ -363,21 +481,13 @@ async function scanSourceFile(file, linked, linkedPrefixes, stringRe) {
 
     const dollar = lit.indexOf('${');
     if (dollar < 0) {
-      // Pure literal path: register both the form and its trailing-slash-stripped form.
       let p = lit;
       if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
       linked.add(p);
     } else {
-      // Template path with at least one ${...} placeholder. Take the prefix
-      // up to the first placeholder as a prefix-match key. This treats any
-      // sitemap path beginning with that prefix (and at least one extra
-      // segment) as "potentially linked dynamically".
       const prefix = lit.slice(0, dollar);
-      // Strip trailing slash to keep the prefix consistent with linked-path normalisation.
       let pre = prefix;
       if (pre.length > 1 && pre.endsWith('/')) pre = pre.slice(0, -1);
-      // Require the prefix to contain at least one slash beyond the leading one
-      // — `/${slug}` alone is too generic and would match every URL on the site.
       const slashCount = (pre.match(/\//g) || []).length;
       if (slashCount >= 2) {
         linkedPrefixes.add(pre);
@@ -394,8 +504,6 @@ function isLinked(path, linked, linkedPrefixes) {
   if (linked.has(path)) return true;
   if (!linkedPrefixes || linkedPrefixes.size === 0) return false;
   for (const pre of linkedPrefixes) {
-    // path is "linked dynamically" if it starts with `${pre}/` AND has at
-    // least one more segment beyond the prefix.
     if (path === pre) return true;
     if (path.startsWith(pre + '/')) return true;
   }
@@ -403,7 +511,7 @@ function isLinked(path, linked, linkedPrefixes) {
 }
 
 function computeOrphans(sitemapsToUrls, linked, linkedPrefixes, canonicalToOriginal) {
-  /** @type {Record<string, { total: number; orphans: number; examples: string[] }>} */
+  /** @type {Record<string, { total: number; orphans: number; examples: string[]; orphansList: string[] }>} */
   const perSitemap = {};
   let totalSitemapUrls = 0;
   let totalOrphans = 0;
@@ -421,6 +529,9 @@ function computeOrphans(sitemapsToUrls, linked, linkedPrefixes, canonicalToOrigi
       total: urls.size,
       orphans: orphans.length,
       examples: orphans.slice(0, LIMIT).map((p) => canonicalToOriginal.get(p) || p),
+      // Internal field used for regression diff; not retained in baseline copy
+      // because the example slice is already representative.
+      orphansList: orphans,
     };
     totalSitemapUrls += urls.size;
     totalOrphans += orphans.length;
@@ -458,7 +569,6 @@ function printTable(report, mode) {
     `${'TOTAL'.padEnd(40)} ${String(report.totalSitemapUrls).padStart(7)} ${String(report.totalOrphans).padStart(8)} ${totalPct.toFixed(1).padStart(6)}%`,
   );
 
-  // Examples per sitemap (only those with ≥1 orphan).
   for (const [name, row] of rows) {
     if (row.orphans === 0) continue;
     lines.push('');
@@ -470,7 +580,7 @@ function printTable(report, mode) {
 }
 
 // ---------------------------------------------------------------------------
-// Baseline / ratchet plumbing — wired but not enforced (Phase 3).
+// Baseline / ratchet plumbing.
 // ---------------------------------------------------------------------------
 
 async function readBaseline() {
@@ -482,9 +592,14 @@ async function readBaseline() {
   }
 }
 
-// Phase 3 will wire `--gate=baseline` to call this. Returning a result
-// object now keeps the structure stable.
-// eslint-disable-next-line no-unused-vars
+/**
+ * Compare current run against baseline. Returns:
+ *   { regressed: bool, regressions: Array<{ sitemap, prev, current, newOrphans }> }
+ * Where `newOrphans` is up to 10 paths present in `current` but not in
+ * `baseline` for that sitemap (best-effort: when baseline doesn't carry the
+ * full orphan list — which it shouldn't, to keep file size sane — we fall
+ * back to listing the current-run examples).
+ */
 function compareAgainstBaseline(current, baseline) {
   if (!baseline) return { regressed: false, regressions: [] };
   const regressions = [];
@@ -492,7 +607,14 @@ function compareAgainstBaseline(current, baseline) {
     const prev = baseline.perSitemap?.[name];
     if (!prev) continue;
     if (row.orphans > prev.orphans) {
-      regressions.push({ sitemap: name, prev: prev.orphans, current: row.orphans });
+      const baselineExamplesSet = new Set(prev.examples || []);
+      const currentExamples = row.examples || [];
+      const newOrphans = currentExamples.filter((u) => !baselineExamplesSet.has(u)).slice(0, 10);
+      // If the diff happens to be empty (e.g. baseline carried different
+      // examples), at least surface the current top-10 examples so the
+      // operator has something concrete to investigate.
+      const surfaced = newOrphans.length > 0 ? newOrphans : currentExamples.slice(0, 10);
+      regressions.push({ sitemap: name, prev: prev.orphans, current: row.orphans, newOrphans: surfaced });
     }
   }
   return { regressed: regressions.length > 0, regressions };
@@ -503,26 +625,51 @@ function compareAgainstBaseline(current, baseline) {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { sitemapsToUrls, canonicalToOriginal } = await fetchAllSitemaps();
-
+  // Determine mode FIRST so we can fail fast on gate-vs-mode mismatch before
+  // any network traffic.
   const useModeA = !FORCE_SOURCE_MODE && (await distHasEnoughHtml());
   const mode = useModeA ? 'html' : 'source';
-  process.stderr.write(`[audit] Using Mode ${useModeA ? 'A (dist HTML scan)' : 'B (source scan)'}\n`);
+
+  if (GATE_BASELINE && !useModeA) {
+    process.stderr.write(
+      '[audit] FATAL: --gate=baseline requires Mode A (built dist/). Run `npm run build` first, then re-run.\n',
+    );
+    process.exit(1);
+  }
+
+  const { sitemapsToUrls, canonicalToOriginal } = await fetchAllSitemaps();
+  process.stderr.write(`[audit] Using Mode ${useModeA ? 'A (BFS from /)' : 'B (source scan)'}\n`);
 
   let linked;
   let linkedPrefixes;
   if (useModeA) {
-    linked = await collectLinkedUrlsModeA();
+    const r = await bfsReachableFromHome(DIST);
+    linked = r.linked;
     linkedPrefixes = new Set();
+    process.stderr.write(
+      `[audit] BFS visited ${r.stats.visited} reachable pages (skipped ${r.stats.noindex} noindex bridges, ${r.stats.dead} dead-ends)\n`,
+    );
   } else {
     const r = await collectLinkedUrlsModeB();
     linked = r.linked;
     linkedPrefixes = r.linkedPrefixes;
+    process.stderr.write(
+      `[audit] Linked set: ${linked.size} exact paths, ${linkedPrefixes.size} dynamic prefixes\n`,
+    );
   }
 
-  process.stderr.write(`[audit] Linked set: ${linked.size} exact paths, ${linkedPrefixes.size} dynamic prefixes\n`);
-
   const report = computeOrphans(sitemapsToUrls, linked, linkedPrefixes, canonicalToOriginal);
+
+  // Strip the heavy orphansList field before serialising so the JSON stays
+  // small. examples[] is already capped at LIMIT (default 20).
+  const perSitemapForOutput = {};
+  for (const [name, row] of Object.entries(report.perSitemap)) {
+    perSitemapForOutput[name] = {
+      total: row.total,
+      orphans: row.orphans,
+      examples: row.examples,
+    };
+  }
 
   const json = {
     version: 1,
@@ -530,14 +677,39 @@ async function main() {
     mode,
     totalSitemapUrls: report.totalSitemapUrls,
     totalOrphans: report.totalOrphans,
-    perSitemap: report.perSitemap,
+    perSitemap: perSitemapForOutput,
   };
 
   await writeFile(OUT_PATH, JSON.stringify(json, null, 2) + '\n', 'utf8');
   process.stderr.write(`[audit] Wrote report → ${relative(ROOT, OUT_PATH)}\n`);
 
-  // Baseline handling.
+  // Baseline read + gate-check / rebaseline handling.
   const existing = await readBaseline();
+
+  if (GATE_BASELINE) {
+    if (!existing) {
+      process.stderr.write('[audit] FATAL: --gate=baseline invoked but no baseline found.\n');
+      process.exit(1);
+    }
+    const cmp = compareAgainstBaseline(json, existing);
+    if (cmp.regressed) {
+      const lines = [];
+      lines.push('[gate] REGRESSION — orphan-pages-in-sitemaps');
+      for (const r of cmp.regressions) {
+        lines.push(
+          `  ${r.sitemap}: baseline=${r.prev} → current=${r.current} (+${r.current - r.prev})`,
+        );
+        for (const u of r.newOrphans) lines.push(`    - ${u}`);
+      }
+      process.stderr.write(lines.join('\n') + '\n');
+      printTable(report, mode);
+      process.exit(1);
+    }
+    process.stderr.write('[gate] OK — no regression\n');
+    printTable(report, mode);
+    return;
+  }
+
   if (REBASELINE || !existing) {
     await writeFile(BASELINE_PATH, JSON.stringify(json, null, 2) + '\n', 'utf8');
     process.stderr.write(
@@ -548,7 +720,36 @@ async function main() {
   printTable(report, mode);
 }
 
-main().catch((err) => {
-  process.stderr.write(`[audit] FATAL: ${err.stack || err.message}\n`);
-  process.exit(1);
-});
+// Only run main() when invoked directly as a script (not when imported by
+// tests via dynamic import).
+const invokedDirectly = (() => {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const argv1 = process.argv[1] ? process.argv[1] : '';
+    return argv1 && (argv1 === thisFile || argv1.endsWith('audit-orphan-pages-in-sitemaps.mjs'));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    process.stderr.write(`[audit] FATAL: ${err.stack || err.message}\n`);
+    process.exit(1);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal exports for tests. (Node ignores these when invoked as a script;
+// they're only reachable via dynamic import().)
+// ---------------------------------------------------------------------------
+
+export const __test = {
+  bfsReachableFromHome,
+  extractAnchorHrefs,
+  htmlHasNoindex,
+  normaliseInternalPath,
+  resolvePathToDistFile,
+  compareAgainstBaseline,
+  distHasEnoughHtml,
+};

--- a/tests/audit-orphan-pages.test.ts
+++ b/tests/audit-orphan-pages.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// Pull internal helpers out of the audit script via dynamic import. The
+// script's `main()` only runs when invoked as the entrypoint (we guard with
+// `process.argv[1]` matching), so a regular import returns its `__test`
+// bundle without executing the audit pipeline.
+const SCRIPT_URL = new URL('../scripts/audit-orphan-pages-in-sitemaps.mjs', import.meta.url);
+
+interface AuditTestExports {
+  bfsReachableFromHome: (
+    distRoot: string,
+  ) => Promise<{
+    linked: Set<string>;
+    stats: { visited: number; noindex: number; dead: number };
+  }>;
+  extractAnchorHrefs: (html: string) => string[];
+  htmlHasNoindex: (html: string) => boolean;
+  normaliseInternalPath: (href: string) => string | null;
+  resolvePathToDistFile: (distRoot: string, path: string) => Promise<string | null>;
+  compareAgainstBaseline: (
+    current: { perSitemap: Record<string, { orphans: number; examples: string[] }> },
+    baseline: { perSitemap: Record<string, { orphans: number; examples: string[] }> } | null,
+  ) => { regressed: boolean; regressions: Array<{ sitemap: string; prev: number; current: number; newOrphans: string[] }> };
+  distHasEnoughHtml: (distRoot: string) => Promise<boolean>;
+}
+
+async function loadHelpers(): Promise<AuditTestExports> {
+  const mod = (await import(SCRIPT_URL.href)) as { __test: AuditTestExports };
+  return mod.__test;
+}
+
+describe('audit-orphan-pages: BFS reachability', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'orphan-audit-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('visits a 3-page chain reachable from /', async () => {
+    const { bfsReachableFromHome } = await loadHelpers();
+    await mkdir(join(tmpDir, 'a'), { recursive: true });
+    await mkdir(join(tmpDir, 'a', 'b'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'index.html'),
+      `<html><body><a href="/a/">A</a></body></html>`,
+      'utf8',
+    );
+    await writeFile(
+      join(tmpDir, 'a', 'index.html'),
+      `<html><body><a href="/a/b/">B</a></body></html>`,
+      'utf8',
+    );
+    await writeFile(
+      join(tmpDir, 'a', 'b', 'index.html'),
+      `<html><body><p>leaf</p></body></html>`,
+      'utf8',
+    );
+
+    const result = await bfsReachableFromHome(tmpDir);
+    expect(result.linked.has('/')).toBe(true);
+    expect(result.linked.has('/a')).toBe(true);
+    expect(result.linked.has('/a/b')).toBe(true);
+    expect(result.stats.visited).toBe(3);
+  });
+
+  it('records noindex pages as reachable but does not follow their links', async () => {
+    const { bfsReachableFromHome } = await loadHelpers();
+    await mkdir(join(tmpDir, 'gate'), { recursive: true });
+    await mkdir(join(tmpDir, 'beyond'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'index.html'),
+      `<html><body><a href="/gate/">Gate</a></body></html>`,
+      'utf8',
+    );
+    await writeFile(
+      join(tmpDir, 'gate', 'index.html'),
+      `<html><head><meta name="robots" content="noindex,follow"></head>` +
+        `<body><a href="/beyond/">Beyond</a></body></html>`,
+      'utf8',
+    );
+    await writeFile(
+      join(tmpDir, 'beyond', 'index.html'),
+      `<html><body>far</body></html>`,
+      'utf8',
+    );
+
+    const result = await bfsReachableFromHome(tmpDir);
+    expect(result.linked.has('/')).toBe(true);
+    expect(result.linked.has('/gate')).toBe(true);
+    expect(result.linked.has('/beyond')).toBe(false);
+    expect(result.stats.noindex).toBe(1);
+  });
+
+  it('does not follow <link rel="alternate"> hreflang tags', async () => {
+    const { bfsReachableFromHome } = await loadHelpers();
+    await mkdir(join(tmpDir, 'en'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'index.html'),
+      `<html><head>` +
+        `<link rel="alternate" hreflang="en" href="/en/">` +
+        `<link rel="canonical" href="https://frontaliereticino.ch/">` +
+        `</head><body><p>home only</p></body></html>`,
+      'utf8',
+    );
+    await writeFile(
+      join(tmpDir, 'en', 'index.html'),
+      `<html><body>en home</body></html>`,
+      'utf8',
+    );
+
+    const result = await bfsReachableFromHome(tmpDir);
+    expect(result.linked.has('/')).toBe(true);
+    expect(result.linked.has('/en')).toBe(false);
+  });
+
+  it('counts dangling links as dead-ends and never as reachable', async () => {
+    const { bfsReachableFromHome } = await loadHelpers();
+    await writeFile(
+      join(tmpDir, 'index.html'),
+      `<html><body><a href="/missing-page/">Missing</a></body></html>`,
+      'utf8',
+    );
+
+    const result = await bfsReachableFromHome(tmpDir);
+    expect(result.linked.has('/missing-page')).toBe(false);
+    expect(result.stats.dead).toBe(1);
+  });
+
+  it('throws when dist/index.html is missing', async () => {
+    const { bfsReachableFromHome } = await loadHelpers();
+    await expect(bfsReachableFromHome(tmpDir)).rejects.toThrow(/start node missing/i);
+  });
+});
+
+describe('audit-orphan-pages: extractors and helpers', () => {
+  it('extractAnchorHrefs picks <a> hrefs but ignores <link>', async () => {
+    const { extractAnchorHrefs } = await loadHelpers();
+    const html =
+      `<link rel="alternate" hreflang="en" href="/en/"/>` +
+      `<a href="/foo">F</a>` +
+      `<a href='/bar'>B</a>` +
+      `<a href="/baz#x">Z</a>`;
+    const hrefs = extractAnchorHrefs(html);
+    expect(hrefs).toEqual(['/foo', '/bar', '/baz#x']);
+  });
+
+  it('htmlHasNoindex detects various meta-robots formats', async () => {
+    const { htmlHasNoindex } = await loadHelpers();
+    expect(htmlHasNoindex('<meta name="robots" content="noindex">')).toBe(true);
+    expect(htmlHasNoindex('<meta name="robots" content="noindex, follow">')).toBe(true);
+    expect(htmlHasNoindex(`<meta name='robots' content='index,follow'>`)).toBe(false);
+    expect(htmlHasNoindex('<p>no meta</p>')).toBe(false);
+  });
+
+  it('normaliseInternalPath handles internal absolute, relative, and external URLs', async () => {
+    const { normaliseInternalPath } = await loadHelpers();
+    expect(normaliseInternalPath('/foo/')).toBe('/foo');
+    expect(normaliseInternalPath('/foo')).toBe('/foo');
+    expect(normaliseInternalPath('https://frontaliereticino.ch/foo/')).toBe('/foo');
+    expect(normaliseInternalPath('https://www.frontaliereticino.ch/foo')).toBe('/foo');
+    expect(normaliseInternalPath('https://other.example/foo')).toBe(null);
+    expect(normaliseInternalPath('mailto:x@y.z')).toBe(null);
+    expect(normaliseInternalPath('//cdn.example/foo')).toBe(null);
+    expect(normaliseInternalPath('/foo?q=1#frag')).toBe('/foo');
+  });
+});
+
+describe('audit-orphan-pages: --gate=baseline', () => {
+  it('compareAgainstBaseline flags regressions only when count is higher', async () => {
+    const { compareAgainstBaseline } = await loadHelpers();
+    const baseline = {
+      perSitemap: {
+        'sitemap-blog.xml': { orphans: 100, examples: ['https://x/a', 'https://x/b'] },
+        'sitemap-jobs.xml': { orphans: 50, examples: [] },
+      },
+    };
+    const current = {
+      perSitemap: {
+        'sitemap-blog.xml': { orphans: 105, examples: ['https://x/a', 'https://x/c', 'https://x/d'] },
+        'sitemap-jobs.xml': { orphans: 40, examples: [] },
+      },
+    };
+    const cmp = compareAgainstBaseline(current, baseline);
+    expect(cmp.regressed).toBe(true);
+    expect(cmp.regressions).toHaveLength(1);
+    expect(cmp.regressions[0]?.sitemap).toBe('sitemap-blog.xml');
+    expect(cmp.regressions[0]?.prev).toBe(100);
+    expect(cmp.regressions[0]?.current).toBe(105);
+    // newOrphans should surface the items not in baseline examples
+    expect(cmp.regressions[0]?.newOrphans).toEqual(['https://x/c', 'https://x/d']);
+  });
+
+  it('compareAgainstBaseline returns no regression when counts are flat or lower', async () => {
+    const { compareAgainstBaseline } = await loadHelpers();
+    const baseline = {
+      perSitemap: { 'sitemap-blog.xml': { orphans: 100, examples: [] } },
+    };
+    const flat = compareAgainstBaseline(
+      { perSitemap: { 'sitemap-blog.xml': { orphans: 100, examples: [] } } },
+      baseline,
+    );
+    expect(flat.regressed).toBe(false);
+    const lower = compareAgainstBaseline(
+      { perSitemap: { 'sitemap-blog.xml': { orphans: 50, examples: [] } } },
+      baseline,
+    );
+    expect(lower.regressed).toBe(false);
+  });
+
+  it('script exits 1 when --gate=baseline runs in Mode B (no dist/)', async () => {
+    // Spawn the script in source-mode against a worktree without dist/. We
+    // can't realistically fetch remote sitemaps from a unit test, so we
+    // instead force an early-exit path: the Mode B + gate combo bails out
+    // before any network call.
+    const scriptPath = fileURLToPath(SCRIPT_URL);
+    const { code, stderr } = await runScript(scriptPath, ['--source-mode', '--gate=baseline'], {
+      // Run in a temp cwd with no dist/ so fetchAllSitemaps wouldn't be
+      // reached anyway.
+      cwd: process.cwd(),
+      timeoutMs: 60_000,
+    });
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/gate=baseline requires Mode A|FATAL/i);
+  });
+});
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runScript(
+  scriptPath: string,
+  args: string[],
+  opts: { cwd: string; timeoutMs: number },
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: opts.cwd,
+      env: { ...process.env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => {
+      stdout += c.toString('utf8');
+    });
+    child.stderr.on('data', (c) => {
+      stderr += c.toString('utf8');
+    });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+    }, opts.timeoutMs);
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Rewrite `scripts/audit-orphan-pages-in-sitemaps.mjs` Mode A as proper BFS reachability from `/` (matches Semrush's "orphaned pages in sitemaps" definition).
- Add `--gate=baseline` flag for use as a blocking deploy gate after sibling agents land the archive-nav links.
- Regenerate `data/orphan-pages-baseline.json` from the new BFS measurement.

## What changed

- **BFS rewrite**: start at `dist/index.html`, follow only `<a href>` tags, stop at `<meta name="robots" noindex>` pages (don't extract their outgoing links — Semrush wouldn't propagate equity through them), treat dangling links as dead-ends. Returns the reachable subgraph rather than a "every href anywhere in dist/" union.
- **`--gate=baseline`**: compares per-sitemap orphan counts to baseline; exits 1 on regression with a per-sitemap breakdown + top-10 newly-orphan URLs. Mode A only — invoking the gate in Mode B exits 1 with a clear error (different definitions, not comparable).
- **Mode B unchanged** (kept as fallback for empty-`dist/` workflows).
- **Stats one-liner**: `[audit] BFS visited X reachable pages (skipped Y noindex bridges, Z dead-ends)`.
- **Tests** (`tests/audit-orphan-pages.test.ts`): BFS chain, noindex bridge containment, `<link rel="alternate">` ignored, dangling links → dead-end, gate regression detection, gate-in-Mode-B rejection.

## Local Mode A measurement

```
Mode: html
TOTAL                                   7536     6933   92.0%
sitemap-jobs.xml             2416 2415  (99.96%)
sitemap-salary-hub.xml       1732 1732  (100%)
sitemap-blog.xml             1080  983  (91.0%)
sitemap-fuel-italian-stations.xml  424  424  (100%)
sitemap-fuel-stations.xml          488  415  (85.0%)
```

Semrush reports ~4,936 on the live site; local is slightly higher because the worktree predates the article/job archive nav links sibling agents 2 and 3 are landing. After their PRs merge, the gate will measure the correct floor.

The script correctly identifies known-orphan articles like `/articoli-frontaliere/redditi-varesotti-2024-luvinate/` (sitemap-news.xml).

## Test plan

- [ ] Orchestrator unified vitest run includes `tests/audit-orphan-pages.test.ts` and passes
- [ ] After agent 2 + 3 archive-nav links merge, rerun `npm run audit:orphan-sitemap-pages` and `:rebaseline` so the gate locks in the post-fix floor
- [ ] Wire `npm run audit:orphan-sitemap-pages -- --gate=baseline` into `.github/workflows/deploy.yml` as a blocking step (separate PR)