### PR TITLE
ci: split validate into dist + live (4-job pipeline, sitemaps artifact bundle)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ permissions:
   id-token: write
 
 jobs:
-  build-and-deploy:
+  build:
     # JOB-LEVEL concurrency. Critical: must be on the JOB, not on the
     # workflow. With job-level concurrency the lock is released as soon
     # as `build-and-deploy` finishes, even when the `post-deploy` job
@@ -363,6 +363,67 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+      # Pack the new sitemap URLs (extracted from dist/sitemap-*.xml) into
+      # /tmp/new-sitemap-urls.json so validate-live can submit them to
+      # IndexNow / Google Indexing API without scraping the live site or
+      # downloading the 1.5 GB github-pages artifact. Bundled together
+      # with the pre-deploy snapshot into a single small `sitemaps-`
+      # artifact for convenience.
+      - name: Pack new sitemap URLs from dist/
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        run: |
+          node -e "
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const distDir = 'dist';
+            if (!fs.existsSync(distDir)) {
+              console.error('dist/ missing — skipping new-sitemap-urls.json');
+              process.exit(0);
+            }
+            const files = fs.readdirSync(distDir)
+              .filter(f => /^sitemap-.+\.xml\$/.test(f) && f !== 'sitemap-index.xml')
+              .sort();
+            const perSitemap = {};
+            const all = new Set();
+            for (const f of files) {
+              const xml = fs.readFileSync(path.join(distDir, f), 'utf8');
+              const urls = [...new Set([...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim()))].sort();
+              perSitemap[f] = urls;
+              for (const u of urls) all.add(u);
+            }
+            const out = {
+              version: 2,
+              capturedAt: new Date().toISOString(),
+              source: 'dist',
+              perSitemap,
+              _allUrls: [...all].sort(),
+            };
+            fs.writeFileSync('/tmp/new-sitemap-urls.json', JSON.stringify(out));
+            console.log('📦 Packed ' + out._allUrls.length + ' new sitemap URLs across ' + Object.keys(perSitemap).length + ' files → /tmp/new-sitemap-urls.json');
+          "
+
+      - name: Stage sitemaps bundle (pre-deploy + new)
+        if: github.event.inputs.profile_sequential != 'true'
+        continue-on-error: true
+        run: |
+          mkdir -p /tmp/sitemaps-bundle
+          cp -f /tmp/pre-deploy-sitemap-urls.json /tmp/sitemaps-bundle/ 2>/dev/null || true
+          cp -f /tmp/new-sitemap-urls.json /tmp/sitemaps-bundle/ 2>/dev/null || true
+          ls -la /tmp/sitemaps-bundle/
+
+      # Single small artifact (~tens of KB) consumed by validate-live for
+      # IndexNow / Google Indexing diff. Lets validate-live skip the
+      # 1.5 GB github-pages artifact entirely.
+      - name: Upload sitemaps bundle artifact
+        if: github.event.inputs.profile_sequential != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sitemaps-${{ github.run_id }}
+          path: /tmp/sitemaps-bundle/
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Merge previous CSS/JS assets for Clarity recordings
         # Runs as the LAST mutation of dist/ before upload, on purpose.
         # Earlier in the pipeline this step ran right after the build, but
