### PR TITLE
fix(discovery): broaden domain-anchor regex + load CH/IT municipality datasets

### DIFF
--- a/scripts/lib/discovery/domainAnchor.mjs
+++ b/scripts/lib/discovery/domainAnchor.mjs
@@ -17,29 +17,53 @@
 //   noise, not topic similarity). Article published.
 //
 // The fix is structural: every discovery candidate that comes from a
-// generic-keyword source MUST mention at least one domain anchor token
-// before it can enter the ranker. Anchors fall into four buckets:
+// generic-keyword source MUST mention at least one domain anchor before
+// it can enter the ranker. Anchors come from two sources:
 //
-//   1. core domain words      frontaliere/i, ticino/esi, svizzero/a, CH
-//   2. cross-border concepts  permesso G, telelavoro, ristorni, AVS, LPP, LAMal
-//   3. Ticino toponyms        Lugano, Chiasso, Mendrisio, Locarno, Bellinzona, …
-//   4. CH-side & other CH cantons that recur in our content (Berna,
-//      Zurigo, Basilea, Ginevra, Losanna, Vaud, Argovia, Vallese, …)
+//   A. ANCHOR_TOKENS — curated regex of concepts + institutional words
+//      + Italian-side border towns + frontalieri-specific vocabulary
+//      (frontaliere, permesso G, AVS, LPP, LAMal, telelavoro, ristorni,
+//      federale, cantonale, secondo pilastro, …).
 //
