### PR TITLE
perf(firestore): cut article_views + _meta_ read costs

### DIFF
--- a/.github/workflows/refresh-article-trending.yml
+++ b/.github/workflows/refresh-article-trending.yml
@@ -1,0 +1,80 @@
+name: Refresh Article Trending
+
+# Reads the `article_views` Firestore collection ONCE per day and commits the
+# resulting `public/article-trending.json` snapshot to main. The SPA's
+# components/community/BlogArticles.tsx reads the committed file instead of
+# scanning ~1377 docs from the browser on every cache-miss visit.
+#
+# Cost rationale: before this workflow, fetchTrendingArticles() in
+# BlogArticles.tsx executed `getDocs(collection('article_views'))` from each
+# unique browser session whenever the 1h localStorage cache missed. With
+# `allow read: if true` rules and ~1377 docs growing, this was estimated at
+# ~500k–5M Firestore reads/wk (correlated with blog SEO traffic).
+# Daily cron drops that to ~7 server-side scans/wk, ~10k reads/wk total.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 5 * * *'  # 06:15 CET / 07:15 CEST — 15 min after job-popularity to avoid push race
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-article-trending
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            echo "❌ FIREBASE_SERVICE_ACCOUNT_JSON missing"
+            exit 1
+          fi
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Fetch article trending from Firestore
+        run: node scripts/fetch-article-trending.mjs
+
+      - name: Commit and push trending snapshot
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "GitHub Actions"
+          git add public/article-trending.json
+          git diff --cached --quiet && echo "No trending changes to commit" && exit 0
+          git commit -m "chore(data): refresh article trending snapshot"
+          # Concurrent data-refresh workflows can push to main at the same
+          # time (memory project_workflow_push_race_pattern). Use the shared
+          # rebase-retry helper. The fetch is deterministic given the
+          # current article_views state, so on conflict we re-run it after
+          # rebasing.
+          bash scripts/lib/git-push-with-retry.sh \
+            --regenerate-cmd "node scripts/fetch-article-trending.mjs && git add public/article-trending.json"
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "CI Failure: Refresh Article Trending — run ${{ github.run_number }}" \
+            --description "Article trending refresh failed. Check https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -60,7 +60,7 @@ async function trackArticleView(articleId: string): Promise<void> {
 
 export { trackArticleView };
 
-/* ─── Trending articles (Firestore → localStorage cache) ─── */
+/* ─── Trending articles (static JSON snapshot → localStorage cache) ─── */
 
 interface TrendingEntry { id: string; views: number; lastViewed: number }
 
@@ -79,39 +79,22 @@ async function fetchTrendingArticles(validIds: Set<string>): Promise<TrendingEnt
  }
  } catch { /* corrupt cache — refetch */ }
 
