### PR TITLE
fix(seo): BreadcrumbList JSON-LD on 5 bridge plugins + silence winners-artifact noise

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -116,11 +116,25 @@ jobs:
           path: /tmp/pre-deploy-snapshot
 
       - name: Download previous-slug winners (optional)
-        uses: actions/download-artifact@v5
-        continue-on-error: true   # winners file uploaded only when changed
-        with:
-          name: winners-${{ inputs.deploy_run_id }}
-          path: /tmp/winners
+        # The build job only uploads `winners-${RUN_ID}` when
+        # `data/previous-slug-winners.json` actually changed in the
+        # build commit. Most builds → no upload → download would emit
+        # a noisy "Artifact not found" annotation if we used
+        # actions/download-artifact (continue-on-error suppresses the
+        # failure but NOT the annotation). `gh run download` fails
+        # silently with a clean stderr message instead.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/winners
+          if gh run download "${{ inputs.deploy_run_id }}" \
+               --name "winners-${{ inputs.deploy_run_id }}" \
+               --dir /tmp/winners 2>/dev/null; then
+            echo "[winners] downloaded artifact for run ${{ inputs.deploy_run_id }}"
+          else
+            echo "[winners] artifact not present (file unchanged this build) — skipping"
+          fi
 
       - name: Extract dist/ + restore data files from artifact
         run: |

