### PR TITLE
feat(crawlers): Adzuna free-tier fallback for Richemont + MSC Cargo (Tier-3)

### DIFF
--- a/.github/workflows/update-jobs-msc-cargo.yml
+++ b/.github/workflows/update-jobs-msc-cargo.yml
@@ -74,6 +74,9 @@ jobs:
           JOBS_MSC_CARGO_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
           CRAWLER_SLICE_ONLY: '1'
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          # Adzuna free-tier metadata fallback (anti-bot WAF on direct site)
+          ADZUNA_APP_ID: ${{ secrets.ADZUNA_APP_ID }}
+          ADZUNA_APP_KEY: ${{ secrets.ADZUNA_APP_KEY }}
         run: node scripts/update-msc-cargo-jobs.mjs
 
       - name: Housekeeping — remove expired job listings (scoped)

--- a/.github/workflows/update-jobs-richemont.yml
+++ b/.github/workflows/update-jobs-richemont.yml
@@ -74,6 +74,9 @@ jobs:
           JOBS_RICHEMONT_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
           CRAWLER_SLICE_ONLY: '1'
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          # Adzuna free-tier metadata fallback (anti-bot WAF on direct site)
+          ADZUNA_APP_ID: ${{ secrets.ADZUNA_APP_ID }}
+          ADZUNA_APP_KEY: ${{ secrets.ADZUNA_APP_KEY }}
         run: node scripts/update-richemont-jobs.mjs
 
       - name: Housekeeping — remove expired job listings (scoped)

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ playwright-report/
 test-results/
 .worktrees/
 data/.weather-cache/
+data/adzuna-cache/

--- a/docs/CATHEDRAL-STATUS.md
+++ b/docs/CATHEDRAL-STATUS.md
@@ -103,7 +103,9 @@
 
 6. **Sitemap submission to Google + IndexNow** — script esistono (`scripts/submit-google-indexing-jobs.js`, `scripts/submit-indexnow-batch.mjs`) ma NON sono wired in `deploy.yml`. Va aggiunto un step post-deploy. Deve usare auth Service Account + GSC ownership configurata.
 7. **5 alreadyCrawled marquee** (UBS, Pictet, Mobiliar HQ, HUG, Syngenta) — verifica se la loro location filter è ancora TI-anchored e se va espansa a CH-wide tramite canton-quorum-gate.
