### PR TITLE
ci: post-deploy-validation as workflow_call from deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,12 +50,17 @@ on:
         default: false
 
 permissions:
-  # This workflow only needs repository read access: the previous-slug winners
-  # sync moved to post-deploy-validation.yml, while the deploy itself only
-  # uploads artifacts and publishes to GitHub Pages.
-  contents: read
+  # build-and-deploy itself only uploads artifacts and publishes to Pages.
+  # The wider scopes here are caps for the reusable post-deploy-validate job
+  # called below as `needs: build-and-deploy`:
+  #   - contents: write — sync previous-slug-winners commit/push
+  #   - actions:  read  — download github-pages / winners / snapshot artifacts
+  # The build-and-deploy job inherits them but does not exercise the extra
+  # write/read capabilities; only the post-deploy validate/rollback jobs do.
+  contents: write
   pages: write
   id-token: write
+  actions: read
 
 concurrency:
   # GitHub Pages allows only one active deployment at a time. Every trigger —
@@ -527,3 +532,28 @@ jobs:
             --priority 1 \
             --label Bug \
             --workflow "${{ github.workflow }}"
+
+  # Post-deploy validation runs as a reusable workflow in the SAME run as the
+  # deploy. This makes `github.sha` invariant (no more workflow_run.head_sha
+  # drift — see commit 53cf789d94 for the regression that motivated it) and
+  # any cancellation of the deploy propagates automatically without spawning
+  # an orphan post-deploy that has to be cancelled by a sibling concurrency
+  # group.
+  #
+  # Skipped on profile-only investigation runs (build-only, no Pages artifact).
+  # On deploy failure, this job is skipped automatically by `needs:` semantics
+  # — that is the desired UI behaviour: red deploy, skipped post-deploy, no
+  # confusing orphan run to interpret.
+  post-deploy-validate:
+    needs: build-and-deploy
+    if: github.event.inputs.profile_sequential != 'true'
+    uses: ./.github/workflows/post-deploy-validation.yml
+    permissions:
+      contents: write   # sync-previous-slug-winners commit/push
+      pages: write      # rollback re-deploy via actions/deploy-pages
+      id-token: write   # rollback deploy-pages OIDC
+      actions: read     # gh run download (github-pages / winners / snapshot)
+    secrets: inherit
+    with:
+      deploy_run_id: ${{ github.run_id }}
+      deploy_event_name: ${{ github.event_name }}

--- a/.github/workflows/post-deploy-validation.yml
+++ b/.github/workflows/post-deploy-validation.yml
@@ -1,100 +1,30 @@
 name: Post-deploy Validation
 
+# Reusable workflow called by deploy.yml as `needs: build-and-deploy`. Running
+# in the same run as the deploy makes `github.sha` invariant (no more
+# workflow_run.head_sha drift), and any cancellation of the deploy propagates
+# automatically — no orphan post-deploys cancelled by concurrency races.
+#
+# Migration history: previously triggered by `on: workflow_run`. That model
+# silently passed an audit:title-length regression in run 25377607613 because
+# `workflow_run.head_sha` resolved to an older SHA than the deploy was built
+# from, so the validate job checked out the wrong source (with a stale
+# `--threshold=90` npm wrapper) while auditing the right dist. See commit
+# 53cf789d94 and the follow-up that introduced this workflow_call refactor.
 on:
