### PR TITLE
ci(canary): remove redundant push:main trigger

### DIFF
--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -1,9 +1,15 @@
 name: production-canary
 
 # Agent F — 5XX hardening canary.
-# Runs `npm run probe:5xx` on a schedule, on manual dispatch, and after every
-# push to main (post-deploy). Fails the workflow if any production URL returns
-# 5XX or a network error on all retry attempts.
+# Runs `npm run probe:5xx` on a schedule and on manual dispatch. Fails the
+# workflow if any production URL returns 5XX or a network error on all retry
+# attempts.
+#
+# Post-deploy probing is handled by `post-deploy-validate-live.yml` (which
+# runs `probe:5xx` + `test:e2e:live` after every deploy), so this canary
+# intentionally does NOT trigger on `push: main` — its unique value is
+# catching regressions BETWEEN deploys (Pages outage, RC config breakage,
+# DNS/CDN/cert issues, upstream rate-limits).
 #
 # No external notifications (Slack etc.) are wired — CI failure surfaces via
 # GitHub Actions status and emails project maintainers.
@@ -13,9 +19,6 @@ on:
     # Every 15 minutes. Cron runs in UTC.
     - cron: '*/15 * * * *'
   workflow_dispatch: {}
-  push:
-    branches:
-      - main
 
 concurrency:
   # Only one canary in flight at a time; cancel an older run if a newer one starts.


### PR DESCRIPTION
## Summary
- `production-canary` triggered on `push: main` duplicated the 5XX probe that `post-deploy-validate-live.yml` already runs on every deploy (alongside `test:e2e:live`).
- Drop the redundant trigger; keep `schedule` (every 15min) + `workflow_dispatch`.
- Updated comment to clarify the canary's unique value: catching regressions **between** deploys (Pages outage, RC config breakage, DNS/CDN/cert issues, upstream rate-limits).

## Test plan
- [ ] CI green on this PR
- [ ] After merge, no canary run fires on the merge push to main
- [ ] Next 15-min cron tick still runs as expected