### PR TITLE
fix(ci): 3-way set-merge resolver for discover-404s push conflicts

### DIFF
--- a/.github/workflows/discover-404s.yml
+++ b/.github/workflows/discover-404s.yml
@@ -108,11 +108,16 @@ jobs:
           URLs that recovered are dropped from compat."
 
           # Centralized rebase-retry helper survives concurrent pushes from
-          # other workflows. The two staged files are exclusively owned by
-          # this workflow, so rebasing onto a newer main is always safe —
-          # there cannot be a conflict on our changes (no --regenerate-cmd
-          # needed; an unexpected conflict surfaces as a hard failure).
-          bash scripts/lib/git-push-with-retry.sh
+          # other workflows. `data/seo-404-compat-paths.json` is shared with
+          # sync-gsc-orphans.yml and a handful of slug-maintenance scripts,
+          # so a rebase conflict on `paths` is possible (run 25716042219).
+          # The in-place resolver does a 3-way set merge:
+          #   final = upstream ∪ (local − base) − (base − local)
+          # `data/inspection-state.json` is single-writer (this workflow);
+          # if it ever conflicts the resolver fails loud rather than masking
+          # a real bug.
+          bash scripts/lib/git-push-with-retry.sh \
+            --in-place-resolver-cmd "node scripts/lib/resolve-404-compat-conflict.mjs && git add -A"
 
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 

--- a/scripts/lib/resolve-404-compat-conflict.mjs
+++ b/scripts/lib/resolve-404-compat-conflict.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * In-place rebase resolver for `data/seo-404-compat-paths.json`.
+ *
+ * Why this exists: discover-404s.yml is not the only workflow that writes
+ * this file. sync-gsc-orphans.yml (and a few scripts: backfill-slug-aliases,
+ * mine-all-job-slugs, enrich-compat-orphan-slugs) also append/remove paths.
+ * When two workflows push back-to-back the rebase inside
+ * `scripts/lib/git-push-with-retry.sh` hits a content conflict on the
+ * `paths` array — run 25716042219 was exactly this. Git has no built-in way
+ * to merge a JSON array, so the helper aborted with "no resolver provided".
+ *
+ * Resolution semantics: 3-way set merge on `paths`.
+ *
+ *   final = upstream ∪ (local − base) − (base − local)
+ *
+ *   - paths the local commit ADDED (in local but not in base) are added on
+ *     top of upstream → preserves our newly-discovered 404s.
+ *   - paths the local commit REMOVED (in base but not in local) are removed
+ *     from upstream → preserves our "URL recovered, drop from compat".
+ *   - paths upstream added since base are kept → preserves sync-gsc-orphans'
+ *     additions that we did not see when we read the file.
+ *
+ * Metadata fields (generatedAt / lastUpdated / source): take local's values
+ * (this commit is the freshest write).
+ *
+ * Runs INSIDE the rebase (--in-place-resolver-cmd contract), leaves the
+ * file resolved + staged. `git rebase --continue` then closes the cycle.
+ * No abort, no human intervention.
+ *
+ * `data/inspection-state.json` is exclusively owned by
+ * discover-404s-via-inspection.mjs — if it ever shows up as conflicted,
+ * surface the fact instead of merging silently.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TARGET = 'data/seo-404-compat-paths.json';
+const STATE_FILE = 'data/inspection-state.json';
+
+function readStage(stage, file) {
+  // During `git rebase`, stage 1 = base, stage 2 = "ours" (the rebase base,
+  // i.e. upstream we replay onto), stage 3 = "theirs" (our local commit
+  // being applied). See scripts/lib/resolve-winners-conflict.mjs for the
+  // same inverted-meaning explanation.
+  try {
+    return execFileSync('git', ['show', `:${stage}:${file}`], { encoding: 'utf-8' });
+  } catch {
+    return null;
+  }
+}
+
+function parseCompat(label, raw) {
+  if (raw == null) return { paths: [] };
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      if (!Array.isArray(parsed.paths)) parsed.paths = [];
+      return parsed;
+    }
+    process.stderr.write(`[resolve-404-compat] ${label} not a JSON object; treating as empty\n`);
+    return { paths: [] };
+  } catch (err) {
+    process.stderr.write(`[resolve-404-compat] ${label} JSON parse failed: ${err.message}\n`);
+    return { paths: [] };
+  }
+}
+
+const conflicted = execFileSync('git', ['diff', '--name-only', '--diff-filter=U'], { encoding: 'utf-8' })
+  .split('\n')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+if (conflicted.includes(STATE_FILE)) {
+  process.stderr.write(
+    `[resolve-404-compat] unexpected conflict on ${STATE_FILE} — this file is single-writer; aborting\n`,
+  );
+  process.exit(1);
+}
+
+if (!conflicted.includes(TARGET)) {
+  process.stdout.write(`[resolve-404-compat] no conflict on ${TARGET}\n`);
+  process.exit(0);
+}
+
+const otherConflicts = conflicted.filter((f) => f !== TARGET);
+if (otherConflicts.length > 0) {
+  process.stderr.write(
+    `[resolve-404-compat] unexpected conflicted files alongside ${TARGET}: ${otherConflicts.join(', ')}\n`,
+  );
+  process.exit(1);
+}
+
+const base = parseCompat('base', readStage(1, TARGET));
+const upstream = parseCompat('upstream', readStage(2, TARGET));
+const local = parseCompat('local', readStage(3, TARGET));
+
+const baseSet = new Set(base.paths);
+const upstreamSet = new Set(upstream.paths);
+const localSet = new Set(local.paths);
+
+const added = [...localSet].filter((p) => !baseSet.has(p));
+const removed = [...baseSet].filter((p) => !localSet.has(p));
+
+const finalSet = new Set(upstreamSet);
+for (const p of added) finalSet.add(p);
+for (const p of removed) finalSet.delete(p);
+
+const merged = {
+  ...upstream,
+  ...local,
+  paths: [...finalSet].sort(),
+};
+if (local.lastUpdated || upstream.lastUpdated) {
+  merged.lastUpdated = local.lastUpdated || upstream.lastUpdated;
+}
+if (local.generatedAt) merged.generatedAt = local.generatedAt;
+
+const outPath = path.resolve(process.cwd(), TARGET);
+fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+
+process.stdout.write(
+  `[resolve-404-compat] base=${baseSet.size} upstream=${upstreamSet.size} local=${localSet.size} ` +
+    `→ +${added.length} added, -${removed.length} removed = ${finalSet.size} final\n`,
+);
+
+execFileSync('git', ['add', TARGET]);


