### PR TITLE
feat(seo): bridge 35 misc 404s from GSC across 9 sub-cohorts (Cohort 5)

### DIFF
--- a/build-plugins/legacyAliasPlugin.ts
+++ b/build-plugins/legacyAliasPlugin.ts
@@ -1,0 +1,249 @@
+/**
+ * Legacy-alias plugin — emits 200 HTML bridge pages for the 35 GSC
+ * `Indicizzata Non trovata` URLs across 9 small misc sub-cohorts
+ * (Cohort 5 of the GSC repair effort).
+ *
+ * Sub-cohorts (see `data/legacy-aliases.json`)
+ * --------------------------------------------
+ *   blogLocaleMismatch (17): article-id used as slug under non-IT locale
+ *                            prefix instead of the locale-translated slug
+ *                            from routerBlogData.
+ *   blogITMissing (1):       /articoli-frontaliere/{slug} for a slug not
+ *                            present in routerBlogData (article renamed
+ *                            or removed).
+ *   fuelStation (8):         per-station fuel pages for stations that
+ *                            rotated out of `data/fuel-prices.json`.
+ *   fuelLocaleAlias (1):     /de/dieselpreise/heute/ — DE locale alias of
+ *                            the IT fuel section that was never emitted.
+ *   jobLegacySection (2):    /cerca-lavoro/{slug} — old section slug
+ *                            before `-ticino` was appended.
+ *   legacySectionAlt (2):    /ricerca/posti-di-lavoro-ticino/,
+ *                            /fr/recherche-emploi-tessin/ — obsolete
+ *                            section slug variants.
+ *   subSlugOnly (1):         /confronta-casse-malati/ — sub-slug without
+ *                            its section prefix.
+ *   localePrefixed (2):      /en/consulting/, /de/api-status/ — IT-only
+ *                            utility pages linked under locale prefix.
+ *   weeklyEmployersDeep (1): /aziende-che-assumono/{city}/{company}/settimana-corrente/
+ *                            company×city deep F5 page that wasn't emitted.
+ *
+ * Approach (200, no 301) mirrors PR #85 (calculator alias), PR #88
+ * (job orphans), PR #89 (location hubs), PR #90 (company hubs):
+ *
+ *   - All pages return 200 via `buildSeoPageHtml` (rule 14 compliant)
+ *   - `robots: 'index,follow'` (never-noindex policy)
+ *   - `matched` entries: `<link rel="canonical">` → target canonical +
+ *     inline pre-hydration `history.replaceState` that rewrites the URL
+ *     bar to the canonical (preserves search + hash). SPA boots on the
+ *     canonical path → real content renders → AdSense fires.
+ *   - `unmatched` entries: canonical → hub/section landing (no replaceState).
+ *     User stays on the orphan URL with a brief "pagina non disponibile"
+ *     body + browse-all CTA.
+ *
+ * Plugin contract: apply 'build', enforce 'post', emit in closeBundle.
+ * Collision-safe: skips writing if dist already has real content.
+ * Sitemap policy: alias pages NOT added to any sitemap.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import type { Plugin } from 'vite';
+import { buildSeoPageHtml } from './shared/seoPageShell';
+import type { Locale } from '../services/i18n';
+
+const BASE_URL = 'https://frontaliereticino.ch';
+
+const OG_LOCALE: Record<Locale, string> = {
+  it: 'it_IT',
+  en: 'en_US',
+  de: 'de_DE',
+  fr: 'fr_FR',
+};
+
+interface AliasEntry {
+  readonly orphanPath: string;
+  readonly locale: Locale;
+  readonly kind: 'matched' | 'unmatched';
+  readonly canonicalPath: string;
+  readonly cohort: string;
+}
+
+interface AliasesFile {
+  readonly generatedAt: string;
+  readonly counts: Record<string, number>;
+  readonly aliases: AliasEntry[];
+}
+
+interface CohortCopy {
+  readonly matched: {
+    readonly title: string;
+    readonly description: string;
+    readonly h1: string;
+    readonly lede: string;
+  };
+  readonly unmatched: {
+    readonly title: string;
+    readonly description: string;
+    readonly h1: string;
+    readonly lede: string;
+  };
+  readonly browseAllLabel: string;
+}
+
+/**
+ * Per-locale copy bundles. Same shape used by all cohorts in this plugin —
+ * SEO body is generic enough that one bundle per locale covers all 9
+ * sub-cohorts. Specific titles can be customized per-cohort via the
+ * `cohortOverrides` map below.
+ */
+const COPY: Record<Locale, CohortCopy> = {
+  it: {
+    matched: {
+      title: 'Pagina aggiornata — apertura in corso',
+      description: 'La pagina richiesta è stata aggiornata. Ti stiamo portando alla versione corrente.',
+      h1: 'Pagina aggiornata',
+      lede: 'L\'URL che hai cliccato corrisponde a una pagina aggiornata in un indirizzo diverso. Ti stiamo portando automaticamente alla versione corrente, dove trovi tutte le informazioni più recenti. Se la pagina non si apre, usa il link in fondo per navigare al menù principale.',
+    },
+    unmatched: {
+      title: 'Pagina non disponibile — esplora alternative',
+      description: 'Questa pagina non è più disponibile. Esplora le sezioni principali del sito per trovare informazioni aggiornate sui frontalieri italo-svizzeri.',
+      h1: 'Pagina non disponibile',
+      lede: 'La pagina che cercavi non è più disponibile in questo indirizzo. Sul nostro sito trovi guide aggiornate sul Nuovo Accordo bilaterale 2026, calcolatore stipendio netto Permit G/B, comparatori cassa malati e cambio valuta, oltre a oltre 2000 annunci di lavoro frontalieri attivi nel Ticino. Usa il link qui sotto per esplorare i contenuti più recenti.',
+    },
+    browseAllLabel: 'Esplora il menù principale',
+  },
+  en: {
+    matched: {
+      title: 'Page updated — opening the latest version',
+      description: 'The page you requested has been updated. We are taking you to the current version.',
+      h1: 'Page updated',
+      lede: 'The URL you clicked corresponds to a page that has been updated at a new address. We are taking you to the current version with the latest content. If the page does not open, use the link below to navigate to the main menu.',
+    },
+    unmatched: {
+      title: 'Page unavailable — explore alternatives',
+      description: 'This page is no longer available. Browse the main sections of the site for up-to-date information for Italian-Swiss cross-border workers.',
+      h1: 'Page unavailable',
+      lede: 'The page you were looking for is no longer available at this address. Our site has updated guides on the 2026 New Bilateral Agreement, the cross-border net-salary calculator under Permit G/B, health insurance and currency exchange comparators, plus over 2000 active cross-border job listings in Ticino. Use the link below to browse the latest content.',
+    },
+    browseAllLabel: 'Browse the main menu',
+  },
+  de: {
+    matched: {
+      title: 'Seite aktualisiert — Sie werden weitergeleitet',
+      description: 'Die angeforderte Seite wurde aktualisiert. Wir leiten Sie zur aktuellen Version weiter.',
+      h1: 'Seite aktualisiert',
+      lede: 'Die angeklickte URL entspricht einer Seite, die unter einer neuen Adresse aktualisiert wurde. Wir leiten Sie automatisch zur aktuellen Version weiter, wo Sie alle neuesten Informationen finden. Falls die Seite nicht öffnet, nutzen Sie den Link unten, um zum Hauptmenü zu navigieren.',
+    },
+    unmatched: {
+      title: 'Seite nicht verfügbar — Alternativen erkunden',
+      description: 'Diese Seite ist nicht mehr verfügbar. Erkunden Sie die Hauptbereiche der Website für aktuelle Informationen für italienisch-schweizerische Grenzgänger.',
+      h1: 'Seite nicht verfügbar',
+      lede: 'Die gesuchte Seite ist unter dieser Adresse nicht mehr verfügbar. Auf unserer Website finden Sie aktualisierte Leitfäden zum neuen bilateralen Abkommen 2026, den Grenzgänger-Nettolohnrechner unter Permit G/B, Krankenkassen- und Währungsvergleicher sowie über 2000 aktive Grenzgänger-Stellenanzeigen im Tessin. Nutzen Sie den Link unten, um die neuesten Inhalte zu erkunden.',
+    },
+    browseAllLabel: 'Hauptmenü erkunden',
+  },
+  fr: {
+    matched: {
+      title: 'Page mise à jour — ouverture en cours',
+      description: 'La page demandée a été mise à jour. Nous vous dirigeons vers la version actuelle.',
+      h1: 'Page mise à jour',
+      lede: 'L\'URL que vous avez cliquée correspond à une page mise à jour à une nouvelle adresse. Nous vous dirigeons automatiquement vers la version actuelle, où vous trouverez toutes les informations les plus récentes. Si la page ne s\'ouvre pas, utilisez le lien ci-dessous pour naviguer vers le menu principal.',
+    },
+    unmatched: {
+      title: 'Page indisponible — explorer les alternatives',
+      description: 'Cette page n\'est plus disponible. Parcourez les sections principales du site pour des informations actualisées sur les frontaliers italo-suisses.',
+      h1: 'Page indisponible',
+      lede: 'La page que vous recherchiez n\'est plus disponible à cette adresse. Notre site propose des guides actualisés sur le nouvel Accord bilatéral 2026, le calculateur de salaire net frontalier sous Permit G/B, les comparateurs d\'assurance-maladie et de change, ainsi que plus de 2000 annonces frontalières actives au Tessin. Utilisez le lien ci-dessous pour parcourir les contenus les plus récents.',
+    },
+    browseAllLabel: 'Parcourir le menu principal',
+  },
+};
+
+function esc(value: string): string {
+  return String(value || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function buildRewriteScript(orphanPath: string, canonicalPath: string): string {
+  const safeOrphan = JSON.stringify(orphanPath);
+  const safeCanonical = JSON.stringify(canonicalPath);
+  return `<script>(function(){try{if(location.pathname===${safeOrphan}){history.replaceState(null,'',${safeCanonical}+location.search+location.hash);}}catch(e){}})();</script>`;
+}
+
+function renderPage(entry: AliasEntry, distDir: string): string {
+  const locale = entry.locale;
+  const copy = COPY[locale];
+  const block = entry.kind === 'matched' ? copy.matched : copy.unmatched;
+  const canonicalUrl = `${BASE_URL}${entry.canonicalPath}`;
+
+  const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
+    <header style="margin-bottom:16px">
+      <h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(block.h1)}</h1>
+    </header>
+    <p style="margin:0 0 12px;font-size:15.5px">${esc(block.lede)}</p>
+    <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(canonicalUrl)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
+  </main>`;
+
+  return buildSeoPageHtml({
+    locale,
+    title: block.title,
+    description: block.description,
+    canonicalUrl,
+    robots: 'index,follow',
+    ogType: 'website',
+    ogLocale: OG_LOCALE[locale],
+    hreflangHtml: '',
+    jsonLdScripts: [],
+    extraHeadHtml: entry.kind === 'matched' ? buildRewriteScript(entry.orphanPath, entry.canonicalPath) : '',
+    bodyHtml,
+    distDir,
+    seoMainClass: 'cluster-seo-prose',
+  });
+}
+
+export function legacyAliasPlugin(rootDir: string): Plugin {
+  return {
+    name: 'legacy-alias',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      const dataPath = path.join(rootDir, 'data', 'legacy-aliases.json');
+      if (!fs.existsSync(dataPath)) {
+        console.warn('\x1b[33m[legacy-alias]\x1b[0m data/legacy-aliases.json missing — skipping');
+        return;
+      }
+      const distDir = path.join(rootDir, 'dist');
+      if (!fs.existsSync(distDir)) return;
+
+      let file: AliasesFile;
+      try { file = JSON.parse(fs.readFileSync(dataPath, 'utf-8')); }
+      catch (err) { console.warn('\x1b[33m[legacy-alias]\x1b[0m parse failed:', err); return; }
+      if (!Array.isArray(file.aliases) || file.aliases.length === 0) return;
+
+      let emitted = 0;
+      let skipped = 0;
+      const start = Date.now();
+
+      for (const entry of file.aliases) {
+        const indexTarget = path.join(distDir, entry.orphanPath, 'index.html');
+        const flatTarget = path.join(distDir, entry.orphanPath.replace(/\/+$/, '') + '.html');
+        if (fs.existsSync(indexTarget)) { skipped++; continue; }
+
+        const html = renderPage(entry, distDir);
+
+        try {
+          fs.mkdirSync(path.dirname(indexTarget), { recursive: true });
+          fs.writeFileSync(indexTarget, html, 'utf-8');
+          fs.writeFileSync(flatTarget, html, 'utf-8');
+          emitted += 2;
+        } catch (err) {
+          console.warn(`\x1b[33m[legacy-alias]\x1b[0m failed to write ${indexTarget}:`, err);
+        }
+      }
+
+      const dur = ((Date.now() - start) / 1000).toFixed(1);
+      console.log(
+        `\x1b[36m[legacy-alias]\x1b[0m emitted ${emitted} bridge files (${file.aliases.length - skipped} pages, ${skipped} skipped) in ${dur}s`,
+      );
+    },
+  };
+}

--- a/data/legacy-aliases.json
+++ b/data/legacy-aliases.json
@@ -1,0 +1,263 @@
+{
+  "generatedAt": "2026-05-11T17:35:31.502Z",
+  "counts": {
+    "fuelStation": 8,
+    "blogLocaleMismatch": 17,
+    "fuelLocaleAlias": 1,
+    "jobLegacySection": 2,
+    "legacySectionAltIT": 1,
+    "legacySectionAltFR": 1,
+    "localePrefixedConsulting": 1,
+    "localePrefixedApiStatus": 1,
+    "blogITMissing": 1,
+    "weeklyEmployersDeep": 1,
+    "subSlugOnly": 1
+  },
+  "aliases": [
+    {
+      "orphanPath": "/prezzi-benzina/locarno/stazioni/locarno-migrol/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/prezzi-benzina/locarno/",
+      "cohort": "fuelStation"
+    },
+    {
+      "orphanPath": "/fr/articles-frontalier/visita-ticinese-coira-criminalita-organizzata/",
+      "locale": "fr",
+      "kind": "matched",
+      "canonicalPath": "/fr/articles-frontalier/delegation-tessinoise-coire-criminalite-organisee/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/dieselpreise/heute/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/prezzi-diesel/",
+      "cohort": "fuelLocaleAlias"
+    },
+    {
+      "orphanPath": "/cerca-lavoro/barbecue-genossenschaft-migros-ostschweiz-bellinzona/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/cerca-lavoro-ticino/barbecue-genossenschaft-migros-ostschweiz-bellinzona/",
+      "cohort": "jobLegacySection"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/tessin-lombardei-fertigung/",
+      "locale": "de",
+      "kind": "unmatched",
+      "canonicalPath": "/de/grenzgaenger-artikel/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/en/cross-border-articles/carnevale-bambini-lugano-tinguely/",
+      "locale": "en",
+      "kind": "matched",
+      "canonicalPath": "/en/cross-border-articles/carnival-holidays-children-ticino-workshops-museo-erba-lugano/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/congedo-genitori-frontaliere-ticino/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/de/grenzgaenger-artikel/elternurlaub-grenzgaenger-schweiz-italien-leitfaden-2026/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/tessiner-lohninitiative-anti-dumping-abstimmung/",
+      "locale": "de",
+      "kind": "unmatched",
+      "canonicalPath": "/de/grenzgaenger-artikel/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/en/cross-border-articles/scambio-dati-polizia-ticino/",
+      "locale": "en",
+      "kind": "matched",
+      "canonicalPath": "/en/cross-border-articles/swiss-police-data-sharing-impact-ticino/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/fr/articles-frontalier/suisse-ue-paquet-accord/",
+      "locale": "fr",
+      "kind": "unmatched",
+      "canonicalPath": "/fr/articles-frontalier/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/fr/prix-essence-suisse/bellinzona/stations/socar-via-san-gottardo/",
+      "locale": "fr",
+      "kind": "matched",
+      "canonicalPath": "/fr/prix-essence-suisse/bellinzona/",
+      "cohort": "fuelStation"
+    },
+    {
+      "orphanPath": "/fr/prix-essence-suisse/chiasso/stations/bp-via-san-gottardo/",
+      "locale": "fr",
+      "kind": "matched",
+      "canonicalPath": "/fr/prix-essence-suisse/chiasso/",
+      "cohort": "fuelStation"
+    },
+    {
+      "orphanPath": "/ricerca/posti-di-lavoro-ticino/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/cerca-lavoro-ticino/",
+      "cohort": "legacySectionAltIT"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/mappa-fiscale-comuni-frontiera/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/de/grenzgaenger-artikel/irpef-zuschlag-grenzgemeinden-steuerkarte-grenzgaenger-2026/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/stop-ristorni-tassa-salute/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/de/grenzgaenger-artikel/gesundheitssteuer-tessin-fordert-stopp-der-steuerrueckerstattungen-an-italien/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/fr/articles-frontalier/annunci-lavoro-dumping-ticino-governo/",
+      "locale": "fr",
+      "kind": "matched",
+      "canonicalPath": "/fr/articles-frontalier/offres-emploi-dumping-salarial-ticino-gouvernement/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/calo-frontalieri-non-tassa-salute/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/de/grenzgaenger-artikel/rueckgang-grenzgaenger-tessin-wirtschaft-nicht-gesundheitsabgabe/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/banca-ditalia-varese-10-anni-dopo/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/de/grenzgaenger-artikel/italienische-bank-varese-10-jahre-spater/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/fr/recherche-emploi-tessin/",
+      "locale": "fr",
+      "kind": "matched",
+      "canonicalPath": "/fr/trouver-emploi-tessin/",
+      "cohort": "legacySectionAltFR"
+    },
+    {
+      "orphanPath": "/en/gasoline-price-switzerland/lugano/stations/migrol-via-cantonale/",
+      "locale": "en",
+      "kind": "matched",
+      "canonicalPath": "/en/gasoline-price-switzerland/lugano/",
+      "cohort": "fuelStation"
+    },
+    {
+      "orphanPath": "/fr/prix-essence-suisse/lugano/stations/bp-via-a-riva/",
+      "locale": "fr",
+      "kind": "matched",
+      "canonicalPath": "/fr/prix-essence-suisse/lugano/",
+      "cohort": "fuelStation"
+    },
+    {
+      "orphanPath": "/en/consulting/",
+      "locale": "en",
+      "kind": "matched",
+      "canonicalPath": "/consulting/",
+      "cohort": "localePrefixedConsulting"
+    },
+    {
+      "orphanPath": "/de/api-status/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/api-status/",
+      "cohort": "localePrefixedApiStatus"
+    },
+    {
+      "orphanPath": "/prezzi-diesel/locarno/stazioni/ecsa-via-cantonale/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/prezzi-diesel/locarno/",
+      "cohort": "fuelStation"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/g-bewilligung-vorteile-nachteile-grenzgaenger-tessin-2026/",
+      "locale": "de",
+      "kind": "unmatched",
+      "canonicalPath": "/de/grenzgaenger-artikel/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/en/cross-border-articles/cross-border-workers-health-tax-piemonte/",
+      "locale": "en",
+      "kind": "unmatched",
+      "canonicalPath": "/en/cross-border-articles/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/articoli-frontaliere/referendum-ue-svizzera-ticino/",
+      "locale": "it",
+      "kind": "unmatched",
+      "canonicalPath": "/articoli-frontaliere/",
+      "cohort": "blogITMissing"
+    },
+    {
+      "orphanPath": "/cerca-lavoro/miu-miu-instore-crm-manager-prada-group-mendrisio/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/cerca-lavoro-ticino/miu-miu-instore-crm-manager-prada-group-mendrisio/",
+      "cohort": "jobLegacySection"
+    },
+    {
+      "orphanPath": "/en/cross-border-articles/cu-2026-novita-frontalieri/",
+      "locale": "en",
+      "kind": "matched",
+      "canonicalPath": "/en/cross-border-articles/cu-2026-deadlines-telework-cross-border-workers/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/grenzgaenger-artikel/sepolti-con-animali-domestici-berna-2026/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/de/grenzgaenger-artikel/bestattung-mit-haustieren-bern-2026/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/de/benzinpreis-schweiz/lugano/tankstellen/avia-via-cantonale/",
+      "locale": "de",
+      "kind": "matched",
+      "canonicalPath": "/de/benzinpreis-schweiz/lugano/",
+      "cohort": "fuelStation"
+    },
+    {
+      "orphanPath": "/aziende-che-assumono/bellinzona/migros-restaurant/settimana-corrente/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/aziende-che-assumono/bellinzona/",
+      "cohort": "weeklyEmployersDeep"
+    },
+    {
+      "orphanPath": "/confronta-casse-malati/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/compara-servizi/confronta-casse-malati/",
+      "cohort": "subSlugOnly"
+    },
+    {
+      "orphanPath": "/fr/articles-frontalier/lamal-cmi-scelta-frontaliere-2026/",
+      "locale": "fr",
+      "kind": "matched",
+      "canonicalPath": "/fr/articles-frontalier/lamal-ou-cmi-frontalier-lequel-choisir-2026/",
+      "cohort": "blogLocaleMismatch"
+    },
+    {
+      "orphanPath": "/prezzi-diesel/lugano/stazioni/ecsa-via-colombera-2/",
+      "locale": "it",
+      "kind": "matched",
+      "canonicalPath": "/prezzi-diesel/lugano/",
+      "cohort": "fuelStation"
+    }
+  ]
+}

--- a/scripts/build-legacy-aliases.mjs
+++ b/scripts/build-legacy-aliases.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * build-legacy-aliases.mjs
+ *
+ * One-shot generator for `data/legacy-aliases.json` — the canonical
+ * source of all "miscellaneous" 404 → bridge mappings (Cohort 5 of the
+ * GSC `Indicizzata Non trovata` repair effort).
+ *
+ * Reads two inputs:
+ *   - download/frontaliereticino.ch-Coverage-{date}/Tabella.csv
+ *   - services/routerBlogData.ts (for article-id → locale-slug lookup)
+ *
+ * Classifies each unresolved-cohort URL into one of:
+ *
+ *   blogLocaleMismatch (17): /(en|de|fr)/{blog-section}/{IT-slug-or-article-id}
+ *     Try to resolve `article-id` → locale-canonical slug via routerBlogData.
+ *     - matched   → canonical: the locale-canonical blog URL (full content
+ *                   bridge via replaceState)
+ *     - unmatched → canonical: locale blog hub (article id missing)
+ *
+ *   blogITMissing (1): /articoli-frontaliere/{slug-not-in-routerBlogData}
+ *     - canonical: IT blog hub
+ *
+ *   fuelStation (8): /{locale-prefix}/{fuel-section}/{city}/{stations-slug}/{station}
+ *     - canonical: city-level fuel page (matched) or section root
+ *
+ *   fuelLocaleAlias (1): /de/dieselpreise/heute/
+ *     - canonical: IT fuel root (the DE locale slug never existed)
+ *
+ *   jobLegacySection (2): /cerca-lavoro/{slug} (no -ticino, no slash)
+ *     - canonical: current /cerca-lavoro-ticino/{slug}/
+ *
+ *   legacySectionAlt (2): /ricerca/posti-di-lavoro-ticino/, /fr/recherche-emploi-tessin/
+ *     - canonical: locale section landing
+ *
+ *   subSlugOnly (1): /confronta-casse-malati/ (sub without section)
+ *     - canonical: /compara-servizi/confronta-casse-malati/
+ *
+ *   localePrefixed (2): /en/consulting/, /de/api-status/ (IT-only utility
+ *     pages mistakenly linked under locale)
+ *     - canonical: IT canonical path
+ *
+ *   weeklyEmployersDeep (1): /aziende-che-assumono/{city}/{company}/settimana-corrente/
+ *     - canonical: F5 city landing
+ *
+ * Output schema (consumed by `build-plugins/legacyAliasPlugin.ts`):
+ *
+ *   {
+ *     "generatedAt": ISO-8601,
+ *     "counts": { ... },
+ *     "aliases": [
+ *       {
+ *         "orphanPath": "/de/grenzgaenger-artikel/tessin-lombardei-fertigung/",
+ *         "locale": "de",
+ *         "kind": "matched" | "unmatched",
+ *         "canonicalPath": "/de/grenzgaenger-artikel/the-translated-slug/",
+ *         "cohort": "blogLocaleMismatch",
+ *         "displayName": "Article title hint (optional)"
+ *       },
+ *       ...
+ *     ]
+ *   }
+ *
+ * Run after dropping a new GSC CSV into download/ to re-classify and refresh.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(__filename, '..', '..');
+const DOWNLOADS_DIR = path.join(ROOT, 'download');
+const ROUTER_BLOG_PATH = path.join(ROOT, 'services', 'routerBlogData.ts');
+const OUT_PATH = path.join(ROOT, 'data', 'legacy-aliases.json');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// ── routerBlogData parsing ──────────────────────────────────────────────
+
+function loadBlogIdToSlug() {
+  if (!fs.existsSync(ROUTER_BLOG_PATH)) return new Map();
+  const src = fs.readFileSync(ROUTER_BLOG_PATH, 'utf-8');
+  const map = new Map();
+  const re = /'([a-z0-9-]+)':\s*\{\s*it:\s*'([^']+)',\s*en:\s*'([^']+)',\s*de:\s*'([^']+)',\s*fr:\s*'([^']+)'\s*\}/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    map.set(m[1], { it: m[2], en: m[3], de: m[4], fr: m[5] });
+  }
+  return map;
+}
+
+const BLOG_HUB_PATH = {
+  it: '/articoli-frontaliere',
+  en: '/en/cross-border-articles',
+  de: '/de/grenzgaenger-artikel',
+  fr: '/fr/articles-frontalier',
+};
+
+// ── CSV ingest ──────────────────────────────────────────────────────────
+
+function findCsvFiles() {
+  if (!fs.existsSync(DOWNLOADS_DIR)) return [];
+  const out = [];
+  for (const e of fs.readdirSync(DOWNLOADS_DIR)) {
+    if (!e.startsWith('frontaliereticino.ch-Coverage-')) continue;
+    const csv = path.join(DOWNLOADS_DIR, e, 'Tabella.csv');
+    if (fs.existsSync(csv)) out.push(csv);
+  }
+  return out;
+}
+
+function parseCsvUrls(file) {
+  return fs.readFileSync(file, 'utf-8').split(/\r?\n/).slice(1).filter(Boolean)
+    .map((l) => l.split(',')[0]).filter(Boolean);
+}
+
+function normalizePath(rawUrl) {
+  let p;
+  try { p = new URL(rawUrl).pathname; } catch { return null; }
+  // Always end with trailing slash (GH Pages canonical form)
+  if (!p.endsWith('/')) p = p + '/';
+  return p;
+}
+
+// ── Cohort detection ────────────────────────────────────────────────────
+
+const COHORT_PATTERNS = [
+  // Cohorts already handled in earlier PRs — exclude
+  { cohort: 'covered-related-search', re: /^\/(cerca-lavoro-ticino|en\/find-jobs-ticino|de\/jobs-im-tessin|fr\/trouver-emploi-tessin)\/(ricerca|search|suche|recherche)-/ },
+  { cohort: 'covered-calculator', re: /^\/(en|de|fr)\/calcola-stipendio\// },
+  { cohort: 'covered-job-detail', re: /^\/(cerca-lavoro-ticino|en\/find-jobs-ticino|de\/jobs-im-tessin|fr\/trouver-emploi-tessin)\/(?!(?:ricerca|search|suche|recherche|azienda|company|unternehmen|firma|entreprise|societe|localita|location|standort|ort|stadt|localite|ville|lieu)-)[^/]+\/$/ },
+  { cohort: 'covered-location-hub', re: /^\/(cerca-lavoro-ticino|en\/find-jobs-ticino|de\/jobs-im-tessin|fr\/trouver-emploi-tessin)\/(localita|location|standort|ort|stadt|localite|ville|lieu)-/ },
+  { cohort: 'covered-company-hub', re: /^\/(cerca-lavoro-ticino|en\/find-jobs-ticino|de\/jobs-im-tessin|fr\/trouver-emploi-tessin)\/(azienda|company|unternehmen|firma|entreprise|societe)-/ },
+  // This PR's cohorts
+  { cohort: 'blogLocaleMismatch', re: /^\/(en|de|fr)\/(cross-border-articles|grenzgaenger-artikel|articles-frontalier)\// },
+  { cohort: 'blogITMissing', re: /^\/articoli-frontaliere\// },
+  { cohort: 'fuelStation', re: /^\/(prezzi-(benzina|diesel)|en\/gasoline-price-switzerland|de\/benzinpreis-schweiz|fr\/prix-essence-suisse)\/.+\/(stazioni|stations|tankstellen)\// },
+  { cohort: 'fuelLocaleAlias', re: /^\/de\/dieselpreise\// },
+  { cohort: 'jobLegacySection', re: /^\/cerca-lavoro\/[^/]+\/?$/ },
+  { cohort: 'legacySectionAltIT', re: /^\/ricerca\/posti-di-lavoro-ticino\/?$/ },
+  { cohort: 'legacySectionAltFR', re: /^\/fr\/recherche-emploi-tessin\/?$/ },
+  { cohort: 'subSlugOnly', re: /^\/confronta-casse-malati\/?$/ },
+  { cohort: 'localePrefixedConsulting', re: /^\/en\/consulting\/?$/ },
+  { cohort: 'localePrefixedApiStatus', re: /^\/de\/api-status\/?$/ },
+  { cohort: 'weeklyEmployersDeep', re: /^\/aziende-che-assumono\/.+\/settimana-corrente\/?$/ },
+];
+
+function classifyCohort(p) {
+  for (const { cohort, re } of COHORT_PATTERNS) {
+    if (re.test(p)) return cohort;
+  }
+  return null;
+}
+
+// ── Per-cohort canonical resolvers ──────────────────────────────────────
+
+function resolveBlogLocaleMismatch(orphanPath, blogIdToSlug) {
+  const m = orphanPath.match(/^\/(en|de|fr)\/(cross-border-articles|grenzgaenger-artikel|articles-frontalier)\/([^/]+)\/?$/);
+  if (!m) return null;
+  const locale = m[1];
+  const candidate = m[3];
+
+  // Look up by article-id first
+  if (blogIdToSlug.has(candidate)) {
+    const slug = blogIdToSlug.get(candidate)[locale];
+    return { kind: 'matched', canonicalPath: `${BLOG_HUB_PATH[locale]}/${slug}/` };
+  }
+  // Then by slug-in-any-locale
+  for (const [, slugs] of blogIdToSlug) {
+    for (const [, s] of Object.entries(slugs)) {
+      if (s === candidate) {
+        const slug = slugs[locale];
+        return { kind: 'matched', canonicalPath: `${BLOG_HUB_PATH[locale]}/${slug}/` };
+      }
+    }
+  }
+  // Article gone — fallback to locale blog hub
+  return { kind: 'unmatched', canonicalPath: `${BLOG_HUB_PATH[locale]}/` };
+}
+
+function resolveBlogITMissing(orphanPath, blogIdToSlug) {
+  const m = orphanPath.match(/^\/articoli-frontaliere\/([^/]+)\/?$/);
+  if (!m) return null;
+  const candidate = m[1];
+  if (blogIdToSlug.has(candidate)) {
+    return { kind: 'matched', canonicalPath: `${BLOG_HUB_PATH.it}/${blogIdToSlug.get(candidate).it}/` };
+  }
+  for (const [, slugs] of blogIdToSlug) {
+    if (slugs.it === candidate) {
+      return { kind: 'matched', canonicalPath: `${BLOG_HUB_PATH.it}/${slugs.it}/` };
+    }
+  }
+  return { kind: 'unmatched', canonicalPath: `${BLOG_HUB_PATH.it}/` };
+}
+
+const FUEL_SECTION_ROOT = {
+  it: { benzina: '/prezzi-benzina', diesel: '/prezzi-diesel' },
+  en: { benzina: '/en/gasoline-price-switzerland', diesel: '/en/diesel-price-switzerland' },
+  de: { benzina: '/de/benzinpreis-schweiz', diesel: '/de/dieselpreis-schweiz' },
+  fr: { benzina: '/fr/prix-essence-suisse', diesel: '/fr/prix-diesel-suisse' },
+};
+
+function resolveFuelStation(orphanPath) {
+  const m = orphanPath.match(/^\/(prezzi-benzina|prezzi-diesel|en\/gasoline-price-switzerland|de\/benzinpreis-schweiz|fr\/prix-essence-suisse)\/([^/]+)\/(stazioni|stations|tankstellen)\/[^/]+\/?$/);
+  if (!m) return null;
+  const sectionPath = '/' + m[1];
+  const city = m[2];
+  // City page is the parent dir of /stazioni|stations|tankstellen
+  return { kind: 'matched', canonicalPath: `${sectionPath}/${city}/` };
+}
+
+function resolveFuelLocaleAlias(orphanPath) {
+  // /de/dieselpreise/heute/ → /prezzi-diesel/oggi/ (IT canonical) or section root
+  return { kind: 'matched', canonicalPath: '/prezzi-diesel/' };
+}
+
+function resolveJobLegacySection(orphanPath) {
+  // /cerca-lavoro/{slug} → /cerca-lavoro-ticino/{slug}/
+  const m = orphanPath.match(/^\/cerca-lavoro\/([^/]+)\/?$/);
+  if (!m) return null;
+  return { kind: 'matched', canonicalPath: `/cerca-lavoro-ticino/${m[1]}/` };
+}
+
+function resolveLegacySectionAltIT() {
+  return { kind: 'matched', canonicalPath: '/cerca-lavoro-ticino/' };
+}
+
+function resolveLegacySectionAltFR() {
+  return { kind: 'matched', canonicalPath: '/fr/trouver-emploi-tessin/' };
+}
+
+function resolveSubSlugOnly() {
+  return { kind: 'matched', canonicalPath: '/compara-servizi/confronta-casse-malati/' };
+}
+
+function resolveLocalePrefixedConsulting() {
+  // /en/consulting/ — IT-only utility page. Canonical: IT /consulting/
+  return { kind: 'matched', canonicalPath: '/consulting/' };
+}
+
+function resolveLocalePrefixedApiStatus() {
+  return { kind: 'matched', canonicalPath: '/api-status/' };
+}
+
+function resolveWeeklyEmployersDeep(orphanPath) {
+  // /aziende-che-assumono/{city}/{company}/settimana-corrente/
+  // Canonical: /aziende-che-assumono/{city}/ (city-level F5 landing)
+  const m = orphanPath.match(/^\/aziende-che-assumono\/([^/]+)\/[^/]+\/settimana-corrente\/?$/);
+  if (!m) return null;
+  return { kind: 'matched', canonicalPath: `/aziende-che-assumono/${m[1]}/` };
+}
+
+function pathLocale(orphanPath) {
+  if (orphanPath.startsWith('/en/')) return 'en';
+  if (orphanPath.startsWith('/de/')) return 'de';
+  if (orphanPath.startsWith('/fr/')) return 'fr';
+  return 'it';
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+
+function main() {
+  const csvFiles = findCsvFiles();
+  if (csvFiles.length === 0) {
+    console.error('No GSC CSVs under download/');
+    process.exit(1);
+  }
+
+  const blogIdToSlug = loadBlogIdToSlug();
+  console.log(`Loaded ${blogIdToSlug.size} blog article-id translations.`);
+
+  const seen = new Set();
+  const aliases = [];
+  const cohortCounts = {};
+
+  for (const file of csvFiles) {
+    for (const url of parseCsvUrls(file)) {
+      const p = normalizePath(url);
+      if (!p) continue;
+      const cohort = classifyCohort(p);
+      if (!cohort || cohort.startsWith('covered-')) continue;
+      if (seen.has(p)) continue;
+      seen.add(p);
+
+      let resolution = null;
+      switch (cohort) {
+        case 'blogLocaleMismatch':       resolution = resolveBlogLocaleMismatch(p, blogIdToSlug); break;
+        case 'blogITMissing':            resolution = resolveBlogITMissing(p, blogIdToSlug); break;
+        case 'fuelStation':              resolution = resolveFuelStation(p); break;
+        case 'fuelLocaleAlias':          resolution = resolveFuelLocaleAlias(p); break;
+        case 'jobLegacySection':         resolution = resolveJobLegacySection(p); break;
+        case 'legacySectionAltIT':       resolution = resolveLegacySectionAltIT(); break;
+        case 'legacySectionAltFR':       resolution = resolveLegacySectionAltFR(); break;
+        case 'subSlugOnly':              resolution = resolveSubSlugOnly(); break;
+        case 'localePrefixedConsulting': resolution = resolveLocalePrefixedConsulting(); break;
+        case 'localePrefixedApiStatus':  resolution = resolveLocalePrefixedApiStatus(); break;
+        case 'weeklyEmployersDeep':      resolution = resolveWeeklyEmployersDeep(p); break;
+      }
+      if (!resolution) continue;
+
+      aliases.push({
+        orphanPath: p,
+        locale: pathLocale(p),
+        kind: resolution.kind,
+        canonicalPath: resolution.canonicalPath,
+        cohort,
+      });
+      cohortCounts[cohort] = (cohortCounts[cohort] || 0) + 1;
+    }
+  }
+
+  console.log(`\nTotal legacy aliases: ${aliases.length}`);
+  console.log('By cohort:', cohortCounts);
+
+  if (DRY_RUN) {
+    console.log('\n--dry-run sample:');
+    aliases.slice(0, 8).forEach((a) => console.log(`  [${a.locale}/${a.kind}] ${a.orphanPath} → ${a.canonicalPath}`));
+    return;
+  }
+
+  const out = {
+    generatedAt: new Date().toISOString(),
+    counts: cohortCounts,
+    aliases,
+  };
+  fs.writeFileSync(OUT_PATH, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  console.log(`\nWrote ${aliases.length} legacy-alias entries to ${path.relative(ROOT, OUT_PATH)}`);
+}
+
+main();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ import { calculatorLegacyAliasPlugin } from './build-plugins/calculatorLegacyAli
 import { jobOrphanBridgePlugin } from './build-plugins/jobOrphanBridgePlugin';
 import { locationHubBridgePlugin } from './build-plugins/locationHubBridgePlugin';
 import { companyHubBridgePlugin } from './build-plugins/companyHubBridgePlugin';
+import { legacyAliasPlugin } from './build-plugins/legacyAliasPlugin';
 // flatHtmlRedirectPlugin + hreflangPostprocessPlugin imports retained for
 // type re-exports / unit tests. Their plugin exports are now consumed
 // internally by `postWalkCoordinatorPlugin` (single-walk perf optimization).
@@ -217,6 +218,14 @@ export default defineConfig(({ mode }) => {
  // Matched (4): canonical=self + SPA hydrates JobBoard with company filter.
  // Unmatched (11): canonical→section + "azienda non disponibile" body.
  companyHubBridgePlugin(__dirname),
+ // Legacy-alias bridge: recover the 35 GSC 404s spread across 9 small misc
+ // sub-cohorts (Cohort 5). Reads classified entries from data/legacy-aliases.json
+ // (refreshed via scripts/build-legacy-aliases.mjs). Each entry is `matched`
+ // (canonical+replaceState to live page) or `unmatched` (canonical→hub fallback).
+ // Covers: blogLocaleMismatch (17), blogITMissing (1), fuelStation (8),
+ // fuelLocaleAlias (1), jobLegacySection (2), legacySectionAlt (2),
+ // subSlugOnly (1), localePrefixed (2), weeklyEmployersDeep (1).
+ legacyAliasPlugin(__dirname),
  // AE-7 — after static pages are written, inject a contextual link into
  // a handful of parent pages so the comparisons hub has inbound links
  // from homepage + confronti hub + salary pillars. Idempotent.


### PR DESCRIPTION
## Summary
Recovers the final 35 GSC `Indicizzata Non trovata` URLs across 9 small sub-cohorts (the long tail after Cohorts 1-4 closed the top 911 URLs).

## Sub-cohorts + canonical strategy

| # | Sub-cohort | Count | Canonical |
|---|---|---|---|
| 1 | blogLocaleMismatch | 17 | locale-canonical blog URL (12 resolved) or locale blog hub (5 article gone) |
| 2 | blogITMissing | 1 | IT blog hub |
| 3 | fuelStation | 8 | city-level fuel page |
| 4 | fuelLocaleAlias | 1 | IT fuel root |
| 5 | jobLegacySection | 2 | current `-ticino` section |
| 6 | legacySectionAlt | 2 | locale section landing |
| 7 | subSlugOnly | 1 | `/compara-servizi/confronta-casse-malati/` |
| 8 | localePrefixed | 2 | IT canonical |
| 9 | weeklyEmployersDeep | 1 | F5 city landing |

Total: 29 matched + 6 unmatched.

## Approach
Single generic plugin (`legacyAliasPlugin.ts`) with locale-keyed copy. Same bridge mechanics as PRs #85/#88/#89/#90: `buildSeoPageHtml`, 200, canonical signal, optional `history.replaceState` for matched, AdSense fires.

## Files
- `scripts/build-legacy-aliases.mjs` — generates `data/legacy-aliases.json` from CSV + routerBlogData
- `build-plugins/legacyAliasPlugin.ts` — generic bridge plugin
- `data/legacy-aliases.json` — 35 classified entries
- `vite.config.ts` — register after companyHubBridgePlugin

## Cumulative GSC repair
PR #81 (757) + #85 (22) + #88 (92) + #89 (60) + #90 (15) + this (35) = **981/999** URLs recovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)