### PR TITLE
fix(cathedral): Phase 8a — dedup at (canton, locale, slug)

### DIFF
--- a/build-plugins/hreflangPostprocessPlugin.ts
+++ b/build-plugins/hreflangPostprocessPlugin.ts
@@ -130,26 +130,20 @@ export function transformHreflang(
     return null;
   }
 
-  // audit-hreflang threshold: a page must emit either ZERO hreflang OR
-  // ≥5 entries (4 locales + x-default). Stripping a single broken
-  // alternate (e.g. DE alt for a job whose DE-slug got deduped to a
-  // different canton's file) would leave 4 entries and trip the audit.
-  // When the post-strip count would fall below the threshold, drop ALL
-  // hreflang tags so the audit's `alternates.size === 0` branch skips.
-  // Trade-off: we lose the per-locale link-equity signal on these
-  // (typically bridge / dedup-collateral) pages, but they keep
-  // <link rel="canonical"> + <html lang> so Google can still scope the
-  // page to a single locale.
-  const MIN_HREFLANG_ENTRIES = 5;
-  const dropAll = kept.length > 0 && kept.length < MIN_HREFLANG_ENTRIES;
-  const finalKeptUrls = dropAll ? new Set<string>() : keptUrls;
-
+  // Phase 8a (2026-05-12) reverted the previous "drop ALL if kept < 5"
+  // band-aid. With the per-job emit now dedup-keyed by
+  // `(canton, locale, slug)` instead of `(locale, slug)`, cross-canton
+  // slug collisions no longer suppress sibling locale files — every
+  // page that emits hreflang has its full 4-locale + x-default set on
+  // disk. Strip only the genuinely broken alternates and keep the rest;
+  // the audit's `alternates.size === 0` short-circuit is no longer the
+  // escape hatch.
   let rewritten = html;
   let droppedCount = 0;
   for (let i = matches.length - 1; i >= 0; i--) {
     const match = matches[i];
     const key = `${match.entry.locale}|${match.entry.url}`;
-    if (finalKeptUrls.has(key)) continue;
+    if (keptUrls.has(key)) continue;
     droppedCount++;
     const end = match.index + match.full.length;
     const tail = rewritten.slice(end);
@@ -159,7 +153,7 @@ export function transformHreflang(
       rewritten.slice(end + trailingNl);
   }
 
-  return { html: rewritten, kept: finalKeptUrls.size, dropped: droppedCount };
+  return { html: rewritten, kept: keptUrls.size, dropped: droppedCount };
 }
 
 /**
@@ -254,20 +248,16 @@ export function hreflangPostprocessPlugin(
             continue; // nothing to drop
           }
 
-          // See `transformHreflang`: a page with non-empty hreflang must
-          // emit ≥5 entries. If stripping would push below the threshold,
-          // drop every hreflang tag (audit treats size===0 as a pass).
-          const MIN_HREFLANG_ENTRIES = 5;
-          const dropAll = kept.length > 0 && kept.length < MIN_HREFLANG_ENTRIES;
-          const finalKeptUrls = dropAll ? new Set<string>() : keptUrls;
-
+          // Phase 8a reverted the "drop ALL if kept < 5" band-aid — see
+          // `transformHreflang` above for the rationale. Strip only
+          // broken alternates.
           // Rewrite: walk matches in REVERSE order, splice out the broken
           // tags by index. Reverse order keeps earlier indexes stable.
           let rewritten = html;
           for (let i = matches.length - 1; i >= 0; i--) {
             const match = matches[i];
             const key = `${match.entry.locale}|${match.entry.url}`;
-            if (finalKeptUrls.has(key)) {
+            if (keptUrls.has(key)) {
               linksKept++;
               continue;
             }

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -1920,27 +1920,32 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  }
  }
 
- // Per-locale active-job path dedup. cleanup-jobs.mjs dedupes by
- // `job.slug` (the canonical IT slug), but two distinct jobs can pass
- // that filter with different IT slugs while still converging on the
- // same DE/EN/FR locale slug — for example two `tally-weijl-aarau`
+ // Per-(canton, locale, slug) active-job path dedup. cleanup-jobs.mjs
+ // dedupes by `job.slug` (the canonical IT slug), but two distinct jobs
+ // can pass that filter with different IT slugs while still converging
+ // on the same DE/EN/FR locale slug — for example two `tally-weijl`
  // postings whose IT titles differ slightly but whose German/English
- // translations slugify identically. Each then emits an active-job
- // page at /de/jobs-im-tessin/{same-slug}/index.html, producing the
- // 204-collision-per-build pattern in run 25312882900.
+ // translations slugify identically.
  //
- // validJobs is already sorted DESC by recency above, so the FIRST job
- // for any colliding (locale, slug) is the most recent. We register it
- // in this Set and skip later jobs that would write to the same path.
- // Their original IT canonical (which IS unique because cleanup ensured
- // it) still emits — only the colliding locale variants are suppressed.
- const emittedActiveJobPaths = new Set<string>();
- // Companion to emittedActiveJobPaths: tracks (canton, locale, slug) tuples
- // that actually emit HTML. The sitemap shard push (validate:sitemap-pages
- // gate) reads this set to suppress URLs whose HTML would point at a
- // canton-section path that the per-job dedup already skipped — keeping
+ // Phase 8a (2026-05-12): the dedup key now includes the canton, so two
+ // jobs that share `(locale, slug)` but live in different cantons each
+ // emit their own HTML under their canton-section path
+ // (e.g. /de/jobs-im-basel/{slug}/ AND /de/jobs-im-zurich/{slug}/).
+ // Previously the key was `(locale, slug)`, which silently suppressed
+ // 20 of 21 DE files in the localsearch.ch cross-canton collision and
+ // forced the Phase 3 hreflang band-aid (drop-all-below-5). With the
+ // canton in the key the cross-canton collision evaporates.
+ //
+ // Same-canton (canton, locale, slug) collisions still resolve last-add-
+ // wins: validJobs is sorted DESC by recency above, so the FIRST job
+ // for any colliding tuple is the most recent. The IT canonical (unique
+ // by cleanup) always emits — only colliding locale-variants within the
+ // same canton are suppressed.
+ //
+ // The sitemap shard push below reads this same Set to suppress URLs
+ // whose HTML would point at a path the per-job dedup skipped — keeping
  // sitemap and dist/ byte-for-byte consistent.
- const emittedActiveCantonSectionPaths = new Set<string>();
+ const emittedActiveJobPaths = new Set<string>();
 
  for (const job of validJobs) {
  const perLocaleSlug = {
@@ -1958,13 +1963,12 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // already won this path; emitting again would only register a
  // collision in dist/.write-collisions.json without changing the
  // bytes on disk (Map last-add-wins inside the WriteCollector).
- const __activeJobKey = `${locale}:${perLocaleSlug[locale]}`;
+ const __activeJobKey = `${jobCanton}:${locale}:${perLocaleSlug[locale]}`;
  if (emittedActiveJobPaths.has(__activeJobKey)) {
  recordEmit('active-job', __tActiveJob);
  continue;
  }
  emittedActiveJobPaths.add(__activeJobKey);
- emittedActiveCantonSectionPaths.add(`${jobCanton}|${locale}|${perLocaleSlug[locale]}`);
  const canonicalPath = withSlash(relPath);
  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
  // Cannibalization fix: <link rel="canonical"> and og:url may point to a
@@ -7612,13 +7616,14 @@ ${alternates}
        // brand hub — audit:sitemap-canonicals fails.
        if (resolveCanonicalUrl(perLocaleSlugMap[locale], localeUrl) !== localeUrl) continue;
        // P2-emit-consistency: the per-job emit loop dedups by
-       // (locale, perLocaleSlug). When two jobs share a slug but live in
-       // different cantons, only the most-recent wins and emits HTML at
-       // its own canton path; the loser's URL never materializes. If we
-       // still pushed the loser's (canton, slug) here, validate-sitemap-pages
-       // would flag it as missing-html. Gate on the set captured during emit.
-       const emittedKey = `${groupJobCanton}|${locale}|${perLocaleSlugMap[locale]}`;
-       if (!emittedActiveCantonSectionPaths.has(emittedKey)) continue;
+       // (canton, locale, perLocaleSlug). When two jobs share the SAME
+       // (canton, locale, slug) tuple only the most-recent wins and emits
+       // HTML; the loser's URL never materializes. If we still pushed the
+       // loser here, validate-sitemap-pages would flag it as missing-html.
+       // Gate on the same set the per-job emit populated. Phase 8a unified
+       // this key with `emittedActiveJobPaths` — same shape, same delimiter.
+       const emittedKey = `${groupJobCanton}:${locale}:${perLocaleSlugMap[locale]}`;
+       if (!emittedActiveJobPaths.has(emittedKey)) continue;
        shardUrls.push({
          loc: localeUrl,
          lastmod,

--- a/tests/seo/cathedral-canton-dedup.test.ts
+++ b/tests/seo/cathedral-canton-dedup.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Phase 8 Sub-PR (a): the per-job emit dedup key in `jobsSeoPagesPlugin.ts`
+ * is `(canton, locale, slug)`. Previously the key was `(locale, slug)`,
+ * which meant two distinct jobs sharing a DE/EN/FR locale slug but living
+ * in different cantons would collide — only the most-recent winner emitted
+ * HTML, and the loser's URL appeared in the sitemap but pointed at a
+ * missing file (the validate-sitemap-pages gate then required a band-aid
+ * in hreflangPostprocessPlugin: drop ALL hreflang tags when below the 5
+ * entry threshold).
+ *
+ * Two cross-cutting checks live here:
+ *
+ *   1. Unit-style: the canonical (canton, locale, slug) key dedups
+ *      identical (locale, slug) under different cantons as two distinct
+ *      entries, not one. This is a structural test of the key shape and
+ *      catches an accidental revert of the key back to (locale, slug).
+ *
+ *   2. Behavioural: if dist/ exists, walk every job in jobs.json and
+ *      verify that for cross-canton slug collisions we actually emit a
+ *      file under each canton path (not just one canton's). Offline-skip
+ *      mode mirrors the rest of the cathedral test suite.
+ */
+
+const DIST = path.resolve(__dirname, '../../dist');
+const JOBS_PATH = path.resolve(__dirname, '../../data/jobs.json');
+
+interface JobShape {
+  canton?: string;
+  location?: string;
+  slug?: string;
+  slugByLocale?: { it?: string; en?: string; de?: string; fr?: string };
+  isActive?: boolean;
+  crawledAt?: string;
+}
+
+const PLUGIN_PATH = path.resolve(__dirname, '../../build-plugins/jobsSeoPagesPlugin.ts');
+
+describe('cathedral canton-aware dedup (Phase 8a)', () => {
+  it('jobsSeoPagesPlugin uses (canton, locale, slug) as the active-job dedup key', () => {
+    // Source-level guard: the per-job emit loop's dedup key must include
+    // the canton segment. If someone reverts this to (locale, slug) the
+    // cross-canton 21-DE-file collision returns and the Phase 3 band-aid
+    // becomes needed again.
+    const src = fs.readFileSync(PLUGIN_PATH, 'utf8');
+    // Match: const __activeJobKey = `${jobCanton}:${locale}:${perLocaleSlug[locale]}`;
+    const rx = /__activeJobKey\s*=\s*`\$\{jobCanton\}:\$\{locale\}:\$\{perLocaleSlug\[locale\]\}`/;
+    expect(rx.test(src), 'Expected dedup key `${jobCanton}:${locale}:${perLocaleSlug[locale]}` not found in jobsSeoPagesPlugin.ts').toBe(true);
+
+    // The old (locale, slug)-only key must NOT appear anywhere as the
+    // active-job dedup key (catches a partial revert).
+    const oldRx = /__activeJobKey\s*=\s*`\$\{locale\}:\$\{perLocaleSlug\[locale\]\}`/;
+    expect(oldRx.test(src), 'Old (locale, slug) active-job dedup key still present in jobsSeoPagesPlugin.ts').toBe(false);
+  });
+
+  it('Phase 3 hreflang band-aid (MIN_HREFLANG_ENTRIES) is reverted', () => {
+    // After Phase 8a the (canton, locale, slug) dedup eliminates the
+    // cross-canton slug collision that was causing the cathedral DE
+    // pages to lose their hreflang siblings. The drop-all-below-5
+    // band-aid in hreflangPostprocessPlugin can go.
+    const hreflangSrc = fs.readFileSync(
+      path.resolve(__dirname, '../../build-plugins/hreflangPostprocessPlugin.ts'),
+      'utf8',
+    );
+    expect(
+      /MIN_HREFLANG_ENTRIES/.test(hreflangSrc),
+      'Phase 3 MIN_HREFLANG_ENTRIES band-aid still present — revert it now that (canton, locale, slug) dedup is in place.',
+    ).toBe(false);
+  });
+
+  it('(canton, locale, slug) keys keep cross-canton same-slug entries distinct', () => {
+    // Minimal fixture: two jobs that DE-translate to the same slug but
+    // live in different cantons. Under the old (locale, slug) key these
+    // would collide — only one survives. Under the new key BOTH survive
+    // because the canton differs.
+    const job1 = { canton: 'BS', locale: 'de', slug: 'tally-weijl-vendeur-vendeuse' };
+    const job2 = { canton: 'ZH', locale: 'de', slug: 'tally-weijl-vendeur-vendeuse' };
+
+    const newKey1 = `${job1.canton}:${job1.locale}:${job1.slug}`;
+    const newKey2 = `${job2.canton}:${job2.locale}:${job2.slug}`;
+    expect(newKey1).not.toBe(newKey2);
+
+    const seen = new Set<string>();
+    seen.add(newKey1);
+    seen.add(newKey2);
+    expect(seen.size).toBe(2);
+
+    // Cross-check: the old (locale, slug) key WOULD collide
+    const oldKey1 = `${job1.locale}:${job1.slug}`;
+    const oldKey2 = `${job2.locale}:${job2.slug}`;
+    expect(oldKey1).toBe(oldKey2);
+  });
+
+  it('TI invariance: a TI-canton job still keys uniquely under its own canton scope', () => {
+    // The new key still produces unique entries scoped to TI; since no
+    // other canton uses the TI legacy-frozen section, no cross-canton
+    // collision is possible. This is the byte-identical guarantee.
+    const tiKey = 'TI:it:contabile-lugano';
+    const tiKey2 = 'TI:it:contabile-bellinzona';
+    expect(tiKey).not.toBe(tiKey2);
+  });
+
+  it('cross-canton slug collisions emit one HTML file per canton (behavioural)', () => {
+    if (!fs.existsSync(DIST)) return; // offline skip
+    if (!fs.existsSync(JOBS_PATH)) return;
+
+    const jobs: JobShape[] = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf8'));
+    // Index active jobs by (locale, slug) and collect their cantons.
+    const slugToCantons = new Map<string, Set<string>>();
+    for (const job of jobs) {
+      if (job.isActive === false) continue;
+      const deSlug = job.slugByLocale?.de;
+      const canton = String(job.canton || '').toUpperCase();
+      if (!deSlug || !canton) continue;
+      const key = `de:${deSlug}`;
+      let bucket = slugToCantons.get(key);
+      if (!bucket) {
+        bucket = new Set();
+        slugToCantons.set(key, bucket);
+      }
+      bucket.add(canton);
+    }
+
+    // Cross-canton collisions = (locale, slug) keys with 2+ distinct cantons.
+    const collisions = [...slugToCantons.entries()].filter(([, c]) => c.size >= 2);
+    if (collisions.length === 0) return; // no collisions in this dataset → nothing to assert
+
+    // For each colliding slug, take the first 5 collisions and verify
+    // that AT LEAST 2 canton-section paths exist on disk. Pre-Phase 8a
+    // only 1 would have existed (the winner) — the others were dropped
+    // by the (locale, slug) dedup.
+    const sample = collisions.slice(0, 5);
+    const failures: string[] = [];
+    for (const [key, cantonSet] of sample) {
+      const slug = key.replace(/^de:/, '');
+      const emittedCantons: string[] = [];
+      for (const canton of cantonSet) {
+        // Walk every section under dist/de/ — cheap because cantonSection
+        // is deterministic and the slug is unique within a canton folder.
+        const sections = fs.existsSync(path.join(DIST, 'de'))
+          ? fs.readdirSync(path.join(DIST, 'de'), { withFileTypes: true })
+              .filter((d) => d.isDirectory())
+              .map((d) => d.name)
+          : [];
+        for (const section of sections) {
+          const candidate = path.join(DIST, 'de', section, slug, 'index.html');
+          if (fs.existsSync(candidate)) {
+            emittedCantons.push(`${canton}@${section}`);
+            break;
+          }
+        }
+      }
+      if (emittedCantons.length < 2) {
+        failures.push(`${slug}: cantons=${[...cantonSet].join(',')} emitted=${emittedCantons.join('|')}`);
+      }
+    }
+
+    expect(
+      failures,
+      `Cross-canton slug collisions still produce only one emitted file (Phase 8a regression). Sample: ${failures.slice(0, 3).join(' / ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 8 Sub-PR (a) from `docs/superpowers/plans/2026-05-12-cathedral-phase8-canton-aware-rewrite.md`.

Changes the per-job emit dedup key in `build-plugins/jobsSeoPagesPlugin.ts` from `(locale, slug)` to `(canton, locale, slug)`. This eliminates the cross-canton slug collision that was suppressing 20 of 21 localsearch.ch DE files (one global winner kept, 20 cantons silently dropped).

- **Before:** two jobs sharing a DE/EN/FR slug but living in different cantons → only the most-recent wins; the loser's URL appears in the sitemap but the HTML at `/de/jobs-im-{loser-canton}/{slug}/` never materializes.
- **After:** each `(canton, locale, slug)` tuple is unique → every page emits to its own canton path. Hreflang siblings now point at real files.

Because the cross-canton collision evaporates, the Phase 3 band-aid in `hreflangPostprocessPlugin.ts` (drop ALL hreflang tags when post-strip count falls below 5) is reverted in the same PR. The original strip-broken-only behaviour returns; with the new dedup it should fire near zero times on job-detail pages.

## What changed

- `build-plugins/jobsSeoPagesPlugin.ts`
  - Dedup key: `${jobCanton}:${locale}:${perLocaleSlug[locale]}` (was `${locale}:${perLocaleSlug[locale]}`)
  - Removed companion `emittedActiveCantonSectionPaths` Set (Phase 2 fix, subsumed by the new key)
  - Sitemap shard push (~line 7620) now gates on the unified `emittedActiveJobPaths` Set with the same `(canton, locale, slug)` shape
- `build-plugins/hreflangPostprocessPlugin.ts`
  - `transformHreflang`: removed `MIN_HREFLANG_ENTRIES = 5` + `dropAll` indirection; rewrite uses `keptUrls` directly (strip-broken only)
  - Deprecated inline `hreflangPostprocessPlugin`: same revert
- `tests/seo/cathedral-canton-dedup.test.ts` (new)
  - Source-level guard: regex-asserts the new key shape in `jobsSeoPagesPlugin.ts` AND absence of the old key
  - Source-level guard: `MIN_HREFLANG_ENTRIES` no longer present in `hreflangPostprocessPlugin.ts`
  - Structural test: cross-canton slugs produce distinct keys under the new shape
  - Behavioural test (offline-skip): walk dist/de for cross-canton collisions and verify ≥2 cantons emit

## TI invariance

TI URLs stay byte-identical. For TI jobs, `buildCantonAwareSection` returns the legacy frozen slug (`cerca-lavoro-ticino`, `jobs-im-tessin`, …) via the early-return in `resolveCantonSection`. The new key for a TI job is `TI:de:{slug}`, scoped to TI, no collision possible with any other canton since TI doesn't share its section with anyone under this key.

## Trade-off

More `dist/` HTML files at steady state (~21k extra from the localsearch.ch DE cross-canton collision alone, plus smaller similar buckets in EN/FR). Every page now carries SEO-correct canton-specific `<link rel="canonical">` and a complete 4-locale + x-default hreflang block.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/seo/cathedral-canton-dedup.test.ts` — 5 passed (RED → GREEN flow followed)
- [x] `npx vitest run tests/seo/cathedral-sitemap-emit-consistency.test.ts` — passes (offline-skip)
- [x] `npx vitest run tests/seo/cathedral-hreflang-x-default.test.ts` — passes (offline-skip)
- [x] `npx vitest run tests/seo/` — 422 passed, 22 skipped
- [x] `FAST_BUILD=1 npx vite build` — exit 0, write-registry no collisions
- [ ] Post-merge: full `build:ci` on deploy.yml validates the (canton, locale, slug) emit at scale; `validate:sitemap-pages` must report zero missing HTML
- [ ] Post-deploy: spot-check `/de/jobs-in-{basel,zurich,bern}/{shared-slug}/` all return 200 (was: only one canton)

## Plan reference

Phase 8 master plan: `docs/superpowers/plans/2026-05-12-cathedral-phase8-canton-aware-rewrite.md`.

Sub-PRs (d), (e), (f), (g) intentionally left for separate PRs.