### PR TITLE
feat(seo): bridge 15 company-hub 404s from GSC (Cohort 4)

### DIFF
--- a/build-plugins/companyHubBridgePlugin.ts
+++ b/build-plugins/companyHubBridgePlugin.ts
@@ -1,0 +1,224 @@
+/**
+ * Company-hub bridge plugin — emits 200 HTML pages for the 15 GSC
+ * `Indicizzata Non trovata` URLs of the form
+ * `/{locale}/{section}/(azienda|company|unternehmen|firma|entreprise|societe)-{company}/`
+ * (Cohort 4).
+ *
+ * Why these 404 today
+ * -------------------
+ * JobBoard.tsx renders `<a href>` to company-filtered URLs from the
+ * job-detail gate (`buildCompanySearchSlug`). Google crawls them but no
+ * build plugin emitted static HTML for the `azienda-*` namespace — the
+ * SPA's `parseCompanySlugFilter` handles the filter on hydration, but a
+ * cold visit to the URL hits GH Pages' 404 fallback before JS runs.
+ *
+ * Approach (200, no 301) mirrors locationHubBridgePlugin (PR #89):
+ *
+ *   matched   (4 URLs, company in jobs.json):
+ *     - canonical → self
+ *     - body: H1 "Annunci di {Company}" + count + locale lede
+ *     - SPA hydrates with company filter → real listings + AdSense
+ *
+ *   unmatched (11 URLs, company has rotated out or never existed):
+ *     - canonical → section landing
+ *     - body: "Azienda non disponibile" + browse-all CTA
+ *
+ * Both: `robots: 'index,follow'`, collision-safe.
+ *
+ * Sitemap policy: bridge pages NOT added — they're alias filter URLs.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import type { Plugin } from 'vite';
+import { buildSeoPageHtml } from './shared/seoPageShell';
+import type { Locale } from '../services/i18n';
+
+const BASE_URL = 'https://frontaliereticino.ch';
+
+const SECTION_SLUG: Record<Locale, string> = {
+  it: 'cerca-lavoro-ticino',
+  en: 'find-jobs-ticino',
+  de: 'jobs-im-tessin',
+  fr: 'trouver-emploi-tessin',
+};
+
+const COMP_PREFIX: Record<Locale, string> = {
+  it: 'azienda',
+  en: 'company',
+  de: 'unternehmen',
+  fr: 'entreprise',
+};
+
+const LOCALE_PREFIX: Record<Locale, string> = { it: '', en: '/en', de: '/de', fr: '/fr' };
+const OG_LOCALE: Record<Locale, string> = { it: 'it_IT', en: 'en_US', de: 'de_DE', fr: 'fr_FR' };
+
+interface HubEntry {
+  readonly locale: Locale;
+  readonly companySlug: string;
+  readonly url: string;
+  readonly kind: 'matched' | 'unmatched';
+  readonly displayName: string;
+  readonly jobCount: number;
+}
+
+interface HubsFile {
+  readonly hubs: HubEntry[];
+}
+
+interface BridgeCopy {
+  readonly matchedTitle: (c: string, n: number) => string;
+  readonly matchedDescription: (c: string, n: number) => string;
+  readonly matchedH1: (c: string, n: number) => string;
+  readonly matchedLede: (c: string, n: number) => string;
+  readonly unmatchedTitle: string;
+  readonly unmatchedDescription: string;
+  readonly unmatchedH1: (c: string) => string;
+  readonly unmatchedLede: string;
+  readonly browseAllLabel: string;
+}
+
+const COPY: Record<Locale, BridgeCopy> = {
+  it: {
+    matchedTitle: (c, n) => `Offerte di lavoro ${c} — ${n} annunci attivi`,
+    matchedDescription: (c, n) => `${n} annunci attivi di ${c} per frontalieri italo-svizzeri. Stipendio netto Permit G/B, fiscalità Accordo 2026, mappa pendolarismo TILO.`,
+    matchedH1: (c, n) => `${n} annunci di ${c}`,
+    matchedLede: (c, n) => `Trovi ${n} annunci attivi di ${c} aggiornati ogni giorno. Ogni offerta riporta il calcolo automatico dello stipendio netto Permit G (vivere in Italia) vs Permit B (vivere in Svizzera), le tempistiche di pendolarismo verso il confine ticinese e le agevolazioni fiscali introdotte dal Nuovo Accordo bilaterale italo-svizzero del 2026.`,
+    unmatchedTitle: 'Azienda non più attiva — alternative aggiornate ogni giorno',
+    unmatchedDescription: 'Nessun annuncio attivo per questa azienda. Esplora oltre 2000 offerte frontaliere su tutto il Ticino, filtrabili per ruolo, città, contratto e azienda.',
+    unmatchedH1: (c) => `${c} — nessun annuncio attivo`,
+    unmatchedLede: 'In questo momento non ci sono annunci attivi per l\'azienda cercata. Sul job board frontaliere trovi ogni giorno offerte aggiornate in tutto il Ticino, filtrabili per ruolo, città, tipo di contratto e azienda. Iscriviti per ricevere notifiche quando arrivano nuovi annunci compatibili.',
+    browseAllLabel: 'Sfoglia tutti gli annunci attivi',
+  },
+  en: {
+    matchedTitle: (c, n) => `Jobs at ${c} — ${n} cross-border openings`,
+    matchedDescription: (c, n) => `${n} active openings at ${c} for Italian-Swiss cross-border workers. Permit G/B net salary, 2026 bilateral agreement tax adjustments, TILO commute map.`,
+    matchedH1: (c, n) => `${n} openings at ${c}`,
+    matchedLede: (c, n) => `Find ${n} active openings at ${c}, updated daily. Each listing carries the automatic net-salary calculation under Permit G (commuting from Italy) vs Permit B (Swiss residency), commute timetables to the Ticino border and the tax adjustments introduced by the 2026 Italy-Switzerland bilateral agreement.`,
+    unmatchedTitle: 'Employer no longer active — alternatives updated daily',
+    unmatchedDescription: 'No active openings at this employer. Browse 2000+ cross-border job listings across Ticino, filtered by role, city, contract type and employer.',
+    unmatchedH1: (c) => `${c} — no active listings`,
+    unmatchedLede: 'There are no active listings for the employer you searched. Our cross-border job board refreshes daily with new openings across all of Ticino, filtered by role, city, contract type and employer. Subscribe for notifications when matching openings are posted.',
+    browseAllLabel: 'Browse all active listings',
+  },
+  de: {
+    matchedTitle: (c, n) => `Stellen bei ${c} — ${n} aktive Inserate`,
+    matchedDescription: (c, n) => `${n} aktive Stellen bei ${c} für italienisch-schweizerische Grenzgänger. Permit G/B Nettolohn, Steuer-Anpassungen Abkommen 2026, TILO-Pendelfahrpläne.`,
+    matchedH1: (c, n) => `${n} Inserate von ${c}`,
+    matchedLede: (c, n) => `Finden Sie ${n} aktive Stellen bei ${c}, täglich aktualisiert. Jedes Inserat enthält die automatische Nettolohn-Berechnung unter Permit G (Pendeln aus Italien) vs Permit B (Wohnsitz Schweiz), Pendlerfahrpläne zur Tessiner Grenze und die steuerlichen Anpassungen des neuen italienisch-schweizerischen Abkommens 2026.`,
+    unmatchedTitle: 'Arbeitgeber nicht mehr aktiv — täglich aktualisierte Alternativen',
+    unmatchedDescription: 'Keine offenen Stellen bei diesem Arbeitgeber. Über 2000 Grenzgänger-Inserate im Tessin, filterbar nach Rolle, Stadt, Vertragsart und Arbeitgeber.',
+    unmatchedH1: (c) => `${c} — keine aktiven Inserate`,
+    unmatchedLede: 'Es gibt derzeit keine aktiven Inserate für den gesuchten Arbeitgeber. Unser Grenzgänger-Job-Board wird täglich mit neuen Stellen im gesamten Tessin aktualisiert, filterbar nach Rolle, Stadt, Vertragsart und Arbeitgeber.',
+    browseAllLabel: 'Alle aktiven Stellen ansehen',
+  },
+  fr: {
+    matchedTitle: (c, n) => `Emplois chez ${c} — ${n} offres actives`,
+    matchedDescription: (c, n) => `${n} offres actives chez ${c} pour frontaliers italo-suisses. Salaire net Permit G/B, ajustements fiscaux Accord 2026, horaires TILO.`,
+    matchedH1: (c, n) => `${n} annonces de ${c}`,
+    matchedLede: (c, n) => `Trouvez ${n} offres actives chez ${c}, mises à jour quotidiennement. Chaque annonce inclut le calcul automatique du salaire net sous Permit G (frontalier depuis l'Italie) vs Permit B (résidence suisse), les horaires de transport vers la frontière tessinoise et les ajustements fiscaux du nouvel Accord bilatéral italo-suisse 2026.`,
+    unmatchedTitle: 'Employeur non disponible — alternatives mises à jour quotidiennement',
+    unmatchedDescription: 'Aucune offre active chez cet employeur. Parcourez plus de 2000 annonces frontalières au Tessin, filtrables par rôle, ville, type de contrat et entreprise.',
+    unmatchedH1: (c) => `${c} — aucune offre active`,
+    unmatchedLede: 'Il n\'y a actuellement aucune offre active pour l\'employeur recherché. Notre job board frontalier s\'actualise quotidiennement avec de nouvelles offres dans tout le Tessin, filtrables par rôle, ville, type de contrat et employeur.',
+    browseAllLabel: 'Parcourir toutes les annonces actives',
+  },
+};
+
+function esc(value: string): string {
+  return String(value || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function buildHubPath(locale: Locale, companySlug: string): string {
+  return `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/${COMP_PREFIX[locale]}-${companySlug}/`.replace(/\/+/g, '/');
+}
+
+function buildSectionCanonical(locale: Locale): string {
+  return `${BASE_URL}${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/(?<!:)\/+/g, '/');
+}
+
+function renderMatchedPage(entry: HubEntry, distDir: string): string {
+  const locale = entry.locale;
+  const copy = COPY[locale];
+  const hubPath = buildHubPath(locale, entry.companySlug);
+  const canonicalUrl = `${BASE_URL}${hubPath}`;
+  const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
+    <header style="margin-bottom:16px"><h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(copy.matchedH1(entry.displayName, entry.jobCount))}</h1></header>
+    <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.matchedLede(entry.displayName, entry.jobCount))}</p>
+    <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(buildSectionCanonical(locale))}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
+  </main>`;
+  return buildSeoPageHtml({
+    locale, title: copy.matchedTitle(entry.displayName, entry.jobCount),
+    description: copy.matchedDescription(entry.displayName, entry.jobCount),
+    canonicalUrl, robots: 'index,follow', ogType: 'website', ogLocale: OG_LOCALE[locale],
+    hreflangHtml: '', jsonLdScripts: [], bodyHtml, distDir, seoMainClass: 'cluster-seo-prose',
+  });
+}
+
+function renderUnmatchedPage(entry: HubEntry, distDir: string): string {
+  const locale = entry.locale;
+  const copy = COPY[locale];
+  const canonicalUrl = buildSectionCanonical(locale);
+  const sectionPath = buildSectionCanonical(locale);
+  const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
+    <header style="margin-bottom:16px"><h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(copy.unmatchedH1(entry.displayName))}</h1></header>
+    <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.unmatchedLede)}</p>
+    <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(sectionPath)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
+  </main>`;
+  return buildSeoPageHtml({
+    locale, title: copy.unmatchedTitle, description: copy.unmatchedDescription,
+    canonicalUrl, robots: 'index,follow', ogType: 'website', ogLocale: OG_LOCALE[locale],
+    hreflangHtml: '', jsonLdScripts: [], bodyHtml, distDir, seoMainClass: 'cluster-seo-prose',
+  });
+}
+
+export function companyHubBridgePlugin(rootDir: string): Plugin {
+  return {
+    name: 'company-hub-bridge',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      const dataPath = path.join(rootDir, 'data', 'gsc-company-hubs.json');
+      if (!fs.existsSync(dataPath)) {
+        console.warn('\x1b[33m[company-hub-bridge]\x1b[0m data/gsc-company-hubs.json missing — skipping');
+        return;
+      }
+      const distDir = path.join(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) return;
+
+      let file: HubsFile;
+      try { file = JSON.parse(fs.readFileSync(dataPath, 'utf-8')); }
+      catch (err) { console.warn('\x1b[33m[company-hub-bridge]\x1b[0m parse failed:', err); return; }
+      if (!Array.isArray(file.hubs) || file.hubs.length === 0) return;
+
+      let emitted = 0;
+      let skipped = 0;
+      const start = Date.now();
+
+      for (const entry of file.hubs) {
+        const hubPath = buildHubPath(entry.locale, entry.companySlug);
+        const indexTarget = path.join(distDir, hubPath, 'index.html');
+        const flatTarget = path.join(distDir, hubPath.replace(/\/+$/, '') + '.html');
+        if (fs.existsSync(indexTarget)) { skipped++; continue; }
+
+        const html = entry.kind === 'matched'
+          ? renderMatchedPage(entry, distDir)
+          : renderUnmatchedPage(entry, distDir);
+
+        try {
+          fs.mkdirSync(path.dirname(indexTarget), { recursive: true });
+          fs.writeFileSync(indexTarget, html, 'utf-8');
+          fs.writeFileSync(flatTarget, html, 'utf-8');
+          emitted += 2;
+        } catch (err) {
+          console.warn(`\x1b[33m[company-hub-bridge]\x1b[0m failed to write ${indexTarget}:`, err);
+        }
+      }
+
+      const dur = ((Date.now() - start) / 1000).toFixed(1);
+      console.log(
+        `\x1b[36m[company-hub-bridge]\x1b[0m emitted ${emitted} bridge files (${file.hubs.length - skipped} pages, ${skipped} skipped) in ${dur}s`,
+      );
+    },
+  };
+}

--- a/data/gsc-company-hubs.json
+++ b/data/gsc-company-hubs.json
@@ -1,0 +1,147 @@
+{
+  "generatedAt": "2026-05-11T17:17:53.643Z",
+  "sources": [
+    "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+  ],
+  "counts": {
+    "matched": 4,
+    "unmatched": 11
+  },
+  "hubs": [
+    {
+      "locale": "en",
+      "companySlug": "a-group",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/azienda-a-group/",
+      "kind": "matched",
+      "displayName": "A++ Group",
+      "jobCount": 4,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "companySlug": "axa-svizzera",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/azienda-axa-svizzera/",
+      "kind": "unmatched",
+      "displayName": "Axa Svizzera",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "companySlug": "regionalspital-surselva",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/azienda-regionalspital-surselva/",
+      "kind": "unmatched",
+      "displayName": "Regionalspital Surselva",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "companySlug": "rsi",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/unternehmen-rsi/",
+      "kind": "unmatched",
+      "displayName": "Rsi",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "companySlug": "mikron-group",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/azienda-mikron-group/",
+      "kind": "matched",
+      "displayName": "Mikron Group",
+      "jobCount": 10,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "companySlug": "postfinance-ag",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/entreprise-postfinance-ag/",
+      "kind": "unmatched",
+      "displayName": "Postfinance Ag",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "companySlug": "laderach-schweiz-ag",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/azienda-laderach-schweiz-ag/",
+      "kind": "matched",
+      "displayName": "Läderach (Schweiz) AG",
+      "jobCount": 28,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "companySlug": "citta-di-mendrisio",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/azienda-citta-di-mendrisio/",
+      "kind": "matched",
+      "displayName": "Città di Mendrisio",
+      "jobCount": 8,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "companySlug": "ariston-group",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/azienda-ariston-group/",
+      "kind": "unmatched",
+      "displayName": "Ariston Group",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "fr",
+      "companySlug": "die-mobiliar",
+      "url": "https://frontaliereticino.ch/fr/trouver-emploi-tessin/entreprise-die-mobiliar",
+      "kind": "unmatched",
+      "displayName": "Die Mobiliar",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "en",
+      "companySlug": "mabetex-group",
+      "url": "https://frontaliereticino.ch/en/find-jobs-ticino/company-mabetex-group/",
+      "kind": "unmatched",
+      "displayName": "Mabetex Group",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "companySlug": "post-ch-ag",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/unternehmen-post-ch-ag/",
+      "kind": "unmatched",
+      "displayName": "Post Ch Ag",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "companySlug": "gemeinde-st-moritz",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/unternehmen-gemeinde-st-moritz/",
+      "kind": "unmatched",
+      "displayName": "Gemeinde St Moritz",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "companySlug": "the-swatch-group-netherlands-b-v",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/unternehmen-the-swatch-group-netherlands-b-v/",
+      "kind": "unmatched",
+      "displayName": "The Swatch Group Netherlands B V",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    },
+    {
+      "locale": "de",
+      "companySlug": "galenica-ag",
+      "url": "https://frontaliereticino.ch/de/jobs-im-tessin/unternehmen-galenica-ag/",
+      "kind": "unmatched",
+      "displayName": "Galenica Ag",
+      "jobCount": 0,
+      "csvOrigin": "frontaliereticino.ch-Coverage-Drilldown-2026-05-11"
+    }
+  ]
+}

--- a/scripts/ingest-gsc-company-hubs.mjs
+++ b/scripts/ingest-gsc-company-hubs.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * ingest-gsc-company-hubs.mjs
+ *
+ * Ingests GSC Coverage Drilldown CSV exports and extracts company-hub
+ * orphan URLs of the form `/{locale}/{section}/(azienda|company|unternehmen|firma|entreprise|societe)-{company}/`.
+ *
+ * For each orphan: cross-checks the company slug against the slugified
+ * `company` field of every active job in `data/jobs.json`. Classifies as:
+ *   - `matched`   → at least one active job from that company.
+ *                   Bridge page renders the SPA shell at the orphan URL;
+ *                   the SPA's `parseCompanySlugFilter` (JobBoard.tsx)
+ *                   applies the company filter on hydration.
+ *   - `unmatched` → no active job. Soft-landing with canonical → section.
+ *
+ * Output: `data/gsc-company-hubs.json`, consumed by the build plugin.
+ * Mirrors `ingest-gsc-location-hubs.mjs` (PR #89).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(__filename, '..', '..');
+const JOBS_PATH = path.join(ROOT, 'data', 'jobs.json');
+const DOWNLOADS_DIR = path.join(ROOT, 'download');
+const OUT_PATH = path.join(ROOT, 'data', 'gsc-company-hubs.json');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const COMP_PATTERNS = [
+  [/^\/cerca-lavoro-ticino\/azienda-([^/]+)\/?$/, 'it'],
+  [/^\/en\/find-jobs-ticino\/(?:azienda|company)-([^/]+)\/?$/, 'en'],
+  [/^\/de\/jobs-im-tessin\/(?:unternehmen|firma)-([^/]+)\/?$/, 'de'],
+  [/^\/fr\/trouver-emploi-tessin\/(?:entreprise|societe)-([^/]+)\/?$/, 'fr'],
+];
+
+function slugify(value) {
+  return String(value || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function findCsvFiles() {
+  if (!fs.existsSync(DOWNLOADS_DIR)) return [];
+  const out = [];
+  for (const e of fs.readdirSync(DOWNLOADS_DIR)) {
+    if (!e.startsWith('frontaliereticino.ch-Coverage-')) continue;
+    const csv = path.join(DOWNLOADS_DIR, e, 'Tabella.csv');
+    if (fs.existsSync(csv)) out.push({ file: csv, basename: e });
+  }
+  return out;
+}
+
+function parseCsvUrls(file) {
+  return fs.readFileSync(file, 'utf-8').split(/\r?\n/).slice(1).filter(Boolean).map((l) => l.split(',')[0]).filter(Boolean);
+}
+
+function urlToHub(url) {
+  let p;
+  try { p = new URL(url).pathname; } catch { return null; }
+  for (const [re, locale] of COMP_PATTERNS) {
+    const m = p.match(re);
+    if (m) return { locale, companySlug: m[1], url };
+  }
+  return null;
+}
+
+function buildCompanyIndex(jobs) {
+  const idx = new Map();
+  for (const j of jobs) {
+    const c = (j.company || '').trim();
+    if (!c) continue;
+    const slug = slugify(c);
+    if (!idx.has(slug)) idx.set(slug, { displayName: c, jobCount: 0 });
+    idx.get(slug).jobCount++;
+    // Also index by companyKey if present
+    const ck = (j.companyKey || '').trim();
+    if (ck) {
+      const cks = slugify(ck);
+      if (!idx.has(cks)) idx.set(cks, { displayName: c, jobCount: 0 });
+      idx.get(cks).jobCount++;
+    }
+  }
+  return idx;
+}
+
+function humanize(slug) {
+  return slug.split('-').filter(Boolean).map((t) => t.charAt(0).toUpperCase() + t.slice(1)).join(' ');
+}
+
+function classifyHub(hub, compIdx, csvBasename) {
+  const direct = compIdx.get(hub.companySlug);
+  if (direct) return { ...hub, kind: 'matched', displayName: direct.displayName, jobCount: direct.jobCount, csvOrigin: csvBasename };
+  return { ...hub, kind: 'unmatched', displayName: humanize(hub.companySlug), jobCount: 0, csvOrigin: csvBasename };
+}
+
+function main() {
+  if (!fs.existsSync(JOBS_PATH)) { console.error(`✗ ${JOBS_PATH} not found.`); process.exit(1); }
+  const csvFiles = findCsvFiles();
+  if (csvFiles.length === 0) { console.error('No GSC CSV under download/'); process.exit(1); }
+  const jobs = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf-8'));
+  const compIdx = buildCompanyIndex(jobs);
+  console.log(`Loaded ${jobs.length} jobs, ${compIdx.size} distinct company slugs.`);
+
+  const seen = new Set();
+  const hubs = [];
+  for (const { file, basename } of csvFiles) {
+    for (const url of parseCsvUrls(file)) {
+      const h = urlToHub(url);
+      if (!h) continue;
+      const key = `${h.locale}::${h.companySlug}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      hubs.push(classifyHub(h, compIdx, basename));
+    }
+  }
+
+  const counts = hubs.reduce((a, h) => { a[h.kind] = (a[h.kind] || 0) + 1; return a; }, {});
+  console.log(`\nTotal company-hub orphans: ${hubs.length}`);
+  console.log('By kind:', counts);
+
+  if (DRY_RUN) {
+    for (const kind of ['matched', 'unmatched']) {
+      const sample = hubs.filter((h) => h.kind === kind).slice(0, 5);
+      if (sample.length) console.log(`\n${kind}:`);
+      for (const s of sample) console.log(`  [${s.locale}] ${s.companySlug}${s.jobCount ? ' (' + s.jobCount + ' jobs)' : ''}`);
+    }
+    return;
+  }
+
+  const out = { generatedAt: new Date().toISOString(), sources: csvFiles.map((c) => c.basename), counts, hubs };
+  fs.writeFileSync(OUT_PATH, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  console.log(`\nWrote ${hubs.length} company-hub records to ${path.relative(ROOT, OUT_PATH)}`);
+}
+
+main();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,7 @@ import { legacyRedirectsPlugin } from './build-plugins/legacyRedirectsPlugin';
 import { calculatorLegacyAliasPlugin } from './build-plugins/calculatorLegacyAliasPlugin';
 import { jobOrphanBridgePlugin } from './build-plugins/jobOrphanBridgePlugin';
 import { locationHubBridgePlugin } from './build-plugins/locationHubBridgePlugin';
+import { companyHubBridgePlugin } from './build-plugins/companyHubBridgePlugin';
 // flatHtmlRedirectPlugin + hreflangPostprocessPlugin imports retained for
 // type re-exports / unit tests. Their plugin exports are now consumed
 // internally by `postWalkCoordinatorPlugin` (single-walk perf optimization).
@@ -210,6 +211,12 @@ export default defineConfig(({ mode }) => {
  // applied (real listings + AdSense). Unmatched (22): canonical→section
  // landing + "località non disponibile" body. Collision-safe.
  locationHubBridgePlugin(__dirname),
+ // Company-hub bridge: recover the 15 GSC 404s for /{locale}/{section}/{comp-prefix}-{company}/
+ // employer-filter URLs (Cohort 4). Reads classified entries from
+ // data/gsc-company-hubs.json (refreshed via scripts/ingest-gsc-company-hubs.mjs).
+ // Matched (4): canonical=self + SPA hydrates JobBoard with company filter.
+ // Unmatched (11): canonical→section + "azienda non disponibile" body.
+ companyHubBridgePlugin(__dirname),
  // AE-7 — after static pages are written, inject a contextual link into
  // a handful of parent pages so the comparisons hub has inbound links
  // from homepage + confronti hub + salary pillars. Idempotent.


### PR DESCRIPTION
## Summary
Recovers 15 `/{locale}/{section}/(azienda|company|unternehmen|firma|entreprise|societe)-{company}/` 404s.

## Root cause
JobBoard emits `<a href>` to company-filtered URLs from the job-detail gate (`buildCompanySearchSlug`). No build plugin emitted static HTML → 404 before SPA hydration runs.

## Classification (vs jobs.json)
- **4 matched** — company in jobs.json (Läderach, Mikron, A++ Group, Città di Mendrisio)
- **11 unmatched** — no active job (AXA Svizzera, PostFinance, RSI, etc.)

## Approach
Same as PR #89 (location hubs): 200 + canonical=self (matched) or →section (unmatched), SPA hydration applies the filter, AdSense fires.

## Files
- `scripts/ingest-gsc-company-hubs.mjs`
- `build-plugins/companyHubBridgePlugin.ts`
- `data/gsc-company-hubs.json`
- `vite.config.ts` — register after locationHubBridgePlugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)