-  workflow_run:
-    workflows: ["Deploy to GitHub Pages"]
-    types: [completed]
-
-concurrency:
-  # 1:1 alignment with the deploy workflow — each deploy run gets its own
-  # validation that runs to completion. Keying the concurrency group on the
-  # triggering deploy's run ID guarantees no two post-deploys ever share a
-  # group, so `cancel-in-progress` (still true as a defensive default) only
-  # ever fires on a re-run of the same deploy.
-  #
-  # Previous setting `group: post-deploy-validation` with cancel-in-progress
-  # killed validation A mid-flight whenever validation B started (regardless
-  # of whether deploy A had already succeeded). For workflow_dispatch flows
-  # that publish articles to Facebook/LinkedIn, this dropped posts whenever
-  # two articles deployed back-to-back. The new key isolates each run.
-  group: post-deploy-validation-${{ github.event.workflow_run.id }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      deploy_run_id:
+        description: 'Run ID of the calling deploy workflow. Used to download the github-pages artifact, winners artifact, and pre-deploy snapshot. Pass `${{ github.run_id }}` from the caller.'
+        required: true
+        type: string
+      deploy_event_name:
+        description: 'github.event_name from the caller. Used to gate Facebook/LinkedIn posting and live-meta wait to workflow_dispatch deploys (article publishing pipeline).'
+        required: true
+        type: string
 
 jobs:
-  # Quick pre-check: did the deploy actually succeed and produce a Pages
-  # artifact?
-  #
-  # Mirroring contract — every deploy run produces exactly one
-  # post-deploy run with the SAME terminal conclusion:
-  #   - deploy success   → post-deploy continues to validate (success on green)
-  #   - deploy cancelled → post-deploy cancels itself via `gh run cancel`
-  #     so the Actions UI shows "cancelled", not the misleading "skipped"
-  #     that a job-level `if` evaluates-false would produce
-  #   - deploy failure   → post-deploy fails (exit 1) so the UI shows
-  #     "failure", again preserving the deploy's terminal state
-  #   - profile-only run → post-deploy succeeds with a no-op (the only
-  #     case where mirroring deliberately diverges, because a profile run
-  #     never reaches a deployable artifact and there is nothing to validate)
-  #
-  # Why mirror at all: a 1:1 deploy↔post-deploy alignment makes the
-  # Actions UI a faithful audit log. When you see 8 deploy runs and 8
-  # post-deploys, each pair shares a status, you can scan the list and
-  # immediately tell "every red here matches a red there" instead of
-  # decoding "skipped" as either "deploy succeeded but profile run" or
-  # "deploy cancelled by concurrency" or "validation gated off".
-  pre-check:
-    runs-on: ubuntu-latest
-    outputs:
-      deployable: ${{ steps.check.outputs.deployable }}
-    permissions:
-      actions: write   # gh run cancel on this run when deploy was cancelled
-    steps:
-      - name: Mirror deploy conclusion (cancel/fail to match deploy terminal state)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPLOY_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-        run: |
-          echo "Triggering deploy concluded with: $DEPLOY_CONCLUSION"
-          case "$DEPLOY_CONCLUSION" in
-            success)
-              echo "Deploy succeeded — proceeding to artifact check + validation."
-              ;;
-            cancelled)
-              echo "Deploy was cancelled — cancelling this post-deploy run to mirror."
-              gh run cancel "${{ github.run_id }}" -R "${{ github.repository }}"
-              # `gh run cancel` is async; sleep so the runner sees SIGTERM
-              # before the next step starts. exit 1 is a belt-and-suspenders
-              # in case cancel doesn't land in time — the run still ends red,
-              # which matches the deploy's red better than a green "skipped".
-              sleep 30
-              exit 1
-              ;;
-            *)
-              # failure / timed_out / action_required / stale / null etc.
-              # Fail loud so the UI status mirrors the deploy's failure.
-              echo "Deploy did not succeed — failing this post-deploy run to mirror."
-              exit 1
-              ;;
-          esac
-
-      - name: Check for GitHub Pages artifact
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          count=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
-            --jq "[.artifacts[] | select(.name == \"github-pages\")] | length")
-          if [ "${count:-0}" -gt 0 ]; then
-            echo "deployable=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "deployable=false" >> "$GITHUB_OUTPUT"
-            echo "No github-pages artifact — profile-only run. Skipping validation."
-          fi
-
   validate:
