### PR TITLE
feat(seo): bridge 92 job-orphan 404s from GSC (Cohort 1)

### DIFF
--- a/build-plugins/jobOrphanBridgePlugin.ts
+++ b/build-plugins/jobOrphanBridgePlugin.ts
@@ -1,0 +1,345 @@
+/**
+ * Job-orphan bridge plugin — emits 200 HTML pages for the 92 GSC
+ * `Indicizzata Non trovata` job-detail URLs (Cohort 1).
+ *
+ * Why these URLs 404 today
+ * ------------------------
+ * The ingest script (`scripts/ingest-gsc-job-orphans.mjs`) classifies each
+ * orphan URL from the GSC Coverage Drilldown CSV as one of:
+ *
+ *   - `matched`  → 21 URLs whose source job is still in `data/jobs.json`
+ *                  but under a different slug. Three sub-causes:
+ *                    a) 90-char truncation in `slugifyJobPart`
+ *                       (services/relatedSearchClusters.ts:52). Old SPA
+ *                       fallback emitted `<a href>` with slug cut at 90
+ *                       chars; current code emits the full slug.
+ *                    b) Translation drift (re-translated slug changed).
+ *                    c) Tail-hash mutation (e.g. `-ncbhm0` → `-9yar0z`).
+ *                  These never landed in `previousSlugs` because the
+ *                  bridge pipeline doesn't capture translation/hash drift.
+ *
+ *   - `expired-tracked` / `expired` → 71 URLs whose source job has rotated
+ *                  out of jobs.json and is not in expired-jobs.json either
+ *                  (0/92 hits during ingest). These predate the expired-
+ *                  job tracking infra OR weren't captured during rotation.
+ *
+ * Why not a 301
+ * -------------
+ * Same rationale as the calculator-legacy-alias plugin (PR #85): a 301
+ * strips AdSense rendering. We need 200 pages that keep monetization,
+ * carry a canonical signal so Google de-duplicates, and (for matched
+ * cases) hand the user off to the live job page seamlessly.
+ *
+ * Output strategy
+ * ---------------
+ *   `matched` orphans:
+ *     - canonical → current locale-canonical job URL
+ *     - inline pre-hydration script `history.replaceState`s to the current
+ *       URL (preserves query string + hash). SPA boots on the canonical
+ *       and renders the full job detail.
+ *     - body: forward-framed lede + "loading the latest version" prose.
+ *
+ *   `expired*` orphans:
+ *     - canonical → section landing (`/cerca-lavoro-ticino/`, `/en/find-
+ *       jobs-ticino/`, etc.). DO NOT canonical-redirect (no replaceState)
+ *       — the orphan page must stay visible so the section search UX has
+ *       the orphan as entry-point context.
+ *     - body: "Annuncio scaduto" heading + extracted company hint (from
+ *       slug trailing tokens) + a `<noscript>` fallback link to the
+ *       section landing.
+ *
+ * Both kinds emit `robots: 'index,follow'` (per the
+ * `never_noindex_without_approval` policy). Google de-duplicates via the
+ * canonical signal; if a page genuinely should be dropped, Google decides.
+ *
+ * Plugin contract (CLAUDE.md non-negotiable #14)
+ * ----------------------------------------------
+ *   apply: 'build', enforce: 'post', emit in closeBundle.
+ *   Uses `buildSeoPageHtml` so every emitted page gets the SPA shell
+ *   (nav, footer, theme, AdSense markup, hashed entry JS/CSS).
+ *   Pass `distDir` to every call.
+ *
+ * Sitemap policy
+ * --------------
+ * Orphan bridge pages are NOT added to any sitemap. The canonical URLs
+ * already are; we don't want to advertise these as fresh crawl targets,
+ * just to repair the existing 404 cohort.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import type { Plugin } from 'vite';
+import { buildSeoPageHtml } from './shared/seoPageShell';
+import type { Locale } from '../services/i18n';
+
+const BASE_URL = 'https://frontaliereticino.ch';
+
+const SECTION_SLUG: Record<Locale, string> = {
+  it: 'cerca-lavoro-ticino',
+  en: 'find-jobs-ticino',
+  de: 'jobs-im-tessin',
+  fr: 'trouver-emploi-tessin',
+};
+
+const LOCALE_PREFIX: Record<Locale, string> = {
+  it: '',
+  en: '/en',
+  de: '/de',
+  fr: '/fr',
+};
+
+const OG_LOCALE: Record<Locale, string> = {
+  it: 'it_IT',
+  en: 'en_US',
+  de: 'de_DE',
+  fr: 'fr_FR',
+};
+
+interface OrphanEntry {
+  readonly locale: Locale;
+  readonly slug: string;
+  readonly url: string;
+  readonly kind: 'matched' | 'expired-tracked' | 'expired';
+  readonly jobId?: string;
+  readonly currentSlug?: string;
+  readonly matchType?: string;
+  readonly expiredJobId?: string;
+  readonly company?: string | null;
+  readonly csvOrigin?: string;
+}
+
+interface OrphansFile {
+  readonly generatedAt: string;
+  readonly sources: string[];
+  readonly counts: Record<string, number>;
+  readonly orphans: OrphanEntry[];
+}
+
+/** Locale copy bundles for the static body. */
+interface BridgeCopy {
+  readonly matchedTitle: string;
+  readonly matchedDescription: string;
+  readonly matchedH1: string;
+  readonly matchedLede: string;
+  readonly expiredTitle: string;
+  readonly expiredDescription: string;
+  readonly expiredH1: (companyHint: string | null) => string;
+  readonly expiredLede: string;
+  readonly browseAllLabel: string;
+}
+
+const COPY: Record<Locale, BridgeCopy> = {
+  it: {
+    matchedTitle: 'Annuncio aggiornato — apertura in corso',
+    matchedDescription: 'L\'annuncio che cerchi è stato aggiornato. Apri la versione corrente per leggere mansioni, requisiti, sede e candidarti direttamente.',
+    matchedH1: 'Annuncio aggiornato',
+    matchedLede: 'Questo annuncio è ancora aperto, ma il suo indirizzo è cambiato. Ti stiamo portando alla versione corrente — sede, requisiti e modulo di candidatura sono già pronti. Se la pagina non si apre, usa il link in fondo per tornare al job board e ritrovare l\'annuncio.',
+    expiredTitle: 'Annuncio non più disponibile — alternative aggiornate ogni giorno',
+    expiredDescription: 'Questa offerta di lavoro non è più online. Trova alternative simili nel Ticino con il nostro job board aggiornato ogni giorno: oltre 2000 annunci frontalieri attivi.',
+    expiredH1: (hint) => hint ? `Annuncio scaduto — vedi le offerte recenti di ${hint}` : 'Annuncio scaduto — vedi le offerte recenti',
+    expiredLede: 'L\'annuncio che cercavi è stato rimosso dall\'azienda inserzionista. Sul job board frontaliere trovi ogni giorno offerte simili filtrabili per ruolo, città, tipologia di contratto e azienda. Per chi vive in Italia e lavora in Svizzera, ogni risultato riporta il calcolo automatico dello stipendio netto Permit G vs Permit B, le tabelle di pendolarismo e le agevolazioni fiscali del Nuovo Accordo bilaterale 2026.',
+    browseAllLabel: 'Sfoglia tutti gli annunci attivi',
+  },
+  en: {
+    matchedTitle: 'Listing updated — opening the latest version',
+    matchedDescription: 'The listing you were looking for has been updated. We are taking you to the current version with the latest role description, location and application form.',
+    matchedH1: 'Listing updated',
+    matchedLede: 'This listing is still live but its URL has changed. We are taking you to the current version — role description, requirements, location and apply button are all there. If the page does not open, use the link below to browse the latest cross-border openings.',
+    expiredTitle: 'Listing no longer available — similar openings updated daily',
+    expiredDescription: 'This job posting is no longer online. Find similar Ticino-based openings on our cross-border job board, updated daily — over 2000 active listings.',
+    expiredH1: (hint) => hint ? `Listing closed — see recent openings from ${hint}` : 'Listing closed — see recent openings',
+    expiredLede: 'The listing you were looking for has been removed by the employer. Our cross-border job board refreshes daily with new openings filtered by role, city, contract type and employer. Each result includes the automatic net-salary calculation under Permit G vs Permit B, commute timetables and the 2026 New Bilateral Agreement tax adjustments for Italian-Swiss frontalieri.',
+    browseAllLabel: 'Browse all active listings',
+  },
+  de: {
+    matchedTitle: 'Anzeige aktualisiert — Sie werden weitergeleitet',
+    matchedDescription: 'Die gesuchte Stellenanzeige wurde aktualisiert. Wir leiten Sie zur aktuellen Version mit Tätigkeitsbeschreibung, Anforderungen und Bewerbungsformular weiter.',
+    matchedH1: 'Anzeige aktualisiert',
+    matchedLede: 'Diese Stelle ist weiterhin offen, ihre URL hat sich aber geändert. Wir leiten Sie zur aktuellen Version weiter — Tätigkeit, Anforderungen, Standort und Bewerbungsformular finden Sie dort. Falls die Seite nicht öffnet, nutzen Sie den Link unten, um zum Job-Board zurückzukehren.',
+    expiredTitle: 'Anzeige nicht mehr verfügbar — täglich aktualisierte Alternativen',
+    expiredDescription: 'Diese Stellenanzeige ist nicht mehr online. Finden Sie ähnliche Stellen im Tessin auf unserem Grenzgänger-Job-Board — täglich aktualisiert, über 2000 offene Stellen.',
+    expiredH1: (hint) => hint ? `Anzeige geschlossen — aktuelle Stellen von ${hint}` : 'Anzeige geschlossen — aktuelle Stellen',
+    expiredLede: 'Die gesuchte Stellenanzeige wurde vom Arbeitgeber entfernt. Unser Grenzgänger-Job-Board wird täglich aktualisiert und lässt sich nach Rolle, Stadt, Vertragsart und Unternehmen filtern. Jedes Ergebnis enthält die automatische Nettolohn-Berechnung unter Permit G vs Permit B, Pendlerfahrpläne und die steuerlichen Anpassungen des neuen bilateralen Abkommens 2026 für italienisch-schweizerische Grenzgänger.',
+    browseAllLabel: 'Alle aktiven Stellen ansehen',
+  },
+  fr: {
+    matchedTitle: 'Annonce mise à jour — ouverture en cours',
+    matchedDescription: 'L\'annonce que vous cherchiez a été mise à jour. Nous vous dirigeons vers la version actuelle avec la description du poste, le lieu et le formulaire de candidature.',
+    matchedH1: 'Annonce mise à jour',
+    matchedLede: 'Cette annonce est toujours active, mais son adresse a changé. Nous vous dirigeons vers la version actuelle — description, exigences, lieu et formulaire de candidature y sont. Si la page ne s\'ouvre pas, utilisez le lien ci-dessous pour parcourir les annonces frontalières les plus récentes.',
+    expiredTitle: 'Annonce non disponible — alternatives mises à jour quotidiennement',
+    expiredDescription: 'Cette offre d\'emploi n\'est plus en ligne. Trouvez des alternatives similaires au Tessin sur notre job board frontalier — mis à jour quotidiennement, plus de 2000 annonces actives.',
+    expiredH1: (hint) => hint ? `Annonce fermée — offres récentes de ${hint}` : 'Annonce fermée — offres récentes',
+    expiredLede: 'L\'annonce que vous recherchiez a été retirée par l\'employeur. Notre job board frontalier s\'actualise quotidiennement avec de nouvelles offres filtrables par rôle, ville, type de contrat et entreprise. Chaque résultat inclut le calcul automatique du salaire net Permit G vs Permit B, les horaires de transport frontalier et les ajustements fiscaux du Nouvel Accord bilatéral 2026 pour les frontaliers italo-suisses.',
+    browseAllLabel: 'Parcourir toutes les annonces actives',
+  },
+};
+
+function esc(value: string): string {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Convert a slug fragment like "lonza-visp" or "guess-europe-sagl-bioggio"
+ *  back to a human label like "Lonza Visp" / "Guess Europe Sagl Bioggio". */
+function humanizeCompanyHint(hint: string | null | undefined): string | null {
+  if (!hint) return null;
+  return hint
+    .split('-')
+    .filter(Boolean)
+    .map((t) => t.charAt(0).toUpperCase() + t.slice(1))
+    .join(' ')
+    .trim() || null;
+}
+
+function buildOrphanPath(locale: Locale, slug: string): string {
+  return `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/${slug}/`.replace(/\/+/g, '/');
+}
+
+function buildCanonicalForMatched(locale: Locale, currentSlug: string): string {
+  return `${BASE_URL}${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/${currentSlug}/`.replace(/(?<!:)\/+/g, '/');
+}
+
+function buildSectionCanonical(locale: Locale): string {
+  return `${BASE_URL}${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/(?<!:)\/+/g, '/');
+}
+
+/** Inline pre-hydration rewrite for matched orphans. */
+function buildMatchedRewriteScript(orphanPath: string, currentPath: string): string {
+  const safeOrphan = JSON.stringify(orphanPath);
+  const safeCurrent = JSON.stringify(currentPath);
+  return `<script>(function(){try{if(location.pathname===${safeOrphan}){history.replaceState(null,'',${safeCurrent}+location.search+location.hash);}}catch(e){}})();</script>`;
+}
+
+function renderMatchedPage(entry: OrphanEntry, distDir: string): string {
+  const locale = entry.locale;
+  const copy = COPY[locale];
+  const orphanPath = buildOrphanPath(locale, entry.slug);
+  const currentPath = `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/${entry.currentSlug!}/`.replace(/\/+/g, '/');
+  const canonicalUrl = buildCanonicalForMatched(locale, entry.currentSlug!);
+
+  const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
+    <header style="margin-bottom:16px">
+      <h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(copy.matchedH1)}</h1>
+    </header>
+    <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.matchedLede)}</p>
+    <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(buildSectionCanonical(locale))}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
+  </main>`;
+
+  return buildSeoPageHtml({
+    locale,
+    title: copy.matchedTitle,
+    description: copy.matchedDescription,
+    canonicalUrl,
+    robots: 'index,follow',
+    ogType: 'website',
+    ogLocale: OG_LOCALE[locale],
+    hreflangHtml: '',
+    jsonLdScripts: [],
+    extraHeadHtml: buildMatchedRewriteScript(orphanPath, currentPath),
+    bodyHtml,
+    distDir,
+    seoMainClass: 'cluster-seo-prose',
+  });
+}
+
+function renderExpiredPage(entry: OrphanEntry, distDir: string): string {
+  const locale = entry.locale;
+  const copy = COPY[locale];
+  const companyHint = humanizeCompanyHint(entry.company);
+  const canonicalUrl = buildSectionCanonical(locale);
+  const sectionPath = buildSectionCanonical(locale);
+
+  const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
+    <header style="margin-bottom:16px">
+      <h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(copy.expiredH1(companyHint))}</h1>
+    </header>
+    <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.expiredLede)}</p>
+    <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(sectionPath)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
+  </main>`;
+
+  return buildSeoPageHtml({
+    locale,
+    title: copy.expiredTitle,
+    description: copy.expiredDescription,
+    canonicalUrl,
+    robots: 'index,follow',
+    ogType: 'website',
+    ogLocale: OG_LOCALE[locale],
+    hreflangHtml: '',
+    jsonLdScripts: [],
+    bodyHtml,
+    distDir,
+    seoMainClass: 'cluster-seo-prose',
+  });
+}
+
+export function jobOrphanBridgePlugin(rootDir: string): Plugin {
+  return {
+    name: 'job-orphan-bridge',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      const dataPath = path.join(rootDir, 'data', 'gsc-job-orphans.json');
+      if (!fs.existsSync(dataPath)) {
+        console.warn('\x1b[33m[job-orphan-bridge]\x1b[0m data/gsc-job-orphans.json missing — skipping');
+        return;
+      }
+      const distDir = path.join(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) {
+        console.warn('\x1b[33m[job-orphan-bridge]\x1b[0m dist/ missing — skipping');
+        return;
+      }
+
+      let file: OrphansFile;
+      try {
+        file = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+      } catch (err) {
+        console.warn('\x1b[33m[job-orphan-bridge]\x1b[0m failed to parse data file:', err);
+        return;
+      }
+      if (!Array.isArray(file.orphans) || file.orphans.length === 0) {
+        console.warn('\x1b[33m[job-orphan-bridge]\x1b[0m no orphan entries — skipping');
+        return;
+      }
+
+      let emitted = 0;
+      let skippedCollision = 0;
+      const start = Date.now();
+
+      for (const entry of file.orphans) {
+        const orphanPath = buildOrphanPath(entry.locale, entry.slug);
+        const indexTarget = path.join(distDir, orphanPath, 'index.html');
+        const flatTarget = path.join(distDir, orphanPath.replace(/\/+$/, '') + '.html');
+
+        // Skip if another plugin already wrote real content here (e.g. a
+        // re-activated job that re-uses the same slug). Idempotency guard.
+        if (fs.existsSync(indexTarget)) {
+          skippedCollision++;
+          continue;
+        }
+
+        const html = entry.kind === 'matched'
+          ? renderMatchedPage(entry, distDir)
+          : renderExpiredPage(entry, distDir);
+
+        try {
+          fs.mkdirSync(path.dirname(indexTarget), { recursive: true });
+          fs.writeFileSync(indexTarget, html, 'utf-8');
+          fs.writeFileSync(flatTarget, html, 'utf-8');
+          emitted += 2;
+        } catch (err) {
+          console.warn(`\x1b[33m[job-orphan-bridge]\x1b[0m failed to write ${indexTarget}:`, err);
+        }
+      }
+
+      const dur = ((Date.now() - start) / 1000).toFixed(1);
+      console.log(
+        `\x1b[36m[job-orphan-bridge]\x1b[0m emitted ${emitted} bridge files (${file.orphans.length - skippedCollision} pages, ${skippedCollision} skipped due to live-page collision) in ${dur}s`,
+      );
+    },
+  };
+}

--- a/data/gsc-job-orphans.json
+++ b/data/gsc-job-orphans.json
@@ -1,0 +1,790 @@
+{
+  "generatedAt": "2026-05-11T17:03:41.762Z",
+  "sources": [
+    "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+  ],
+  "counts": {
+    "expired": 71,
+    "matched": 21
+  },
+  "orphans": [
+    {
+      "locale": "de",
+      "slug": "specialista-content-campagna-e-commerce-guess-europe-sagl-bioggio",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/specialista-content-campagna-e-commerce-guess-europe-sagl-bioggio/",
+      "kind": "expired",
+      "company": "guess-europe-sagl-bioggio",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "gestionnaire-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-stabio",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/gestionnaire-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-stabio/",
+      "kind": "matched",
+      "jobId": "company-kqop8j",
+      "currentSlug": "gestionnaire-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-kqop8j",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "talent-community-chur-aufzug-monteur-reparateur-servicetechniker-m-w-d-otis-sa-triststrass",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/talent-community-chur-aufzug-monteur-reparateur-servicetechniker-m-w-d-otis-sa-triststrass/",
+      "kind": "matched",
+      "jobId": "otis-38c4a4ee7c00",
+      "currentSlug": "talent-community-chur-aufzug-monteur-reparateur-servicetechniker-m-w-d-otis-triststrasse-8",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "coordinateur-des-services-generaux-et-de-la-securite-des-installations-ibsa-institut-bioch",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/coordinateur-des-services-generaux-et-de-la-securite-des-installations-ibsa-institut-bioch/",
+      "kind": "expired",
+      "company": "installations-ibsa-institut-bioch",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "infirmier-e-specialise-e-en-soins-urgents-et-soins-intensifs-eoc-ente-ospedaliero-cantonal",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/infirmier-e-specialise-e-en-soins-urgents-et-soins-intensifs-eoc-ente-ospedaliero-cantonal/",
+      "kind": "expired",
+      "company": "eoc-ente-ospedaliero-cantonal",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "capo-arte-a-tempo-parziale-90-presso-le-strutture-carceraria-lugano-cadro-amministrazione-",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/capo-arte-a-tempo-parziale-90-presso-le-strutture-carceraria-lugano-cadro-amministrazione-/",
+      "kind": "expired",
+      "company": "carceraria-lugano-cadro-amministrazione",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "automatico-80-100-m-w-d-lonza-visp",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/automatico-80-100-m-w-d-lonza-visp/",
+      "kind": "expired",
+      "company": "w-d-lonza-visp",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "quereinstieg-collaboratore-trice-fleisch-e-fisch-coop-grigioni-ncbhm0",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/quereinstieg-collaboratore-trice-fleisch-e-fisch-coop-grigioni-ncbhm0/",
+      "kind": "matched",
+      "jobId": "company-ncbhm0",
+      "currentSlug": "quereinstieg-mitarbeiter-in-fleisch-und-fisch-coop-grigioni-9yar0z",
+      "matchType": "current-flat",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "maintenance-planner-reliability-ingegnere-80-100-m-w-d-lonza-visp",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/maintenance-planner-reliability-ingegnere-80-100-m-w-d-lonza-visp/",
+      "kind": "expired",
+      "company": "w-d-lonza-visp",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "tecnico-a-hvac-scuola-tecnica-ingegnere-a-hvac-universita-di-scienze-applicate-60-100-imwi",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/tecnico-a-hvac-scuola-tecnica-ingegnere-a-hvac-universita-di-scienze-applicate-60-100-imwi/",
+      "kind": "matched",
+      "jobId": "burkhalter-group-0d7bd984375d",
+      "currentSlug": "tecnico-a-hvac-scuola-tecnica-ingegnere-a-hvac-universita-di-scienze-applicate-60-100-imwinkelried-luftung-und-klima-ag-visp",
+      "matchType": "prefix",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "concours-pour-embaucher-un-ingenieur-en-systemes-informatiques-a-temps-plein-oscam-ospedal",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/concours-pour-embaucher-un-ingenieur-en-systemes-informatiques-a-temps-plein-oscam-ospedal/",
+      "kind": "expired",
+      "company": "temps-plein-oscam-ospedal",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "operateur-utilities-ibex-mitarbeiter-technischer-unterhalt-m-w-d-lonza-visp",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/operateur-utilities-ibex-mitarbeiter-technischer-unterhalt-m-w-d-lonza-visp/",
+      "kind": "expired",
+      "company": "w-d-lonza-visp",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "kaltetechniker-im-technical-support-mit-internationaler-reisetatigkeit-80-100-w-m-d-hamilt",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/kaltetechniker-im-technical-support-mit-internationaler-reisetatigkeit-80-100-w-m-d-hamilt/",
+      "kind": "matched",
+      "jobId": "hamilton-bonaduz-ag-87c22fca377e",
+      "currentSlug": "kaltetechniker-im-technischen-support-mit-internationaler-reisetatigkeit-80-100-w-m-d-hamilton-bonaduz-ag-domat-ems",
+      "matchType": "prefix",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "rif-508-perito-meccanico-jobcourier-mendrisio-ticino-switzerland",
+      "url": "https://www.frontaliereticino.ch/cerca-lavoro-ticino/rif-508-perito-meccanico-jobcourier-mendrisio-ticino-switzerland/",
+      "kind": "expired",
+      "company": "jobcourier-mendrisio-ticino-switzerland",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "privati-consultant-3a-3b-ibrido-convit-holding-gmbh-sementina",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/privati-consultant-3a-3b-ibrido-convit-holding-gmbh-sementina/",
+      "kind": "expired",
+      "company": "convit-holding-gmbh-sementina",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "assistant-avec-diplome-de-bachelor-ou-master-pour-le-programme-de-diplome-en-architecture-supsi-dti-mendrisio",
+      "url": "https://www.frontaliereticino.ch/fr/trouver-emploi-tessin/assistant-avec-diplome-de-bachelor-ou-master-pour-le-programme-de-diplome-en-architecture-supsi-dti-mendrisio/",
+      "kind": "expired",
+      "company": "architecture-supsi-dti-mendrisio",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/culinary-advisor-im-foodservice-deutschland-m-w-d-hilcona-undefined/",
+      "kind": "expired",
+      "company": "w-d-hilcona-undefined",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "apprenti-e-en-assistance-commerciale-eba-alimentaire-volg-untervaz",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/apprenti-e-en-assistance-commerciale-eba-alimentaire-volg-untervaz/",
+      "kind": "expired",
+      "company": "eba-alimentaire-volg-untervaz",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "infermieri",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/infermieri/",
+      "kind": "matched",
+      "jobId": "lis-lugano-istituti-sociali-f650fe01210f",
+      "currentSlug": "pflegefachkrafte-lis-lugano-istituti-sociali-pregassona-isfspc",
+      "matchType": "previous",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-collombey-",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-collombey-/",
+      "kind": "matched",
+      "jobId": "volg-fenaco-77eaeb225a2b",
+      "currentSlug": "posto-di-apprendistato-come-gestore-o-assistente-del-commercio-al-dettaglio-volg-veysonnaz",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "apprendista-impiegato-di-commercio-afc-sintetica-sa-mendrisio",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/apprendista-impiegato-di-commercio-afc-sintetica-sa-mendrisio/",
+      "kind": "matched",
+      "jobId": "company-mawo6w",
+      "currentSlug": "lernende-r-kauffrau-kaufmann-efz-sintetica-sa-mendrisio-mawo6w",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "bioprocess-ingegnere-lonza-ch",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/bioprocess-ingegnere-lonza-ch/",
+      "kind": "expired",
+      "company": "lonza-ch",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "installateurs-electriciens-installatrices-electriciennes-cfc-100-grichting-valterio-electr",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/installateurs-electriciens-installatrices-electriciennes-cfc-100-grichting-valterio-electr/",
+      "kind": "matched",
+      "jobId": "burkhalter-group-a1d6475181ae",
+      "currentSlug": "elektroinstallateure-elektroinstallateurinnen-cfc-100-grichting-valterio-electro-sa-collombey",
+      "matchType": "prefix",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "employe-e-de-gastronomie-standardisee-afc-coop-ristorante-ticino",
+      "url": "https://www.frontaliereticino.ch/fr/trouver-emploi-tessin/employe-e-de-gastronomie-standardisee-afc-coop-ristorante-ticino/",
+      "kind": "matched",
+      "jobId": "company-z0zxuf",
+      "currentSlug": "employe-e-de-gastronomie-standardisee-assistant-e-de-gastronomie-standardisee-marche-dietlikon",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "installateurs-electriciens-installatrices-electriciennes-oriente-industrie-100-grichting-v",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/installateurs-electriciens-installatrices-electriciennes-oriente-industrie-100-grichting-v/",
+      "kind": "matched",
+      "jobId": "burkhalter-group-6f32ac7a6326",
+      "currentSlug": "elektroinstallateure-in-industrieorientiert-100-grichting-valterio-electro-sa-collombey",
+      "matchType": "prefix",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "application-manager-managerin-hilcona-undefined",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/application-manager-managerin-hilcona-undefined/",
+      "kind": "expired",
+      "company": "hilcona-undefined",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "master-in-energy-environment-intern-microbiology-institute-supsi-dti-mendrisio",
+      "url": "https://www.frontaliereticino.ch/en/find-jobs-ticino/master-in-energy-environment-intern-microbiology-institute-supsi-dti-mendrisio/",
+      "kind": "expired",
+      "company": "institute-supsi-dti-mendrisio",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "social-and-health-care-workers-lis-lugano-istituti-sociali-pregassona",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/social-and-health-care-workers-lis-lugano-istituti-sociali-pregassona/",
+      "kind": "expired",
+      "company": "lugano-istituti-sociali-pregassona",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "tirocinio-in-architettura-e-tecnologia-usi-mendrisio",
+      "url": "https://www.frontaliereticino.ch/cerca-lavoro-ticino/tirocinio-in-architettura-e-tecnologia-usi-mendrisio/",
+      "kind": "expired",
+      "company": "tecnologia-usi-mendrisio",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-di-acquisto-jumbo-dietl",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-di-acquisto-jumbo-dietl/",
+      "kind": "matched",
+      "jobId": "company-oal0zl",
+      "currentSlug": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "specialista-di-supporto-pb-medio-oriente-ch-efg-international-ag-geneve",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/specialista-di-supporto-pb-medio-oriente-ch-efg-international-ag-geneve/",
+      "kind": "expired",
+      "company": "efg-international-ag-geneve",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "personnel-en-planification-disposition-80-100-ferrovia-retica-rhb-chur",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/personnel-en-planification-disposition-80-100-ferrovia-retica-rhb-chur/",
+      "kind": "expired",
+      "company": "ferrovia-retica-rhb-chur",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "deputy-store-manager-m-f-d-volg-laax-signina",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/deputy-store-manager-m-f-d-volg-laax-signina/",
+      "kind": "expired",
+      "company": "d-volg-laax-signina",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "bauleitende-r-installatore-trice-elettrico-a-in-100-triulzi-ag-st-moritz",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/bauleitende-r-installatore-trice-elettrico-a-in-100-triulzi-ag-st-moritz/",
+      "kind": "expired",
+      "company": "triulzi-ag-st-moritz",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "collaboratore-trice-logistica-tecnico-impiantista-usi-lugano",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/collaboratore-trice-logistica-tecnico-impiantista-usi-lugano/",
+      "kind": "matched",
+      "jobId": "usi-universita-della-svizzera-italiana-5786c4fb1ec9",
+      "currentSlug": "collaboratore-trice-logistique-technicien-impiantista-usi-universita-della-svizzera-italiana-lugano",
+      "matchType": "current-flat",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "venditore-30-38-5h-settimana-chocolaterie-kitzbuhel-u-m-d-laderach-schweiz-ag-kitzbuhel",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/venditore-30-38-5h-settimana-chocolaterie-kitzbuhel-u-m-d-laderach-schweiz-ag-kitzbuhel/",
+      "kind": "expired",
+      "company": "laderach-schweiz-ag-kitzbuhel",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell/",
+      "kind": "expired",
+      "company": "hugli-nahrungsmittel-gmbh-radolfzell",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "risikomanager-alm-und-liquiditatsrisiko-corner-banca-lugano",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/risikomanager-alm-und-liquiditatsrisiko-corner-banca-lugano/",
+      "kind": "expired",
+      "company": "corner-banca-lugano",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "levatrice-ostetrica-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offerta-ospedali",
+      "url": "https://www.frontaliereticino.ch/cerca-lavoro-ticino/levatrice-ostetrica-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offerta-ospedali/",
+      "kind": "expired",
+      "company": "popolazione-un-offerta-ospedali",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "sap-sd-inhouse-consultant-m-w-d-hilcona-undefined",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/sap-sd-inhouse-consultant-m-w-d-hilcona-undefined/",
+      "kind": "expired",
+      "company": "w-d-hilcona-undefined",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "collaboratore-trice-gestione-crediti-bps-banca-popolare-di-sondrio-suisse-lugano",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/collaboratore-trice-gestione-crediti-bps-banca-popolare-di-sondrio-suisse-lugano/",
+      "kind": "matched",
+      "jobId": "bps-suisse-ec1de76eae01",
+      "currentSlug": "collaboratore-trice-gestion-crediti-bps-banca-popolare-di-sondrio-suisse-lugano",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "quereinstieg-collaboratore-trice-fleisch-e-fisch-coop-grigioni-ncbhm0",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/quereinstieg-collaboratore-trice-fleisch-e-fisch-coop-grigioni-ncbhm0/",
+      "kind": "matched",
+      "jobId": "company-ncbhm0",
+      "currentSlug": "entry-level-meat-and-fish-team-member-coop-genossenschaft-muttenz",
+      "matchType": "current-flat",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "in-room-dining-supervisor-f-m-d-grand-hotel-des-bains-kempinski-st-moritz-st",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/in-room-dining-supervisor-f-m-d-grand-hotel-des-bains-kempinski-st-moritz-st/",
+      "kind": "expired",
+      "company": "kempinski-st-moritz-st",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "group-insurance-expert-efg-zurich",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/group-insurance-expert-efg-zurich/",
+      "kind": "expired",
+      "company": "efg-zurich",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "sage-femme-obstetricien-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offerta-ospe",
+      "url": "https://www.frontaliereticino.ch/fr/trouver-emploi-tessin/sage-femme-obstetricien-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offerta-ospe/",
+      "kind": "expired",
+      "company": "popolazione-un-offerta-ospe",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-bell-schweiz-ag-zell",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/betriebsmechanikerin-betriebsmechaniker-fleischgewinnung-100-bell-schweiz-ag-zell/",
+      "kind": "expired",
+      "company": "bell-schweiz-ag-zell",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "initiativbewerbung-lehre-corner-banca-switzerland",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/initiativbewerbung-lehre-corner-banca-switzerland/",
+      "kind": "expired",
+      "company": "banca-switzerland",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "vendeur-denner-wilderswil",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/vendeur-denner-wilderswil/",
+      "kind": "expired",
+      "company": null,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "mechatroniker-m-w-d-hilcona-pfaffstatt",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/mechatroniker-m-w-d-hilcona-pfaffstatt/",
+      "kind": "expired",
+      "company": "d-hilcona-pfaffstatt",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "vorarbeiter-standort-edewecht-m-w-d-hilcona-undefined",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/vorarbeiter-standort-edewecht-m-w-d-hilcona-undefined/",
+      "kind": "expired",
+      "company": "w-d-hilcona-undefined",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "dottoranda-dottorando-in-dinamica-dei-materiali-compositi-avanzati-per-droni-supsi-dti-mendrisio-grado-d-l4rl4l",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/dottoranda-dottorando-in-dinamica-dei-materiali-compositi-avanzati-per-droni-supsi-dti-mendrisio-grado-d-l4rl4l/",
+      "kind": "matched",
+      "jobId": "company-l4rl4l",
+      "currentSlug": "dottoranda-dottorando-in-dinamica-dei-materiali-compositi-avanzati-per-droni-supsi-dti-manno",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "coordinatore-trice-scientifico-a-con-incarichi-di-docenza-per-la-casa-della-sostenibilita-usi-universita-della-svizzera-italiana-lugano",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/coordinatore-trice-scientifico-a-con-incarichi-di-docenza-per-la-casa-della-sostenibilita-usi-universita-della-svizzera-italiana-lugano/",
+      "kind": "expired",
+      "company": "della-svizzera-italiana-lugano",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "sme-insurance-consultant-for-ash-surfaces-axa-svizzera-ticino",
+      "url": "https://www.frontaliereticino.ch/en/find-jobs-ticino/sme-insurance-consultant-for-ash-surfaces-axa-svizzera-ticino/",
+      "kind": "expired",
+      "company": "surfaces-axa-svizzera-ticino",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "amministratore-trice-di-reti-network-engineer-usi-lugano",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/amministratore-trice-di-reti-network-engineer-usi-lugano/",
+      "kind": "expired",
+      "company": "network-engineer-usi-lugano",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "ki-produktingenieur-80-100-localsearch-zurich",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/ki-produktingenieur-80-100-localsearch-zurich/",
+      "kind": "expired",
+      "company": "100-localsearch-zurich",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "company-mabetex-group",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/company-mabetex-group/",
+      "kind": "expired",
+      "company": null,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "apprenticeship-retail-sales-assistant-efz-swisscom-sede-ticino-bellinzona",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/apprenticeship-retail-sales-assistant-efz-swisscom-sede-ticino-bellinzona/",
+      "kind": "matched",
+      "jobId": "swisscom-sede-ticino-6ec9c0a4427c",
+      "currentSlug": "apprenticeship-retail-sales-assistant-efz-swisscom-sede-ticino-balerna",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "technischer-allrounder-technische-allrounderin-facility-management-hilcona-undefined",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/technischer-allrounder-technische-allrounderin-facility-management-hilcona-undefined/",
+      "kind": "expired",
+      "company": "facility-management-hilcona-undefined",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "unterstutzung-des-leiters-der-gold-und-silberraffinerie-mks-pamp-castel-san-pietro",
+      "url": "https://www.frontaliereticino.ch/de/jobs-im-tessin/unterstutzung-des-leiters-der-gold-und-silberraffinerie-mks-pamp-castel-san-pietro/",
+      "kind": "expired",
+      "company": "pamp-castel-san-pietro",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "assistant-in-the-center-line-alc-monteceneri-swiss-armed-forces-vtg-bellinzona",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/assistant-in-the-center-line-alc-monteceneri-swiss-armed-forces-vtg-bellinzona/",
+      "kind": "expired",
+      "company": "armed-forces-vtg-bellinzona",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "general-competition-2026-administrative-assistants-reception-staff-insurance-advisors-telephone-consultants-collectors-bankruptcy-managers-s",
+      "url": "https://www.frontaliereticino.ch/en/find-jobs-ticino/general-competition-2026-administrative-assistants-reception-staff-insurance-advisors-telephone-consultants-collectors-bankruptcy-managers-s/",
+      "kind": "expired",
+      "company": "collectors-bankruptcy-managers-s",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "consulente-vendita-giardino-jumbo-divisione-di-coop-societa-cooperativa-tenero-contra",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/consulente-vendita-giardino-jumbo-divisione-di-coop-societa-cooperativa-tenero-contra/",
+      "kind": "matched",
+      "jobId": "company-98b1xm",
+      "currentSlug": "consulente-vendita-giardino-jumbo-tenero-contra-ticino-98b1xm",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "mechanical-assembler-of-industrial-machinery-pemsa-lamone",
+      "url": "https://www.frontaliereticino.ch/en/find-jobs-ticino/mechanical-assembler-of-industrial-machinery-pemsa-lamone/",
+      "kind": "expired",
+      "company": "machinery-pemsa-lamone",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "monteur-mecanique-de-machines-industrielles-pemsa-lamone",
+      "url": "https://www.frontaliereticino.ch/fr/trouver-emploi-tessin/monteur-mecanique-de-machines-industrielles-pemsa-lamone/",
+      "kind": "expired",
+      "company": "industrielles-pemsa-lamone",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "plumber-installer-3-pemsa-lugano",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/plumber-installer-3-pemsa-lugano/",
+      "kind": "expired",
+      "company": "pemsa-lugano",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "responsabile-servizio-trasporti-underwriting-e-sinistri",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/responsabile-servizio-trasporti-underwriting-e-sinistri/",
+      "kind": "expired",
+      "company": "underwriting-e-sinistri",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "un-e-comptable-50-70-fondazione-la-fonte-lugano",
+      "url": "https://www.frontaliereticino.ch/fr/trouver-emploi-tessin/un-e-comptable-50-70-fondazione-la-fonte-lugano/",
+      "kind": "expired",
+      "company": "fondazione-la-fonte-lugano",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "logistico-a-eba-coop-grigioni",
+      "url": "https://www.frontaliereticino.ch/cerca-lavoro-ticino/logistico-a-eba-coop-grigioni/",
+      "kind": "expired",
+      "company": "coop-grigioni",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "coordinatore-trice-scientifico-a-con-incarichi-di-docenza-per-la-casa-della-sostenibilita-",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/coordinatore-trice-scientifico-a-con-incarichi-di-docenza-per-la-casa-della-sostenibilita-/",
+      "kind": "expired",
+      "company": "la-casa-della-sostenibilita",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "manager-of-railway-signal-safety-systems-m-f-d-ffs-officine-ferrovie-federali-biasca",
+      "url": "https://www.frontaliereticino.ch/en/find-jobs-ticino/manager-of-railway-signal-safety-systems-m-f-d-ffs-officine-ferrovie-federali-biasca/",
+      "kind": "expired",
+      "company": "officine-ferrovie-federali-biasca",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "associate-operazioni-marketplace-digitale-copertura-maternita-a-termine-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1",
+      "url": "https://www.frontaliereticino.ch/cerca-lavoro-ticino/associate-operazioni-marketplace-digitale-copertura-maternita-a-termine-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1",
+      "kind": "expired",
+      "company": "stabio-vf-campus-vf1",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "wettbewerbsausschreibung-fur-eine-vertragslehre-in-der-offentlichen-verwaltung-usi-univers",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/wettbewerbsausschreibung-fur-eine-vertragslehre-in-der-offentlichen-verwaltung-usi-univers/",
+      "kind": "matched",
+      "jobId": "usi-universita-della-svizzera-italiana-729fc508e5f2",
+      "currentSlug": "wettbewerbsausschreibung-fur-eine-vertragslehre-in-der-offentlichen-verwaltung-usi-lugano",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "assistant-ventes-marketing-service-clientele-mercato-francese-cambiavalute-ch-lugano",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/assistant-ventes-marketing-service-clientele-mercato-francese-cambiavalute-ch-lugano/",
+      "kind": "matched",
+      "jobId": "company-a24znt",
+      "currentSlug": "assistant-ventes-marketing-service-clientele-mercato-francese-cambiavalute-ch-chiasso-svizzera-posizione-esclusivamente-in-presenza-no-remot-a24znt",
+      "matchType": "reslug",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "senior-firmware-entwickler-r-d-80-100-abb-svizzera-sede-ticino-quartino-ticino",
+      "url": "https://www.frontaliereticino.ch/de/jobs-im-tessin/senior-firmware-entwickler-r-d-80-100-abb-svizzera-sede-ticino-quartino-ticino/",
+      "kind": "expired",
+      "company": "sede-ticino-quartino-ticino",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "autista-di-camion-heineken-switzerland-ierung",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/autista-di-camion-heineken-switzerland-ierung/",
+      "kind": "expired",
+      "company": "heineken-switzerland-ierung",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "gaststattenmitarbeiter-in-eoc-ente-ospedaliero-cantonale-novaggio",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/gaststattenmitarbeiter-in-eoc-ente-ospedaliero-cantonale-novaggio/",
+      "kind": "expired",
+      "company": "ospedaliero-cantonale-novaggio",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "junior-process-engineer-anlagemeister-anlagespezialist-biotechnology-pharma-80-100-m-w-d-l",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/junior-process-engineer-anlagemeister-anlagespezialist-biotechnology-pharma-80-100-m-w-d-l/",
+      "kind": "expired",
+      "company": "m-w-d-l",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "assistente-event-manager-m-w-d-kulm-hotel-st-moritz-st",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/assistente-event-manager-m-w-d-kulm-hotel-st-moritz-st/",
+      "kind": "expired",
+      "company": "hotel-st-moritz-st",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "network-engineer-usi-universita-della-svizzera-italiana-lugano",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/network-engineer-usi-universita-della-svizzera-italiana-lugano/",
+      "kind": "expired",
+      "company": "della-svizzera-italiana-lugano",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "stagiaire-en-gastronomie-systemique-eba-marche-dietlikon",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/stagiaire-en-gastronomie-systemique-eba-marche-dietlikon/",
+      "kind": "expired",
+      "company": "eba-marche-dietlikon",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "employe-e-saisonnier-ere-coop-grigioni",
+      "url": "https://www.frontaliereticino.ch/fr/trouver-emploi-tessin/employe-e-saisonnier-ere-coop-grigioni/",
+      "kind": "expired",
+      "company": "ere-coop-grigioni",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "allgemeiner-wettbewerb-2026-verwaltungsassistenten-empfangspersonal-versicherungsberater-telefonberater-inkassobeauftragte-insolvenzverwalte",
+      "url": "https://www.frontaliereticino.ch/de/jobs-im-tessin/allgemeiner-wettbewerb-2026-verwaltungsassistenten-empfangspersonal-versicherungsberater-telefonberater-inkassobeauftragte-insolvenzverwalte/",
+      "kind": "expired",
+      "company": "versicherungsberater-telefonberater-inkassobeauftragte-insolvenzverwalte",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "quality-engineer-m-f-d-ffs-officine-ferrovie-federali-bellinzona",
+      "url": "https://www.frontaliereticino.ch/en/find-jobs-ticino/quality-engineer-m-f-d-ffs-officine-ferrovie-federali-bellinzona/",
+      "kind": "expired",
+      "company": "officine-ferrovie-federali-bellinzona",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "sales-assistant-damiani-group-serravalle-scrivia",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/sales-assistant-damiani-group-serravalle-scrivia/",
+      "kind": "expired",
+      "company": "group-serravalle-scrivia",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "consulente-previdenziale-senza-esperienza-formazione-pagata-convit-tenero-contra",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/consulente-previdenziale-senza-esperienza-formazione-pagata-convit-tenero-contra/",
+      "kind": "matched",
+      "jobId": "convit-61a23c9ee42f",
+      "currentSlug": "consultant-en-securite-sociale-sans-experience-convit-holding-gmbh-tenero-contra",
+      "matchType": "current-flat",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "assistent-mit-bachelor-oder-masterabschluss-fur-das-architekturstudium-supsi-dti-mendrisio",
+      "url": "https://www.frontaliereticino.ch/de/jobs-im-tessin/assistent-mit-bachelor-oder-masterabschluss-fur-das-architekturstudium-supsi-dti-mendrisio/",
+      "kind": "expired",
+      "company": "architekturstudium-supsi-dti-mendrisio",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "slug": "mechanischer-monteur-von-industriemaschinen-pemsa-lamone",
+      "url": "https://www.frontaliereticino.ch/de/jobs-im-tessin/mechanischer-monteur-von-industriemaschinen-pemsa-lamone/",
+      "kind": "expired",
+      "company": "industriemaschinen-pemsa-lamone",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "responsabile-del-centro-di-competenza-danni-personali-responsabilita-civile-axa-svizzera-8",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/responsabile-del-centro-di-competenza-danni-personali-responsabilita-civile-axa-svizzera-8/",
+      "kind": "expired",
+      "company": "civile-axa-svizzera-8",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "linea-di-ricarica-w-m-d-landi-oberwallis-ag-visp",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/linea-di-ricarica-w-m-d-landi-oberwallis-ag-visp/",
+      "kind": "expired",
+      "company": "landi-oberwallis-ag-visp",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "slug": "senior-ai-ingegnere-business-automation-information-management-all-genders-axa-svizzera-winterthur-smart-working",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/senior-ai-ingegnere-business-automation-information-management-all-genders-axa-svizzera-winterthur-smart-working/",
+      "kind": "expired",
+      "company": "svizzera-winterthur-smart-working",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "slug": "verkaufer-verkauferin-mit-schichtverantwortung-m-w-d-60-80-lidl-svizzera-st-moritz",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/verkaufer-verkauferin-mit-schichtverantwortung-m-w-d-60-80-lidl-svizzera-st-moritz/",
+      "kind": "expired",
+      "company": "lidl-svizzera-st-moritz",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "slug": "concierge-a-temps-partiel-50-au-centre-professionnel-technique-cpt-lugano-trevano-amminist",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/concierge-a-temps-partiel-50-au-centre-professionnel-technique-cpt-lugano-trevano-amminist/",
+      "kind": "expired",
+      "company": "cpt-lugano-trevano-amminist",
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    }
+  ]
+}

--- a/scripts/ingest-gsc-job-orphans.mjs
+++ b/scripts/ingest-gsc-job-orphans.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * ingest-gsc-job-orphans.mjs
+ *
+ * Ingests GSC Coverage Drilldown CSV exports and classifies each job-detail
+ * 404 URL as either:
+ *   - "matched"  → current jobs.json has a slug that is a longer prefix of
+ *                  the orphan slug OR shares the first 30 chars with the
+ *                  orphan. The orphan can bridge to the current canonical.
+ *   - "expired"  → no current job matches. Render a soft-landing with
+ *                  related-by-company content.
+ *
+ * Output: `data/gsc-job-orphans.json`, consumed by
+ * `build-plugins/jobOrphanBridgePlugin.ts` to emit 200 HTML bridge pages
+ * for every entry (closing the GSC "Indicizzata Non trovata" cohort
+ * without 301-redirecting — preserves AdSense rendering).
+ *
+ * Mirrors the pattern of `ingest-gsc-orphans-into-candidates.mjs` for the
+ * related-search cluster cohort (PR #81).
+ *
+ * Usage:
+ *   node scripts/ingest-gsc-job-orphans.mjs              # write
+ *   node scripts/ingest-gsc-job-orphans.mjs --dry-run    # report only
+ *
+ * Reads every `Tabella.csv` under `download/frontaliereticino.ch-Coverage-*`
+ * + `data/jobs.json` + `data/expired-jobs.json` (optional, may be missing).
+ * Idempotent.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(__filename, '..', '..');
+const JOBS_PATH = path.join(ROOT, 'data', 'jobs.json');
+const EXPIRED_PATH = path.join(ROOT, 'data', 'expired-jobs.json');
+const DOWNLOADS_DIR = path.join(ROOT, 'download');
+const OUT_PATH = path.join(ROOT, 'data', 'gsc-job-orphans.json');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const SECTION_PATTERNS = [
+  [/^\/cerca-lavoro-ticino\/([^/]+)\/?$/, 'it'],
+  [/^\/en\/find-jobs-ticino\/([^/]+)\/?$/, 'en'],
+  [/^\/de\/jobs-im-tessin\/([^/]+)\/?$/, 'de'],
+  [/^\/fr\/trouver-emploi-tessin\/([^/]+)\/?$/, 'fr'],
+];
+
+const SECTION_SLUG = {
+  it: 'cerca-lavoro-ticino',
+  en: 'find-jobs-ticino',
+  de: 'jobs-im-tessin',
+  fr: 'trouver-emploi-tessin',
+};
+
+const LOCALE_PREFIX = { it: '', en: '/en', de: '/de', fr: '/fr' };
+
+/** Reserved hub prefixes — slugs starting with these are NOT job-details. */
+const HUB_PREFIXES = [
+  /^(ricerca|search|suche|recherche)-/,
+  /^(azienda|localita|location|standort|ort|stadt|unternehmen|firma|entreprise|ville|lieu|localite)-/,
+];
+
+function findCsvFiles() {
+  if (!fs.existsSync(DOWNLOADS_DIR)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(DOWNLOADS_DIR)) {
+    if (!entry.startsWith('frontaliereticino.ch-Coverage-')) continue;
+    const csv = path.join(DOWNLOADS_DIR, entry, 'Tabella.csv');
+    if (fs.existsSync(csv)) out.push({ file: csv, basename: entry });
+  }
+  return out;
+}
+
+function parseCsvUrls(file) {
+  const text = fs.readFileSync(file, 'utf-8');
+  return text.split(/\r?\n/).slice(1).filter(Boolean).map((l) => l.split(',')[0]).filter(Boolean);
+}
+
+function urlToOrphan(url) {
+  let pathname;
+  try { pathname = new URL(url).pathname; } catch { return null; }
+  for (const [re, locale] of SECTION_PATTERNS) {
+    const m = pathname.match(re);
+    if (!m) continue;
+    const slug = m[1];
+    if (HUB_PREFIXES.some((rx) => rx.test(slug))) return null;
+    return { locale, slug, url };
+  }
+  return null;
+}
+
+/**
+ * Build a slug index keyed by `${locale}::${slug}` → { jobId, currentSlug:[per locale] }.
+ * Includes current slugs, slugByLocale entries, previousSlugs (flat + per-locale).
+ */
+function buildSlugIndex(jobs) {
+  const idx = new Map();
+  const slugsByJob = new Map(); // jobId → per-locale current slug map for canonical URL
+  for (const job of jobs) {
+    const perLocale = {};
+    for (const loc of ['it', 'en', 'de', 'fr']) {
+      const s = job.slugByLocale?.[loc] || job.slug || '';
+      if (s) perLocale[loc] = s;
+    }
+    slugsByJob.set(job.id, perLocale);
+
+    for (const [loc, s] of Object.entries(job.slugByLocale || {})) {
+      if (s) idx.set(`${loc}::${s}`, { jobId: job.id, locale: loc, kind: 'current' });
+    }
+    if (job.slug) idx.set(`it::${job.slug}`, { jobId: job.id, locale: 'it', kind: 'current-flat' });
+    for (const ps of (job.previousSlugs || [])) idx.set(`it::${ps}`, { jobId: job.id, locale: 'it', kind: 'previous' });
+    if (job.previousSlugsByLocale) {
+      for (const [loc, arr] of Object.entries(job.previousSlugsByLocale)) {
+        for (const s of (arr || [])) if (s) idx.set(`${loc}::${s}`, { jobId: job.id, locale: loc, kind: 'previous' });
+      }
+    }
+  }
+  return { idx, slugsByJob };
+}
+
+/** Try prefix match: any current/previous slug whose first chars equal the orphan. */
+function findPrefixMatch(orphan, jobs) {
+  for (const job of jobs) {
+    const slugs = [job.slug, ...Object.values(job.slugByLocale || {})].filter(Boolean);
+    for (const s of slugs) {
+      if (s.startsWith(orphan.slug) && s.length > orphan.slug.length) {
+        const localizedSlug = job.slugByLocale?.[orphan.locale] || job.slug || '';
+        if (localizedSlug) return { job, localizedSlug };
+      }
+    }
+  }
+  return null;
+}
+
+/** Try 30-char head match (reslug case): different slug, same job. */
+function findReslugMatch(orphan, jobs) {
+  const head = orphan.slug.slice(0, 30);
+  if (head.length < 20) return null; // Too short, unreliable signal
+  for (const job of jobs) {
+    const slugs = [job.slug, ...Object.values(job.slugByLocale || {})].filter(Boolean);
+    for (const s of slugs) {
+      if (s.startsWith(head) && s !== orphan.slug) {
+        const localizedSlug = job.slugByLocale?.[orphan.locale] || job.slug || '';
+        if (localizedSlug) return { job, localizedSlug };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract a company "hint" from the orphan slug — the trailing N-K tokens that
+ * usually carry the company name + city. Used for soft-landing related-jobs
+ * matching when no current job is found.
+ *
+ * Slug shape (audit-derived):
+ *   <title-tokens>-<company-tokens>-<city>
+ * Heuristic: take the last 3-5 tokens.
+ */
+function extractCompanyHint(slug) {
+  const tokens = slug.split('-').filter(Boolean);
+  if (tokens.length < 4) return null;
+  return tokens.slice(-Math.min(4, Math.max(2, Math.floor(tokens.length / 2)))).join('-');
+}
+
+function classifyOrphan(orphan, jobs, expiredIdx, csvBasename) {
+  const slugIndex = buildSlugIndex(jobs);
+
+  // Match against current jobs (any locale's current/previous slug)
+  for (const loc of ['it', 'en', 'de', 'fr']) {
+    const hit = slugIndex.idx.get(`${loc}::${orphan.slug}`);
+    if (hit) {
+      const localizedSlug = slugIndex.slugsByJob.get(hit.jobId)?.[orphan.locale];
+      if (localizedSlug) {
+        return {
+          ...orphan,
+          kind: 'matched',
+          jobId: hit.jobId,
+          currentSlug: localizedSlug,
+          matchType: hit.kind,
+          csvOrigin: csvBasename,
+        };
+      }
+    }
+  }
+
+  // Prefix match (90-char truncation case)
+  const prefix = findPrefixMatch(orphan, jobs);
+  if (prefix) {
+    return {
+      ...orphan,
+      kind: 'matched',
+      jobId: prefix.job.id,
+      currentSlug: prefix.localizedSlug,
+      matchType: 'prefix',
+      csvOrigin: csvBasename,
+    };
+  }
+
+  // Reslug match (translation/hash drift)
+  const reslug = findReslugMatch(orphan, jobs);
+  if (reslug) {
+    return {
+      ...orphan,
+      kind: 'matched',
+      jobId: reslug.job.id,
+      currentSlug: reslug.localizedSlug,
+      matchType: 'reslug',
+      csvOrigin: csvBasename,
+    };
+  }
+
+  // Check expired-jobs.json
+  const expiredHit = expiredIdx.get(`${orphan.locale}::${orphan.slug}`);
+  if (expiredHit) {
+    return {
+      ...orphan,
+      kind: 'expired-tracked',
+      expiredJobId: expiredHit.id,
+      company: expiredHit.company || extractCompanyHint(orphan.slug),
+      csvOrigin: csvBasename,
+    };
+  }
+
+  // Truly expired — no record anywhere
+  return {
+    ...orphan,
+    kind: 'expired',
+    company: extractCompanyHint(orphan.slug),
+    csvOrigin: csvBasename,
+  };
+}
+
+function buildExpiredIndex(expiredArr) {
+  const idx = new Map();
+  for (const ej of expiredArr) {
+    for (const [loc, s] of Object.entries(ej.slugByLocale || {})) if (s) idx.set(`${loc}::${s}`, ej);
+    if (ej.slug) idx.set(`it::${ej.slug}`, ej);
+    for (const ps of (ej.previousSlugs || [])) idx.set(`it::${ps}`, ej);
+    if (ej.previousSlugsByLocale) {
+      for (const [loc, arr] of Object.entries(ej.previousSlugsByLocale)) {
+        for (const s of (arr || [])) if (s) idx.set(`${loc}::${s}`, ej);
+      }
+    }
+  }
+  return idx;
+}
+
+function main() {
+  if (!fs.existsSync(JOBS_PATH)) {
+    console.error(`✗ ${JOBS_PATH} not found.`);
+    process.exit(1);
+  }
+
+  const csvFiles = findCsvFiles();
+  if (csvFiles.length === 0) {
+    console.error('No GSC CSV exports found under download/frontaliereticino.ch-Coverage-*');
+    process.exit(1);
+  }
+
+  const jobs = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf-8'));
+  const expiredArr = fs.existsSync(EXPIRED_PATH)
+    ? (() => { const e = JSON.parse(fs.readFileSync(EXPIRED_PATH, 'utf-8')); return Array.isArray(e) ? e : (e.jobs || e.entries || []); })()
+    : [];
+  const expiredIdx = buildExpiredIndex(expiredArr);
+
+  console.log(`Loaded ${jobs.length} jobs, ${expiredArr.length} expired-job records.`);
+
+  const seen = new Set();
+  const orphans = [];
+
+  for (const { file, basename } of csvFiles) {
+    const urls = parseCsvUrls(file);
+    for (const url of urls) {
+      const o = urlToOrphan(url);
+      if (!o) continue;
+      const key = `${o.locale}::${o.slug}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      orphans.push(classifyOrphan(o, jobs, expiredIdx, basename));
+    }
+  }
+
+  // Summary
+  const counts = orphans.reduce((acc, o) => { acc[o.kind] = (acc[o.kind] || 0) + 1; return acc; }, {});
+  console.log(`\nTotal job-orphans: ${orphans.length}`);
+  console.log('By kind:');
+  for (const [k, n] of Object.entries(counts)) console.log(`  ${k}: ${n}`);
+
+  if (DRY_RUN) {
+    console.log('\n--dry-run: not writing. First 5 of each kind:');
+    for (const kind of ['matched', 'expired-tracked', 'expired']) {
+      const sample = orphans.filter((o) => o.kind === kind).slice(0, 5);
+      if (sample.length) console.log(`\n${kind}:`);
+      for (const s of sample) console.log(`  [${s.locale}] ${s.slug.slice(0, 70)}${s.slug.length > 70 ? '…' : ''}${s.currentSlug ? ` → ${s.currentSlug.slice(0, 50)}` : ''}`);
+    }
+    return;
+  }
+
+  const out = {
+    generatedAt: new Date().toISOString(),
+    sources: csvFiles.map((c) => c.basename),
+    counts,
+    orphans,
+  };
+  fs.writeFileSync(OUT_PATH, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  console.log(`\nWrote ${orphans.length} job-orphan records to ${path.relative(ROOT, OUT_PATH)}`);
+}
+
+main();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ import { staticPagesPlugin } from './build-plugins/staticPagesPlugin';
 import { sitemapAliasPlugin } from './build-plugins/sitemapAliasPlugin';
 import { legacyRedirectsPlugin } from './build-plugins/legacyRedirectsPlugin';
 import { calculatorLegacyAliasPlugin } from './build-plugins/calculatorLegacyAliasPlugin';
+import { jobOrphanBridgePlugin } from './build-plugins/jobOrphanBridgePlugin';
 // flatHtmlRedirectPlugin + hreflangPostprocessPlugin imports retained for
 // type re-exports / unit tests. Their plugin exports are now consumed
 // internally by `postWalkCoordinatorPlugin` (single-walk perf optimization).
@@ -192,6 +193,15 @@ export default defineConfig(({ mode }) => {
  // canonical slug before the SPA boots — preserves `?reddito=...` so
  // urlStateService prefills the simulation. No 301, AdSense fires.
  calculatorLegacyAliasPlugin(__dirname),
+ // Job-orphan bridge: recover the 92 GSC 404s for /{locale}/{section}/{slug}/
+ // job-detail URLs (Cohort 1). Reads classified entries from
+ // data/gsc-job-orphans.json (refreshed via scripts/ingest-gsc-job-orphans.mjs).
+ // Matched orphans (21): canonical + JS history.replaceState to current job.
+ // Expired orphans (71): canonical to section landing + "annuncio scaduto"
+ // body with extracted company hint. No 301, AdSense fires on both. The
+ // plugin is collision-safe — skips writing if another plugin already
+ // produced real content at the target path (e.g. a re-activated job).
+ jobOrphanBridgePlugin(__dirname),
  // AE-7 — after static pages are written, inject a contextual link into
  // a handful of parent pages so the comparisons hub has inbound links
  // from homepage + confronti hub + salary pillars. Idempotent.


### PR DESCRIPTION
## Summary
Recovers all 92 `/{locale}/{section}/{slug}/` job-detail 404s flagged `Indicizzata Non trovata` in the 2026-05-11 GSC Coverage report.

## Root cause (why we lost them)
Cross-checked 92 orphan slugs vs `data/jobs.json` (2092 active jobs) + `data/expired-jobs.json` (337 records):
- **21 matched** — job still active under a different slug. Drivers: 90-char truncation in `slugifyJobPart` fallback (services/relatedSearchClusters.ts:52), translation drift, tail-hash mutation. None captured by `previousSlugs` pipeline.
- **71 expired** — job rotated out of jobs.json. **0/71 hit expired-jobs.json** — predate the tracking infra.

## Approach (no 301, AdSense-preserved)
- `matched`: canonical → current job URL + inline `history.replaceState` so SPA hydrates the current job detail
- `expired`: canonical → section landing + "Annuncio scaduto" body with company hint from slug + locale lede
- Both: `robots: index,follow` (per never-noindex policy), `buildSeoPageHtml` SPA shell (rule 14 compliant), 200 status code
- Collision-safe: skips writing if dist already has real content (handles re-activated jobs)

## Files
- `scripts/ingest-gsc-job-orphans.mjs` — new ingestion (CSV → `data/gsc-job-orphans.json`)
- `build-plugins/jobOrphanBridgePlugin.ts` — new bridge plugin
- `data/gsc-job-orphans.json` — 92 classified orphans (40 KB)
- `vite.config.ts` — register plugin after calculator-legacy-alias

## Scope
Downstream recovery only. Upstream prevention (drop 90-char cap, auto-track previousSlugs on translation drift) deferred per user direction.

## Test plan
- [ ] CI build green
- [ ] Post-deploy curl 5 sample URLs from each cohort → 200
- [ ] GSC re-validate the 92 URLs in "Indicizzata Non trovata"

🤖 Generated with [Claude Code](https://claude.com/claude-code)