### PR DESCRIPTION
## Summary

Fixes the failure in [run 25716042219](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/25716042219/job/75506100279):

- `discover-404s` workflow's `Commit and push` step failed: `git push` was rejected (concurrent push from `sync-gsc-orphans`), rebase produced `CONFLICT (content): Merge conflict in data/seo-404-compat-paths.json`, and `git-push-with-retry.sh` aborted with `Rebase conflict and no resolver provided`.
- Root cause: the workflow's comment claimed the file was "exclusively owned" by this workflow — but `sync-gsc-orphans.yml` and several slug-maintenance scripts also write `data/seo-404-compat-paths.json`. The exclusivity assumption was wrong.

## Fix

- New `scripts/lib/resolve-404-compat-conflict.mjs` — 3-way set merge on the `paths` array using rebase stages 1/2/3 (base / upstream / local). Matches the pattern of the existing `resolve-winners-conflict.mjs`.
  - Final = `upstream ∪ (local − base) − (base − local)` → keeps sync-gsc-orphans' additions, re-applies our newly-discovered 404s, re-applies our "URL recovered, drop" deletions.
  - Metadata (`generatedAt`, `lastUpdated`, `source`) takes local's values (this commit is the freshest write).
  - `data/inspection-state.json` is single-writer; if it ever conflicts the resolver fails loud rather than silently merging.
- `.github/workflows/discover-404s.yml` passes `--in-place-resolver-cmd "node scripts/lib/resolve-404-compat-conflict.mjs && git add -A"` to `git-push-with-retry.sh`, matching the established pattern in `refresh-keyword-config.yml` et al.

## Test plan

- [x] Offline simulation of a 3-way rebase conflict (base=`a,b,c`; upstream=`a,b,c,u`; local removed `b` + added `n`) → resolver produces `a,c,n,u` ✓ and the rebase completes cleanly.
- [ ] Live: re-dispatch `discover-404s.yml` after merge to confirm the workflow succeeds end-to-end (including the deploy trigger).