### PR TITLE
feat(seo): bridge 60 location-hub 404s from GSC (Cohort 2)

### DIFF
--- a/build-plugins/locationHubBridgePlugin.ts
+++ b/build-plugins/locationHubBridgePlugin.ts
@@ -1,0 +1,289 @@
+/**
+ * Location-hub bridge plugin — emits 200 HTML pages for the 60 GSC
+ * `Indicizzata Non trovata` URLs of the form
+ * `/{locale}/{section}/(localita|location|standort|localite)-{city}/`
+ * (Cohort 2).
+ *
+ * Why these 404 today
+ * -------------------
+ * JobBoard.tsx renders `<a href>` to location-filtered URLs from the
+ * job-detail "gate" (JobBoard.tsx:5881 → `buildLocationSearchSlug`).
+ * Google crawls these links and expects pages — but until today no
+ * build plugin emitted static HTML for the `localita-*` namespace.
+ * The SPA's `parseLocationSlugFilter` (JobBoard.tsx:2250) handles the
+ * filter on hydration, but a cold visit to the URL hits GH Pages' 404
+ * before any JS runs → indexed as "Indicizzata Non trovata".
+ *
+ * Approach (200, no 301)
+ * ----------------------
+ * One static page per orphan via `buildSeoPageHtml` (rule 14 compliant).
+ * The SPA hydrates `#root` with its JobBoard component, sees the
+ * `localita-{city}` slug in the URL, applies the location filter, and
+ * renders the city's job listings. AdSense fires natively.
+ *
+ *   `matched`   (38 URLs, city present in jobs.json):
+ *     - canonical → self (the page is a legitimate city-filter view)
+ *     - body: H1 "Offerte di lavoro a {City}" + job count + lede
+ *     - SPA renders the filtered listings post-hydration
+ *
+ *   `unmatched` (22 URLs, no active job for that city — bogus or expired):
+ *     - canonical → section landing (`/cerca-lavoro-ticino/` etc.)
+ *       so Google de-duplicates these into the section
+ *     - body: "Località non disponibile" + browse-all CTA
+ *
+ * Both kinds: `robots: 'index,follow'` (never-noindex policy).
+ *
+ * Sitemap policy: bridge pages NOT added to any sitemap. The
+ * cityJobsHubPlugin owns the canonical city hubs (Lugano/Mendrisio/
+ * Bellinzona/Locarno/Chiasso). The `localita-{city}` pattern is a
+ * secondary filter URL we only emit to repair the 404 cohort.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import type { Plugin } from 'vite';
+import { buildSeoPageHtml } from './shared/seoPageShell';
+import type { Locale } from '../services/i18n';
+
+const BASE_URL = 'https://frontaliereticino.ch';
+
+const SECTION_SLUG: Record<Locale, string> = {
+  it: 'cerca-lavoro-ticino',
+  en: 'find-jobs-ticino',
+  de: 'jobs-im-tessin',
+  fr: 'trouver-emploi-tessin',
+};
+
+const LOC_PREFIX: Record<Locale, string> = {
+  it: 'localita',
+  en: 'location',
+  de: 'standort',
+  fr: 'localite',
+};
+
+const LOCALE_PREFIX: Record<Locale, string> = {
+  it: '',
+  en: '/en',
+  de: '/de',
+  fr: '/fr',
+};
+
+const OG_LOCALE: Record<Locale, string> = {
+  it: 'it_IT',
+  en: 'en_US',
+  de: 'de_DE',
+  fr: 'fr_FR',
+};
+
+interface HubEntry {
+  readonly locale: Locale;
+  readonly citySlug: string;
+  readonly url: string;
+  readonly kind: 'matched' | 'unmatched';
+  readonly displayName: string;
+  readonly jobCount: number;
+}
+
+interface HubsFile {
+  readonly generatedAt: string;
+  readonly sources: string[];
+  readonly counts: Record<string, number>;
+  readonly hubs: HubEntry[];
+}
+
+interface BridgeCopy {
+  readonly matchedTitle: (city: string, count: number) => string;
+  readonly matchedDescription: (city: string, count: number) => string;
+  readonly matchedH1: (city: string, count: number) => string;
+  readonly matchedLede: (city: string, count: number) => string;
+  readonly unmatchedTitle: string;
+  readonly unmatchedDescription: string;
+  readonly unmatchedH1: (city: string) => string;
+  readonly unmatchedLede: string;
+  readonly browseAllLabel: string;
+}
+
+const COPY: Record<Locale, BridgeCopy> = {
+  it: {
+    matchedTitle: (c, n) => `Offerte di lavoro a ${c} — ${n} annunci aggiornati`,
+    matchedDescription: (c, n) => `${n} offerte di lavoro a ${c} per frontalieri italo-svizzeri, aggiornate ogni giorno. Stipendio netto Permit G/B, fiscalità Accordo bilaterale 2026, mappa pendolarismo TILO.`,
+    matchedH1: (c, n) => `${n} annunci a ${c}`,
+    matchedLede: (c, n) => `Trovi ${n} annunci di lavoro a ${c} aggiornati ogni giorno. Ogni offerta riporta il calcolo automatico dello stipendio netto Permit G (vivere in Italia) vs Permit B (vivere in Svizzera), le tempistiche di pendolarismo verso il confine ticinese e le agevolazioni fiscali introdotte dal Nuovo Accordo bilaterale italo-svizzero del 2026. Filtra per ruolo, contratto o azienda per restringere la ricerca.`,
+    unmatchedTitle: 'Località non più disponibile — alternative aggiornate ogni giorno',
+    unmatchedDescription: 'Nessuna offerta attiva per questa località. Esplora oltre 2000 annunci frontalieri su tutto il Ticino con filtri per ruolo, città, contratto e azienda.',
+    unmatchedH1: (c) => `Località ${c} — nessun annuncio attivo`,
+    unmatchedLede: 'In questo momento non ci sono annunci attivi per la località cercata. Sul job board frontaliere trovi ogni giorno offerte aggiornate in tutto il Ticino, filtrabili per ruolo, città, tipo di contratto e azienda. Iscriviti per ricevere notifiche quando arrivano nuovi annunci compatibili.',
+    browseAllLabel: 'Sfoglia tutti gli annunci attivi',
+  },
+  en: {
+    matchedTitle: (c, n) => `Jobs in ${c} — ${n} cross-border openings`,
+    matchedDescription: (c, n) => `${n} job openings in ${c} for Italian-Swiss cross-border workers. Net salary under Permit G/B, 2026 bilateral agreement tax adjustments, TILO commute map.`,
+    matchedH1: (c, n) => `${n} jobs in ${c}`,
+    matchedLede: (c, n) => `Find ${n} job openings in ${c}, updated daily. Each listing carries the automatic net-salary calculation under Permit G (commuting from Italy) vs Permit B (Swiss residency), commute timetables to the Ticino border and the tax adjustments introduced by the 2026 Italy-Switzerland bilateral agreement. Filter by role, contract type or employer to narrow your search.`,
+    unmatchedTitle: 'Location no longer available — alternatives updated daily',
+    unmatchedDescription: 'No active openings for this location. Browse 2000+ cross-border job listings across Ticino filtered by role, city, contract type and employer.',
+    unmatchedH1: (c) => `${c} — no active listings`,
+    unmatchedLede: 'There are no active listings for the location you searched. Our cross-border job board refreshes daily with new openings across all of Ticino, filtered by role, city, contract type and employer. Subscribe for notifications when matching openings are posted.',
+    browseAllLabel: 'Browse all active listings',
+  },
+  de: {
+    matchedTitle: (c, n) => `Stellen in ${c} — ${n} aktuelle Inserate`,
+    matchedDescription: (c, n) => `${n} Stellen in ${c} für italienisch-schweizerische Grenzgänger. Nettolohn Permit G/B, Steuer-Anpassungen Abkommen 2026, TILO-Pendelfahrpläne.`,
+    matchedH1: (c, n) => `${n} Stellen in ${c}`,
+    matchedLede: (c, n) => `Finden Sie ${n} aktuelle Stellen in ${c}, täglich aktualisiert. Jedes Inserat enthält die automatische Nettolohn-Berechnung unter Permit G (Pendeln aus Italien) vs Permit B (Wohnsitz Schweiz), Pendlerfahrpläne zur Tessiner Grenze und die steuerlichen Anpassungen des neuen italienisch-schweizerischen Abkommens 2026. Filtern Sie nach Rolle, Vertragsart oder Arbeitgeber.`,
+    unmatchedTitle: 'Standort nicht mehr verfügbar — täglich aktualisierte Alternativen',
+    unmatchedDescription: 'Keine offenen Stellen für diesen Standort. Über 2000 Grenzgänger-Inserate im Tessin, filterbar nach Rolle, Stadt, Vertragsart und Arbeitgeber.',
+    unmatchedH1: (c) => `${c} — keine aktiven Inserate`,
+    unmatchedLede: 'Es gibt derzeit keine aktiven Inserate für den gesuchten Standort. Unser Grenzgänger-Job-Board wird täglich mit neuen Stellen im gesamten Tessin aktualisiert, filterbar nach Rolle, Stadt, Vertragsart und Arbeitgeber. Abonnieren Sie Benachrichtigungen für passende neue Inserate.',
+    browseAllLabel: 'Alle aktiven Stellen ansehen',
+  },
+  fr: {
+    matchedTitle: (c, n) => `Emplois à ${c} — ${n} offres frontalières`,
+    matchedDescription: (c, n) => `${n} offres d'emploi à ${c} pour les frontaliers italo-suisses. Salaire net Permit G/B, ajustements fiscaux Accord 2026, horaires TILO.`,
+    matchedH1: (c, n) => `${n} emplois à ${c}`,
+    matchedLede: (c, n) => `Trouvez ${n} offres d'emploi à ${c}, mises à jour quotidiennement. Chaque annonce inclut le calcul automatique du salaire net sous Permit G (frontalier depuis l'Italie) vs Permit B (résidence suisse), les horaires de transport vers la frontière tessinoise et les ajustements fiscaux du nouvel Accord bilatéral italo-suisse 2026. Filtrez par rôle, type de contrat ou employeur.`,
+    unmatchedTitle: 'Lieu non disponible — alternatives mises à jour quotidiennement',
+    unmatchedDescription: 'Aucune offre active pour ce lieu. Parcourez plus de 2000 annonces frontalières au Tessin, filtrables par rôle, ville, type de contrat et entreprise.',
+    unmatchedH1: (c) => `${c} — aucune offre active`,
+    unmatchedLede: 'Il n\'y a actuellement aucune offre active pour le lieu recherché. Notre job board frontalier s\'actualise quotidiennement avec de nouvelles offres dans tout le Tessin, filtrables par rôle, ville, type de contrat et employeur. Abonnez-vous pour recevoir des notifications.',
+    browseAllLabel: 'Parcourir toutes les annonces actives',
+  },
+};
+
+function esc(value: string): string {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function buildHubPath(locale: Locale, citySlug: string): string {
+  return `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/${LOC_PREFIX[locale]}-${citySlug}/`.replace(/\/+/g, '/');
+}
+
+function buildSectionCanonical(locale: Locale): string {
+  return `${BASE_URL}${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/(?<!:)\/+/g, '/');
+}
+
+function renderMatchedPage(entry: HubEntry, distDir: string): string {
+  const locale = entry.locale;
+  const copy = COPY[locale];
+  const hubPath = buildHubPath(locale, entry.citySlug);
+  const canonicalUrl = `${BASE_URL}${hubPath}`;
+  const city = entry.displayName;
+  const n = entry.jobCount;
+
+  const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
+    <header style="margin-bottom:16px">
+      <h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(copy.matchedH1(city, n))}</h1>
+    </header>
+    <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.matchedLede(city, n))}</p>
+    <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(buildSectionCanonical(locale))}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
+  </main>`;
+
+  return buildSeoPageHtml({
+    locale,
+    title: copy.matchedTitle(city, n),
+    description: copy.matchedDescription(city, n),
+    canonicalUrl,
+    robots: 'index,follow',
+    ogType: 'website',
+    ogLocale: OG_LOCALE[locale],
+    hreflangHtml: '',
+    jsonLdScripts: [],
+    bodyHtml,
+    distDir,
+    seoMainClass: 'cluster-seo-prose',
+  });
+}
+
+function renderUnmatchedPage(entry: HubEntry, distDir: string): string {
+  const locale = entry.locale;
+  const copy = COPY[locale];
+  const canonicalUrl = buildSectionCanonical(locale);
+  const sectionPath = buildSectionCanonical(locale);
+  const city = entry.displayName;
+
+  const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
+    <header style="margin-bottom:16px">
+      <h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(copy.unmatchedH1(city))}</h1>
+    </header>
+    <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.unmatchedLede)}</p>
+    <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(sectionPath)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
+  </main>`;
+
+  return buildSeoPageHtml({
+    locale,
+    title: copy.unmatchedTitle,
+    description: copy.unmatchedDescription,
+    canonicalUrl,
+    robots: 'index,follow',
+    ogType: 'website',
+    ogLocale: OG_LOCALE[locale],
+    hreflangHtml: '',
+    jsonLdScripts: [],
+    bodyHtml,
+    distDir,
+    seoMainClass: 'cluster-seo-prose',
+  });
+}
+
+export function locationHubBridgePlugin(rootDir: string): Plugin {
+  return {
+    name: 'location-hub-bridge',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      const dataPath = path.join(rootDir, 'data', 'gsc-location-hubs.json');
+      if (!fs.existsSync(dataPath)) {
+        console.warn('\x1b[33m[location-hub-bridge]\x1b[0m data/gsc-location-hubs.json missing — skipping');
+        return;
+      }
+      const distDir = path.join(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) {
+        console.warn('\x1b[33m[location-hub-bridge]\x1b[0m dist/ missing — skipping');
+        return;
+      }
+
+      let file: HubsFile;
+      try {
+        file = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+      } catch (err) {
+        console.warn('\x1b[33m[location-hub-bridge]\x1b[0m failed to parse data file:', err);
+        return;
+      }
+      if (!Array.isArray(file.hubs) || file.hubs.length === 0) return;
+
+      let emitted = 0;
+      let skipped = 0;
+      const start = Date.now();
+
+      for (const entry of file.hubs) {
+        const hubPath = buildHubPath(entry.locale, entry.citySlug);
+        const indexTarget = path.join(distDir, hubPath, 'index.html');
+        const flatTarget = path.join(distDir, hubPath.replace(/\/+$/, '') + '.html');
+
+        if (fs.existsSync(indexTarget)) { skipped++; continue; }
+
+        const html = entry.kind === 'matched'
+          ? renderMatchedPage(entry, distDir)
+          : renderUnmatchedPage(entry, distDir);
+
+        try {
+          fs.mkdirSync(path.dirname(indexTarget), { recursive: true });
+          fs.writeFileSync(indexTarget, html, 'utf-8');
+          fs.writeFileSync(flatTarget, html, 'utf-8');
+          emitted += 2;
+        } catch (err) {
+          console.warn(`\x1b[33m[location-hub-bridge]\x1b[0m failed to write ${indexTarget}:`, err);
+        }
+      }
+
+      const dur = ((Date.now() - start) / 1000).toFixed(1);
+      console.log(
+        `\x1b[36m[location-hub-bridge]\x1b[0m emitted ${emitted} bridge files (${file.hubs.length - skipped} pages, ${skipped} skipped due to collision) in ${dur}s`,
+      );
+    },
+  };
+}

--- a/data/gsc-location-hubs.json
+++ b/data/gsc-location-hubs.json
@@ -1,0 +1,552 @@
+{
+  "generatedAt": "2026-05-11T17:12:51.644Z",
+  "sources": [
+    "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+  ],
+  "counts": {
+    "matched": 38,
+    "unmatched": 22
+  },
+  "hubs": [
+    {
+      "locale": "en",
+      "citySlug": "hunenberg",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-hunenberg/",
+      "kind": "matched",
+      "displayName": "Hünenberg",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "herbriggen",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-herbriggen/",
+      "kind": "unmatched",
+      "displayName": "Herbriggen",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "laax",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-laax/",
+      "kind": "matched",
+      "displayName": "Laax",
+      "jobCount": 9,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "buchs-sg",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-buchs-sg/",
+      "kind": "matched",
+      "displayName": "Buchs SG",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "uri",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-uri/",
+      "kind": "matched",
+      "displayName": "Uri",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "gais",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-gais/",
+      "kind": "matched",
+      "displayName": "Gais",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "ernen",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-ernen/",
+      "kind": "matched",
+      "displayName": "Ernen",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "quinto",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-quinto/",
+      "kind": "unmatched",
+      "displayName": "Quinto",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "camorino",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-camorino/",
+      "kind": "matched",
+      "displayName": "Camorino",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "saas-fee",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-saas-fee/",
+      "kind": "matched",
+      "displayName": "Saas-Fee",
+      "jobCount": 5,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "bergun-filisur",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-bergun-filisur/",
+      "kind": "matched",
+      "displayName": "Bergün/Filisur",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "wiler-lotschen",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-wiler-lotschen/",
+      "kind": "matched",
+      "displayName": "Wiler (Lötschen)",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "stein-ag",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-stein-ag/",
+      "kind": "unmatched",
+      "displayName": "Stein Ag",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "pratteln",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-pratteln/",
+      "kind": "matched",
+      "displayName": "Pratteln",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "geneve",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-geneve/",
+      "kind": "matched",
+      "displayName": "Genève",
+      "jobCount": 10,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "serravalle-scrivia",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-serravalle-scrivia/",
+      "kind": "unmatched",
+      "displayName": "Serravalle Scrivia",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "grancia",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-grancia/",
+      "kind": "matched",
+      "displayName": "Grancia",
+      "jobCount": 4,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "milano-performance-apparel-product-developer-prada-linea-rossa",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-milano-performance-apparel-product-developer-prada-linea-rossa/",
+      "kind": "unmatched",
+      "displayName": "Milano Performance Apparel Product Developer Prada Linea Rossa",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "meyrin",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-meyrin/",
+      "kind": "matched",
+      "displayName": "Meyrin",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "brig-glis",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-brig-glis/",
+      "kind": "matched",
+      "displayName": "Brig-Glis",
+      "jobCount": 7,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "haute-sorne",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-haute-sorne/",
+      "kind": "unmatched",
+      "displayName": "Haute Sorne",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "new-york",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-new-york/",
+      "kind": "unmatched",
+      "displayName": "New York",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "harkebrugge",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-harkebrugge/",
+      "kind": "unmatched",
+      "displayName": "Harkebrugge",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "tenna-gr",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-tenna-gr/",
+      "kind": "unmatched",
+      "displayName": "Tenna Gr",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "oensingen",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-oensingen/",
+      "kind": "matched",
+      "displayName": "Oensingen",
+      "jobCount": 22,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "harkebrugge",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-harkebrugge/",
+      "kind": "unmatched",
+      "displayName": "Harkebrugge",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "verbier",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-verbier/",
+      "kind": "matched",
+      "displayName": "Verbier",
+      "jobCount": 31,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "uznach",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-uznach/",
+      "kind": "matched",
+      "displayName": "Uznach",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "zofingen",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-zofingen/",
+      "kind": "matched",
+      "displayName": "Zofingen",
+      "jobCount": 9,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "uznach",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-uznach/",
+      "kind": "matched",
+      "displayName": "Uznach",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "neggio",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-neggio/",
+      "kind": "matched",
+      "displayName": "Neggio",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "novaggio",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-novaggio/",
+      "kind": "matched",
+      "displayName": "Novaggio",
+      "jobCount": 12,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "pany",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-pany/",
+      "kind": "matched",
+      "displayName": "Pany",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "80-winterthur-smart-working",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-80-winterthur-smart-working/",
+      "kind": "unmatched",
+      "displayName": "80 Winterthur Smart Working",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "zurich-flughafen",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-zurich-flughafen/",
+      "kind": "matched",
+      "displayName": "Zürich-Flughafen",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "cadempino",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-cadempino/",
+      "kind": "matched",
+      "displayName": "Cadempino",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "grigioni",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-grigioni/",
+      "kind": "matched",
+      "displayName": "Grigioni",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "brusio",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-brusio/",
+      "kind": "matched",
+      "displayName": "Brusio",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "kirchberg",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-kirchberg/",
+      "kind": "unmatched",
+      "displayName": "Kirchberg",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "conthey",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-conthey/",
+      "kind": "matched",
+      "displayName": "Conthey",
+      "jobCount": 7,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "en-in-elf-landern-weltweit",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-en-in-elf-landern-weltweit/",
+      "kind": "unmatched",
+      "displayName": "En In Elf Landern Weltweit",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "biberist",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-biberist/",
+      "kind": "unmatched",
+      "displayName": "Biberist",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "agenzia-generale-andrea-tarello",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-agenzia-generale-andrea-tarello/",
+      "kind": "unmatched",
+      "displayName": "Agenzia Generale Andrea Tarello",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "uster",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-uster/",
+      "kind": "matched",
+      "displayName": "Uster",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "magadino",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-magadino/",
+      "kind": "matched",
+      "displayName": "Magadino",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "untervaz",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-untervaz/",
+      "kind": "matched",
+      "displayName": "Untervaz",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "freiburg-im-breisgau",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-freiburg-im-breisgau/",
+      "kind": "unmatched",
+      "displayName": "Freiburg Im Breisgau",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "cazis",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-cazis/",
+      "kind": "matched",
+      "displayName": "Cazis",
+      "jobCount": 10,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "gamsen",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-gamsen/",
+      "kind": "matched",
+      "displayName": "Gamsen",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "felsberg",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-felsberg/",
+      "kind": "matched",
+      "displayName": "Felsberg",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "agenzia-generale-lugano",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-agenzia-generale-lugano/",
+      "kind": "unmatched",
+      "displayName": "Agenzia Generale Lugano",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "olten",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-olten/",
+      "kind": "matched",
+      "displayName": "Olten",
+      "jobCount": 5,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "citySlug": "jura",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/standort-jura/",
+      "kind": "matched",
+      "displayName": "Jura",
+      "jobCount": 2,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "schiltach",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-schiltach/",
+      "kind": "unmatched",
+      "displayName": "Schiltach",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "castione",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-castione/",
+      "kind": "matched",
+      "displayName": "Castione",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "it",
+      "citySlug": "dubai",
+      "url": "https://frontaliereticino.ch/cerca-lavoro-ticino/localita-dubai/",
+      "kind": "unmatched",
+      "displayName": "Dubai",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "radolfzell",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-radolfzell/",
+      "kind": "unmatched",
+      "displayName": "Radolfzell",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "zermatt-oberwald-andermatt",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-zermatt-oberwald-andermatt/",
+      "kind": "unmatched",
+      "displayName": "Zermatt Oberwald Andermatt",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "citySlug": "burgdorf",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/location-burgdorf/",
+      "kind": "unmatched",
+      "displayName": "Burgdorf",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "citySlug": "grachen",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/localite-grachen/",
+      "kind": "matched",
+      "displayName": "Grächen",
+      "jobCount": 1,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    }
+  ]
+}

--- a/scripts/ingest-gsc-location-hubs.mjs
+++ b/scripts/ingest-gsc-location-hubs.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * ingest-gsc-location-hubs.mjs
+ *
+ * Ingests GSC Coverage Drilldown CSV exports and extracts location-hub
+ * orphan URLs of the form `/{locale}/{section}/{loc-prefix}-{city}/`:
+ *
+ *   IT: /cerca-lavoro-ticino/localita-{city}/
+ *   EN: /en/find-jobs-ticino/location-{city}/
+ *   DE: /de/jobs-im-tessin/(standort|ort|stadt)-{city}/
+ *   FR: /fr/trouver-emploi-tessin/(localite|ville|lieu)-{city}/
+ *
+ * For each orphan: cross-checks the city slug against the slugified
+ * `location` field of every active job in `data/jobs.json`. Classifies as:
+ *   - `matched`   → at least one active job has that location.
+ *                   Bridge page renders the SPA shell at the orphan URL;
+ *                   the SPA's `parseLocationSlugFilter` (JobBoard.tsx:2250)
+ *                   applies the city filter on hydration → real job
+ *                   listings + AdSense fire.
+ *   - `unmatched` → no active job. Soft-landing with canonical → section.
+ *
+ * Output: `data/gsc-location-hubs.json`, consumed by the build plugin.
+ *
+ * Mirrors the pattern of `ingest-gsc-job-orphans.mjs` (PR #88).
+ *
+ * Usage:
+ *   node scripts/ingest-gsc-location-hubs.mjs              # write
+ *   node scripts/ingest-gsc-location-hubs.mjs --dry-run    # report only
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(__filename, '..', '..');
+const JOBS_PATH = path.join(ROOT, 'data', 'jobs.json');
+const DOWNLOADS_DIR = path.join(ROOT, 'download');
+const OUT_PATH = path.join(ROOT, 'data', 'gsc-location-hubs.json');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const LOC_PATTERNS = [
+  [/^\/cerca-lavoro-ticino\/localita-([^/]+)\/?$/, 'it'],
+  [/^\/en\/find-jobs-ticino\/location-([^/]+)\/?$/, 'en'],
+  [/^\/de\/jobs-im-tessin\/(?:standort|ort|stadt)-([^/]+)\/?$/, 'de'],
+  [/^\/fr\/trouver-emploi-tessin\/(?:localite|ville|lieu)-([^/]+)\/?$/, 'fr'],
+];
+
+function slugify(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function findCsvFiles() {
+  if (!fs.existsSync(DOWNLOADS_DIR)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(DOWNLOADS_DIR)) {
+    if (!entry.startsWith('frontaliereticino.ch-Coverage-')) continue;
+    const csv = path.join(DOWNLOADS_DIR, entry, 'Tabella.csv');
+    if (fs.existsSync(csv)) out.push({ file: csv, basename: entry });
+  }
+  return out;
+}
+
+function parseCsvUrls(file) {
+  const text = fs.readFileSync(file, 'utf-8');
+  return text.split(/\r?\n/).slice(1).filter(Boolean).map((l) => l.split(',')[0]).filter(Boolean);
+}
+
+function urlToHub(url) {
+  let pathname;
+  try { pathname = new URL(url).pathname; } catch { return null; }
+  for (const [re, locale] of LOC_PATTERNS) {
+    const m = pathname.match(re);
+    if (m) return { locale, citySlug: m[1], url };
+  }
+  return null;
+}
+
+/** Build location-slug → [job count, display name] from jobs.json. */
+function buildLocationIndex(jobs) {
+  const idx = new Map();
+  for (const j of jobs) {
+    const loc = (j.location || '').trim();
+    if (!loc) continue;
+    const slug = slugify(loc);
+    if (!idx.has(slug)) idx.set(slug, { displayName: loc, jobCount: 0 });
+    idx.get(slug).jobCount += 1;
+  }
+  return idx;
+}
+
+/** Capitalize hyphen-separated tokens for display fallback. */
+function humanize(slug) {
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((t) => t.charAt(0).toUpperCase() + t.slice(1))
+    .join(' ');
+}
+
+function classifyHub(hub, locIdx, csvBasename) {
+  const direct = locIdx.get(hub.citySlug);
+  if (direct) {
+    return {
+      ...hub,
+      kind: 'matched',
+      displayName: direct.displayName,
+      jobCount: direct.jobCount,
+      csvOrigin: csvBasename,
+    };
+  }
+  return {
+    ...hub,
+    kind: 'unmatched',
+    displayName: humanize(hub.citySlug),
+    jobCount: 0,
+    csvOrigin: csvBasename,
+  };
+}
+
+function main() {
+  if (!fs.existsSync(JOBS_PATH)) {
+    console.error(`✗ ${JOBS_PATH} not found.`);
+    process.exit(1);
+  }
+  const csvFiles = findCsvFiles();
+  if (csvFiles.length === 0) {
+    console.error('No GSC CSV exports found under download/frontaliereticino.ch-Coverage-*');
+    process.exit(1);
+  }
+
+  const jobs = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf-8'));
+  const locIdx = buildLocationIndex(jobs);
+  console.log(`Loaded ${jobs.length} jobs, ${locIdx.size} distinct location slugs.`);
+
+  const seen = new Set();
+  const hubs = [];
+  for (const { file, basename } of csvFiles) {
+    const urls = parseCsvUrls(file);
+    for (const url of urls) {
+      const h = urlToHub(url);
+      if (!h) continue;
+      const key = `${h.locale}::${h.citySlug}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      hubs.push(classifyHub(h, locIdx, basename));
+    }
+  }
+
+  const counts = hubs.reduce((acc, h) => { acc[h.kind] = (acc[h.kind] || 0) + 1; return acc; }, {});
+  console.log(`\nTotal location-hub orphans: ${hubs.length}`);
+  console.log('By kind:', counts);
+
+  if (DRY_RUN) {
+    console.log('\n--dry-run: not writing. First 5 of each:');
+    for (const kind of ['matched', 'unmatched']) {
+      const sample = hubs.filter((h) => h.kind === kind).slice(0, 5);
+      if (sample.length) console.log(`\n${kind}:`);
+      for (const s of sample) console.log(`  [${s.locale}] ${s.citySlug}${s.jobCount ? ' (' + s.jobCount + ' jobs)' : ''}`);
+    }
+    return;
+  }
+
+  const out = {
+    generatedAt: new Date().toISOString(),
+    sources: csvFiles.map((c) => c.basename),
+    counts,
+    hubs,
+  };
+  fs.writeFileSync(OUT_PATH, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  console.log(`\nWrote ${hubs.length} location-hub records to ${path.relative(ROOT, OUT_PATH)}`);
+}
+
+main();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ import { sitemapAliasPlugin } from './build-plugins/sitemapAliasPlugin';
 import { legacyRedirectsPlugin } from './build-plugins/legacyRedirectsPlugin';
 import { calculatorLegacyAliasPlugin } from './build-plugins/calculatorLegacyAliasPlugin';
 import { jobOrphanBridgePlugin } from './build-plugins/jobOrphanBridgePlugin';
+import { locationHubBridgePlugin } from './build-plugins/locationHubBridgePlugin';
 // flatHtmlRedirectPlugin + hreflangPostprocessPlugin imports retained for
 // type re-exports / unit tests. Their plugin exports are now consumed
 // internally by `postWalkCoordinatorPlugin` (single-walk perf optimization).
@@ -202,6 +203,13 @@ export default defineConfig(({ mode }) => {
  // plugin is collision-safe — skips writing if another plugin already
  // produced real content at the target path (e.g. a re-activated job).
  jobOrphanBridgePlugin(__dirname),
+ // Location-hub bridge: recover the 60 GSC 404s for /{locale}/{section}/{loc-prefix}-{city}/
+ // city-filter URLs (Cohort 2). Reads classified entries from
+ // data/gsc-location-hubs.json (refreshed via scripts/ingest-gsc-location-hubs.mjs).
+ // Matched (38): canonical=self + SPA hydrates JobBoard with location filter
+ // applied (real listings + AdSense). Unmatched (22): canonical→section
+ // landing + "località non disponibile" body. Collision-safe.
+ locationHubBridgePlugin(__dirname),
  // AE-7 — after static pages are written, inject a contextual link into
  // a handful of parent pages so the comparisons hub has inbound links
  // from homepage + confronti hub + salary pillars. Idempotent.


### PR DESCRIPTION
## Summary
Recovers 60 `/{locale}/{section}/(localita|location|standort|localite)-{city}/` 404s flagged `Indicizzata Non trovata` in the 2026-05-11 GSC report.

## Root cause
JobBoard renders `<a href>` to location-filtered URLs from the job-detail gate (`buildLocationSearchSlug`). Google crawls them but no build plugin emitted static HTML for the `localita-*` namespace → 404 before SPA hydration runs.

## Classification (vs jobs.json)
- **38 matched** — city present in jobs.json: SPA filter UX legitimate
- **22 unmatched** — bogus extractions ("dubai", "new-york", agency names) or obscure cities not active

## Approach (200, no 301)
- **matched**: canonical=self + body shows "Offerte a {City}" + lede; SPA hydrates JobBoard with location filter → real listings render → AdSense fires
- **unmatched**: canonical→section landing + "Località non disponibile" body
- Both: `robots: index,follow`, collision-safe

## Files
- `scripts/ingest-gsc-location-hubs.mjs` — new ingestion
- `build-plugins/locationHubBridgePlugin.ts` — new bridge plugin
- `data/gsc-location-hubs.json` — 60 classified hubs (18 KB)
- `vite.config.ts` — register after jobOrphanBridgePlugin

## Test plan
- [ ] CI build green
- [ ] Post-deploy curl 5 sample URLs → 200
- [ ] GSC re-validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)