### PR TITLE
fix(article-gen): prevent fabricated frontaliere case-examples (3-layer)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -76,6 +76,7 @@ import {
 import {
   stripCompetitorPromotion,
   sanitizeNavLinkSemantics,
+  stripFabricatedExamples,
 } from './lib/article-sanitizers.mjs';
 import {
   PERFORMANCE_PATH as ARTICLE_PERF_PATH,
@@ -1530,6 +1531,18 @@ VERIFICA SISTEMATICA — controlla OGNI categoria:
 
 7. **FATTI INVENTATI**: Cerca eventi, conferenze, referendum, proteste, dichiarazioni che sembrano plausibili ma potrebbero non essere mai avvenuti. SEGNALE D'ALLARME: eventi descritti con molti dettagli specifici (data precisa, luogo, partecipanti) che non appaiono in nessuna fonte nota.
 
+   **SOTTOCATEGORIA — ESEMPI CONCRETI FABBRICATI (CRITICAL — incidente 2026-05-12 USZ whistleblower)**: scrutina con MASSIMA attenzione le sezioni titolate "Esempi concreti / Casi pratici / Casi reali / Per esempio / Caso 1, Caso 2". Pattern shipped che il fact-check aveva mancato:
+   - "Lugano: Un'infermiera frontaliera ha segnalato carenze igieniche..."
+   - "Chiasso: Un medico ha denunciato pratiche non etiche..."
+   - "Un infermiere dell'ORL ha ottenuto il recupero di CHF 50.000..."
+   - "Un medico dell'Ospedale Civico di Lugano ha denunciato pratiche di bilancio fraudolente, risultando in un'indagine della FINMA"
+
+   REGOLA: qualunque bullet o paragrafo che combini (a) [Città CH o nome ospedale/azienda] + (b) [ruolo professionale: infermiere/medico/operaio/impiegato/chirurgo] + (c) [verbo specifico: ha segnalato/denunciato/ottenuto/recuperato] + (d) [esito o cifra specifica: CHF nnn, indagine, risarcimento, recupero], SENZA che il caso compaia nella fonte originale → CRITICAL: fatti_inventati. Onere della prova: l'articolo deve PROVARE che il caso esiste nella fonte; altrimenti è inventato per gonfiare la rilevanza frontaliere.
+
+   Anche istituzioni applicate al dominio sbagliato sono CRITICAL: FINMA è autorità per mercati finanziari/banche, NON per ospedali/sanità. Citarla in contesti sanitari = fabbricazione di istituzione → critical:istituzioni.
+
+   Leggi/sigle che sembrano plausibili ma non esistono = critical:leggi. Esempi shipped: "LProtInfo del 2023" (inesistente — è art. 321a CO), "LPAP del 2000" (è LPers, non LPAP). Se non puoi verificare la SIGLA UFFICIALE della legge, è critical.
+
 8. **NOMI DI PERSONE E CITAZIONI**: Verifica che ogni persona citata (politici, consiglieri federali, funzionari) esista realmente con il ruolo indicato. Consiglieri federali attuali (2024-2027): Baume-Schneider, Parmelin, Cassis, Keller-Sutter, Amherd, Jans, Rösti. Citazioni dirette ("ha dichiarato:") di persone non verificabili sono quasi sempre inventate dall'IA.
 
 9. **SVIZZERA ≠ UE**: La Svizzera NON è membro dell'Unione Europea né dello Spazio Economico Europeo (SEE/EEA). Frasi come "accordo EU-Svizzera", "normativa UE applicabile in Svizzera" o "la Svizzera come membro" sono ERRORI. I rapporti sono regolati da Accordi Bilaterali I (1999) e II (2004).
@@ -2700,6 +2713,27 @@ Se le implicazioni sono DEBOLI o GENERICHE (la fonte non parla direttamente di f
 
 Il notizia/evento è solo il punto di partenza. Il valore sta nelle implicazioni PRATICHE per chi vive in Italia e lavora in Svizzera. Se queste implicazioni non esistono, l'articolo non doveva essere generato.
 
+═══ DIVIETO ASSOLUTO — INVENZIONE DI CASI O ESEMPI (CRITICO) ═══
+
+È VIETATO inventare casi specifici (persona + luogo + ruolo + verbo + esito/cifra) per gonfiare la rilevanza frontaliere o riempire spazio. Il fact-check tratta come FALSE INFORMATION qualunque "esempio concreto" non presente nella fonte.
+
+PATTERN ESPLICITAMENTE PROIBITI (anche se sembrano plausibili):
+- "Lugano: Un'infermiera frontaliera ha segnalato carenze igieniche..." (FABBRICAZIONE)
+- "Chiasso: Un medico ha denunciato pratiche non etiche..." (FABBRICAZIONE)
+- "Un infermiere dell'ORL ha ottenuto un recupero di CHF 50.000..." (FABBRICAZIONE)
+- "Un medico dell'Ospedale Civico di Lugano ha denunciato..." (FABBRICAZIONE)
+- Qualunque bullet del tipo "- [Città CH]: Un [ruolo] ha [verbo]..." dove né la persona, né il luogo, né il caso sono nella fonte originale.
+- Qualunque legge inventata con sigla approssimativa: "LProtInfo 2023" (non esiste — è art. 321a CO), "LPAP 2000" (è LPers, non LPAP). Se non sei certo della SIGLA UFFICIALE di una legge, NON citarla.
+
+REGOLE OPERATIVE:
+1. Sezioni titolate "Esempi concreti / Casi pratici / Casi reali / Per esempio" sono AMMESSE solo se gli esempi vengono ESPLICITAMENTE dalla fonte (con citazione/dettagli verificabili nella fonte originale).
+2. Se la fonte non contiene casi reali → OMETTI la sezione "Esempi concreti". Mai inventare per riempire.
+3. Se hai bisogno di un esempio ipotetico, usa frasing GENERICO E DICHIARATAMENTE IPOTETICO: "Un frontaliere che si trovi in una situazione simile potrebbe…" (senza nomi di città, ruoli specifici o cifre inventate).
+4. Cifre specifiche (CHF 50.000, 200 CHF, 1.80 CHF/litro, percentuali precise) sono AMMESSE solo se nella fonte o in dato pubblico ufficiale. Se non puoi citare la fonte, non inserire il numero.
+5. Nomi di istituzioni (FINMA, USTAT, UFAS, INSAI, SUVA) sono AMMESSI solo se RILEVANTI per il caso. FINMA = mercati finanziari/banche, NON ospedali/sanità. Non applicare istituzioni a domini sbagliati.
+
+VIOLAZIONE = articolo bocciato in fact-check con verdict=FAIL + critical:fatti_inventati. Il sistema rimuove automaticamente sezioni "Esempi concreti" sospette anche se passano il fact-check.
+
 Genera JSON (no markdown, no code fences):
 {
   "id": "kebab-case-3-5-words-max-40-chars",
@@ -3606,7 +3640,17 @@ function validate(data) {
       // generation step and are not re-checked semantically (Italian
       // keywords don't transfer 1:1 across locales).
       if (locale === 'it') {
-        const comp = stripCompetitorPromotion(text);
+        // 3) Strip fabricated "Esempi concreti / Casi pratici" sections
+        //    that the LLM injects to force frontaliere relevance on a
+        //    non-frontaliere source. See incident 2026-05-12 article
+        //    `direttrice-unispital-zurigo-whistleblower` — body1 and
+        //    body3 both ended with invented Ticino case bullets.
+        //    Conservative: requires heading match + ≥1 suspicious bullet.
+        const fab = stripFabricatedExamples(text);
+        if (fab.removedSections > 0) {
+          console.error(`  🧹  Strippate ${fab.removedSections} sezioni "Esempi concreti" fabbricate in ${locale}.${field} — es: ${(fab.examples[0] || '').slice(0, 80)}`);
+        }
+        const comp = stripCompetitorPromotion(fab.text);
         if (comp.removed > 0) {
           console.error(`  🧹  Rimossa promozione competitor in ${locale}.${field}: ${comp.removed} frase(i) — es: "${(comp.examples[0] || '').slice(0, 80)}..."`);
         }

--- a/scripts/lib/article-sanitizers.mjs
+++ b/scripts/lib/article-sanitizers.mjs
@@ -397,17 +397,197 @@ export function sanitizeNavLinkSemantics(text) {
   return { text: result, stripped, examples };
 }
 
+// ─── Forced fabricated frontaliere examples ──────────────────────────
+//
+// Pattern observed live on 2026-05-12 article
+// `direttrice-unispital-zurigo-whistleblower` (run 25715879161): the
+// LLM took a Zurich whistleblower story and force-injected invented
+// "frontaliere-relevant" cases to satisfy the keyword-density gate:
+//
+//   #### Esempi concreti
+//   - Lugano: Un'infermiera frontaliera ha segnalato carenze igieniche…
+//   - Chiasso: Un medico ha denunciato pratiche non etiche, ottenendo…
+//
+//   ### Esempi concreti
+//   - Un infermiere dell'ORL ha segnalato irregolarità nella gestione
+//     dei farmaci, portando a un'indagine interna e al recupero di
+//     CHF 50.000.
+//   - Un medico dell'Ospedale Civico di Lugano ha denunciato pratiche
+//     di bilancio fraudolente, risultando in un'indagine della FINMA.
+//
+// All four bullets are fabricated. None appears in the source article.
+// They exist only to bolt a Ticino frontaliere angle onto a story
+// that has no such angle.
+//
+// Detection signal: a markdown heading (###, ####, ##) whose label
+// contains "Esempi concreti / Casi pratici / Casi reali / Esempi
+// reali / Per esempio" followed by 1+ bullets each matching:
+//
+//   - <CH city/locality>: …
+//   - Un/Una <role> [in|a|dell'|del] <CH locality>… <specific outcome>
+//
+// where <role> is from a short list of medical/work roles and the
+// outcome contains specific verbs (segnalato, denunciato, ottenuto,
+// risultato, recupero, indagine, …) and/or specific numbers/currencies.
+// Sections matching the heading + ≥1 suspicious bullet are STRIPPED
+// (heading + all consecutive bullets dropped). Quality-preserving:
+// the rest of the article is untouched.
+//
+// Conservative: requires BOTH the heading signal AND a suspicious
+// bullet so we don't accidentally strip legitimate sections.
+
+const FABRICATED_EXAMPLES_HEADING_RE = /^(?:#{2,4})\s*(?:Esempi\s+concreti|Esempi\s+pratici|Casi\s+pratici|Casi\s+reali|Esempi\s+reali|Casi\s+specifici|Per\s+esempio[:.]?)\s*$/im;
+
+// Curated list of CH/IT-border localities that the LLM picks when
+// fabricating examples. Lowercased, stem-friendly.
+const CH_LOCALITY_TOKENS = [
+  'lugano', 'bellinzona', 'mendrisio', 'chiasso', 'locarno', 'biasca',
+  'gordola', 'massagno', 'paradiso', 'stabio', 'coldrerio', 'balerna',
+  'morbio', 'caslano', 'breganzona', 'giubiasco', 'losone', 'capolago',
+  'melide', 'rancate', 'comano', 'cadempino', 'manno', 'magliaso',
+  'montagnola', 'sementina', 'tesserete', 'agno', 'taverne', 'cadenazzo',
+  'gambarogno', 'lamone', 'savosa', 'porza', 'arbedo', 'cugnasco',
+  'minusio', 'muralto', 'tenero', 'gentilino', 'collina d\'oro',
+  'zurigo', 'zürich', 'berna', 'basilea', 'ginevra', 'losanna',
+  'como', 'varese', 'milano', // (LLM also injects these as proximity hooks)
+];
+const CH_LOCALITY_RE = new RegExp(
+  `\\b(?:${CH_LOCALITY_TOKENS.join('|')})\\b`,
+  'i',
+);
+
+// Worker roles that the LLM consistently picks when fabricating.
+// Italian plural/feminine forms: infermiere/infermiera/infermieri, etc.
+const FAB_ROLE_RE = /\b(?:infermier[aei]\b|medico\b|medica\b|medici\b|dottore\b|dottoressa\b|dottori\b|impiegat[aoie]\b|operai[ao]\b|operaio\b|operaia\b|tecnic[aoi]\b|chirurg[aoi]\b|frontalier[aei]\b|lavorator[eai]\b)/i;
+
+// Specific outcome verbs / nouns the LLM uses to make the case sound
+// concrete and verifiable. Combined with role + locality + (number
+// OR a definite article + named institution) → strong fabrication
+// signal.
+const FAB_OUTCOME_RE = /\b(?:ha\s+(?:segnalato|denunciato|ottenuto|ricevuto|recuperato|risultato)|denunci[oa]\b|segnal[oa]\b|risarciment|recupero\s+di|indagine\s+(?:interna|della\s+FINMA|delle?\s+autorit))/i;
+
+// Specific monetary amount in CHF/EUR/euro/franchi as additional
+// signal — fabricated examples almost always include a fake number to
+// look convincing.
+const FAB_MONEY_RE = /(?:CHF|EUR|€|euro|franchi|fr\.)\s*\d/i;
+
+// "Lugano:" / "Chiasso:" / "Un'infermiera…" pattern in a bullet line.
+const SUSPICIOUS_BULLET_RE = /^[\s>]*[-*•]\s*(?:[\p{Emoji}\p{Extended_Pictographic}]\s*)?(.{2,300})$/u;
+
+function bulletLooksFabricated(line) {
+  const m = line.match(SUSPICIOUS_BULLET_RE);
+  if (!m) return false;
+  const text = m[1];
+  // Pattern A: "Lugano: …" / "Chiasso: …" — locality prefix on bullet
+  const localityPrefix = /^\s*[A-ZÀ-Ý][\w\s'-]{2,30}:\s+/.test(text)
+    && CH_LOCALITY_RE.test(text.slice(0, 40));
+  // Pattern B: "Un/Una <role> dell'/della <named institution>…"
+  const roleAndInstitution =
+    FAB_ROLE_RE.test(text) &&
+    (/\bdel(?:l['ae])?\s+[A-Z][\w\s]+/.test(text) || CH_LOCALITY_RE.test(text));
+  // Strong signal: role + outcome + (locality OR amount)
+  const roleOutcome = FAB_ROLE_RE.test(text) && FAB_OUTCOME_RE.test(text);
+  const hasLocOrMoney = CH_LOCALITY_RE.test(text) || FAB_MONEY_RE.test(text);
+
+  // A bullet is "fabricated-looking" when:
+  //   • it has a locality prefix AND mentions a role, OR
+  //   • it describes role+institution+outcome, OR
+  //   • role + outcome + (locality OR money) — most common shipped pattern
+  return (
+    (localityPrefix && FAB_ROLE_RE.test(text)) ||
+    (roleAndInstitution && FAB_OUTCOME_RE.test(text)) ||
+    (roleOutcome && hasLocOrMoney)
+  );
+}
+
 /**
- * Apply both sanitizers to a body field on the IT locale. Returns the
+ * Detect and strip "Esempi concreti / Casi" sections whose bullets
+ * look fabricated (locality + role + specific outcome / amount).
+ *
+ * Conservative: requires BOTH the heading signal AND ≥1 fabricated
+ * bullet. Legitimate sections without role+outcome patterns survive.
+ *
+ * Strips the heading + the consecutive bullet block (until first
+ * non-bullet line or another heading). Leaves the rest intact.
+ *
+ * @param {string} text — IT body content
+ * @returns {{ text: string, removedSections: number, examples: string[] }}
+ */
+export function stripFabricatedExamples(text) {
+  if (!text || typeof text !== 'string') {
+    return { text: text || '', removedSections: 0, examples: [] };
+  }
+
+  const lines = text.split('\n');
+  const out = [];
+  const examples = [];
+  let removed = 0;
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!FABRICATED_EXAMPLES_HEADING_RE.test(line)) {
+      out.push(line);
+      i += 1;
+      continue;
+    }
+    // Collect consecutive bullet lines + blank lines until next heading
+    // or non-bullet/non-blank content.
+    const sectionStart = i;
+    let j = i + 1;
+    const sectionBullets = [];
+    while (j < lines.length) {
+      const lj = lines[j];
+      if (/^\s*$/.test(lj)) { j += 1; continue; }
+      if (/^[\s>]*[-*•]\s+/.test(lj)) { sectionBullets.push(lj); j += 1; continue; }
+      break; // hit heading or paragraph
+    }
+
+    const suspicious = sectionBullets.some(bulletLooksFabricated);
+    if (suspicious) {
+      removed += 1;
+      if (examples.length < 3) {
+        const sample = sectionBullets.find(bulletLooksFabricated) || sectionBullets[0] || '';
+        examples.push(sample.trim().slice(0, 120));
+      }
+      // Drop heading + bullets entirely. Skip blank lines immediately
+      // after so we don't leave a double newline gap.
+      i = j;
+      while (i < lines.length && /^\s*$/.test(lines[i])) i += 1;
+      continue;
+    }
+
+    // Section looks legitimate — keep heading + bullets verbatim.
+    for (let k = sectionStart; k < j; k += 1) out.push(lines[k]);
+    i = j;
+  }
+
+  return { text: out.join('\n'), removedSections: removed, examples };
+}
+
+/**
+ * Apply all sanitizers to a body field on the IT locale. Returns the
  * sanitized text plus per-step stats so the caller can log a single
  * summary line. Translations are NOT touched here — they go through
  * the per-locale nav-action validity check in create-article.mjs.
  *
+ * Order: fabricated examples → competitor promo → nav: semantics.
+ * Fabricated examples first so the stripped bullets don't accidentally
+ * leave orphan "Iscriviti a X" or invalid nav links behind.
+ *
  * @param {string} text
- * @returns {{ text: string, competitorRemoved: number, competitorExamples: string[], navStripped: number, navExamples: string[] }}
+ * @returns {{
+ *   text: string,
+ *   competitorRemoved: number,
+ *   competitorExamples: string[],
+ *   navStripped: number,
+ *   navExamples: string[],
+ *   fabricatedSectionsRemoved: number,
+ *   fabricatedExamples: string[],
+ * }}
  */
 export function sanitizeBodyIt(text) {
-  const c = stripCompetitorPromotion(text);
+  const f = stripFabricatedExamples(text);
+  const c = stripCompetitorPromotion(f.text);
   const n = sanitizeNavLinkSemantics(c.text);
   return {
     text: n.text,
@@ -415,5 +595,7 @@ export function sanitizeBodyIt(text) {
     competitorExamples: c.examples,
     navStripped: n.stripped,
     navExamples: n.examples,
+    fabricatedSectionsRemoved: f.removedSections,
+    fabricatedExamples: f.examples,
   };
 }

--- a/tests/article-sanitizers.test.ts
+++ b/tests/article-sanitizers.test.ts
@@ -30,6 +30,7 @@ import { describe, expect, it } from 'vitest';
 import {
   stripCompetitorPromotion,
   sanitizeNavLinkSemantics,
+  stripFabricatedExamples,
   sanitizeBodyIt,
 } from '../scripts/lib/article-sanitizers.mjs';
 
@@ -219,5 +220,152 @@ describe('sanitizeBodyIt — orchestration', () => {
     const r = sanitizeBodyIt("Usa il [calcolatore fiscale](nav:calculator) per il netto.");
     expect(r.navStripped).toBe(0);
     expect(r.competitorRemoved).toBe(0);
+  });
+});
+
+describe('stripFabricatedExamples — forced frontaliere case-injection', () => {
+  it('strips the shipped Unispital body1 "Esempi concreti" (Lugano/Chiasso)', () => {
+    // Real text from `direttrice-unispital-zurigo-whistleblower` body1
+    const body = `### Impatto sui frontalieri
+Per i frontalieri che lavorano nel settore sanitario...
+
+#### Checklist per i frontalieri
+1. Conoscere i diritti.
+2. Documentazione.
+
+#### Esempi concreti
+- Lugano: Un'infermiera frontaliera ha segnalato carenze igieniche in un ospedale, portando a un'indagine.
+- Chiasso: Un medico ha denunciato pratiche non etiche, ottenendo protezione legale e un risarcimento.
+`;
+    const r = stripFabricatedExamples(body);
+    expect(r.removedSections).toBe(1);
+    expect(r.examples[0]).toMatch(/Lugano/);
+    expect(r.text).toMatch(/Checklist per i frontalieri/);
+    expect(r.text).not.toMatch(/Lugano:.+infermiera/);
+    expect(r.text).not.toMatch(/Chiasso:.+medico/);
+    // The "#### Esempi concreti" heading must be gone
+    expect(r.text).not.toMatch(/Esempi concreti/);
+  });
+
+  it('strips the shipped Unispital body3 "Esempi concreti" (ORL/Ospedale Civico)', () => {
+    const body = `### 5. Seguire le indicazioni delle autorità
+In caso di emergenza, comunicare con le autorità.
+
+### Esempi concreti
+- 💡 Un infermiere dell'ORL ha segnalato irregolarità nella gestione dei farmaci, portando a un'indagine interna e al recupero di CHF 50.000.
+- ⚠️ Un medico dell'Ospedale Civico di Lugano ha denunciato pratiche di bilancio fraudolente, risultando in un'indagine della FINMA.
+
+Per ulteriori informazioni, usa il calcolatore.`;
+    const r = stripFabricatedExamples(body);
+    expect(r.removedSections).toBe(1);
+    expect(r.text).toMatch(/Seguire le indicazioni delle autorità/);
+    expect(r.text).toMatch(/Per ulteriori informazioni, usa il calcolatore/);
+    expect(r.text).not.toMatch(/ORL/);
+    expect(r.text).not.toMatch(/Ospedale Civico di Lugano/);
+    expect(r.text).not.toMatch(/CHF 50\.000/);
+  });
+
+  it('strips "Casi pratici" heading variant', () => {
+    const body = `## Casi pratici
+- Lugano: Un'infermiera ha denunciato un caso di frode e ottenuto un risarcimento.
+`;
+    expect(stripFabricatedExamples(body).removedSections).toBe(1);
+  });
+
+  it('strips "Per esempio" heading variant', () => {
+    const body = `### Per esempio:
+- Mendrisio: Un medico ha segnalato irregolarità, ottenendo protezione legale.
+`;
+    expect(stripFabricatedExamples(body).removedSections).toBe(1);
+  });
+
+  it('PRESERVES legitimate "Esempi concreti" with numeric/legal data (no role+place pattern)', () => {
+    // A real "Esempi concreti" section with verifiable tax data should
+    // NOT match because no bullet has role + locality + outcome pattern.
+    const body = `### Esempi concreti
+- Aliquota fiscale per redditi sotto 50k CHF: 5%.
+- Aliquota fiscale per redditi 50-100k CHF: 12%.
+- La tredicesima è inclusa nel calcolo annuale.
+`;
+    const r = stripFabricatedExamples(body);
+    expect(r.removedSections).toBe(0);
+    expect(r.text).toBe(body);
+  });
+
+  it('PRESERVES generic checklist sections that are not "Esempi concreti"', () => {
+    const body = `### Checklist operativa
+- Verificare il regolamento.
+- Raccogliere documenti.
+- Contattare il superiore.
+`;
+    expect(stripFabricatedExamples(body).removedSections).toBe(0);
+  });
+
+  it('PRESERVES a section with role but no locality/outcome (too weak signal)', () => {
+    const body = `### Profili tipici
+- Infermiere: turni variabili, busta paga oraria.
+- Medico: stipendio annuale, turni di reperibilità.
+`;
+    expect(stripFabricatedExamples(body).removedSections).toBe(0);
+  });
+
+  it('strips a section with mixed bullets when at least one is fabricated', () => {
+    const body = `### Esempi concreti
+- Generic info that\'s fine.
+- Lugano: Un medico ha denunciato pratiche illegali, recuperando CHF 100.000.
+- More generic info.
+`;
+    const r = stripFabricatedExamples(body);
+    expect(r.removedSections).toBe(1);
+    // The whole section dies — conservatism trades a few legitimate
+    // bullets for safety from fabrications.
+    expect(r.text).not.toMatch(/Generic info/);
+  });
+
+  it('handles multiple fabricated sections in one body', () => {
+    const body = `## Sezione 1
+Testo normale.
+
+### Esempi concreti
+- Lugano: Un infermiere ha segnalato CHF 50.000.
+
+## Sezione 2
+Altro testo.
+
+### Casi pratici
+- Chiasso: Una medico ha denunciato e ottenuto un risarcimento.
+`;
+    const r = stripFabricatedExamples(body);
+    expect(r.removedSections).toBe(2);
+    expect(r.text).toMatch(/Testo normale/);
+    expect(r.text).toMatch(/Altro testo/);
+    expect(r.text).not.toMatch(/Lugano:/);
+    expect(r.text).not.toMatch(/Chiasso:/);
+  });
+
+  it('handles empty / null / non-string input safely', () => {
+    expect(stripFabricatedExamples('').text).toBe('');
+    expect(stripFabricatedExamples(null as unknown as string).removedSections).toBe(0);
+    expect(stripFabricatedExamples(undefined as unknown as string).removedSections).toBe(0);
+  });
+});
+
+describe('sanitizeBodyIt — full pipeline including fabricated-examples strip', () => {
+  it('strips fabricated examples + competitor promo + bad nav: in one pass', () => {
+    const body = `### 6. Strumenti utili
+Usa il [calcolatore di tragitti](nav:calculator) per pianificare.
+
+### Esempi concreti
+- Lugano: Un'infermiera ha segnalato CHF 50.000 di irregolarità.
+
+Iscriviti alla newsletter giornaliera di Tio. Le notizie sono importanti.`;
+    const r = sanitizeBodyIt(body);
+    expect(r.fabricatedSectionsRemoved).toBe(1);
+    expect(r.navStripped).toBe(1);
+    expect(r.competitorRemoved).toBe(1);
+    expect(r.text).toMatch(/Le notizie sono importanti/);
+    expect(r.text).not.toMatch(/Lugano:.+infermiera/);
+    expect(r.text).not.toMatch(/nav:calculator/);
+    expect(r.text).not.toMatch(/newsletter giornaliera di Tio/i);
   });
 });


### PR DESCRIPTION
## Summary

Article `direttrice-unispital-zurigo-whistleblower` (2026-05-12) shipped with **4 fabricated case examples + 2 fake law acronyms** that the fact-check missed:

- \`Lugano: Un'infermiera frontaliera ha segnalato carenze igieniche…\`
- \`Chiasso: Un medico ha denunciato pratiche non etiche, ottenendo… risarcimento\`
- \`Un infermiere dell'ORL ha ottenuto il recupero di CHF 50.000…\`
- \`Un medico dell'Ospedale Civico di Lugano ha denunciato pratiche di bilancio fraudolente, risultando in un'indagine della FINMA\`
- \`LProtInfo del 2023\` (inesistente — è art. 321a CO)
- \`LPAP del 2000\` (sigla sbagliata — è LPers)

The LLM force-injected these in \`#### Esempi concreti\` sections to bolt a Ticino frontaliere angle onto a Zurich-only story.

## Three-layer fix

### 1. PREVENT (generation prompt)
New "DIVIETO ASSOLUTO — INVENZIONE DI CASI O ESEMPI" section in the IT prompt. Lists the 4 shipped fabrications verbatim as negative examples. Tells the LLM to OMIT "Esempi concreti" rather than invent cases. Bans citing law acronyms whose ufficial spelling is uncertain.

### 2. DETECT (fact-check prompt)
Extended category #7 \`fatti_inventati\` with subcategory "ESEMPI CONCRETI FABBRICATI". Detection rule: \`[Città CH] + [ruolo professionale] + [verbo specifico] + [esito/cifra]\` not in source → CRITICAL. Adds: FINMA in healthcare = critical:istituzioni; unverifiable law acronyms = critical:leggi.

### 3. STRIP (post-gen sanitizer)
New \`stripFabricatedExamples(text)\` in \`scripts/lib/article-sanitizers.mjs\`. Detects headings \`Esempi concreti / Casi pratici / Casi reali / Per esempio\` followed by ≥1 bullet matching the fabrication pattern. Conservative: requires BOTH heading + suspicious bullet. Wired into the IT body validation alongside existing competitor + nav: sanitizers.

## Bug fix in FAB_ROLE_RE

Original \`infermier[ai]?\\b\` did NOT match \`infermiere\` (single 'e' suffix). Updated to \`infermier[aei]\\b\` + expanded plural/feminine coverage of medico/operaio/tecnico/chirurgo.

## Quality preserved

- Legitimate "Esempi concreti" with numeric tax data / generic checklists / role-only profiles survive (requires fabrication pattern match).
- Critical fact-check, REGOLA #0, frontaliere-density unchanged.
- All existing sanitizers (competitor, nav: semantics) unchanged.

## Test plan

- [x] \`tests/article-sanitizers.test.ts\` 39 cases (was 28). Both shipped Unispital sections caught, heading variants (Esempi/Casi/Per esempio), legitimate sections preserved, mixed bullets, multiple sections, edge cases.
- [x] \`npm run test:articles\` 60/60 pass.
- [x] \`npx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)