-    needs: pre-check
-    if: ${{ needs.pre-check.outputs.deployable == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write   # for git commit/push in sync-previous-slug-winners
@@ -102,32 +32,12 @@ jobs:
     env:
       PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
     steps:
-      # Resolve the deploy's actual head_sha via the gh API instead of trusting
-      # `github.event.workflow_run.head_sha`. The event payload value can drift
-      # from the deploy's true head_sha when concurrent/cancelled deploys race
-      # (observed: post-deploy run 25377607613 had event head_sha=2ee881e while
-      # the deploy run 25377550358 was actually built from 4187b27792). The
-      # gh API on the deploy run is stable.
-      - name: Resolve actual deploy SHA
-        id: deploy-sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          api_sha=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" \
-            --jq .head_sha)
-          event_sha="${{ github.event.workflow_run.head_sha }}"
-          echo "Deploy run ${{ github.event.workflow_run.id }} → API head_sha: $api_sha"
-          if [ "$api_sha" != "$event_sha" ]; then
-            echo "::warning::workflow_run.head_sha drift — event=$event_sha api=$api_sha (using API)"
-          fi
-          echo "sha=$api_sha" >> "$GITHUB_OUTPUT"
-
+      # Same run as the deploy → github.sha is the deploy's SHA by
+      # construction. No need to resolve via workflow_run event payload.
       - name: Checkout (same SHA as deploy)
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.deploy-sha.outputs.sha }}
+          ref: ${{ github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -179,7 +89,7 @@ jobs:
       - name: Source validators + download GitHub Pages artifact (parallel)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPLOY_RUN_ID: ${{ github.event.workflow_run.id }}
+          DEPLOY_RUN_ID: ${{ inputs.deploy_run_id }}
         run: |
           : > /tmp/source-val-failures.txt
 
@@ -414,13 +324,13 @@ jobs:
         continue-on-error: true
         run: |
           DATA=$(node scripts/deploy-registry.mjs get \
-            --run-id="${{ github.event.workflow_run.id }}" 2>/dev/null || echo '{}')
+            --run-id="${{ inputs.deploy_run_id }}" 2>/dev/null || echo '{}')
           echo "data=$DATA" >> "$GITHUB_OUTPUT"
 
       - name: Wait for live article metadata
         if: |
           success() &&
-          github.event.workflow_run.event == 'workflow_dispatch' &&
+          inputs.deploy_event_name == 'workflow_dispatch' &&
           fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl != null
         id: wait_live_meta
         continue-on-error: true
@@ -437,7 +347,7 @@ jobs:
       - name: Post to Facebook Page
         if: |
           success() &&
-          github.event.workflow_run.event == 'workflow_dispatch' &&
+          inputs.deploy_event_name == 'workflow_dispatch' &&
           fromJson(steps.deploy-meta.outputs.data || '{}').articleId != null &&
           steps.wait_live_meta.outcome == 'success'
         continue-on-error: true
@@ -458,7 +368,7 @@ jobs:
       - name: Post to LinkedIn Company Page
         if: |
           success() &&
-          github.event.workflow_run.event == 'workflow_dispatch' &&
+          inputs.deploy_event_name == 'workflow_dispatch' &&
           fromJson(steps.deploy-meta.outputs.data || '{}').articleId != null &&
           steps.wait_live_meta.outcome == 'success'
         continue-on-error: true
@@ -516,8 +426,8 @@ jobs:
         if: success()
         run: |
           node scripts/deploy-registry.mjs set-good \
-            --run-id="${{ github.event.workflow_run.id }}" \
-            --sha="${{ github.event.workflow_run.head_sha }}"
+            --run-id="${{ inputs.deploy_run_id }}" \
+            --sha="${{ github.sha }}"
 
       - name: Report failure to Linear
         if: failure()
@@ -526,10 +436,10 @@ jobs:
           node scripts/lib/linear-issue-creator.mjs \
             --title "Validation Failure: post-deploy-validation — run ${{ github.run_number }}" \
             --description "## Validazione post-deploy fallita
-          **Deploy run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          **Deploy run:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
           **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          **Branch:** ${{ github.event.workflow_run.head_branch }}
-          **SHA:** ${{ github.event.workflow_run.head_sha }}" \
+          **Branch:** ${{ github.ref_name }}
+          **SHA:** ${{ github.sha }}" \
             --priority 1 \
             --label Bug \
             --workflow "Post-deploy Validation"
@@ -628,12 +538,12 @@ jobs:
           if [ "${{ steps.rollback_deploy.outcome }}" = "success" ]; then
             MSG="## Rollback eseguito
           **Rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})