+ // Source: public/article-trending.json — refreshed daily by
+ // .github/workflows/refresh-article-trending.yml. The cron job already
+ // applied recency weighting (7d full, 30d half) and sorted by views, so
+ // here we just slice the top 12 and intersect with currently-valid IDs.
+ // Previously this function did a client-side full scan of `article_views`
+ // (~1377 docs/cache-miss with `allow read: if true` rules) — dominant
+ // Firestore read cost post-May-8 fix.
  try {
- if (!_viewDbInit) {
- const { getFirestore } = await import('firebase/firestore');
- const { app } = await import('@/services/firebase');
- _viewDb = getFirestore(app);
- _viewDbInit = true;
- }
- if (!_viewDb) return [];
-
- const { collection, getDocs } = await import('firebase/firestore');
- const snap = await getDocs(collection(_viewDb, 'article_views'));
- const now = Date.now();
- const sevenDays = 7 * 24 * 60 * 60 * 1000;
- const entries: TrendingEntry[] = [];
-
- snap.forEach((d: any) => {
- const data = d.data();
- const lastViewed = data.lastViewed?.toMillis?.() ?? data.lastViewed?.getTime?.() ?? 0;
- const views = data.views ?? 0;
- // Boost articles viewed recently: full weight within 7 days, half weight within 30 days
- const age = now - lastViewed;
- if (age < sevenDays) {
- entries.push({ id: d.id, views, lastViewed });
- } else if (age < 30 * 24 * 60 * 60 * 1000 && views > 5) {
- entries.push({ id: d.id, views: Math.round(views * 0.5), lastViewed });
- }
- });
-
- entries.sort((a, b) => b.views - a.views);
- const top = entries.slice(0, 12); // cache top 12
+ const res = await fetch('/article-trending.json', { cache: 'no-cache' });
+ if (!res.ok) return [];
+ const payload = await res.json();
+ const rawEntries: TrendingEntry[] = Array.isArray(payload?.entries) ? payload.entries : [];
+ const top = rawEntries.slice(0, 12);
 
  try {
- localStorage.setItem(TRENDING_CACHE_KEY, JSON.stringify({ ts: now, data: top }));
+ localStorage.setItem(TRENDING_CACHE_KEY, JSON.stringify({ ts: Date.now(), data: top }));
  } catch { /* quota — ignore */ }
 
  return top.filter(e => validIds.has(e.id));

--- a/components/pages/AdminPanel.tsx
+++ b/components/pages/AdminPanel.tsx
@@ -455,13 +455,16 @@ export default function AdminPanel() {
  (async () => {
  setNlLoading(true);
  try {
- const { getFirestore, collection, query, where, getDocs, doc: firestoreDoc, getDoc } = await import('firebase/firestore');
+ const { getFirestore, collection, query, where, getDocs, getCountFromServer, limit, doc: firestoreDoc, getDoc } = await import('firebase/firestore');
  const { app } = await import('@/services/firebase');
  const db = getFirestore(app);
 
- // Subscriber count
- const subSnap = await getDocs(query(collection(db, 'newsletter_subscribers'), where('isActive', '==', true)));
- if (!cancelled) setNlSubscriberCount(subSnap.size);
+ const activeSubsQ = query(collection(db, 'newsletter_subscribers'), where('isActive', '==', true));
+
+ // Subscriber count (count() aggregation = 1 Firestore read regardless
+ // of collection size; previously this fetched every active doc).
+ const countSnap = await getCountFromServer(activeSubsQ);
+ if (!cancelled) setNlSubscriberCount(countSnap.data().count);
 
  // Last send (stored under newsletter_subscribers/_meta_)
  const metaSnap = await getDoc(firestoreDoc(db, 'newsletter_subscribers', '_meta_'));
@@ -471,9 +474,11 @@ export default function AdminPanel() {
  setNlLastSend(date.toLocaleDateString('it-IT', { day: 'numeric', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit' }));
  }
 
- // Recipient emails (first 10, masked)
+ // Recipient emails (first 10, masked) — bounded query so we never pull
+ // the whole collection just to render the preview list.
+ const sampleSnap = await getDocs(query(activeSubsQ, limit(10)));
  const recipDocs: string[] = [];
- subSnap.forEach(d => {
+ sampleSnap.forEach(d => {
  const email = d.data().email;
  if (email && recipDocs.length < 10) {
  const [user, domain] = email.split('@');

--- a/public/article-trending.json
+++ b/public/article-trending.json
@@ -1,0 +1,257 @@
+{
+  "generatedAt": "2026-05-11T12:29:24.815Z",
+  "totalScanned": 1380,
+  "eligible": 859,
+  "entries": [
+    {
+      "id": "allentamenti-affitti-brevi-ticino-2025",
+      "views": 180,
+      "lastViewed": 1778354869865
+    },
+    {
+      "id": "presunti-maltrattamenti-asilo-chiasso",
+      "views": 66,
+      "lastViewed": 1778440926466
+    },
+    {
+      "id": "esposizione-segughi-malvaglia-2026",
+      "views": 64,
+      "lastViewed": 1778356414447
+    },
+    {
+      "id": "coppa-del-mondo-orientamento-locarnese-2026",
+      "views": 53,
+      "lastViewed": 1778361875986
+    },
+    {
+      "id": "dogana-chiasso-traffico-2026",
+      "views": 53,
+      "lastViewed": 1778362509113
+    },
+    {
+      "id": "mutuo-casa-frontalieri-italia",
+      "views": 53,
+      "lastViewed": 1778458302564
+    },
+    {
+      "id": "lavena-brano-musicale-leone-xiv",
+      "views": 52,
+      "lastViewed": 1778360024954
+    },
+    {
+      "id": "comuni-migliori-frontalieri",
+      "views": 47,
+      "lastViewed": 1778357392561
+    },
+    {
+      "id": "a9-chiasso-como-chiusure-frontalieri",
+      "views": 46,
+      "lastViewed": 1778439956923
+    },
+    {
+      "id": "costo-vivere-lugano-trasferirsi",
+      "views": 38,
+      "lastViewed": 1778262970990
+    },
+    {
+      "id": "funivia-monteviasco-orari-corsi",
+      "views": 37,
+      "lastViewed": 1778491486731
+    },
+    {
+      "id": "trovare-lavoro-ticino",
+      "views": 33,
+      "lastViewed": 1778502149074
+    },
+    {
+      "id": "calcolo-pensione-avs-inps",
+      "views": 32,
+      "lastViewed": 1778495525622
+    },
+    {
+      "id": "nuovo-contratto-edilizia-ticino-2026-2031",
+      "views": 32,
+      "lastViewed": 1778495155857
+    },
+    {
+      "id": "omaggio-angeli-ponte-chiasso",
+      "views": 32,
+      "lastViewed": 1778363181275
+    },
+    {
+      "id": "g-bewilligung-leitfaden-grenzgaenger-2026",
+      "views": 31,
+      "lastViewed": 1778470955660
+    },
+    {
+      "id": "campione-ditalia-elezioni-sindaco-2026",
+      "views": 28,
+      "lastViewed": 1778196158831
+    },
+    {
+      "id": "miliardari-dubai-svizzera-lugano",
+      "views": 28,
+      "lastViewed": 1778398652109
+    },
+    {
+      "id": "pilastro-3a-frontaliere",
+      "views": 28,
+      "lastViewed": 1778483358406
+    },
+    {
+      "id": "calcio-alpino-ticino-2026",
+      "views": 27,
+      "lastViewed": 1778501473672
+    },
+    {
+      "id": "guida-dichiarazione-redditi-frontalieri",
+      "views": 27,
+      "lastViewed": 1778428279621
+    },
+    {
+      "id": "academy-fnma-autisti-bus-2026",
+      "views": 26,
+      "lastViewed": 1778174087834
+    },
+    {
+      "id": "g7-evian-frontiere-chiuse-2026",
+      "views": 25,
+      "lastViewed": 1778502308655
+    },
+    {
+      "id": "petrolio-uccide-protesta-vezia-2026",
+      "views": 25,
+      "lastViewed": 1778444118893
+    },
+    {
+      "id": "venditti-estival-lugano-2026",
+      "views": 24,
+      "lastViewed": 1778364462968
+    },
+    {
+      "id": "confine-italia-svizzera-6-regole-doganali",
+      "views": 23,
+      "lastViewed": 1778256158904
+    },
+    {
+      "id": "fiera-antiquariato-mendrisio-2026",
+      "views": 23,
+      "lastViewed": 1778434398446
+    },
+    {
+      "id": "naspi-ex-frontalieri-2026",
+      "views": 23,
+      "lastViewed": 1778214234211
+    },
+    {
+      "id": "disagi-tilo-sciopero-italia",
+      "views": 22,
+      "lastViewed": 1778320127082
+    },
+    {
+      "id": "stipendio-netto-2026",
+      "views": 22,
+      "lastViewed": 1777996952869
+    },
+    {
+      "id": "confine-a9-disagi-marzo",
+      "views": 21,
+      "lastViewed": 1778212781445
+    },
+    {
+      "id": "grandine-bellinzonese-allerta-lugano-chiasso-19-aprile-2026",
+      "views": 21,
+      "lastViewed": 1778081612752
+    },
+    {
+      "id": "autostrada-a9-chiude-de-notti-2026",
+      "views": 20,
+      "lastViewed": 1778499053055
+    },
+    {
+      "id": "autostrada-a9-disagi-frontalieri",
+      "views": 20,
+      "lastViewed": 1778350665244
+    },
+    {
+      "id": "guida-contributi-sociali-svizzera",
+      "views": 20,
+      "lastViewed": 1778237983468
+    },
+    {
+      "id": "incendio-auto-a2-camorino",
+      "views": 20,
+      "lastViewed": 1778448851342
+    },
+    {
+      "id": "nuovi-maestri-lavoro-varese-leonardo-2026",
+      "views": 20,
+      "lastViewed": 1778002275449
+    },
+    {
+      "id": "permesso-b-vs-g-differenze",
+      "views": 20,
+      "lastViewed": 1778042448763
+    },
+    {
+      "id": "salario-minimo-ticino-2027-2029-nuove-regole",
+      "views": 20,
+      "lastViewed": 1778079127384
+    },
+    {
+      "id": "svizzera-mediazione-iran-2026",
+      "views": 19,
+      "lastViewed": 1778084759196
+    },
+    {
+      "id": "apertura-pesca-ticino",
+      "views": 18,
+      "lastViewed": 1778420444295
+    },
+    {
+      "id": "auto-cinesi-svizzera-2026",
+      "views": 18,
+      "lastViewed": 1778407465355
+    },
+    {
+      "id": "bollini-rossi-traffico-san-gottardo-2026",
+      "views": 18,
+      "lastViewed": 1778499648921
+    },
+    {
+      "id": "omaggio-angeli-ponte-chiasso-2026",
+      "views": 18,
+      "lastViewed": 1778309467968
+    },
+    {
+      "id": "primo-maggio-varese-2026-lavoro-dignitoso",
+      "views": 18,
+      "lastViewed": 1778363502933
+    },
+    {
+      "id": "tangenziale-verde-somma-lombardo-2026",
+      "views": 18,
+      "lastViewed": 1778412330785
+    },
+    {
+      "id": "ticino-voto-anti-dumping",
+      "views": 18,
+      "lastViewed": 1778219990055
+    },
+    {
+      "id": "ufficio-postale-chiasso-trasloco",
+      "views": 18,
+      "lastViewed": 1778318427153
+    },
+    {
+      "id": "cantieri-sottoceneri-estate-2024",
+      "views": 17,
+      "lastViewed": 1778230103204
+    },
+    {
+      "id": "ffs-collegamenti-estivi-rimini-francia-2026",
+      "views": 17,
+      "lastViewed": 1778444615911
+    }
+  ]
+}

--- a/scripts/fetch-article-trending.mjs
+++ b/scripts/fetch-article-trending.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * fetch-article-trending.mjs — Export article view counts from Firestore to JSON.
+ *
+ * Reads all documents from `article_views` collection (1 daily scan via cron)
+ * and writes a top-N trending snapshot to public/article-trending.json.
+ *
+ * Replaces the per-visitor client-side `getDocs(collection('article_views'))`
+ * in components/community/BlogArticles.tsx, which was scanning ~1377 docs
+ * on every cache-miss visit (~500k–5M reads/wk estimated).
+ *
+ * Trending logic mirrors the old client logic (BlogArticles.tsx:97-110):
+ *   - views within 7d  → full weight
+ *   - views within 30d AND views > 5 → half weight (round)
+ *   - sort desc, keep top 50 (client filters to top 12 + validIds intersection)
+ *
+ * Usage:
+ *   node scripts/fetch-article-trending.mjs
+ *
+ * Requires GOOGLE_APPLICATION_CREDENTIALS for Firebase Admin SDK.
+ * Graceful fallback: writes empty array if Firestore is unavailable.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const OUTPUT_PATH = path.join(ROOT, 'public', 'article-trending.json');
+
+const TOP_N = 50;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+async function main() {
+  let admin;
+  try {
+    admin = await import('firebase-admin');
+  } catch {
+    console.warn('⚠️  firebase-admin not installed — writing empty trending data');
+    writeFallback();
+    return;
+  }
+
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!credPath || !fs.existsSync(credPath)) {
+    console.warn('⚠️  GOOGLE_APPLICATION_CREDENTIALS not set — writing empty trending data');
+    writeFallback();
+    return;
+  }
+
+  try {
+    if (!admin.default.apps?.length) {
+      admin.default.initializeApp({
+        credential: admin.default.credential.cert(
+          JSON.parse(fs.readFileSync(credPath, 'utf-8')),
+        ),
+      });
+    }
+
+    const db = admin.default.firestore();
+    const snap = await db.collection('article_views').get();
+
+    const now = Date.now();
+    const entries = [];
+
+    snap.forEach((doc) => {
+      const data = doc.data();
+      const lastViewedRaw = data.lastViewed;
+      const lastViewed = lastViewedRaw?.toMillis?.()
+        ?? (lastViewedRaw?._seconds ? lastViewedRaw._seconds * 1000 : 0)
+        ?? (lastViewedRaw instanceof Date ? lastViewedRaw.getTime() : 0);
+      const views = Number(data.views) || 0;
+      const age = now - lastViewed;
+
+      if (age < SEVEN_DAYS_MS) {
+        entries.push({ id: doc.id, views, lastViewed });
+      } else if (age < THIRTY_DAYS_MS && views > 5) {
+        entries.push({ id: doc.id, views: Math.round(views * 0.5), lastViewed });
+      }
+    });
+
+    entries.sort((a, b) => b.views - a.views);
+    const top = entries.slice(0, TOP_N);
+
+    const payload = {
+      generatedAt: new Date().toISOString(),
+      totalScanned: snap.size,
+      eligible: entries.length,
+      entries: top,
+    };
+
+    fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(payload, null, 2) + '\n');
+    console.log(
+      `✅ Wrote top ${top.length} trending articles (of ${entries.length} eligible, ${snap.size} scanned) to ${path.relative(ROOT, OUTPUT_PATH)}`,
+    );
+  } catch (err) {
+    console.error(`❌ Firestore read failed: ${err.message}`);
+    writeFallback();
+  }
+}
+
+function writeFallback() {
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  const payload = { generatedAt: new Date().toISOString(), totalScanned: 0, eligible: 0, entries: [] };
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(payload, null, 2) + '\n');
+  console.log(`📄 Wrote empty trending fallback to ${path.relative(ROOT, OUTPUT_PATH)}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  writeFallback();
+});

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -866,26 +866,51 @@ function localizeArticle(articleId, locale) {
  * Returns a function (locale) => article object, so each subscriber gets localized content.
  * Uses Firestore article_views (most viewed this week), falls back to hardcoded default.
  */
+// ─── _meta_ doc memoization ─────────────
+// newsletter_subscribers/_meta_ is read by 5 functions per send-newsletter
+// run. Only this process mutates it during a run, so an in-process cache
+// with write-through stays consistent.
+let _metaCache = null;
+let _metaPromise = null;
+
+function metaDocRef() {
+  return db.collection('newsletter_subscribers').doc('_meta_');
+}
+
+async function readMetaDoc() {
+  if (_metaCache !== null) return _metaCache;
+  if (_metaPromise) return _metaPromise;
+  _metaPromise = (async () => {
+    try {
+      const doc = await metaDocRef().get();
+      _metaCache = doc.exists ? (doc.data() || {}) : {};
+    } catch {
+      _metaCache = {};
+    }
+    return _metaCache;
+  })();
+  return _metaPromise;
+}
+
+async function writeMetaDoc(updates) {
+  await metaDocRef().set(updates, { merge: true });
+  if (_metaCache === null) await readMetaDoc();
+  Object.assign(_metaCache, updates);
+}
+
 async function fetchRecentlyFeaturedArticles() {
   if (!db) return [];
-  try {
-    const metaRef = db.collection('newsletter_subscribers').doc('_meta_');
-    const doc = await metaRef.get();
-    return doc.exists ? (doc.data().recently_featured_articles || []) : [];
-  } catch {
-    return [];
-  }
+  const data = await readMetaDoc();
+  return data.recently_featured_articles || [];
 }
 
 async function saveRecentlyFeaturedArticle(articleId) {
   if (!db) return;
   const MAX_HISTORY = 12; // exclude last 12 articles → ~3 months of variety with weekly sends
   try {
-    const metaRef = db.collection('newsletter_subscribers').doc('_meta_');
-    const doc = await metaRef.get();
-    const history = doc.exists ? (doc.data().recently_featured_articles || []) : [];
+    const history = await fetchRecentlyFeaturedArticles();
     const updated = [articleId, ...history.filter(id => id !== articleId)].slice(0, MAX_HISTORY);
-    await metaRef.set({ recently_featured_articles: updated }, { merge: true });
+    await writeMetaDoc({ recently_featured_articles: updated });
   } catch (e) {
     console.warn('\u26a0\ufe0f Save featured article history failed:', e.message);
   }
@@ -897,23 +922,16 @@ const MAX_FEATURED_JOBS_HISTORY = 8; // 2 weeks \u00d7 4 cards = 8 slots
 
 async function fetchRecentlyFeaturedJobs() {
   if (!db) return [];
-  try {
-    const metaRef = db.collection('newsletter_subscribers').doc('_meta_');
-    const doc = await metaRef.get();
-    return doc.exists ? (doc.data()[RECENTLY_FEATURED_JOBS_KEY] || []) : [];
-  } catch {
-    return [];
-  }
+  const data = await readMetaDoc();
+  return data[RECENTLY_FEATURED_JOBS_KEY] || [];
 }
 
 async function saveRecentlyFeaturedJobs(slugs) {
   if (!db || !slugs.length) return;
   try {
-    const metaRef = db.collection('newsletter_subscribers').doc('_meta_');
-    const doc = await metaRef.get();
-    const existing = doc.exists ? (doc.data()[RECENTLY_FEATURED_JOBS_KEY] || []) : [];
+    const existing = await fetchRecentlyFeaturedJobs();
     const updated = [...new Set([...slugs, ...existing])].slice(0, MAX_FEATURED_JOBS_HISTORY);
-    await metaRef.set({ [RECENTLY_FEATURED_JOBS_KEY]: updated }, { merge: true });
+    await writeMetaDoc({ [RECENTLY_FEATURED_JOBS_KEY]: updated });
     console.log(`\u2705 Job rotation: saved ${updated.length} recently featured slugs`);
   } catch (e) {
     console.warn('\u26a0\ufe0f Save recently featured jobs failed:', e.message);
@@ -1379,11 +1397,10 @@ async function sendEmailBatch(emails, apiKey) {
 async function getNextIssueNumber() {
   if (!db) return null;
   try {
-    const metaRef = db.collection('newsletter_subscribers').doc('_meta_');
-    const doc = await metaRef.get();
-    const current = doc.exists ? (doc.data().issue_number || 0) : 0;
+    const data = await readMetaDoc();
+    const current = data.issue_number || 0;
     const next = current + 1;
-    await metaRef.set({ issue_number: next }, { merge: true });
+    await writeMetaDoc({ issue_number: next });
     return next;
   } catch (e) {
     console.warn('\u26a0\ufe0f Issue number fetch failed:', e.message);


### PR DESCRIPTION
## Summary

Three Firestore cost reductions, motivated by post-May-8-fix audit (memory `project_firestore_cost_fix_may8`). Live data via SA: `article_views` collection grew to 1,377 docs, while `BlogArticles.tsx:92` was scanning the whole collection from the browser on every cache-miss visit — likely the dominant read source.

- **Article trending → daily cron + static JSON** (same pattern as `refresh-job-popularity.yml`). Saves an estimated **500k–5M reads/wk** depending on blog traffic. New file `public/article-trending.json` keeps top 50 by recency-weighted views.
- **`newsletter_subscribers/_meta_` memoization** in `send-newsletter.mjs` — 1 read per run instead of 5 (same doc previously fetched 5 times across `fetchRecentlyFeaturedArticles`, `saveRecentlyFeaturedArticle`, `fetchRecentlyFeaturedJobs`, `saveRecentlyFeaturedJobs`, `getNextIssueNumber`).
- **`count()` aggregation** in `AdminPanel.tsx` newsletter dashboard — `getCountFromServer` (1 read) + bounded `limit(10)` for the masked preview, instead of fetching every active subscriber doc.

Skipped from the original 5-item punch list:
- `#2` newsletter_subscribers indexed query — cost/benefit too thin (~$0.05/year saving; needs `is_active` backfill to avoid `not-in` missing-field caveat).
- `#3` events subcollection cleanup TTL — user prefers retain for future analytics; storage cost <$1/year.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run tests/newsletter-*.ts tests/related-articles.test.ts` — 64/64 pass
- [x] Smoke test of new script with real SA: scanned 1,380 docs, wrote 50 trending entries with realistic data
- [x] `FAST_BUILD= vite build` (with SEO plugins enabled, heavy crons skipped) — exit 0
- [ ] After merge: run `gh workflow run refresh-article-trending.yml --ref main` and confirm first scheduled run writes `public/article-trending.json` successfully (CLAUDE.md non-negotiable #13)
- [ ] Production verification: confirm GCP Console > Firestore > Usage shows the read-rate drop within 24-48h
- [ ] Note: pre-existing `tests/scripts/demand-vocabulary.test.ts` failure on main — unrelated, separate debt

🤖 Generated with [Claude Code](https://claude.com/claude-code)