### PR TITLE
fix(playwright-runtime): use `headless: true` (Playwright API)

### DIFF
--- a/scripts/lib/ats-clients/playwright-runtime.mjs
+++ b/scripts/lib/ats-clients/playwright-runtime.mjs
@@ -105,7 +105,7 @@ export async function createBrowser(options = {}) {
   const userAgent = options.userAgent || DEFAULT_USER_AGENT;
   try {
     const browser = await chromium.launch({
-      headless: 'new',
+      headless: true,
       args: ['--disable-blink-features=AutomationControlled'],
     });
     // Stash the UA on the browser instance for context creation.


### PR DESCRIPTION
Playwright validates `launch({ headless })` as a boolean and fails on `'new'` (old Puppeteer API). Caught live in pictet workflow run 25670282557. One-line fix; unblocks Pictet + future Richemont/MSC Playwright anti-bot work.