### PR TITLE
fix(crawlers): remove minimum-volume gates; allow even 1 job

### DIFF
--- a/scripts/update-guess-jobs.mjs
+++ b/scripts/update-guess-jobs.mjs
@@ -420,8 +420,8 @@ async function main() {
   if (Array.isArray(pre)) beforeSnapshot = snapshotJobSlugs(pre.filter(isTargetJob));
 
   const listings = await fetchGuessListings();
-  if (listings.length < 5) {
-    throw new Error(`Guess discovery returned only ${listings.length} Ticino jobs (<5).`);
+  if (listings.length === 0) {
+    throw new Error('Guess discovery returned 0 Ticino jobs.');
   }
 
   const discoveredJobs = [];
@@ -443,8 +443,8 @@ async function main() {
   postProcessJobs();
   const stats = logStats(beforeSnapshot);
   const crawlDiff = stats.crawlDiff;
-  if (stats.total < 5) {
-    throw new Error(`Guess crawler produced only ${stats.total} jobs (<5).`);
+  if (stats.total === 0) {
+    throw new Error('Guess crawler produced 0 jobs.');
   }
   validateLocales();
 

--- a/scripts/update-lwphr-jobs.mjs
+++ b/scripts/update-lwphr-jobs.mjs
@@ -240,8 +240,8 @@ async function main() {
   const html = await fetchPage(CAREERS_URL);
   const listings = parseLwphrOpenJobs(html);
   console.log(`📋 Open PDF jobs found on page: ${listings.length}`);
-  if (listings.length < 10) {
-    throw new Error(`LWPHR discovery returned only ${listings.length} open PDF jobs.`);
+  if (listings.length === 0) {
+    throw new Error('LWPHR discovery returned 0 open PDF jobs.');
   }
 
   const discoveredJobs = [];


### PR DESCRIPTION
## Summary

User policy: a crawler producing N>=1 jobs should not fail. The `< 5` (Guess) and `< 10` (LWPHR) thresholds caused legitimate runs to exit non-zero whenever the source temporarily listed fewer jobs.

- `scripts/update-guess-jobs.mjs`: discovery + post-merge guards now fail only on 0 jobs.
- `scripts/update-lwphr-jobs.mjs`: discovery guard now fails only on 0 PDFs.

The 0-job guard is kept everywhere — empty result means the parser broke.

## Test plan
- [ ] Trigger `Update Guess Jobs (Dedicated)` workflow → should now pass even with 4 listings
- [ ] Trigger `Update LWPHR Jobs (Dedicated)` workflow → should now pass even with <10 PDFs