### PR TITLE
fix(cathedral): Phase 8d — short editorial slugs for 21 cantons + TI invariance

### DIFF
--- a/build-plugins/jobEditorialLanding.ts
+++ b/build-plugins/jobEditorialLanding.ts
@@ -94,55 +94,65 @@ export const EDITORIAL_CANTONS: readonly string[] = Object.freeze(
 // (Phase 5 P1-A — TI editorial URLs must stay invariant). Remaining cantons
 // auto-generated from CANTON_SLUG_LOCALE with locale-specific templates.
 
+// Phase 8 sub-PR (d): Non-TI/GR/VS cantons use a SHORT slug
+// (`oggi` / `today` / `heute` / `aujourdhui`) so the URL becomes
+// `/cerca-lavoro-{canton}/oggi/` instead of nesting a canton-named slug
+// under the TI section. TI/GR/VS legacy slugs are preserved byte-identical
+// (test suite locks these). Pair the short slug with the canton-aware
+// section produced by `buildCantonAwareSection(locale, canton)`.
 const JOB_TODAY_LANDING_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale, string>> = (() => {
  const out: Record<string, Record<JobLandingLocale, string>> = {
   TI: { it: 'offerte-di-lavoro-ticino-oggi', en: 'ticino-jobs-today', de: 'jobs-tessin-heute', fr: 'offres-emploi-tessin-aujourdhui' },
   GR: { it: 'offerte-di-lavoro-grigioni-oggi', en: 'graubunden-jobs-today', de: 'jobs-graubunden-heute', fr: 'offres-emploi-grisons-aujourdhui' },
   VS: { it: 'offerte-di-lavoro-vallese-oggi', en: 'valais-jobs-today', de: 'jobs-wallis-heute', fr: 'offres-emploi-valais-aujourdhui' },
  };
- for (const [code, slugs] of Object.entries(CANTON_SLUG_LOCALE)) {
+ for (const code of Object.keys(CANTON_SLUG_LOCALE)) {
   if (out[code]) continue;
   out[code] = {
-   it: `offerte-di-lavoro-${slugs.it}-oggi`,
-   en: `${slugs.en}-jobs-today`,
-   de: `jobs-${slugs.de}-heute`,
-   fr: `offres-emploi-${slugs.fr}-aujourdhui`,
+   it: 'oggi',
+   en: 'today',
+   de: 'heute',
+   fr: 'aujourdhui',
   };
  }
  return out;
 })();
 
+// Phase 8 sub-PR (d): non-TI/GR/VS cantons collapse to a short slug; the
+// canton is encoded in the section segment (`/cerca-lavoro-{canton}/`).
 const JOB_NURSES_HUB_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale, string>> = (() => {
  const out: Record<string, Record<JobLandingLocale, string>> = {
   TI: { it: 'infermieri-in-ticino', en: 'nurses-in-ticino', de: 'pflege-jobs-im-tessin', fr: 'infirmiers-au-tessin' },
   GR: { it: 'infermieri-in-grigioni', en: 'nurses-in-graubunden', de: 'pflege-jobs-in-graubunden', fr: 'infirmiers-aux-grisons' },
   VS: { it: 'infermieri-in-vallese', en: 'nurses-in-valais', de: 'pflege-jobs-im-wallis', fr: 'infirmiers-en-valais' },
  };
- for (const [code, slugs] of Object.entries(CANTON_SLUG_LOCALE)) {
+ for (const code of Object.keys(CANTON_SLUG_LOCALE)) {
   if (out[code]) continue;
   out[code] = {
-   it: `infermieri-in-${slugs.it}`,
-   en: `nurses-in-${slugs.en}`,
-   de: `pflege-jobs-in-${slugs.de}`,
-   fr: `infirmiers-dans-le-canton-de-${slugs.fr}`,
+   it: 'infermieri',
+   en: 'nurses',
+   de: 'pflege-jobs',
+   fr: 'infirmiers',
   };
  }
  return out;
 })();
 
+// Phase 8 sub-PR (d): non-TI/GR/VS cantons collapse to a short slug; the
+// canton is encoded in the section segment (`/cerca-lavoro-{canton}/`).
 const JOB_PART_TIME_LANDING_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale, string>> = (() => {
  const out: Record<string, Record<JobLandingLocale, string>> = {
   TI: { it: 'lavoro-part-time-ticino', en: 'part-time-jobs-ticino', de: 'teilzeit-jobs-tessin', fr: 'emploi-temps-partiel-tessin' },
   GR: { it: 'lavoro-part-time-grigioni', en: 'part-time-jobs-graubunden', de: 'teilzeit-jobs-graubunden', fr: 'emploi-temps-partiel-grisons' },
   VS: { it: 'lavoro-part-time-vallese', en: 'part-time-jobs-valais', de: 'teilzeit-jobs-wallis', fr: 'emploi-temps-partiel-valais' },
  };
- for (const [code, slugs] of Object.entries(CANTON_SLUG_LOCALE)) {
+ for (const code of Object.keys(CANTON_SLUG_LOCALE)) {
   if (out[code]) continue;
   out[code] = {
-   it: `lavoro-part-time-${slugs.it}`,
-   en: `part-time-jobs-${slugs.en}`,
-   de: `teilzeit-jobs-${slugs.de}`,
-   fr: `emploi-temps-partiel-${slugs.fr}`,
+   it: 'lavoro-part-time',
+   en: 'part-time-jobs',
+   de: 'teilzeit-jobs',
+   fr: 'emploi-temps-partiel',
   };
  }
  return out;
@@ -862,15 +872,25 @@ function makeNursesHubCopy(cantonCode: string): Record<JobLandingLocale, {
 
 const NURSES_HUB_COPY = makeNursesHubCopy('TI');
 
+// Phase 8 sub-PR (d): TI/GR/VS retain legacy form `cliniche-ticino` (canton
+// embedded in slug) for URL invariance — those URLs are locked by tests and
+// by the production index. For the other 21 cantons, the slug collapses to
+// the short form (e.g. `cliniche`) because the canton is already encoded in
+// the section segment via `buildCantonAwareSection(locale, canton)`. The
+// trailing `-jobs` suffix in EN/DE is preserved for TI/GR/VS only.
+const _LEGACY_CARE_CLUSTER_CANTONS = new Set(['TI', 'GR', 'VS']);
 function careClusterSlug(key: JobCareClusterKey, cantonCode: string, locale: JobLandingLocale): string {
- const cantonSlug = CANTON_SLUG_LOCALE[cantonCode]?.[locale] || CANTON_SLUG_LOCALE['TI'][locale];
  const base: Record<JobCareClusterKey, Record<JobLandingLocale, string>> = {
  clinics: { it: 'cliniche', en: 'clinics', de: 'kliniken', fr: 'cliniques' },
  careHomes: { it: 'case-anziani', en: 'care-homes', de: 'altersheime', fr: 'maisons-retraite' },
  oss: { it: 'oss', en: 'healthcare-assistants', de: 'pflegeassistenz', fr: 'oss' },
  educators: { it: 'educatori', en: 'educators', de: 'paedagogen', fr: 'educateurs' },
  };
- return `${base[key][locale]}-${cantonSlug}${locale === 'en' || locale === 'de' ? '-jobs' : ''}`;
+ if (_LEGACY_CARE_CLUSTER_CANTONS.has(cantonCode)) {
+   const cantonSlug = CANTON_SLUG_LOCALE[cantonCode]?.[locale] || CANTON_SLUG_LOCALE['TI'][locale];
+   return `${base[key][locale]}-${cantonSlug}${locale === 'en' || locale === 'de' ? '-jobs' : ''}`;
+ }
+ return base[key][locale];
 }
 
 function careClusterLabel(key: JobCareClusterKey, cantonCode: string, locale: JobLandingLocale): string {
@@ -1331,11 +1351,34 @@ function findSectorKeyBySlugExtended(slug: string): JobLandingSectorKey | null {
  return findSectorKeyBySlug(slug) || SECTOR_SLUG_ALIASES[normalizeSpace(slug)] || null;
 }
 
+// Short-form (non-TI canton) care-cluster slugs — mapping locale slug → key.
+// `clinics-it` short → `cliniche` (no canton suffix). For TI/GR/VS the slug
+// keeps the canton suffix and is resolved via `CARE_CLUSTER_DEFS[key].slug`.
+const CARE_CLUSTER_SHORT_SLUG_TO_KEY: Record<string, JobCareClusterKey> = {
+ cliniche: 'clinics',
+ clinics: 'clinics',
+ kliniken: 'clinics',
+ cliniques: 'clinics',
+ 'case-anziani': 'careHomes',
+ 'care-homes': 'careHomes',
+ altersheime: 'careHomes',
+ 'maisons-retraite': 'careHomes',
+ oss: 'oss',
+ 'healthcare-assistants': 'oss',
+ pflegeassistenz: 'oss',
+ educatori: 'educators',
+ educators: 'educators',
+ paedagogen: 'educators',
+ educateurs: 'educators',
+};
+
 function findCareClusterKeyBySlug(slug: string): JobCareClusterKey | null {
  const clean = normalizeSpace(slug);
- return (Object.keys(CARE_CLUSTER_DEFS) as JobCareClusterKey[]).find((key) =>
+ const fromLegacy = (Object.keys(CARE_CLUSTER_DEFS) as JobCareClusterKey[]).find((key) =>
  Object.values(CARE_CLUSTER_DEFS[key].slug).includes(clean),
- ) || null;
+ );
+ if (fromLegacy) return fromLegacy;
+ return CARE_CLUSTER_SHORT_SLUG_TO_KEY[clean] || null;
 }
 
 function matchesLocation(job: JobLike, location: string): boolean {
@@ -1517,10 +1560,20 @@ export function resolveEditorialJobLandingDescriptor(value: string): EditorialLa
  if (Object.values(JOB_OFFICIAL_GAZETTE_LANDING_SLUGS).includes(slug as (typeof JOB_OFFICIAL_GAZETTE_LANDING_SLUGS)[JobLandingLocale])) {
  return { kind: 'official-gazette' };
  }
- if (Object.values(JOB_NURSES_HUB_SLUGS).includes(slug as (typeof JOB_NURSES_HUB_SLUGS)[JobLandingLocale]) || slug === 'lavoro-infermieri') {
+ // Phase 8 sub-PR (d): scan ALL canton variants for the nurses-hub and
+ // part-time slugs (TI long-form + 21 short-form non-TI cantons).
+ const nursesSlugSet = new Set<string>();
+ for (const cantonSlugs of Object.values(JOB_NURSES_HUB_SLUGS_BY_CANTON)) {
+ for (const localeSlug of Object.values(cantonSlugs)) nursesSlugSet.add(localeSlug);
+ }
+ if (nursesSlugSet.has(slug) || slug === 'lavoro-infermieri') {
  return { kind: 'nurses-hub' };
  }
- if (Object.values(JOB_PART_TIME_LANDING_SLUGS).includes(slug as (typeof JOB_PART_TIME_LANDING_SLUGS)[JobLandingLocale])) {
+ const partTimeSlugSet = new Set<string>();
+ for (const cantonSlugs of Object.values(JOB_PART_TIME_LANDING_SLUGS_BY_CANTON)) {
+ for (const localeSlug of Object.values(cantonSlugs)) partTimeSlugSet.add(localeSlug);
+ }
+ if (partTimeSlugSet.has(slug)) {
  return { kind: 'part-time' };
  }
  const careClusterKey = findCareClusterKeyBySlug(slug);
@@ -2311,9 +2364,14 @@ export function buildJobPartTimeLandingModel(options: {
 
  return {
  kind: 'part-time',
- slug: cantonCode !== 'TI' && JOB_PART_TIME_LANDING_SLUGS_BY_CANTON[cantonCode]
- ? JOB_PART_TIME_LANDING_SLUGS_BY_CANTON[cantonCode][locale]
- : JOB_PART_TIME_LANDING_SLUGS[locale],
+ // Phase 8 sub-PR (d): the canton-aware table is the single source of
+ // truth. TI/GR/VS rows preserve the legacy long-form (`lavoro-part-time-
+ // ticino`) byte-identically; non-TI cantons collapse to the short form
+ // (`lavoro-part-time`) because the canton is encoded in the section
+ // segment. `JOB_PART_TIME_LANDING_SLUGS` is kept as a backward-compatible
+ // short-form export and must NOT be consulted from the model — using it
+ // for TI would silently change the indexed URL.
+ slug: (JOB_PART_TIME_LANDING_SLUGS_BY_CANTON[cantonCode] || JOB_PART_TIME_LANDING_SLUGS_BY_CANTON['TI'])[locale],
  title: copy.title,
  heading: copy.heading,
  description: copy.description(matches.length),

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -3904,9 +3904,14 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  const pushEditorialSitemapEntry = (
  buildModel: (locale: typeof localeList[number]) => { slug: string },
  priority: string,
+ // Phase 8 sub-PR (d): per-canton editorial emit lives at a canton-aware
+ // section (e.g. `cerca-lavoro-zurigo`). Defaults to the legacy TI
+ // section for backward compatibility (non-canton editorial pages: the
+ // official gazette).
+ sectionFor: (locale: typeof localeList[number]) => string = (l) => sectionByLocale[l],
  ) => {
  const itModel = buildModel('it');
- const itPath = withSlash(`/${sectionByLocale.it}/${itModel.slug}`.replace(/\/+/g, '/'));
+ const itPath = withSlash(`/${sectionFor('it')}/${itModel.slug}`.replace(/\/+/g, '/'));
  // Sitemap-jobs alignment (Issue 18): never advertise a URL whose static
  // HTML wasn't actually emitted to dist/. The same plugin emits both the
  // page HTML and the sitemap entry; if an earlier step skipped emission
@@ -3919,7 +3924,7 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  if (!itEmitted) return;
  const alternateLinks = localeList.map((locale) => {
  const localeModel = buildModel(locale);
- const path = `${localePrefix[locale]}/${sectionByLocale[locale]}/${localeModel.slug}`.replace(/\/+/g, '/');
+ const path = `${localePrefix[locale]}/${sectionFor(locale)}/${localeModel.slug}`.replace(/\/+/g, '/');
  return ` <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${withSlash(path)}" />`;
  }).join('\n');
  editorialSitemapEntries.push(` <url>\n <loc>${BASE_URL}${itPath}</loc>\n${alternateLinks}\n <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${itPath}" />\n <lastmod>${dateStamp}</lastmod>\n <changefreq>daily</changefreq>\n <priority>${priority}</priority>\n </url>`);
@@ -3939,6 +3944,13 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
 
  for (const editorialCanton of EDITORIAL_CANTONS) {
  if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ // Phase 8 sub-PR (d): for non-TI editorial cantons the URL section
+ // becomes the canton-aware form (e.g. `cerca-lavoro-zurigo`) and the
+ // model emits a short slug (`oggi` / `today` / `heute` / `aujourdhui`).
+ // TI continues to use the legacy `sectionByLocale[locale]` value,
+ // which `buildCantonAwareSection(locale, 'TI')` returns by design,
+ // so TI URLs stay byte-identical.
+ const sectionByLocaleCanton = (l: 'it' | 'en' | 'de' | 'fr') => buildCantonAwareSection(l, editorialCanton);
  for (const locale of localeList) {
  const __tEdJobsToday = startTimer();
  const model = buildJobTodayLandingModel({
@@ -3947,12 +3959,12 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
  });
 
- const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${model.slug}`.replace(/\/+/g, '/'));
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}/${model.slug}`.replace(/\/+/g, '/'));
  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
  // x-default required by audit-hreflang alongside the 4 locale entries.
  // OPT: hreflang only needs the slug per locale — call the lightweight
@@ -3962,7 +3974,7 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  // 12 editorial-jobs-today emits = ~3.7s of build wall.
  const todayHreflangPairs = localeList.map((altLocale) => {
  const altSlug = getJobTodayLandingSlug(altLocale, editorialCanton);
- const altPath = `${localePrefix[altLocale]}/${sectionByLocale[altLocale]}/${altSlug}`.replace(/\/+/g, '/');
+ const altPath = `${localePrefix[altLocale]}/${sectionByLocaleCanton(altLocale)}/${altSlug}`.replace(/\/+/g, '/');
  return { lang: altLocale, href: `${BASE_URL}${withSlash(altPath)}` };
  });
  // audit-hreflang requires 5 entries — force x-default with canonicalUrl fallback.
@@ -3971,14 +3983,14 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  ...todayHreflangPairs.map((p) => ` <link rel="alternate" hreflang="${p.lang}" href="${p.href}">`),
  ` <link rel="alternate" hreflang="x-default" href="${xDefaultToday}">`,
  ].join('\n');
- const openAllHref = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'))}`;
+ const openAllHref = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}`.replace(/\/+/g, '/'))}`;
  const cityCards = model.sections.cities.length > 0
  ? model.sections.cities.map((city) => city.href
      ? `<a href="${city.href}" style="display:flex;justify-content:space-between;gap:12px;padding:12px 14px;border:1px solid var(--color-accent-border);border-radius:16px;background:var(--color-accent-subtle);color:var(--color-heading);text-decoration:none;font-weight:600"><span>${esc(city.name)}</span><span style="color:var(--color-link)">${city.count}</span></a>`
      : `<div style="display:flex;justify-content:space-between;gap:12px;padding:12px 14px;border:1px solid var(--color-accent-border);border-radius:16px;background:var(--color-accent-subtle);color:var(--color-heading);font-weight:600"><span>${esc(city.name)}</span><span style="color:var(--color-link)">${city.count}</span></div>`).join('')
  : '<p style="margin:0;color:var(--color-subtle);font-size:14px">—</p>';
  const internalLinks = model.internalLinks.map((item) => `<a href="${item.href}" style="display:inline-flex;padding:8px 12px;border-radius:999px;background:var(--color-accent-subtle);color:var(--color-accent);text-decoration:none;font-weight:700;font-size:13px">${esc(item.label)}</a>`).join('');
- const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'))}`;
+ const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}`.replace(/\/+/g, '/'))}`;
  const { breadcrumbLd, collectionLd, itemListLd } = buildEditorialJsonLd({
  locale,
  name: model.heading,
@@ -4081,10 +4093,10 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
- }), '0.8');
+ }), '0.8', sectionByLocaleCanton);
  }
 
  for (const locale of localeList) {
@@ -4243,6 +4255,8 @@ ${alternates}
 
  for (const editorialCanton of EDITORIAL_CANTONS) {
  if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ // Phase 8 sub-PR (d): canton-aware section + short slug for non-TI.
+ const sectionByLocaleCanton = (l: 'it' | 'en' | 'de' | 'fr') => buildCantonAwareSection(l, editorialCanton);
  for (const locale of localeList) {
  const __tEdNurses = startTimer();
  const model = buildJobNursesHubLandingModel({
@@ -4251,13 +4265,13 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
  partition: careClusterPartition,
  });
  editorialSearchSlugsByLocale.get(locale)?.add(model.slug);
- const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${model.slug}`.replace(/\/+/g, '/'));
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}/${model.slug}`.replace(/\/+/g, '/'));
  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
  const _altPairs = localeList
  .map((altLocale) => {
@@ -4267,12 +4281,12 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[altLocale],
+ sectionSlug: sectionByLocaleCanton(altLocale),
  localePrefix: localePrefix[altLocale],
  canton: editorialCanton,
  partition: careClusterPartition,
  });
- const altPath = `${localePrefix[altLocale]}/${sectionByLocale[altLocale]}/${altModel.slug}`.replace(/\/+/g, '/');
+ const altPath = `${localePrefix[altLocale]}/${sectionByLocaleCanton(altLocale)}/${altModel.slug}`.replace(/\/+/g, '/');
  return { lang: altLocale, href: `${BASE_URL}${withSlash(altPath)}` };
  });
  const _xDefaultAltHref = _altPairs.find((p) => p.lang === "it")?.href ?? _altPairs[0]?.href ?? canonicalUrl;
@@ -4284,7 +4298,7 @@ ${alternates}
  ? model.variants.map((link) => `<a href="${link.href}" style="display:flex;justify-content:space-between;gap:12px;padding:12px 14px;border:1px solid var(--color-accent-border);border-radius:16px;background:var(--color-accent-subtle);color:var(--color-heading);text-decoration:none;font-weight:600"><span>${esc(link.label)}</span><span style="color:var(--color-link)">${link.count}</span></a>`).join('')
  : '<p style="margin:0;color:var(--color-subtle);font-size:14px">—</p>';
  const explainerCards = model.explainerCards.map((card) => `<div style="padding:18px;border-radius:18px;border:1px solid var(--color-edge);background:var(--color-surface)"><h3 style="margin:0 0 8px;font-size:18px;color:var(--color-heading)">${esc(card.title)}</h3><p style="margin:0;color:var(--color-subtle);line-height:1.7">${esc(card.body)}</p></div>`).join('');
- const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'))}`;
+ const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}`.replace(/\/+/g, '/'))}`;
  const { breadcrumbLd, collectionLd, itemListLd } = buildEditorialJsonLd({
  locale,
  name: model.heading,
@@ -4408,16 +4422,18 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
  partition: careClusterPartition,
- }), '0.77');
+ }), '0.77', sectionByLocaleCanton);
  }
 
  /* ── Editorial landing: global part-time ───────────────────── */
  for (const editorialCanton of EDITORIAL_CANTONS) {
  if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ // Phase 8 sub-PR (d): canton-aware section + short slug for non-TI.
+ const sectionByLocaleCanton = (l: 'it' | 'en' | 'de' | 'fr') => buildCantonAwareSection(l, editorialCanton);
  for (const locale of localeList) {
  const __tEdPartTimeCanton = startTimer();
  const model = buildJobPartTimeLandingModel({
@@ -4426,12 +4442,12 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
  });
  editorialSearchSlugsByLocale.get(locale)?.add(model.slug);
- const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${model.slug}`.replace(/\/+/g, '/'));
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}/${model.slug}`.replace(/\/+/g, '/'));
  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
  const _altPairs = localeList
  .map((altLocale) => {
@@ -4441,11 +4457,11 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[altLocale],
+ sectionSlug: sectionByLocaleCanton(altLocale),
  localePrefix: localePrefix[altLocale],
  canton: editorialCanton,
  });
- const altPath = `${localePrefix[altLocale]}/${sectionByLocale[altLocale]}/${altModel.slug}`.replace(/\/+/g, '/');
+ const altPath = `${localePrefix[altLocale]}/${sectionByLocaleCanton(altLocale)}/${altModel.slug}`.replace(/\/+/g, '/');
  return { lang: altLocale, href: `${BASE_URL}${withSlash(altPath)}` };
  });
  const _xDefaultAltHref = _altPairs.find((p) => p.lang === "it")?.href ?? _altPairs[0]?.href ?? canonicalUrl;
@@ -4453,7 +4469,7 @@ ${alternates}
   ..._altPairs.map((p) => ` <link rel="alternate" hreflang="${p.lang}" href="${p.href}">`),
   ` <link rel="alternate" hreflang="x-default" href="${_xDefaultAltHref}">`,
  ].join('\n');
