### PR TITLE
fix(newsletter): preserve content URL on click-through from newsletter links

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -23,10 +23,21 @@ export const BUILD_ID = String(Date.now());
  * If the URL carries SPA-relevant query params (newsletter confirmation,
  * auth tokens, unsubscribe, etc.), save the full URL in sessionStorage and
  * redirect to / so the React app can process the action.
+ *
+ * IMPORTANT: tracking + autologin params (`ne`, `ac`) are intentionally NOT
+ * in the trigger set. They appear on EVERY newsletter content link (article,
+ * job detail, company hub) and are processed in-place by `App.tsx` after
+ * hydration — App.tsx exchanges `ac` for a fresh auth token and strips both
+ * params from the URL via `history.replaceState`. Triggering a redirect on
+ * `ne`/`ac` destroys the static document the user just landed on (and any
+ * window-seeded data like `__EXPIRED_JOB_DATA__` / `__BRIDGE_TARGET_SLUG__`)
+ * because `location.replace('/')` loads a fresh `index.html` that no longer
+ * has those globals — soft-landing pages then fall back to the generic
+ * "annuncio non trovato" view instead of the rich expired-job content.
  */
 export const SPA_ACTION_REDIRECT_SCRIPT = `<script>(function(){
  var p=new URLSearchParams(location.search);
- if(p.get('action')||p.get('ac')||p.get('at')||p.get('authToken')||p.get('newsletter_autologin')||p.get('ne')){
+ if(p.get('action')||p.get('at')||p.get('authToken')||p.get('newsletter_autologin')){
  sessionStorage.redirect=location.href;
  location.replace('/');
  }

--- a/hooks/useNavigationState.ts
+++ b/hooks/useNavigationState.ts
@@ -661,7 +661,19 @@ export function useNavigationState(): NavigationState {
  suppressNextRouteSyncForTabRef.current = null;
  return;
  }
- const route: AppRoute = { activeTab: 'blog', blogArticle: blogArticle || undefined };
+ // When the lazy-loaded blog data hasn't resolved the URL slug yet,
+ // the URL contains `/articoli-frontaliere/<slug>/` but `blogArticle`
+ // is still null. Re-parse the current URL to recover the pending slug
+ // and include it in the route, so `pushRoute` → `buildPath` preserves
+ // it instead of rewriting the URL to the hub root.
+ const pendingSlug = blogArticle
+ ? undefined
+ : parsePath(window.location.pathname).route.blogSlug;
+ const route: AppRoute = {
+ activeTab: 'blog',
+ blogArticle: blogArticle || undefined,
+ ...(pendingSlug ? { blogSlug: pendingSlug } : {}),
+ };
  const seoKey = getSeoSection(route);
  updateMetaTags(seoKey);
  trackSectionView(seoKey);

--- a/services/router.ts
+++ b/services/router.ts
@@ -2970,6 +2970,14 @@ export function buildPath(route: AppRoute, locale?: Locale): string {
  const slug = _blogSlugs?.[article]?.[lang] ?? article;
  return finish(`${prefix}/${table.blog}/${slug}${hashSuffix}`);
  }
+ // Defense-in-depth: when the lazy-loaded blog data hasn't resolved the
+ // slug yet, parsePath returns `blogSlug` instead of `blogArticle`.
+ // Preserve it in the URL so a stray `pushRoute(route)` during the
+ // resolution window doesn't strip the slug and rewrite the URL to the
+ // hub root (e.g. /articoli-frontaliere/<slug>/ → /articoli-frontaliere/).
+ if (route.blogSlug) {
+ return finish(`${prefix}/${table.blog}/${route.blogSlug}${hashSuffix}`);
+ }
  return finish(`${prefix}/${table.blog}${hashSuffix}`);
  }
  case 'admin':


### PR DESCRIPTION
## Summary

Three coordinated fixes so a newsletter recipient who clicks a link in the email lands on the article / job detail / company hub they expected — not on the section root or a generic "annuncio non trovato" view.

### 1. `build-plugins/constants.ts` — stop forcing a redirect on tracking params

`SPA_ACTION_REDIRECT_SCRIPT` used to fire `sessionStorage.redirect = location.href; location.replace('/')` whenever `?ne=` (recipient email) or `?ac=` (HMAC autologin code) was on the URL. These appear on **every** newsletter content link (built by `scripts/send-newsletter.mjs:556-566`), so every click destroyed the static document the user just landed on:

- Job-detail / soft-landing pages lost `window.__EXPIRED_JOB_DATA__` (seeded inline by `jobsSeoPagesPlugin.ts:7528`) → `useExpiredJob` fell back to `/data/expired-jobs.json`, which doesn't include the canonical slug for our reported URL → user saw "annuncio non trovato" instead of `JobExpiredView`.
- Brand-hub HTML (rich EOC body, FAQ, salary context) was thrown away before the React shell could render over it, leaving a generic JobBoard listing filtered by company.

`App.tsx:336-388` already exchanges `ac` for a fresh auth token and strips `ne`/`ac` from the URL in-place after hydration, so the redirect-to-`/` is redundant for those params. The script still triggers for real SPA actions (`action`, `at`, `authToken`, `newsletter_autologin`) which live on dedicated URLs.

### 2. `services/router.ts` — `buildPath('blog')` preserves an unresolved slug

When the lazy-loaded blog chunk (`routerBlogData.ts`, ~95 KB) hasn't loaded yet, `parsePath` returns `{ activeTab: 'blog', blogSlug: '<slug>' }` instead of a resolved `blogArticle`. The old `case 'blog'` only handled `blogArticle` and fell through to `/articoli-frontaliere/` — so any `pushRoute` during the resolution window stripped the slug and rewrote `/articoli-frontaliere/<slug>/?utm_medium=newsletter` to `/articoli-frontaliere/?utm_medium=newsletter`. Now the `blogSlug` fallback is honoured.

### 3. `hooks/useNavigationState.ts` — blog effect carries the pending slug

The blog `useEffect` built the route from React state, which only tracks `blogArticle`. When `blogArticle` was `null` it called `pushRoute({ activeTab: 'blog', blogArticle: undefined })` — `buildPath` had no way to see the URL still had a slug. Now the effect re-parses `window.location.pathname`, recovers the pending `blogSlug`, and passes it through, so `buildPath` (point 2) keeps the slug in the URL until `setBlogArticle(resolved)` arrives.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `FAST_BUILD=1 npx vite build` exits 0
- [x] `npx vitest run tests/router.test.ts tests/hooks/useNavigationState.test.ts` — only pre-existing `jobBoardCanton: 'TI'` assertion in `tests/router.test.ts:362` fails (on `main` unchanged, unrelated)
- [ ] Post-deploy: click a newsletter link with `?ne=…&ac=…&utm_medium=newsletter` against an article, an active job, an expired job soft-landing, and a company hub — URL stays intact, expected content renders

https://claude.ai/code/session_01HQg6eMX7Y5skSesy55zaFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQg6eMX7Y5skSesy55zaFv)_