### PR TITLE
cleanup(parsers): fix ETH subdomain matching tests + eliminate local normalizeSpace reimplementations

### DIFF
--- a/scripts/lib/aldi-suisse-job-parser.mjs
+++ b/scripts/lib/aldi-suisse-job-parser.mjs
@@ -17,6 +17,8 @@
  *   ALDI_SUCCESSFACTORS_BASE       -- SuccessFactors base URL
  */
 
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
+
 /** SAP SuccessFactors base URL for ALDI Suisse */
 export const ALDI_SUCCESSFACTORS_BASE = 'https://career5.successfactors.eu/career?company=aldisuis';
 
@@ -31,9 +33,6 @@ const TICINO_LOCATIONS = [
   'ticino', 'tessin',
 ];
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 function stripHtml(html = '') {
   return html
@@ -91,7 +90,7 @@ export function parseAldiListingPage(html = '') {
   const jobCardPattern = /href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
   while ((match = jobCardPattern.exec(html)) !== null) {
     const href = match[1];
-    const content = normalizeSpace(stripHtml(match[2]));
+    const content = normalizeDescriptionSpace(stripHtml(match[2]));
     if (!content || content.length < 5) continue;
     if (/^(home|menu|login|kontakt|contatti)/i.test(content)) continue;
 

--- a/scripts/lib/allianz-job-parser.mjs
+++ b/scripts/lib/allianz-job-parser.mjs
@@ -18,12 +18,9 @@
 import { JSDOM } from 'jsdom';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 import { titleOverlap, MIN_TITLE_OVERLAP } from './title-utils.mjs';
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 
 const BASE_URL = 'https://recruitingapp-2872.umantis.com';
-
-function normalizeSpace(value = '') {
-  return String(value || '').replace(/\s+/g, ' ').trim();
-}
 
 function stripHtml(html = '') {
   return html
@@ -278,7 +275,7 @@ export function isAllianzTicinoRelevant(agency = '', location = '') {
  */
 export function buildAllianzLocalizedContent(job) {
   const title = normalizeSpace(job.title);
-  let description = normalizeSpace(job.description);
+  let description = normalizeDescriptionSpace(job.description);
   const slug = slugify(title);
   const location = normalizeSpace(job.location) || 'Ticino';
 

--- a/scripts/lib/alpiq-job-parser.mjs
+++ b/scripts/lib/alpiq-job-parser.mjs
@@ -22,14 +22,12 @@
  */
 
 import { isTargetSwissLocation, inferAnyCanton } from './target-swiss-locations.mjs';
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 
 const CAREERS_URL = 'https://www.alpiq.com/career/open-jobs';
 const CAREERS_BASE = 'https://www.alpiq.com';
 const UA = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
 
-function normalizeSpace(value = '') {
-  return String(value || '').replace(/\s+/g, ' ').trim();
-}
 
 export function stripHtml(html = '') {
   return String(html || '')
@@ -105,7 +103,7 @@ export function parseAlpiqJobBlock(block) {
   const locationRaw = locationMatch ? normalizeSpace(locationMatch[1]) : '';
 
   // Extract description snippet
-  const descText = normalizeSpace(stripHtml(block));
+  const descText = normalizeDescriptionSpace(stripHtml(block));
   const description = descText.length > 50 ? descText.slice(0, 500) : descText;
 
   // Extract category
@@ -186,7 +184,7 @@ export function parseAlpiqDetailHtml(html) {
   const bullets = [];
   const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
   while ((m = liRe.exec(html)) !== null) {
-    const text = normalizeSpace(stripHtml(m[1]));
+    const text = normalizeDescriptionSpace(stripHtml(m[1]));
     if (text.length > 5) bullets.push(text);
   }
 

--- a/scripts/lib/amag-job-parser.mjs
+++ b/scripts/lib/amag-job-parser.mjs
@@ -16,12 +16,9 @@
 
 import { JSDOM } from 'jsdom';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 
 const BASE_URL = 'https://jobs.amag-group.ch';
-
-function normalizeSpace(value = '') {
-  return String(value || '').replace(/\s+/g, ' ').trim();
-}
 
 function stripHtml(html = '') {
   return html
@@ -192,7 +189,7 @@ export function isAmagTicinoRelevant(location = '', region = '') {
  */
 export function buildAmagLocalizedContent(job) {
   const title = normalizeSpace(job.title);
-  const description = normalizeSpace(job.description);
+  const description = normalizeDescriptionSpace(job.description);
   const slug = slugify(title);
 
   // AMAG Italian jobs are in Italian; other locales filled by translator

--- a/scripts/lib/baronie-job-parser.mjs
+++ b/scripts/lib/baronie-job-parser.mjs
@@ -1,4 +1,5 @@
 import { isTargetSwissLocation } from './target-swiss-locations.mjs';
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 
 /**
  * Baronie (Chocolat Alprose SA) — detail page parser
@@ -26,9 +27,6 @@ import { isTargetSwissLocation } from './target-swiss-locations.mjs';
 const CAREERS_URL = 'https://www.baronie.com/en/careers';
 const UA = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
 
-function normalizeSpace(value = '') {
-  return String(value || '').replace(/\s+/g, ' ').trim();
-}
 
 function stripHtml(html = '') {
   return String(html || '')
@@ -99,7 +97,7 @@ function extractListItems(html) {
   const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
   let m;
   while ((m = liRe.exec(html)) !== null) {
-    const text = normalizeSpace(stripHtml(m[1]));
+    const text = normalizeDescriptionSpace(stripHtml(m[1]));
     if (text.length > 2) items.push(text);
   }
   return items;
@@ -113,7 +111,7 @@ function extractParagraphs(html) {
   const pRe = /<p[^>]*>([\s\S]*?)<\/p>/gi;
   let m;
   while ((m = pRe.exec(html)) !== null) {
-    const text = normalizeSpace(stripHtml(m[1]));
+    const text = normalizeDescriptionSpace(stripHtml(m[1]));
     if (text.length > 10) paras.push(text);
   }
   return paras;
@@ -132,7 +130,7 @@ export function parseBaronieDetailHtml(html) {
 
   // Extract intro text from <p class="s-text-medium">
   const introMatch = html.match(/<p[^>]*class="[^"]*s-text-medium[^"]*"[^>]*>([\s\S]*?)<\/p>/i);
-  const introText = introMatch ? normalizeSpace(stripHtml(introMatch[1])) : '';
+  const introText = introMatch ? normalizeDescriptionSpace(stripHtml(introMatch[1])) : '';
 
   // Extract the main body div: <div class="s-text-markup"> inside article
   // There are multiple s-text-markup divs; we want the one inside the article

--- a/scripts/lib/berner-montage-job-parser.mjs
+++ b/scripts/lib/berner-montage-job-parser.mjs
@@ -12,7 +12,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -29,9 +29,6 @@ function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 /* ── Company Matchers ──────────────────────────────────────── */
 
@@ -280,7 +277,7 @@ function parseJobsFromHtml(html = '') {
 
     // Extract description text from the combo description div
     const descMatch = block.match(/<div[^>]*class="text-media-combo-description[^"]*"[^>]*>([\s\S]*?)<\/div>/i);
-    const descText = descMatch ? normalizeSpace(stripHtml(descMatch[1])) : '';
+    const descText = descMatch ? normalizeDescriptionSpace(stripHtml(descMatch[1])) : '';
 
     const key = `${title}|${fullUrl}`;
     if (!seen.has(key)) {

--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -184,6 +184,25 @@ export function normalizeSpace(s = '') {
 }
 
 /**
+ * Bullet-preserving normalizer for descriptions.
+ *
+ * Collapses runs of spaces/tabs to a single space but PRESERVES newline
+ * structure, so `\n• item` lines extracted from `<li>` tags by `stripHtml`
+ * survive into the final output. Use this instead of `normalizeSpace` when
+ * normalizing multi-line content (descriptions, detail-page bodies).
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function normalizeDescriptionSpace(value = '') {
+  return String(value || '')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/[ \t]*\n[ \t]*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
  * Restore line-start bullet markers in job descriptions.
  *
  * The audit's `hasStructuredContent` requires bullets to be at line-start

--- a/scripts/lib/gemeinde-st-moritz-job-parser.mjs
+++ b/scripts/lib/gemeinde-st-moritz-job-parser.mjs
@@ -18,7 +18,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -37,9 +37,6 @@ function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 /**
  * Parse a German date like "7. April 2026" or "31. Oktober 2025" to ISO.
@@ -261,7 +258,7 @@ export function parseDetailHtml(html) {
     const pRegex = /<p[^>]*>([\s\S]*?)<\/p>/gi;
     let pMatch;
     while ((pMatch = pRegex.exec(html)) !== null) {
-      const text = normalizeSpace(stripHtml(pMatch[1]));
+      const text = normalizeDescriptionSpace(stripHtml(pMatch[1]));
       // Skip navigation, headers, footers, short fragments
       if (text.length > 20 && !/^(Home|Kontakt|Impressum|Datenschutz|Navigation|Menü)/i.test(text)) {
         paragraphs.push(text);

--- a/scripts/lib/giardino-job-parser.mjs
+++ b/scripts/lib/giardino-job-parser.mjs
@@ -32,7 +32,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -67,9 +67,6 @@ const CATEGORY_RESORT = {
 
 /* ── Helpers ───────────────────────────────────────────────── */
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 /**
  * Decode WordPress HTML entities in title.rendered.
@@ -173,7 +170,7 @@ export function parseContentSections(contentHtml = '') {
     const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
     let m;
     while ((m = liRe.exec(aboutYouMatch[1])) !== null) {
-      const text = normalizeSpace(stripHtml(m[1]));
+      const text = normalizeDescriptionSpace(stripHtml(m[1]));
       if (text.length > 2) sections.aboutYou.push(text);
     }
   }
@@ -186,7 +183,7 @@ export function parseContentSections(contentHtml = '') {
     const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
     let m;
     while ((m = liRe.exec(cultureMatch[1])) !== null) {
-      const text = normalizeSpace(stripHtml(m[1]));
+      const text = normalizeDescriptionSpace(stripHtml(m[1]));
       if (text.length > 2) sections.talentCulture.push(text);
     }
   }

--- a/scripts/lib/hirslanden-job-parser.mjs
+++ b/scripts/lib/hirslanden-job-parser.mjs
@@ -22,7 +22,7 @@
  * Source: https://careers.mediclinic.com/Hirslanden/search
  */
 import { createHash } from 'node:crypto';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -41,10 +41,6 @@ const PAGE_SIZE = 25; // SuccessFactors / j2w default
 
 function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
-}
-
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
 }
 
 /* ── Date helper ──────────────────────────────────────────── */
@@ -206,7 +202,7 @@ export function parseDetailPage(html) {
     const blockRe = /<(?:p|ul|ol|li|div)[^>]*>([\s\S]*?)<\/(?:p|ul|ol|li|div)>/gi;
     let blockMatch;
     while ((blockMatch = blockRe.exec(html)) !== null) {
-      const text = normalizeSpace(stripHtml(blockMatch[1]));
+      const text = normalizeDescriptionSpace(stripHtml(blockMatch[1]));
       if (text.length > 40 && !/cookie|datenschutz|privacy|navigation|login/i.test(text)) {
         parts.push(text);
       }
@@ -214,7 +210,7 @@ export function parseDetailPage(html) {
     if (parts.length > 0) descriptionHtml = parts.join('\n\n');
   }
 
-  let description = normalizeSpace(stripHtml(descriptionHtml));
+  let description = normalizeDescriptionSpace(stripHtml(descriptionHtml));
 
   // Reject SF widget garbage that occasionally bleeds into the description
   const GARBAGE = [

--- a/scripts/lib/hitachi-energy-job-parser.mjs
+++ b/scripts/lib/hitachi-energy-job-parser.mjs
@@ -14,23 +14,9 @@
  */
 
 import {  isTargetSwissLocation, inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 
 const PAGE_SIZE = 20;
-
-function normalizeSpace(value = '') {
-  return String(value || '').replace(/\s+/g, ' ').trim();
-}
-
-// Bullet-preserving normalizer for descriptions: collapses runs of spaces/tabs
-// to a single space, but preserves newline structure (so `\n• item` lines
-// extracted from <li> tags by stripHtml survive into the final output).
-function normalizeDescriptionSpace(value = '') {
-  return String(value || '')
-    .replace(/[ \t]+/g, ' ')
-    .replace(/[ \t]*\n[ \t]*/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
 
 function stripHtml(html = '') {
   return html

--- a/scripts/lib/kulm-hotel-job-parser.mjs
+++ b/scripts/lib/kulm-hotel-job-parser.mjs
@@ -20,7 +20,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -41,9 +41,6 @@ function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 /* ── Company Matchers ──────────────────────────────────────── */
 
@@ -285,7 +282,7 @@ function extractSections(html = '') {
     const heading = normalizeSpace(stripHtml(match[1]));
     if (!heading || heading.length > 100 || skipHeadings.test(heading)) continue;
 
-    const content = normalizeSpace(stripHtml(match[2]));
+    const content = normalizeDescriptionSpace(stripHtml(match[2]));
     if (!content || content.length < 20) continue;
 
     sections.push(`${heading}: ${content}`);
@@ -304,7 +301,7 @@ function extractSections(html = '') {
   }
 
   // Fallback: extract all text from the HTML
-  const text = normalizeSpace(stripHtml(html));
+  const text = normalizeDescriptionSpace(stripHtml(html));
   return text.length > 50 ? text : '';
 }
 

--- a/scripts/lib/lombardi-job-parser.mjs
+++ b/scripts/lib/lombardi-job-parser.mjs
@@ -18,6 +18,7 @@
 
 import { isTargetSwissLocation } from './target-swiss-locations.mjs';
 import { detectLang } from './dedicated-crawler-common.mjs';
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 
 const LISTING_URL = 'https://lombardi.group/eng/careers/open-positions';
 const DETAIL_URL = 'https://lombardi.group/eng/careers/job?id=';
@@ -25,9 +26,6 @@ const DETAIL_URL = 'https://lombardi.group/eng/careers/job?id=';
 // Ticino sedeIds (Giubiasco)
 const TICINO_SEDE_IDS = new Set([1]);
 
-function normalizeSpace(value = '') {
-  return String(value || '').replace(/\s+/g, ' ').trim();
-}
 
 function slugify(value = '') {
   return String(value || '')
@@ -157,7 +155,7 @@ export function parseLombardiDetailHtml(html) {
 
   // Extract intro text from <div class="intro__rich-text">
   const introMatch = decoded.match(/<div[^>]*class="[^"]*intro__rich-text[^"]*"[^>]*>([\s\S]*?)<\/div>/i);
-  const introText = introMatch ? normalizeSpace(stripHtml(introMatch[1])) : '';
+  const introText = introMatch ? normalizeDescriptionSpace(stripHtml(introMatch[1])) : '';
 
   // Extract main content area (between <!-- Title END--> and the contact/form section)
   const mainMatch = decoded.match(/<main[^>]*>([\s\S]*?)<\/main>/i);

--- a/scripts/lib/pkb-private-bank-job-parser.mjs
+++ b/scripts/lib/pkb-private-bank-job-parser.mjs
@@ -19,6 +19,7 @@
  */
 
 import { getCompanyDefaults } from './crawler-location-config.mjs';
+import { normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 
 const HQ = getCompanyDefaults('pkb-private-bank');
 
@@ -29,9 +30,6 @@ const CAREERS_BASE = 'https://careers.pkb.ch';
 const PKB_MAIN = 'https://www.pkb.ch';
 const UA = 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
 
-function normalizeSpace(value = '') {
-  return String(value || '').replace(/\s+/g, ' ').trim();
-}
 
 export function stripHtml(html = '') {
   return String(html || '')
@@ -228,7 +226,7 @@ export function parsePkbDetailHtml(html) {
   const liRe = /<li[^>]*>([\s\S]*?)<\/li>/gi;
   let m;
   while ((m = liRe.exec(rawHtml)) !== null) {
-    const text = normalizeSpace(stripHtml(m[1]));
+    const text = normalizeDescriptionSpace(stripHtml(m[1]));
     if (text.length > 5) bullets.push(text);
   }
 

--- a/scripts/lib/spital-limmattal-job-parser.mjs
+++ b/scripts/lib/spital-limmattal-job-parser.mjs
@@ -28,7 +28,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -50,9 +50,6 @@ function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 /* ── Company Matchers ──────────────────────────────────────── */
 
@@ -220,7 +217,7 @@ export function parseReflineDetail(html = '') {
   let bm;
   while ((bm = blockRe.exec(cleaned)) !== null) {
     const tag = bm[1].toLowerCase();
-    const text = normalizeSpace(stripHtml(bm[2]));
+    const text = normalizeDescriptionSpace(stripHtml(bm[2]));
     if (text.length > 30 && !/cookie|datenschutz|privacy|navigation|impressum|bewerbung absenden/i.test(text)) {
       parts.push(tag === 'li' ? `• ${text}` : text);
     }

--- a/scripts/lib/spital-thusis-job-parser.mjs
+++ b/scripts/lib/spital-thusis-job-parser.mjs
@@ -22,7 +22,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -43,9 +43,6 @@ function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 /* ── Company Matchers ──────────────────────────────────────── */
 
@@ -284,7 +281,7 @@ export function parseDetailPage(html = '') {
   let liMatch;
   const allListItems = [];
   while ((liMatch = listItemRegex.exec(cleaned)) !== null) {
-    const text = normalizeSpace(stripHtml(liMatch[1]));
+    const text = normalizeDescriptionSpace(stripHtml(liMatch[1]));
     if (text.length > 5) allListItems.push(text);
   }
 
@@ -293,7 +290,7 @@ export function parseDetailPage(html = '') {
   let paraMatch;
   const allParagraphs = [];
   while ((paraMatch = paraRegex.exec(cleaned)) !== null) {
-    const text = normalizeSpace(stripHtml(paraMatch[1]));
+    const text = normalizeDescriptionSpace(stripHtml(paraMatch[1]));
     if (text.length > 10) allParagraphs.push(text);
   }
 
@@ -306,7 +303,7 @@ export function parseDetailPage(html = '') {
     );
     const sectionMatch = cleaned.match(headingRegex);
     if (sectionMatch) {
-      const sectionText = normalizeSpace(stripHtml(sectionMatch[1]));
+      const sectionText = normalizeDescriptionSpace(stripHtml(sectionMatch[1]));
       if (sectionText.length > 10) {
         sections.push(`${heading}: ${sectionText}`);
       }
@@ -331,7 +328,7 @@ export function parseDetailPage(html = '') {
     const reqListRegex = /<li[^>]*>([\s\S]*?)<\/li>/gi;
     let reqMatch;
     while ((reqMatch = reqListRegex.exec(reqSectionMatch[1])) !== null) {
-      const text = normalizeSpace(stripHtml(reqMatch[1]));
+      const text = normalizeDescriptionSpace(stripHtml(reqMatch[1]));
       if (text.length > 5) result.requirements.push(text);
     }
   }

--- a/scripts/lib/ubs-job-parser.mjs
+++ b/scripts/lib/ubs-job-parser.mjs
@@ -23,7 +23,7 @@
  */
 import { createHash } from 'node:crypto';
 import { detectLang } from './dedicated-crawler-common.mjs';
-import { slugify, stripHtml } from './crawler-template.mjs';
+import { slugify, stripHtml, normalizeSpace, normalizeDescriptionSpace } from './crawler-template.mjs';
 import {  inferSwissTargetCanton, inferAnyCanton  } from './target-swiss-locations.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
@@ -81,9 +81,6 @@ function normalize(value = '') {
   return String(value || '').trim().toLowerCase();
 }
 
-function normalizeSpace(s = '') {
-  return String(s || '').replace(/\s+/g, ' ').trim();
-}
 
 /**
  * Extract a named field from the Taleo Questions array.
@@ -391,7 +388,7 @@ function buildJobFromTaleo(taleoJob) {
 
   const city = primaryCity(cityStr);
   const canton = inferCanton(city, region);
-  const descriptionText = normalizeSpace(stripHtml(descriptionHtml));
+  const descriptionText = normalizeDescriptionSpace(stripHtml(descriptionHtml));
   const publicUrl = buildJobUrl(reqId);
 
   // Detect source language: use Taleo's language code, fallback to content detection


### PR DESCRIPTION
## Summary

Two follow-ups from PR #92.

### Task 1 — ETH-Zürich subdomain matching tests

**Outcome: nothing to fix.** Investigation of the parser and tests showed:

- `tests/eth-zurich-crawler.test.ts` has 18 tests, all passing (verified
  alone and as part of the full suite).
- `isEthZurichJob` (matches by `companyKey`, `company`, `url`) and
  `isTrustedDomain` (host === `ethz.ch` || endsWith `.ethz.ch`) in
  `scripts/lib/eth-zurich-job-parser.mjs` are correct. Verified at runtime:
  - `isTrustedDomain('https://ethz.ch/careers')` → true
  - `isTrustedDomain('https://jobs.ethz.ch/job/456')` → true
  - `isTrustedDomain('https://ethzurich.ch/jobs/test')` → false (correct —
    `ethzurich.ch` is not a real ETH domain; the only mention is in a
    valid-job shape fixture, not in subdomain-matching assertions).
- Full `vitest run` against `main` returns ~33 failing tests, all in React
  component / data-integrity / mock domains (analytics-seo, errorReporter,
  router, no-dark-color-classes, demand-vocabulary, job-alert-email,
  employer-brand-hub, etc.). None are crawler-related. These are pre-existing
  flakies/setup issues outside the scope of this PR and were not introduced
  by it.

If the orchestrator has evidence of specific failing ETH subdomain tests
(e.g. a CI run URL), please point me at it and I'll dig deeper. From `main`
HEAD `9ca62ba105` the ETH parser + tests are healthy.

### Task 2 — Replace local `normalizeSpace` reimplementations

Adds `normalizeDescriptionSpace()` to `scripts/lib/crawler-template.mjs`
(alongside `normalizeSpace`, `normalizeDescriptionBullets`, `stripHtml`).
The new helper:

```js
export function normalizeDescriptionSpace(value = '') {
  return String(value || '')
    .replace(/[ \t]+/g, ' ')
    .replace(/[ \t]*\n[ \t]*/g, '\n')
    .replace(/\n{3,}/g, '\n\n')
    .trim();
}
```

Collapses horizontal whitespace but preserves `\n` — so `<li>` bullets
emitted by `stripHtml` as `\n• item` survive into the final description
output, unlike `normalizeSpace(stripHtml(html))` which flattens everything
to a single line.

**Surgical scope.** Did NOT touch all 148 parsers with a local
`normalizeSpace`; instead, focused on the 16 parsers where the helper is
applied to multi-line description-flow content. For each one:

- `normalizeSpace(stripHtml(<descHtml>))` → `normalizeDescriptionSpace(stripHtml(<descHtml>))`
- `normalizeSpace(<jobDescription>)` (where the field is already multi-line)
  → `normalizeDescriptionSpace(...)`
- Local single-line `function normalizeSpace` removed; import added/extended
  to use the shared `normalizeSpace` + `normalizeDescriptionSpace` exports
  from `crawler-template.mjs`. Title/location/single-line metadata call
  sites unchanged in behavior — same `normalizeSpace`, just imported now.

**Parsers touched (16):** aldi-suisse, alpiq, allianz, amag, baronie,
berner-montage, gemeinde-st-moritz, giardino, hirslanden, hitachi-energy,
kulm-hotel, lombardi, pkb-private-bank, spital-limmattal, spital-thusis,
ubs.

**Parsers deliberately NOT touched.** The other ~130 parsers also have a
local single-line `normalizeSpace`, but they apply it only to single-line
fields (title, company, locality, slug input, URLs) where the existing
semantics are correct. Replacing them would be churn for zero behavior
change, and would balloon the diff well beyond the surgical scope the task
called for. They can be cleaned up separately if/when desired.

`scripts/lib/{crawler-quality-guards,shared-jobs-crawler,dedicated-crawler-common}.mjs`
deliberately unchanged — they're widely used for non-description
normalization and the task explicitly forbade changing them.

## Pre-flight verification

```
npx tsc --noEmit                                   # 0 errors
node scripts/audit-parser-quality.mjs --strict     # 0 critical (193 crawlers, 56 warnings — unchanged from main baseline)
npx vitest run tests/{16 crawler tests}            # 455/455 pass
npx vitest run                                     # full suite — same ~33 pre-existing failures as main, no new failures
```

## Test plan

- [ ] CI green on this branch (parser-quality audit + full vitest + tsc + build)
- [ ] Post-merge cron picks up `normalizeDescriptionSpace` in `crawler-template.mjs`