@@ -479,32 +540,97 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Report failure to Linear (build)
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "CI Failure (build): ${{ github.workflow }} — run ${{ github.run_number }}" \
+            --description "## Build fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 1 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"
+
+  # ───────────────────────────────────────────────────────────────────────
+  # deploy: publish dist/ to GitHub Pages (actions/deploy-pages reads the
+  # `github-pages` artifact from this run automatically). Inherits the
+  # `pages-deploy` concurrency group so build+deploy together hold the
+  # serial Pages lock for the upload+publish sequence — but each job
+  # individually rilascia la lock when complete.
+  # ───────────────────────────────────────────────────────────────────────
+  deploy:
+    needs: build
+    if: |
+      success() &&
+      github.event.inputs.profile_sequential != 'true'
+    concurrency:
+      group: ${{ github.event.inputs.profile_sequential == 'true' && format('pages-deploy-profile-{0}', github.run_id) || 'pages-deploy' }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_first.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          fi
+
       # GitHub Pages allows only one deployment at a time. When concurrent
       # pushes trigger this workflow, the second run can hit "in progress
       # deployment" errors. Retry once after a short wait to handle this.
       - name: Deploy to GitHub Pages
-        if: github.event.inputs.profile_sequential != 'true'
         id: deployment_first
         uses: actions/deploy-pages@v5
         continue-on-error: true
 
       - name: Wait for previous Pages deployment to finish
-        if: github.event.inputs.profile_sequential != 'true' && steps.deployment_first.outcome == 'failure'
+        if: steps.deployment_first.outcome == 'failure'
         run: |
           echo "::warning::First deploy attempt failed (likely Pages busy). Retrying in 30s..."
           sleep 30
 
       - name: Deploy to GitHub Pages (retry)
         id: deployment
-        if: github.event.inputs.profile_sequential != 'true' && steps.deployment_first.outcome == 'failure'
+        if: steps.deployment_first.outcome == 'failure'
         uses: actions/deploy-pages@v5
 
       - name: Fail if both deploy attempts failed
-        if: github.event.inputs.profile_sequential != 'true' && steps.deployment_first.outcome == 'failure' && steps.deployment.outcome != 'success'
+        if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome != 'success'
         run: exit 1
 
       - name: Save deploy metadata to Firestore
-        if: success() && github.event.inputs.profile_sequential != 'true'
+        if: success()
         env:
           ARTICLE_ID: ${{ github.event.inputs.article_id }}
           ARTICLE_URL: ${{ github.event.inputs.article_url }}
@@ -524,12 +650,12 @@ jobs:
             --og-image="${OG_IMAGE}" \
             --article-category="${ARTICLE_CATEGORY}"
 
-      - name: Report failure to Linear
+      - name: Report failure to Linear (deploy)
         if: failure()
         continue-on-error: true
         run: |
           node scripts/lib/linear-issue-creator.mjs \
-            --title "CI Failure: ${{ github.workflow }} — run ${{ github.run_number }}" \
+            --title "CI Failure (deploy): ${{ github.workflow }} — run ${{ github.run_number }}" \
             --description "## Deploy fallito
           **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** ${{ github.ref_name }}
@@ -538,30 +664,217 @@ jobs:
             --label Bug \
             --workflow "${{ github.workflow }}"
 
-  # Validation runs as a downstream job in this same workflow run, NOT as a
-  # separate workflow_run-triggered run. Same-run validation:
-  #   • removes the workflow_run.head_sha drift (github.sha is invariant);
-  #   • removes the cross-workflow `gh run download` lookup lag (we use
-  #     actions/download-artifact@v5 against the current run id);
-  #   • produces a 1:1 deploy ↔ validate mapping in the Actions UI (no
-  #     more "cancelled" post-deploys for cancelled/skipped deploys).
-  #
-  # The lock on `pages-deploy` is released by `build-and-deploy` above as
-  # soon as it completes (job-level concurrency). Validation can therefore
-  # run in parallel with the *next* deploy, which is the whole point of
-  # this refactor for cron-driven content (~15 min cadence).
-  post-deploy:
-    needs: build-and-deploy
+  # ───────────────────────────────────────────────────────────────────────
+  # validate-dist: dist-side gates (bfs-depth, text-html-ratio, ...).
+  # Runs in PARALLEL with `deploy` — only needs `build` (the artifact).
+  # ───────────────────────────────────────────────────────────────────────
+  validate-dist:
+    needs: build
     if: |
       success() &&
       github.event.inputs.profile_sequential != 'true'
-    uses: ./.github/workflows/post-deploy-validation.yml
+    uses: ./.github/workflows/post-deploy-validate-dist.yml
     with:
       deploy_run_id: ${{ github.run_id }}
       deploy_event_name: ${{ github.event_name }}
     secrets: inherit
     permissions:
-      contents: write   # sync-previous-slug-winners + git push
+      contents: read    # checkout
       actions: read     # download-artifact same-run
-      pages: write      # rollback redeploy
-      id-token: write   # rollback redeploy
+
+  # ───────────────────────────────────────────────────────────────────────
+  # validate-live: live smoke + social posting + indexing submission.
+  # Needs `deploy` to have published the new dist before fetching live.
+  # ───────────────────────────────────────────────────────────────────────
+  validate-live:
+    needs: deploy
+    if: |
+      success() &&
+      github.event.inputs.profile_sequential != 'true'
+    uses: ./.github/workflows/post-deploy-validate-live.yml
+    with:
+      deploy_run_id: ${{ github.run_id }}
+      deploy_event_name: ${{ github.event_name }}
+    secrets: inherit
+    permissions:
+      contents: write   # sync previous-slug winners (git push)
+      actions: read     # download small artifacts (sitemaps, winners)
+
+  # ───────────────────────────────────────────────────────────────────────
+  # rollback: revert Pages to last_known_good if either validate fails.
+  # Still-live guard: skip rollback if a newer deploy has already replaced
+  # ours on Pages — the bad version is gone, no need to clobber the new
+  # good one.
+  # ───────────────────────────────────────────────────────────────────────
+  rollback:
+    needs: [deploy, validate-dist, validate-live]
+    if: |
+      always() &&
+      (needs.validate-dist.result == 'failure' || needs.validate-live.result == 'failure') &&
+      needs.deploy.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
+    environment:
+      name: github-pages
+      url: ${{ steps.rollback_deploy.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          fi
+
+      # Validate-dist + validate-live run concurrently with the next
+      # deploy's build. By the time this rollback fires, a newer deploy
+      # may already be live on Pages — reverting our (failed) deploy
+      # would clobber a valid newer one. Check the live Pages deployment
+      # SHA before proceeding.
+      - name: Verify our deploy is still live (still-live guard)
+        id: still-live
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          live_sha=$(gh api \
+            "repos/${{ github.repository }}/deployments?environment=github-pages&per_page=1" \
+            --jq '.[0].sha // empty')
+          my_sha="${{ github.sha }}"
+          echo "Live Pages deployment SHA: ${live_sha:-(unknown)}"
+          echo "My deploy SHA:             $my_sha"
+          if [ -z "$live_sha" ]; then
+            echo "::warning::Could not resolve live deployment SHA — proceeding with rollback as best-effort"
+            echo "still_live=true" >> "$GITHUB_OUTPUT"
+          elif [ "$live_sha" = "$my_sha" ]; then
+            echo "✅ My deploy is still live — rollback is the right action."
+            echo "still_live=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ℹ️ A newer deploy ($live_sha) has already replaced mine on Pages."
+            echo "   Rollback is a no-op — skipping. The newer deploy already removed the bad version."
+            echo "still_live=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get last known good deploy
+        if: steps.still-live.outputs.still_live == 'true'
+        id: last-good
+        run: |
+          DATA=$(node scripts/deploy-registry.mjs get-good 2>/dev/null || echo '{}')
+          RUN_ID=$(echo "$DATA" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(d).runId||'')}catch{console.log('')}})")
+          SHA=$(echo "$DATA" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(d).sha||'')}catch{console.log('')}})")
+          echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          if [ -z "$RUN_ID" ]; then
+            echo "::warning::No last_known_good found in Firestore — cannot rollback."
+          else
+            echo "Rolling back to run $RUN_ID (sha $SHA)"
+          fi
+
+      - name: Fail if no last known good deploy is available
+        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id == ''
+        run: |
+          echo "::error::No last_known_good deploy found in Firestore. Cannot perform rollback."
+          exit 1
+
+      # Cross-run download. Pin to the SPECIFIC artifact id (resolved via
+      # gh api) to avoid the "Multiple artifacts named github-pages were
+      # unexpectedly found for this workflow run" error that
+      # actions/download-artifact@v5 throws when the source run had both
+      # a deploy AND a self-rollback (which uploads a second
+      # `github-pages` artifact for re-publishing).
+      - name: Resolve last-good github-pages artifact id
+        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
+        id: last-good-artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Pick the FIRST `github-pages` (oldest = the original deploy
+          # upload, not a later rollback re-upload).
+          artifact_id=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ steps.last-good.outputs.run-id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name == "github-pages")] | sort_by(.created_at) | .[0].id // empty')
+          if [ -z "$artifact_id" ]; then
+            echo "::error::No github-pages artifact in run ${{ steps.last-good.outputs.run-id }}"
+            exit 1
+          fi
+          echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
+          echo "Resolved last-good github-pages artifact id: $artifact_id"
+
+      - name: Download last known good GitHub Pages artifact (by id)
+        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p ./rollback-archive
+          gh api "repos/${{ github.repository }}/actions/artifacts/${{ steps.last-good-artifact.outputs.id }}/zip" \
+            > ./rollback-archive/__artifact.zip
+          unzip -q -o ./rollback-archive/__artifact.zip -d ./rollback-archive
+          rm -f ./rollback-archive/__artifact.zip
+
+      - name: Reconstruct rollback site from downloaded Pages artifact
+        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
+        run: |
+          test -f ./rollback-archive/artifact.tar
+          mkdir -p ./rollback-dist
+          tar -xf ./rollback-archive/artifact.tar -C ./rollback-dist
+
+      - name: Re-upload last known good artifact for Pages
+        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ./rollback-dist
+
+      - name: Deploy last known good to GitHub Pages
+        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
+        id: rollback_deploy
+        uses: actions/deploy-pages@v5
+
+      - name: Report rollback to Linear
+        if: always()
+        continue-on-error: true
+        run: |
+          if [ "${{ steps.still-live.outputs.still_live }}" != "true" ]; then
+            MSG="## Rollback skippato (newer deploy already live)
+          **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Last good (NOT rolled back):** ${{ steps.last-good.outputs.run-id }}"
+          elif [ "${{ steps.rollback_deploy.outcome }}" = "success" ]; then
+            MSG="## Rollback eseguito
+          **Rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})
+          **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            MSG="## Rollback fallito
+          **Tentato rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})
+          **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Rollback: post-deploy — run ${{ github.run_number }}" \
+            --description "$MSG" \
+            --priority 1 \
+            --label Bug \
+            --workflow "Post-deploy Rollback"

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -1,15 +1,21 @@
-name: Post-deploy Validation
+name: Post-deploy Validate (dist)
 
-# Reusable workflow called from deploy.yml as the `post-deploy` job.
+# Reusable workflow called from deploy.yml as the `validate-dist` job.
+# Runs in PARALLEL with `deploy` (the actual Pages publication), starting
+# as soon as the `build` job finishes uploading the `github-pages`
+# artifact. Everything here reads from `dist/` only — no live site
+# dependency. By design this job does NOT need `actions/deploy-pages`
+# to have completed.
+#
 # Same-run model:
 #   • github.sha is invariant — no more workflow_run.head_sha drift
 #   • actions/download-artifact@v5 with run-id same-run → no API lag
 #   • 1:1 deploy↔validate mapping in the Actions UI by construction;
 #     no more "cancelled" post-deploys for cancelled/skipped deploys
 #     (the parent gates this entire workflow with `if: success()`)
