### PR TITLE
fix(jobs): preserve real locality over company HQ defaults

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -3222,7 +3222,20 @@ export function applyCompanyDefaults(job, companySlug) {
   if (defaults) {
     if (!job.streetAddress)    job.streetAddress    = defaults.streetAddress;
     if (!job.postalCode)       job.postalCode       = defaults.postalCode;
-    if (!job.addressLocality)  job.addressLocality  = defaults.addressLocality;
+    // Prefer the per-job location over the company HQ city. The HQ city is
+    // the fallback when neither addressLocality nor location is set.
+    if (!job.addressLocality) {
+      const realLoc = String(job.location || '').trim();
+      job.addressLocality = realLoc || defaults.addressLocality;
+    } else if (
+      job.addressLocality === defaults.addressLocality &&
+      job.location &&
+      String(job.location).trim() !== defaults.addressLocality
+    ) {
+      // Heal contamination: previous runs filled addressLocality with HQ.
+      // If location is now populated with a real city, restore it.
+      job.addressLocality = String(job.location).trim();
+    }
     if (!job.addressRegion)    job.addressRegion     = defaults.addressRegion;
     if (!job.addressCountry)   job.addressCountry   = defaults.addressCountry;
   }
@@ -3246,11 +3259,27 @@ export function hardenJobsRichResultsData({ dataJobsPath }) {
 
   // ── Company HQ defaults: fill missing streetAddress / postalCode / employmentType ──
   let companyDefaultsFilled = 0;
+  let localityHealed = 0;
   for (const job of hardened) {
-    const before = `${job.streetAddress || ''}|${job.postalCode || ''}|${job.addressLocality || ''}|${job.employmentType || ''}`;
+    const aLBefore = String(job.addressLocality || '');
+    const before = `${job.streetAddress || ''}|${job.postalCode || ''}|${aLBefore}|${job.employmentType || ''}`;
     applyCompanyDefaults(job);
-    const after = `${job.streetAddress || ''}|${job.postalCode || ''}|${job.addressLocality || ''}|${job.employmentType || ''}`;
+    const aLAfter = String(job.addressLocality || '');
+    const after = `${job.streetAddress || ''}|${job.postalCode || ''}|${aLAfter}|${job.employmentType || ''}`;
     if (before !== after) companyDefaultsFilled++;
+    // If applyCompanyDefaults healed the locality away from the HQ default,
+    // re-infer canton from the now-correct locality so it matches reality.
+    if (aLBefore !== aLAfter && aLAfter) {
+      const inferred = inferAnyCanton(aLAfter);
+      if (inferred && inferred !== job.canton) {
+        job.canton = inferred;
+        job.addressRegion = inferred;
+        localityHealed++;
+      }
+    }
+  }
+  if (localityHealed > 0) {
+    console.log(`  🩺 Locality heal: re-inferred canton for ${localityHealed} jobs after HQ-contamination cleanup`);
   }
   if (companyDefaultsFilled > 0) {
     console.log(`  🏢 Company defaults: enriched ${companyDefaultsFilled}/${total} jobs with HQ address/employmentType.`);

--- a/scripts/re-enrich-jobs.mjs
+++ b/scripts/re-enrich-jobs.mjs
@@ -983,11 +983,18 @@ async function enrichJob(job, aiState) {
   // --- Update address from company lookup ---
   const knownAddr = COMPANY_ADDRESSES[companyKey];
   if (knownAddr) {
+    // Preserve the per-job locality (location/addressLocality) instead of
+    // overwriting it with the company HQ. Only fall back to HQ when the job
+    // has no real city. When the job has a real city, prefer a matching
+    // postal code from TICINO_CITY_POSTAL over the HQ default.
+    const realLocality = String(job.location || job.addressLocality || '').trim();
+    const realLocalityKey = realLocality.toLowerCase();
+    const postalFromRealCity = realLocality && TICINO_CITY_POSTAL[realLocalityKey];
     job = {
       ...job,
-      streetAddress: knownAddr.streetAddress,
-      postalCode: knownAddr.postalCode,
-      addressLocality: knownAddr.addressLocality,
+      streetAddress: job.streetAddress || knownAddr.streetAddress,
+      postalCode: job.postalCode || postalFromRealCity || knownAddr.postalCode,
+      addressLocality: realLocality || knownAddr.addressLocality,
       addressCountry: 'CH',
     };
   } else {


### PR DESCRIPTION
## Summary
Two enrichment paths were unconditionally overwriting per-job `addressLocality` with the company HQ city, breaking SEO accuracy for multi-location employers (Galenica, VTG, Migros-Ticino, banca-cler, EOC, …). Jobs in Lugano were getting tagged "Bern", jobs in Zurich tagged "Bellinzona", jobs in Graubünden tagged "Ticino".

## Three fixes

1. **`re-enrich-jobs.mjs`** (lines 984-992): when `COMPANY_ADDRESSES` matches, prefer the per-job `location` for `addressLocality` and look up the matching `postalCode` from `TICINO_CITY_POSTAL` before falling back to the HQ default.
2. **`applyCompanyDefaults`** (`lib/dedicated-crawler-common.mjs`):
   - When `addressLocality` is empty, fill from `job.location` first; HQ default only as final fallback.
   - Heal step: if existing `addressLocality === HQ default` while `job.location` has a different real city, restore the real city.
3. **`hardenJobsRichResultsData`**: after locality heal, re-infer canton from the corrected locality so canton + city stay consistent.

## Impact on production data
Dry-run of `hardenJobsRichResultsData` on current `data/jobs.json`:
- **233 jobs** got `addressLocality` restored to their real city
- **46 jobs** got `canton` corrected:
  - TI→GR: 23 (Migros-Ticino jobs in Graubünden)
  - BE→TI: 11 (Galenica jobs in Ticino erroneously Bern)
  - TI→VS: 6, TI→GE: 3, TI→BE: 2, TI→ZH: 1

## Idempotent
Jobs already correct stay untouched. Slices in `data/jobs/by-crawler/*.json` self-heal on the next assemble + harden cycle — no manual migration required.

## Test plan
- [x] Unit-tested `applyCompanyDefaults` with 5 cases (HQ-contaminated, empty, at-HQ, real-locality, multi-canton)
- [x] Dry-run `hardenJobsRichResultsData` on production `data/jobs.json` — 233 healed, 46 canton-corrected, 0 regressions on already-correct rows
- [ ] Post-deploy: spot-check live URLs for previously-wrong companies (Galenica Lugano → should show Ticino, not BE)