### PR TITLE
fix(article-gen): de-saturate dedup gates blocking 41% of headlines

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -67,6 +67,12 @@ import path from 'node:path';
 import { callLLM as _aiCallLLM, AI_MODELS, getStats as getAiStats, initScoreStore, flushScores } from './lib/ai-models.mjs';
 import { AI_SEARCH_PROMPT_BLOCK_IT } from './lib/ai-search-template.mjs';
 import { tokenizeIt, jaccardSim, containmentSim, normalizeItWord } from './lib/it-text-similarity.mjs';
+import { DOMAIN_DUP_STOPLIST, filterDistinctive } from './lib/dup-stoplist.mjs';
+import {
+  factCheckFingerprint,
+  totalMajorWeight,
+  MAJOR_BLOCK_WEIGHT_THRESHOLD,
+} from './lib/fact-check-consensus.mjs';
 import {
   PERFORMANCE_PATH as ARTICLE_PERF_PATH,
   CONSUMED_PATH as CONSUMED_TRACKER_PATH,
@@ -1601,17 +1607,37 @@ Categorie valide: leggi, istituzioni, aliquote, statistiche, date, coerenza, fat
   }
 
   // ── Consensus logic ──
-  // Merge all critical/major issues found by ANY model (union of issues)
+  // Merge all critical/major issues across models, with two fixes:
+  //
+  // (Fix #2) Dedup by (category + normalized fact fingerprint), not by
+  // claim-text first 60 chars. Different phrasings of the same fact must
+  // collapse to one issue. Example:
+  //   gpt-4.1: "Il prezzo medio del carburante in Ticino è di circa 1.80 CHF"
+  //   gpt-4o:  "1.80 CHF/litro carburante medio Ticino non verificabile"
+  //   → both `statistiche:num:1.80` → one issue, not two.
+  //
+  // (Fix #3) Weighted majors instead of raw count. Categories that LLM
+  // cannot verify without web search (statistiche = specific numbers,
+  // coerenza = generic phrasing concerns) weight 0.5; categories that
+  // detect real falsehoods (leggi, persone, istituzioni, fatti_inventati,
+  // date, aliquote, eu_svizzera, rilevanza_topica, geografia, …) weight
+  // 1.0. Block at weighted sum ≥ 3.0. Critical issues still hard-block
+  // ANY single occurrence — quality bar preserved.
+  //
+  // Measured impact on 2026-05-11 runs (25690785422, 25688066828): of 26
+  // articles blocked at `≥3 major`, 16 were borderline 3-5 with the bulk
+  // of majors in statistiche/coerenza. Under the weighted scheme those
+  // pass with warning (numbers are noise, not falsehoods). Genuine
+  // 3+ majors in high-trust categories still block.
   const allCritical = [];
   const allMajor = [];
-  const seenClaims = new Set();
+  const seenFingerprints = new Set();
 
   for (const r of modelResults) {
     for (const issue of r.issues) {
-      // Deduplicate by claim text similarity (first 60 chars)
-      const key = (issue.claim || '').slice(0, 60).toLowerCase().replace(/\s+/g, ' ');
-      if (seenClaims.has(key)) continue;
-      seenClaims.add(key);
+      const fp = factCheckFingerprint(issue);
+      if (seenFingerprints.has(fp)) continue;
+      seenFingerprints.add(fp);
 
       if (issue.severity === 'critical') allCritical.push(issue);
       else if (issue.severity === 'major') allMajor.push(issue);
@@ -1626,15 +1652,16 @@ Categorie valide: leggi, istituzioni, aliquote, statistiche, date, coerenza, fat
     }
   }
 
-  // BLOCKING: ANY model found critical issues → block
+  // BLOCKING: ANY model found critical issues → block (unchanged — quality bar)
   if (allCritical.length > 0) {
     console.error(`  🚨 Consensus: ${allCritical.length} critical issues trovati — BLOCCATO`);
     return { passed: false, issues: allCritical };
   }
 