-#   • the parent `build-and-deploy` job has job-level concurrency on
-#     `pages-deploy` so the lock is released as soon as deploy finishes,
-#     and the next deploy can build while validate runs in parallel
+#   • the parent `build` job has job-level concurrency on
+#     `pages-deploy` so the lock is released as soon as build finishes,
+#     and the next deploy can start while validate-dist + deploy run.
 on:
   workflow_call:
     inputs:
@@ -23,11 +29,10 @@ on:
         type: string
 
 jobs:
-  validate:
+  validate-dist:
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # for git commit/push in sync-previous-slug-winners
-      actions: read     # for download-artifact same-run
+      actions: read     # for download-artifact same-run (github-pages, sitemaps)
     env:
       PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
     steps:
@@ -381,8 +386,11 @@ jobs:
             npm run audit:image-object-license
           spawn_capped audit:max-bfs-depth           /tmp/g19.log \
             npm run audit:max-bfs-depth
-          spawn_capped live:post-deploy-smoke        /tmp/live-smoke.log \
-            bash -lc 'node scripts/wait-for-pages-propagation.mjs && npm run probe:5xx && LIVE_BASE_URL=https://frontaliereticino.ch npm run test:e2e:live'
+          # NOTE: live:post-deploy-smoke moved to validate-live workflow.
+          # This validate-dist job runs in parallel with `deploy`, before
+          # the new dist is published — there's nothing live to smoke
+          # yet. The smoke + e2e:live now lives in
+          # post-deploy-validate-live.yml as a dedicated step.
 
           # Wait for the serialized dist-multi chain explicitly, then the
           # rest of the spawn_capped pool. Two `wait` calls (one targeted,
@@ -433,7 +441,13 @@ jobs:
       # the log into data/bfs-depth-baseline.json — no artifact download,
       # no re-run of the seed workflow. Informational only — never fails.
       - name: Dump bfs-depth baseline candidate (informational)
-        if: success()
+        # `if: always()` so the baseline JSON is dumped even when another
+        # gate in the pool fails — the dump is informational and never
+        # blocks the workflow. Without `always()` a failure of any other
+        # gate would skip this step and force a manual seed-workflow run
+        # to refresh the baseline. Pairs with continue-on-error so a bad
+        # snapshot itself can't fail the job either.
+        if: always()
         continue-on-error: true
         run: |
           echo "══════════════════════════════════════════════════════════════"
@@ -475,295 +489,17 @@ jobs:
           echo "Sitemaps:"
           find dist -name "sitemap*.xml" -exec du -sh {} + | sort -rh || true
 
-      - name: Sync previous-slug winners registry
-        # The build in deploy.yml may update data/previous-slug-winners.json.
-        # The updated file is downloaded from the winners artifact above.
-        # If it changed relative to HEAD, commit and push it here.
-        if: success()
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet data/previous-slug-winners.json; then
-            echo "[previous-slug-winners] no changes to commit"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/previous-slug-winners.json
-          git commit -m "chore(seo): sync previous-slug winners registry"
-          git stash push --keep-index --include-untracked -m "validation-build-tree" || true
-          bash scripts/lib/git-push-with-retry.sh \
-            --in-place-resolver-cmd "node scripts/lib/resolve-winners-conflict.mjs && git add -A"
-          git stash pop || true
-
-      - name: Read deploy metadata from Firestore
-        id: deploy-meta
-        continue-on-error: true
-        run: |
-          DATA=$(node scripts/deploy-registry.mjs get \
-            --run-id="${{ inputs.deploy_run_id }}" 2>/dev/null || echo '{}')
-          echo "data=$DATA" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for live article metadata
-        if: |
-          success() &&
-          inputs.deploy_event_name == 'workflow_dispatch' &&
-          fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl != null
-        id: wait_live_meta
-        continue-on-error: true
-        env:
-          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
-          OG_TITLE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogTitle }}
-          OG_IMAGE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogImage }}
-        run: |
-          node scripts/wait-for-live-article-meta.mjs \
-            "$ARTICLE_URL" \
-            "$OG_TITLE" \
-            "$OG_IMAGE"
-
-      - name: Post to Facebook Page
-        if: |
-          success() &&
-          inputs.deploy_event_name == 'workflow_dispatch' &&
-          fromJson(steps.deploy-meta.outputs.data || '{}').articleId != null &&
-          steps.wait_live_meta.outcome == 'success'
-        continue-on-error: true
-        env:
-          ARTICLE_ID: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleId }}
-          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
-          OG_TITLE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogTitle }}
-          OG_DESCRIPTION: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogDescription }}
-          ARTICLE_CATEGORY: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleCategory }}
-        run: |
-          node scripts/post-to-facebook.mjs \
-            "$ARTICLE_ID" \
-            "$ARTICLE_URL" \
-            "$OG_TITLE" \
-            "$OG_DESCRIPTION" \
-            "$ARTICLE_CATEGORY"
-
-      - name: Post to LinkedIn Company Page
-        if: |
-          success() &&
-          inputs.deploy_event_name == 'workflow_dispatch' &&
-          fromJson(steps.deploy-meta.outputs.data || '{}').articleId != null &&
-          steps.wait_live_meta.outcome == 'success'
-        continue-on-error: true
-        env:
-          ARTICLE_ID: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleId }}
-          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
-          OG_TITLE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogTitle }}
-          OG_DESCRIPTION: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogDescription }}
-          ARTICLE_CATEGORY: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleCategory }}
-        run: |
-          node scripts/post-to-linkedin.mjs \
-            "$ARTICLE_ID" \
-            "$ARTICLE_URL" \
-            "$OG_TITLE" \
-            "$OG_DESCRIPTION" \
-            "$ARTICLE_CATEGORY"
-
-      - name: Restore indexing API daily tracker
-        id: indexing-cache
-        uses: actions/cache@v5
-        with:
-          path: /tmp/indexing-api-submitted-today.json
-          key: indexing-api-${{ github.run_id }}
-          restore-keys: |
-            indexing-api-
-
-      - name: Post-deploy indexing (parallel)
-        if: success()
-        continue-on-error: true
-        timeout-minutes: 5
-        env:
-          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
-        run: |
-          timeout 90 node scripts/submit-google-indexing-jobs.js &
-          PID_GOOGLE=$!
-          timeout 90 node scripts/submit-indexnow.js &
-          PID_INDEXNOW=$!
-          timeout 180 node scripts/submit-google-indexing.js &
-          PID_GSC=$!
-          timeout 90 node scripts/verify-post-deploy-seo.mjs &
-          PID_SEO=$!
-
-          FAIL=0
-          wait $PID_GOOGLE  || { echo "⚠️ Google Indexing API failed"; FAIL=1; }
-          wait $PID_INDEXNOW || { echo "⚠️ IndexNow submission failed"; FAIL=1; }
-          wait $PID_GSC     || { echo "⚠️ GSC submission failed"; FAIL=1; }
-          wait $PID_SEO     || { echo "⚠️ Post-deploy SEO verification failed"; FAIL=1; }
-
-          if [ $FAIL -ne 0 ]; then
-            echo "::warning::Some post-deploy indexing steps failed (non-blocking)"
-          fi
-          echo "✅ Post-deploy indexing complete"
-
-      - name: Mark deploy as last known good
-        if: success()
-        run: |
-          node scripts/deploy-registry.mjs set-good \
-            --run-id="${{ inputs.deploy_run_id }}" \
-            --sha="${{ github.sha }}"
-
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
         run: |
           node scripts/lib/linear-issue-creator.mjs \