--- a/build-plugins/calculatorLegacyAliasPlugin.ts
+++ b/build-plugins/calculatorLegacyAliasPlugin.ts
@@ -113,6 +113,7 @@ function buildRewriteScript(legacyPath: string, canonicalPath: string): string {
 function renderAliasPage(entry: LegacyAliasEntry, distDir: string): string {
   const legacyPath = `/${entry.locale}/calcola-stipendio/`;
   const canonicalUrl = `${BASE_URL}${entry.canonicalPath}`;
+  const legacyAbsoluteUrl = `${BASE_URL}${legacyPath}`;
 
   const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
     <header style="margin-bottom:16px">
@@ -120,6 +121,22 @@ function renderAliasPage(entry: LegacyAliasEntry, distDir: string): string {
     </header>
     <p style="margin:0;font-size:15.5px">${entry.prose}</p>
   </main>`;
+
+  // Minimal 2-level BreadcrumbList (Home → page) — required by the D.2 SEO
+  // gate (`tests/seo/breadcrumb-coverage.test.ts`). Describes the legacy URL
+  // visitors actually land on; canonical points to the live calculator.
+  // entry.locale is 'en' | 'de' | 'fr' (the alias is only emitted for non-IT
+  // locales; IT lives at the canonical `/calcola-stipendio/`).
+  const homeLabel = entry.locale === 'de' ? 'Startseite' : entry.locale === 'fr' ? 'Accueil' : 'Home';
+  const homeUrl = `${BASE_URL}/${entry.locale}/`;
+  const breadcrumbLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: homeLabel, item: homeUrl },
+      { '@type': 'ListItem', position: 2, name: entry.h1, item: legacyAbsoluteUrl },
+    ],
+  });
 
   return buildSeoPageHtml({
     locale: entry.locale,
@@ -130,7 +147,7 @@ function renderAliasPage(entry: LegacyAliasEntry, distDir: string): string {
     ogType: 'website',
     ogLocale: entry.ogLocale,
     hreflangHtml: '',
-    jsonLdScripts: [],
+    jsonLdScripts: [breadcrumbLd],
     extraHeadHtml: buildRewriteScript(legacyPath, entry.canonicalPath),
     bodyHtml,
     distDir,

--- a/build-plugins/companyHubBridgePlugin.ts
+++ b/build-plugins/companyHubBridgePlugin.ts
@@ -32,6 +32,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import type { Plugin } from 'vite';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { buildBridgeBreadcrumbLd, JOBS_SECTION_LABEL } from './shared/bridgeBreadcrumb';
 import type { Locale } from '../services/i18n';
 
 const BASE_URL = 'https://frontaliereticino.ch';
@@ -147,28 +148,47 @@ function renderMatchedPage(entry: HubEntry, distDir: string): string {
     <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.matchedLede(entry.displayName, entry.jobCount))}</p>
     <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(buildSectionCanonical(locale))}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
   </main>`;
+  const breadcrumbLd = buildBridgeBreadcrumbLd({
+    locale,
+    baseUrl: BASE_URL,
+    sectionLabel: JOBS_SECTION_LABEL[locale],
+    sectionPath: `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/\/+/g, '/'),
+    pageLabel: entry.displayName,
+    canonicalUrl,
+  });
   return buildSeoPageHtml({
     locale, title: copy.matchedTitle(entry.displayName, entry.jobCount),
     description: copy.matchedDescription(entry.displayName, entry.jobCount),
     canonicalUrl, robots: 'index,follow', ogType: 'website', ogLocale: OG_LOCALE[locale],
-    hreflangHtml: '', jsonLdScripts: [], bodyHtml, distDir, seoMainClass: 'cluster-seo-prose',
+    hreflangHtml: '', jsonLdScripts: [breadcrumbLd], bodyHtml, distDir, seoMainClass: 'cluster-seo-prose',
   });
 }
 
 function renderUnmatchedPage(entry: HubEntry, distDir: string): string {
   const locale = entry.locale;
   const copy = COPY[locale];
+  // Canonical points to the section landing for unmatched entries; the
+  // BreadcrumbList still describes the bridge URL the visitor landed on.
   const canonicalUrl = buildSectionCanonical(locale);
   const sectionPath = buildSectionCanonical(locale);
+  const hubAbsoluteUrl = `${BASE_URL}${buildHubPath(locale, entry.companySlug)}`;
   const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
     <header style="margin-bottom:16px"><h1 style="font-size:26px;font-weight:700;color:var(--color-heading);margin:0 0 8px;letter-spacing:-0.01em">${esc(copy.unmatchedH1(entry.displayName))}</h1></header>
     <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.unmatchedLede)}</p>
     <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(sectionPath)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
   </main>`;
+  const breadcrumbLd = buildBridgeBreadcrumbLd({
+    locale,
+    baseUrl: BASE_URL,
+    sectionLabel: JOBS_SECTION_LABEL[locale],
+    sectionPath: `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/\/+/g, '/'),
+    pageLabel: entry.displayName,
+    canonicalUrl: hubAbsoluteUrl,
+  });
   return buildSeoPageHtml({
     locale, title: copy.unmatchedTitle, description: copy.unmatchedDescription,
     canonicalUrl, robots: 'index,follow', ogType: 'website', ogLocale: OG_LOCALE[locale],
-    hreflangHtml: '', jsonLdScripts: [], bodyHtml, distDir, seoMainClass: 'cluster-seo-prose',
+    hreflangHtml: '', jsonLdScripts: [breadcrumbLd], bodyHtml, distDir, seoMainClass: 'cluster-seo-prose',
   });
 }
 

--- a/build-plugins/jobOrphanBridgePlugin.ts
+++ b/build-plugins/jobOrphanBridgePlugin.ts
@@ -70,6 +70,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import type { Plugin } from 'vite';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { buildBridgeBreadcrumbLd, JOBS_SECTION_LABEL } from './shared/bridgeBreadcrumb';
 import type { Locale } from '../services/i18n';
 
 const BASE_URL = 'https://frontaliereticino.ch';
@@ -220,6 +221,7 @@ function renderMatchedPage(entry: OrphanEntry, distDir: string): string {
   const orphanPath = buildOrphanPath(locale, entry.slug);
   const currentPath = `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/${entry.currentSlug!}/`.replace(/\/+/g, '/');
   const canonicalUrl = buildCanonicalForMatched(locale, entry.currentSlug!);
+  const orphanAbsoluteUrl = `${BASE_URL}${orphanPath}`;
 
   const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
     <header style="margin-bottom:16px">
@@ -228,6 +230,17 @@ function renderMatchedPage(entry: OrphanEntry, distDir: string): string {
     <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.matchedLede)}</p>
     <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(buildSectionCanonical(locale))}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
   </main>`;
+
+  // Breadcrumb describes the orphan URL the visitor actually landed on
+  // (canonical points to the live job, but the bridge is what's served).
+  const breadcrumbLd = buildBridgeBreadcrumbLd({
+    locale,
+    baseUrl: BASE_URL,
+    sectionLabel: JOBS_SECTION_LABEL[locale],
+    sectionPath: `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/\/+/g, '/'),
+    pageLabel: copy.matchedH1,
+    canonicalUrl: orphanAbsoluteUrl,
+  });
 
   return buildSeoPageHtml({
     locale,
@@ -238,7 +251,7 @@ function renderMatchedPage(entry: OrphanEntry, distDir: string): string {
     ogType: 'website',
     ogLocale: OG_LOCALE[locale],
     hreflangHtml: '',
-    jsonLdScripts: [],
+    jsonLdScripts: [breadcrumbLd],
     extraHeadHtml: buildMatchedRewriteScript(orphanPath, currentPath),
     bodyHtml,
     distDir,
@@ -250,8 +263,11 @@ function renderExpiredPage(entry: OrphanEntry, distDir: string): string {
   const locale = entry.locale;
   const copy = COPY[locale];
   const companyHint = humanizeCompanyHint(entry.company);
+  // Canonical points to the section landing for expired entries; the
+  // BreadcrumbList still describes the bridge URL the visitor landed on.
   const canonicalUrl = buildSectionCanonical(locale);
   const sectionPath = buildSectionCanonical(locale);
+  const orphanAbsoluteUrl = `${BASE_URL}${buildOrphanPath(locale, entry.slug)}`;
 
   const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
     <header style="margin-bottom:16px">
@@ -260,6 +276,15 @@ function renderExpiredPage(entry: OrphanEntry, distDir: string): string {
     <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.expiredLede)}</p>
     <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(sectionPath)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
   </main>`;
+
+  const breadcrumbLd = buildBridgeBreadcrumbLd({
+    locale,
+    baseUrl: BASE_URL,
+    sectionLabel: JOBS_SECTION_LABEL[locale],
+    sectionPath: `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/\/+/g, '/'),
+    pageLabel: copy.expiredH1(companyHint),
+    canonicalUrl: orphanAbsoluteUrl,
+  });
 
   return buildSeoPageHtml({
     locale,
@@ -270,7 +295,7 @@ function renderExpiredPage(entry: OrphanEntry, distDir: string): string {
     ogType: 'website',
     ogLocale: OG_LOCALE[locale],
     hreflangHtml: '',
-    jsonLdScripts: [],
+    jsonLdScripts: [breadcrumbLd],
     bodyHtml,
     distDir,
     seoMainClass: 'cluster-seo-prose',

--- a/build-plugins/legacyAliasPlugin.ts
+++ b/build-plugins/legacyAliasPlugin.ts
@@ -60,6 +60,37 @@ const OG_LOCALE: Record<Locale, string> = {
   fr: 'fr_FR',
 };
 
+const HOME_LABEL: Record<Locale, string> = {
+  it: 'Home',
+  en: 'Home',
+  de: 'Startseite',
+  fr: 'Accueil',
+};
+
+const HOME_PREFIX: Record<Locale, string> = {
+  it: '',
+  en: '/en',
+  de: '/de',
+  fr: '/fr',
+};
+
+/**
+ * 2-level BreadcrumbList JSON-LD (Home → page) — broad enough to cover
+ * all 9 sub-cohorts handled by this plugin without per-cohort routing.
+ * Required by `tests/seo/breadcrumb-coverage.test.ts` (D.2 SEO gate).
+ */
+function buildAliasBreadcrumbLd(locale: Locale, pageLabel: string, pageUrl: string): string {
+  const homeUrl = `${BASE_URL}${HOME_PREFIX[locale]}/`.replace(/(?<!:)\/+/g, '/');
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: HOME_LABEL[locale], item: homeUrl },
+      { '@type': 'ListItem', position: 2, name: pageLabel, item: pageUrl },
+    ],
+  });
+}
+
 interface AliasEntry {
   readonly orphanPath: string;
   readonly locale: Locale;
@@ -174,6 +205,7 @@ function renderPage(entry: AliasEntry, distDir: string): string {
   const copy = COPY[locale];
   const block = entry.kind === 'matched' ? copy.matched : copy.unmatched;
   const canonicalUrl = `${BASE_URL}${entry.canonicalPath}`;
+  const orphanAbsoluteUrl = `${BASE_URL}${entry.orphanPath}`;
 
   const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
     <header style="margin-bottom:16px">
@@ -182,6 +214,11 @@ function renderPage(entry: AliasEntry, distDir: string): string {
     <p style="margin:0 0 12px;font-size:15.5px">${esc(block.lede)}</p>
     <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(canonicalUrl)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
   </main>`;
+
+  // Breadcrumb describes the orphan URL the visitor actually landed on
+  // (canonical points to the live target — but the bridge HTML is what's
+  // served from this path). Required by D.2 SEO gate.
+  const breadcrumbLd = buildAliasBreadcrumbLd(locale, block.h1, orphanAbsoluteUrl);
 
   return buildSeoPageHtml({
     locale,
@@ -192,7 +229,7 @@ function renderPage(entry: AliasEntry, distDir: string): string {
     ogType: 'website',
     ogLocale: OG_LOCALE[locale],
     hreflangHtml: '',
-    jsonLdScripts: [],
+    jsonLdScripts: [breadcrumbLd],
     extraHeadHtml: entry.kind === 'matched' ? buildRewriteScript(entry.orphanPath, entry.canonicalPath) : '',
     bodyHtml,
     distDir,

--- a/build-plugins/locationHubBridgePlugin.ts
+++ b/build-plugins/locationHubBridgePlugin.ts
@@ -43,6 +43,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import type { Plugin } from 'vite';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { buildBridgeBreadcrumbLd, JOBS_SECTION_LABEL } from './shared/bridgeBreadcrumb';
 import type { Locale } from '../services/i18n';
 
 const BASE_URL = 'https://frontaliereticino.ch';
@@ -182,6 +183,15 @@ function renderMatchedPage(entry: HubEntry, distDir: string): string {
     <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(buildSectionCanonical(locale))}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
   </main>`;
 
+  const breadcrumbLd = buildBridgeBreadcrumbLd({
+    locale,
+    baseUrl: BASE_URL,
+    sectionLabel: JOBS_SECTION_LABEL[locale],
+    sectionPath: `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/\/+/g, '/'),
+    pageLabel: city,
+    canonicalUrl,
+  });
+
   return buildSeoPageHtml({
     locale,
     title: copy.matchedTitle(city, n),
@@ -191,7 +201,7 @@ function renderMatchedPage(entry: HubEntry, distDir: string): string {
     ogType: 'website',
     ogLocale: OG_LOCALE[locale],
     hreflangHtml: '',
-    jsonLdScripts: [],
+    jsonLdScripts: [breadcrumbLd],
     bodyHtml,
     distDir,
     seoMainClass: 'cluster-seo-prose',
@@ -201,9 +211,14 @@ function renderMatchedPage(entry: HubEntry, distDir: string): string {
 function renderUnmatchedPage(entry: HubEntry, distDir: string): string {
   const locale = entry.locale;
   const copy = COPY[locale];
+  // Canonical points to the section landing for unmatched entries
+  // (they consolidate into the section), but the BreadcrumbList still
+  // describes the bridge URL the visitor actually landed on.
   const canonicalUrl = buildSectionCanonical(locale);
   const sectionPath = buildSectionCanonical(locale);
   const city = entry.displayName;
+  const hubPath = buildHubPath(locale, entry.citySlug);
+  const hubAbsoluteUrl = `${BASE_URL}${hubPath}`;
 
   const bodyHtml = `<main class="cluster-seo-prose" style="max-width:860px;margin:0 auto;padding:24px 16px;color:var(--color-body);line-height:1.65">
     <header style="margin-bottom:16px">
@@ -212,6 +227,15 @@ function renderUnmatchedPage(entry: HubEntry, distDir: string): string {
     <p style="margin:0 0 12px;font-size:15.5px">${esc(copy.unmatchedLede)}</p>
     <p style="margin:12px 0 0;font-size:14.5px"><a href="${esc(sectionPath)}" style="color:var(--color-link);text-decoration:underline;font-weight:600">${esc(copy.browseAllLabel)} →</a></p>
   </main>`;
+
+  const breadcrumbLd = buildBridgeBreadcrumbLd({
+    locale,
+    baseUrl: BASE_URL,
+    sectionLabel: JOBS_SECTION_LABEL[locale],
+    sectionPath: `${LOCALE_PREFIX[locale]}/${SECTION_SLUG[locale]}/`.replace(/\/+/g, '/'),
+    pageLabel: city,
+    canonicalUrl: hubAbsoluteUrl,
+  });
 
   return buildSeoPageHtml({
     locale,
@@ -222,7 +246,7 @@ function renderUnmatchedPage(entry: HubEntry, distDir: string): string {
     ogType: 'website',
     ogLocale: OG_LOCALE[locale],
     hreflangHtml: '',
-    jsonLdScripts: [],
+    jsonLdScripts: [breadcrumbLd],
     bodyHtml,
     distDir,
     seoMainClass: 'cluster-seo-prose',

--- a/build-plugins/shared/bridgeBreadcrumb.ts
+++ b/build-plugins/shared/bridgeBreadcrumb.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared BreadcrumbList JSON-LD builder for bridge plugins.
+ *
+ * Why this exists
+ * ---------------
+ * locationHubBridgePlugin, companyHubBridgePlugin and jobOrphanBridgePlugin
+ * all emit `index,follow` HTML pages via `buildSeoPageHtml`. The
+ * `tests/seo/breadcrumb-coverage.test.ts` (D.2 SEO gate) requires every
+ * non-noindex page in `dist/` to carry a `BreadcrumbList` JSON-LD block —
+ * before this helper, all three plugins passed `jsonLdScripts: []` and
+ * tripped the gate (195 pages flagged in CI run 25688204009).
+ *
+ * Chain shape (3-level, identical for all bridge pages)
+ * ----------------------------------------------------
+ *   1. Home              (locale-prefixed root, e.g. `https://…/` or `/fr/`)
+ *   2. Section landing   (e.g. `/cerca-lavoro-ticino/`,
+ *                              `/fr/trouver-emploi-tessin/`)
+ *   3. The bridge page itself (entity name, item = canonical of the leaf)
+ */
+
+import type { Locale } from '../../services/i18n';
+
+const HOME_LABEL: Record<Locale, string> = {
+  it: 'Home',
+  en: 'Home',
+  de: 'Startseite',
+  fr: 'Accueil',
+};
+
+const LOCALE_PREFIX: Record<Locale, string> = {
+  it: '',
+  en: '/en',
+  de: '/de',
+  fr: '/fr',
+};
+
+interface BridgeBreadcrumbInput {
+  readonly locale: Locale;
+  readonly baseUrl: string;
+  /** Section label shown as the 2nd crumb (e.g. "Lavoro in Ticino"). */
+  readonly sectionLabel: string;
+  /** Section URL path with leading slash and trailing slash. */
+  readonly sectionPath: string;
+  /** Leaf-page label shown as the 3rd crumb (e.g. city or company name). */
+  readonly pageLabel: string;
+  /** Canonical absolute URL of the bridge page itself. */
+  readonly canonicalUrl: string;
+}
+
+/**
+ * Build a 3-level BreadcrumbList JSON-LD string ready to drop into
+ * `jsonLdScripts` of `buildSeoPageHtml`.
+ */
+export function buildBridgeBreadcrumbLd(opts: BridgeBreadcrumbInput): string {
+  const homeUrl = `${opts.baseUrl}${LOCALE_PREFIX[opts.locale]}/`.replace(/(?<!:)\/+/g, '/');
+  const sectionUrl = `${opts.baseUrl}${opts.sectionPath}`.replace(/(?<!:)\/+/g, '/');
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: HOME_LABEL[opts.locale], item: homeUrl },
+      { '@type': 'ListItem', position: 2, name: opts.sectionLabel, item: sectionUrl },
+      { '@type': 'ListItem', position: 3, name: opts.pageLabel, item: opts.canonicalUrl },
+    ],
+  });
+}
+
+/** Locale-aware label for the cross-border jobs section landing. */
+export const JOBS_SECTION_LABEL: Record<Locale, string> = {
+  it: 'Lavoro in Ticino',
+  en: 'Jobs in Ticino',
+  de: 'Stellen im Tessin',
+  fr: 'Emplois au Tessin',
+};


### PR DESCRIPTION
## Summary

Two deploy-fail follow-ups from run [25688204009](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/25688204009).

### 1. `gate:seo-source` fails — 195 pages missing BreadcrumbList JSON-LD

`tests/seo/breadcrumb-coverage.test.ts` (D.2 SEO gate) walks `dist/` and requires every non-noindex page to carry a `BreadcrumbList` JSON-LD block. 5 bridge plugins were emitting `jsonLdScripts: []`.

Patched plugins (all emit `robots: 'index,follow'`):
- `locationHubBridgePlugin.ts` — `/{loc}/{section}/(localita|location|standort|localite)-{city}/`
- `companyHubBridgePlugin.ts` — `/{loc}/{section}/(azienda|company|unternehmen|entreprise)-{co}/`
- `jobOrphanBridgePlugin.ts` — matched + expired job orphans
- `legacyAliasPlugin.ts` — 9 misc sub-cohorts (fuel-station, blog, jobs)
- `calculatorLegacyAliasPlugin.ts` — non-IT `/{loc}/calcola-stipendio/`

New helper `build-plugins/shared/bridgeBreadcrumb.ts` provides a 3-level chain (Home → Section → Page) for the 3 job-bridge plugins; the other 2 use inline 2-level chains because their cohorts are too heterogeneous for a shared section label.

Breadcrumb `item` URLs point at the bridge URL the visitor actually landed on (not the canonical) — canonical drives SERP consolidation while BreadcrumbList describes the served page.

### 2. Winners artifact noise

`actions/download-artifact@v5` emits a noisy `Unable to download artifact` annotation in the run summary even with `continue-on-error: true`. The winners artifact is genuinely optional (uploaded only when `data/previous-slug-winners.json` changes in the build commit). Replaced with `gh run download` which fails silently.

## Out of scope (intentional)

- BFS-depth (330 URLs at depth>4 in `data/bfs-depth-baseline.json`) — the gate currently passes (ratchet only fails on regressions). Reducing depth requires structural internal-link work from depth-2/3 hubs to weekly-employers + job-detail cohorts — separate PR.

## Pre-flight verification

- `npx tsc --noEmit` → 0 errors
- `npx vitest run tests/seo/breadcrumb-coverage.test.ts` → 1 skipped (no dist locally; CI will exercise the real gate)

## Test plan

- [ ] Deploy CI green: `validate-dist/gate:seo-source` passes
- [ ] No `winners-${run_id}` annotation in next validate-dist summary
- [ ] BFS-depth ratchet stays at 330 baseline (no regression)