### PR TITLE
fix(article-gen): catch REGOLA #0 topic-gate aborts in retry loop

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -5943,10 +5943,21 @@ async function main() {
               console.error(`\n⚠️  ${MAX_DUPLICATE_RETRIES} tentativi ${pool.name} esauriti — tutti duplicati.`);
               break; // try next pool, then evergreen
             }
-            // Fact-check / quality failures → skip this article, try next
-            const isQualityReject = /fact-check|rigettato|veridicità|fabricat/i.test(e.message);
+            // Fact-check / quality failures → skip this article, try next.
+            // Includes REGOLA #0 topic-gate aborts: when the LLM correctly
+            // refuses to fabricate a frontaliere angle on a cronaca-nera or
+            // non-relevant source (see line ~2787), the error carries
+            // err.topicGateAbort=true. Without this branch the abort
+            // propagates to main() and fails the whole run instead of
+            // letting the loop try a different headline (run 25697916845,
+            // 2026-05-11). Same quality outcome (slop not published)
+            // but workflow stays green and retry budget is honored.
+            const isTopicGateAbort = e.topicGateAbort === true || /topic-gate abort/i.test(e.message);
+            const isQualityReject = isTopicGateAbort
+              || /fact-check|rigettato|veridicità|fabricat/i.test(e.message);
             if (isQualityReject && attempt < MAX_DUPLICATE_RETRIES) {
-              console.error(`\n⚠️  Articolo rigettato per qualità — provo un altro headline... (${attempt}/${MAX_DUPLICATE_RETRIES})\n`);
+              const tag = isTopicGateAbort ? 'topic-gate (REGOLA #0)' : 'qualità';
+              console.error(`\n⚠️  Articolo rigettato per ${tag} — provo un altro headline... (${attempt}/${MAX_DUPLICATE_RETRIES})\n`);
               url = null;
               continue;
             }