-            --title "Validation Failure: post-deploy-validation — run ${{ github.run_number }}" \
-            --description "## Validazione post-deploy fallita
+            --title "Validation Failure (dist): post-deploy — run ${{ github.run_number }}" \
+            --description "## Dist validation post-deploy fallita
           **Deploy run:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
           **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** ${{ github.ref_name }}
           **SHA:** ${{ github.sha }}" \
             --priority 1 \
             --label Bug \
-            --workflow "Post-deploy Validation"
-
-  rollback:
-    needs: validate
-    if: ${{ always() && needs.validate.result == 'failure' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-      actions: read
-    environment:
-      name: github-pages
-      url: ${{ steps.rollback_deploy.outputs.page_url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-
-      - name: Cache node_modules
-        id: node-modules-cache
-        uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: npm ci
-
-      - name: Prepare Firebase credentials
-        env:
-          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
-        run: |
-          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
-            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
-            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
-          fi
-
-      # Still-live guard. Validate runs in parallel with the next deploy
-      # (job-level concurrency on `pages-deploy` releases the lock when
-      # build-and-deploy finishes). So when this rollback fires, a NEWER
-      # deploy may already be live on GitHub Pages — in which case
-      # reverting our own (failed) deploy would clobber a perfectly good
-      # one. Check the live Pages deployment's SHA: if it isn't ours,
-      # skip rollback and just alert (the next deploy already replaced
-      # the bad one).
-      - name: Verify our deploy is still live (still-live guard)
-        id: still-live
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Get the latest github-pages environment deployment SHA.
-          live_sha=$(gh api \
-            "repos/${{ github.repository }}/deployments?environment=github-pages&per_page=1" \
-            --jq '.[0].sha // empty')
-          my_sha="${{ github.sha }}"
-          echo "Live Pages deployment SHA: ${live_sha:-(unknown)}"
-          echo "My deploy SHA:             $my_sha"
-          if [ -z "$live_sha" ]; then
-            echo "::warning::Could not resolve live deployment SHA — proceeding with rollback as best-effort"
-            echo "still_live=true" >> "$GITHUB_OUTPUT"
-          elif [ "$live_sha" = "$my_sha" ]; then
-            echo "✅ My deploy is still live — rollback is the right action."
-            echo "still_live=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ℹ️ A newer deploy ($live_sha) has already replaced mine on Pages."
-            echo "   Rollback is a no-op — skipping. The newer deploy already removed the bad version."
-            echo "still_live=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Get last known good deploy
-        if: steps.still-live.outputs.still_live == 'true'
-        id: last-good
-        run: |
-          DATA=$(node scripts/deploy-registry.mjs get-good 2>/dev/null || echo '{}')
-          RUN_ID=$(echo "$DATA" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(d).runId||'')}catch{console.log('')}})")
-          SHA=$(echo "$DATA" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(d).sha||'')}catch{console.log('')}})")
-          echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          if [ -z "$RUN_ID" ]; then
-            echo "::warning::No last_known_good found in Firestore — cannot rollback."
-          else
-            echo "Rolling back to run $RUN_ID (sha $SHA)"
-          fi
-
-      - name: Fail if no last known good deploy is available
-        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id == ''
-        run: |
-          echo "::error::No last_known_good deploy found in Firestore. Cannot perform rollback."
-          exit 1
-
-      - name: Download last known good GitHub Pages artifact
-        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
-        uses: actions/download-artifact@v5
-        with:
-          name: github-pages
-          path: ./rollback-archive
-          run-id: ${{ steps.last-good.outputs.run-id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Reconstruct rollback site from downloaded Pages artifact
-        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
-        run: |
-          test -f ./rollback-archive/artifact.tar
-          mkdir -p ./rollback-dist
-          tar -xf ./rollback-archive/artifact.tar -C ./rollback-dist
-
-      - name: Re-upload last known good artifact for Pages
-        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
-        uses: actions/upload-pages-artifact@v5
-        # Note: rollback path — compression-level 9 would be ideal here too
-        # but upload-pages-artifact does not expose that parameter. The rollback
-        # path is rare enough that the default level-6 zip is acceptable.
-        with:
-          path: ./rollback-dist
-
-      - name: Deploy last known good to GitHub Pages
-        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != ''
-        id: rollback_deploy
-        uses: actions/deploy-pages@v5
-
-      - name: Report rollback to Linear
-        if: always()
-        continue-on-error: true
-        run: |
-          if [ "${{ steps.rollback_deploy.outcome }}" = "success" ]; then
-            MSG="## Rollback eseguito
-          **Rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})
-          **Deploy fallito:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
-          **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          else
-            MSG="## Rollback fallito
-          **Tentato rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})
-          **Deploy fallito:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
-          **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          fi
-          node scripts/lib/linear-issue-creator.mjs \
-            --title "Rollback: post-deploy-validation — run ${{ github.run_number }}" \
-            --description "$MSG" \
-            --priority 1 \
-            --label Bug \
-            --workflow "Post-deploy Validation Rollback"
+            --workflow "Post-deploy Validate Dist"

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -1,0 +1,273 @@
+name: Post-deploy Validate (live)
+
+# Reusable workflow called from deploy.yml as the `validate-live` job.
+# Runs AFTER `actions/deploy-pages@v5` has published the new dist to
+# GitHub Pages. Everything here needs the live site (smoke E2E, OG meta
+# scraping, social posting, indexing submission).
+#
+# By design, this job does NOT download the 1.5 GB github-pages artifact:
+# every step here either fetches the live site directly or reads small
+# JSON artifacts (winners, sitemaps snapshot). That keeps the job light
+# and lets it run in parallel with `validate-dist` (which holds the
+# dist).
+#
+# Inputs:
+#   deploy_run_id     — caller's github.run_id (for cross-job artifact
+#                       names like winners-${run_id})
+#   deploy_event_name — caller's github.event_name; used to gate
+#                       Facebook/LinkedIn posting + live-meta wait to
+#                       workflow_dispatch deploys (article publishing
+#                       pipeline only).
+on:
+  workflow_call:
+    inputs:
+      deploy_run_id:
+        description: 'Run ID of the calling deploy workflow run.'
+        required: true
+        type: string
+      deploy_event_name:
+        description: 'github.event_name from the caller (workflow_dispatch / push / etc.)'
+        required: true
+        type: string
+
+jobs:
+  validate-live:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # for git push in sync-previous-slug-winners
+      actions: read     # for download-artifact same-run
+    steps:
+      - name: Checkout (same SHA as deploy — invariant in workflow_call)
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node22-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ Firebase secrets not set — registry operations will be skipped."
+          fi
+
+      # Hydrate the runner env with secrets pulled from Firebase Remote
+      # Config so the social-media post steps below see FB / LinkedIn
+      # tokens as `process.env.*`. Without this, post-to-facebook.mjs
+      # finds nothing and silently exits with a "missing token" warning,
+      # appearing green in the UI but never publishing.
+      - name: Load secrets from Remote Config (FB + LinkedIn tokens)
+        run: node scripts/load-rc-env.mjs
+
+      # Small JSON artifacts only — NO github-pages download here.
+      # The pre-deploy-snapshot is consumed by submit-indexnow.js
+      # (diff against new live site for IndexNow submission).
+      - name: Download pre-deploy sitemap snapshot (optional)
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: pre-deploy-snapshot-${{ inputs.deploy_run_id }}
+          path: /tmp/pre-deploy-snapshot
+
+      - name: Download previous-slug winners (optional)
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: winners-${{ inputs.deploy_run_id }}
+          path: /tmp/winners
+
+      - name: Stage downloaded data files
+        run: |
+          if [ -f /tmp/pre-deploy-snapshot/pre-deploy-sitemap-urls.json ]; then
+            cp /tmp/pre-deploy-snapshot/pre-deploy-sitemap-urls.json /tmp/pre-deploy-sitemap-urls.json
+          fi
+          if [ -f /tmp/winners/previous-slug-winners.json ]; then
+            cp /tmp/winners/previous-slug-winners.json data/previous-slug-winners.json
+          fi
+
+      # Live smoke — Playwright fetches the deployed site directly.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
+        with:
+          path: /home/runner/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Live smoke (probe 5xx + e2e:live)
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
+          LIVE_BASE_URL: https://frontaliereticino.ch
+        run: |
+          node scripts/wait-for-pages-propagation.mjs
+          npm run probe:5xx
+          npm run test:e2e:live
+
+      - name: Sync previous-slug winners registry
+        # The build in deploy.yml may update data/previous-slug-winners.json.
+        # The updated file is downloaded from the winners artifact above.
+        # If it changed relative to HEAD, commit and push it here.
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet data/previous-slug-winners.json; then
+            echo "[previous-slug-winners] no changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/previous-slug-winners.json
+          git commit -m "chore(seo): sync previous-slug winners registry"
+          git stash push --keep-index --include-untracked -m "validation-build-tree" || true
+          bash scripts/lib/git-push-with-retry.sh \
+            --in-place-resolver-cmd "node scripts/lib/resolve-winners-conflict.mjs && git add -A"
+          git stash pop || true
+
+      - name: Read deploy metadata from Firestore
+        id: deploy-meta
+        continue-on-error: true
+        run: |
+          DATA=$(node scripts/deploy-registry.mjs get \
+            --run-id="${{ inputs.deploy_run_id }}" 2>/dev/null || echo '{}')
+          echo "data=$DATA" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for live article metadata
+        if: |
+          success() &&
+          inputs.deploy_event_name == 'workflow_dispatch' &&
+          fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl != null
+        id: wait_live_meta
+        continue-on-error: true
+        env:
+          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
+          OG_TITLE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogTitle }}
+          OG_IMAGE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogImage }}
+        run: |
+          node scripts/wait-for-live-article-meta.mjs \
+            "$ARTICLE_URL" \
+            "$OG_TITLE" \
+            "$OG_IMAGE"
+
+      - name: Post to Facebook Page
+        if: |
+          success() &&
+          inputs.deploy_event_name == 'workflow_dispatch' &&
+          fromJson(steps.deploy-meta.outputs.data || '{}').articleId != null &&
+          steps.wait_live_meta.outcome == 'success'
+        continue-on-error: true
+        env:
+          ARTICLE_ID: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleId }}
+          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
+          OG_TITLE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogTitle }}
+          OG_DESCRIPTION: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogDescription }}
+          ARTICLE_CATEGORY: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleCategory }}
+        run: |
+          node scripts/post-to-facebook.mjs \
+            "$ARTICLE_ID" \
+            "$ARTICLE_URL" \
+            "$OG_TITLE" \
+            "$OG_DESCRIPTION" \
+            "$ARTICLE_CATEGORY"
+
+      - name: Post to LinkedIn Company Page
+        if: |
+          success() &&
+          inputs.deploy_event_name == 'workflow_dispatch' &&
+          fromJson(steps.deploy-meta.outputs.data || '{}').articleId != null &&
+          steps.wait_live_meta.outcome == 'success'
+        continue-on-error: true
+        env:
+          ARTICLE_ID: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleId }}
+          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
+          OG_TITLE: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogTitle }}
+          OG_DESCRIPTION: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').ogDescription }}
+          ARTICLE_CATEGORY: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleCategory }}
+        run: |
+          node scripts/post-to-linkedin.mjs \
+            "$ARTICLE_ID" \
+            "$ARTICLE_URL" \
+            "$OG_TITLE" \
+            "$OG_DESCRIPTION" \
+            "$ARTICLE_CATEGORY"
+
+      - name: Restore indexing API daily tracker
+        id: indexing-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/indexing-api-submitted-today.json
+          key: indexing-api-${{ github.run_id }}
+          restore-keys: |
+            indexing-api-
+
+      - name: Post-deploy indexing (parallel)
+        if: success()
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          ARTICLE_URL: ${{ fromJson(steps.deploy-meta.outputs.data || '{}').articleUrl }}
+        run: |
+          timeout 90 node scripts/submit-google-indexing-jobs.js &
+          PID_GOOGLE=$!
+          timeout 90 node scripts/submit-indexnow.js &
+          PID_INDEXNOW=$!
+          timeout 180 node scripts/submit-google-indexing.js &
+          PID_GSC=$!
+          timeout 90 node scripts/verify-post-deploy-seo.mjs &
+          PID_SEO=$!
+
+          FAIL=0
+          wait $PID_GOOGLE  || { echo "⚠️ Google Indexing API failed"; FAIL=1; }
+          wait $PID_INDEXNOW || { echo "⚠️ IndexNow submission failed"; FAIL=1; }
+          wait $PID_GSC     || { echo "⚠️ GSC submission failed"; FAIL=1; }
+          wait $PID_SEO     || { echo "⚠️ Post-deploy SEO verification failed"; FAIL=1; }
+
+          if [ $FAIL -ne 0 ]; then
+            echo "::warning::Some post-deploy indexing steps failed (non-blocking)"
+          fi
+          echo "✅ Post-deploy indexing complete"
+
+      - name: Mark deploy as last known good
+        if: success()
+        run: |
+          node scripts/deploy-registry.mjs set-good \
+            --run-id="${{ inputs.deploy_run_id }}" \
+            --sha="${{ github.sha }}"
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Validation Failure (live): post-deploy — run ${{ github.run_number }}" \
+            --description "## Live validation post-deploy fallita
+          **Deploy run:** https://github.com/${{ github.repository }}/actions/runs/${{ inputs.deploy_run_id }}
+          **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **SHA:** ${{ github.sha }}" \
+            --priority 1 \
+            --label Bug \
+            --workflow "Post-deploy Validate Live"

