### PR TITLE
fix(cathedral): Phase 8c — expired-job tracking canton-aware

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -8056,8 +8056,17 @@ ${alternates}
  }
  if (!tracking[job.slug]) {
  tracking[job.slug] = {};
+ // Phase 8c — emit the tracking entry under the JOB'S canton-aware
+ // section (e.g. /cerca-lavoro-zurigo/, /de/jobs-in-zurich/) instead of
+ // the legacy TI section. Soft-landing emission downstream reads this
+ // path directly + checks activeJobDirs for collisions; before the
+ // canton-aware switch the TI URL would either land a stale soft-
+ // landing or, worse, clobber an active non-TI page at the same slug.
+ // TI invariance is preserved by buildCantonAwareSection (early-return
+ // on code === 'TI' returns the legacy section verbatim).
+ const jobCantonForTracking = sharedResolveJobCanton(job as { canton?: string; location?: string });
  for (const locale of localeList) {
- const relPath = `${localePrefix[locale]}/${sectionByLocale[locale]}/${localizedSlug(job, locale)}`.replace(/\/+/g, '/');
+ const relPath = `${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCantonForTracking)}/${localizedSlug(job, locale)}`.replace(/\/+/g, '/');
  tracking[job.slug][locale] = relPath;
  }
  }

--- a/scripts/migrate-all-known-job-slugs-canton-aware.mjs
+++ b/scripts/migrate-all-known-job-slugs-canton-aware.mjs
@@ -1,0 +1,208 @@
+// scripts/migrate-all-known-job-slugs-canton-aware.mjs
+// Phase 8 Sub-PR (c): one-shot migration that rewrites every per-locale path in
+// data/all-known-job-slugs.json so that non-TI jobs use their canton-aware
+// section slug (e.g. /cerca-lavoro-zurigo/...) instead of the legacy TI section.
+//
+// Before this migration, every tracking entry was emitted under the frozen TI
+// section path because the builder at jobsSeoPagesPlugin.ts (~line 8057) used
+// `sectionByLocale[locale]` unconditionally. With cathedral now emitting the
+// active per-job pages at canton-aware URLs, expired soft-landings written
+// from the TI-section tracking path are stale (best case) or clobber an
+// active non-TI page that happens to slug-collide (worst case).
+//
+// Strategy:
+//   1. Build a slug -> canton index from data/jobs.json. Index by job.slug,
+//      every slugByLocale.* value, and every previousSlugs[*] entry.
+//   2. For every tracking entry, look up the master slug in that index.
+//        Found  -> rewrite each per-locale path's section slug using the
+//                  canton-aware resolver (mirrors build-plugins/shared/
+//                  cantonSection.ts so the migration has no .ts dependency).
+//        Missing-> keep the TI path (orphan slug; preserves prior behaviour).
+//   3. Preserve any non-locale metadata on the entry (e.g. `source`,
+//      `importedAt` from the GSC-404 import path).
+//   4. Re-emit the file with 2-space indent + trailing newline.
+//
+// TI invariance: jobs whose resolved canton is TI keep the legacy section
+// path verbatim — resolveCantonSection short-circuits on 'TI'.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TRACKING_PATH = path.resolve('data/all-known-job-slugs.json');
+const JOBS_PATH = path.resolve('data/jobs.json');
+const CANTON_SLUGS_PATH = path.resolve('data/canton-url-slugs.json');
+const MUNI_PATH = path.resolve('data/canton-municipalities.json');
+
+const LOCALES = ['it', 'en', 'de', 'fr'];
+const LOCALE_PREFIX = { it: '', en: '/en', de: '/de', fr: '/fr' };
+
+const TI_SECTION_BY_LOCALE = {
+  it: 'cerca-lavoro-ticino',
+  en: 'find-jobs-ticino',
+  de: 'jobs-im-tessin',
+  fr: 'trouver-emploi-tessin',
+};
+
+const SECTION_PREFIX_BY_LOCALE = {
+  it: 'cerca-lavoro',
+  en: 'find-jobs',
+  de: 'jobs-in',
+  fr: 'trouver-emploi',
+};
+
+const AGGREGATE_KEY = '_AGGREGATE_';
+
+// ── Load canton + municipality reference data (mirrors cantonSection.ts) ──
+const cantonSlugFile = JSON.parse(fs.readFileSync(CANTON_SLUGS_PATH, 'utf8'));
+const muniFile = JSON.parse(fs.readFileSync(MUNI_PATH, 'utf8'));
+const cantons = cantonSlugFile.cantons;
+const cantonGroups = cantonSlugFile.cantonGroups || {};
+const aggregateSlugs = cantonSlugFile.aggregate;
+
+const memberToGroup = {};
+for (const [group, info] of Object.entries(cantonGroups)) {
+  for (const member of info.members) memberToGroup[member] = group;
+}
+
+function resolveCantonGroup(cantonCode) {
+  const code = String(cantonCode || '').toUpperCase().trim();
+  if (!code) return 'TI';
+  return memberToGroup[code] ?? code;
+}
+
+function getCantonUrlSlug(code, locale) {
+  if (code === AGGREGATE_KEY) return aggregateSlugs[locale] ?? aggregateSlugs.it;
+  const entry = cantons[code];
+  return entry?.[locale] ?? aggregateSlugs[locale] ?? aggregateSlugs.it;
+}
+
+function resolveCantonSection(locale, cantonCode) {
+  const raw = String(cantonCode || '').toUpperCase();
+  if (!raw || raw === 'TI') return TI_SECTION_BY_LOCALE[locale];
+  if (raw === AGGREGATE_KEY) {
+    return `${SECTION_PREFIX_BY_LOCALE[locale]}-${getCantonUrlSlug(AGGREGATE_KEY, locale)}`;
+  }
+  const code = resolveCantonGroup(raw);
+  if (locale === 'de') {
+    const entry = cantons[code];
+    if (entry?.dePrefix) return `${entry.dePrefix}${entry.de}`;
+  }
+  return `${SECTION_PREFIX_BY_LOCALE[locale]}-${getCantonUrlSlug(code, locale)}`;
+}
+
+function normalizeCityKey(s) {
+  return String(s)
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
+const CITY_TO_CANTON = (() => {
+  const out = {};
+  for (const [canton, info] of Object.entries(muniFile.cantons)) {
+    for (const city of info.municipalities) {
+      out[normalizeCityKey(city).split(' (')[0].trim()] = canton;
+    }
+  }
+  return out;
+})();
+
+function resolveJobCanton(job) {
+  const explicit = String(job.canton || '').toUpperCase().trim();
+  if (explicit && (cantons[explicit] || memberToGroup[explicit])) {
+    return resolveCantonGroup(explicit);
+  }
+  const locRaw = normalizeCityKey(String(job.location || ''));
+  const loc = locRaw.replace(/\bsankt\s+/g, 'st. ');
+  const fullCity = loc.split(/[,(]/)[0].trim();
+  if (fullCity && CITY_TO_CANTON[fullCity]) return resolveCantonGroup(CITY_TO_CANTON[fullCity]);
+  const tokens = loc.replace(/[(),]/g, ' ').split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    if (CITY_TO_CANTON[token]) return resolveCantonGroup(CITY_TO_CANTON[token]);
+    const up = token.toUpperCase();
+    if (cantons[up] || memberToGroup[up]) return resolveCantonGroup(up);
+  }
+  return 'TI';
+}
+
+// ── Migration body ─────────────────────────────────────────────────
+const tracking = JSON.parse(fs.readFileSync(TRACKING_PATH, 'utf8'));
+const jobs = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf8'));
+
+// 1. Index every job slug-alias -> job (so we can resolve its canton).
+const slugToJob = new Map();
+for (const job of jobs) {
+  const aliases = new Set();
+  if (job?.slug) aliases.add(String(job.slug));
+  if (job?.slugByLocale && typeof job.slugByLocale === 'object') {
+    for (const v of Object.values(job.slugByLocale)) {
+      if (v) aliases.add(String(v));
+    }
+  }
+  if (Array.isArray(job?.previousSlugs)) {
+    for (const v of job.previousSlugs) {
+      if (v) aliases.add(String(v));
+    }
+  }
+  for (const alias of aliases) {
+    if (!slugToJob.has(alias)) slugToJob.set(alias, job);
+  }
+}
+
+// 2. Pre-compute TI legacy path prefixes for cheap matching.
+const TI_PATH_PREFIX = {};
+for (const locale of LOCALES) {
+  TI_PATH_PREFIX[locale] = `${LOCALE_PREFIX[locale]}/${TI_SECTION_BY_LOCALE[locale]}/`;
+}
+
+let rewritten = 0;
+let kept = 0;
+let orphanKept = 0;
+const cantonStats = new Map();
+
+const out = {};
+for (const [trackingSlug, entry] of Object.entries(tracking)) {
+  if (!entry || typeof entry !== 'object') {
+    out[trackingSlug] = entry;
+    continue;
+  }
+  const job = slugToJob.get(trackingSlug);
+  if (!job) {
+    orphanKept++;
+    out[trackingSlug] = entry;
+    continue;
+  }
+  const canton = resolveJobCanton({ canton: job.canton, location: job.location });
+  cantonStats.set(canton, (cantonStats.get(canton) || 0) + 1);
+  if (canton === 'TI') {
+    kept++;
+    out[trackingSlug] = entry;
+    continue;
+  }
+  const newEntry = { ...entry };
+  let touched = false;
+  for (const locale of LOCALES) {
+    const oldPath = entry[locale];
+    if (typeof oldPath !== 'string') continue;
+    const tiPrefix = TI_PATH_PREFIX[locale];
+    if (!oldPath.startsWith(tiPrefix)) continue; // already canton-aware or hand-edited
+    const remainder = oldPath.slice(tiPrefix.length);
+    const newSection = resolveCantonSection(locale, canton);
+    newEntry[locale] = `${LOCALE_PREFIX[locale]}/${newSection}/${remainder}`.replace(/\/+/g, '/');
+    touched = true;
+  }
+  if (touched) rewritten++;
+  else kept++;
+  out[trackingSlug] = newEntry;
+}
+
+fs.writeFileSync(TRACKING_PATH, JSON.stringify(out, null, 2) + '\n');
+
+console.log('all-known-job-slugs canton-aware migration:');
+console.log(`  total tracking entries:      ${Object.keys(tracking).length}`);
+console.log(`  rewritten (non-TI job):      ${rewritten}`);
+console.log(`  kept (TI job — invariance):  ${kept}`);
+console.log(`  kept (orphan, no live job):  ${orphanKept}`);
+console.log('  canton distribution of matched jobs:');
+const cantonSorted = [...cantonStats.entries()].sort((a, b) => b[1] - a[1]);
+for (const [c, n] of cantonSorted) console.log(`    ${c.padEnd(6)} ${n}`);

--- a/tests/seo/cathedral-expired-tracking-canton.test.ts
+++ b/tests/seo/cathedral-expired-tracking-canton.test.ts
@@ -1,0 +1,100 @@
+// Phase 8 Sub-PR (c) — expired-job soft-landing tracking must be canton-aware.
+//
+// Before this change, every entry in data/all-known-job-slugs.json was minted
+// under the legacy TI section (`/cerca-lavoro-ticino/...`) by the builder in
+// jobsSeoPagesPlugin.ts. With cathedral now emitting active per-job pages at
+// canton-aware URLs, the soft-landing emitter wrote stale TI URLs and the
+// `activeJobDirs.has(...)` collision check missed non-TI active pages.
+//
+// Two guards in this file:
+//   1. Source-level: the tracking builder region of jobsSeoPagesPlugin.ts
+//      references the canton-aware section helper (not the hard-coded
+//      `sectionByLocale[locale]`).
+//   2. Data assertion: tracking entries for non-TI jobs no longer carry
+//      legacy TI section path segments.
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const PLUGIN_PATH = path.resolve(__dirname, '../../build-plugins/jobsSeoPagesPlugin.ts');
+const TRACKING_PATH = path.resolve(__dirname, '../../data/all-known-job-slugs.json');
+const JOBS_PATH = path.resolve(__dirname, '../../data/jobs.json');
+
+const TI_SECTION_FRAGMENTS = [
+  '/cerca-lavoro-ticino/',
+  '/find-jobs-ticino/',
+  '/jobs-im-tessin/',
+  '/trouver-emploi-tessin/',
+] as const;
+
+describe('Phase 8c — expired-tracking is canton-aware', () => {
+  it('source: tracking[job.slug][locale] builder uses buildCantonAwareSection', () => {
+    const src = fs.readFileSync(PLUGIN_PATH, 'utf8');
+    // Locate the tracking builder region by anchor strings that surround it.
+    const anchor = 'if (!tracking[job.slug]) {';
+    const idx = src.indexOf(anchor);
+    expect(idx).toBeGreaterThan(-1);
+    // Look at the next ~600 chars (the small if-block builds the entry).
+    const region = src.slice(idx, idx + 800);
+    expect(region).toMatch(/buildCantonAwareSection|sharedResolveCantonSection/);
+    // And it must NOT still hard-code sectionByLocale[locale] inside the
+    // tracking-entry builder.
+    expect(region).not.toMatch(/sectionByLocale\[locale\]/);
+  });
+
+  it('data: non-TI tracking entries no longer reference the TI section path', () => {
+    if (!fs.existsSync(JOBS_PATH) || !fs.existsSync(TRACKING_PATH)) return;
+    const jobs: Array<{
+      slug?: string;
+      canton?: string;
+      location?: string;
+      slugByLocale?: Record<string, string>;
+      previousSlugs?: string[];
+    }> = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf8'));
+    const tracking: Record<string, Record<string, string>> = JSON.parse(
+      fs.readFileSync(TRACKING_PATH, 'utf8'),
+    );
+
+    // Build slug-alias -> job index so we can look up by tracking key.
+    const slugToJob = new Map<string, (typeof jobs)[number]>();
+    for (const job of jobs) {
+      const aliases = new Set<string>();
+      if (job.slug) aliases.add(job.slug);
+      if (job.slugByLocale) {
+        for (const v of Object.values(job.slugByLocale)) if (v) aliases.add(v);
+      }
+      if (Array.isArray(job.previousSlugs)) {
+        for (const v of job.previousSlugs) if (v) aliases.add(v);
+      }
+      for (const a of aliases) if (!slugToJob.has(a)) slugToJob.set(a, job);
+    }
+
+    // Sample non-TI jobs that ARE represented in tracking.
+    const nonTiJobs = jobs.filter((j) => {
+      const c = String(j.canton || '').toUpperCase();
+      if (!c || c === 'TI') return false;
+      const key = j.slug && tracking[j.slug] ? j.slug : null;
+      return Boolean(key);
+    });
+    if (nonTiJobs.length === 0) return; // dataset has no non-TI jobs
+
+    // Deterministic sample (first 20 sorted by slug) — covers multiple cantons
+    // and keeps the assertion cheap.
+    const sample = nonTiJobs
+      .slice()
+      .sort((a, b) => String(a.slug).localeCompare(String(b.slug)))
+      .slice(0, 20);
+
+    for (const job of sample) {
+      const entry = tracking[job.slug!];
+      expect(entry).toBeTruthy();
+      for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+        const p = entry[locale];
+        if (typeof p !== 'string') continue;
+        for (const frag of TI_SECTION_FRAGMENTS) {
+          expect(p, `non-TI job ${job.slug} (canton=${job.canton}) [${locale}] still references ${frag}: ${p}`).not.toContain(frag);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 8 Sub-PR (c) — make expired-job soft-landing tracking canton-aware.

Today every entry written by the tracking builder in `build-plugins/jobsSeoPagesPlugin.ts` lands under the legacy TI section path. With per-job pages now emitting at canton-aware URLs in the cathedral, the soft-landing emitter wrote stale TI URLs, and the `activeJobDirs.has(...)` collision check missed non-TI active pages — allowing a soft-landing to clobber a live page.

- **Plugin builder** now resolves `sharedResolveJobCanton(job)` once and uses `buildCantonAwareSection(locale, canton)` per locale. TI invariance is preserved by the helper's early-return on code === 'TI'.
- **Migration script** (`scripts/migrate-all-known-job-slugs-canton-aware.mjs`) rewrites `data/all-known-job-slugs.json` in place using the same canton resolver. Orphan slugs (no live job claims them) keep the TI path. The script has no `.ts` dependency — it inlines the resolver from `data/canton-url-slugs.json` + `data/canton-municipalities.json`.
- **Test** (`tests/seo/cathedral-expired-tracking-canton.test.ts`) adds a source-level guard (the tracking builder region references `buildCantonAwareSection`) and a data assertion (sampled non-TI tracking entries no longer contain the TI section fragments).

## Migration result (production data, 38,772 tracking entries)

| Bucket | Count |
|---|---|
| rewritten (non-TI jobs) | 6,766 |
| kept (TI invariance) | 5,421 |
| kept (orphan, no live job) | 26,585 |

## Existence guards verified

- `writeSoftLandingPage`: `activeJobDirs.has(normPath)` now matches the canton-aware tracking path against the canton-aware active page path — clobber check works.
- `previousSlugs` bridge at ~line 9674: unaffected. `oldRelPath` is the bridge path under `sectionByLocale`, not the tracking path.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/seo/cathedral-expired-tracking-canton.test.ts` (2 pass — source + data guards)
- [x] `npx vitest run tests/seo/` (424 pass / 22 skip, no regression)
- [x] `tests/seo/cathedral-no-ti-hardcodes.test.ts` still passes (no new hardcodes introduced)
- [ ] CI green on the full pipeline post-merge

Refs Phase 8 of the cathedral canton-aware completion plan.