-          **Deploy fallito:** https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          **Deploy fallito:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
           **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             MSG="## Rollback fallito
           **Tentato rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})
-          **Deploy fallito:** https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          **Deploy fallito:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
           **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
           node scripts/lib/linear-issue-creator.mjs \


### PR DESCRIPTION
## Summary
Convert `post-deploy-validation.yml` from `on: workflow_run` → `on: workflow_call`, and chain it from `deploy.yml` as a `needs: build-and-deploy` job in the **same run**.

This kills both failure modes that produced the silent `audit:title-length` regression discussed in commit 53cf789d94:

- `github.event.workflow_run.head_sha` drift (validate job checked out the wrong SHA → audited the right dist with a stale `--threshold=90` npm wrapper, masking 53k+ offender regression vs 16k baseline).
- Double concurrency groups → every cancelled deploy left an orphan cancelled post-deploy run.

In same-run mode, `github.sha` is invariant by construction and deploy cancellation propagates via `needs:` semantics — no more orphans.

## Behaviour matrix

| Deploy outcome | Before (workflow_run) | After (workflow_call) |
|---|---|---|
| success | post-deploy runs in separate run | post-deploy runs in same run |
| cancelled | orphan cancelled post-deploy | post-deploy skipped (needs:) |
| failure | post-deploy mirrors failure via pre-check | post-deploy skipped (needs:) |
| profile-only | post-deploy success no-op | post-deploy skipped via if: |

## Files
- `.github/workflows/post-deploy-validation.yml` — `on: workflow_call` + 2 inputs (`deploy_run_id`, `deploy_event_name`); drop `pre-check` job; drop concurrency block; drop the resolve-SHA step from 53cf789d94 (no longer needed); substitute all `github.event.workflow_run.*` references.
- `.github/workflows/deploy.yml` — new \`post-deploy-validate\` job (\`uses:\` reusable); top-level permissions widened (contents:read → write, +actions:read) as caps for the called job; build-and-deploy itself doesn't exercise the wider scopes.

## Test plan
- [ ] Branch CI passes (build-and-deploy + post-deploy-validate chained)
- [ ] Push to main triggers exactly ONE Actions run, not two (no separate Post-deploy Validation entry)
- [ ] On a deliberately failing audit (e.g. tighten a baseline), post-deploy-validate fails the run (proves the gate is hooked up after the spawn_capped fix in 53cf789d94)
- [ ] On a profile-only workflow_dispatch (`profile_sequential=true`), post-deploy-validate is skipped, deploy completes
- [ ] On article-publishing workflow_dispatch, FB/LinkedIn posts still fire (uses `inputs.deploy_event_name == 'workflow_dispatch'`)
- [ ] Rollback path still functional (rollback job inherits the same call-site permissions cap)

## Notes
- `secrets: inherit` passes all repo/org secrets to the reusable workflow (Firebase SA, FB tokens, etc.) — same access as before.
- The `github-pages` environment used by the rollback job exists in the repo (already used by build-and-deploy), so the environment binding still resolves.
- No backward compatibility broken: workflow filename + `name:` header unchanged; the only consumer of the old `workflow_run` linkage was GitHub itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)