--- a/scripts/capture-deployed-sitemaps.mjs
+++ b/scripts/capture-deployed-sitemaps.mjs
@@ -2,12 +2,33 @@
 /**
  * scripts/capture-deployed-sitemaps.mjs
  *
- * Fetches all sitemap URLs from the currently deployed (live) site and saves
- * them to /tmp/pre-deploy-sitemap-urls.json.
+ * Fetches the URL list from each sitemap-*.xml on the currently deployed
+ * (live) site and saves the snapshot to /tmp/pre-deploy-sitemap-urls.json.
  *
- * This snapshot is used by submit-indexnow.js to diff against the new build
- * and determine which URLs are truly new. Without this step the diff would
- * compare the new build against itself (since deploy happens before submission).
+ * Output format (v2 — per-sitemap struct):
+ *   {
+ *     version: 2,
+ *     capturedAt: "2026-05-06T08:00:00Z",
+ *     host: "frontaliereticino.ch",
+ *     perSitemap: {
+ *       "sitemap-blog.xml": [ "https://...", ... ],
+ *       "sitemap-jobs.xml": [ ... ],
+ *       ...
+ *     },
+ *     _allUrls: [ "https://...", ... ]    // sorted union, kept for backward
+ *                                         // compat with old submit-indexnow.js
+ *   }
+ *
+ * Why per-sitemap: the post-deploy validate diffs the new dist sitemaps
+ * against the live snapshot. Without per-sitemap structure the diff can
+ * only report a single global +N/-M; with it we get +/-counts per file
+ * (e.g. "sitemap-weekly-employers.xml: +28 added"). The IndexNow / Google
+ * indexing pipelines also benefit by submitting only the URLs that
+ * actually moved.
+ *
+ * Discovery: starts from sitemap-index.xml so the file list stays in sync
+ * with build-plugins (no hardcoded list to drift from). Falls back to a
+ * curated short list if the index isn't reachable (first deploy, etc).
  *
  * Usage (in deploy.yml, BEFORE the deploy step):
  *   node scripts/capture-deployed-sitemaps.mjs
@@ -15,9 +36,14 @@
 
 import { writeFileSync } from 'node:fs';
 
-const HOST = 'frontaliereticino.ch';
-const OUTPUT = '/tmp/pre-deploy-sitemap-urls.json';
-const SITEMAP_FILES = [
+const HOST = process.env.HOST || 'frontaliereticino.ch';
+const OUTPUT = process.env.OUTPUT || '/tmp/pre-deploy-sitemap-urls.json';
+const FETCH_TIMEOUT_MS = 10_000;
+
+// Fallback list when sitemap-index.xml is unreachable (e.g. very first
+// deploy). Match what older versions of this script used so the snapshot
+// shape stays compatible with downstream consumers in degraded mode.
+const FALLBACK_FILES = [
   'sitemap-pages.xml',
   'sitemap-blog.xml',
   'sitemap-glossario.xml',
@@ -25,31 +51,88 @@ const SITEMAP_FILES = [
   'sitemap-news.xml',
 ];
 
-async function main() {
+function parseSitemapBody(xml) {
   const urls = new Set();
+  for (const m of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) urls.add(m[1].trim());
+  // hreflang `<a>`-style alternates in sitemap-pages — keep them so the
+  // diff covers locale variants too.
+  for (const m of xml.matchAll(/hreflang="[^"]*"\s+href="([^"]+)"/g)) urls.add(m[1].trim());
+  return [...urls];
+}
 
-  for (const file of SITEMAP_FILES) {
-    try {
-      const res = await fetch(`https://${HOST}/${file}`, {
-        headers: { Accept: 'application/xml, text/xml' },
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!res.ok) continue;
-      const xml = await res.text();
-      for (const m of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) urls.add(m[1].trim());
-      for (const m of xml.matchAll(/hreflang="[^"]*"\s+href="([^"]+)"/g)) urls.add(m[1].trim());
-    } catch {
-      // Sitemap may not exist on deployed site — skip
+async function fetchText(url) {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/xml, text/xml' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Discover the list of sitemap-*.xml files by reading sitemap-index.xml.
+ * Each entry there is a full URL — we strip back to the basename so callers
+ * can refer to it as "sitemap-X.xml" regardless of host.
+ */
+async function discoverSitemapFiles() {
+  const indexXml = await fetchText(`https://${HOST}/sitemap-index.xml`);
+  if (!indexXml) return null;
+  const files = new Set();
+  for (const m of indexXml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    const u = m[1].trim();
+    const tail = u.split('/').pop();
+    if (tail && /^sitemap-.+\.xml$/.test(tail) && tail !== 'sitemap-index.xml') {
+      files.add(tail);
     }
   }
+  return [...files].sort();
+}
 