-// We deliberately keep the list explicit and tight. False negatives
+//   B. CH_MUNICIPALITY_SET — every Swiss municipality (~2,100 entries
+//      across all 26 cantons), loaded from data/canton-municipalities.json.
+//      Multi-word names (e.g. "Riva San Vitale", "Beinwil am See") are
+//      matched via a sliding 1-3-token window against the normalized set.
+//      Names in parentheses ("Arni (AG)" → "arni") are stripped during
+//      normalization. Entries shorter than 3 chars are dropped to avoid
+//      collisions with common Italian words.
+//
+// We deliberately keep ANCHOR_TOKENS explicit and tight, and let the
+// municipality Set carry the long-tail toponym coverage. False negatives
 // (real Ticino topics rejected) are recoverable by adding the missing
 // token. False positives (Palermo articles published) are not.
 
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve as resolvePath } from 'node:path';
+
 const ANCHOR_TOKENS = [
   // Core domain words
-  'frontalier[ei]?',
+  // 2026-05-11 audit: broadened — `frontalier[ei]?` was missing
+  // "frontaliero" (m. sing.); `svizzer[ao]` was missing "svizzeri"
+  // (m. pl.) and "svizzere" (f. pl.). Caused 11/15 false positives in
+  // the slug-anchor backfill audit. See domainAnchor.test.ts regression
+  // block for the full list.
+  'frontalier[aeio]',
   'ticin(o|esi?)',
-  'svizzer[ao]',
+  'svizzer[aeio]',
   'svizzera',
+  'svizzeri',
   '\\bch\\b',
   '\\bchf\\b',
+  '\\bswiss\\b',
   'cross.?border',
   'grenzg(?:a|ae|ä)nger',
+  // Swiss federal/cantonal institutions — "votazioni federali",
+  // "giudici federali", "polizia cantonale", "consiglio cantonale".
+  'federal[ei]',
+  'cantonal[ei]',
+  'confederazion',
 
   // Cross-border concepts
   'permesso\\s*[gb]',
@@ -56,6 +80,12 @@ const ANCHOR_TOKENS = [
   'dichiarazione\\s*frontalieri',
   'nuovo\\s*accordo\\s*fiscale',
   'pendolar(i|ismo)\\s*svizzer',
+  // "secondo pilastro" / "terzo pilastro" / "pilastro 3a" — Italian
+  // for the LPP / pension fund pillars. Standalone "pilastro" alone is
+  // ambiguous (Pilastro is also a Bologna neighborhood); we require it
+  // to follow an ordinal (secondo/terzo) or letter+digit (3a/3b).
+  '(?:secondo|terzo)\\s*pilastro',
+  'pilastro\\s*3[ab]',
 
   // Ticino toponyms (curated — the ones that recur in our slug-registry)
   'lugano',
@@ -101,6 +131,28 @@ const ANCHOR_TOKENS = [
   'arbedo',
   'mezzovico',
   'muralto',
+  // 2026-05-11 audit additions — TI micro-toponyms appearing in slugs:
+  'san\\s*antonino',
+  'cornaredo',          // Lugano stadium
+  'cardada',            // Cardada-Cimetta (Locarno)
+  'cimetta',
+  'vedeggio',           // valle / fiume Ticino
+  'malcantone',
+  'leventina',
+  'blenio',
+  'bedretto',
+  'verzasca',
+  'onsernone',
+  'centovalli',
+  'mendrisiotto',
+  'luganese',
+  'bellinzonese',
+  'locarnese',
+  'gambarogno',
+  // Ticino highways used daily by frontalieri (slugs use hyphens, so
+  // accept `\\s` OR `-` between "autostrada" and the road code):
+  'autostrada[\\s-]*a[2913]\\b',
+  '\\ba[2913][\\s-]*(?:autostrada|svizzer|ticin)',
 
   // Border IT towns where frontalieri live
   'como',
@@ -116,6 +168,28 @@ const ANCHOR_TOKENS = [
   'tirano',
   'luino',
   'gravedona',
+  // 2026-05-11 audit additions — IT regions that source frontalieri:
+  'ossola',
+  'ossolan[ao]',
+  'val\\s*d.?ossola',
+  'cislago',
+  'cittiglio',
+  'laveno',
+  'cantello',
+  'gallarate',
+  'busto\\s*arsizio',
+  'erba\\b',
+  'mariano',
+  'cantu',
+  'cantù',
+  'merate',
+  'olgiate',
+  'ponte\\s*tresa',
+  'cuasso',
+  'malnate',
+  'arcisate',
+  'varesotto',
+  'comasco',
 
   // Other CH cantons & cities that recur in cross-border content
   'berna',
@@ -143,20 +217,180 @@ const ANCHOR_TOKENS = [
   'graub[üu]nden',
   'briga',
   'brig',
+  // 2026-05-11 audit additions — CH cantons / cities still missing:
+  'friburgo',
+  'fribourg',
+  'lucerna',
+  'luzern',
+  'sciaffusa',
+  'schaffhausen',
+  'neuchâtel',
+  'neuchatel',
+  'neuenburg',
+  'giura\\b',
+  '\\bjura\\b',
+  'soletta',
+  'solothurn',
+  'glarona',
+  'glarus',
+  'uri\\b',
+  'svitto',
+  'schwyz',
+  'zugo',
+  'zug\\b',
+  'appenzello',
+  'appenzell',
+  'nidvaldo',
+  'nidwalden',
+  'obvaldo',
+  'obwalden',
+  'turgovia',
+  'thurgau',
+  'visp\\b',
+  'sion\\b',
+  'martigny',
+  'crans.?montana',
+  'verbier',
+  'zermatt',
+  'davos',
+  'st\\.?\\s*moritz',
+  'gstaad',
+  'interlaken',
+  'thun\\b',
 ];
 
 const DOMAIN_ANCHOR_RE = new RegExp(`\\b(?:${ANCHOR_TOKENS.join('|')})\\b`, 'i');
 
+// ── Municipality lookup (CH + IT border) ─────────────────────────────
+//
+// Two datasets, loaded once at module init and merged into a single
+// normalized Set:
+//
+//   1. data/canton-municipalities.json — BFS snapshot of all ~2,100
+//      Swiss municipalities across the 26 cantons.
+//   2. data/municipalities.ts — official ti.ch list of 518 Italian
+//      "comuni di frontiera" (border municipalities where frontalieri
+//      live, across CO/VA/VB/SO/LC/BG/BS).
+//
+// Normalization: lowercased, parentheticals stripped ("Arni (AG)" →
+// "arni"), internal whitespace collapsed, multi-word names preserved
+// (matched via 1-3 token sliding window in `hasSwissMunicipality`).
+// Entries shorter than MIN_NAME_LEN are dropped to avoid collisions
+// with common Italian/English words ("Or" the Bern town vs the
+// conjunction; "Uri" the canton vs other senses).
+
+const MIN_NAME_LEN = 4;
+const MAX_NAME_TOKENS = 3;
+
+function normalizeMunicipalityName(raw) {
+  if (typeof raw !== 'string') return '';
+  // Strip parenthetical canton/region disambiguators: "Arni (AG)" → "Arni",
+  // "Beinwil (Freiamt)" → "Beinwil". Collapse internal whitespace.
+  return raw
+    .replace(/\s*\([^)]*\)\s*/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+function addCleanedNamesToSet(set, names) {
+  if (!Array.isArray(names)) return;
+  for (const name of names) {
+    const norm = normalizeMunicipalityName(name);
+    if (norm.length >= MIN_NAME_LEN) set.add(norm);
+  }
+}
+
+function loadCantonMunicipalities(set, dataDir) {
+  try {
+    const raw = JSON.parse(readFileSync(resolvePath(dataDir, 'canton-municipalities.json'), 'utf8'));
+    if (raw && raw.cantons && typeof raw.cantons === 'object') {
+      for (const canton of Object.values(raw.cantons)) {
+        addCleanedNamesToSet(set, canton?.municipalities);
+      }
+    }
+  } catch {
+    // Non-fatal — curated tokens still cover the common cases.
+  }
+}
+
+function loadItalianBorderMunicipalities(set, dataDir) {
+  try {
+    // data/municipalities.ts is hand-edited TypeScript (518 ti.ch comuni
+    // di frontiera). Parse the `name: '...'` literals via regex — keeps
+    // this module dependency-free and avoids needing a TS loader at
+    // runtime. If the format ever changes to an exported JSON, swap
+    // this for a plain JSON.parse.
+    const source = readFileSync(resolvePath(dataDir, 'municipalities.ts'), 'utf8');
+    const names = [];
+    for (const match of source.matchAll(/name:\s*'([^']+)'/g)) {
+      names.push(match[1]);
+    }
+    addCleanedNamesToSet(set, names);
+  } catch {
+    // Non-fatal.
+  }
+}
+
+function loadMunicipalitySet() {
+  // Resolve via this file's own location so the lookup works whether
+  // we're running from the repo root, a worktree, or a script context.
+  const here = dirname(fileURLToPath(import.meta.url));
+  // scripts/lib/discovery/ → repo root → data/
+  const dataDir = resolvePath(here, '..', '..', '..', 'data');
+  const set = new Set();
+  loadCantonMunicipalities(set, dataDir);
+  loadItalianBorderMunicipalities(set, dataDir);
+  return set;
+}
+
+const CH_MUNICIPALITY_SET = loadMunicipalitySet();
+
+function tokenizeForLookup(text) {
+  // Split on anything that isn't a letter/digit/apostrophe; keep the
+  // accented latin-1 range so "Neuchâtel" stays one token.
+  return String(text).toLowerCase().match(/[a-z0-9à-ÿ']+/g) || [];
+}
+
+/**
+ * Test whether `text` references a Swiss municipality (single- or
+ * multi-word, up to MAX_NAME_TOKENS tokens) by checking every 1..N
+ * consecutive token slice against the BFS-derived municipality set.
+ *
+ * Exported for testing; in normal use call hasDomainAnchor.
+ *
+ * @param {string|null|undefined} text
+ * @returns {boolean}
+ */
+export function hasSwissMunicipality(text) {
+  if (!text || typeof text !== 'string') return false;
+  if (CH_MUNICIPALITY_SET.size === 0) return false;
+  const tokens = tokenizeForLookup(text);
+  for (let i = 0; i < tokens.length; i += 1) {
+    const limit = Math.min(MAX_NAME_TOKENS, tokens.length - i);
+    for (let span = 1; span <= limit; span += 1) {
+      const phrase = tokens.slice(i, i + span).join(' ');
+      if (CH_MUNICIPALITY_SET.has(phrase)) return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Test whether `text` mentions any token that anchors it to the
  * Ticino-frontalieri domain. Returns false for null/empty input.
+ *
+ * Two-stage check: curated regex first (fast, covers concepts +
+ * cross-border vocabulary), municipality Set second (covers every
+ * Swiss town).
  *
  * @param {string|null|undefined} text
  * @returns {boolean}
  */
 export function hasDomainAnchor(text) {
   if (!text || typeof text !== 'string') return false;
-  return DOMAIN_ANCHOR_RE.test(text);
+  if (DOMAIN_ANCHOR_RE.test(text)) return true;
+  return hasSwissMunicipality(text);
 }
 
 /**
@@ -174,4 +408,4 @@ export function anchorSeed(seed) {
   return `${s} frontalieri`;
 }
 
-export { DOMAIN_ANCHOR_RE };
+export { DOMAIN_ANCHOR_RE, CH_MUNICIPALITY_SET };

--- a/tests/scripts/lib/discovery/domainAnchor.test.ts
+++ b/tests/scripts/lib/discovery/domainAnchor.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from 'vitest';
 import {
   anchorSeed,
   hasDomainAnchor,
+  hasSwissMunicipality,
+  CH_MUNICIPALITY_SET,
 } from '../../../../scripts/lib/discovery/domainAnchor.mjs';
 
 describe('hasDomainAnchor', () => {
@@ -68,6 +70,115 @@ describe('hasDomainAnchor', () => {
     expect(hasDomainAnchor('salute')).toBe(false);
     expect(hasDomainAnchor('pensioni')).toBe(false);
     expect(hasDomainAnchor('fiscale')).toBe(false);
+  });
+
+  // 2026-05-11 backfill audit — these slugs were previously rejected
+  // (false positives) because the regex was too narrow. Each must now
+  // pass hasDomainAnchor. See reports/articles-anchorless-slug-2026-05-11.md
+  // for the full list and triage notes.
+  describe('audit-driven regression — false positives that MUST now pass', () => {
+    const cases: Array<[string, string]> = [
+      ['svizzeri (m. plural)', 'svizzeri ottimisti finanze 2026'],
+      ['svizzere (f. plural)', 'imprese svizzere e cassa malati'],
+      ['frontaliero (m. singular)', 'frontaliero ossolano morto a visp'],
+      ['federali (Swiss federal vote)', 'votazioni federali 14 giugno 2026'],
+      ['federale (singular)', 'consiglio federale conferma accordo'],
+      ['cantonale (TI institutions)', 'malessere polizia cantonale audit'],
+      ['secondo pilastro (LPP synonym)', 'svizzeri secondo pilastro casa'],
+      ['terzo pilastro', 'terzo pilastro come funziona'],
+      ['Friburgo (CH canton)', 'friburgo finale europa league'],
+      ['Lucerna (CH city)', 'lapo elkann lucerna 2024'],
+      ['Crans-Montana (Vallese CH)', 'crans montana ore straordinarie'],
+      ['Visp (Vallese CH)', 'incidente lavoro a visp'],
+      ['Cornaredo (Lugano stadium)', 'picnic stadio cornaredo'],
+      ['San Antonino (TI)', 'pfas filtrazione san antonino 2026'],
+      ['Cardada (Locarno)', 'cardada cimetta riapre bikers'],
+      ['Vedeggio (TI valley)', 'aggregazione comuni vedeggio 2026'],
+      ['Val d\'Ossola (IT frontalieri source)', 'frontaliere val d\'ossola morto'],
+      ['Cislago (varesotto)', 'grandine cislago protezione civile'],
+      ['Autostrada A9 (Lugano-Chiasso)', 'autostrada a9 chiusure notturne svizzera'],
+      ['swiss (English brand)', 'swiss riduce personale amministrativo'],
+    ];
+    for (const [label, headline] of cases) {
+      it(`accepts: ${label} → "${headline}"`, () => {
+        expect(hasDomainAnchor(headline)).toBe(true);
+      });
+    }
+  });
+
+  // Negative regression — these LOOK borderline but are genuinely
+  // off-topic. The broader regex must NOT regress and accept them.
+  describe('audit-driven regression — true off-topic must STAY rejected', () => {
+    const cases: Array<[string, string]> = [
+      // Pilastro is a Bologna neighborhood; the article is about a
+      // tragic incident there, not the LPP/AVS pension pillar.
+      ['Pilastro (Bologna neighborhood, no ordinal)', 'questore bimbo pilastro responsabilita'],
+      ['Real Madrid soccer drama', 'real madrid caos rissa tchouameni valverde'],
+      ['Sanremo Eurovision', 'sanremo eurovision campione 2026'],
+      // LPP S.A. is a Polish apparel retailer (GPW = Warsaw Stock
+      // Exchange ticker), not the Swiss Loi LPP pension fund. The
+      // googleSuggest.mjs LPP_RETAIL_RE denylist was specifically
+      // designed for this collision.
+      ['LPP S.A. Polish retailer (no \\b boundary)', 'utili fatturato lppsa gpw'],
+      ['Trump tariffs', 'trump dazi corte commercio 2026'],
+      ['Iran blackout', 'blackout internet iran 70 giorni'],
+    ];
+    for (const [label, headline] of cases) {
+      it(`rejects: ${label} → "${headline}"`, () => {
+        expect(hasDomainAnchor(headline)).toBe(false);
+      });
+    }
+  });
+});
+
+describe('hasSwissMunicipality (CH BFS + IT comuni di frontiera)', () => {
+  it('loaded both datasets with >2500 normalized entries', () => {
+    // ~2,100 CH municipalities + 518 IT comuni di frontiera, minus
+    // <MIN_NAME_LEN drops + dedup overlaps. Floor at 2,500.
+    expect(CH_MUNICIPALITY_SET.size).toBeGreaterThan(2500);
+  });
+
+  it('matches Italian comuni di frontiera (ti.ch official list)', () => {
+    expect(hasSwissMunicipality('incidente ad albavilla')).toBe(true);
+    expect(hasSwissMunicipality('inter ad appiano gentile')).toBe(true);
+    expect(hasSwissMunicipality('cantello dogana svizzera')).toBe(true);
+    expect(hasSwissMunicipality('alta valle intelvi')).toBe(true);
+  });
+
+  it('matches single-token municipality names across cantons', () => {
+    expect(hasSwissMunicipality('lugano centro storico')).toBe(true);
+    expect(hasSwissMunicipality('zermatt skilift incidente')).toBe(true);
+    expect(hasSwissMunicipality('davos forum economico 2026')).toBe(true);
+    // Verbier sits inside the merged "Val de Bagnes" municipality.
+    expect(hasSwissMunicipality('val de bagnes turismo invernale')).toBe(true);
+  });
+
+  it('matches multi-word municipality names (1-3 token sliding window)', () => {
+    expect(hasSwissMunicipality('chiesa di riva san vitale')).toBe(true);
+    expect(hasSwissMunicipality('incidente a beinwil am see')).toBe(true);
+  });
+
+  it('matches paren-stripped names like "Arni (AG)"', () => {
+    expect(hasSwissMunicipality('arni inaugurazione comunale')).toBe(true);
+  });
+
+  it('REJECTS plain Italian / international cities not in CH', () => {
+    expect(hasSwissMunicipality('mobilita palermo')).toBe(false);
+    expect(hasSwissMunicipality('real madrid rissa')).toBe(false);
+    expect(hasSwissMunicipality('roma centro città')).toBe(false);
+    expect(hasSwissMunicipality('napoli stazione')).toBe(false);
+  });
+
+  it('REJECTS short ambiguous names below MIN_NAME_LEN (e.g. "or", "on")', () => {
+    // "Or" is a Bern town but it's stripped at load time; testing
+    // that random short tokens don't false-trigger.
+    expect(hasSwissMunicipality('on or off')).toBe(false);
+  });
+
+  it('handles null / empty / non-string input safely', () => {
+    expect(hasSwissMunicipality(null as unknown as string)).toBe(false);
+    expect(hasSwissMunicipality(undefined as unknown as string)).toBe(false);
+    expect(hasSwissMunicipality('')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Audit-driven follow-up to #73. Manually scored 15 representative slugs from the 69 flagged by the slug-anchor backfill audit and found **11 false positives (73%)** where the regex was too narrow to be useful as a content gate.

This PR:
- Broadens `ANCHOR_TOKENS` across 10 buckets the prior version missed (`frontaliero` m. sing.; `svizzeri/svizzere` plural; `swiss`; `federali/federale`; `cantonale/i`; `secondo/terzo pilastro`; TI micro-toponyms; A2/A9/A13 highways; IT-side regions like Val d'Ossola; missing CH cantons like Friburgo, Lucerna, Crans-Montana, Visp).
- Adds long-tail coverage via two existing datasets, loaded once at module init: `data/canton-municipalities.json` (~2,100 CH BFS municipalities) + `data/municipalities.ts` (518 ti.ch comuni di frontiera). Total **2,566 normalized entries** in `CH_MUNICIPALITY_SET`. Multi-word names matched via 1-3 token sliding window in new `hasSwissMunicipality` helper.

## Impact

Re-audit of `data/blog-articles/` after the fix:
- Before: 69 / 192 anchorless slugs
- After: **50 / 192** anchorless slugs (-28%)

The remaining 50 are genuinely off-topic news (Lula/Trump, Iran blackout, Real Madrid drama, Sanremo Eurovision, LPP S.A. Polish retailer, etc) — manual triage via `reports/articles-anchorless-slug-2026-05-11.md`.

## Test plan

- [x] 91 tests across 6 discovery test files green
- [x] 11 new positive regression cases for the audit's false positives
- [x] 6 new negative tests asserting genuine off-topic stays rejected
- [x] 7 new tests for `hasSwissMunicipality` (dataset size, single/multi-word matching, paren-stripped names, IT coverage, short-name rejection, null safety)
- [x] `tsc --noEmit` clean