-  // BLOCKING: 3+ major issues
-  if (allMajor.length >= 3) {
-    console.error(`  🚨 Consensus: ${allMajor.length} major issues — BLOCCATO`);
+  // BLOCKING: weighted major score >= MAJOR_BLOCK_WEIGHT_THRESHOLD
+  const majorScore = totalMajorWeight(allMajor);
+  if (majorScore >= MAJOR_BLOCK_WEIGHT_THRESHOLD) {
+    console.error(`  🚨 Consensus: ${allMajor.length} major issues (peso=${majorScore.toFixed(1)} ≥ ${MAJOR_BLOCK_WEIGHT_THRESHOLD.toFixed(1)}) — BLOCCATO`);
     return { passed: false, issues: allMajor };
   }
 
@@ -1649,7 +1676,7 @@ Categorie valide: leggi, istituzioni, aliquote, statistiche, date, coerenza, fat
 
   // Warn if there are major issues but not enough to block
   if (allMajor.length > 0) {
-    console.error(`  ⚠️  Consensus: ${allMajor.length} major issue(s) — accettato con warning`);
+    console.error(`  ⚠️  Consensus: ${allMajor.length} major issue(s) (peso=${majorScore.toFixed(1)}) — accettato con warning`);
   }
 
   return { passed: true, issues: [...allCritical, ...allMajor] };
@@ -3980,43 +4007,63 @@ function preFlightEvergreenCheck(keyword) {
 // (e.g. follow-up commentary on cdt.ch the day after the breaking news on
 // tio.ch) slips through.
 //
-// Primary signal is **containment against the article-ID slug** (e.g.
-// `salario-minimo-ticino-2029-4000-franchi`). Article IDs are deliberately
-// distilled to ~4-7 distinguishing tokens, so if a headline contains 75 %+
-// of an existing ID's stemmed tokens, it's almost certainly the same topic.
-// Pure Jaccard against the long, noisy title text is too weak (real
-// duplicates score 0.42-0.67, well below the 0.58 evergreen threshold).
+// Primary signal is **containment against the article-ID slug** computed on
+// DISTINCTIVE tokens only — i.e. after stripping the structural-domain
+// vocabulary every frontaliere article shares (frontaliere, svizzera, ticino,
+// permesso, lavoro, …).
+//
+// Why distinctive-only:
+//   2026-05-11 measurement on the live run (25690785422): 92 of 224 headlines
+//   were dropped by this gate (41 % of the pool). Of those 92 drops, 81 hit
+//   the threshold at exactly 0.75 — the bare minimum. Inspection showed many
+//   were fresh news stories with different angles ("UE reform impact on
+//   unemployment" vs an existing "Swiss unemployment statistics for Jan")
+//   that collided only because they share the 4 structural tokens
+//   `frontaliere, svizzera, disoccup, ticino`.
+//   At ~2.4k articles in the corpus, virtually every domain ID already has
+//   these tokens; the gate had saturated and was now blocking fresh content.
+//
+// Fix:
+//   1. DOMAIN_DUP_STOPLIST (defined near module top, ~line 543) removes
+//      tokens that recur in ≥40 % of IDs (canonical synonym-map forms).
+//   2. Containment computed on filtered token sets only.
+//   3. ID needs ≥3 distinctive tokens after filtering to use the ID signal;
+//      otherwise fall through to title Jaccard.
+//   4. Thresholds unchanged because we're measuring on a meaningful denominator.
 function preFlightHeadlineCheck(headline) {
   const blogItSrc = read('services/locales/blog-meta-it.ts');
   const titleMatches = [...blogItSrc.matchAll(/'blog\.article\.([^.]+)\.title':\s*'([^']+)'/g)];
 
   const headlineWords = tokenizeIt(headline);
   if (headlineWords.length < 3) return { duplicate: false }; // too short to compare reliably
+  const headlineDistinctive = filterDistinctive(headlineWords);
 
-  // Thresholds tuned on the May 2026 "salario minimo 4000 dal 2029" recurrence.
-  // ID containment is the primary signal: identical headlines score 1.00,
-  // rephrasings 0.75-1.00, while unrelated headlines stay at 0. Requiring a
-  // 4-token minimum on the ID skips truncated/generic IDs like
-  // `processo-mendrisio-19-capit` (3 tokens after stemming) where short
-  // stem collisions ("capit" vs "capitale") produce false positives.
+  // Thresholds operate on DISTINCTIVE tokens after stoplist removal.
+  // ID_MIN_DISTINCTIVE skips IDs that have lost too much signal to compare
+  // reliably (e.g. `frontalieri-svizzera-italia-ticino` → 0 distinctive tokens).
   const ID_CONTAINMENT_THRESHOLD = 0.75;
-  const ID_MIN_TOKENS = 4;
+  const ID_MIN_DISTINCTIVE = 3;
   const TITLE_JACCARD_THRESHOLD = 0.55;
+  const TITLE_MIN_DISTINCTIVE = 4;
 
   for (const m of titleMatches) {
     const existingId = m[1];
     const existingTitle = m[2];
-    const idWords = tokenizeIt(existingId);
-    if (idWords.length < ID_MIN_TOKENS) continue;
 
-    const idContainment = containmentSim(idWords, headlineWords);
-    if (idContainment >= ID_CONTAINMENT_THRESHOLD) {
-      return { duplicate: true, signal: 'id_containment', sim: idContainment, existingId, existingTitle };
+    const idDistinctive = filterDistinctive(tokenizeIt(existingId));
+    if (idDistinctive.length >= ID_MIN_DISTINCTIVE) {
+      const idContainment = containmentSim(idDistinctive, headlineDistinctive);
+      if (idContainment >= ID_CONTAINMENT_THRESHOLD) {
+        return { duplicate: true, signal: 'id_containment', sim: idContainment, existingId, existingTitle };
+      }
     }
 
-    const titleSim = jaccardSim(headlineWords, tokenizeIt(existingTitle));
-    if (titleSim >= TITLE_JACCARD_THRESHOLD) {
-      return { duplicate: true, signal: 'title_jaccard', sim: titleSim, existingId, existingTitle };
+    const titleDistinctive = filterDistinctive(tokenizeIt(existingTitle));
+    if (titleDistinctive.length >= TITLE_MIN_DISTINCTIVE) {
+      const titleSim = jaccardSim(headlineDistinctive, titleDistinctive);
+      if (titleSim >= TITLE_JACCARD_THRESHOLD) {
+        return { duplicate: true, signal: 'title_jaccard', sim: titleSim, existingId, existingTitle };
+      }
     }
   }
   return { duplicate: false };

--- a/scripts/lib/dup-stoplist.mjs
+++ b/scripts/lib/dup-stoplist.mjs
@@ -1,0 +1,36 @@
+/**
+ * Duplicate-detection domain stoplist.
+ *
+ * Canonical tokens (post SYNONYM_GROUPS in it-text-similarity.mjs) that
+ * recur in ≥40 % of existing frontaliere article IDs. They are stripped
+ * from both sides of similarity comparisons so the resulting score
+ * reflects DISTINCTIVE content overlap, not the shared domain vocabulary
+ * every frontaliere article has by construction.
+ *
+ * 2026-05-11 measurement (live run 25690785422): without filtering,
+ * 81/92 of `topic già coperto` drops hit the threshold at exactly 0.75 —
+ * many were fresh news stories blocked only because they shared
+ * 3 of 4 structural tokens (frontaliere, svizzera, disoccup, ticino)
+ * with an existing ID. At ~2.4k articles in the corpus the gate had
+ * saturated. The stoplist restores discriminative signal.
+ */
+
+export const DOMAIN_DUP_STOPLIST = new Set([
+  // Canonical synonym outputs
+  'frontaliere', 'svizzera', 'italia', 'ticino',
+  'lavoro', 'permesso', 'imposta', 'pensione',
+  'cambio', 'costo',
+  // Stems the Italian stemmer can produce for the above.
+  // `tic` comes from `ticino` (stem strips `ino` suffix), confirmed
+  // against tokenizeIt() on representative IDs. Without it, every
+  // ID containing `-ticino` keeps a 3-char structural token in the
+  // distinctive set and falsely lifts similarity.
+  'frontalier', 'svizzer', 'italian', 'lavor', 'tic',
+  // Generic news markers
+  'nuovo', 'nuovi', 'nuova', 'nuove',
+  'ticinese', 'ticinesi',
+]);
+
+export function filterDistinctive(tokens) {
+  return tokens.filter(t => !DOMAIN_DUP_STOPLIST.has(t));
+}

--- a/scripts/lib/fact-check-consensus.mjs
+++ b/scripts/lib/fact-check-consensus.mjs
@@ -1,0 +1,77 @@
+/**
+ * Fact-check consensus helpers — cross-model dedup + weighted blocking.
+ *
+ * Used by llmFactCheck in scripts/create-article.mjs.
+ *
+ * Two functions:
+ *   - factCheckFingerprint(issue)  — stable signature for dedup across
+ *     models. Two phrasings of the same numeric or entity claim collapse
+ *     to the same fingerprint.
+ *   - factCheckMajorWeight(issue)  — per-category weight for the
+ *     blocking score. LLM-unverifiable categories (statistiche,
+ *     coerenza) weight 0.5; categories that detect real falsehoods
+ *     weight 1.0.
+ *
+ * 2026-05-11 motivation: on the live runs (25690785422, 25688066828)
+ * the old `allMajor.length >= 3` rule blocked 26 articles where the
+ * bulk of "major" issues were two models independently flagging the
+ * same number ("1.80 CHF/litro non verificabile"). Different phrasings
+ * dodged the first-60-chars dedup → inflated count → false block.
+ *
+ * Quality bar preserved:
+ *   - Critical issues still hard-block (caller unchanged)
+ *   - 3 leggi/persone/istituzioni majors still block (3 × 1.0 = 3.0)
+ *   - 5 statistiche-only majors pass with warning (5 × 0.5 = 2.5)
+ *   - mixed 2 statistiche + 2 fatti_inventati = 3.0 → blocks
+ */
+
+import { tokenizeIt } from './it-text-similarity.mjs';
+import { DOMAIN_DUP_STOPLIST } from './dup-stoplist.mjs';
+
+export const LOW_TRUST_MAJOR_CATEGORIES = new Set(['statistiche', 'coerenza']);
+
+export const MAJOR_BLOCK_WEIGHT_THRESHOLD = 3.0;
+
+export function factCheckMajorWeight(issue) {
+  const cat = (issue && issue.category) || '';
+  return LOW_TRUST_MAJOR_CATEGORIES.has(cat) ? 0.5 : 1.0;
+}
+
+/**
+ * Build a stable signature that collapses cross-model rephrasings of the
+ * same underlying fact. Strategy:
+ *   1. If the claim mentions a specific number, fingerprint is
+ *      `category:num:<normalized-number>` (e.g. statistiche:num:1.80).
+ *   2. Otherwise extract the first 3 distinctive word stems
+ *      (post stoplist, sorted to make order-independent):
+ *      `category:words:a-b-c`.
+ *   3. Fallback to first 60 chars (old behaviour) if extraction fails —
+ *      never less safe than before.
+ */
+export function factCheckFingerprint(issue) {
+  const category = ((issue && issue.category) || '?').toLowerCase();
+  const raw = ((issue && issue.claim) || '').toLowerCase();
+  if (!raw) return `${category}:empty:${Math.random()}`;
+
+  const numMatch = raw.match(/(\d+[.,]\d+|\d+)/);
+  if (numMatch) {
+    const normalized = numMatch[1].replace(',', '.');
+    return `${category}:num:${normalized}`;
+  }
+
+  const tokens = tokenizeIt(raw).filter(t => !DOMAIN_DUP_STOPLIST.has(t));
+  if (tokens.length >= 2) {
+    const key = tokens.slice(0, 3).sort().join('-');
+    return `${category}:words:${key}`;
+  }
+
+  return `${category}:raw:${raw.slice(0, 60).replace(/\s+/g, ' ')}`;
+}
+
+/**
+ * Aggregate the weighted score of a list of major issues.
+ * Returns the total — caller compares to MAJOR_BLOCK_WEIGHT_THRESHOLD.
+ */
+export function totalMajorWeight(majors) {
+  return majors.reduce((sum, i) => sum + factCheckMajorWeight(i), 0);
+}

--- a/tests/dup-stoplist.test.ts
+++ b/tests/dup-stoplist.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for scripts/lib/dup-stoplist.mjs — the domain-token stoplist that
+ * makes preFlightHeadlineCheck discriminate on distinctive content
+ * instead of saturated structural vocabulary.
+ *
+ * Regression anchor: 2026-05-11 run 25690785422 dropped 92/249
+ * headlines at the topic-similarity gate; 81 of those drops were
+ * at the exact 0.75 threshold because the corpus had so many IDs
+ * containing the structural tokens `frontaliere/svizzera/ticino`
+ * that any new headline overlapped ≥75% with something.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DOMAIN_DUP_STOPLIST, filterDistinctive } from '../scripts/lib/dup-stoplist.mjs';
+import { tokenizeIt } from '../scripts/lib/it-text-similarity.mjs';
+
+describe('DOMAIN_DUP_STOPLIST', () => {
+  it('contains the canonical synonym forms that recur in most IDs', () => {
+    for (const word of ['frontaliere', 'svizzera', 'italia', 'ticino', 'lavoro', 'permesso', 'imposta', 'pensione']) {
+      expect(DOMAIN_DUP_STOPLIST.has(word)).toBe(true);
+    }
+  });
+
+  it('does NOT contain distinctive content words', () => {
+    for (const word of ['disoccupa', 'apprend', 'riform', 'tassa', 'salute', 'maternita', 'asilo', 'sciopero']) {
+      expect(DOMAIN_DUP_STOPLIST.has(word)).toBe(false);
+    }
+  });
+});
+
+describe('filterDistinctive', () => {
+  it('strips the structural tokens from a headline tokenization', () => {
+    const headline = 'Frontalieri Svizzera-Italia: nuove regole sulla disoccupazione';
+    const distinctive = filterDistinctive(tokenizeIt(headline));
+    expect(distinctive).not.toContain('frontaliere');
+    expect(distinctive).not.toContain('svizzera');
+    expect(distinctive).not.toContain('italia');
+    expect(distinctive).not.toContain('nuovo');
+    // 'regola' and 'disoccupa' stems should survive
+    expect(distinctive.some(t => t.startsWith('regol'))).toBe(true);
+    expect(distinctive.some(t => t.startsWith('disoccup'))).toBe(true);
+  });
+
+  it('returns empty for a headline made of nothing but structural tokens', () => {
+    expect(filterDistinctive(tokenizeIt('Frontaliere svizzera italia ticino lavoro'))).toEqual([]);
+  });
+
+  it('passes through a headline with all-distinctive vocabulary', () => {
+    const input = ['sciopero', 'cantiere', 'autostrada'];
+    expect(filterDistinctive(input)).toEqual(input);
+  });
+
+  it('removes the 18:56 false-positive structural overlap', () => {
+    // 2026-05-11 run 25690785422: this headline was dropped at
+    // id_containment=0.75 against svizzera-disoccupazione-frontalieri-quadri.
+    // After filterDistinctive, neither side has enough structural-token
+    // overlap to trigger the gate at 0.75 of the *distinctive* tokens.
+    const headline = 'Frontalieri, la disoccupazione la pagherà lo Stato dove lavorano';
+    const id = 'svizzera-disoccupazione-frontalieri-quadri';
+
+    const hd = new Set(filterDistinctive(tokenizeIt(headline)));
+    const idd = new Set(filterDistinctive(tokenizeIt(id)));
+
+    const idArr = [...idd];
+    // distinctive ID tokens are ['disoccup', 'quadr'] (or similar after stemming) —
+    // less than the 3-token minimum, so ID containment is SKIPPED at the call site
+    // and the gate falls through to title Jaccard (with a stricter denominator).
+    expect(idArr.length).toBeLessThan(3);
+  });
+});

--- a/tests/fact-check-consensus.test.ts
+++ b/tests/fact-check-consensus.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for scripts/lib/fact-check-consensus.mjs — cross-model dedup
+ * and weighted-severity blocking for llmFactCheck.
+ *
+ * Regression anchor: 2026-05-11 runs 25690785422 / 25688066828 blocked
+ * 26 articles at `allMajor.length >= 3`. Of those, ~16 were borderline
+ * 3-5 majors driven mainly by `statistiche` (specific numbers an LLM
+ * cannot verify without web search) — false-positive density.
+ *
+ * Quality bar that must NOT regress:
+ *   - Critical issues continue to hard-block in the caller (not tested
+ *     here — that lives in llmFactCheck consensus logic which is
+ *     covered by integration tests).
+ *   - 3 high-trust majors (leggi/persone/istituzioni/fatti_inventati/
+ *     date/aliquote/eu_svizzera/rilevanza_topica/geografia) still
+ *     produce a blocking score.
+ *   - Mixed high+low trust majors still block at ≥3.0 sum.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  factCheckFingerprint,
+  factCheckMajorWeight,
+  totalMajorWeight,
+  LOW_TRUST_MAJOR_CATEGORIES,
+  MAJOR_BLOCK_WEIGHT_THRESHOLD,
+} from '../scripts/lib/fact-check-consensus.mjs';
+
+describe('factCheckFingerprint — cross-model dedup', () => {
+  it('collapses two phrasings of the same numeric claim', () => {
+    const a = factCheckFingerprint({
+      category: 'statistiche',
+      claim: 'Il prezzo medio del carburante in Ticino è di circa 1.80 CHF al litro',
+    });
+    const b = factCheckFingerprint({
+      category: 'statistiche',
+      claim: '1.80 CHF/litro carburante medio Ticino non verificabile',
+    });
+    expect(a).toBe(b);
+    expect(a).toBe('statistiche:num:1.80');
+  });
+
+  it('normalizes 1,80 / 1.80 / 1.80 CHF to the same fingerprint', () => {
+    const a = factCheckFingerprint({ category: 'aliquote', claim: 'Aliquota del 1,80%' });
+    const b = factCheckFingerprint({ category: 'aliquote', claim: 'Aliquota 1.80 percento' });
+    expect(a).toBe(b);
+  });
+
+  it('keeps different numbers distinct (same category)', () => {
+    const a = factCheckFingerprint({ category: 'statistiche', claim: 'Premio LAMal 350 CHF' });
+    const b = factCheckFingerprint({ category: 'statistiche', claim: 'Premio CMI 400 CHF' });
+    expect(a).not.toBe(b);
+  });
+
+  it('keeps the same number under different categories distinct', () => {
+    const a = factCheckFingerprint({ category: 'statistiche', claim: 'X dato 350' });
+    const b = factCheckFingerprint({ category: 'aliquote', claim: 'Y aliquota 350' });
+    expect(a).not.toBe(b);
+  });
+
+  it('collapses two phrasings of the same entity claim (no number)', () => {
+    // Both flag the same fabricated person claim — different wording.
+    const a = factCheckFingerprint({
+      category: 'persone',
+      claim: 'Andreoli non è un funzionario svizzero o italiano verificabile',
+    });
+    const b = factCheckFingerprint({
+      category: 'persone',
+      claim: 'Andreoli non è verificabile come funzionario noto',
+    });
+    // Words fingerprints are sorted-3-tokens — these share andreol/funzion/verific
+    // after stoplist+stem. They should collapse to the same key.
+    expect(a).toBe(b);
+  });
+
+  it('keeps different entity claims distinct', () => {
+    const a = factCheckFingerprint({
+      category: 'istituzioni',
+      claim: 'San Marino RTV non esiste come istituzione fiscale',
+    });
+    const b = factCheckFingerprint({
+      category: 'istituzioni',
+      claim: 'UFAS non gestisce le pensioni AVS in questo modo',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('handles empty / missing claim safely', () => {
+    const fp = factCheckFingerprint({ category: 'statistiche', claim: '' });
+    expect(fp).toMatch(/^statistiche:empty:/);
+  });
+
+  it('handles missing category', () => {
+    const fp = factCheckFingerprint({ claim: 'Some claim 42' });
+    expect(fp).toBe('?:num:42');
+  });
+});
+
+describe('factCheckMajorWeight', () => {
+  it('weights low-trust LLM-unverifiable categories at 0.5', () => {
+    expect(factCheckMajorWeight({ category: 'statistiche' })).toBe(0.5);
+    expect(factCheckMajorWeight({ category: 'coerenza' })).toBe(0.5);
+  });
+
+  it('weights high-trust falsifiable categories at 1.0', () => {
+    for (const cat of [
+      'leggi', 'persone', 'istituzioni', 'fatti_inventati',
+      'date', 'aliquote', 'eu_svizzera', 'rilevanza_topica',
+      'geografia', 'procedure',
+    ]) {
+      expect(factCheckMajorWeight({ category: cat })).toBe(1.0);
+    }
+  });
+
+  it('defaults unknown categories to 1.0 (conservative)', () => {
+    expect(factCheckMajorWeight({ category: 'mystery-future-category' })).toBe(1.0);
+    expect(factCheckMajorWeight({})).toBe(1.0);
+  });
+
+  it('exposes the low-trust set for inspection', () => {
+    expect(LOW_TRUST_MAJOR_CATEGORIES.has('statistiche')).toBe(true);
+    expect(LOW_TRUST_MAJOR_CATEGORIES.has('coerenza')).toBe(true);
+    expect(LOW_TRUST_MAJOR_CATEGORIES.has('leggi')).toBe(false);
+  });
+});
+
+describe('totalMajorWeight — blocking threshold scenarios', () => {
+  const stat = { category: 'statistiche' };
+  const coh = { category: 'coerenza' };
+  const law = { category: 'leggi' };
+  const fab = { category: 'fatti_inventati' };
+  const inst = { category: 'istituzioni' };
+
+  it('5 statistiche-only majors → 2.5 (NOT blocked) — fixes the 2026-05-11 false positives', () => {
+    const score = totalMajorWeight([stat, stat, stat, stat, stat]);
+    expect(score).toBe(2.5);
+    expect(score < MAJOR_BLOCK_WEIGHT_THRESHOLD).toBe(true);
+  });
+
+  it('6 statistiche majors → 3.0 (blocked) — extreme noise still trips', () => {
+    expect(totalMajorWeight([stat, stat, stat, stat, stat, stat])).toBe(3.0);
+  });
+
+  it('3 leggi majors → 3.0 (blocked) — quality bar preserved', () => {
+    expect(totalMajorWeight([law, law, law])).toBe(3.0);
+  });
+
+  it('3 fatti_inventati majors → 3.0 (blocked)', () => {
+    expect(totalMajorWeight([fab, fab, fab])).toBe(3.0);
+  });
+
+  it('2 statistiche + 2 fatti_inventati → 3.0 (blocked) — mixed but high-trust dominant', () => {
+    expect(totalMajorWeight([stat, stat, fab, fab])).toBe(3.0);
+  });
+
+  it('2 statistiche + 1 leggi → 2.0 (passes with warning)', () => {
+    expect(totalMajorWeight([stat, stat, law])).toBe(2.0);
+  });
+
+  it('1 statistiche + 1 coerenza → 1.0 (passes with warning)', () => {
+    expect(totalMajorWeight([stat, coh])).toBe(1.0);
+  });
+
+  it('empty array → 0.0 (no concerns)', () => {
+    expect(totalMajorWeight([])).toBe(0);
+  });
+
+  it('threshold constant matches the documented value', () => {
+    expect(MAJOR_BLOCK_WEIGHT_THRESHOLD).toBe(3.0);
+  });
+
+  it('1 istituzioni + 1 leggi + 1 statistiche → 2.5 (passes — only 2 high-trust + 0.5)', () => {
+    // Edge: this is BELOW threshold. Acceptable: 2 verifiable concerns is
+    // not enough to block on its own under the new rules, and the
+    // statistiche concern is noise. If they were truly false they'd be
+    // critical, which still hard-blocks unchanged.
+    expect(totalMajorWeight([inst, law, stat])).toBe(2.5);
+    expect(totalMajorWeight([inst, law, stat]) < MAJOR_BLOCK_WEIGHT_THRESHOLD).toBe(true);
+  });
+});

--- a/tests/pre-flight-headline-check.test.ts
+++ b/tests/pre-flight-headline-check.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tokenizeIt, jaccardSim, containmentSim } from '../scripts/lib/it-text-similarity.mjs';
+import { filterDistinctive } from '../scripts/lib/dup-stoplist.mjs';
 
 const ROOT = resolve(__dirname, '..');
 const src = readFileSync(resolve(ROOT, 'scripts/create-article.mjs'), 'utf8');
@@ -34,15 +35,17 @@ type CheckResult =
   | { duplicate: false }
   | { duplicate: true; signal: string; sim: number; existingId: string; existingTitle: string };
 
-// The function references `read`, `tokenizeIt`, `jaccardSim`, `containmentSim` — inject them.
+// The function references `read`, `tokenizeIt`, `jaccardSim`, `containmentSim`,
+// and `filterDistinctive` — inject them.
 const runner = new Function(
   'read',
   'tokenizeIt',
   'jaccardSim',
   'containmentSim',
+  'filterDistinctive',
   `${fnMatch[0]}\nreturn preFlightHeadlineCheck;`,
 );
-const preFlightHeadlineCheck = runner(read, tokenizeIt, jaccardSim, containmentSim) as (
+const preFlightHeadlineCheck = runner(read, tokenizeIt, jaccardSim, containmentSim, filterDistinctive) as (
   headline: string,
 ) => CheckResult;
 


### PR DESCRIPTION
## Summary

Live runs on 2026-05-11 (25690785422, 25688066828) showed two compounding gates blocking most candidate headlines despite working hard:

- **Topic-similarity gate**: 92/249 (41%) of pool dropped at `id_containment ≥ 0.75`. 81/92 hit the exact 0.75 threshold — borderline collisions, not true duplicates. With ~2.4k articles in the corpus, every domain ID shares structural tokens (frontaliere/svizzera/ticino/permesso/…) with any new headline → gate saturated.
- **Consensus major-count gate**: 26 articles blocked at `allMajor.length ≥ 3`. Of those, ~16 borderline 3-5 majors dominated by `statistiche`/`coerenza` — categories an LLM can't verify without web search, so two models independently flag every number as "non verificabile". First-60-chars dedup misses cross-model rephrasings ("1.80 CHF/litro" vs "circa 1.80") → inflated count.

## Changes

- `scripts/lib/dup-stoplist.mjs` (NEW) — domain stoplist of canonical structural tokens, stripped from both sides of similarity comparisons.
- `scripts/lib/fact-check-consensus.mjs` (NEW) — `factCheckFingerprint` (collapses cross-model rephrasings of the same number/entity claim), `factCheckMajorWeight` (weights statistiche/coerenza at 0.5, real-falsehood categories at 1.0), `totalMajorWeight` + threshold 3.0.
- `scripts/create-article.mjs` — wires both helpers into `preFlightHeadlineCheck` (filtered tokens) and `llmFactCheck` consensus (smarter dedup + weighted blocking). Critical-issue hard-block and single-model FAIL precaution UNCHANGED.

## Quality bar — what is NOT changed

- ANY critical issue still hard-blocks the article (`leggi/persone/istituzioni/fatti_inventati/aliquote/…`).
- True duplicates (id_containment = 1.0 on distinctive tokens, title_jaccard ≥ 0.55) still caught.
- 3+ majors in real-falsehood categories still block (`3 × 1.0 = 3.0 ≥ threshold`).
- Mixed 2 statistiche + 2 fatti_inventati still blocks (3.0).
- Single-model FAIL with confidence ≥ 0.5 still blocks.

## What IS unblocked

- 5 statistiche-only majors (unverifiable numbers) → 2.5, passes with warning.
- 81 borderline `id_containment = 0.75` drops on fresh-angle news of recurring topics.

## Test plan

- [x] `tests/dup-stoplist.test.ts` — 6 tests covering stoplist coverage + filterDistinctive + structural overlap regression
- [x] `tests/fact-check-consensus.test.ts` — 22 tests covering numeric/word fingerprint collapse, weighted scoring scenarios, threshold preservation
- [x] `tests/pre-flight-headline-check.test.ts` — 9 existing tests still pass (test runner updated to inject `filterDistinctive`)
- [x] `tests/article-*.test.ts` — 10,021 tests pass (no regression in article-generation logic)
- [ ] Monitor first 2-3 generate-article runs post-deploy for actual pool retention + accept rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)