-  const sorted = [...urls].sort();
-  writeFileSync(OUTPUT, JSON.stringify(sorted), 'utf-8');
-  console.log(`📸 Captured ${sorted.length} pre-deploy sitemap URLs → ${OUTPUT}`);
+async function main() {
+  let files = await discoverSitemapFiles();
+  if (!files || files.length === 0) {
+    console.warn(`⚠️ Could not read sitemap-index.xml from https://${HOST}/ — falling back to curated list`);
+    files = FALLBACK_FILES;
+  }
+
+  /** @type {Record<string, string[]>} */
+  const perSitemap = {};
+  const allUrls = new Set();
+
+  for (const file of files) {
+    const xml = await fetchText(`https://${HOST}/${file}`);
+    if (!xml) {
+      // Sitemap referenced by index but currently unreachable — record empty
+      // so the diff later treats it as "no urls live" instead of "missing entry".
+      perSitemap[file] = [];
+      continue;
+    }
+    const urls = parseSitemapBody(xml).sort();
+    perSitemap[file] = urls;
+    for (const u of urls) allUrls.add(u);
+  }
+
+  const snapshot = {
+    version: 2,
+    capturedAt: new Date().toISOString(),
+    host: HOST,
+    perSitemap,
+    _allUrls: [...allUrls].sort(),
+  };
+
+  writeFileSync(OUTPUT, JSON.stringify(snapshot), 'utf-8');
+  const fileCount = Object.keys(perSitemap).length;
+  console.log(
+    `📸 Captured ${snapshot._allUrls.length} pre-deploy URLs across ${fileCount} sitemap files → ${OUTPUT}`,
+  );
 }
 
 main().catch((err) => {
   console.warn(`⚠️ Failed to capture pre-deploy sitemaps: ${err.message}`);
-  // Non-fatal — submit-indexnow.js will fall back to submitting all URLs
+  // Non-fatal — submit-indexnow.js will fall back to submitting all URLs.
   process.exit(0);
 });

--- a/scripts/diff-sitemaps.mjs
+++ b/scripts/diff-sitemaps.mjs
@@ -2,54 +2,46 @@
 /**
  * scripts/diff-sitemaps.mjs
  *
- * Compare per-sitemap URL lists between the currently deployed live site
- * (https://frontaliereticino.ch) and the freshly built dist/ directory.
- * Used in post-deploy validation to surface what each deploy actually
- * adds, removes, or shifts in the public sitemap surface.
+ * Compare the per-sitemap URL list captured PRE-deploy from the live site
+ * (saved by `scripts/capture-deployed-sitemaps.mjs` to a JSON snapshot)
+ * against the freshly built `dist/sitemap-*.xml`. The post-deploy validate
+ * job uses this to surface what each deploy actually adds, removes, or
+ * shifts in the public sitemap surface.
+ *
+ * Why this design (vs fetching live AT diff time):
+ *   When run after the deploy step, the live site already serves the new
+ *   sitemap — diffing live-vs-dist would always be 0. The pre-deploy
+ *   snapshot, captured BEFORE actions/deploy-pages, is the only honest
+ *   "before" state to compare against.
  *
  * Output is INFORMATIONAL only — the script always exits 0 so it can never
- * block validation. The numbers help spot anomalies (e.g. 500 URLs removed
- * unexpectedly when only 5 jobs expired) before SEO regressions hit live.
+ * block validation.
  *
  * Usage:
  *   node scripts/diff-sitemaps.mjs
  *
  * Env vars:
- *   DIST_DIR     — dist directory to read new sitemaps from (default: dist)
- *   HOST         — host to fetch live sitemaps from (default: frontaliereticino.ch)
- *   DIFF_FIRST_N — how many added/removed URLs to print per category (default: 20)
+ *   DIST_DIR          — dist directory to read new sitemaps from (default: dist)
+ *   PRE_DEPLOY_FILE   — path to the snapshot JSON
+ *                       (default: /tmp/pre-deploy-sitemap-urls.json)
+ *   DIFF_FIRST_N      — how many added/removed URLs to print per category
+ *                       (default: 20)
  */
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
-const HOST = process.env.HOST || 'frontaliereticino.ch';
 const DIST = process.env.DIST_DIR || 'dist';