-8. **Tier-3 marquee Playwright DOM logic** (Richemont, MSC Cargo, Bobst, Vaudoise) — placeholder con `--playwright` flag ma DOM selectors non implementati. Richiedono CH-residential-proxy per anti-bot Cloudflare/Akamai.
+8. **Tier-3 marquee Playwright DOM logic** (Bobst, Vaudoise) — placeholder con `--playwright` flag ma DOM selectors non implementati. Richiedono CH-residential-proxy per anti-bot Cloudflare/Akamai.
+   - ✅ **Richemont — DONE-WITH-ADZUNA-FALLBACK 2026-05-10** — Cloudflare 403 sulla pagina careers; sostituita con il client free-tier Adzuna (`scripts/lib/adzuna-client.mjs`). `applyUrl` punta alla landing Adzuna (aggregator → deep-link ufficiale, ToS-compliant). Cache giornaliera in `data/adzuna-cache/` per stare nei 1000 calls/mo della free tier. Richiede secrets `ADZUNA_APP_ID` + `ADZUNA_APP_KEY` (signup gratuito su https://developer.adzuna.com/, no credit card). Budget: $0/mo.
+   - ✅ **MSC Cargo — DONE-WITH-ADZUNA-FALLBACK 2026-05-10** — Akamai BMP 403 sulla pagina careers; stesso pattern Adzuna. Filtro brand-family include MSC Mediterranean/Technology/Logistics e ESCLUDE MSC Cruises (employer separato). Budget: $0/mo.
 9. **Hospital wave 3 runners + workflows** (gzo-wetzikon, spital-maennedorf, spital-uster, ksb, see-spital) — parser scaffolded ma `scripts/update-{slug}-jobs.mjs` + `.github/workflows/update-jobs-{slug}.yml` skippati. Quick fix: `node scripts/scaffold-crawler.mjs --finish-existing-parser {slug}` (~5 min ognuno).
 10. **3 NEW ATS client extractions** (quando 2° tenant landa per ognuno):
     - `phenom-client.mjs` — quando trovi un secondo Phenom-using employer

--- a/scripts/lib/adzuna-client.mjs
+++ b/scripts/lib/adzuna-client.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+/**
+ * Adzuna free-tier API client — Swiss jobs metadata fallback.
+ *
+ * Used as a metadata-only fallback for employers whose career sites are
+ * blocked by anti-bot WAFs (Cloudflare, Akamai BMP, etc.) and where running
+ * a residential-proxy + Playwright stack would break the $0/mo budget.
+ *
+ * Adzuna is itself a job aggregator: each `redirect_url` is the canonical
+ * Adzuna landing page for the listing, which then deep-links to the
+ * employer's official posting. We expose Adzuna's URL as `applyUrl` —
+ * no ToS violation since the user lands on Adzuna first.
+ *
+ * Free tier: 1000 calls/mo per app_id. To stay within the cap, every
+ * `searchAdzuna` call is cached on disk under `data/adzuna-cache/` keyed
+ * by `{employer}-{country}-{date-yyyy-mm-dd}-page-{n}.json`. Re-running
+ * the parser the same UTC day reads from disk and never hits the API.
+ *
+ * Endpoint: https://api.adzuna.com/v1/api/jobs/{country}/search/{page}
+ * Docs:     https://developer.adzuna.com/docs/search
+ *
+ * Required env (production): ADZUNA_APP_ID, ADZUNA_APP_KEY
+ * Tests inject `_fetchImpl` to avoid hitting the live API.
+ */
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULT_CACHE_DIR = path.join(ROOT, 'data', 'adzuna-cache');
+
+const ADZUNA_BASE = 'https://api.adzuna.com/v1/api/jobs';
+const FREE_TIER_MONTHLY_CAP = 1000;
+const DEFAULT_RESULTS_PER_PAGE = 50; // max Adzuna allows
+const DEFAULT_MAX_PAGES = 4; // 4 × 50 = up to 200 listings/employer/day
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+function cacheKey({ employer, country, page, date }) {
+  const safeEmployer = slugify(employer || 'unknown');
+  return `${safeEmployer}-${country}-${date}-page-${page}.json`;
+}
+
+async function readCache(cacheDir, key) {
+  try {
+    const raw = await fs.readFile(path.join(cacheDir, key), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(cacheDir, key, payload) {
+  try {
+    await fs.mkdir(cacheDir, { recursive: true });
+    await fs.writeFile(
+      path.join(cacheDir, key),
+      JSON.stringify(payload, null, 2),
+      'utf8',
+    );
+  } catch (err) {
+    // Cache failures must never block the crawler — log and continue.
+    console.warn(`⚠️ Adzuna cache write failed (${key}): ${err?.message || err}`);
+  }
+}
+
+/**
+ * Search Adzuna for jobs matching a company name.
+ *
+ * @param {object} params
+ * @param {string} params.company         — Employer brand to search for (Adzuna's `what_phrase`)
+ * @param {string} [params.country='ch']  — ISO country code (lowercase)
+ * @param {number} [params.resultsPerPage=50]
+ * @param {number} [params.page=1]
+ * @param {string} [params.appId]         — defaults to process.env.ADZUNA_APP_ID
+ * @param {string} [params.appKey]        — defaults to process.env.ADZUNA_APP_KEY
+ * @param {string} [params.cacheDir]      — defaults to data/adzuna-cache/
+ * @param {Function} [params._fetchImpl]  — test hook (signature mirrors fetch)
+ * @param {string}   [params._cacheDate]  — test hook to freeze "today"
+ * @returns {Promise<{ count: number, results: Array<object>, _fromCache: boolean }>}
+ */
+export async function searchAdzuna({
+  company,
+  country = 'ch',
+  resultsPerPage = DEFAULT_RESULTS_PER_PAGE,
+  page = 1,
+  appId = process.env.ADZUNA_APP_ID,
+  appKey = process.env.ADZUNA_APP_KEY,
+  cacheDir = DEFAULT_CACHE_DIR,
+  _fetchImpl = globalThis.fetch,
+  _cacheDate = todayUtc(),
+} = {}) {
+  if (!company || typeof company !== 'string') {
+    throw new Error('searchAdzuna: `company` is required');
+  }
+
+  const key = cacheKey({ employer: company, country, page, date: _cacheDate });
+  const cached = await readCache(cacheDir, key);
+  if (cached) {
+    return { ...cached, _fromCache: true };
+  }
+
+  if (!appId || !appKey) {
+    throw new Error(
+      'searchAdzuna: ADZUNA_APP_ID and ADZUNA_APP_KEY must be set (or pass appId/appKey explicitly)',
+    );
+  }
+  if (typeof _fetchImpl !== 'function') {
+    throw new Error('searchAdzuna: no fetch implementation available');
+  }
+
+  const url = new URL(`${ADZUNA_BASE}/${encodeURIComponent(country)}/search/${encodeURIComponent(page)}`);
+  url.searchParams.set('app_id', appId);
+  url.searchParams.set('app_key', appKey);
+  url.searchParams.set('results_per_page', String(resultsPerPage));
+  url.searchParams.set('what_phrase', company);
+  url.searchParams.set('content-type', 'application/json');
+
+  const res = await _fetchImpl(url.toString(), {
+    headers: { 'User-Agent': 'FrontaliereTicino-AdzunaFallback/1.0' },
+  });
+  if (!res || !res.ok) {
+    const status = res?.status ?? 'unknown';
+    throw new Error(`Adzuna API request failed: HTTP ${status}`);
+  }
+  const json = await res.json();
+
+  const payload = {
+    count: typeof json?.count === 'number' ? json.count : (json?.results?.length ?? 0),
+    results: Array.isArray(json?.results) ? json.results : [],
+  };
+
+  await writeCache(cacheDir, key, payload);
+  return { ...payload, _fromCache: false };
+}
+
+/**
+ * Fetch all pages for one employer, capped at `maxPages` to honour free-tier.
+ * Stops early when a page returns fewer results than `resultsPerPage`.
+ *
+ * @param {object} [params]
+ * @param {string} params.company
+ * @param {string} [params.country='ch']
+ * @param {number} [params.resultsPerPage]
+ * @param {number} [params.maxPages]
+ * @param {string} [params.appId]
+ * @param {string} [params.appKey]
+ * @param {string} [params.cacheDir]
+ * @param {Function} [params._fetchImpl]
+ * @param {string}   [params._cacheDate]
+ * @returns {Promise<{ results: Array<object>, liveCalls: number }>}
+ */
+export async function searchAdzunaAllPages({
+  company,
+  country = 'ch',
+  resultsPerPage = DEFAULT_RESULTS_PER_PAGE,
+  maxPages = DEFAULT_MAX_PAGES,
+  appId,
+  appKey,
+  cacheDir,
+  _fetchImpl,
+  _cacheDate,
+} = {}) {
+  const all = [];
+  let liveCalls = 0;
+  for (let page = 1; page <= maxPages; page += 1) {
+    const { results, _fromCache } = await searchAdzuna({
+      company,
+      country,
+      resultsPerPage,
+      page,
+      appId,
+      appKey,
+      cacheDir,
+      _fetchImpl,
+      _cacheDate,
+    });
+    if (!_fromCache) liveCalls += 1;
+    all.push(...results);
+    if (results.length < resultsPerPage) break;
+  }
+  return { results: all, liveCalls };
+}
+
+/**
+ * Convert raw Adzuna search results to ParsedJob objects matching the
+ * dedicated-crawler shape. Filters out listings whose `company.display_name`
+ * does NOT match `employer.match` (free-text Adzuna search is fuzzy).
+ *
+ * @param {{ results: Array<object> }} rawResponse
+ * @param {object} employer
+ * @param {string} employer.key                — companyKey (e.g. 'richemont')
+ * @param {string} employer.name               — display name (e.g. 'Richemont')
+ * @param {string} employer.domain             — primary domain (e.g. 'richemont.com')
+ * @param {(displayName: string) => boolean} employer.match — predicate to keep listings
+ * @param {string} [employer.sector='Altro']
+ * @param {string} [employer.defaultLocation]  — fallback when listing has no location
+ * @param {string} [employer.defaultCanton]
+ * @param {string} [employer.parserSourceLabel]
+ * @returns {Array<object>} ParsedJob[]
+ */
+export function parseAdzunaJobs(rawResponse, employer) {
+  if (!employer || typeof employer !== 'object') {
+    throw new Error('parseAdzunaJobs: `employer` is required');
+  }
+  const {
+    key,
+    name,
+    domain,
+    match,
+    sector = 'Altro',
+    defaultLocation = '',
+    defaultCanton = '',
+    parserSourceLabel = `${name} Adzuna Fallback`,
+  } = employer;
+  if (!key || !name || !domain || typeof match !== 'function') {
+    throw new Error('parseAdzunaJobs: employer.key/name/domain/match are required');
+  }
+
+  const raw = Array.isArray(rawResponse?.results) ? rawResponse.results : [];
+  const out = [];
+  const seen = new Set();
+
+  for (const listing of raw) {
+    const displayName = String(listing?.company?.display_name || '');
+    if (!match(displayName)) continue;
+
+    const title = normalizeSpace(listing?.title || '');
+    if (!title || title.length < 3) continue;
+
+    const descriptionHtml = listing?.description || '';
+    const descriptionText = normalizeSpace(stripHtml(descriptionHtml));
+
+    const locationDisplay = normalizeSpace(
+      listing?.location?.display_name ||
+        (Array.isArray(listing?.location?.area) ? listing.location.area.join(', ') : '') ||
+        defaultLocation,
+    );
+    const canton = inferSwissTargetCanton(locationDisplay) || defaultCanton || 'CH';
+
+    const redirectUrl = listing?.redirect_url || '';
+    if (!redirectUrl) continue;
+    let publicUrl;
+    try {
+      // Validate URL shape early; skip malformed entries.
+      publicUrl = new URL(redirectUrl).toString();
+    } catch {
+      continue;
+    }
+
+    const sourceLang = detectLang(descriptionText || title, 'en');
+    const jobSlug = slugify(`${title} ${key} ch`);
+    const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+    const id = `${key}-${urlHash}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const postedDate = listing?.created
+      ? String(listing.created).slice(0, 10)
+      : new Date().toISOString().slice(0, 10);
+
+    out.push({
+      // ── Required fields ──
+      id,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: name,
+      companyKey: key,
+      companyDomain: domain,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description: descriptionText || `${title} — ${name}`,
+      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — ${name}` },
+      location: locationDisplay || defaultLocation || 'Switzerland',
+      canton,
+      url: publicUrl,
+      source: parserSourceLabel,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      // ── Recommended fields ──
+      addressLocality: locationDisplay || defaultLocation || '',
+      addressCountry: 'CH',
+      country: 'CH',
+      category: 'Altro',
+      contract: 'full-time',
+      employmentType: 'OTHER',
+      experienceLevel: 'mid',
+      sector,
+      currency: 'CHF',
+      featured: false,
+      postedDate,
+      applyUrl: publicUrl,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  return out;
+}
+
+export const ADZUNA_FREE_TIER_MONTHLY_CAP = FREE_TIER_MONTHLY_CAP;
+export const ADZUNA_DEFAULT_MAX_PAGES = DEFAULT_MAX_PAGES;
+export const ADZUNA_DEFAULT_RESULTS_PER_PAGE = DEFAULT_RESULTS_PER_PAGE;

--- a/scripts/lib/msc-cargo-job-parser.mjs
+++ b/scripts/lib/msc-cargo-job-parser.mjs
@@ -1,19 +1,30 @@
 #!/usr/bin/env node
 /**
- * MSC Cargo job parser — Fetcher and job builder.
+ * MSC Cargo job parser — Adzuna free-tier metadata fallback.
  *
- * Source: https://www.msc.com/en/careers
+ * Source (anti-bot): https://www.msc.com/en/careers  → Akamai BMP 403
+ *                    (akamai-grn header)
+ * Fallback:          Adzuna Switzerland (`ch`) free-tier search API
+ *
+ * Why Adzuna?
+ *   - Direct careers URL is behind Akamai Bot Manager Premier and would
+ *     require ~$8/mo residential proxy + Playwright stack to bypass.
+ *   - Adzuna is itself a job aggregator: each listing's `redirect_url`
+ *     is an Adzuna landing that deep-links to MSC's official posting,
+ *     so applyUrl pointing at Adzuna is fully ToS-compliant.
+ *   - Free tier (1000 calls/mo per app_id) covers daily refreshes for
+ *     both Tier-3 anti-bot employers (~30-60 calls/mo combined).
+ *
+ * Required env: ADZUNA_APP_ID, ADZUNA_APP_KEY (set as GitHub Actions secrets).
  *
  * Exports the 4 required functions for the crawler template:
- *   - fetchAllMscCargoJobs()  — Fetch and parse all jobs
- *   - isMscCargoJob()         — Match jobs belonging to this company
- *   - isTrustedDomain()           — Validate URLs belong to this company
- *   - slugify() / stripHtml()     — Re-exported from crawler-template.mjs
+ *   - fetchAllMscCargoJobs()   — Fetch via Adzuna and build ParsedJob[]
+ *   - isMscCargoJob()          — Match jobs belonging to this company
+ *   - isTrustedDomain()        — Validate URLs (Adzuna domain allowed as fallback)
+ *   - slugify() / stripHtml()  — Re-exported from crawler-template.mjs
  */
-import { createHash } from 'node:crypto';
-import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { searchAdzunaAllPages, parseAdzunaJobs } from './adzuna-client.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -23,26 +34,34 @@ export const MSC_CARGO_COMPANY_DOMAIN = 'msc.com';
 
 const CAREER_URL = 'https://www.msc.com/en/careers';
 
+// MSC trades under several legal entities; match the family broadly but
+// reject MSC the cruise line (`MSC Cruises`) which is a separate employer.
+const MSC_BRAND_PATTERNS = [
+  /\bmsc\s+(mediterranean|cargo|shipping|ag|sa|ch|switzerland|logistics|terminals|technology|air)/i,
+  /\bmediterranean shipping company\b/i,
+  /\bmsc gva\b/i,
+  /^\s*msc\s*$/i, // bare "MSC" employer name
+];
+const MSC_REJECT_PATTERNS = [
+  /\bmsc cruises?\b/i,
+  /\bcruise\b/i,
+];
+
 /* ── Helpers ───────────────────────────────────────────────── */
 
 function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
-
 /* ── Company Matchers ──────────────────────────────────────── */
 
 /**
  * Check if a job belongs to MSC Cargo.
- * Used by the template to filter this company's jobs from the global dataset.
  */
 export function isMscCargoJob(job) {
   const key = normalize(job?.companyKey || job?.company || '')
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[̀-ͯ]/g, '')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
   const company = normalize(job?.company || '');
@@ -57,154 +76,68 @@ export function isMscCargoJob(job) {
 }
 
 /**
- * Validate that a URL belongs to MSC Cargo's domain.
+ * Validate that a URL belongs to a trusted MSC surface OR Adzuna
+ * (since the Adzuna fallback emits applyUrl pointing at adzuna.com/...).
  */
 export function isTrustedDomain(rawUrl = '') {
   try {
     const host = new URL(rawUrl).hostname.toLowerCase();
-    return host === 'msc.com' || host.endsWith('.msc.com');
+    return (
+      host === 'msc.com' ||
+      host.endsWith('.msc.com') ||
+      host === 'adzuna.com' ||
+      host.endsWith('.adzuna.com') ||
+      host === 'adzuna.ch' ||
+      host.endsWith('.adzuna.ch')
+    );
   } catch {
     return false;
   }
 }
 
-/* ── Category Detection ────────────────────────────────────── */
-
-function detectCategory(title = '') {
-  const t = normalize(title);
-  if (/\b(ingegner|engineer|entwickl)/.test(t)) return 'Ingegneria';
-  if (/\b(techni|tecnic|mecanic|elektr|install)/.test(t)) return 'Tecnica';
-  if (/\b(admin|segret|contab|buchhalt|account)/.test(t)) return 'Amministrazione';
-  if (/\b(vendita|sales|verkauf|commerce)/.test(t)) return 'Commerciale';
-  if (/\b(logist|magazz|lager|warehouse)/.test(t)) return 'Logistica';
-  if (/\b(produz|operat|operator|manufactur)/.test(t)) return 'Produzione';
-  if (/\b(qualit|qa|qc|quality)/.test(t)) return 'Qualità';
-  if (/\b(it|software|develop|programm)/.test(t)) return 'IT';
-  if (/\b(hr|human|risorse|personal)/.test(t)) return 'Risorse Umane';
-  if (/\b(market|kommunik|comunicaz)/.test(t)) return 'Marketing';
-  if (/\b(finanz|finance|financ)/.test(t)) return 'Finanza';
-  if (/\b(legal|giurid|recht)/.test(t)) return 'Legale';
-  return 'Altro';
-}
-
-function detectExperienceLevel(title = '') {
-  const t = normalize(title);
-  if (/\b(praktik|stage|stagiair|intern|apprendist|lehrling|lernend|apprenti)/.test(t)) return 'intern';
-  if (/\b(junior|jr)/.test(t)) return 'junior';
-  if (/\b(senior|sr|lead|head|director|dirett|chef|verantwort|responsab)/.test(t)) return 'senior';
-  return 'mid';
-}
-
-function detectEmploymentType(text = '') {
-  const t = normalize(text);
-  if (/\b(part.?time|teilzeit|tempo parziale|temps partiel)/.test(t)) return 'PART_TIME';
-  if (/\b(full.?time|vollzeit|tempo pieno|temps plein)/.test(t)) return 'FULL_TIME';
-  return 'OTHER';
-}
-
 /* ── Fetch + Parse ─────────────────────────────────────────── */
 
-// TODO: Implement the actual fetching logic for MSC Cargo's career page.
-// This is a placeholder. Replace with the actual API/scraping logic.
-//
-// Common patterns:
-//   - JSON API:     use --source api for a ready-made paginated API template
-//   - Workday API:  re-scaffold with --ats=workday for a ready-made template
-//   - Greenhouse:   --ats=greenhouse
-//   - Lever:        --ats=lever
-//   - SuccessFactors: --ats=successfactors
-//   - Generic HTML: fetch + parse with regex or cheerio
-
-async function fetchJobListings() {
-  // TODO: Replace with actual fetch logic
-  console.log(`   Fetching from: ${CAREER_URL}`);
-
-  // Example for a JSON API:
-  // const res = await fetch(CAREER_URL, {
-  //   headers: { 'User-Agent': 'FrontaliereTicino-JobCrawler/2.0' },
-  // });
-  // if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  // return await res.json();
-
-  return [];
+function mscMatcher(displayName = '') {
+  if (!displayName) return false;
+  if (MSC_REJECT_PATTERNS.some((rx) => rx.test(displayName))) return false;
+  return MSC_BRAND_PATTERNS.some((rx) => rx.test(displayName));
 }
 
 /**
- * Fetch all MSC Cargo jobs.
+ * Fetch all MSC Cargo jobs via the Adzuna free-tier API.
  * Returns an array of ParsedJob objects (source-locale only).
  *
- * IMPORTANT: Only set source-locale fields. Other locales are filled
- * by the AI localization step and translate-pending pipeline.
+ * Test/dev hook: `opts._fetchImpl` and `opts._cacheDate` are forwarded to
+ * `searchAdzunaAllPages` so suites never hit the live Adzuna API.
  */
-export async function fetchAllMscCargoJobs() {
-  console.log(`🔍 Fetching MSC Cargo jobs`);
-  console.log(`   Source: ${CAREER_URL}\n`);
+export async function fetchAllMscCargoJobs(opts = {}) {
+  console.log(`🔍 Fetching MSC Cargo jobs via Adzuna fallback`);
+  console.log(`   Direct careers URL (blocked by Akamai BMP): ${CAREER_URL}`);
+  console.log(`   Adzuna country: ch — MSC family brand match (excluding MSC Cruises)\n`);
 
-  const listings = await fetchJobListings();
-  if (!listings || listings.length === 0) {
-    console.warn('⚠️ No job listings returned.');
-    return [];
-  }
+  const employer = {
+    key: MSC_CARGO_KEY,
+    name: MSC_CARGO_COMPANY_NAME,
+    domain: MSC_CARGO_COMPANY_DOMAIN,
+    match: mscMatcher,
+    sector: 'Logistica',
+    defaultLocation: 'Geneva',
+    defaultCanton: 'GE',
+    parserSourceLabel: 'MSC Cargo Adzuna Fallback',
+  };
 
-  console.log(`  📋 Listings found: ${listings.length}`);
+  const { results, liveCalls } = await searchAdzunaAllPages({
+    company: 'MSC',
+    country: 'ch',
+    ...opts,
+  });
 
-  const jobs = [];
-  for (const listing of listings) {
-    // TODO: Extract fields from each listing.
-    // Adapt these field names to match the actual API response.
-    const title = normalizeSpace(listing.title || '');
-    if (!title || title.length < 3) continue;
+  console.log(`  📋 Adzuna listings raw: ${results.length} (live API calls: ${liveCalls})`);
 
-    const location = listing.location || 'Geneva'; // HQ: Geneva
-    const canton = inferSwissTargetCanton(location) || 'GE';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
-    const publicUrl = listing.url || CAREER_URL;
-
-    const sourceLang = detectLang(descriptionText || title, 'en');
-    const jobSlug = slugify(`${title} msc-cargo ch`);
-    const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
-
-    const job = {
-      // ── Required fields ──
-      id: `msc-cargo-${urlHash}`,
-      slug: jobSlug,
-      slugByLocale: { [sourceLang]: jobSlug },
-      company: MSC_CARGO_COMPANY_NAME,
-      companyKey: MSC_CARGO_KEY,
-      companyDomain: MSC_CARGO_COMPANY_DOMAIN,
-      title,
-      titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — MSC Cargo`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — MSC Cargo` },
-      location,
-      canton,
-      url: publicUrl,
-      source: 'MSC Cargo Dedicated Parser',
-      sourceLang,
-      crawledAt: new Date().toISOString(),
-
-      // ── Recommended fields ──
-      addressLocality: location,
-      addressCountry: 'CH',
-      country: 'CH',
-      category: detectCategory(title),
-      contract: 'full-time',
-      employmentType: detectEmploymentType(listing.timeType || title),
-      experienceLevel: detectExperienceLevel(title),
-      sector: 'Logistica', // Container shipping / cargo logistics
-      currency: 'CHF',
-      featured: false,
-      postedDate: listing.postedDate || new Date().toISOString().split('T')[0],
-      applyUrl: publicUrl,
-      requirements: [],
-      requirementsByLocale: { [sourceLang]: [] },
-    };
-
-    jobs.push(job);
-    await new Promise((r) => setTimeout(r, 300)); // Rate limiting
-  }
-
-  console.log(`\n📋 Total MSC Cargo jobs discovered: ${jobs.length}`);
+  const jobs = parseAdzunaJobs({ results }, employer);
+  console.log(`\n📋 Total MSC Cargo jobs (post-filter): ${jobs.length}`);
   return jobs;
 }
+
+// Re-export shared utilities so callers can pull everything from one module.
+export { slugify, stripHtml };

--- a/scripts/lib/richemont-job-parser.mjs
+++ b/scripts/lib/richemont-job-parser.mjs
@@ -1,19 +1,29 @@
 #!/usr/bin/env node
 /**
- * Richemont job parser — Fetcher and job builder.
+ * Richemont job parser — Adzuna free-tier metadata fallback.
  *
- * Source: https://careers.richemont.com/en/jobs/
+ * Source (anti-bot): https://careers.richemont.com/en/jobs/  → Cloudflare 403
+ * Fallback:          Adzuna Switzerland (`ch`) free-tier search API
+ *
+ * Why Adzuna?
+ *   - Direct careers URL is behind Cloudflare (`cf-ray` header) and would
+ *     require ~$8/mo residential proxy + Playwright stack to bypass.
+ *   - Adzuna is itself a job aggregator: each listing's `redirect_url`
+ *     is an Adzuna landing that deep-links to Richemont's official posting,
+ *     so applyUrl pointing at Adzuna is fully ToS-compliant.
+ *   - Free tier (1000 calls/mo per app_id) covers daily refreshes for
+ *     both Tier-3 anti-bot employers (~30-60 calls/mo combined).
+ *
+ * Required env: ADZUNA_APP_ID, ADZUNA_APP_KEY (set as GitHub Actions secrets).
  *
  * Exports the 4 required functions for the crawler template:
- *   - fetchAllRichemontJobs()  — Fetch and parse all jobs
+ *   - fetchAllRichemontJobs()  — Fetch via Adzuna and build ParsedJob[]
  *   - isRichemontJob()         — Match jobs belonging to this company
- *   - isTrustedDomain()           — Validate URLs belong to this company
- *   - slugify() / stripHtml()     — Re-exported from crawler-template.mjs
+ *   - isTrustedDomain()        — Validate URLs (Adzuna domain allowed as fallback)
+ *   - slugify() / stripHtml()  — Re-exported from crawler-template.mjs
  */
-import { createHash } from 'node:crypto';
-import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
-import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+import { searchAdzunaAllPages, parseAdzunaJobs } from './adzuna-client.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -23,26 +33,45 @@ export const RICHEMONT_COMPANY_DOMAIN = 'richemont.com';
 
 const CAREER_URL = 'https://careers.richemont.com/en/jobs/';
 
+// Brands inside Richemont group — Adzuna free-text search returns listings
+// where the company display_name is the maison, not the holding. Match all
+// known maisons so the fallback captures the full Richemont footprint.
+const RICHEMONT_BRAND_PATTERNS = [
+  /richemont/i,
+  /cartier/i,
+  /\bvan cleef\b/i,
+  /\biwc\b/i,
+  /jaeger.?lecoultre/i,
+  /piaget/i,
+  /vacheron constantin/i,
+  /panerai/i,
+  /\bmontblanc\b/i,
+  /baume.?\&?.?mercier/i,
+  /\ba\.?\s*lange\s*&?\s*söhne\b/i,
+  /\bdunhill\b/i,
+  /\bchloé\b|\bchloe\b/i,
+  /\balaïa\b|\balaia\b/i,
+  /\bnet.?a.?porter\b/i,
+  /\bmr\s*porter\b/i,
+  /\byoox\b/i,
+  /watchfinder/i,
+];
+
 /* ── Helpers ───────────────────────────────────────────────── */
 
 function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
-
 /* ── Company Matchers ──────────────────────────────────────── */
 
 /**
- * Check if a job belongs to Richemont.
- * Used by the template to filter this company's jobs from the global dataset.
+ * Check if a job belongs to Richemont (incl. its maisons).
  */
 export function isRichemontJob(job) {
   const key = normalize(job?.companyKey || job?.company || '')
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[̀-ͯ]/g, '')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
   const company = normalize(job?.company || '');
@@ -57,157 +86,66 @@ export function isRichemontJob(job) {
 }
 
 /**
- * Validate that a URL belongs to Richemont's domain.
+ * Validate that a URL belongs to a trusted Richemont surface OR Adzuna
+ * (since the Adzuna fallback emits applyUrl pointing at adzuna.com/...).
  */
 export function isTrustedDomain(rawUrl = '') {
   try {
     const host = new URL(rawUrl).hostname.toLowerCase();
     return (
       host === 'richemont.com' ||
-      host.endsWith('.richemont.com')
+      host.endsWith('.richemont.com') ||
+      host === 'adzuna.com' ||
+      host.endsWith('.adzuna.com') ||
+      host === 'adzuna.ch' ||
+      host.endsWith('.adzuna.ch')
     );
   } catch {
     return false;
   }
 }
 
-/* ── Category Detection ────────────────────────────────────── */
-
-function detectCategory(title = '') {
-  const t = normalize(title);
-  if (/\b(ingegner|engineer|entwickl)/.test(t)) return 'Ingegneria';
-  if (/\b(techni|tecnic|mecanic|elektr|install)/.test(t)) return 'Tecnica';
-  if (/\b(admin|segret|contab|buchhalt|account)/.test(t)) return 'Amministrazione';
-  if (/\b(vendita|sales|verkauf|commerce)/.test(t)) return 'Commerciale';
-  if (/\b(logist|magazz|lager|warehouse)/.test(t)) return 'Logistica';
-  if (/\b(produz|operat|operator|manufactur)/.test(t)) return 'Produzione';
-  if (/\b(qualit|qa|qc|quality)/.test(t)) return 'Qualità';
-  if (/\b(it|software|develop|programm)/.test(t)) return 'IT';
-  if (/\b(hr|human|risorse|personal)/.test(t)) return 'Risorse Umane';
-  if (/\b(market|kommunik|comunicaz)/.test(t)) return 'Marketing';
-  if (/\b(finanz|finance|financ)/.test(t)) return 'Finanza';
-  if (/\b(legal|giurid|recht)/.test(t)) return 'Legale';
-  return 'Altro';
-}
-
-function detectExperienceLevel(title = '') {
-  const t = normalize(title);
-  if (/\b(praktik|stage|stagiair|intern|apprendist|lehrling|lernend|apprenti)/.test(t)) return 'intern';
-  if (/\b(junior|jr)/.test(t)) return 'junior';
-  if (/\b(senior|sr|lead|head|director|dirett|chef|verantwort|responsab)/.test(t)) return 'senior';
-  return 'mid';
-}
-
-function detectEmploymentType(text = '') {
-  const t = normalize(text);
-  if (/\b(part.?time|teilzeit|tempo parziale|temps partiel)/.test(t)) return 'PART_TIME';
-  if (/\b(full.?time|vollzeit|tempo pieno|temps plein)/.test(t)) return 'FULL_TIME';
-  return 'OTHER';
-}
-
 /* ── Fetch + Parse ─────────────────────────────────────────── */
 
-// TODO: Implement the actual fetching logic for Richemont's career page.
-// This is a placeholder. Replace with the actual API/scraping logic.
-//
-// Common patterns:
-//   - JSON API:     use --source api for a ready-made paginated API template
-//   - Workday API:  re-scaffold with --ats=workday for a ready-made template
-//   - Greenhouse:   --ats=greenhouse
-//   - Lever:        --ats=lever
-//   - SuccessFactors: --ats=successfactors
-//   - Generic HTML: fetch + parse with regex or cheerio
-
-async function fetchJobListings() {
-  // TODO: Replace with actual fetch logic
-  console.log(`   Fetching from: ${CAREER_URL}`);
-
-  // Example for a JSON API:
-  // const res = await fetch(CAREER_URL, {
-  //   headers: { 'User-Agent': 'FrontaliereTicino-JobCrawler/2.0' },
-  // });
-  // if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  // return await res.json();
-
-  return [];
+function richemontMatcher(displayName = '') {
+  return RICHEMONT_BRAND_PATTERNS.some((rx) => rx.test(displayName));
 }
 
 /**
- * Fetch all Richemont jobs.
+ * Fetch all Richemont jobs via the Adzuna free-tier API.
  * Returns an array of ParsedJob objects (source-locale only).
  *
- * IMPORTANT: Only set source-locale fields. Other locales are filled
- * by the AI localization step and translate-pending pipeline.
+ * Test/dev hook: `opts._fetchImpl` and `opts._cacheDate` are forwarded to
+ * `searchAdzunaAllPages` so suites never hit the live Adzuna API.
  */
-export async function fetchAllRichemontJobs() {
-  console.log(`🔍 Fetching Richemont jobs`);
-  console.log(`   Source: ${CAREER_URL}\n`);
+export async function fetchAllRichemontJobs(opts = {}) {
+  console.log(`🔍 Fetching Richemont jobs via Adzuna fallback`);
+  console.log(`   Direct careers URL (blocked by Cloudflare): ${CAREER_URL}`);
+  console.log(`   Adzuna country: ch — brand match across ${RICHEMONT_BRAND_PATTERNS.length} maisons\n`);
 
-  const listings = await fetchJobListings();
-  if (!listings || listings.length === 0) {
-    console.warn('⚠️ No job listings returned.');
-    return [];
-  }
+  const employer = {
+    key: RICHEMONT_KEY,
+    name: RICHEMONT_COMPANY_NAME,
+    domain: RICHEMONT_COMPANY_DOMAIN,
+    match: richemontMatcher,
+    sector: 'Lusso',
+    defaultLocation: 'Bellevue',
+    defaultCanton: 'GE',
+    parserSourceLabel: 'Richemont Adzuna Fallback',
+  };
 
-  console.log(`  📋 Listings found: ${listings.length}`);
+  const { results, liveCalls } = await searchAdzunaAllPages({
+    company: 'Richemont',
+    country: 'ch',
+    ...opts,
+  });
 
-  const jobs = [];
-  for (const listing of listings) {
-    // TODO: Extract fields from each listing.
-    // Adapt these field names to match the actual API response.
-    const title = normalizeSpace(listing.title || '');
-    if (!title || title.length < 3) continue;
+  console.log(`  📋 Adzuna listings raw: ${results.length} (live API calls: ${liveCalls})`);
 
-    const location = listing.location || 'Bellevue'; // HQ: Bellevue (GE)
-    const canton = inferSwissTargetCanton(location) || 'GE';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
-    const publicUrl = listing.url || CAREER_URL;
-
-    const sourceLang = detectLang(descriptionText || title, 'en');
-    const jobSlug = slugify(`${title} richemont ch`);
-    const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
-
-    const job = {
-      // ── Required fields ──
-      id: `richemont-${urlHash}`,
-      slug: jobSlug,
-      slugByLocale: { [sourceLang]: jobSlug },
-      company: RICHEMONT_COMPANY_NAME,
-      companyKey: RICHEMONT_KEY,
-      companyDomain: RICHEMONT_COMPANY_DOMAIN,
-      title,
-      titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — Richemont`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — Richemont` },
-      location,
-      canton,
-      url: publicUrl,
-      source: 'Richemont Dedicated Parser',
-      sourceLang,
-      crawledAt: new Date().toISOString(),
-
-      // ── Recommended fields ──
-      addressLocality: location,
-      addressCountry: 'CH',
-      country: 'CH',
-      category: detectCategory(title),
-      contract: 'full-time',
-      employmentType: detectEmploymentType(listing.timeType || title),
-      experienceLevel: detectExperienceLevel(title),
-      sector: 'Lusso', // Luxury goods (Cartier, IWC, Van Cleef & Arpels, ...)
-      currency: 'CHF',
-      featured: false,
-      postedDate: listing.postedDate || new Date().toISOString().split('T')[0],
-      applyUrl: publicUrl,
-      requirements: [],
-      requirementsByLocale: { [sourceLang]: [] },
-    };
-
-    jobs.push(job);
-    await new Promise((r) => setTimeout(r, 300)); // Rate limiting
-  }
-
-  console.log(`\n📋 Total Richemont jobs discovered: ${jobs.length}`);
+  const jobs = parseAdzunaJobs({ results }, employer);
+  console.log(`\n📋 Total Richemont jobs (post-filter): ${jobs.length}`);
   return jobs;
 }
+
+// Re-export shared utilities so callers can pull everything from one module.
+export { slugify, stripHtml };

--- a/tests/adzuna-client.test.ts
+++ b/tests/adzuna-client.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  searchAdzuna,
+  searchAdzunaAllPages,
+  parseAdzunaJobs,
+  ADZUNA_DEFAULT_RESULTS_PER_PAGE,
+  ADZUNA_DEFAULT_MAX_PAGES,
+  ADZUNA_FREE_TIER_MONTHLY_CAP,
+} from '../scripts/lib/adzuna-client.mjs';
+
+interface MockJob {
+  id?: string;
+  title?: string;
+  description?: string;
+  company?: { display_name?: string };
+  location?: { display_name?: string; area?: string[] };
+  redirect_url?: string;
+  created?: string;
+}
+
+function buildResponse(overrides: { count?: number; results?: MockJob[] } = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      count: overrides.count ?? overrides.results?.length ?? 0,
+      results: overrides.results ?? [],
+    }),
+  } as unknown as Response;
+}
+
+describe('adzuna-client', () => {
+  let tmpCacheDir: string;
+
+  beforeEach(async () => {
+    tmpCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adzuna-cache-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpCacheDir, { recursive: true, force: true });
+  });
+
+  describe('exports', () => {
+    it('exposes free-tier constants', () => {
+      expect(ADZUNA_DEFAULT_RESULTS_PER_PAGE).toBe(50);
+      expect(ADZUNA_DEFAULT_MAX_PAGES).toBeGreaterThanOrEqual(1);
+      expect(ADZUNA_FREE_TIER_MONTHLY_CAP).toBe(1000);
+    });
+  });
+
+  describe('searchAdzuna', () => {
+    it('throws when company is missing', async () => {
+      await expect(
+        // @ts-expect-error — intentional bad input
+        searchAdzuna({ appId: 'x', appKey: 'y', cacheDir: tmpCacheDir }),
+      ).rejects.toThrow(/company/);
+    });
+
+    it('throws when credentials are missing and no cache hit', async () => {
+      await expect(
+        searchAdzuna({
+          company: 'Richemont',
+          cacheDir: tmpCacheDir,
+          appId: '',
+          appKey: '',
+          _fetchImpl: () => {
+            throw new Error('should not be called');
+          },
+        }),
+      ).rejects.toThrow(/ADZUNA_APP_ID/);
+    });
+
+    it('calls Adzuna API with correct URL + params', async () => {
+      let calledUrl = '';
+      const fetchImpl = async (url: string) => {
+        calledUrl = url;
+        return buildResponse({ results: [] });
+      };
+      await searchAdzuna({
+        company: 'Richemont',
+        country: 'ch',
+        page: 2,
+        resultsPerPage: 25,
+        appId: 'APPID123',
+        appKey: 'KEY456',
+        cacheDir: tmpCacheDir,
+        _fetchImpl: fetchImpl,
+      });
+      expect(calledUrl).toContain('https://api.adzuna.com/v1/api/jobs/ch/search/2');
+      expect(calledUrl).toContain('app_id=APPID123');
+      expect(calledUrl).toContain('app_key=KEY456');
+      expect(calledUrl).toContain('results_per_page=25');
+      expect(calledUrl).toContain('what_phrase=Richemont');
+    });
+
+    it('caches the response and avoids a second network call same day', async () => {
+      let calls = 0;
+      const fetchImpl = async () => {
+        calls += 1;
+        return buildResponse({ results: [{ id: '1', title: 'Test', redirect_url: 'https://adzuna.ch/jobs/1' }] });
+      };
+      const args = {
+        company: 'Richemont',
+        appId: 'A',
+        appKey: 'B',
+        cacheDir: tmpCacheDir,
+        _fetchImpl: fetchImpl,
+        _cacheDate: '2026-05-10',
+      };
+      const first = await searchAdzuna(args);
+      const second = await searchAdzuna(args);
+      expect(calls).toBe(1);
+      expect(first._fromCache).toBe(false);
+      expect(second._fromCache).toBe(true);
+      expect(second.results).toHaveLength(1);
+    });
+
+    it('throws on non-OK HTTP response', async () => {
+      const fetchImpl = async () => ({ ok: false, status: 503, json: async () => ({}) }) as unknown as Response;
+      await expect(
+        searchAdzuna({
+          company: 'Richemont',
+          appId: 'A',
+          appKey: 'B',
+          cacheDir: tmpCacheDir,
+          _fetchImpl: fetchImpl,
+        }),
+      ).rejects.toThrow(/HTTP 503/);
+    });
+  });
+
+  describe('searchAdzunaAllPages', () => {
+    it('stops paginating when results.length < resultsPerPage', async () => {
+      const pages = [
+        Array.from({ length: 50 }, (_, i) => ({
+          id: `${i}`,
+          title: `Job ${i}`,
+          redirect_url: `https://adzuna.ch/jobs/${i}`,
+          company: { display_name: 'Richemont' },
+        })),
+        // page 2: short → stop
+        Array.from({ length: 3 }, (_, i) => ({
+          id: `p2-${i}`,
+          title: `Job p2-${i}`,
+          redirect_url: `https://adzuna.ch/jobs/p2-${i}`,
+          company: { display_name: 'Richemont' },
+        })),
+      ];
+      let pageCalls = 0;
+      const fetchImpl = async () => {
+        const page = pages[pageCalls] ?? [];
+        pageCalls += 1;
+        return buildResponse({ results: page });
+      };
+      const { results, liveCalls } = await searchAdzunaAllPages({
+        company: 'Richemont',
+        appId: 'A',
+        appKey: 'B',
+        cacheDir: tmpCacheDir,
+        _fetchImpl: fetchImpl,
+        _cacheDate: '2026-05-10',
+        maxPages: 5,
+      });
+      expect(results).toHaveLength(53);
+      expect(liveCalls).toBe(2);
+      expect(pageCalls).toBe(2);
+    });
+
+    it('respects maxPages cap to honour free tier', async () => {
+      const fullPage = Array.from({ length: 50 }, (_, i) => ({
+        id: `${i}`,
+        title: `Job ${i}`,
+        redirect_url: `https://adzuna.ch/jobs/${i}`,
+        company: { display_name: 'MSC Cargo' },
+      }));
+      let pageCalls = 0;
+      const fetchImpl = async () => {
+        pageCalls += 1;
+        return buildResponse({ results: fullPage });
+      };
+      const { liveCalls } = await searchAdzunaAllPages({
+        company: 'MSC',
+        appId: 'A',
+        appKey: 'B',
+        cacheDir: tmpCacheDir,
+        _fetchImpl: fetchImpl,
+        _cacheDate: '2026-05-10',
+        maxPages: 2,
+      });
+      expect(liveCalls).toBe(2);
+      expect(pageCalls).toBe(2);
+    });
+  });
+
+  describe('parseAdzunaJobs', () => {
+    const employer = {
+      key: 'richemont',
+      name: 'Richemont',
+      domain: 'richemont.com',
+      match: (display: string) => /richemont|cartier/i.test(display),
+      sector: 'Lusso',
+      defaultLocation: 'Bellevue',
+      defaultCanton: 'GE',
+      parserSourceLabel: 'Richemont Adzuna Fallback',
+    };
+
+    it('throws when employer is missing required keys', () => {
+      expect(() =>
+        // @ts-expect-error — intentional bad input
+        parseAdzunaJobs({ results: [] }, { key: 'richemont' }),
+      ).toThrow();
+    });
+
+    it('returns empty array for empty results', () => {
+      expect(parseAdzunaJobs({ results: [] }, employer)).toEqual([]);
+      // @ts-expect-error — intentional missing key
+      expect(parseAdzunaJobs({}, employer)).toEqual([]);
+    });
+
+    it('filters out listings whose company.display_name does not match', () => {
+      const raw = {
+        results: [
+          {
+            id: '1',
+            title: 'Watchmaker',
+            company: { display_name: 'Richemont International' },
+            location: { display_name: 'Geneva' },
+            redirect_url: 'https://www.adzuna.ch/jobs/details/1',
+            created: '2026-05-01T10:00:00Z',
+            description: 'Watchmaker role at the maison.',
+          },
+          {
+            id: '2',
+            title: 'Pilot',
+            company: { display_name: 'SWISS Air Lines' },
+            location: { display_name: 'Zurich' },
+            redirect_url: 'https://www.adzuna.ch/jobs/details/2',
+            created: '2026-05-02T10:00:00Z',
+            description: 'Pilot role.',
+          },
+          {
+            id: '3',
+            title: 'Sales Associate',
+            company: { display_name: 'Cartier Joaillerie' },
+            location: { display_name: 'Geneva' },
+            redirect_url: 'https://www.adzuna.ch/jobs/details/3',
+            created: '2026-05-03T10:00:00Z',
+            description: 'Sales role at Cartier boutique.',
+          },
+        ],
+      };
+      const jobs = parseAdzunaJobs(raw, employer);
+      expect(jobs).toHaveLength(2);
+      expect(jobs.map((j: { title: string }) => j.title)).toEqual([
+        'Watchmaker',
+        'Sales Associate',
+      ]);
+    });
+
+    it('emits ParsedJob shape with required fields', () => {
+      const raw = {
+        results: [
+          {
+            id: '1',
+            title: 'Senior Watchmaker',
+            company: { display_name: 'Richemont International' },
+            location: { display_name: 'Geneva, Switzerland' },
+            redirect_url: 'https://www.adzuna.ch/jobs/details/1',
+            created: '2026-05-01T10:00:00Z',
+            description: 'Lead watchmaker.',
+          },
+        ],
+      };
+      const [job] = parseAdzunaJobs(raw, employer);
+      const required = [
+        'id', 'slug', 'slugByLocale', 'company', 'companyKey', 'companyDomain',
+        'title', 'titleByLocale', 'description', 'descriptionByLocale',
+        'location', 'canton', 'url', 'source', 'sourceLang', 'crawledAt',
+        'applyUrl', 'postedDate', 'sector', 'currency',
+      ];
+      for (const f of required) expect(job).toHaveProperty(f);
+      expect(job.id).toMatch(/^richemont-/);
+      expect(job.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+      expect(job.applyUrl).toBe('https://www.adzuna.ch/jobs/details/1');
+      expect(job.url).toBe('https://www.adzuna.ch/jobs/details/1');
+      expect(job.postedDate).toBe('2026-05-01');
+      expect(job.sector).toBe('Lusso');
+      expect(job.source).toBe('Richemont Adzuna Fallback');
+      expect(job.companyDomain).toBe('richemont.com');
+    });
+
+    it('skips listings with missing redirect_url or invalid URL', () => {
+      const raw = {
+        results: [
+          {
+            id: '1',
+            title: 'Watchmaker',
+            company: { display_name: 'Richemont' },
+            redirect_url: '',
+          },
+          {
+            id: '2',
+            title: 'Designer',
+            company: { display_name: 'Cartier' },
+            redirect_url: 'not-a-url',
+          },
+          {
+            id: '3',
+            title: 'Engineer',
+            company: { display_name: 'Richemont' },
+            redirect_url: 'https://www.adzuna.ch/jobs/details/3',
+          },
+        ],
+      };
+      const jobs = parseAdzunaJobs(raw, employer);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].title).toBe('Engineer');
+    });
+
+    it('deduplicates by stable id derived from URL hash', () => {
+      const raw = {
+        results: [
+          {
+            id: '1',
+            title: 'Watchmaker',
+            company: { display_name: 'Richemont' },
+            redirect_url: 'https://www.adzuna.ch/jobs/details/duplicate',
+          },
+          {
+            id: '2',
+            title: 'Watchmaker',
+            company: { display_name: 'Richemont' },
+            redirect_url: 'https://www.adzuna.ch/jobs/details/duplicate',
+          },
+        ],
+      };
+      const jobs = parseAdzunaJobs(raw, employer);
+      expect(jobs).toHaveLength(1);
+    });
+  });
+});

