### PR TITLE
fix(workflow): assemble jobs.json before build in generate-article

### DIFF
--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -148,6 +148,17 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         run: node scripts/generate-image-thumbnails.mjs
 
+      # 2026-05-11 23:19 CEST commit c7c6ac6292 (cathedral redirect canton-inference)
+      # added non-optional `import jobsFile from '../data/jobs.json'` to
+      # build-plugins/legacyRedirectsPlugin.ts and build-plugins/shared/slugCantonIndex.ts.
+      # data/jobs.json is gitignored — it must be assembled at runtime before
+      # any `vite build` runs. Three articles (23:33, 00:05, 04:01 UTC on 2026-05-12)
+      # were generated successfully but LOST because build:prod could not resolve
+      # the import. Mirror the prepush hook's assemble step.
+      - name: Assemble jobs dataset (build prerequisite)
+        if: steps.changes.outputs.has_changes == 'true'
+        run: node scripts/assemble-jobs-dataset.mjs --stats
+
       - name: Build for production
         if: steps.changes.outputs.has_changes == 'true'
         env:


### PR DESCRIPTION
## Summary

Three articles generated in the last 9 hours were LOST because \`build:prod\` couldn't resolve \`data/jobs.json\` (gitignored):

- 04:01 UTC — \`temporali-grandine-luganese-11-maggio-2026\` → LOST
- 00:05 UTC — \`allevamento-abusivo-brusimpiano-40-cuccioli\` → LOST
- 23:33 UTC — (article) → LOST

All three workflow runs (25712525378, 25704790946, 25703628166) failed identically:

\`\`\`
✘ [ERROR] Could not resolve "../data/jobs.json"
✘ [ERROR] Could not resolve "../../data/jobs.json"
\`\`\`

## Root cause

Commit \`c7c6ac6292\` (cathedral redirect canton-inference, 2026-05-11 23:19 CEST) added non-optional JSON imports of \`data/jobs.json\` in two build plugins. \`data/jobs.json\` is gitignored — must be assembled at runtime before \`vite build\` runs. The prepush hook and the deploy workflow both do this; the generate-article workflow did not.

## Fix

Add an "Assemble jobs dataset" step between "Generate responsive image thumbnails" and "Build for production", gated on \`has_changes == 'true'\`.

## Test plan

- [x] YAML validates locally
- [x] \`scripts/assemble-jobs-dataset.mjs\` exists and is the same script used by prepush + deploy workflows
- [ ] Next post-merge generate-article run completes through Build for production and commits the article (monitor via \`gh run watch\`)

Unrelated to PR #100 / PR #101 (gate-precision work) — workflow-level prerequisite gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)