+const PRE_DEPLOY_FILE = process.env.PRE_DEPLOY_FILE || '/tmp/pre-deploy-sitemap-urls.json';
 const FIRST_N = Number(process.env.DIFF_FIRST_N || '20');
-const FETCH_TIMEOUT_MS = 15_000;
 
 const SEP = '═'.repeat(72);
 const SUB = '─'.repeat(72);
 
 function parseLocs(xml) {
   const urls = new Set();
-  for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
-    urls.add(match[1].trim());
-  }
+  for (const m of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) urls.add(m[1].trim());
   return urls;
-}
-
-async function fetchLiveSitemap(name) {
-  try {
-    const res = await fetch(`https://${HOST}/${name}`, {
-      headers: { Accept: 'application/xml, text/xml' },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!res.ok) return null;
-    return parseLocs(await res.text());
-  } catch {
-    return null;
-  }
 }
 
 function readDistSitemap(name) {
@@ -65,85 +57,142 @@ function listDistSitemaps(dir) {
     .sort();
 }
 
+/**
+ * Load the pre-deploy snapshot in either v2 (per-sitemap struct) or v1
+ * (flat array — older capture-deployed-sitemaps.mjs format). v1 fallback
+ * maps everything into a single virtual `_legacy_flat` bucket so the diff
+ * still produces a meaningful global +N/-M instead of crashing.
+ */
+function loadPreDeploySnapshot(file) {
+  if (!existsSync(file)) return null;
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(file, 'utf8'));
+  } catch (err) {
+    console.warn(`⚠️ Could not parse ${file}: ${err.message}`);
+    return null;
+  }
+  if (Array.isArray(raw)) {
+    return { version: 1, perSitemap: { _legacy_flat: new Set(raw) } };
+  }
+  if (raw && raw.version === 2 && raw.perSitemap) {
+    /** @type {Record<string, Set<string>>} */
+    const perSitemap = {};
+    for (const [name, urls] of Object.entries(raw.perSitemap)) {
+      perSitemap[name] = new Set(urls);
+    }
+    return { version: 2, perSitemap };
+  }
+  console.warn(`⚠️ Unknown snapshot shape in ${file} — skipping diff`);
+  return null;
+}
+
 function main() {
   const distSitemaps = listDistSitemaps(DIST);
-  if (distSitemaps.length === 0) {
-    console.log(`ℹ️ No sitemap-*.xml found under ${DIST} — skipping diff`);
+  const snapshot = loadPreDeploySnapshot(PRE_DEPLOY_FILE);
+
+  console.log(SEP);
+  console.log(`Sitemap diff vs pre-deploy snapshot`);
+  console.log(SEP);
+
+  if (!snapshot) {
+    console.log(`ℹ️ Snapshot ${PRE_DEPLOY_FILE} not present — first deploy or capture failed`);
+    console.log(`   Skipping diff (informational, not fatal).`);
+    console.log(SEP);
     return;
   }
 
-  console.log(SEP);
-  console.log(`Sitemap diff vs live (https://${HOST})`);
-  console.log(SEP);
-
-  return Promise.all(
-    distSitemaps.map(async (name) => {
-      const [live, next] = await Promise.all([
-        fetchLiveSitemap(name),
-        Promise.resolve(readDistSitemap(name)),
-      ]);
-      return { name, live, next };
-    }),
-  ).then((rows) => {
-    let totalAdded = 0;
-    let totalRemoved = 0;
-    const allAdded = [];
-    const allRemoved = [];
-
-    for (const { name, live, next } of rows) {
-      if (!next) {
-        console.log(`  ${name.padEnd(48)} (missing in dist — skipped)`);
-        continue;
-      }
-      if (!live) {
-        console.log(
-          `  ${name.padEnd(48)} ${String(next.size).padStart(5)} URLs · live unreachable (treated as net-new)`,
-        );
-        totalAdded += next.size;
-        for (const u of next) allAdded.push(u);
-        continue;
-      }
-      const added = [];
-      const removed = [];
-      for (const u of next) if (!live.has(u)) added.push(u);
-      for (const u of live) if (!next.has(u)) removed.push(u);
-
-      totalAdded += added.length;
-      totalRemoved += removed.length;
-      for (const u of added) allAdded.push(u);
-      for (const u of removed) allRemoved.push(u);
-
-      const net = added.length - removed.length;
-      const marker = net === 0 ? '·' : net > 0 ? '↑' : '↓';
-      console.log(
-        `  ${name.padEnd(48)} +${String(added.length).padStart(4)}  -${String(removed.length).padStart(4)}  net ${net >= 0 ? '+' : ''}${net} ${marker}`,
-      );
-    }
-
-    console.log(SUB);
-    console.log(`Totals: +${totalAdded} added, -${totalRemoved} removed across ${rows.length} sitemap files`);
+  if (distSitemaps.length === 0) {
+    console.log(`ℹ️ No sitemap-*.xml found under ${DIST} — skipping diff`);
     console.log(SEP);
+    return;
+  }
 
-    if (allAdded.length > 0) {
-      console.log(`\nFirst ${Math.min(FIRST_N, allAdded.length)} added URLs:`);
-      for (const u of allAdded.slice(0, FIRST_N)) console.log(`  + ${u}`);
+  if (snapshot.version === 1) {
+    const next = new Set();
+    for (const name of distSitemaps) {
+      for (const u of readDistSitemap(name) ?? []) next.add(u);
     }
-    if (allRemoved.length > 0) {
-      console.log(`\nFirst ${Math.min(FIRST_N, allRemoved.length)} removed URLs:`);
-      for (const u of allRemoved.slice(0, FIRST_N)) console.log(`  - ${u}`);
+    const live = snapshot.perSitemap._legacy_flat;
+    const added = [...next].filter((u) => !live.has(u));
+    const removed = [...live].filter((u) => !next.has(u));
+    console.log(`(v1 flat snapshot — global diff only)`);
+    console.log(`Total: +${added.length} added, -${removed.length} removed`);
+    if (added.length > 0) {
+      console.log(`\nFirst ${Math.min(FIRST_N, added.length)} added URLs:`);
+      for (const u of added.slice(0, FIRST_N)) console.log(`  + ${u}`);
     }
-    if (allAdded.length === 0 && allRemoved.length === 0) {
-      console.log('\nNo URL changes detected.');
+    if (removed.length > 0) {
+      console.log(`\nFirst ${Math.min(FIRST_N, removed.length)} removed URLs:`);
+      for (const u of removed.slice(0, FIRST_N)) console.log(`  - ${u}`);
     }
     console.log(SEP);
-  });
+    return;
+  }
+
+  let totalAdded = 0;
+  let totalRemoved = 0;
+  const allAdded = [];
+  const allRemoved = [];
+  const allFiles = new Set([...distSitemaps, ...Object.keys(snapshot.perSitemap)]);
+
+  for (const name of [...allFiles].sort()) {
+    const next = readDistSitemap(name);
+    const live = snapshot.perSitemap[name];
+
+    if (!next && !live) continue;
+
+    if (!next) {
+      console.log(`  ${name.padEnd(48)} (deleted from dist)  -${live.size}`);
+      totalRemoved += live.size;
+      for (const u of live) allRemoved.push(u);
+      continue;
+    }
+    if (!live) {
+      console.log(`  ${name.padEnd(48)} (new in dist)         +${next.size}`);
+      totalAdded += next.size;
+      for (const u of next) allAdded.push(u);
+      continue;
+    }
+
+    const added = [];
+    const removed = [];
+    for (const u of next) if (!live.has(u)) added.push(u);
+    for (const u of live) if (!next.has(u)) removed.push(u);
+
+    totalAdded += added.length;
+    totalRemoved += removed.length;
+    for (const u of added) allAdded.push(u);
+    for (const u of removed) allRemoved.push(u);
+
+    const net = added.length - removed.length;
+    const marker = net === 0 ? '·' : net > 0 ? '↑' : '↓';
+    console.log(
+      `  ${name.padEnd(48)} +${String(added.length).padStart(4)}  -${String(removed.length).padStart(4)}  net ${net >= 0 ? '+' : ''}${net} ${marker}`,
+    );
+  }
+
+  console.log(SUB);
+  console.log(`Totals: +${totalAdded} added, -${totalRemoved} removed across ${allFiles.size} sitemap files`);
+  console.log(SEP);
+
+  if (allAdded.length > 0) {
+    console.log(`\nFirst ${Math.min(FIRST_N, allAdded.length)} added URLs:`);
+    for (const u of allAdded.slice(0, FIRST_N)) console.log(`  + ${u}`);
+  }
+  if (allRemoved.length > 0) {
+    console.log(`\nFirst ${Math.min(FIRST_N, allRemoved.length)} removed URLs:`);
+    for (const u of allRemoved.slice(0, FIRST_N)) console.log(`  - ${u}`);
+  }
+  if (allAdded.length === 0 && allRemoved.length === 0) {
+    console.log(`\nNo URL changes detected.`);
+  }
+  console.log(SEP);
 }
 
-main()
-  .catch((err) => {
-    console.warn(`⚠️ diff-sitemaps failed: ${err?.message ?? err}`);
-  })
-  .finally(() => {
-    // Always exit 0 — informational only.
-    process.exit(0);
-  });
+try {
+  main();
+} catch (err) {
+  console.warn(`⚠️ diff-sitemaps failed: ${err?.message ?? err}`);
+}
+process.exit(0);

--- a/scripts/submit-indexnow.js
+++ b/scripts/submit-indexnow.js
@@ -183,13 +183,21 @@ function getBingUrlsSubset() {
 const PRE_DEPLOY_SNAPSHOT = '/tmp/pre-deploy-sitemap-urls.json';
 
 async function getDeployedUrls() {
-  // 1. Try the pre-deploy snapshot (reliable baseline)
+  // 1. Try the pre-deploy snapshot (reliable baseline). Supports both
+  // shapes:
+  //   v1 (legacy): flat array `[ "url", "url", ... ]`
+  //   v2 (current): `{ version: 2, perSitemap: {...}, _allUrls: [...] }`
+  // We only need the union of URLs; v2 exposes it in `_allUrls`.
   if (existsSync(PRE_DEPLOY_SNAPSHOT)) {
     try {
       const data = JSON.parse(readFileSync(PRE_DEPLOY_SNAPSHOT, 'utf-8'));
       if (Array.isArray(data) && data.length > 0) {
-        console.log(`📸 Using pre-deploy snapshot: ${data.length} URLs from ${PRE_DEPLOY_SNAPSHOT}`);
+        console.log(`📸 Using pre-deploy snapshot (v1 flat): ${data.length} URLs from ${PRE_DEPLOY_SNAPSHOT}`);
         return new Set(data);
+      }
+      if (data && data.version === 2 && Array.isArray(data._allUrls) && data._allUrls.length > 0) {
+        console.log(`📸 Using pre-deploy snapshot (v2 per-sitemap): ${data._allUrls.length} URLs from ${PRE_DEPLOY_SNAPSHOT}`);
+        return new Set(data._allUrls);
       }
     } catch { /* malformed file — fall through */ }
   }


### PR DESCRIPTION
## Summary

Continua il refactor di PR #51. Splitta il single `build-and-deploy` + `post-deploy.validate` (validate monolitico) in **4 job**:

```
build → ┬→ validate-dist  (downloads github-pages, runs ratchet gates)
        ├→ deploy         (actions/deploy-pages, holds pages-deploy lock)
        │     ↓
        │   validate-live (smoke + social + indexing, NO github-pages download)
        ↓
      rollback (needs all three; still-live guard)
```

## Vantaggi

- **`validate-dist` e `deploy` in parallelo** → ~3 min wall time saved sul critical path
- **`validate-live` non scarica più i 1.5 GB di github-pages**: consuma il nuovo `sitemaps-${run_id}` artifact (~KB) che bundle pre-deploy snapshot + new sitemap URLs
- **Sitemap diff finalmente sensata**: confronta `pre-deploy snapshot` vs `new dist sitemap` (prima reportava sempre +0/-0 perché fetchava live AFTER deploy)
- **Bug fix `if: always()` sul `Dump bfs-depth baseline candidate`**: il JSON esce anche se un altro gate fallisce — niente più seed-workflow rerun manuali per refresh baseline
- **Bug fix multiple-artifact rollback**: il rollback resolve il last-good `github-pages` per ID (oldest-first), così non trip sull'error "Multiple artifacts named github-pages were unexpectedly found" quando il source run aveva sia un deploy che un self-rollback
- **`post-deploy-validation.yml` → `post-deploy-validate-dist.yml`** (rinomino per chiarezza); nuovo `post-deploy-validate-live.yml` estratto per gli step live

## Cambi side script

### `capture-deployed-sitemaps.mjs`
v2 per-sitemap struct:
```json
{ \"version\": 2, \"capturedAt\": ..., \"host\": ..., \"perSitemap\": {\"sitemap-blog.xml\": [...], ...}, \"_allUrls\": [...] }
```
Discovery automatica via `sitemap-index.xml` (no più hardcoded list di 5 file).

### `diff-sitemaps.mjs`
Riscritto: legge il pre-deploy snapshot v2 da `/tmp/pre-deploy-sitemap-urls.json`, **non fetch live**. Compara per-sitemap. Backward-compat con v1 flat-array.

### `submit-indexnow.js`
Backward-compat per consumare sia v1 (flat array) che v2 (`._allUrls`).

## Test plan

- [ ] CI smoke su questo PR (workflow_dispatch sul branch fallirà su Pages protection rule, ma confermerà YAML)
- [ ] **Post-merge**: primo deploy reale dovrebbe mostrare 4 job nel run (build, deploy, validate-dist, validate-live), niente rollback
- [ ] **Test concurrency**: 2 push entro 1-2 min — il secondo deve iniziare a buildare appena il primo `build` finisce (NON aspetta deploy + validate)
- [ ] **Test JSON dump baseline**: anche se un altro gate fallisce (es. title-no-disambig-hash), il bfs-depth baseline JSON deve essere stampato nel log
- [ ] **Test sitemap diff**: deve mostrare numbers sensati (+/- URLs reali aggiunte/rimosse), non più tutti 0

## Backout

`git revert <merge-sha>` torna al modello unified single-validate (PR #51). Tutti i fix scripts (capture, diff, submit-indexnow) sono backward-compat — nessuno script attuale rompe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)