- const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'))}`;
+ const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}`.replace(/\/+/g, '/'))}`;
  const cityCards = model.cityLinks.length > 0
  ? model.cityLinks.map((city) => city.href
      ? `<a href="${city.href}" style="display:flex;justify-content:space-between;gap:12px;padding:12px 14px;border:1px solid var(--color-accent-border);border-radius:16px;background:var(--color-accent-subtle);color:var(--color-heading);text-decoration:none;font-weight:600"><span>${esc(city.name)}</span><span style="color:var(--color-link)">${city.count}</span></a>`
@@ -4571,15 +4587,17 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
- }), '0.76');
+ }), '0.76', sectionByLocaleCanton);
  }
 
  for (const clusterKey of editorialCareKeys) {
  for (const editorialCanton of EDITORIAL_CANTONS) {
  if ((editorialCantonJobCounts.get(editorialCanton) ?? 0) < MIN_JOBS_FOR_CANTON_PAGE) continue;
+ // Phase 8 sub-PR (d): canton-aware section + short slug for non-TI.
+ const sectionByLocaleCanton = (l: 'it' | 'en' | 'de' | 'fr') => buildCantonAwareSection(l, editorialCanton);
  const italianCareModel = buildJobCareVariantLandingModel({
  jobs: validJobs,
  locale: 'it',
@@ -4587,7 +4605,7 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale.it,
+ sectionSlug: sectionByLocaleCanton('it'),
  localePrefix: localePrefix.it,
  canton: editorialCanton,
  partition: careClusterPartition,
@@ -4603,13 +4621,13 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
  partition: careClusterPartition,
  });
  editorialSearchSlugsByLocale.get(locale)?.add(model.slug);
- const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${model.slug}`.replace(/\/+/g, '/'));
+ const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}/${model.slug}`.replace(/\/+/g, '/'));
  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
  const _altPairs = localeList
  .map((altLocale) => {
@@ -4620,12 +4638,12 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[altLocale],
+ sectionSlug: sectionByLocaleCanton(altLocale),
  localePrefix: localePrefix[altLocale],
  canton: editorialCanton,
  partition: careClusterPartition,
  });
- const altPath = `${localePrefix[altLocale]}/${sectionByLocale[altLocale]}/${altModel.slug}`.replace(/\/+/g, '/');
+ const altPath = `${localePrefix[altLocale]}/${sectionByLocaleCanton(altLocale)}/${altModel.slug}`.replace(/\/+/g, '/');
  return { lang: altLocale, href: `${BASE_URL}${withSlash(altPath)}` };
  });
  const _xDefaultAltHref = _altPairs.find((p) => p.lang === "it")?.href ?? _altPairs[0]?.href ?? canonicalUrl;
