### PR TITLE
ci: add orphan-pages-in-sitemaps gate to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -252,6 +252,12 @@ jobs:
       #                            (page's <link rel="canonical"> = the loc).
       #                            Fix the build plugin emitting the offending
       #                            sitemap entry — never weaken the gate.
+      #   - orphan-sitemap-pages → CLAUDE.md "SEO content gate — orphaned pages
+      #                            in sitemaps" playbook. BFS reachability from
+      #                            homepage; ratchet baseline against
+      #                            data/orphan-pages-baseline.json. Default fix:
+      #                            add internal links — never noindex without
+      #                            explicit approval (CLAUDE.md non-negotiable #5).
       - name: Post-build validations + SEO audits + SPA render + E2E (all parallel)
         run: |
           # Group A — 7 file validators
@@ -275,6 +281,11 @@ jobs:
           # mismatch / missing-canonical / missing-html in dist/sitemap-*.xml
           # fails the deploy). Sitemap entries must always self-canonicalize.
           npm run audit:sitemap-canonicals   > /tmp/g8.log 2>&1 & PID15=$!
+          # Gate — orphaned pages in sitemaps (BFS reachability from homepage;
+          # ratchet baseline in data/orphan-pages-baseline.json). Mirrors the
+          # text-html-ratio gate semantics: improvements accepted silently,
+          # any sitemap whose orphan count goes UP fails the deploy.
+          npm run audit:orphan-sitemap-pages -- --gate=baseline > /tmp/g9.log 2>&1 & PID16=$!
 
           # Group C — SPA render validation (5 min internal budget)
           timeout 300 node scripts/validate-spa-render.mjs > /tmp/spa.log 2>&1 & PID_SPA=$!
@@ -298,11 +309,12 @@ jobs:
           wait $PID13 || { echo "::error::audit:h1-title-duplicates failed"; cat /tmp/g6.log; FAIL=1; }
           wait $PID14 || { echo "::error::audit:title-length failed"; cat /tmp/g7.log; FAIL=1; }
           wait $PID15 || { echo "::error::audit:sitemap-canonicals failed (HARD gate)"; cat /tmp/g8.log; FAIL=1; }
+          wait $PID16 || { echo "::error::audit:orphan-sitemap-pages failed"; cat /tmp/g9.log; FAIL=1; }
           wait $PID_SPA || { echo "::error::validate-spa-render failed"; cat /tmp/spa.log; FAIL=1; }
           wait $PID_E2E || { echo "::error::E2E smoke tests failed"; cat /tmp/e2e.log; FAIL=1; }
 
           if [ $FAIL -ne 0 ]; then exit 1; fi
-          echo "✅ All 17 post-build validators+audits+SPA+E2E passed"
+          echo "✅ All 18 post-build validators+audits+SPA+E2E passed"
 
       # Visual regression baselines are OS-sensitive (darwin vs linux pixel
       # diffs). We run them only when a linux-specific baseline has been

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,49 @@ not ratchet up.
 
 ---
 
+# SEO content gate — orphaned pages in sitemaps
+
+**Why it exists.** Semrush flagged 4,936 "orphaned pages in sitemaps" — pages
+listed in any sitemap-*.xml but not reachable via internal `<a href>` BFS from
+the homepage. Crawlers waste budget on these pages, and they tend to rank
+worse since they lack site-structure support.
+
+**Where it runs.** Two places:
+- Local: `npm run audit:orphan-sitemap-pages` (after `npm run build`).
+- CI: `Gate — orphan pages in sitemaps` step in `.github/workflows/deploy.yml`,
+  blocking deploy on regression.
+
+**The gate is a ratchet.** It compares the current dist/ orphan count to
+`data/orphan-pages-baseline.json` and FAILS only when any sitemap's orphan
+count goes UP. Improvements (count drops) are always accepted but do NOT
+auto-rebaseline; run `npm run audit:orphan-sitemap-pages:rebaseline` after
+a deliberate improvement and commit the new baseline together with the fix.
+
+**If the gate fails, here is the playbook:**
+
+1. Reproduce locally: `npm run build && npm run audit:orphan-sitemap-pages`.
+   Stdout names which sitemap regressed and shows top-10 newly-orphan URLs.
+2. The cause is almost always one of:
+   - **Static archive page lost an internal link** (e.g. nav widget removed).
+     Fix the link source.
+   - **New auto-generated content** (cron-published article/job) that no
+     existing static page links to. Add a link from the relevant index
+     (e.g. `/articoli-frontaliere/` → `/articoli-frontaliere/tutti/`) or
+     update the archive pagination so the new content is reachable.
+   - **Sitemap entry without HTML** (stale entry). Either restore the page
+     or remove from the sitemap.
+3. Rebuild and rerun the audit. Once the regression is gone:
+   ```
+   npm run audit:orphan-sitemap-pages:rebaseline
+   ```
+   Commit the updated baseline together with the fix in the same PR.
+
+**Hard rule.** Per CLAUDE.md non-negotiable rule #5, **never** "fix" an
+orphan by setting `noindex` without explicit approval. The default fix is
+to **add internal links**.
+
+---
+
 # Completion Checklist — Before Every PR
 
 - [ ] All tests pass: `npx vitest run`


### PR DESCRIPTION
Wires npm run audit:orphan-sitemap-pages -- --gate=baseline as the 16th
parallel post-build check (PID16) in .github/workflows/deploy.yml. Mirrors
the text-html-ratio gate semantics: ratchet against
data/orphan-pages-baseline.json — improvements accepted silently,
regressions block the deploy.

Adds the matching playbook section to CLAUDE.md so the failure mode and
fix paths (add internal links — never noindex without explicit approval,
per non-negotiable rule #5) are documented next to the existing
text-to-HTML ratio gate.
