### PR TITLE
fix(traffic): mock banner warning + HERE source type

### DIFF
--- a/components/guide/TrafficAlerts.tsx
+++ b/components/guide/TrafficAlerts.tsx
@@ -213,10 +213,10 @@ const TrafficAlerts: React.FC<TrafficAlertsProps> = ({ initialCrossingId }) => {
 
  const statusCallout = (
  <Callout
- status={liveTrafficAvailable ? 'success' : 'accent'}
+ status={liveTrafficAvailable ? 'success' : 'warning'}
  icon={liveTrafficAvailable ? <CheckCircle2 size={16} /> : <AlertTriangle size={16} />}
  >
- <span className={`text-sm ${liveTrafficAvailable ? 'text-success' : 'text-accent'}`}>
+ <span className={`text-sm ${liveTrafficAvailable ? 'text-success' : 'text-warning'}`}>
  {liveTrafficAvailable ? t('traffic.dataReal') : t('traffic.dataSimulated')}
  </span>
  </Callout>

--- a/services/trafficService.ts
+++ b/services/trafficService.ts
@@ -19,7 +19,7 @@ export interface TrafficData {
  status: 'green' | 'yellow' | 'red';
  direction: string;
  lastUpdate: Date;
- source: 'tomtom' | 'google-maps' | 'mock' | 'firestore';
+ source: 'tomtom' | 'google-maps' | 'here' | 'mock' | 'firestore';
  /** Traffic delay on the ≈500 m approach road on the Italian side (set by scheduled function) */
  approachMinutes?: number;
  /** Total estimated crossing time: approach delay + border queue (set by scheduled function) */
@@ -31,7 +31,7 @@ const BORDER_CROSSINGS: BorderCrossingCoordinates[] = centralizedCrossings
  .map(c => ({ name: c.name }));
 
 export function hasLiveTrafficData(data: TrafficData[]): boolean {
- return data.some(item => item.source === 'firestore' || item.source === 'tomtom' || item.source === 'google-maps');
+ return data.some(item => item.source === 'firestore' || item.source === 'tomtom' || item.source === 'google-maps' || item.source === 'here');
 }
 
 class TrafficService {


### PR DESCRIPTION
## Summary
- Changes mock data Callout from accent (blue) to warning (yellow) so users clearly see when they are looking at simulated estimates instead of live data
- Adds 'here' to the TrafficData source union type and hasLiveTrafficData() so the new HERE Maps provider is recognized as live data

## Test plan
- [ ] Navigate to /guida-frontaliere/tempi-attesa-dogana/ with no Firestore data → should see yellow warning banner
- [ ] With fresh Firestore data → should see green success banner