@@ -4636,7 +4654,7 @@ ${alternates}
  const siblingLinks = model.siblingLinks.length > 0
  ? model.siblingLinks.map((link) => `<a href="${link.href}" style="display:flex;justify-content:space-between;gap:12px;padding:12px 14px;border:1px solid var(--color-accent-border);border-radius:16px;background:var(--color-accent-subtle);color:var(--color-heading);text-decoration:none;font-weight:600"><span>${esc(link.label)}</span><span style="color:var(--color-link)">${link.count}</span></a>`).join('')
  : '<p style="margin:0;color:var(--color-subtle);font-size:14px">—</p>';
- const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'))}`;
+ const sectionRootUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocaleCanton(locale)}`.replace(/\/+/g, '/'))}`;
  const { breadcrumbLd, collectionLd, itemListLd } = buildEditorialJsonLd({
  locale,
  name: model.heading,
@@ -4735,11 +4753,11 @@ ${alternates}
  now: new Date().toISOString(),
  localizedSlug,
  baseUrl: BASE_URL,
- sectionSlug: sectionByLocale[locale],
+ sectionSlug: sectionByLocaleCanton(locale),
  localePrefix: localePrefix[locale],
  canton: editorialCanton,
  partition: careClusterPartition,
- }), '0.71');
+ }), '0.71', sectionByLocaleCanton);
  }
  }
 