--- a/tests/msc-cargo-crawler.test.ts
+++ b/tests/msc-cargo-crawler.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import {
   MSC_CARGO_KEY,
   MSC_CARGO_COMPANY_NAME,
   isMscCargoJob,
   isTrustedDomain,
+  fetchAllMscCargoJobs,
 } from '../scripts/lib/msc-cargo-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -47,6 +51,11 @@ describe('MSC Cargo crawler parser', () => {
 
     it('trusts subdomains', () => {
       expect(isTrustedDomain('https://careers.msc.com/job/456')).toBe(true);
+    });
+
+    it('trusts Adzuna domains (fallback aggregator)', () => {
+      expect(isTrustedDomain('https://www.adzuna.ch/jobs/details/abc')).toBe(true);
+      expect(isTrustedDomain('https://adzuna.com/jobs/details/abc')).toBe(true);
     });
 
     it('rejects other domains', () => {
@@ -124,6 +133,91 @@ describe('MSC Cargo crawler parser', () => {
 
     it('slug is URL-safe', () => {
       expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+
+  // ── fetchAllMscCargoJobs (Adzuna fallback path, mocked fetch) ──
+  describe('fetchAllMscCargoJobs (Adzuna fallback)', () => {
+    let tmpCacheDir: string;
+
+    beforeEach(async () => {
+      tmpCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adz-msc-'));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpCacheDir, { recursive: true, force: true });
+    });
+
+    it('returns ParsedJobs from a mocked Adzuna response, excluding MSC Cruises', async () => {
+      const fetchImpl = async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            count: 4,
+            results: [
+              {
+                id: '1',
+                title: 'Logistics Coordinator',
+                company: { display_name: 'MSC Mediterranean Shipping' },
+                location: { display_name: 'Geneva' },
+                redirect_url: 'https://www.adzuna.ch/jobs/details/1',
+                created: '2026-05-01T10:00:00Z',
+                description: 'Coordinator role.',
+              },
+              {
+                id: '2',
+                title: 'IT Operations Specialist',
+                company: { display_name: 'MSC Technology' },
+                location: { display_name: 'Geneva' },
+                redirect_url: 'https://www.adzuna.ch/jobs/details/2',
+                created: '2026-05-02T10:00:00Z',
+                description: 'Ops role.',
+              },
+              {
+                id: '3',
+                title: 'Cruise Director',
+                company: { display_name: 'MSC Cruises' },
+                location: { display_name: 'Geneva' },
+                redirect_url: 'https://www.adzuna.ch/jobs/details/3',
+                created: '2026-05-03T10:00:00Z',
+                description: 'Cruise role.',
+              },
+              {
+                id: '4',
+                title: 'Sales Lead',
+                company: { display_name: 'Some Other Company' },
+                location: { display_name: 'Zurich' },
+                redirect_url: 'https://www.adzuna.ch/jobs/details/4',
+                created: '2026-05-04T10:00:00Z',
+                description: 'Sales role.',
+              },
+            ],
+          }),
+        }) as unknown as Response;
+
+      const jobs = await fetchAllMscCargoJobs({
+        appId: 'TEST_ID',
+        appKey: 'TEST_KEY',
+        cacheDir: tmpCacheDir,
+        _fetchImpl: fetchImpl,
+        _cacheDate: '2026-05-10',
+        maxPages: 1,
+      });
+
+      expect(jobs).toHaveLength(2);
+      const titles = jobs.map((j: { title: string }) => j.title);
+      expect(titles).toContain('Logistics Coordinator');
+      expect(titles).toContain('IT Operations Specialist');
+      expect(titles).not.toContain('Cruise Director');
+      expect(titles).not.toContain('Sales Lead');
+      for (const job of jobs) {
+        expect(job.companyKey).toBe('msc-cargo');
+        expect(job.source).toBe('MSC Cargo Adzuna Fallback');
+        expect(job.sector).toBe('Logistica');
+        expect(job.applyUrl).toMatch(/^https:\/\/www\.adzuna\.ch\//);
+        expect(isTrustedDomain(job.applyUrl)).toBe(true);
+      }
     });
   });
 });

--- a/tests/richemont-crawler.test.ts
+++ b/tests/richemont-crawler.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import {
   RICHEMONT_KEY,
   RICHEMONT_COMPANY_NAME,
   isRichemontJob,
   isTrustedDomain,
+  fetchAllRichemontJobs,
 } from '../scripts/lib/richemont-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -47,6 +51,11 @@ describe('Richemont crawler parser', () => {
 
     it('trusts subdomains', () => {
       expect(isTrustedDomain('https://careers.richemont.com/job/456')).toBe(true);
+    });
+
+    it('trusts Adzuna domains (fallback aggregator)', () => {
+      expect(isTrustedDomain('https://www.adzuna.ch/jobs/details/abc')).toBe(true);
+      expect(isTrustedDomain('https://adzuna.com/jobs/details/abc')).toBe(true);
     });
 
     it('rejects other domains', () => {
@@ -124,6 +133,81 @@ describe('Richemont crawler parser', () => {
 
     it('slug is URL-safe', () => {
       expect(validJob.slug).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    });
+  });
+
+  // ── fetchAllRichemontJobs (Adzuna fallback path, mocked fetch) ──
+  describe('fetchAllRichemontJobs (Adzuna fallback)', () => {
+    let tmpCacheDir: string;
+
+    beforeEach(async () => {
+      tmpCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adz-richemont-'));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpCacheDir, { recursive: true, force: true });
+    });
+
+    it('returns ParsedJobs from a mocked Adzuna response, filtering non-Richemont brands', async () => {
+      const fetchImpl = async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            count: 3,
+            results: [
+              {
+                id: '1',
+                title: 'Senior Watchmaker',
+                company: { display_name: 'Richemont International SA' },
+                location: { display_name: 'Geneva, Switzerland' },
+                redirect_url: 'https://www.adzuna.ch/jobs/details/1',
+                created: '2026-05-01T10:00:00Z',
+                description: 'Lead watchmaker role.',
+              },
+              {
+                id: '2',
+                title: 'Boutique Manager',
+                company: { display_name: 'Cartier' },
+                location: { display_name: 'Zurich' },
+                redirect_url: 'https://www.adzuna.ch/jobs/details/2',
+                created: '2026-05-02T10:00:00Z',
+                description: 'Boutique management role.',
+              },
+              {
+                id: '3',
+                title: 'Pilot',
+                company: { display_name: 'SWISS Air Lines' },
+                location: { display_name: 'Zurich' },
+                redirect_url: 'https://www.adzuna.ch/jobs/details/3',
+                created: '2026-05-03T10:00:00Z',
+                description: 'Pilot role.',
+              },
+            ],
+          }),
+        }) as unknown as Response;
+
+      const jobs = await fetchAllRichemontJobs({
+        appId: 'TEST_ID',
+        appKey: 'TEST_KEY',
+        cacheDir: tmpCacheDir,
+        _fetchImpl: fetchImpl,
+        _cacheDate: '2026-05-10',
+        maxPages: 1,
+      });
+
+      expect(jobs).toHaveLength(2);
+      const titles = jobs.map((j: { title: string }) => j.title);
+      expect(titles).toContain('Senior Watchmaker');
+      expect(titles).toContain('Boutique Manager');
+      expect(titles).not.toContain('Pilot');
+      for (const job of jobs) {
+        expect(job.companyKey).toBe('richemont');
+        expect(job.source).toBe('Richemont Adzuna Fallback');
+        expect(job.sector).toBe('Lusso');
+        expect(job.applyUrl).toMatch(/^https:\/\/www\.adzuna\.ch\//);
+        expect(isTrustedDomain(job.applyUrl)).toBe(true);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Replaces the Tier-3 Playwright placeholders for **Richemont** (Cloudflare 403) and **MSC Cargo** (Akamai BMP 403) with a free-tier Adzuna metadata fallback. Adzuna is itself a job aggregator — its `redirect_url` deep-links to the employer's official posting, so `applyUrl` pointing at `adzuna.ch` is fully ToS-compliant.

- **$0/mo budget preserved.** Adzuna free tier = 1000 calls/mo per `app_id`. Per-employer daily on-disk cache (`data/adzuna-cache/`, gitignored) keeps both crawlers well under the cap (~30–60 live calls/mo combined for daily refresh).
- **No residential proxy needed.** Saves the ~\$16/mo (\$8/mo × 2) the Playwright + proxy alternative would have cost.
- **Brand-family filter.** Richemont matches 18 maisons (Cartier, IWC, VCA, Montblanc, ...). MSC matches Mediterranean/Technology/Logistics and explicitly **excludes MSC Cruises** (separate employer).

## Files

**New**
- `scripts/lib/adzuna-client.mjs` — `searchAdzuna`, `searchAdzunaAllPages`, `parseAdzunaJobs`. Injectable `_fetchImpl` so tests never hit the live API.
- `tests/adzuna-client.test.ts` — 14 tests (cache hit/miss, URL build, pagination cap, employer match filter, ParsedJob shape, dedup).

**Modified**
- `scripts/lib/richemont-job-parser.mjs` + `scripts/lib/msc-cargo-job-parser.mjs` — placeholders replaced with Adzuna integration. `isTrustedDomain` extended to allow `adzuna.com`/`.ch` as fallback applyUrl host.
- `tests/richemont-crawler.test.ts` + `tests/msc-cargo-crawler.test.ts` — added integration tests with mocked Adzuna fetch + new `isTrustedDomain` assertions.
- `.github/workflows/update-jobs-richemont.yml` + `.github/workflows/update-jobs-msc-cargo.yml` — `ADZUNA_APP_ID` + `ADZUNA_APP_KEY` secrets wired into the run step.
- `.gitignore` — `data/adzuna-cache/` ignored.
- `docs/CATHEDRAL-STATUS.md` — Richemont + MSC marked **DONE-WITH-ADZUNA-FALLBACK 2026-05-10**; Bobst + Vaudoise remain as Tier-3 follow-up.

## Setup required (operator action before workflow_dispatch)

The Adzuna credentials are not committed (placeholders only via `process.env.*`). To obtain them:

1. Sign up at <https://developer.adzuna.com/> — free, **no credit card**.
2. Create an application; copy the resulting `app_id` and `app_key`.
3. Add two GitHub repository secrets:
   - `ADZUNA_APP_ID`
   - `ADZUNA_APP_KEY`
4. Trigger live: `gh workflow run update-jobs-richemont.yml` and `gh workflow run update-jobs-msc-cargo.yml`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/adzuna-client.test.ts tests/richemont-crawler.test.ts tests/msc-cargo-crawler.test.ts` — 54/54 passing
- [x] `npx vitest run tests/scripts/audit-parser-quality.test.ts` — 14/14 passing (no parser-quality regression)
- [ ] After merge: add `ADZUNA_APP_ID` + `ADZUNA_APP_KEY` repo secrets
- [ ] After merge: `gh workflow run update-jobs-richemont.yml --ref main` → verify `gh run view` `conclusion: success` + commit lands in `data/jobs-crawler-adapters/`
- [ ] After merge: `gh workflow run update-jobs-msc-cargo.yml --ref main` → same validation
- [ ] Verify `data/jobs/by-crawler/richemont.json` + `msc-cargo.json` contain ParsedJobs whose `applyUrl` is an Adzuna URL and whose `companyKey` matches