@@ -6084,11 +6095,17 @@ async function main() {
         } catch (e) {
           const isDuplicate = e.message.includes('DUPLICATO');
           if (isDuplicate) captureDuplicateReasons(e.message);
-          // Fact-check / quality failures → try next keyword instead of crashing
-          const isQualityReject = /fact-check|rigettato|veridicità|fabricat/i.test(e.message);
+          // Fact-check / quality failures → try next keyword instead of crashing.
+          // Includes REGOLA #0 topic-gate aborts — same rationale as the proven-pool
+          // branch above (~line 5946).
+          const isTopicGateAbort = e.topicGateAbort === true || /topic-gate abort/i.test(e.message);
+          const isQualityReject = isTopicGateAbort
+            || /fact-check|rigettato|veridicità|fabricat/i.test(e.message);
           if (!isDuplicate && !isQualityReject) throw e; // Infrastructure error → propagate
 
-          if (isQualityReject) {
+          if (isTopicGateAbort) {
+            console.error(`\n⚠️  Keyword evergreen rigettata da topic-gate (REGOLA #0) — cerco prossima keyword...\n`);
+          } else if (isQualityReject) {
             console.error(`\n⚠️  Articolo evergreen rigettato per qualità — cerco prossima keyword...\n`);
           } else {
             console.error(`\n🔄 Duplicato post-generazione, cerco prossima keyword sicura...\n`);

--- a/tests/topic-gate-abort-retry.test.ts
+++ b/tests/topic-gate-abort-retry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for the topic-gate-abort retry logic in
+ * scripts/create-article.mjs.
+ *
+ * 2026-05-11 incident (run 25697916845): the REGOLA #0 topic-gate added
+ * in PR #94 correctly rejected a cronaca-nera headline (good!) by
+ * throwing an Error with `err.topicGateAbort = true`. The headline-retry
+ * loops (proven pool + evergreen) detected fact-check / fabrication
+ * rejects via a regex on the error message, but the regex did NOT cover
+ * `Topic-gate abort: …`. So the error propagated up to main(), the
+ * workflow exited with code 1, and the next headline was never tried.
+ *
+ * Fix: both quality-reject branches now also flag `err.topicGateAbort
+ * === true` OR `/topic-gate abort/i` in the message. The loop continues
+ * to the next headline / keyword. Same quality outcome (slop not
+ * published) but workflow stays green and retry budget is honored.
+ *
+ * This test parses the source file and asserts the recognition logic
+ * matches both error shapes at both call sites.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '..', 'scripts/create-article.mjs'),
+  'utf8',
+);
+
+describe('topic-gate-abort recovery in headline retry loops', () => {
+  it('recognises err.topicGateAbort and the message pattern at the proven-pool catch site', () => {
+    // The proven-pool retry loop is around line 5946 (Fact-check / quality
+    // failures branch inside the per-pool catch). Both shapes must be checked.
+    const provenBlock = SRC.match(
+      /\/\/ Fact-check \/ quality failures → skip this article, try next[\s\S]*?break; \/\/ try next pool, then evergreen\n\s+\}/,
+    );
+    expect(provenBlock, 'proven-pool quality-reject block not found').toBeTruthy();
+    expect(provenBlock![0]).toMatch(/e\.topicGateAbort\s*===\s*true/);
+    expect(provenBlock![0]).toMatch(/\/topic-gate abort\/i/);
+    expect(provenBlock![0]).toMatch(/isQualityReject\s*=\s*isTopicGateAbort/);
+  });
+
+  it('recognises err.topicGateAbort and the message pattern at the evergreen catch site', () => {
+    const evergreenBlock = SRC.match(
+      /\/\/ Fact-check \/ quality failures → try next keyword instead of crashing[\s\S]*?Duplicato post-generazione[\s\S]*?\}/,
+    );
+    expect(evergreenBlock, 'evergreen quality-reject block not found').toBeTruthy();
+    expect(evergreenBlock![0]).toMatch(/e\.topicGateAbort\s*===\s*true/);
+    expect(evergreenBlock![0]).toMatch(/\/topic-gate abort\/i/);
+  });
+
+  it('the original topicGateAbort throw site still tags the error', () => {
+    // Sanity: the throw site that creates err.topicGateAbort=true is still
+    // present. If this guard is ever removed without updating the recognition
+    // regex, the loop falls back to the message-pattern match instead.
+    expect(SRC).toMatch(/err\.topicGateAbort\s*=\s*true/);
+    expect(SRC).toMatch(/Topic-gate abort:/);
+  });
+
+  it('recognition is order-safe: topicGateAbort flag is checked before the message regex', () => {
+    // Both shapes are valid signals; the flag check is faster and clearer.
+    // We use `||` so even if the message text changes, the flag catches it.
+    const provenBlock = SRC.match(
+      /isTopicGateAbort\s*=\s*e\.topicGateAbort\s*===\s*true\s*\|\|\s*\/topic-gate abort\/i\.test\(e\.message\)/g,
+    );
+    expect(provenBlock).toBeTruthy();
+    expect(provenBlock!.length).toBeGreaterThanOrEqual(2); // both call sites
+  });
+});


### PR DESCRIPTION
## Summary

Run 25697916845 (post-PR-100, 2026-05-11) failed with exit code 1 because the topic-gate abort error from REGOLA #0 (PR #94) propagated to main() instead of being caught by the headline-retry loop. The off-topic rejection itself was correct — a cronaca-nera headline rightly refused — but the workflow exited red instead of trying the next headline.

## Root cause

The two quality-reject branches detect rejection via a regex on `e.message`:

```js
const isQualityReject = /fact-check|rigettato|veridicità|fabricat/i.test(e.message);
```

The throw at line 2787 produces `Error("Topic-gate abort: …")` with `err.topicGateAbort = true`. Neither shape matches the regex → the error escapes the loop → main() catches it → exit 1.

## Fix

Both call sites (`scripts/create-article.mjs:5946` proven-pool, `:6087` evergreen) now also flag `e.topicGateAbort === true` OR `/topic-gate abort/i` in the message as a quality-reject. Loop continues to the next headline / keyword.

## Quality bar — UNCHANGED

- REGOLA #0 still rejects off-topic content (cronaca nera, music, weather, generic non-frontaliere news).
- No slop / fabricated article is published — same rejection outcome.
- The only change: workflow stays green when the retry budget is honored, instead of red-flagging exit-1.

## Test plan

- [x] `tests/topic-gate-abort-retry.test.ts` — 4 tests asserting both call sites recognise both signal shapes (flag + regex), and the throw site still tags the error
- [x] 10,022 article-gen tests still pass (no regression)
- [ ] Monitor next 2-3 runs to confirm topic-gate-abort runs now succeed (no_changes status instead of failure)

Follow-up to #100 — the dedup-gate de-saturation is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)