--- a/tests/seo/cathedral-editorial-slug-tables.test.ts
+++ b/tests/seo/cathedral-editorial-slug-tables.test.ts
@@ -18,6 +18,11 @@ describe('editorial slug tables — all cantons covered', () => {
   expect(EDITORIAL_PRIMARY_CANTONS).toEqual(['TI', 'GR', 'VS']);
  });
 
+ // Phase 8 sub-PR (d) — TI invariance HARD constraint: TI editorial URL
+ // slugs MUST stay byte-identical to the pre-Phase-8 emit. The canton is
+ // encoded in the section segment for non-TI/GR/VS, so the leaf slug for
+ // those collapses to a short form (`oggi` / `today` / …). TI/GR/VS keep
+ // the legacy long-form slug to preserve their indexed URLs.
  it('TI today-landing slug is byte-identical to legacy', () => {
   expect(getJobTodayLandingSlug('it', 'TI')).toBe('offerte-di-lavoro-ticino-oggi');
   expect(getJobTodayLandingSlug('en', 'TI')).toBe('ticino-jobs-today');
@@ -25,8 +30,31 @@ describe('editorial slug tables — all cantons covered', () => {
   expect(getJobTodayLandingSlug('fr', 'TI')).toBe('offres-emploi-tessin-aujourdhui');
  });
 
- it('ZH today-landing slug is generated per canton (no TI fallback)', () => {
-  expect(getJobTodayLandingSlug('it', 'ZH')).toBe('offerte-di-lavoro-zurigo-oggi');
-  expect(getJobTodayLandingSlug('de', 'ZH')).toBe('jobs-zurich-heute');
+ it('GR today-landing slug is byte-identical to legacy', () => {
+  expect(getJobTodayLandingSlug('it', 'GR')).toBe('offerte-di-lavoro-grigioni-oggi');
+  expect(getJobTodayLandingSlug('en', 'GR')).toBe('graubunden-jobs-today');
+  expect(getJobTodayLandingSlug('de', 'GR')).toBe('jobs-graubunden-heute');
+  expect(getJobTodayLandingSlug('fr', 'GR')).toBe('offres-emploi-grisons-aujourdhui');
+ });
+
+ it('VS today-landing slug is byte-identical to legacy', () => {
+  expect(getJobTodayLandingSlug('it', 'VS')).toBe('offerte-di-lavoro-vallese-oggi');
+  expect(getJobTodayLandingSlug('en', 'VS')).toBe('valais-jobs-today');
+  expect(getJobTodayLandingSlug('de', 'VS')).toBe('jobs-wallis-heute');
+  expect(getJobTodayLandingSlug('fr', 'VS')).toBe('offres-emploi-valais-aujourdhui');
+ });
+
+ // Phase 8 sub-PR (d) — non-TI/GR/VS cantons collapse to a short slug.
+ // The canton sits in the section segment, e.g. `/cerca-lavoro-zurigo/oggi/`.
+ it('ZH today-landing slug uses the short Phase-8d form', () => {
+  expect(getJobTodayLandingSlug('it', 'ZH')).toBe('oggi');
+  expect(getJobTodayLandingSlug('en', 'ZH')).toBe('today');
+  expect(getJobTodayLandingSlug('de', 'ZH')).toBe('heute');
+  expect(getJobTodayLandingSlug('fr', 'ZH')).toBe('aujourdhui');
+ });
+
+ it('AG today-landing slug uses the short Phase-8d form (no canton in slug)', () => {
+  expect(getJobTodayLandingSlug('it', 'AG')).toBe('oggi');
+  expect(getJobTodayLandingSlug('de', 'AG')).toBe('heute');
  });
 });

--- a/tests/seo/cathedral-phase8d-ti-invariance.test.ts
+++ b/tests/seo/cathedral-phase8d-ti-invariance.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Phase 8 sub-PR (d) — TI invariance snapshot.
+ *
+ * HARD INVARIANT (plan + CLAUDE.md non-negotiables #1, #5, #6):
+ * For every editorial landing emitted on canton == 'TI', the full URL path
+ * (section + slug) MUST equal the pre-Phase-8 form byte-for-byte. The
+ * "/cerca-lavoro-{canton}/" architecture extends to non-TI cantons only;
+ * TI uses the legacy `cerca-lavoro` / `find-jobs-ticino` / `jobs-im-tessin` /
+ * `trouver-emploi-tessin` sections AND the canton-named slug variants.
+ *
+ * If any URL in this snapshot changes for the TI canton, that's a
+ * regression that breaks indexed pages. Fix the code, not the snapshot.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+ getJobTodayLandingSlug,
+ buildJobNursesHubLandingModel,
+ buildJobPartTimeLandingModel,
+ buildJobCareVariantLandingModel,
+ partitionCareClusters,
+} from '../../build-plugins/jobEditorialLanding';
+
+const BASE_URL = 'https://frontaliereticino.ch';
+const TI_SECTION_BY_LOCALE = {
+ it: 'cerca-lavoro',
+ en: 'find-jobs-ticino',
+ de: 'jobs-im-tessin',
+ fr: 'trouver-emploi-tessin',
+} as const;
+const LOCALE_PREFIX = { it: '', en: '/en', de: '/de', fr: '/fr' } as const;
+const LOCALES = ['it', 'en', 'de', 'fr'] as const;
+
+const localizedSlug = (job: any, locale: 'it' | 'en' | 'de' | 'fr') =>
+ (job?.slug || job?.id || 'job') + '-' + locale;
+
+const SAMPLE_JOBS = [
+ {
+  id: 'j1', slug: 'job-1', title: 'Infermiere', titleByLocale: { it: 'Infermiere', en: 'Nurse', de: 'Krankenpfleger', fr: 'Infirmier' },
+  company: 'Clinica', location: 'Lugano', canton: 'TI', addressLocality: 'Lugano', datePosted: new Date().toISOString(),
+  sector: 'sanita', contract: 'tempo-pieno',
+ },
+ {
+  id: 'j2', slug: 'job-2', title: 'Educatore', titleByLocale: { it: 'Educatore', en: 'Educator', de: 'Pädagoge', fr: 'Éducateur' },
+  company: 'Casa Anziani Lugano', location: 'Lugano', canton: 'TI', addressLocality: 'Lugano', datePosted: new Date().toISOString(),
+  sector: 'sanita', contract: 'part-time',
+ },
+];
+
+describe('Phase 8 sub-PR (d) — TI editorial URL invariance', () => {
+ it('TI today-landing slug × 4 locales is the legacy long form', () => {
+  expect(getJobTodayLandingSlug('it', 'TI')).toBe('offerte-di-lavoro-ticino-oggi');
+  expect(getJobTodayLandingSlug('en', 'TI')).toBe('ticino-jobs-today');
+  expect(getJobTodayLandingSlug('de', 'TI')).toBe('jobs-tessin-heute');
+  expect(getJobTodayLandingSlug('fr', 'TI')).toBe('offres-emploi-tessin-aujourdhui');
+ });
+
+ it('TI nurses-hub model slug × 4 locales matches the legacy long form', () => {
+  const partition = partitionCareClusters(SAMPLE_JOBS as any);
+  const expected = {
+   it: 'infermieri-in-ticino',
+   en: 'nurses-in-ticino',
+   de: 'pflege-jobs-im-tessin',
+   fr: 'infirmiers-au-tessin',
+  } as const;
+  for (const locale of LOCALES) {
+   const model = buildJobNursesHubLandingModel({
+    jobs: SAMPLE_JOBS as any,
+    locale,
+    now: new Date().toISOString(),
+    localizedSlug,
+    baseUrl: BASE_URL,
+    sectionSlug: TI_SECTION_BY_LOCALE[locale],
+    localePrefix: LOCALE_PREFIX[locale],
+    canton: 'TI',
+    partition,
+   });
+   expect(model.slug).toBe(expected[locale]);
+  }
+ });
+
+ it('TI part-time landing slug × 4 locales matches the legacy long form', () => {
+  const expected = {
+   it: 'lavoro-part-time-ticino',
+   en: 'part-time-jobs-ticino',
+   de: 'teilzeit-jobs-tessin',
+   fr: 'emploi-temps-partiel-tessin',
+  } as const;
+  for (const locale of LOCALES) {
+   const model = buildJobPartTimeLandingModel({
+    jobs: SAMPLE_JOBS as any,
+    locale,
+    now: new Date().toISOString(),
+    localizedSlug,
+    baseUrl: BASE_URL,
+    sectionSlug: TI_SECTION_BY_LOCALE[locale],
+    localePrefix: LOCALE_PREFIX[locale],
+    canton: 'TI',
+   });
+   expect(model.slug).toBe(expected[locale]);
+  }
+ });
+
+ it('TI care-cluster (clinics) slug × 4 locales matches the legacy long form', () => {
+  const partition = partitionCareClusters(SAMPLE_JOBS as any);
+  const expected = {
+   it: 'cliniche-ticino',
+   en: 'clinics-ticino-jobs',
+   de: 'kliniken-tessin-jobs',
+   fr: 'cliniques-tessin',
+  } as const;
+  for (const locale of LOCALES) {
+   const model = buildJobCareVariantLandingModel({
+    jobs: SAMPLE_JOBS as any,
+    locale,
+    clusterKey: 'clinics',
+    now: new Date().toISOString(),
+    localizedSlug,
+    baseUrl: BASE_URL,
+    sectionSlug: TI_SECTION_BY_LOCALE[locale],
+    localePrefix: LOCALE_PREFIX[locale],
+    canton: 'TI',
+    partition,
+   });
+   expect(model.slug).toBe(expected[locale]);
+  }
+ });
+});


### PR DESCRIPTION
## Summary
- Editorial landings for the 21 non-TI/GR/VS cantons collapse to short slugs (e.g. `oggi`/`today`/`heute`/`aujourdhui`, `infermieri`/`nurses`, `lavoro-part-time`, `cliniche`). Canton is already encoded in the section segment (`/cerca-lavoro-{canton}/`), so the slug no longer needs to repeat it.
- TI/GR/VS keep the legacy long-form slugs byte-identical — indexed URLs are locked.
- New `tests/seo/cathedral-phase8d-ti-invariance.test.ts` hard-locks the TI URL invariance across 4 locales × 4 editorial slots (today, nurses-hub, part-time, care variants).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run cathedral-phase8d-ti-invariance.test.ts cathedral-editorial-slug-tables.test.ts\` — 11/11 verdi
- [ ] Full vitest + vite build delegated to CI (avoids local OOM with parallel worktrees)