### PR TITLE
fix(cathedral): Phase 8b — previousSlugWinners canton-aware key

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -7374,9 +7374,13 @@ ${alternates}
  if (localeAwareAll.size === 0 && legacyOnly.length === 0) continue;
 
  const currentItSlug = localizedSlug(job, 'it');
- const currentItPath = withSlash(`/${sectionByLocale.it}/${currentItSlug}`.replace(/\/+/g, '/'));
+ // Phase 8b: previousSlugs sitemap entries live at the JOB'S canton path,
+ // not the legacy TI section. Compute once per job; reused inside addEntry
+ // and the canonicalAlternates emit below.
+ const jobCantonForSitemapPrevSlugs = sharedResolveJobCanton(job as { canton?: string; location?: string });
+ const currentItPath = withSlash(`/${buildCantonAwareSection('it', jobCantonForSitemapPrevSlugs)}/${currentItSlug}`.replace(/\/+/g, '/'));
  const canonicalAlternates = localeList.map((l) => {
- const p = `${localePrefix[l]}/${sectionByLocale[l]}/${localizedSlug(job, l)}`.replace(/\/+/g, '/');
+ const p = `${localePrefix[l]}/${buildCantonAwareSection(l, jobCantonForSitemapPrevSlugs)}/${localizedSlug(job, l)}`.replace(/\/+/g, '/');
  return ` <xhtml:link rel="alternate" hreflang="${l}" href="${BASE_URL}${withSlash(p)}" />`;
  }).join('\n');
  const xDefault = ` <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${currentItPath}" />`;
@@ -7386,7 +7390,7 @@ ${alternates}
  const currentSlug = localizedSlug(job, locale);
  if (!ps || ps === currentSlug) return;
  if (!jobHtmlCache.has(`${locale}:${currentSlug}`)) return;
- const psRelPath = `${localePrefix[locale]}/${sectionByLocale[locale]}/${ps}`.replace(/\/+/g, '/').replace(/^\//, '');
+ const psRelPath = `${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCantonForSitemapPrevSlugs)}/${ps}`.replace(/\/+/g, '/').replace(/^\//, '');
  if (activeJobDirs.has(psRelPath)) return;
  if (prevSlugSitemapPaths.has(psRelPath)) return;
  prevSlugSitemapPaths.add(psRelPath);
@@ -9545,10 +9549,22 @@ ${hreflangLinks}
  // for the full rationale and heuristic.
 
  // Pre-scan #1: build the claimant map BEFORE the emit loop. For each
- // (locale, oldSlug) pair, list every active job that claims it via either
- // previousSlugsByLocale[locale] or the legacy flat previousSlugs (locale-
- // unattributed entries fan out across all locales).
+ // (canton, locale, oldSlug) triple, list every active job in that canton
+ // that claims the oldSlug via either previousSlugsByLocale[locale] or the
+ // legacy flat previousSlugs (locale-unattributed entries fan out across
+ // all locales).
+ //
+ // Phase 8b (2026-05-12): canton is the first key segment because the
+ // bridge URL path now derives from the job's canton (e.g. a ZH job emits
+ // its bridge under /cerca-lavoro-zurigo/). Two jobs in different cantons
+ // that legitimately share a prevSlug emit DIFFERENT bridge URLs —
+ // ownership is per (canton, locale, oldSlug), not per (locale, oldSlug).
  const previousSlugClaimants = new Map<string, PreviousSlugCandidate[]>();
+ // Cache key → canton so we can re-derive the canton for the resolveWinner
+ // call without re-splitting the composite key (split('::', 3) doesn't help
+ // when oldSlug itself contains '::', and historically slugs don't but the
+ // contract shouldn't depend on that).
+ const cantonByKey = new Map<string, string>();
  for (const job of validJobs) {
  const localeAwareAll = new Set<string>();
  const pslByLocale = (job as any).previousSlugsByLocale;
@@ -9561,6 +9577,7 @@ ${hreflangLinks}
  ? job.previousSlugs.filter((s: string) => !localeAwareAll.has(s))
  : [];
  if (localeAwareAll.size === 0 && legacyOnly.length === 0) continue;
+ const jobCantonForClaim = sharedResolveJobCanton(job as { canton?: string; location?: string });
  for (const locale of localeList) {
  const currentSlug = localizedSlug(job, locale);
  if (!currentSlug) continue;
@@ -9569,14 +9586,17 @@ ${hreflangLinks}
  for (const oldSlug of prevSlugsForLocale) {
  if (!oldSlug || oldSlug === currentSlug) continue;
  if (RESERVED_HUB_SLUGS.has(oldSlug)) continue;
- const key = previousSlugWinnerKey(locale, oldSlug);
+ const key = previousSlugWinnerKey(jobCantonForClaim, locale, oldSlug);
  const list = previousSlugClaimants.get(key);
  const candidate: PreviousSlugCandidate = {
  jobIdentifier: String((job as any).id || (job as any).slug || currentSlug),
  canonicalSlug: currentSlug,
  };
  if (list) list.push(candidate);
- else previousSlugClaimants.set(key, [candidate]);
+ else {
+ previousSlugClaimants.set(key, [candidate]);
+ cantonByKey.set(key, jobCantonForClaim);
+ }
  }
  }
  }
@@ -9600,9 +9620,17 @@ ${hreflangLinks}
  const nowIso = new Date().toISOString().slice(0, 10) + 'T00:00:00.000Z';
  let multiClaimantKeys = 0;
  for (const [key, candidates] of previousSlugClaimants) {
- const [locale, oldSlug] = key.split('::', 2);
+ // Key shape: `${canton}::${locale}::${oldSlug}`. We split on the FIRST
+ // two '::' separators only, so an oldSlug containing '::' (defensive —
+ // not expected in real slugs) is preserved as the remainder.
+ const firstSep = key.indexOf('::');
+ const secondSep = firstSep >= 0 ? key.indexOf('::', firstSep + 2) : -1;
+ if (firstSep < 0 || secondSep < 0) continue;
+ const canton = key.slice(0, firstSep);
+ const locale = key.slice(firstSep + 2, secondSep);
+ const oldSlug = key.slice(secondSep + 2);
  if (candidates.length > 1) multiClaimantKeys += 1;
- const winner = resolveWinner(previousSlugWinners, locale, oldSlug, candidates, nowIso);
+ const winner = resolveWinner(previousSlugWinners, canton, locale, oldSlug, candidates, nowIso);
  if (winner) winnerByPrevSlugKey.set(key, winner.winnerJobIdentifier);
  }
  if (multiClaimantKeys > 0) {
@@ -9657,6 +9685,11 @@ ${hreflangLinks}
  };
 
  const myJobIdentifier = String((job as any).id || (job as any).slug || currentSlug);
+ // Canton resolution is per-job (not per-oldSlug) — the same job emits all
+ // its bridges under the same section regardless of locale-aware vs legacy
+ // previousSlugs entries.
+ const jobCantonForBridge = sharedResolveJobCanton(job as { canton?: string; location?: string });
+ const bridgeSection = buildCantonAwareSection(locale, jobCantonForBridge);
  for (const oldSlug of prevSlugsForLocale) {
  if (oldSlug === currentSlug) continue;
  // Skip bridge generation when the previousSlug is a reserved sector/city
@@ -9666,17 +9699,20 @@ ${hreflangLinks}
  // jobSectorPagesPlugin's curated sector hub at the same path and sends
  // both users and Google to a job soft-landing instead of the canonical hub.
  if (RESERVED_HUB_SLUGS.has(oldSlug)) continue;
- // Dedup at write time: if multiple active jobs share this prevSlug, only
- // the registered winner emits the bridge. Other claimants skip silently —
- // their canonical content is still indexed at THEIR own canonical URL,
- // and the bridge URL stably points at the winner's canonical across builds.
- const winnerKey = previousSlugWinnerKey(locale, oldSlug);
+ // Dedup at write time: if multiple active jobs share this prevSlug WITHIN
+ // THIS CANTON, only the registered winner emits the bridge. Other
+ // claimants skip silently — their canonical content is still indexed at
+ // THEIR own canonical URL, and the bridge URL stably points at the
+ // winner's canonical across builds. Phase 8b: ownership is per
+ // (canton, locale, oldSlug); jobs in different cantons that share an old
+ // slug emit at DIFFERENT URLs and never collide here.
+ const winnerKey = previousSlugWinnerKey(jobCantonForBridge, locale, oldSlug);
  const winnerId = winnerByPrevSlugKey.get(winnerKey);
  if (winnerId && winnerId !== myJobIdentifier) {
  bridgeSkippedNotWinner += 1;
  continue;
  }
- const oldPath = `${localePrefix[locale]}/${sectionByLocale[locale]}/${oldSlug}`.replace(/\/+/g, '/');
+ const oldPath = `${localePrefix[locale]}/${bridgeSection}/${oldSlug}`.replace(/\/+/g, '/');
  const oldRelPath = oldPath.replace(/^\//, '');
  // Skip if an active job page already occupies this path (buffered writes
  // are invisible to fs.existsSync — use the activeJobDirs set instead).

--- a/data/previous-slug-winners.json
+++ b/data/previous-slug-winners.json
@@ -1,3586 +1,4034 @@
 {
-  "de::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4706,
-    "candidatesCount": 2
-  },
-  "de::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.5625,
-    "candidatesCount": 2
-  },
-  "de::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "automobil-mechatroniker-in-swiss-armed-forces-vtg-bellinzona",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5385,
-    "candidatesCount": 1
-  },
-  "de::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
+  "BE::de::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-05-04T09:24:16.306Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
+  "BE::de::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::de::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
+  "BE::de::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::arztsekretar-in-unispital-basel-ch": {
-    "winnerJobIdentifier": "unispital-basel-640a59e26647",
-    "winnerCanonical": "arztsekretar-in-universitatsspital-basel-basel",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::arztsekretarin-arztsekretar-ksw-ch": {
-    "winnerJobIdentifier": "ksw-491c8feebb0b",
-    "winnerCanonical": "arztsekretarin-arztsekretar-kantonsspital-winterthur-ksw-winterthur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 3
-  },
-  "de::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medizinischer-studienassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medizinischer-studienassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::assistenz-oder-fachpsychologe-in-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-12451701d2ea",
-    "winnerCanonical": "assistenz-oder-fachpsychologe-in-psychiatrische-dienste-graubunden-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4,
-    "candidatesCount": 2
-  },
-  "de::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medizinischer-assistent-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-05-01T08:59:01.541Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.625,
-    "candidatesCount": 2
-  },
-  "de::assistenzarztin-assistenzarzt-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-9b3b5d5accd6",
-    "winnerCanonical": "assistenzarztin-assistenzarzt-psychiatrische-dienste-graubunden-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 3
-  },
-  "de::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "de::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5455,
-    "candidatesCount": 2
-  },
-  "de::autista-di-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
-    "winnerCanonical": "truck-driver-heineken-ch-baltschieder",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "de::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8,
-    "candidatesCount": 2
-  },
-  "de::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6364,
-    "candidatesCount": 2
-  },
-  "de::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8,
-    "candidatesCount": 2
-  },
-  "de::bauzeichner-m-f-x-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-3ce9ee408868",
-    "winnerCanonical": "konstrukteur-fur-bauingenieurwesen-m-f-x-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "de::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "betreiberbehandlungen-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
-    "winnerJobIdentifier": "grand-hotel-kronenhof-517f2506113d",
-    "winnerCanonical": "buroangestellte-steward-personal-restaurant-capricorn-m-w-d-grand-hotel-kronenhof-pontresina",
-    "decidedAt": "2026-05-06T00:00:00.000Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 1
-  },
-  "de::career-start-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich": {
-    "winnerJobIdentifier": "pwc-652904fb04f9",
-    "winnerCanonical": "karriere-start-in-digital-assurance-it-audit-und-process-analytics-finanzdienstleistungen-pwc-switzerland-zurich",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "de::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-d99433996e9d",
-    "winnerCanonical": "fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-e483453a",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3636,
-    "candidatesCount": 2
-  },
-  "de::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
-    "winnerCanonical": "chauffeur-kat-c-e-heineken-ch-luzern",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.1538,
-    "candidatesCount": 2
-  },
-  "de::consulente-assicurativo": {
-    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
-    "winnerCanonical": "versicherungsberater-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0,
-    "candidatesCount": 2
-  },
-  "de::consulenza-finanziaria-entrata-laterale-fisso-bonus-teilzeit-o-100-convit-holding-gmbh-losone": {
-    "winnerJobIdentifier": "convit-e629adda55fe",
-    "winnerCanonical": "berater-patrimonio-junior-teilzeit-o-100-convit-holding-gmbh-agra",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.3529,
-    "candidatesCount": 2
-  },
-  "de::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "berufslehre-kochin-koch-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.375,
-    "candidatesCount": 2
-  },
-  "de::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::de::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::diet-chef-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "berufslehre-kochin-koch-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.375,
-    "candidatesCount": 2
-  },
-  "de::dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-adaa0bd12412",
-    "winnerCanonical": "dipl-pflegefachperson-hf-fur-die-nachtwache-psychiatrische-dienste-graubunden-cazis",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-8569cb344e08",
-    "winnerCanonical": "dipl-pflegefachperson-hf-uberwachungsstation-40-60-spital-davos-ch",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5455,
-    "candidatesCount": 2
-  },
-  "de::doktorandenstelle-usi-universita-della-svizzera-italiana-lugano": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-c86503b7b022",
-    "winnerCanonical": "doktorandenstelle-im-internationalen-wirtschaftsrecht-usi-universita-della-svizzera-italiana-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "de::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-d99433996e9d",
-    "winnerCanonical": "fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-e483453a",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3636,
-    "candidatesCount": 2
-  },
-  "de::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
+  "BE::de::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.1667,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::de::einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.3077,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "de::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4706,
-    "candidatesCount": 2
-  },
-  "de::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
-    "winnerJobIdentifier": "9770821",
-    "winnerCanonical": "fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8571,
-    "candidatesCount": 2
-  },
-  "de::fachperson-gesundheit-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-80501bd9710d",
-    "winnerCanonical": "fachperson-gesundheit-psychiatrische-dienste-graubunden-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 2
-  },
-  "de::fachpsychologe-in-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-4f88a64e2238",
-    "winnerCanonical": "fachpsychologe-in-psychiatrische-dienste-graubunden-chur",
-    "decidedAt": "2026-05-04T09:24:16.306Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 1
-  },
-  "de::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-d99433996e9d",
-    "winnerCanonical": "fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-e483453a",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 2
-  },
-  "de::fisioterapista-diplomata-o-eoc-ente-ospedaliero-cantonale-locarno-uillzl": {
-    "winnerJobIdentifier": "company-uillzl",
-    "winnerCanonical": "diplomierte-r-physiotherapeut-in-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "de::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::de::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
-    "winnerCanonical": "vollzeitstelle-eines-instrumentierungswissenschaftlers-ingenieurs-usi-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1111,
-    "candidatesCount": 2
-  },
-  "de::funktionsanalytikerin-relewant-chiasso": {
-    "winnerJobIdentifier": "company-czslhp",
-    "winnerCanonical": "funktionsanalyst-relewant-chiasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::gerustbauer-pemsa-bellinzona": {
-    "winnerJobIdentifier": "pemsa-2ade426c81c2",
-    "winnerCanonical": "fliesen-pemsa-bellinzona",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "project-ingenieur-project-manager-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "de::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "de::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "de::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "de::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "de::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4118,
-    "candidatesCount": 2
-  },
-  "de::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4706,
-    "candidatesCount": 2
-  },
-  "de::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4706,
-    "candidatesCount": 2
-  },
-  "de::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
-    "winnerJobIdentifier": "burkhalter-group-cf58443dd112",
-    "winnerCanonical": "heizungsinstallateur-in-100-ulrich-huber-ag-malans",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "de::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
-    "winnerJobIdentifier": "volg-fenaco-f28ee877c0a5",
-    "winnerCanonical": "lehrstelle-als-detailhandelsfachmann-frau-oder-detailhandelsassistent-in-volg-visperterminen",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1176,
-    "candidatesCount": 2
-  },
-  "de::kaeltetechniker-m-w-d-hilcona-pfaffstatt": {
-    "winnerJobIdentifier": "hilcona-1c5bc99d5316",
-    "winnerCanonical": "kaeltetechniker-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "de::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
-    "winnerJobIdentifier": "company-ts9gho",
-    "winnerCanonical": "kundenberaterin-basis-bern-w-m-banca-cler",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "de::kundenberaterin-basis-bern-w-m-banca-cler": {
-    "winnerJobIdentifier": "company-ts9gho",
-    "winnerCanonical": "kundenberaterin-basis-bern-w-m-80-100-bank-cler-bellinzona",
-    "decidedAt": "2026-05-10T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5455,
-    "candidatesCount": 2
-  },
-  "de::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.9091,
-    "candidatesCount": 2
-  },
-  "de::lagerungspflegerin-lagerungspfleger-w-m-d-soh-ch": {
-    "winnerJobIdentifier": "solothurner-spitaeler-04d7bd67b00a",
-    "winnerCanonical": "lagerungspflegerin-lagerungspfleger-w-m-d-solothurner-spitaler-soh-solothurn",
-    "decidedAt": "2026-05-10T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "de::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::de::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.2,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::lernende-r-automobil-mechatroniker-in-efz-fachrichtung-personenwagen-swiss-armed-forces-vtg-rivera-cn6k0h": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "automobil-mechatroniker-in-swiss-armed-forces-vtg-bellinzona",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4667,
-    "candidatesCount": 1
-  },
-  "de::levatrice-ostetrica-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uikzn4",
-    "winnerCanonical": "levatrice-ostetrica-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 1
-  },
-  "de::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medizinischer-assistent-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-05-01T08:59:01.541Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "de::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medizinischer-assistent-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-05-01T08:59:01.541Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medizinischer-studienassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "de::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
-    "winnerJobIdentifier": "company-uilpqn",
-    "winnerCanonical": "medizinstudent-chirurgie-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-05-02T08:37:48.781Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "de::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::mitarbeiter-in-hotellerie-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-ba2ff94faee7",
-    "winnerCanonical": "mitarbeiter-in-hotellerie-psychiatrische-dienste-graubunden-chur",
-    "decidedAt": "2026-04-30T11:36:08.696Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "de::oberarztin-oberarzt-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-00699d20e087",
-    "winnerCanonical": "oberarztin-oberarzt-psychiatrische-dienste-graubunden-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 3
-  },
-  "de::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "betreiberbehandlungen-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::operator-in-2-schicht-arxada-ch": {
-    "winnerJobIdentifier": "arxada-89e7dd4a9ec5",
-    "winnerCanonical": "operator-in-2-schicht-arxada-visp",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7143,
-    "candidatesCount": 2
-  },
-  "de::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
-    "winnerCanonical": "vollzeitstelle-als-instrumentierungswissenschaftler-ingenieur-usi-locarno",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1,
-    "candidatesCount": 2
-  },
-  "de::projektingenieur-m-f-x-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
-    "winnerCanonical": "ingenieur-di-progetto-m-f-x-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "de::projektingenieur-projektmanager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "project-ingenieur-project-manager-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.375,
-    "candidatesCount": 2
-  },
-  "de::promotionsstellen-usi-universita-della-svizzera-italiana-lugano": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-c86503b7b022",
-    "winnerCanonical": "doktorandenstelle-im-internationalen-wirtschaftsrecht-usi-universita-della-svizzera-italiana-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5455,
-    "candidatesCount": 2
-  },
-  "de::refinery-department-operator-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "betreiberbehandlungen-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
+  "BE::de::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::de::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::de::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "de::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
+  "BE::de::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.75,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
+  "BE::de::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.6667,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
+  "BE::de::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
+  "BE::de::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
+  "BE::de::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-cf5d10cad016",
-    "winnerCanonical": "schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-05T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "de::senior-it-business-analista-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analyst-bankwesen-fincons-group-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "de::senior-it-business-analyst-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analyst-bankwesen-fincons-group-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.875,
-    "candidatesCount": 2
-  },
-  "de::senior-it-business-analyste-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analyst-bankwesen-fincons-group-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "de::servicetechniker-m-w-d-otis-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "service-techniker-m-w-d-otis-sa-nenzlingerweg-2",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "de::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "service-techniker-m-w-d-otis-sa-nenzlingerweg-2",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "de::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
-    "winnerJobIdentifier": "company-7qutu2",
-    "winnerCanonical": "systemgastronomiefachfrau-mann-efz-marche-dietlikon",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "de::spitex-assistant-de-sante-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "pflegehilfe-srk-spitex-50-100-spital-davos-ch",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "de::spitex-health-care-assistant-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "pflegehilfe-srk-spitex-50-100-spital-davos-ch",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "de::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::de::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::systemgastronomiefachfrau-mann-praktiker-in-marche-grigioni-2p2jlr": {
-    "winnerJobIdentifier": "company-2p2jlr",
-    "winnerCanonical": "systemgastronomiefachfrau-mann-praktiker-in-marche-dietlikon",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.625,
-    "candidatesCount": 2
-  },
-  "de::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "de::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "de::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
+  "BE::de::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.4,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "de::title-truck-driver-heineken-ch-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
-    "winnerCanonical": "chauffeur-kat-c-e-heineken-ch-luzern",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.1538,
-    "candidatesCount": 1
-  },
-  "de::umsatz-finanza-previdenza-entrata-laterale-fisso-bonus-convit-holding-gmbh-giubiasco": {
-    "winnerJobIdentifier": "convit-9d5454d91e22",
-    "winnerCanonical": "verkauf-finanzen-sicherheit-seiteneingang-fest-bonus-convit-holding-gmbh-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.3125,
-    "candidatesCount": 3
-  },
-  "de::verkaufsberater-aussendienst-localsearch-ch": {
-    "winnerJobIdentifier": "localsearch-06277ad042b2",
-    "winnerCanonical": "verkaufsberater-aussendienst-localsearch-zurich",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "de::verkaufsprojektingenieur-in-tessin-rittmeyer-ag-tessin": {
-    "winnerJobIdentifier": "rittmeyer-ag-e474959dc11f",
-    "winnerCanonical": "verkaufsprojektingenieur-in-tessin-rittmeyer-ag-camorino",
-    "decidedAt": "2026-05-10T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8333,
-    "candidatesCount": 2
-  },
-  "de::vollzeitstelle-als-instrumentierungswissenschaftler-ingenieur-usi-universita-della-svizzera-italiana-locarno": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
-    "winnerCanonical": "vollzeitstelle-als-instrumentierungswissenschaftler-ingenieur-usi-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "de::vorsorgeberater-fur-alter-3-nebeneintritt-unbefristet-convit-holding-gmbh-biasca": {
-    "winnerJobIdentifier": "convit-6f7e38966187",
-    "winnerCanonical": "rentenberater-fur-den-ruhestand-3a-side-entry-festanstellung-convit-holding-gmbh-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.2941,
-    "candidatesCount": 4
-  },
-  "de::vorsorgeberater-m-w-d-eintritt-ohne-ausbildung-ote-bis-7-500-chf-convit-holding-gmbh-biasca": {
-    "winnerJobIdentifier": "convit-4ed3cb54692f",
-    "winnerCanonical": "private-berater-sparplane-junior-homeoffice-convit-holding-gmbh-origlio",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.1364,
-    "candidatesCount": 8
-  },
-  "en::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "en::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.7333,
-    "candidatesCount": 2
-  },
-  "en::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "automotive-mechatronics-swiss-armed-forces-vtg-bern-40eki6",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 1
-  },
-  "en::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
+  "BE::en::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-05-04T09:24:16.306Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
+  "BE::en::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::en::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0435,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
+  "BE::en::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0476,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::arztsekretarin-arztsekretar-ksw-ch-3": {
-    "winnerJobIdentifier": "ksw-da54f11b0c98",
-    "winnerCanonical": "doctor-s-secretary-kantonsspital-winterthur-ksw-winterthur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1,
-    "candidatesCount": 2
-  },
-  "en::assembly-operator-befristet-80-100-w-m-d-jr-5751": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-d568e2ba6207",
-    "winnerCanonical": "assembly-operator-befristet-80-100-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "en::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medical-study-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6923,
-    "candidatesCount": 2
-  },
-  "en::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medical-study-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4667,
-    "candidatesCount": 2
-  },
-  "en::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medical-assistant-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.625,
-    "candidatesCount": 2
-  },
-  "en::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5455,
-    "candidatesCount": 2
-  },
-  "en::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "en::autista-di-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
-    "winnerCanonical": "driver-c-e-heineken-switzerland-luzern",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.1667,
-    "candidatesCount": 2
-  },
-  "en::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "en::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "en::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "en::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "operator-treatments-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "en::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
-    "winnerJobIdentifier": "grand-hotel-kronenhof-517f2506113d",
-    "winnerCanonical": "office-employee-steward-start-immediately-m-f-d-grand-hotel-kronenhof-pontresina",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-04-30T10:50:56.200Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "en::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "en::chauffeur-collecteur-de-donnees-in-landquart-switzerland-for-chur-area-tsmg-landquart-061cc5b5": {
-    "winnerJobIdentifier": "tsmg-7a1622ef3f50",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-landquart-switzerland-for-chur-area-tsmg-landquart",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4375,
-    "candidatesCount": 2
-  },
-  "en::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
-    "winnerCanonical": "driver-c-e-heineken-switzerland-luzern",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.1667,
-    "candidatesCount": 2
-  },
-  "en::conseiller-clientele-contact-center-h-f-100-temporaire-3-mois-prolongeable-groupe-mutuel": {
-    "winnerJobIdentifier": "groupe-mutuel-0ebdee6ee1b8",
-    "winnerCanonical": "customer-service-advisor-contact-center-m-f-100-temporary-3-months-extendable-groupe-mutuel-fribourg",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-04-30T10:50:56.200Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "en::consulente-assicurativo": {
-    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
-    "winnerCanonical": "insurance-consultant-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0,
-    "candidatesCount": 2
-  },
-  "en::consulenza-finanziaria-entrata-lateral-fisso-bonus-part-time-o-100-convit-holding-gmbh-losone": {
-    "winnerJobIdentifier": "convit-8b3e25e5db99",
-    "winnerCanonical": "financial-advice-side-entrance-fixed-bonus-part-time-or-100-convit-holding-gmbh-losone",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4,
-    "candidatesCount": 3
-  },
-  "en::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "apprenticeship-as-a-chef-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "en::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::en::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::diet-chef-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "apprenticeship-as-a-chef-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "en::digital-sales-praktikant-emea-praktikumsprogramm-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde": {
-    "winnerJobIdentifier": "company-o38qde",
-    "winnerCanonical": "digital-sales-intern-emea-internship-program-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.7368,
-    "candidatesCount": 2
-  },
-  "en::digital-sales-stagiaire-emea-programme-de-stage-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde": {
-    "winnerJobIdentifier": "company-o38qde",
-    "winnerCanonical": "digital-sales-intern-emea-internship-program-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "en::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-8569cb344e08",
-    "winnerCanonical": "dipl-nurse-hf-monitoring-station-40-60-spital-davos-davos",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "en::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "en::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
+  "BE::en::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "en::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.8571,
-    "candidatesCount": 2
-  },
-  "en::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
-    "winnerJobIdentifier": "9770821",
-    "winnerCanonical": "operating-room-technician-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3,
-    "candidatesCount": 2
-  },
-  "en::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3636,
-    "candidatesCount": 2
-  },
-  "en::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::en::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0417,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::full-time-position-of-an-instrumentation-scientist-engineer-usi-locarno": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
-    "winnerCanonical": "full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "en::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
-    "winnerCanonical": "full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8667,
-    "candidatesCount": 2
-  },
-  "en::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "project-engineer-project-manager-lombardi-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "en::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "en::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "en::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "en::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "en::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.3889,
-    "candidatesCount": 2
-  },
-  "en::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "en::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "en::installateur-m-w-d-hilcona-pfaffstatt": {
-    "winnerJobIdentifier": "hilcona-c770e4ca2339",
-    "winnerCanonical": "installer-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.4,
-    "candidatesCount": 2
-  },
-  "en::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
-    "winnerJobIdentifier": "burkhalter-group-cf58443dd112",
-    "winnerCanonical": "heating-installer-100-ulrich-huber-ag-malans",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "en::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
-    "winnerJobIdentifier": "volg-fenaco-e6906731b758",
-    "winnerCanonical": "job-as-retail-salesperson-or-retail-sales-assistant-volg-grachen",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7273,
-    "candidatesCount": 2
-  },
-  "en::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "en::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona-ts9gho": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "en::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona-a7q9i9": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3571,
-    "candidatesCount": 2
-  },
-  "en::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::en::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0526,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::lernende-r-automobil-mechatroniker-in-efz-fachrichtung-personenwagen-swiss-armed-forces-vtg-rivera-cn6k0h": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "automotive-mechatronics-swiss-armed-forces-vtg-bern-40eki6",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2222,
-    "candidatesCount": 1
-  },
-  "en::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medical-assistant-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "en::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medical-assistant-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "en::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medical-study-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "en::medizinische-praxisassistentin-medizinischer-praxisassistent-ksw-ch-2": {
-    "winnerJobIdentifier": "ksw-5315115335ae",
-    "winnerCanonical": "medical-practice-assistant-kantonsspital-winterthur-ksw-winterthur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "en::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
-    "winnerJobIdentifier": "company-uilpqn",
-    "winnerCanonical": "medical-candidate-surgery-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-05-02T08:37:48.781Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "en::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "en::oberarztin-oberarzt-medizin-w-m-d-soh-ch-2": {
-    "winnerJobIdentifier": "solothurner-spitaeler-4f66ec5870fa",
-    "winnerCanonical": "senior-consultant-m-d-solothurner-spitaler-soh-olten",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2143,
-    "candidatesCount": 2
-  },
-  "en::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "operator-treatments-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "en::pflegefachfrau-pflegefachmann-hf-in-ausbildung-somatik-4-jahre-w-m-d-soh-ch-2": {
-    "winnerJobIdentifier": "solothurner-spitaeler-91e1a9599575",
-    "winnerCanonical": "nursing-specialist-hf-in-training-somatik-4-years-w-m-d-solothurner-spitaler-soh-olten",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.381,
-    "candidatesCount": 2
-  },
-  "en::physiotherapist-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uikzn4",
-    "winnerCanonical": "midwife-midwife-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7143,
-    "candidatesCount": 2
-  },
-  "en::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
-    "winnerCanonical": "full-time-position-of-an-instrumentation-scientist-engineer-usi-locarno",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "en::project-engineer-m-f-x-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
-    "winnerCanonical": "engineer-di-progetto-m-f-x-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "en::project-engineer-project-manager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "project-engineer-project-manager-lombardi-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8333,
-    "candidatesCount": 2
-  },
-  "en::project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-exte": {
-    "winnerJobIdentifier": "bitfinex-e64c68d29124",
-    "winnerCanonical": "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-caracas",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.7333,
-    "candidatesCount": 2
-  },
-  "en::projektingenieur-projektmanager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
-    "winnerCanonical": "engineer-di-progetto-m-f-x-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2727,
-    "candidatesCount": 2
-  },
-  "en::projektleiter-in-kunstbauten-80-100-chur-afry-chur": {
-    "winnerJobIdentifier": "afry-cfe9fcda330d",
-    "winnerCanonical": "project-engineer-artificial-buildings-bridge-construction-80-100-chur-afry-chur",
-    "decidedAt": "2026-05-10T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3077,
-    "candidatesCount": 1
-  },
-  "en::refinery-department-operator-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
-    "winnerCanonical": "operator-department-raffineria-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "en::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
+  "BE::en::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.2857,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::en::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.1579,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::en::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.1,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "en::retail-specialist-efz-creating-shopping-experiences-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::en::retail-specialist-efz-creating-shopping-experiences-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "retail-specialist-efz-creating-shopping-experiences-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T09:24:47.194Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.4,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::safety-officer-80-100-f-m-d-hamilton-bonaduz-ag-bonaduz": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-0a0be4f3eaf0",
-    "winnerCanonical": "ict-engineer-ot-security-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-05-05T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4667,
-    "candidatesCount": 1
-  },
-  "en::sales-finanza-previdenza-entrata-laterale-fisso-bonus-convit-giubiasco": {
-    "winnerJobIdentifier": "convit-131bb55e1c75",
-    "winnerCanonical": "private-consultant-3a-3b-hybrid-convit-holding-gmbh-sementina",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.0588,
-    "candidatesCount": 2
-  },
-  "en::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
+  "BE::en::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.75,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
+  "BE::en::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.6667,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
+  "BE::en::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
+  "BE::en::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
+  "BE::en::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::scaffolder-pemsa-bellinzona": {
-    "winnerJobIdentifier": "pemsa-2ade426c81c2",
-    "winnerCanonical": "tiles-pemsa-bellinzona",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "en::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
-    "winnerCanonical": "apprenticeship-in-computer-science-application-development-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-05T00:00:00.000Z",
-    "score": 0.0667,
-    "candidatesCount": 2
-  },
-  "en::senior-it-business-analista-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analyst-banking-fincons-group-lugano-switzerland",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "en::senior-it-business-analyst-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analyst-banking-fincons-group-lugano-switzerland",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "en::senior-it-business-analyste-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analyst-banking-fincons-group-lugano-switzerland",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "en::servicetechniker-m-w-d-otis-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "servicetechniker-m-w-d-otis-reinach",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.625,
-    "candidatesCount": 2
-  },
-  "en::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "servicetechniker-m-w-d-otis-reinach",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "en::social-security-advisor-m-f-d-untrained-entry-ote-up-to-chf-7-500-convit-holding-gmbh-biasca": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-biasca",
-    "decidedAt": "2026-05-04T09:24:16.306Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.16,
-    "candidatesCount": 7
-  },
-  "en::social-security-consultant-for-old-age-3a-lateral-entry-indefinite-time-convit-holding-gmbh-biasca": {
-    "winnerJobIdentifier": "convit-6f7e38966187",
-    "winnerCanonical": "pension-advisor-for-retirement-3a-side-entry-permanent-convit-holding-gmbh-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.35,
-    "candidatesCount": 4
-  },
-  "en::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
-    "winnerJobIdentifier": "company-2p2jlr",
-    "winnerCanonical": "system-gastronomy-technician-technician-marche-dietlikon",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "en::spitex-assistant-de-sante-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "care-assistant-srk-spitex-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "en::spitex-health-care-assistant-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "care-assistant-srk-spitex-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "en::stagista-nelle-vendite-digitali-programma-di-tirocinio-emea-vf-international-the-north-face-timberland-emea-che-stabio-v": {
-    "winnerJobIdentifier": "company-jvj5fl",
-    "winnerCanonical": "pr-marketing-intern-emea-internship-program-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-jvj5fl",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.36,
-    "candidatesCount": 2
-  },
-  "en::strassenwart-in-kanton-gr-ch": {
-    "winnerJobIdentifier": "kanton-gr-0ffee9d541da",
-    "winnerCanonical": "road-maintenance-in-kantonale-verwaltung-graubunden-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0909,
-    "candidatesCount": 2
-  },
-  "en::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::en::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::system-gastronomy-specialist-practitioner-marche-grigioni": {
-    "winnerJobIdentifier": "company-2p2jlr",
-    "winnerCanonical": "system-gastronomy-technician-technician-marche-dietlikon",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.375,
-    "candidatesCount": 2
-  },
-  "en::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "en::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "en::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
+  "BE::en::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.4,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "en::versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel": {
-    "winnerJobIdentifier": "groupe-mutuel-1822825450f3",
-    "winnerCanonical": "insurance-and-pension-advisor-m-f-80-100-groupe-mutuel-zurich",
-    "decidedAt": "2026-05-01T22:15:20.101Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 3
-  },
-  "fr::80-100-r-d-senior-ingenieur-energy-storage-systems-abb-svizzera-sede-ticino-quartino-ticino-hsi9t8": {
-    "winnerJobIdentifier": "company-noo56s",
-    "winnerCanonical": "r-d-senior-ingenieur-firmware-80-100-abb-svizzera-sede-ticino-quartino-ticino-noo56s",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.6471,
-    "candidatesCount": 2
-  },
-  "fr::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "fr::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "fr::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "mecatronique-automobile-swiss-armed-forces-vtg-bern-40eki6",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 1
-  },
-  "fr::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
+  "BE::fr::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-05-04T09:24:16.306Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0385,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
+  "BE::fr::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.037,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::fr::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.2609,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::apprentissage-d-informaticien-dans-le-domaine-du-developpement-de-plateformes-hamilton-bonaduz-ag-bonaduz": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-cf5d10cad016",
-    "winnerCanonical": "stage-d-introduction-informatique-developpement-de-plateformes-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-05T00:00:00.000Z",
-    "score": 0.4375,
-    "candidatesCount": 2
-  },
-  "fr::apprentissage-de-gestionnaire-du-commerce-de-detail-conception-et-realisation-d-39-experie": {
-    "winnerJobIdentifier": "jumbo-1c670883-34c",
-    "winnerCanonical": "apprentissage-de-gestionnaire-du-commerce-de-detail-conception-et-realisation-d-experiences-d-achat-jumbo-conthey",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.625,
-    "candidatesCount": 2
-  },
-  "fr::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
+  "BE::fr::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.1739,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::arztsekretarin-arztsekretar-ksw-ch-3": {
-    "winnerJobIdentifier": "ksw-da54f11b0c98",
-    "winnerCanonical": "secretaire-du-docteur-kantonsspital-winterthur-ksw-winterthur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1,
-    "candidatesCount": 2
-  },
-  "fr::assembly-operator-befristet-80-100-w-m-d-jr-5751": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-d568e2ba6207",
-    "winnerCanonical": "assembly-operateur-befristet-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-05-09T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "fr::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medical-office-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6923,
-    "candidatesCount": 2
-  },
-  "fr::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medical-office-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4667,
-    "candidatesCount": 2
-  },
-  "fr::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "assistant-medical-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.625,
-    "candidatesCount": 2
-  },
-  "fr::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.125,
-    "candidatesCount": 2
-  },
-  "fr::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2143,
-    "candidatesCount": 2
-  },
-  "fr::autista-di-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
-    "winnerCanonical": "chauffeur-de-camion-heineken-switzerland-baltschieder",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.2727,
-    "candidatesCount": 2
-  },
-  "fr::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2857,
-    "candidatesCount": 2
-  },
-  "fr::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2857,
-    "candidatesCount": 2
-  },
-  "fr::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2857,
-    "candidatesCount": 2
-  },
-  "fr::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
-    "winnerCanonical": "service-operateur-raffineria-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "fr::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
-    "winnerJobIdentifier": "grand-hotel-kronenhof-517f2506113d",
-    "winnerCanonical": "office-employee-steward-staff-restaurant-capricorn-m-w-d-grand-hotel-kronenhof-pontresina",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-04-30T10:50:56.200Z",
-    "score": 0.5714,
-    "candidatesCount": 2
-  },
-  "fr::career-start-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich": {
-    "winnerJobIdentifier": "pwc-88dc0dbaf301",
-    "winnerCanonical": "senior-associate-en-assurance-numerique-audit-it-et-analyse-de-processus-services-financiers-pwc-switzerland-zurich-t7triq",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.24,
-    "candidatesCount": 2
-  },
-  "fr::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8889,
-    "candidatesCount": 2
-  },
-  "fr::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
-    "winnerCanonical": "chauffeur-de-camion-heineken-switzerland-baltschieder",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "fr::conseiller-en-prevoyance-vieillesse-3a-entree-laterale-duree-indeterminee-convit-holding-gmbh-biasca": {
-    "winnerJobIdentifier": "convit-6f7e38966187",
-    "winnerCanonical": "conseiller-en-retraite-pour-la-retraite-3a-entree-laterale-permanent-convit-holding-gmbh-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.5294,
-    "candidatesCount": 4
-  },
-  "fr::consulente-assicurativo": {
-    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
-    "winnerCanonical": "consulente-assicurativo-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.2222,
-    "candidatesCount": 2
-  },
-  "fr::consulente-per-l-agenzia-generale-chur-100": {
-    "winnerJobIdentifier": "spital-davos-5795d1727096",
-    "winnerCanonical": "dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0714,
-    "candidatesCount": 2
-  },
-  "fr::consulenza-finanziaria-entrata-laterale-fisso-bonus-part-time-o-100-convit-losone": {
-    "winnerJobIdentifier": "convit-e629adda55fe",
-    "winnerCanonical": "consultant-patrimonio-junior-temps-partiel-o-100-convit-holding-gmbh-agra",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.15,
-    "candidatesCount": 2
-  },
-  "fr::consultant-en-securite-sociale-h-f-d-entree-sans-formation-ote-jusqu-a-7-500-chf-convit-holding-gmbh-biasca": {
-    "winnerJobIdentifier": "convit-2323c0b40462",
-    "winnerCanonical": "conseils-financiers-en-ligne-entree-laterale-hybride-homeoffice-convit-holding-gmbh-arbedo-castione",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.1786,
-    "candidatesCount": 8
-  },
-  "fr::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "apprentissage-de-cuisinier-ere-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "fr::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::fr::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::diet-chef-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "apprentissage-de-cuisinier-ere-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "fr::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-8569cb344e08",
-    "winnerCanonical": "dipl-infirmiere-hf-service-de-surveillance-40-60-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "fr::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "fr::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
+  "BE::fr::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "fr::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.3684,
-    "candidatesCount": 2
-  },
-  "fr::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
-    "winnerJobIdentifier": "9770821",
-    "winnerCanonical": "technicien-technicienne-de-salle-d-operation-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2308,
-    "candidatesCount": 2
-  },
-  "fr::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "fr::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::fr::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.1538,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
-    "winnerCanonical": "poste-a-temps-plein-de-scientifique-ingenieur-de-l-instrumentation-usi-universita-della-svizzera-italiana-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2609,
-    "candidatesCount": 2
-  },
-  "fr::gestionnaire-de-comptes-m-m-banca-cler-bellinzona": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "gestionnaire-de-comptes-m-m-bank-cler-solothurn",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "fr::gestionnaire-de-comptes-m-w-banca-cler-bellinzona": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "gestionnaire-de-comptes-m-m-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.875,
-    "candidatesCount": 2
-  },
-  "fr::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
-    "winnerCanonical": "ingenieur-di-progetto-m-f-x-lombardi-group-giubiasco-pdpprq",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "fr::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "fr::ingenieur-de-projet-m-f-x-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "ingenieur-de-projet-chef-de-projet-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6,
-    "candidatesCount": 2
-  },
-  "fr::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "fr::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "fr::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "fr::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.9231,
-    "candidatesCount": 2
-  },
-  "fr::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.8571,
-    "candidatesCount": 2
-  },
-  "fr::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.8571,
-    "candidatesCount": 2
-  },
-  "fr::installateur-m-w-d-hilcona-pfaffstatt": {
-    "winnerJobIdentifier": "hilcona-c770e4ca2339",
-    "winnerCanonical": "installation-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.4,
-    "candidatesCount": 2
-  },
-  "fr::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
-    "winnerJobIdentifier": "burkhalter-group-cf58443dd112",
-    "winnerCanonical": "installateur-trice-de-chauffage-100-ulrich-huber-ag-malans",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4615,
-    "candidatesCount": 2
-  },
-  "fr::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
-    "winnerJobIdentifier": "volg-fenaco-e6906731b758",
-    "winnerCanonical": "poste-de-vente-ou-assistant-de-vente-volg-grachen",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1333,
-    "candidatesCount": 2
-  },
-  "fr::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "gestionnaire-de-comptes-m-m-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "fr::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona-a7q9i9": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "gestionnaire-de-comptes-m-m-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2667,
-    "candidatesCount": 2
-  },
-  "fr::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::fr::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0417,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::lernende-r-automobil-mechatroniker-in-efz-fachrichtung-personenwagen-swiss-armed-forces-vtg-rivera-cn6k0h": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "mecatronique-automobile-swiss-armed-forces-vtg-bern-40eki6",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2222,
-    "candidatesCount": 1
-  },
-  "fr::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "assistant-medical-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "fr::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "assistant-medical-eoc-ente-ospedaliero-cantonale-lugano",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "fr::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "medical-office-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "fr::medizinische-praxisassistentin-medizinischer-praxisassistent-ksw-ch-2": {
-    "winnerJobIdentifier": "ksw-5315115335ae",
-    "winnerCanonical": "assistant-de-pratique-medicale-kantonsspital-winterthur-ksw-winterthur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0769,
-    "candidatesCount": 2
-  },
-  "fr::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
-    "winnerJobIdentifier": "company-uilpqn",
-    "winnerCanonical": "candidat-e-en-medecine-chirurgie-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-05-02T08:37:48.781Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "fr::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "fr::oberarztin-oberarzt-medizin-w-m-d-soh-ch-2": {
-    "winnerJobIdentifier": "solothurner-spitaeler-4f66ec5870fa",
-    "winnerCanonical": "consultant-principal-m-j-solothurner-spitaler-soh-olten-acb83f",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.125,
-    "candidatesCount": 2
-  },
-  "fr::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
-    "winnerCanonical": "service-operateur-raffineria-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "fr::pflegefachfrau-pflegefachmann-hf-in-ausbildung-somatik-4-jahre-w-m-d-soh-ch-2": {
-    "winnerJobIdentifier": "solothurner-spitaeler-91e1a9599575",
-    "winnerCanonical": "specialiste-des-soins-infirmiers-hf-en-formation-somatik-4-ans-m-j-solothurner-spitaler-soh-olten",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2,
-    "candidatesCount": 2
-  },
-  "fr::physiotherapeute-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uikzn4",
-    "winnerCanonical": "sage-femme-sage-femme-eoc-ente-ospedaliero-cantonale-locarno",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.625,
-    "candidatesCount": 2
-  },
-  "fr::place-d-apprentissage-en-tant-qu-assistant-e-de-commerce-de-detail-afp-en-denrees-alimentaires-volg-untervaz": {
-    "winnerJobIdentifier": "volg-fenaco-51b4337a6fa7",
-    "winnerCanonical": "apprentissage-d-assistant-de-commerce-de-detail-eba-produits-alimentaires-volg-untervaz-uiccmi",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4737,
-    "candidatesCount": 2
-  },
-  "fr::place-d-apprentissage-en-tant-qu-assistant-e-de-commerce-de-detail-afp-en-denrees-alimentaires-volg-vals": {
-    "winnerJobIdentifier": "volg-fenaco-2568fe5d2c1b",
-    "winnerCanonical": "apprentissage-d-assistant-de-commerce-de-detail-eba-produits-alimentaires-volg-vals-qsaqy0",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4737,
-    "candidatesCount": 2
-  },
-  "fr::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
-    "winnerCanonical": "poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-locarno",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6471,
-    "candidatesCount": 2
-  },
-  "fr::project-ingenieur-project-manager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "ingenieur-de-projet-chef-de-projet-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "fr::projektingenieur-projektmanager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "ingenieur-de-projet-chef-de-projet-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "fr::projektleiter-in-kunstbauten-80-100-chur-afry-chur": {
-    "winnerJobIdentifier": "afry-cfe9fcda330d",
-    "winnerCanonical": "projektingenieur-in-kunstbauten-bruckenbau-80-100-chur-afry-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "fr::refinery-department-operator-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
-    "winnerCanonical": "service-operateur-raffineria-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "fr::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
+  "BE::fr::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0455,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::fr::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0385,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::fr::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "fr::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
+  "BE::fr::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.75,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
+  "BE::fr::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.6667,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
+  "BE::fr::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
+  "BE::fr::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
+  "BE::fr::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
-    "winnerCanonical": "stage-en-informatique-developpement-d-applications-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-05T00:00:00.000Z",
-    "score": 0,
-    "candidatesCount": 2
-  },
-  "fr::senior-associate-assistant-manager-audit-trade-industries-services-pwc-zurich": {
-    "winnerJobIdentifier": "pwc-0054671bedc4",
-    "winnerCanonical": "associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zurich",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.2222,
-    "candidatesCount": 1
-  },
-  "fr::senior-it-business-analista-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "analyste-principal-des-affaires-en-ti-services-bancaires-fincons-group-lugano",
-    "decidedAt": "2026-05-08T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2,
-    "candidatesCount": 1
-  },
-  "fr::senior-it-business-analyst-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "analyste-principal-des-affaires-en-ti-services-bancaires-fincons-group-lugano",
-    "decidedAt": "2026-05-08T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2,
-    "candidatesCount": 1
-  },
-  "fr::senior-it-business-analyste-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "analyste-principal-des-affaires-en-ti-services-bancaires-fincons-group-lugano",
-    "decidedAt": "2026-05-08T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2857,
-    "candidatesCount": 1
-  },
-  "fr::servicetechniker-m-w-d-otis-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "servicetechniker-m-w-d-otis-sa-reinach",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "fr::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "servicetechniker-m-w-d-otis-sa-reinach",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "fr::specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::fr::specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialiste-du-commerce-de-detail-efz-creer-des-experiences-d-achat-interdiscount-jegensdorf",
     "decidedAt": "2026-04-30T09:24:47.194Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.55,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
-    "winnerJobIdentifier": "company-2p2jlr",
-    "winnerCanonical": "technicien-de-la-system-gastronomie-marche-dietlikon",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1538,
-    "candidatesCount": 2
-  },
-  "fr::spitex-assistant-de-sante-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "assistant-de-soins-srk-spitex-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "fr::spitex-health-care-assistant-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "assistant-de-soins-srk-spitex-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5455,
-    "candidatesCount": 2
-  },
-  "fr::stagiaire-en-gestion-de-projet-richemont-meyrin": {
-    "winnerJobIdentifier": "richemont-76f727c86d86",
-    "winnerCanonical": "it-project-management-intern-richemont-meyrin",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1818,
-    "candidatesCount": 2
-  },
-  "fr::strassenwart-in-kanton-gr-ch": {
-    "winnerJobIdentifier": "kanton-gr-0ffee9d541da",
-    "winnerCanonical": "tranche-en-kantonale-verwaltung-graubunden-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0,
-    "candidatesCount": 2
-  },
-  "fr::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::fr::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "fr::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "fr::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
+  "BE::fr::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.4,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "fr::title-truck-driver-heineken-ch-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
-    "winnerCanonical": "chauffeur-c-e-heineken-switzerland-content-width-device-width",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "fr::ventes-finanza-previdenza-entrata-laterale-fisso-bonus-convit-holding-gmbh-giubiasco": {
-    "winnerJobIdentifier": "convit-9d5454d91e22",
-    "winnerCanonical": "finance-des-ventes-securite-entree-laterale-fixe-bonus-convit-holding-gmbh-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.4375,
-    "candidatesCount": 3
-  },
-  "fr::versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel": {
-    "winnerJobIdentifier": "groupe-mutuel-e7eaf500fc99",
-    "winnerCanonical": "conseiller-en-assurance-et-prevoyance-m-f-80-100-groupe-mutuel-wil",
-    "decidedAt": "2026-05-01T22:15:20.101Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3125,
-    "candidatesCount": 3
-  },
-  "it::account-manager-m-w-banca-cler-bellinzona": {
-    "winnerJobIdentifier": "company-ts9gho",
-    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona-213e54",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.875,
-    "candidatesCount": 2
-  },
-  "it::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "it::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "it::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "meccatronica-automobilistica-swiss-armed-forces-vtg-bellinzona",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2667,
-    "candidatesCount": 1
-  },
-  "it::apprendista-meccatronico-automobilistico-efz-settore-veicoli-personali-swiss-armed-forces-vtg-rivera": {
-    "winnerJobIdentifier": "company-40eki6",
-    "winnerCanonical": "meccatronica-automobilistica-swiss-armed-forces-vtg-bellinzona",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2667,
-    "candidatesCount": 1
-  },
-  "it::apprendistato-come-assistente-del-commercio-al-dettaglio-afp-alimentari-volg-untervaz": {
-    "winnerJobIdentifier": "volg-fenaco-8bb331bcabf5",
-    "winnerCanonical": "apprendista-come-specialista-del-commercio-al-dettaglio-afc-prodotti-alimentari-volg-untervaz",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5333,
-    "candidatesCount": 2
-  },
-  "it::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
+  "BE::it::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-05-04T09:24:16.306Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.4737,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
+  "BE::it::apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-ie4nz4": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.45,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-balerna": {
-    "winnerJobIdentifier": "swisscom-sede-ticino-6ec9c0a4427c",
-    "winnerCanonical": "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-balerna",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8333,
-    "candidatesCount": 2
-  },
-  "it::apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-balerna-56yj6u": {
-    "winnerJobIdentifier": "swisscom-sede-ticino-6ec9c0a4427c",
-    "winnerCanonical": "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-balerna",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7692,
-    "candidatesCount": 2
-  },
-  "it::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::it::apprentissage-commerce-de-detail-cfc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0345,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
+  "BE::it::apprentissage-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0769,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::arztsekretarin-arztsekretar-ksw-ch-3": {
-    "winnerJobIdentifier": "ksw-da54f11b0c98",
-    "winnerCanonical": "segretario-del-dottore-kantonsspital-winterthur-ksw-winterthur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1,
-    "candidatesCount": 2
-  },
-  "it::assembly-operator-befristet-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-de10ccc90ef5",
-    "winnerCanonical": "assembly-operator-80-100-m-w-d-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.9091,
-    "candidatesCount": 1
-  },
-  "it::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3529,
-    "candidatesCount": 2
-  },
-  "it::assistente-all-assistenza-srk-spitex-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "assistenza-sanitaria-srk-spitex-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "it::assistente-chirurgia-e-ortopedia-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-5a7dd002f54a",
-    "winnerCanonical": "unterassistent-in-chirurgie-orthopala-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2727,
-    "candidatesCount": 2
-  },
-  "it::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8333,
-    "candidatesCount": 2
-  },
-  "it::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7692,
-    "candidatesCount": 2
-  },
-  "it::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4444,
-    "candidatesCount": 2
-  },
-  "it::ausbildung-dipl-pflegefachmann-frau-hf-3-jahre-regular-september-2026-bfgs-spital-thurgau-stgag-munsterlingen": {
-    "winnerJobIdentifier": "spital-thurgau-0fe1a8054d15",
-    "winnerCanonical": "specialista-dell-istruzione-hf-3-anni-regolari-settembre-2026-bfgs-spital-thurgau-stgag-munsterlingen",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.381,
-    "candidatesCount": 2
-  },
-  "it::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "it::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7,
-    "candidatesCount": 2
-  },
-  "it::autista-di-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
-    "winnerCanonical": "autista-di-camion-heineken-switzerland-baltschieder",
-    "decidedAt": "2026-05-02T19:33:03.135Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "it::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6364,
-    "candidatesCount": 2
-  },
-  "it::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6364,
-    "candidatesCount": 2
-  },
-  "it::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6364,
-    "candidatesCount": 2
-  },
-  "it::berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-regionale-kunden-colin-cie-wealth-management-munsbach": {
-    "winnerJobIdentifier": "colin-cie-39bced82bc8b",
-    "winnerCanonical": "berater-m-w-d-im-wealth-management-am-standort-lugano-con-fokus-regionale-kunden-colin-cie-wealth-management-lugano",
-    "decidedAt": "2026-05-04T09:24:16.306Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.8333,
-    "candidatesCount": 1
-  },
-  "it::berufslehre-fachfrau-fachmann-hotellerie-hauswirtschaft-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020193",
-    "winnerCanonical": "apprendista-hotelieria-e-gestione-alberghiera-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2308,
-    "candidatesCount": 2
-  },
-  "it::berufslehre-kochin-koch-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "apprendistato-come-cuoco-a-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3,
-    "candidatesCount": 2
-  },
-  "it::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "operatore-trattamenti-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
-    "winnerJobIdentifier": "grand-hotel-kronenhof-b32669874fc2",
-    "winnerCanonical": "terapista-termale-m-p-g-grand-hotel-kronenhof-pontresina",
-    "decidedAt": "2026-05-04T10:17:25.898Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 1
-  },
-  "it::career-start-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich": {
-    "winnerJobIdentifier": "pwc-88dc0dbaf301",
-    "winnerCanonical": "senior-associate-in-digital-assurance-it-audit-e-process-analytics-servizi-finanziari-pwc-switzerland-zurich",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.45,
-    "candidatesCount": 2
-  },
-  "it::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3077,
-    "candidatesCount": 2
-  },
-  "it::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
-    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
-    "winnerCanonical": "autista-di-camion-heineken-switzerland-baltschieder",
-    "decidedAt": "2026-05-02T19:58:59.198Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.2727,
-    "candidatesCount": 2
-  },
-  "it::consulente-assicurativo": {
-    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
-    "winnerCanonical": "consulente-per-la-sicurezza-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "it::consulente-per-l-agenzia-generale-chur-100": {
-    "winnerJobIdentifier": "spital-davos-5795d1727096",
-    "winnerCanonical": "diplomierte-pflegefachperson-hf-pensum-60-100-becomes-diplomierte-pflegefachperson-hf-remains-the-same-as-pflegefachpers",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0556,
-    "candidatesCount": 1
-  },
-  "it::consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-biasca": {
-    "winnerJobIdentifier": "convit-1f9f769932df",
-    "winnerCanonical": "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-holding-gmbh-biasca",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.8889,
-    "candidatesCount": 8
-  },
-  "it::consulente-previdenziale-per-la-vecchiaia-3a-entrata-laterale-tempo-indeterminato-convit-biasca": {
-    "winnerJobIdentifier": "convit-4afd0f60af04",
-    "winnerCanonical": "consulente-previdenziale-junior-entrata-laterale-mentoring-coaching-convit-camorino",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.3125,
-    "candidatesCount": 3
-  },
-  "it::consulenza-finanziaria-entrata-laterale-fissa-bonus-part-time-o-100-convit-holding-gmbh-losone": {
-    "winnerJobIdentifier": "convit-8b3e25e5db99",
-    "winnerCanonical": "consulenza-finanziaria-entrata-laterale-fisso-bonus-part-time-o-100-convit-losone",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.7333,
-    "candidatesCount": 3
-  },
-  "it::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "apprendistato-come-cuoco-a-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "it::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::it::developpeur-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::diet-chef-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "10020247",
-    "winnerCanonical": "apprendistato-come-cuoco-a-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "it::dipl-infermiere-hf-stazione-di-monitoraggio-40-60-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-8569cb344e08",
-    "winnerCanonical": "dipl-stazione-di-monitoraggio-hf-specialista-di-cura-40-60-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 2
-  },
-  "it::dipl-pflegefachmann-frau-forensik-spital-thurgau-stgag-munsterlingen": {
-    "winnerJobIdentifier": "spital-thurgau-a7017a609abc",
-    "winnerCanonical": "dipl-specialista-di-cura-forense-spital-thurgau-stgag-munsterlingen",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "it::dipl-pflegefachmann-frau-forensik-stgag-ch": {
-    "winnerJobIdentifier": "spital-thurgau-422f0cc4c8e3",
-    "winnerCanonical": "dipl-pflegefachmann-frau-forensik-spital-thurgau-stgag-munsterlingen",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "it::dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-adaa0bd12412",
-    "winnerCanonical": "dipl-pflegefachperson-hf-per-la-nachtwache-psychiatrische-dienste-graubunden-cazis",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2857,
-    "candidatesCount": 2
-  },
-  "it::dipl-pflegefachperson-hf-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-4c55e9af737c",
-    "winnerCanonical": "dipl-specialista-di-cura-hf-psychiatrische-dienste-graubunden-cazis",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1667,
-    "candidatesCount": 1
-  },
-  "it::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-8569cb344e08",
-    "winnerCanonical": "dipl-stazione-di-monitoraggio-hf-specialista-di-cura-40-60-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3571,
-    "candidatesCount": 2
-  },
-  "it::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "it::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
+  "BE::it::einzelhandelsausbildung-afc-einkaufserlebnisse-schaffen-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0476,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "it::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.2632,
-    "candidatesCount": 2
-  },
-  "it::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur": {
-    "winnerJobIdentifier": "9770821",
-    "winnerCanonical": "operatrice-operatore-di-sala-operatoria-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2727,
-    "candidatesCount": 2
-  },
-  "it::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
-    "winnerJobIdentifier": "9770821",
-    "winnerCanonical": "operatrice-operatore-di-sala-operatoria-kantonsspital-graubunden-chur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 2
-  },
-  "it::fachspezialist-qualitassicherung-m-w-d-trumpf-r00039734": {
-    "winnerJobIdentifier": "trumpf-schweiz-ed744dfa8a0e",
-    "winnerCanonical": "consulente-senior-m-w-d-trumpf-schweiz-ag-grusch",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "it::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
-    "winnerJobIdentifier": "tsmg-2d2283cb9788",
-    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::fisioterapista-diplomata-o-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uillzl",
-    "winnerCanonical": "fisioterapista-diplomata-o-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "it::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::it::formation-en-vente-au-detail-afc-creation-d-experiences-d-achat-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.069,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
-    "winnerCanonical": "tempo-pieno-position-of-an-instrumentation-scientist-ingegnere-usi-universita-della-svizzera-italiana-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "it::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "project-ingegnere-project-manager-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 2
-  },
-  "it::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "it::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4167,
-    "candidatesCount": 2
-  },
-  "it::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "it::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3846,
-    "candidatesCount": 2
-  },
-  "it::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.7692,
-    "candidatesCount": 2
-  },
-  "it::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.7143,
-    "candidatesCount": 2
-  },
-  "it::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
-    "winnerJobIdentifier": "convit-cb94b1dded29",
-    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-06T00:00:00.000Z",
-    "score": 0.7143,
-    "candidatesCount": 2
-  },
-  "it::installateur-m-w-d-hilcona-pfaffstatt": {
-    "winnerJobIdentifier": "hilcona-c770e4ca2339",
-    "winnerCanonical": "installateur-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "it::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
-    "winnerJobIdentifier": "burkhalter-group-8b5ff5dd31e8",
-    "winnerCanonical": "installatore-trice-di-riscaldamento-capo-cantiere-100-ulrich-huber-ag-malans",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 2
-  },
-  "it::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
-    "winnerJobIdentifier": "volg-fenaco-f28ee877c0a5",
-    "winnerCanonical": "lavoro-come-dettagliante-o-assistente-dettagliante-volg-visperterminen",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.1333,
-    "candidatesCount": 2
-  },
-  "it::kaeltetechniker-m-w-d-hilcona-pfaffstatt": {
-    "winnerJobIdentifier": "hilcona-1c5bc99d5316",
-    "winnerCanonical": "kaeltetechniker-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-04T08:00:25.302Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "it::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4286,
-    "candidatesCount": 2
-  },
-  "it::kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona-a7q9i9": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.9167,
-    "candidatesCount": 2
-  },
-  "it::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler": {
-    "winnerJobIdentifier": "company-a7q9i9",
-    "winnerCanonical": "kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
-    "decidedAt": "2026-04-30T15:42:20.795Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 2
-  },
-  "it::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::it::lehre-detailhandel-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::lehrstelle-2027-automatiker-in-efz-trumpf-r00039691": {
-    "winnerJobIdentifier": "trumpf-schweiz-83585a10ea69",
-    "winnerCanonical": "apprendistato-2027-automatiker-in-cfc-trumpf-schweiz-ag-grusch",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "it::lehrstelle-2027-konstrukteur-in-efz-trumpf-r00039703": {
-    "winnerJobIdentifier": "trumpf-schweiz-2d1e6fc71e7a",
-    "winnerCanonical": "apprendistato-2027-konstrukteur-in-cfc-trumpf-schweiz-ag-grusch",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3333,
-    "candidatesCount": 2
-  },
-  "it::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4,
-    "candidatesCount": 2
-  },
-  "it::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.75,
-    "candidatesCount": 2
-  },
-  "it::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
-    "winnerJobIdentifier": "company-uilm0d",
-    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "it::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
-    "winnerJobIdentifier": "company-uilqdx",
-    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.375,
-    "candidatesCount": 2
-  },
-  "it::medizinische-praxisassistentin-medizinischer-praxisassistent-ksw-ch-2": {
-    "winnerJobIdentifier": "ksw-5315115335ae",
-    "winnerCanonical": "assistente-di-pratica-medica-kantonsspital-winterthur-ksw-winterthur",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0769,
-    "candidatesCount": 2
-  },
-  "it::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
-    "winnerJobIdentifier": "company-uilpqn",
-    "winnerCanonical": "candidato-medico-chirurgia-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "decidedAt": "2026-05-02T08:37:48.781Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "it::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5,
-    "candidatesCount": 2
-  },
-  "it::oberarztin-oberarzt-medizin-w-m-d-soh-ch-2": {
-    "winnerJobIdentifier": "solothurner-spitaeler-4f66ec5870fa",
-    "winnerCanonical": "consulente-senior-m-d-solothurner-spitaler-soh-olten-acb83f",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2,
-    "candidatesCount": 2
-  },
-  "it::oberarztin-oberarzt-pdgr-ch": {
-    "winnerJobIdentifier": "pdgr-6bea78edbd79",
-    "winnerCanonical": "medico-specialista-in-psichiatria-psychiatrische-dienste-graubunden-cazis",
-    "decidedAt": "2026-05-01T00:00:03.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0,
-    "candidatesCount": 2
-  },
-  "it::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "operatore-trattamenti-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::pflegefachfrau-pflegefachmann-hf-in-ausbildung-somatik-4-jahre-w-m-d-soh-ch-2": {
-    "winnerJobIdentifier": "solothurner-spitaeler-91e1a9599575",
-    "winnerCanonical": "infermieristica-hf-in-formazione-somatik-4-anni-w-m-d-solothurner-spitaler-soh-olten",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4,
-    "candidatesCount": 2
-  },
-  "it::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
-    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
-    "winnerCanonical": "posizione-a-tempo-pieno-di-scienziato-ingegnere-della-strumentazione-usi-locarno",
-    "decidedAt": "2026-05-12T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.125,
-    "candidatesCount": 2
-  },
-  "it::project-engineer-project-manager-lombardi-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "project-ingegnere-project-manager-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5714,
-    "candidatesCount": 2
-  },
-  "it::project-manager-in-kunstbauten-80-100-chur-afry-chur": {
-    "winnerJobIdentifier": "afry-cfe9fcda330d",
-    "winnerCanonical": "ingegnere-a-di-progetto-opere-d-arte-bruckenbau-80-100-chur-afry-chur",
-    "decidedAt": "2026-04-30T13:24:06.236Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 1
-  },
-  "it::projektingenieur-projektmanager-lombardi-group-giubiasco": {
-    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
-    "winnerCanonical": "project-ingegnere-project-manager-lombardi-group-giubiasco",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.375,
-    "candidatesCount": 2
-  },
-  "it::projektleiter-in-kunstbauten-80-100-chur-afry-chur": {
-    "winnerJobIdentifier": "afry-cfe9fcda330d",
-    "winnerCanonical": "ingegnere-a-di-progetto-opere-d-arte-bruckenbau-80-100-chur-afry-chur",
-    "decidedAt": "2026-05-10T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2667,
-    "candidatesCount": 1
-  },
-  "it::refinery-department-operator-mks-pamp-castel-san-pietro": {
-    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
-    "winnerCanonical": "operatore-trattamenti-reflui-mks-pamp-castel-san-pietro",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::responsabile-di-progetto-opere-d-arte-80-100-chur-afry-chur": {
-    "winnerJobIdentifier": "afry-cfe9fcda330d",
-    "winnerCanonical": "ingegnere-a-di-progetto-opere-d-arte-bruckenbau-80-100-chur-afry-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6923,
-    "candidatesCount": 2
-  },
-  "it::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
+  "BE::it::retail-apprenticeship-afc-creating-shopping-experiences-fust-tenero-contra-ticino": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.0435,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::it::retail-sales-training-afc-creating-buying-experiences-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.037,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
+  "BE::it::retail-sales-training-afc-creating-customer-experience-fust-swiss-household-services-ag-tenero-contra": {
     "winnerJobIdentifier": "company-oal0zl",
     "winnerCanonical": "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-oal0zl",
     "decidedAt": "2026-04-30T11:12:04.743Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.037,
-    "candidatesCount": 1
+    "candidatesCount": 1,
+    "canton": "BE"
   },
-  "it::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
+  "BE::it::sap-abap-fiori-developer-agie-charmilles-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.75,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
+  "BE::it::sap-abap-fiori-developer-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.6667,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
+  "BE::it::sap-abap-fiori-developpeur-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
+  "BE::it::sap-abap-fiori-entwickler-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
+  "BE::it::sap-abap-fiori-sviluppatore-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
-    "winnerCanonical": "schnupperlehre-informatiker-in-specializzazione-applikationsentwicklung-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-05T00:00:00.000Z",
-    "score": 0.25,
-    "candidatesCount": 2
-  },
-  "it::schnupperlehre-informatiker-in-specializzazione-plattformentwicklung-hamilton-bonaduz-ag-bonaduz": {
-    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
-    "winnerCanonical": "schnupperlehre-informatiker-in-specializzazione-applikationsentwicklung-hamilton-bonaduz-ag-bonaduz",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-05T00:00:00.000Z",
-    "score": 0.7778,
-    "candidatesCount": 2
-  },
-  "it::senior-associate-assistant-manager-audit-trade-industries-services-pwc-zurich": {
-    "winnerJobIdentifier": "pwc-0054671bedc4",
-    "winnerCanonical": "associato-senior-assistente-responsabile-controllo-del-commercio-delle-industrie-e-dei-servizi-pwc-switzerland-zurich",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.1364,
-    "candidatesCount": 1
-  },
-  "it::senior-associate-datenschutz-expert-in-ict-recht-pwc-zurich": {
-    "winnerJobIdentifier": "pwc-82e32deb8f92",
-    "winnerCanonical": "senior-associate-privacy-expert-in-legge-sull-ict-pwc-switzerland-zurich",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5385,
-    "candidatesCount": 2
-  },
-  "it::senior-associate-legal-regulatory-project-manager-pwc-zurich": {
-    "winnerJobIdentifier": "pwc-f80a4e0781f1",
-    "winnerCanonical": "senior-associate-responsabile-progetti-regolatori-legali-pwc-switzerland-zurich",
-    "decidedAt": "2026-05-11T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3077,
-    "candidatesCount": 2
-  },
-  "it::senior-it-business-analista-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analista-banking-fincons-group-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.875,
-    "candidatesCount": 2
-  },
-  "it::senior-it-business-analyst-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analista-banking-fincons-group-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "it::senior-it-business-analyste-fincons-group-lugano": {
-    "winnerJobIdentifier": "fincons-group-e4fa03014547",
-    "winnerCanonical": "senior-it-business-analista-banking-fincons-group-lugano",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.6667,
-    "candidatesCount": 2
-  },
-  "it::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "tecnico-di-servizio-m-f-d-otis-sa-reinach",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.3077,
-    "candidatesCount": 2
-  },
-  "it::specialista-di-gastronomia-e-cucina-praticante-marche-grigioni": {
-    "winnerJobIdentifier": "company-2p2jlr",
-    "winnerCanonical": "systemgastronomia-tecnico-tecnica-marche-dietlikon",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "it::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
-    "winnerJobIdentifier": "company-2p2jlr",
-    "winnerCanonical": "systemgastronomia-tecnico-tecnica-marche-dietlikon",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.0833,
-    "candidatesCount": 2
-  },
-  "it::spitex-assistant-de-sante-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "assistenza-sanitaria-srk-spitex-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::spitex-assistente-sanitario-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-9804891a5da1",
-    "winnerCanonical": "spitex-salute-specialistica-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.5556,
-    "candidatesCount": 2
-  },
-  "it::spitex-health-care-assistant-50-100-spital-davos-davos": {
-    "winnerJobIdentifier": "spital-davos-016659b12606",
-    "winnerCanonical": "assistenza-sanitaria-srk-spitex-50-100-spital-davos-davos",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::strassenwart-in-kanton-gr-ch": {
-    "winnerJobIdentifier": "kanton-gr-0ffee9d541da",
-    "winnerCanonical": "strassenwart-in-kantonale-verwaltung-graubunden-chur",
-    "decidedAt": "2026-04-30T09:24:47.194Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.2222,
-    "candidatesCount": 2
-  },
-  "it::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
+  "BE::it::sviluppatore-sap-abap-fiori-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
-    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
-    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
-    "decidedAt": "2026-05-07T00:00:00.000Z",
-    "lastSeenAt": "2026-05-12T00:00:00.000Z",
-    "score": 0.4545,
-    "candidatesCount": 2
-  },
-  "it::tecnico-di-servizio-m-f-d-otis-sa-nenzlingerweg-2": {
-    "winnerJobIdentifier": "otis-00f533d5f119",
-    "winnerCanonical": "tecnico-di-servizio-m-f-d-otis-sa-reinach",
-    "decidedAt": "2026-05-01T10:54:27.600Z",
-    "lastSeenAt": "2026-05-11T00:00:00.000Z",
-    "score": 0.7273,
-    "candidatesCount": 2
-  },
-  "it::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
+  "BE::it::tecnico-laboratorio-metrologia-agie-charmilles-sa-biel-bienne": {
     "winnerJobIdentifier": "agie-charmilles-e67647fb366d",
     "winnerCanonical": "sap-developer-agie-charmilles-biel-bienne",
     "decidedAt": "2026-05-07T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.4,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "BE"
   },
-  "it::title-truck-driver-heineken-ch-content-width-device-width": {
+  "BL::de::servicetechniker-m-w-d-otis-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "service-techniker-m-w-d-otis-sa-nenzlingerweg-2",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "BL::de::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "service-techniker-m-w-d-otis-sa-nenzlingerweg-2",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "BL::en::servicetechniker-m-w-d-otis-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "servicetechniker-m-w-d-otis-reinach",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.625,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "BL::en::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "servicetechniker-m-w-d-otis-reinach",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "BL::fr::servicetechniker-m-w-d-otis-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "servicetechniker-m-w-d-otis-sa-reinach",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "BL::fr::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "servicetechniker-m-w-d-otis-sa-reinach",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "BL::it::servicetechniker-m-w-d-otis-sa-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "tecnico-di-servizio-m-f-d-otis-sa-reinach",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3077,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "BL::it::tecnico-di-servizio-m-f-d-otis-sa-nenzlingerweg-2": {
+    "winnerJobIdentifier": "otis-00f533d5f119",
+    "winnerCanonical": "tecnico-di-servizio-m-f-d-otis-sa-reinach",
+    "decidedAt": "2026-05-01T10:54:27.600Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.7273,
+    "candidatesCount": 2,
+    "canton": "BL"
+  },
+  "GR::de::assistenz-oder-fachpsychologe-in-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-12451701d2ea",
+    "winnerCanonical": "assistenz-oder-fachpsychologe-in-psychiatrische-dienste-graubunden-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::assistenzarztin-assistenzarzt-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-9b3b5d5accd6",
+    "winnerCanonical": "assistenzarztin-assistenzarzt-psychiatrische-dienste-graubunden-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 3,
+    "canton": "GR"
+  },
+  "GR::de::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5455,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6364,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
+    "winnerJobIdentifier": "grand-hotel-kronenhof-517f2506113d",
+    "winnerCanonical": "buroangestellte-steward-personal-restaurant-capricorn-m-w-d-grand-hotel-kronenhof-pontresina",
+    "decidedAt": "2026-05-06T00:00:00.000Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::de::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-d99433996e9d",
+    "winnerCanonical": "fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-e483453a",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3636,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "berufslehre-kochin-koch-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.375,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::diet-chef-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "berufslehre-kochin-koch-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.375,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-8569cb344e08",
+    "winnerCanonical": "dipl-pflegefachperson-hf-uberwachungsstation-40-60-spital-davos-ch",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5455,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-d99433996e9d",
+    "winnerCanonical": "fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-e483453a",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3636,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
+    "winnerJobIdentifier": "9770821",
+    "winnerCanonical": "fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8571,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::fachperson-gesundheit-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-80501bd9710d",
+    "winnerCanonical": "fachperson-gesundheit-psychiatrische-dienste-graubunden-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::fachpsychologe-in-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-4f88a64e2238",
+    "winnerCanonical": "fachpsychologe-in-psychiatrische-dienste-graubunden-chur",
+    "decidedAt": "2026-05-04T09:24:16.306Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::de::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-d99433996e9d",
+    "winnerCanonical": "fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-e483453a",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
+    "winnerJobIdentifier": "burkhalter-group-cf58443dd112",
+    "winnerCanonical": "heizungsinstallateur-in-100-ulrich-huber-ag-malans",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::mitarbeiter-in-hotellerie-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-ba2ff94faee7",
+    "winnerCanonical": "mitarbeiter-in-hotellerie-psychiatrische-dienste-graubunden-chur",
+    "decidedAt": "2026-04-30T11:36:08.696Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::oberarztin-oberarzt-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-00699d20e087",
+    "winnerCanonical": "oberarztin-oberarzt-psychiatrische-dienste-graubunden-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 3,
+    "canton": "GR"
+  },
+  "GR::de::spitex-assistant-de-sante-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "pflegehilfe-srk-spitex-50-100-spital-davos-ch",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::de::spitex-health-care-assistant-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "pflegehilfe-srk-spitex-50-100-spital-davos-ch",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::assembly-operator-befristet-80-100-w-m-d-jr-5751": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-d568e2ba6207",
+    "winnerCanonical": "assembly-operator-befristet-80-100-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5455,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
+    "winnerJobIdentifier": "grand-hotel-kronenhof-517f2506113d",
+    "winnerCanonical": "office-employee-steward-start-immediately-m-f-d-grand-hotel-kronenhof-pontresina",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-04-30T10:50:56.200Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::chauffeur-collecteur-de-donnees-in-landquart-switzerland-for-chur-area-tsmg-landquart-061cc5b5": {
+    "winnerJobIdentifier": "tsmg-7a1622ef3f50",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-landquart-switzerland-for-chur-area-tsmg-landquart",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4375,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "apprenticeship-as-a-chef-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::diet-chef-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "apprenticeship-as-a-chef-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-8569cb344e08",
+    "winnerCanonical": "dipl-nurse-hf-monitoring-station-40-60-spital-davos-davos",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
+    "winnerJobIdentifier": "9770821",
+    "winnerCanonical": "operating-room-technician-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3636,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
+    "winnerJobIdentifier": "burkhalter-group-cf58443dd112",
+    "winnerCanonical": "heating-installer-100-ulrich-huber-ag-malans",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::projektleiter-in-kunstbauten-80-100-chur-afry-chur": {
+    "winnerJobIdentifier": "afry-cfe9fcda330d",
+    "winnerCanonical": "project-engineer-artificial-buildings-bridge-construction-80-100-chur-afry-chur",
+    "decidedAt": "2026-05-10T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3077,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::en::safety-officer-80-100-f-m-d-hamilton-bonaduz-ag-bonaduz": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-0a0be4f3eaf0",
+    "winnerCanonical": "ict-engineer-ot-security-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-05-05T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4667,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::en::spitex-assistant-de-sante-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "care-assistant-srk-spitex-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::spitex-health-care-assistant-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "care-assistant-srk-spitex-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::en::strassenwart-in-kanton-gr-ch": {
+    "winnerJobIdentifier": "kanton-gr-0ffee9d541da",
+    "winnerCanonical": "road-maintenance-in-kantonale-verwaltung-graubunden-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0909,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::assembly-operator-befristet-80-100-w-m-d-jr-5751": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-d568e2ba6207",
+    "winnerCanonical": "assembly-operateur-befristet-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-05-09T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.125,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2143,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2857,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2857,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2857,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
+    "winnerJobIdentifier": "grand-hotel-kronenhof-517f2506113d",
+    "winnerCanonical": "office-employee-steward-staff-restaurant-capricorn-m-w-d-grand-hotel-kronenhof-pontresina",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-04-30T10:50:56.200Z",
+    "score": 0.5714,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8889,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::consulente-per-l-agenzia-generale-chur-100": {
+    "winnerJobIdentifier": "spital-davos-5795d1727096",
+    "winnerCanonical": "dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0714,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "apprentissage-de-cuisinier-ere-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::diet-chef-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "apprentissage-de-cuisinier-ere-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-8569cb344e08",
+    "winnerCanonical": "dipl-infirmiere-hf-service-de-surveillance-40-60-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
+    "winnerJobIdentifier": "9770821",
+    "winnerCanonical": "technicien-technicienne-de-salle-d-operation-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2308,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
+    "winnerJobIdentifier": "burkhalter-group-cf58443dd112",
+    "winnerCanonical": "installateur-trice-de-chauffage-100-ulrich-huber-ag-malans",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4615,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::place-d-apprentissage-en-tant-qu-assistant-e-de-commerce-de-detail-afp-en-denrees-alimentaires-volg-untervaz": {
+    "winnerJobIdentifier": "volg-fenaco-51b4337a6fa7",
+    "winnerCanonical": "apprentissage-d-assistant-de-commerce-de-detail-eba-produits-alimentaires-volg-untervaz-uiccmi",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4737,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::place-d-apprentissage-en-tant-qu-assistant-e-de-commerce-de-detail-afp-en-denrees-alimentaires-volg-vals": {
+    "winnerJobIdentifier": "volg-fenaco-2568fe5d2c1b",
+    "winnerCanonical": "apprentissage-d-assistant-de-commerce-de-detail-eba-produits-alimentaires-volg-vals-qsaqy0",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4737,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::projektleiter-in-kunstbauten-80-100-chur-afry-chur": {
+    "winnerJobIdentifier": "afry-cfe9fcda330d",
+    "winnerCanonical": "projektingenieur-in-kunstbauten-bruckenbau-80-100-chur-afry-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::spitex-assistant-de-sante-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "assistant-de-soins-srk-spitex-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::spitex-health-care-assistant-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "assistant-de-soins-srk-spitex-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5455,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::fr::strassenwart-in-kanton-gr-ch": {
+    "winnerJobIdentifier": "kanton-gr-0ffee9d541da",
+    "winnerCanonical": "tranche-en-kantonale-verwaltung-graubunden-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::apprendistato-come-assistente-del-commercio-al-dettaglio-afp-alimentari-volg-untervaz": {
+    "winnerJobIdentifier": "volg-fenaco-8bb331bcabf5",
+    "winnerCanonical": "apprendista-come-specialista-del-commercio-al-dettaglio-afc-prodotti-alimentari-volg-untervaz",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::assistente-all-assistenza-srk-spitex-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "assistenza-sanitaria-srk-spitex-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::assistente-chirurgia-e-ortopedia-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-5a7dd002f54a",
+    "winnerCanonical": "unterassistent-in-chirurgie-orthopala-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2727,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::autista-addetto-raccolta-dati-a-coira-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::autista-addetto-raccolta-dati-in-chur-svizzera-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::autista-mitarbeiter-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6364,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-9fa4vp": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6364,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::autista-prepose-raccolta-dati-in-chur-switzerland-tsmg-chur-tpdis1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6364,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::berufslehre-fachfrau-fachmann-hotellerie-hauswirtschaft-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020193",
+    "winnerCanonical": "apprendista-hotelieria-e-gestione-alberghiera-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2308,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::berufslehre-kochin-koch-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "apprendistato-come-cuoco-a-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::buroangestellte-steward-m-w-d-grand-hotel-kronenhof-pontresina": {
+    "winnerJobIdentifier": "grand-hotel-kronenhof-b32669874fc2",
+    "winnerCanonical": "terapista-termale-m-p-g-grand-hotel-kronenhof-pontresina",
+    "decidedAt": "2026-05-04T10:17:25.898Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::it::chauffeur-collecteur-de-donnees-in-chur-switzerland-tsmg-chur": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3077,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::consulente-per-l-agenzia-generale-chur-100": {
+    "winnerJobIdentifier": "spital-davos-5795d1727096",
+    "winnerCanonical": "diplomierte-pflegefachperson-hf-pensum-60-100-becomes-diplomierte-pflegefachperson-hf-remains-the-same-as-pflegefachpers",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0556,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::it::cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "apprendistato-come-cuoco-a-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::diet-chef-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "10020247",
+    "winnerCanonical": "apprendistato-come-cuoco-a-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::dipl-infermiere-hf-stazione-di-monitoraggio-40-60-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-8569cb344e08",
+    "winnerCanonical": "dipl-stazione-di-monitoraggio-hf-specialista-di-cura-40-60-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::dipl-pflegefachperson-hf-pensum-60-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-8569cb344e08",
+    "winnerCanonical": "dipl-stazione-di-monitoraggio-hf-specialista-di-cura-40-60-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3571,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::driver-data-collector-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur": {
+    "winnerJobIdentifier": "9770821",
+    "winnerCanonical": "operatrice-operatore-di-sala-operatoria-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2727,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::fachfrau-fachmann-operationstechnik-kantonsspital-graubunden-chur-2": {
+    "winnerJobIdentifier": "9770821",
+    "winnerCanonical": "operatrice-operatore-di-sala-operatoria-kantonsspital-graubunden-chur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::fachspezialist-qualitassicherung-m-w-d-trumpf-r00039734": {
+    "winnerJobIdentifier": "trumpf-schweiz-ed744dfa8a0e",
+    "winnerCanonical": "consulente-senior-m-w-d-trumpf-schweiz-ag-grusch",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::fahrer-datenerfasser-in-chur-switzerland-tsmg-chur-dfa1adf1": {
+    "winnerJobIdentifier": "tsmg-2d2283cb9788",
+    "winnerCanonical": "autista-addetto-raccolta-dati-in-chur-switzerland-tsmg-chur-dfa1adf1",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::installatore-trice-di-impianti-di-riscaldamento-100-ulrich-huber-ag-malans": {
+    "winnerJobIdentifier": "burkhalter-group-8b5ff5dd31e8",
+    "winnerCanonical": "installatore-trice-di-riscaldamento-capo-cantiere-100-ulrich-huber-ag-malans",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::lehrstelle-2027-automatiker-in-efz-trumpf-r00039691": {
+    "winnerJobIdentifier": "trumpf-schweiz-83585a10ea69",
+    "winnerCanonical": "apprendistato-2027-automatiker-in-cfc-trumpf-schweiz-ag-grusch",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::lehrstelle-2027-konstrukteur-in-efz-trumpf-r00039703": {
+    "winnerJobIdentifier": "trumpf-schweiz-2d1e6fc71e7a",
+    "winnerCanonical": "apprendistato-2027-konstrukteur-in-cfc-trumpf-schweiz-ag-grusch",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::oberarztin-oberarzt-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-6bea78edbd79",
+    "winnerCanonical": "medico-specialista-in-psichiatria-psychiatrische-dienste-graubunden-cazis",
+    "decidedAt": "2026-05-01T00:00:03.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::project-manager-in-kunstbauten-80-100-chur-afry-chur": {
+    "winnerJobIdentifier": "afry-cfe9fcda330d",
+    "winnerCanonical": "ingegnere-a-di-progetto-opere-d-arte-bruckenbau-80-100-chur-afry-chur",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::it::projektleiter-in-kunstbauten-80-100-chur-afry-chur": {
+    "winnerJobIdentifier": "afry-cfe9fcda330d",
+    "winnerCanonical": "ingegnere-a-di-progetto-opere-d-arte-bruckenbau-80-100-chur-afry-chur",
+    "decidedAt": "2026-05-10T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2667,
+    "candidatesCount": 1,
+    "canton": "GR"
+  },
+  "GR::it::responsabile-di-progetto-opere-d-arte-80-100-chur-afry-chur": {
+    "winnerJobIdentifier": "afry-cfe9fcda330d",
+    "winnerCanonical": "ingegnere-a-di-progetto-opere-d-arte-bruckenbau-80-100-chur-afry-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6923,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::spitex-assistant-de-sante-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "assistenza-sanitaria-srk-spitex-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::spitex-assistente-sanitario-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-9804891a5da1",
+    "winnerCanonical": "spitex-salute-specialistica-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::spitex-health-care-assistant-50-100-spital-davos-davos": {
+    "winnerJobIdentifier": "spital-davos-016659b12606",
+    "winnerCanonical": "assistenza-sanitaria-srk-spitex-50-100-spital-davos-davos",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "GR::it::strassenwart-in-kanton-gr-ch": {
+    "winnerJobIdentifier": "kanton-gr-0ffee9d541da",
+    "winnerCanonical": "strassenwart-in-kantonale-verwaltung-graubunden-chur",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2222,
+    "candidatesCount": 2,
+    "canton": "GR"
+  },
+  "SG::fr::versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel": {
+    "winnerJobIdentifier": "groupe-mutuel-e7eaf500fc99",
+    "winnerCanonical": "conseiller-en-assurance-et-prevoyance-m-f-80-100-groupe-mutuel-wil",
+    "decidedAt": "2026-05-01T22:15:20.101Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3125,
+    "candidatesCount": 3,
+    "canton": "SG"
+  },
+  "TI::de::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4706,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.5625,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "automobil-mechatroniker-in-swiss-armed-forces-vtg-bellinzona",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5385,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::de::arztsekretar-in-unispital-basel-ch": {
+    "winnerJobIdentifier": "unispital-basel-640a59e26647",
+    "winnerCanonical": "arztsekretar-in-universitatsspital-basel-basel",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::arztsekretarin-arztsekretar-ksw-ch": {
+    "winnerJobIdentifier": "ksw-491c8feebb0b",
+    "winnerCanonical": "arztsekretarin-arztsekretar-kantonsspital-winterthur-ksw-winterthur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 3,
+    "canton": "TI"
+  },
+  "TI::de::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medizinischer-studienassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medizinischer-studienassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medizinischer-assistent-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-05-01T08:59:01.541Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.625,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::autista-di-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
+    "winnerCanonical": "truck-driver-heineken-ch-baltschieder",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::bauzeichner-m-f-x-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-3ce9ee408868",
+    "winnerCanonical": "konstrukteur-fur-bauingenieurwesen-m-f-x-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "betreiberbehandlungen-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
+    "winnerCanonical": "chauffeur-kat-c-e-heineken-ch-luzern",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.1538,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::consulente-assicurativo": {
+    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
+    "winnerCanonical": "versicherungsberater-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::consulenza-finanziaria-entrata-laterale-fisso-bonus-teilzeit-o-100-convit-holding-gmbh-losone": {
+    "winnerJobIdentifier": "convit-e629adda55fe",
+    "winnerCanonical": "berater-patrimonio-junior-teilzeit-o-100-convit-holding-gmbh-agra",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.3529,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-adaa0bd12412",
+    "winnerCanonical": "dipl-pflegefachperson-hf-fur-die-nachtwache-psychiatrische-dienste-graubunden-cazis",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::doktorandenstelle-usi-universita-della-svizzera-italiana-lugano": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-c86503b7b022",
+    "winnerCanonical": "doktorandenstelle-im-internationalen-wirtschaftsrecht-usi-universita-della-svizzera-italiana-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4706,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::fisioterapista-diplomata-o-eoc-ente-ospedaliero-cantonale-locarno-uillzl": {
+    "winnerJobIdentifier": "company-uillzl",
+    "winnerCanonical": "diplomierte-r-physiotherapeut-in-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
+    "winnerCanonical": "vollzeitstelle-eines-instrumentierungswissenschaftlers-ingenieurs-usi-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1111,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::funktionsanalytikerin-relewant-chiasso": {
+    "winnerJobIdentifier": "company-czslhp",
+    "winnerCanonical": "funktionsanalyst-relewant-chiasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::gerustbauer-pemsa-bellinzona": {
+    "winnerJobIdentifier": "pemsa-2ade426c81c2",
+    "winnerCanonical": "fliesen-pemsa-bellinzona",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "project-ingenieur-project-manager-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4118,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4706,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "zulassung-3a-3b-finanzberatung-flexible-stunden-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4706,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::kaeltetechniker-m-w-d-hilcona-pfaffstatt": {
+    "winnerJobIdentifier": "hilcona-1c5bc99d5316",
+    "winnerCanonical": "kaeltetechniker-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
+    "winnerJobIdentifier": "company-ts9gho",
+    "winnerCanonical": "kundenberaterin-basis-bern-w-m-banca-cler",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::kundenberaterin-basis-bern-w-m-banca-cler": {
+    "winnerJobIdentifier": "company-ts9gho",
+    "winnerCanonical": "kundenberaterin-basis-bern-w-m-80-100-bank-cler-bellinzona",
+    "decidedAt": "2026-05-10T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5455,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.9091,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::lagerungspflegerin-lagerungspfleger-w-m-d-soh-ch": {
+    "winnerJobIdentifier": "solothurner-spitaeler-04d7bd67b00a",
+    "winnerCanonical": "lagerungspflegerin-lagerungspfleger-w-m-d-solothurner-spitaler-soh-solothurn",
+    "decidedAt": "2026-05-10T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::lernende-r-automobil-mechatroniker-in-efz-fachrichtung-personenwagen-swiss-armed-forces-vtg-rivera-cn6k0h": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "automobil-mechatroniker-in-swiss-armed-forces-vtg-bellinzona",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4667,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::de::levatrice-ostetrica-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uikzn4",
+    "winnerCanonical": "levatrice-ostetrica-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::de::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medizinischer-assistent-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-05-01T08:59:01.541Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medizinischer-assistent-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-05-01T08:59:01.541Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medizinischer-studienassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
+    "winnerJobIdentifier": "company-uilpqn",
+    "winnerCanonical": "medizinstudent-chirurgie-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-05-02T08:37:48.781Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "betreiberbehandlungen-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
+    "winnerCanonical": "vollzeitstelle-als-instrumentierungswissenschaftler-ingenieur-usi-locarno",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::projektingenieur-m-f-x-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
+    "winnerCanonical": "ingenieur-di-progetto-m-f-x-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::projektingenieur-projektmanager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "project-ingenieur-project-manager-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.375,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::promotionsstellen-usi-universita-della-svizzera-italiana-lugano": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-c86503b7b022",
+    "winnerCanonical": "doktorandenstelle-im-internationalen-wirtschaftsrecht-usi-universita-della-svizzera-italiana-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5455,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::refinery-department-operator-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "betreiberbehandlungen-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-cf5d10cad016",
+    "winnerCanonical": "schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-05T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::senior-it-business-analista-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analyst-bankwesen-fincons-group-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::senior-it-business-analyst-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analyst-bankwesen-fincons-group-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.875,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::senior-it-business-analyste-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analyst-bankwesen-fincons-group-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::title-truck-driver-heineken-ch-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
+    "winnerCanonical": "chauffeur-kat-c-e-heineken-ch-luzern",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.1538,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::de::umsatz-finanza-previdenza-entrata-laterale-fisso-bonus-convit-holding-gmbh-giubiasco": {
+    "winnerJobIdentifier": "convit-9d5454d91e22",
+    "winnerCanonical": "verkauf-finanzen-sicherheit-seiteneingang-fest-bonus-convit-holding-gmbh-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.3125,
+    "candidatesCount": 3,
+    "canton": "TI"
+  },
+  "TI::de::verkaufsprojektingenieur-in-tessin-rittmeyer-ag-tessin": {
+    "winnerJobIdentifier": "rittmeyer-ag-e474959dc11f",
+    "winnerCanonical": "verkaufsprojektingenieur-in-tessin-rittmeyer-ag-camorino",
+    "decidedAt": "2026-05-10T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::vollzeitstelle-als-instrumentierungswissenschaftler-ingenieur-usi-universita-della-svizzera-italiana-locarno": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
+    "winnerCanonical": "vollzeitstelle-als-instrumentierungswissenschaftler-ingenieur-usi-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::de::vorsorgeberater-fur-alter-3-nebeneintritt-unbefristet-convit-holding-gmbh-biasca": {
+    "winnerJobIdentifier": "convit-6f7e38966187",
+    "winnerCanonical": "rentenberater-fur-den-ruhestand-3a-side-entry-festanstellung-convit-holding-gmbh-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.2941,
+    "candidatesCount": 4,
+    "canton": "TI"
+  },
+  "TI::de::vorsorgeberater-m-w-d-eintritt-ohne-ausbildung-ote-bis-7-500-chf-convit-holding-gmbh-biasca": {
+    "winnerJobIdentifier": "convit-4ed3cb54692f",
+    "winnerCanonical": "private-berater-sparplane-junior-homeoffice-convit-holding-gmbh-origlio",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.1364,
+    "candidatesCount": 8,
+    "canton": "TI"
+  },
+  "TI::en::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.7333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "automotive-mechatronics-swiss-armed-forces-vtg-bern-40eki6",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::en::arztsekretarin-arztsekretar-ksw-ch-3": {
+    "winnerJobIdentifier": "ksw-da54f11b0c98",
+    "winnerCanonical": "doctor-s-secretary-kantonsspital-winterthur-ksw-winterthur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medical-study-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6923,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medical-study-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medical-assistant-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.625,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::autista-di-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
+    "winnerCanonical": "driver-c-e-heineken-switzerland-luzern",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.1667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "operator-treatments-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
+    "winnerCanonical": "driver-c-e-heineken-switzerland-luzern",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.1667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::conseiller-clientele-contact-center-h-f-100-temporaire-3-mois-prolongeable-groupe-mutuel": {
+    "winnerJobIdentifier": "groupe-mutuel-0ebdee6ee1b8",
+    "winnerCanonical": "customer-service-advisor-contact-center-m-f-100-temporary-3-months-extendable-groupe-mutuel-fribourg",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-04-30T10:50:56.200Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::consulente-assicurativo": {
+    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
+    "winnerCanonical": "insurance-consultant-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::consulenza-finanziaria-entrata-lateral-fisso-bonus-part-time-o-100-convit-holding-gmbh-losone": {
+    "winnerJobIdentifier": "convit-8b3e25e5db99",
+    "winnerCanonical": "financial-advice-side-entrance-fixed-bonus-part-time-or-100-convit-holding-gmbh-losone",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4,
+    "candidatesCount": 3,
+    "canton": "TI"
+  },
+  "TI::en::digital-sales-praktikant-emea-praktikumsprogramm-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde": {
+    "winnerJobIdentifier": "company-o38qde",
+    "winnerCanonical": "digital-sales-intern-emea-internship-program-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.7368,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::digital-sales-stagiaire-emea-programme-de-stage-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde": {
+    "winnerJobIdentifier": "company-o38qde",
+    "winnerCanonical": "digital-sales-intern-emea-internship-program-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-o38qde",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.8571,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::full-time-position-of-an-instrumentation-scientist-engineer-usi-locarno": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
+    "winnerCanonical": "full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
+    "winnerCanonical": "full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "project-engineer-project-manager-lombardi-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.3889,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::installateur-m-w-d-hilcona-pfaffstatt": {
+    "winnerJobIdentifier": "hilcona-c770e4ca2339",
+    "winnerCanonical": "installer-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.4,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona-ts9gho": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona-a7q9i9": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3571,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::lernende-r-automobil-mechatroniker-in-efz-fachrichtung-personenwagen-swiss-armed-forces-vtg-rivera-cn6k0h": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "automotive-mechatronics-swiss-armed-forces-vtg-bern-40eki6",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2222,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::en::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medical-assistant-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medical-assistant-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medical-study-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::medizinische-praxisassistentin-medizinischer-praxisassistent-ksw-ch-2": {
+    "winnerJobIdentifier": "ksw-5315115335ae",
+    "winnerCanonical": "medical-practice-assistant-kantonsspital-winterthur-ksw-winterthur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
+    "winnerJobIdentifier": "company-uilpqn",
+    "winnerCanonical": "medical-candidate-surgery-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-05-02T08:37:48.781Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::oberarztin-oberarzt-medizin-w-m-d-soh-ch-2": {
+    "winnerJobIdentifier": "solothurner-spitaeler-4f66ec5870fa",
+    "winnerCanonical": "senior-consultant-m-d-solothurner-spitaler-soh-olten",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2143,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "operator-treatments-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::pflegefachfrau-pflegefachmann-hf-in-ausbildung-somatik-4-jahre-w-m-d-soh-ch-2": {
+    "winnerJobIdentifier": "solothurner-spitaeler-91e1a9599575",
+    "winnerCanonical": "nursing-specialist-hf-in-training-somatik-4-years-w-m-d-solothurner-spitaler-soh-olten",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.381,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::physiotherapist-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uikzn4",
+    "winnerCanonical": "midwife-midwife-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7143,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
+    "winnerCanonical": "full-time-position-of-an-instrumentation-scientist-engineer-usi-locarno",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::project-engineer-m-f-x-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
+    "winnerCanonical": "engineer-di-progetto-m-f-x-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::project-engineer-project-manager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "project-engineer-project-manager-lombardi-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-exte": {
+    "winnerJobIdentifier": "bitfinex-e64c68d29124",
+    "winnerCanonical": "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-caracas",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.7333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::projektingenieur-projektmanager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
+    "winnerCanonical": "engineer-di-progetto-m-f-x-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2727,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::refinery-department-operator-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
+    "winnerCanonical": "operator-department-raffineria-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::sales-finanza-previdenza-entrata-laterale-fisso-bonus-convit-giubiasco": {
+    "winnerJobIdentifier": "convit-131bb55e1c75",
+    "winnerCanonical": "private-consultant-3a-3b-hybrid-convit-holding-gmbh-sementina",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.0588,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::scaffolder-pemsa-bellinzona": {
+    "winnerJobIdentifier": "pemsa-2ade426c81c2",
+    "winnerCanonical": "tiles-pemsa-bellinzona",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
+    "winnerCanonical": "apprenticeship-in-computer-science-application-development-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-05T00:00:00.000Z",
+    "score": 0.0667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::senior-it-business-analista-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analyst-banking-fincons-group-lugano-switzerland",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::senior-it-business-analyst-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analyst-banking-fincons-group-lugano-switzerland",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::senior-it-business-analyste-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analyst-banking-fincons-group-lugano-switzerland",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::social-security-advisor-m-f-d-untrained-entry-ote-up-to-chf-7-500-convit-holding-gmbh-biasca": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-biasca",
+    "decidedAt": "2026-05-04T09:24:16.306Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.16,
+    "candidatesCount": 7,
+    "canton": "TI"
+  },
+  "TI::en::social-security-consultant-for-old-age-3a-lateral-entry-indefinite-time-convit-holding-gmbh-biasca": {
+    "winnerJobIdentifier": "convit-6f7e38966187",
+    "winnerCanonical": "pension-advisor-for-retirement-3a-side-entry-permanent-convit-holding-gmbh-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.35,
+    "candidatesCount": 4,
+    "canton": "TI"
+  },
+  "TI::en::stagista-nelle-vendite-digitali-programma-di-tirocinio-emea-vf-international-the-north-face-timberland-emea-che-stabio-v": {
+    "winnerJobIdentifier": "company-jvj5fl",
+    "winnerCanonical": "pr-marketing-intern-emea-internship-program-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-jvj5fl",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.36,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::en::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::80-100-r-d-senior-ingenieur-energy-storage-systems-abb-svizzera-sede-ticino-quartino-ticino-hsi9t8": {
+    "winnerJobIdentifier": "company-noo56s",
+    "winnerCanonical": "r-d-senior-ingenieur-firmware-80-100-abb-svizzera-sede-ticino-quartino-ticino-noo56s",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.6471,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "mecatronique-automobile-swiss-armed-forces-vtg-bern-40eki6",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::fr::apprentissage-d-informaticien-dans-le-domaine-du-developpement-de-plateformes-hamilton-bonaduz-ag-bonaduz": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-cf5d10cad016",
+    "winnerCanonical": "stage-d-introduction-informatique-developpement-de-plateformes-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-05T00:00:00.000Z",
+    "score": 0.4375,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::arztsekretarin-arztsekretar-ksw-ch-3": {
+    "winnerJobIdentifier": "ksw-da54f11b0c98",
+    "winnerCanonical": "secretaire-du-docteur-kantonsspital-winterthur-ksw-winterthur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medical-office-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6923,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medical-office-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "assistant-medical-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.625,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::autista-di-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
+    "winnerCanonical": "chauffeur-de-camion-heineken-switzerland-baltschieder",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.2727,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
+    "winnerCanonical": "service-operateur-raffineria-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
+    "winnerCanonical": "chauffeur-de-camion-heineken-switzerland-baltschieder",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::conseiller-en-prevoyance-vieillesse-3a-entree-laterale-duree-indeterminee-convit-holding-gmbh-biasca": {
+    "winnerJobIdentifier": "convit-6f7e38966187",
+    "winnerCanonical": "conseiller-en-retraite-pour-la-retraite-3a-entree-laterale-permanent-convit-holding-gmbh-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.5294,
+    "candidatesCount": 4,
+    "canton": "TI"
+  },
+  "TI::fr::consulente-assicurativo": {
+    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
+    "winnerCanonical": "consulente-assicurativo-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.2222,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::consulenza-finanziaria-entrata-laterale-fisso-bonus-part-time-o-100-convit-losone": {
+    "winnerJobIdentifier": "convit-e629adda55fe",
+    "winnerCanonical": "consultant-patrimonio-junior-temps-partiel-o-100-convit-holding-gmbh-agra",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.15,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::consultant-en-securite-sociale-h-f-d-entree-sans-formation-ote-jusqu-a-7-500-chf-convit-holding-gmbh-biasca": {
+    "winnerJobIdentifier": "convit-2323c0b40462",
+    "winnerCanonical": "conseils-financiers-en-ligne-entree-laterale-hybride-homeoffice-convit-holding-gmbh-arbedo-castione",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.1786,
+    "candidatesCount": 8,
+    "canton": "TI"
+  },
+  "TI::fr::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.3684,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
+    "winnerCanonical": "poste-a-temps-plein-de-scientifique-ingenieur-de-l-instrumentation-usi-universita-della-svizzera-italiana-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2609,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::gestionnaire-de-comptes-m-m-banca-cler-bellinzona": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "gestionnaire-de-comptes-m-m-bank-cler-solothurn",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::gestionnaire-de-comptes-m-w-banca-cler-bellinzona": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "gestionnaire-de-comptes-m-m-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.875,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-b8c45529f0b3",
+    "winnerCanonical": "ingenieur-di-progetto-m-f-x-lombardi-group-giubiasco-pdpprq",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingenieur-de-projet-m-f-x-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "ingenieur-de-projet-chef-de-projet-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.9231,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.8571,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.8571,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::installateur-m-w-d-hilcona-pfaffstatt": {
+    "winnerJobIdentifier": "hilcona-c770e4ca2339",
+    "winnerCanonical": "installation-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.4,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "gestionnaire-de-comptes-m-m-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona-a7q9i9": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "gestionnaire-de-comptes-m-m-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::lernende-r-automobil-mechatroniker-in-efz-fachrichtung-personenwagen-swiss-armed-forces-vtg-rivera-cn6k0h": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "mecatronique-automobile-swiss-armed-forces-vtg-bern-40eki6",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2222,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::fr::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "assistant-medical-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "assistant-medical-eoc-ente-ospedaliero-cantonale-lugano",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "medical-office-assistant-60-70-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::medizinische-praxisassistentin-medizinischer-praxisassistent-ksw-ch-2": {
+    "winnerJobIdentifier": "ksw-5315115335ae",
+    "winnerCanonical": "assistant-de-pratique-medicale-kantonsspital-winterthur-ksw-winterthur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0769,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
+    "winnerJobIdentifier": "company-uilpqn",
+    "winnerCanonical": "candidat-e-en-medecine-chirurgie-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-05-02T08:37:48.781Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::oberarztin-oberarzt-medizin-w-m-d-soh-ch-2": {
+    "winnerJobIdentifier": "solothurner-spitaeler-4f66ec5870fa",
+    "winnerCanonical": "consultant-principal-m-j-solothurner-spitaler-soh-olten-acb83f",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.125,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
+    "winnerCanonical": "service-operateur-raffineria-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::pflegefachfrau-pflegefachmann-hf-in-ausbildung-somatik-4-jahre-w-m-d-soh-ch-2": {
+    "winnerJobIdentifier": "solothurner-spitaeler-91e1a9599575",
+    "winnerCanonical": "specialiste-des-soins-infirmiers-hf-en-formation-somatik-4-ans-m-j-solothurner-spitaler-soh-olten",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::physiotherapeute-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uikzn4",
+    "winnerCanonical": "sage-femme-sage-femme-eoc-ente-ospedaliero-cantonale-locarno",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.625,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
+    "winnerCanonical": "poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-locarno",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6471,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::project-ingenieur-project-manager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "ingenieur-de-projet-chef-de-projet-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::projektingenieur-projektmanager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "ingenieur-de-projet-chef-de-projet-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::refinery-department-operator-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-6b726144ffd1",
+    "winnerCanonical": "service-operateur-raffineria-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
+    "winnerCanonical": "stage-en-informatique-developpement-d-applications-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-05T00:00:00.000Z",
+    "score": 0,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::senior-it-business-analista-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "analyste-principal-des-affaires-en-ti-services-bancaires-fincons-group-lugano",
+    "decidedAt": "2026-05-08T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::fr::senior-it-business-analyst-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "analyste-principal-des-affaires-en-ti-services-bancaires-fincons-group-lugano",
+    "decidedAt": "2026-05-08T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::fr::senior-it-business-analyste-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "analyste-principal-des-affaires-en-ti-services-bancaires-fincons-group-lugano",
+    "decidedAt": "2026-05-08T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2857,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::fr::stagiaire-en-gestion-de-projet-richemont-meyrin": {
+    "winnerJobIdentifier": "richemont-76f727c86d86",
+    "winnerCanonical": "it-project-management-intern-richemont-meyrin",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1818,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::title-truck-driver-heineken-ch-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
+    "winnerCanonical": "chauffeur-c-e-heineken-switzerland-content-width-device-width",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::fr::ventes-finanza-previdenza-entrata-laterale-fisso-bonus-convit-holding-gmbh-giubiasco": {
+    "winnerJobIdentifier": "convit-9d5454d91e22",
+    "winnerCanonical": "finance-des-ventes-securite-entree-laterale-fixe-bonus-convit-holding-gmbh-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.4375,
+    "candidatesCount": 3,
+    "canton": "TI"
+  },
+  "TI::it::account-manager-m-w-banca-cler-bellinzona": {
+    "winnerJobIdentifier": "company-ts9gho",
+    "winnerCanonical": "account-manager-m-w-banca-cler-bellinzona-213e54",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.875,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::admission-3a-3b-conseils-financiers-horaires-flexibles-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::admission-3a-3b-financial-advice-flexible-hours-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::apprendista-automobil-mechatroniker-in-cfc-specializzazione-personenwagen-swiss-armed-forces-vtg-rivera": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "meccatronica-automobilistica-swiss-armed-forces-vtg-bellinzona",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2667,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::it::apprendista-meccatronico-automobilistico-efz-settore-veicoli-personali-swiss-armed-forces-vtg-rivera": {
+    "winnerJobIdentifier": "company-40eki6",
+    "winnerCanonical": "meccatronica-automobilistica-swiss-armed-forces-vtg-bellinzona",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2667,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::it::apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-balerna": {
+    "winnerJobIdentifier": "swisscom-sede-ticino-6ec9c0a4427c",
+    "winnerCanonical": "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-balerna",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-balerna-56yj6u": {
+    "winnerJobIdentifier": "swisscom-sede-ticino-6ec9c0a4427c",
+    "winnerCanonical": "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-balerna",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7692,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::arztsekretarin-arztsekretar-ksw-ch-3": {
+    "winnerJobIdentifier": "ksw-da54f11b0c98",
+    "winnerCanonical": "segretario-del-dottore-kantonsspital-winterthur-ksw-winterthur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::assembly-operator-befristet-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-de10ccc90ef5",
+    "winnerCanonical": "assembly-operator-80-100-m-w-d-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.9091,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::it::assistant-e-de-cabinet-medical-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3529,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8333,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-locarno-uilqdx": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7692,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::assistenzarzt-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4444,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ausbildung-dipl-pflegefachmann-frau-hf-3-jahre-regular-september-2026-bfgs-spital-thurgau-stgag-munsterlingen": {
+    "winnerJobIdentifier": "spital-thurgau-0fe1a8054d15",
+    "winnerCanonical": "specialista-dell-istruzione-hf-3-anni-regolari-settembre-2026-bfgs-spital-thurgau-stgag-munsterlingen",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.381,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::autista-di-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
+    "winnerCanonical": "autista-di-camion-heineken-switzerland-baltschieder",
+    "decidedAt": "2026-05-02T19:33:03.135Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-regionale-kunden-colin-cie-wealth-management-munsbach": {
+    "winnerJobIdentifier": "colin-cie-39bced82bc8b",
+    "winnerCanonical": "berater-m-w-d-im-wealth-management-am-standort-lugano-con-fokus-regionale-kunden-colin-cie-wealth-management-lugano",
+    "decidedAt": "2026-05-04T09:24:16.306Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.8333,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::it::betreiber-der-raffinerieabteilung-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "operatore-trattamenti-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::chauffeur-de-camion-heineken-switzerland-content-width-device-width": {
+    "winnerJobIdentifier": "heineken-ch-4f6eb0ce9007",
+    "winnerCanonical": "autista-di-camion-heineken-switzerland-baltschieder",
+    "decidedAt": "2026-05-02T19:58:59.198Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.2727,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::consulente-assicurativo": {
+    "winnerJobIdentifier": "axa-svizzera-782259b279bd",
+    "winnerCanonical": "consulente-per-la-sicurezza-axa-svizzera-agenzia-principale-igor-scheggia-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-biasca": {
+    "winnerJobIdentifier": "convit-1f9f769932df",
+    "winnerCanonical": "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-holding-gmbh-biasca",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.8889,
+    "candidatesCount": 8,
+    "canton": "TI"
+  },
+  "TI::it::consulente-previdenziale-per-la-vecchiaia-3a-entrata-laterale-tempo-indeterminato-convit-biasca": {
+    "winnerJobIdentifier": "convit-4afd0f60af04",
+    "winnerCanonical": "consulente-previdenziale-junior-entrata-laterale-mentoring-coaching-convit-camorino",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.3125,
+    "candidatesCount": 3,
+    "canton": "TI"
+  },
+  "TI::it::consulenza-finanziaria-entrata-laterale-fissa-bonus-part-time-o-100-convit-holding-gmbh-losone": {
+    "winnerJobIdentifier": "convit-8b3e25e5db99",
+    "winnerCanonical": "consulenza-finanziaria-entrata-laterale-fisso-bonus-part-time-o-100-convit-losone",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.7333,
+    "candidatesCount": 3,
+    "canton": "TI"
+  },
+  "TI::it::dipl-pflegefachmann-frau-forensik-spital-thurgau-stgag-munsterlingen": {
+    "winnerJobIdentifier": "spital-thurgau-a7017a609abc",
+    "winnerCanonical": "dipl-specialista-di-cura-forense-spital-thurgau-stgag-munsterlingen",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::dipl-pflegefachmann-frau-forensik-stgag-ch": {
+    "winnerJobIdentifier": "spital-thurgau-422f0cc4c8e3",
+    "winnerCanonical": "dipl-pflegefachmann-frau-forensik-spital-thurgau-stgag-munsterlingen",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-adaa0bd12412",
+    "winnerCanonical": "dipl-pflegefachperson-hf-per-la-nachtwache-psychiatrische-dienste-graubunden-cazis",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2857,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::dipl-pflegefachperson-hf-pdgr-ch": {
+    "winnerJobIdentifier": "pdgr-4c55e9af737c",
+    "winnerCanonical": "dipl-specialista-di-cura-hf-psychiatrische-dienste-graubunden-cazis",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1667,
+    "candidatesCount": 1,
+    "canton": "TI"
+  },
+  "TI::it::elektronikingenieur-in-f-e-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::entrance-financial-counseling-3a-3b-flexible-hours-convit-holding-gmbh-giubiasco-monte-car": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.2632,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::fisioterapista-diplomata-o-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uillzl",
+    "winnerCanonical": "fisioterapista-diplomata-o-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-locarno": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-20d4eef1df72",
+    "winnerCanonical": "tempo-pieno-position-of-an-instrumentation-scientist-ingegnere-usi-universita-della-svizzera-italiana-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingegnere-di-progetto-project-manager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "project-ingegnere-project-manager-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingegnere-elettronico-r-s-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingenieur-electronique-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingenieur-logiciel-expert-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingenieur-plc-logiciel-r-d-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3846,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.7692,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingresso-consulenza-finanziaria-3a-3b-orari-flexibili-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.7143,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::ingresso-consulenza-finanziaria-3a-3b-orari-flexibler-convit-holding-gmbh-giubiasco-monte-carasso": {
+    "winnerJobIdentifier": "convit-cb94b1dded29",
+    "winnerCanonical": "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-giubiasco-monte-carasso",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-06T00:00:00.000Z",
+    "score": 0.7143,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::installateur-m-w-d-hilcona-pfaffstatt": {
+    "winnerJobIdentifier": "hilcona-c770e4ca2339",
+    "winnerCanonical": "installateur-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::kaeltetechniker-m-w-d-hilcona-pfaffstatt": {
+    "winnerJobIdentifier": "hilcona-1c5bc99d5316",
+    "winnerCanonical": "kaeltetechniker-m-w-d-hubers-landhendl-gmbh-pfaffstatt",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-04T08:00:25.302Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::kundenberaterin-basis-bern-m-w-d-banca-cler-bellinzona": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4286,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona-a7q9i9": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.9167,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::kundenberaterin-individual-und-stellvertretende-filialleiterin-solothurn-w-m-banca-cler": {
+    "winnerJobIdentifier": "company-a7q9i9",
+    "winnerCanonical": "kundenberaterin-individual-e-stellvertretende-filialleiterin-solothurn-w-m-banca-cler-bellinzona",
+    "decidedAt": "2026-04-30T15:42:20.795Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::medecin-adjoint-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.75,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::medico-assistente-eoc-ente-ospedaliero-cantonale-lugano-uilm0d": {
+    "winnerJobIdentifier": "company-uilm0d",
+    "winnerCanonical": "medico-assistente-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T13:24:06.236Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::medizinische-praxisassistentin-medizinischer-praxisassistent-60-70-eoc-ente-ospedaliero-cantonale-locarno": {
+    "winnerJobIdentifier": "company-uilqdx",
+    "winnerCanonical": "assistente-di-studio-medico-60-70-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.375,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::medizinische-praxisassistentin-medizinischer-praxisassistent-ksw-ch-2": {
+    "winnerJobIdentifier": "ksw-5315115335ae",
+    "winnerCanonical": "assistente-di-pratica-medica-kantonsspital-winterthur-ksw-winterthur",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0769,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::medizinischer-studienassistent-eoc-ente-ospedaliero-cantonale-bellinzona": {
+    "winnerJobIdentifier": "company-uilpqn",
+    "winnerCanonical": "candidato-medico-chirurgia-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "decidedAt": "2026-05-02T08:37:48.781Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::messtechniker-in-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::oberarztin-oberarzt-medizin-w-m-d-soh-ch-2": {
+    "winnerJobIdentifier": "solothurner-spitaeler-4f66ec5870fa",
+    "winnerCanonical": "consulente-senior-m-d-solothurner-spitaler-soh-olten-acb83f",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.2,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::operateur-service-raffinerie-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "operatore-trattamenti-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::pflegefachfrau-pflegefachmann-hf-in-ausbildung-somatik-4-jahre-w-m-d-soh-ch-2": {
+    "winnerJobIdentifier": "solothurner-spitaeler-91e1a9599575",
+    "winnerCanonical": "infermieristica-hf-in-formazione-somatik-4-anni-w-m-d-solothurner-spitaler-soh-olten",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano": {
+    "winnerJobIdentifier": "usi-universita-della-svizzera-italiana-9177ed8e4482",
+    "winnerCanonical": "posizione-a-tempo-pieno-di-scienziato-ingegnere-della-strumentazione-usi-locarno",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.125,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::project-engineer-project-manager-lombardi-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "project-ingegnere-project-manager-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5714,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::projektingenieur-projektmanager-lombardi-group-giubiasco": {
+    "winnerJobIdentifier": "lombardi-group-5faf0dec3324",
+    "winnerCanonical": "project-ingegnere-project-manager-lombardi-group-giubiasco",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.375,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::refinery-department-operator-mks-pamp-castel-san-pietro": {
+    "winnerJobIdentifier": "mks-pamp-0b07194576f4",
+    "winnerCanonical": "operatore-trattamenti-reflui-mks-pamp-castel-san-pietro",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::schnupperlehre-informatiker-in-fachrichtung-plattformentwicklung-jr-4076": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
+    "winnerCanonical": "schnupperlehre-informatiker-in-specializzazione-applikationsentwicklung-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-05T00:00:00.000Z",
+    "score": 0.25,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::schnupperlehre-informatiker-in-specializzazione-plattformentwicklung-hamilton-bonaduz-ag-bonaduz": {
+    "winnerJobIdentifier": "hamilton-bonaduz-ag-42c949eefac5",
+    "winnerCanonical": "schnupperlehre-informatiker-in-specializzazione-applikationsentwicklung-hamilton-bonaduz-ag-bonaduz",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-05T00:00:00.000Z",
+    "score": 0.7778,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::senior-it-business-analista-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analista-banking-fincons-group-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.875,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::senior-it-business-analyst-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analista-banking-fincons-group-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::senior-it-business-analyste-fincons-group-lugano": {
+    "winnerJobIdentifier": "fincons-group-e4fa03014547",
+    "winnerCanonical": "senior-it-business-analista-banking-fincons-group-lugano",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6667,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::technicien-en-metrologie-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::tecnico-di-metrologia-100-agie-charmilles-sa-biel-bienne": {
+    "winnerJobIdentifier": "agie-charmilles-49a88eb1478c",
+    "winnerCanonical": "sap-developer-100-agie-charmilles-biel-bienne",
+    "decidedAt": "2026-05-07T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.4545,
+    "candidatesCount": 2,
+    "canton": "TI"
+  },
+  "TI::it::title-truck-driver-heineken-ch-content-width-device-width": {
     "winnerJobIdentifier": "heineken-ch-1cdd4bfa05de",
     "winnerCanonical": "autista-c-e-heineken-switzerland-content-width-device-width",
     "decidedAt": "2026-04-30T09:24:47.194Z",
     "lastSeenAt": "2026-05-04T08:00:25.302Z",
     "score": 0.3333,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "TI"
   },
-  "it::vendite-finanza-previdenza-entrata-laterale-fisso-bonus-convit-holding-gmbh-giubiasco": {
+  "TI::it::vendite-finanza-previdenza-entrata-laterale-fisso-bonus-convit-holding-gmbh-giubiasco": {
     "winnerJobIdentifier": "convit-9d5454d91e22",
     "winnerCanonical": "sales-finanza-previdenza-entrata-laterale-fisso-bonus-convit-giubiasco",
     "decidedAt": "2026-04-30T09:24:47.194Z",
     "lastSeenAt": "2026-05-06T00:00:00.000Z",
     "score": 0.6667,
-    "candidatesCount": 3
+    "candidatesCount": 3,
+    "canton": "TI"
   },
-  "it::verkauferin-verkaufer-m-w-d-volg-vals": {
+  "TI::it::verkauferin-verkaufer-m-w-d-volg-vals": {
     "winnerJobIdentifier": "volg-fenaco-699f9076ff23",
     "winnerCanonical": "responsabile-vendite-m-w-d-volg-vals",
     "decidedAt": "2026-05-12T00:00:00.000Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.5556,
-    "candidatesCount": 2
+    "candidatesCount": 2,
+    "canton": "TI"
   },
-  "it::versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel": {
+  "VS::de::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
+    "winnerJobIdentifier": "volg-fenaco-f28ee877c0a5",
+    "winnerCanonical": "lehrstelle-als-detailhandelsfachmann-frau-oder-detailhandelsassistent-in-volg-visperterminen",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1176,
+    "candidatesCount": 2,
+    "canton": "VS"
+  },
+  "VS::de::operator-in-2-schicht-arxada-ch": {
+    "winnerJobIdentifier": "arxada-89e7dd4a9ec5",
+    "winnerCanonical": "operator-in-2-schicht-arxada-visp",
+    "decidedAt": "2026-05-12T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7143,
+    "candidatesCount": 2,
+    "canton": "VS"
+  },
+  "VS::en::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
+    "winnerJobIdentifier": "volg-fenaco-e6906731b758",
+    "winnerCanonical": "job-as-retail-salesperson-or-retail-sales-assistant-volg-grachen",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.7273,
+    "candidatesCount": 2,
+    "canton": "VS"
+  },
+  "VS::fr::apprentissage-de-gestionnaire-du-commerce-de-detail-conception-et-realisation-d-39-experie": {
+    "winnerJobIdentifier": "jumbo-1c670883-34c",
+    "winnerCanonical": "apprentissage-de-gestionnaire-du-commerce-de-detail-conception-et-realisation-d-experiences-d-achat-jumbo-conthey",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.625,
+    "candidatesCount": 2,
+    "canton": "VS"
+  },
+  "VS::fr::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
+    "winnerJobIdentifier": "volg-fenaco-e6906731b758",
+    "winnerCanonical": "poste-de-vente-ou-assistant-de-vente-volg-grachen",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1333,
+    "candidatesCount": 2,
+    "canton": "VS"
+  },
+  "VS::it::job-as-a-retail-salesperson-or-retail-sales-assistant-volg-visperterminen": {
+    "winnerJobIdentifier": "volg-fenaco-f28ee877c0a5",
+    "winnerCanonical": "lavoro-come-dettagliante-o-assistente-dettagliante-volg-visperterminen",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1333,
+    "candidatesCount": 2,
+    "canton": "VS"
+  },
+  "ZH::de::career-start-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich": {
+    "winnerJobIdentifier": "pwc-652904fb04f9",
+    "winnerCanonical": "karriere-start-in-digital-assurance-it-audit-und-process-analytics-finanzdienstleistungen-pwc-switzerland-zurich",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5556,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::de::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
+    "winnerJobIdentifier": "company-7qutu2",
+    "winnerCanonical": "systemgastronomiefachfrau-mann-efz-marche-dietlikon",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::de::systemgastronomiefachfrau-mann-praktiker-in-marche-grigioni-2p2jlr": {
+    "winnerJobIdentifier": "company-2p2jlr",
+    "winnerCanonical": "systemgastronomiefachfrau-mann-praktiker-in-marche-dietlikon",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.625,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::de::verkaufsberater-aussendienst-localsearch-ch": {
+    "winnerJobIdentifier": "localsearch-06277ad042b2",
+    "winnerCanonical": "verkaufsberater-aussendienst-localsearch-zurich",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.6,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::en::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
+    "winnerJobIdentifier": "company-2p2jlr",
+    "winnerCanonical": "system-gastronomy-technician-technician-marche-dietlikon",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::en::system-gastronomy-specialist-practitioner-marche-grigioni": {
+    "winnerJobIdentifier": "company-2p2jlr",
+    "winnerCanonical": "system-gastronomy-technician-technician-marche-dietlikon",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.375,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::en::versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel": {
+    "winnerJobIdentifier": "groupe-mutuel-1822825450f3",
+    "winnerCanonical": "insurance-and-pension-advisor-m-f-80-100-groupe-mutuel-zurich",
+    "decidedAt": "2026-05-01T22:15:20.101Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3333,
+    "candidatesCount": 3,
+    "canton": "ZH"
+  },
+  "ZH::fr::career-start-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich": {
+    "winnerJobIdentifier": "pwc-88dc0dbaf301",
+    "winnerCanonical": "senior-associate-en-assurance-numerique-audit-it-et-analyse-de-processus-services-financiers-pwc-switzerland-zurich-t7triq",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.24,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::fr::senior-associate-assistant-manager-audit-trade-industries-services-pwc-zurich": {
+    "winnerJobIdentifier": "pwc-0054671bedc4",
+    "winnerCanonical": "associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zurich",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.2222,
+    "candidatesCount": 1,
+    "canton": "ZH"
+  },
+  "ZH::fr::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
+    "winnerJobIdentifier": "company-2p2jlr",
+    "winnerCanonical": "technicien-de-la-system-gastronomie-marche-dietlikon",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.1538,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::it::career-start-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich": {
+    "winnerJobIdentifier": "pwc-88dc0dbaf301",
+    "winnerCanonical": "senior-associate-in-digital-assurance-it-audit-e-process-analytics-servizi-finanziari-pwc-switzerland-zurich",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.45,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::it::senior-associate-assistant-manager-audit-trade-industries-services-pwc-zurich": {
+    "winnerJobIdentifier": "pwc-0054671bedc4",
+    "winnerCanonical": "associato-senior-assistente-responsabile-controllo-del-commercio-delle-industrie-e-dei-servizi-pwc-switzerland-zurich",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-11T00:00:00.000Z",
+    "score": 0.1364,
+    "candidatesCount": 1,
+    "canton": "ZH"
+  },
+  "ZH::it::senior-associate-datenschutz-expert-in-ict-recht-pwc-zurich": {
+    "winnerJobIdentifier": "pwc-82e32deb8f92",
+    "winnerCanonical": "senior-associate-privacy-expert-in-legge-sull-ict-pwc-switzerland-zurich",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.5385,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::it::senior-associate-legal-regulatory-project-manager-pwc-zurich": {
+    "winnerJobIdentifier": "pwc-f80a4e0781f1",
+    "winnerCanonical": "senior-associate-responsabile-progetti-regolatori-legali-pwc-switzerland-zurich",
+    "decidedAt": "2026-05-11T00:00:00.000Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.3077,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::it::specialista-di-gastronomia-e-cucina-praticante-marche-grigioni": {
+    "winnerJobIdentifier": "company-2p2jlr",
+    "winnerCanonical": "systemgastronomia-tecnico-tecnica-marche-dietlikon",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::it::specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni": {
+    "winnerJobIdentifier": "company-2p2jlr",
+    "winnerCanonical": "systemgastronomia-tecnico-tecnica-marche-dietlikon",
+    "decidedAt": "2026-04-30T09:24:47.194Z",
+    "lastSeenAt": "2026-05-12T00:00:00.000Z",
+    "score": 0.0833,
+    "candidatesCount": 2,
+    "canton": "ZH"
+  },
+  "ZH::it::versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel": {
     "winnerJobIdentifier": "groupe-mutuel-1822825450f3",
     "winnerCanonical": "versicherungs-e-vorsorgeberater-m-w-80-100-groupe-mutuel-zurich",
     "decidedAt": "2026-04-30T09:24:47.194Z",
     "lastSeenAt": "2026-05-12T00:00:00.000Z",
     "score": 0.7273,
-    "candidatesCount": 3
+    "candidatesCount": 3,
+    "canton": "ZH"
   }
 }

--- a/scripts/migrate-previous-slug-winners-add-canton.mjs
+++ b/scripts/migrate-previous-slug-winners-add-canton.mjs
@@ -1,0 +1,155 @@
+// scripts/migrate-previous-slug-winners-add-canton.mjs
+//
+// One-shot migration that rewrites data/previous-slug-winners.json from the
+// legacy `${locale}::${oldSlug}` key shape to the Phase 8b canton-aware
+// `${canton}::${locale}::${oldSlug}` shape, and stamps a `canton` field on
+// each entry.
+//
+// Canton resolution order, for each entry:
+//   1. Look up `winnerJobIdentifier` in data/jobs.json → use job.canton if set.
+//   2. Else resolve job.location against data/canton-municipalities.json
+//      (matches `build-plugins/shared/cantonSection.ts: resolveJobCanton`).
+//   3. Fallback: 'TI' (preserves legacy bridge URLs for unresolvable entries).
+//
+// This script is idempotent: running it twice on the same file is safe.
+// Entries already in the new shape (key contains 3 segments AND entry.canton
+// is set) are left untouched.
+//
+// Why this migration exists
+// -------------------------
+// Before Phase 8b, every bridge emitted under the TI legacy section
+// (`/cerca-lavoro-ticino/...`) regardless of the winning job's canton. The
+// registry was keyed `(locale, oldSlug)`. Phase 8b makes bridges live under
+// the winning job's canton path (`/cerca-lavoro-zurigo/...` for ZH jobs), so
+// the registry key MUST include canton — two jobs in different cantons can
+// legitimately share the same oldSlug now and they emit at DIFFERENT URLs.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const WINNERS_PATH = path.resolve('data/previous-slug-winners.json');
+const JOBS_PATH = path.resolve('data/jobs.json');
+const MUNI_PATH = path.resolve('data/canton-municipalities.json');
+
+if (!fs.existsSync(WINNERS_PATH)) {
+  console.error(`[migrate-prev-slug-winners] no file at ${WINNERS_PATH}; nothing to migrate`);
+  process.exit(0);
+}
+if (!fs.existsSync(JOBS_PATH)) {
+  console.error(`[migrate-prev-slug-winners] no data/jobs.json — cannot resolve cantons. Aborting.`);
+  process.exit(1);
+}
+if (!fs.existsSync(MUNI_PATH)) {
+  console.error(`[migrate-prev-slug-winners] no data/canton-municipalities.json — cannot resolve cantons. Aborting.`);
+  process.exit(1);
+}
+
+const winners = JSON.parse(fs.readFileSync(WINNERS_PATH, 'utf8'));
+const jobs = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf8'));
+const muni = JSON.parse(fs.readFileSync(MUNI_PATH, 'utf8'));
+
+// Build identifier → job map. The plugin uses
+// `String(job.id || job.slug || currentSlug)` as the identifier; the same
+// value lands in winnerJobIdentifier. Index both id and slug to maximise hit
+// rate (jobs without `id` collapse to slug → also indexed).
+const jobByIdentifier = new Map();
+for (const job of jobs) {
+  if (job?.id) jobByIdentifier.set(String(job.id), job);
+  if (job?.slug) {
+    if (!jobByIdentifier.has(String(job.slug))) jobByIdentifier.set(String(job.slug), job);
+  }
+}
+
+// City → canton lookup (NFD-normalised, disambiguator-aware). Matches the
+// approach used by `build-plugins/shared/cantonSection.ts: resolveJobCanton`
+// closely enough that the migration converges on the same canton at build
+// time.
+function normalizeCityKey(s) {
+  return String(s).normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase().trim();
+}
+const cityToCanton = new Map();
+const cityCounts = new Map();
+for (const [canton, info] of Object.entries(muni.cantons)) {
+  for (const city of info.municipalities) {
+    const lower = normalizeCityKey(city);
+    if (lower.includes(' (')) cityToCanton.set(lower, canton);
+    const bare = lower.split(' (')[0].trim();
+    cityCounts.set(bare, (cityCounts.get(bare) || 0) + 1);
+    if (!cityToCanton.has(bare)) cityToCanton.set(bare, canton);
+  }
+}
+for (const [bare, count] of cityCounts) {
+  if (count > 1) cityToCanton.delete(bare);
+}
+
+const VALID_CANTONS = new Set([
+  'TI','ZH','AG','GE','VD','BE','LU','VS','GR','SG','SO','SZ','SH','OW','NW','UR','TG','GL','FR','JU','NE','ZG','AI','AR','BL','BS',
+]);
+const FALLBACK = 'TI';
+
+function resolveCantonForJob(job) {
+  const explicit = String(job?.canton || '').toUpperCase().trim();
+  if (explicit && VALID_CANTONS.has(explicit)) return explicit;
+  const loc = normalizeCityKey(String(job?.location || '')).replace(/\bsankt\s+/g, 'st. ');
+  const fullCity = loc.split(/[,(]/)[0].trim();
+  if (fullCity && cityToCanton.get(fullCity)) return cityToCanton.get(fullCity);
+  const tokens = loc.replace(/[(),]/g, ' ').split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    if (cityToCanton.get(token)) return cityToCanton.get(token);
+    const up = token.toUpperCase();
+    if (VALID_CANTONS.has(up)) return up;
+  }
+  return null;
+}
+
+// ── Migration ────────────────────────────────────────────────────────────
+let cantonResolved = 0;
+let fallbackUsed = 0;
+let alreadyMigrated = 0;
+let totalMigrated = 0;
+const out = {};
+
+for (const [oldKey, entry] of Object.entries(winners)) {
+  if (!entry || typeof entry !== 'object') continue;
+  totalMigrated += 1;
+
+  // Detect already-migrated rows. The new key shape has exactly TWO `::` in
+  // the canton+locale prefix; canton field present is the stronger signal.
+  const looksMigrated = entry.canton && /^[A-Z]{2,}::[a-z]{2}::/.test(oldKey);
+  if (looksMigrated) {
+    out[oldKey] = entry;
+    alreadyMigrated += 1;
+    continue;
+  }
+
+  // Parse legacy key `${locale}::${oldSlug}`.
+  const sep = oldKey.indexOf('::');
+  if (sep < 0) {
+    // Unparseable legacy row — keep verbatim, no canton stamp possible.
+    out[oldKey] = entry;
+    continue;
+  }
+  const locale = oldKey.slice(0, sep);
+  const oldSlug = oldKey.slice(sep + 2);
+
+  const winnerJob = jobByIdentifier.get(String(entry.winnerJobIdentifier || ''));
+  let canton = null;
+  if (winnerJob) canton = resolveCantonForJob(winnerJob);
+  if (canton) {
+    cantonResolved += 1;
+  } else {
+    canton = FALLBACK;
+    fallbackUsed += 1;
+  }
+
+  const newKey = `${canton}::${locale}::${oldSlug}`;
+  out[newKey] = { ...entry, canton };
+}
+
+// Sort keys for stable diffs (matches saveWinners() behaviour).
+const sorted = {};
+for (const k of Object.keys(out).sort()) sorted[k] = out[k];
+
+fs.writeFileSync(WINNERS_PATH, JSON.stringify(sorted, null, 2) + '\n');
+console.log(
+  `[migrate-prev-slug-winners] migrated ${totalMigrated} entries → canton-resolved ${cantonResolved}, fallback ${FALLBACK} ${fallbackUsed}, already-migrated ${alreadyMigrated}`,
+);

--- a/services/previousSlugWinners.ts
+++ b/services/previousSlugWinners.ts
@@ -73,6 +73,15 @@ export interface WinnerEntry {
   readonly lastSeenAt: string;
   readonly score: number;
   readonly candidatesCount: number;
+  /**
+   * Canton code (e.g. `'TI'`, `'ZH'`) that owns the bridge URL path for this
+   * (locale, oldSlug) pair. Phase 8b (2026-05-12): bridges now live under the
+   * job's canton-aware section (`/cerca-lavoro-zurigo/...` for ZH jobs), not
+   * the legacy hardcoded TI section. Forward-compat: older entries on disk
+   * may lack this field; readers MUST treat it as optional and default to
+   * `'TI'` for backward-compat.
+   */
+  readonly canton?: string;
 }
 
 /** A candidate for ownership of a previous-slug bridge. */
@@ -81,17 +90,31 @@ export interface CandidateInput {
   readonly canonicalSlug: string;
 }
 
-/** The full on-disk format. Keys are `${locale}::${oldSlug}` (see {@link makeKey}). */
+/** The full on-disk format. Keys are `${canton}::${locale}::${oldSlug}` (see {@link makeKey}). */
 export type WinnersFile = Record<string, WinnerEntry>;
 
 /**
- * Compose the storage key for a (locale, oldSlug) pair. Locale is included
- * because previousSlugs ARE locale-specific in `previousSlugsByLocale`, and
- * the same string can legitimately exist as a prevSlug for different jobs in
- * different locales. Using the same key for both would conflate them.
+ * Compose the storage key for a (canton, locale, oldSlug) triple.
+ *
+ * - Canton is the FIRST segment because the bridge URL path depends on the
+ *   winning job's canton — the same (locale, oldSlug) pair can legitimately
+ *   exist for different jobs under different cantons (e.g. an `infermieri-...`
+ *   bridge served at `/cerca-lavoro-ticino/` for a TI job and at
+ *   `/cerca-lavoro-zurigo/` for a ZH job that shared the historical slug).
+ *   Conflating them by dropping canton would resurrect the production bug
+ *   that Phase 8b fixes.
+ * - Locale is included because `previousSlugsByLocale` IS locale-specific.
+ *   The same string can legitimately exist as a prevSlug for different
+ *   jobs in different locales.
+ *
+ * Schema versioning (2026-05-12, Phase 8b): the old key shape was
+ * `${locale}::${oldSlug}` (no canton). The migration script at
+ * `scripts/migrate-previous-slug-winners-add-canton.mjs` rewrites
+ * `data/previous-slug-winners.json` once to the new shape, defaulting
+ * unmappable entries to canton `'TI'`.
  */
-export function makeKey(locale: string, oldSlug: string): string {
-  return `${locale}::${oldSlug}`;
+export function makeKey(canton: string, locale: string, oldSlug: string): string {
+  return `${canton}::${locale}::${oldSlug}`;
 }
 
 /**
@@ -238,6 +261,7 @@ export function saveWinners(filePath: string, winners: WinnersFile): void {
  */
 export function resolveWinner(
   winners: WinnersFile,
+  canton: string,
   locale: string,
   oldSlug: string,
   candidates: readonly CandidateInput[],
@@ -245,7 +269,7 @@ export function resolveWinner(
 ): WinnerEntry | null {
   if (candidates.length === 0) return null;
 
-  const key = makeKey(locale, oldSlug);
+  const key = makeKey(canton, locale, oldSlug);
   const existing = winners[key];
 
   // Branch 2: prior decision still valid — touch lastSeenAt and reuse.
@@ -253,8 +277,14 @@ export function resolveWinner(
     existing &&
     candidates.some((c) => c.jobIdentifier === existing.winnerJobIdentifier)
   ) {
-    if (existing.lastSeenAt !== now) {
-      winners[key] = { ...existing, lastSeenAt: now };
+    const needsTouch = existing.lastSeenAt !== now;
+    const needsCantonStamp = !existing.canton && canton;
+    if (needsTouch || needsCantonStamp) {
+      winners[key] = {
+        ...existing,
+        ...(needsTouch ? { lastSeenAt: now } : {}),
+        ...(needsCantonStamp ? { canton } : {}),
+      };
     }
     return winners[key];
   }
@@ -265,12 +295,13 @@ export function resolveWinner(
   if (existing || candidates.length > 1) {
     const fresh = chooseWinner(oldSlug, candidates, now);
     if (!fresh) return null;
-    winners[key] = fresh;
-    return fresh;
+    const stamped: WinnerEntry = canton ? { ...fresh, canton } : fresh;
+    winners[key] = stamped;
+    return stamped;
   }
 
   // Branch 5: no existing entry, single candidate — trivial, ephemeral.
-  return {
+  const trivial: WinnerEntry = {
     winnerJobIdentifier: candidates[0].jobIdentifier,
     winnerCanonical: candidates[0].canonicalSlug,
     decidedAt: now,
@@ -278,6 +309,7 @@ export function resolveWinner(
     score: jaccardSimilarity(oldSlug, candidates[0].canonicalSlug),
     candidatesCount: 1,
   };
+  return canton ? { ...trivial, canton } : trivial;
 }
 
 /**

--- a/tests/previous-slug-winners.test.ts
+++ b/tests/previous-slug-winners.test.ts
@@ -115,12 +115,12 @@ describe('previousSlugWinners', () => {
  describe('resolveWinner — registry behaviour', () => {
  it('returns null for empty candidates', () => {
  const winners: WinnersFile = {};
- expect(resolveWinner(winners, 'en', 'old', [], NOW)).toBeNull();
+ expect(resolveWinner(winners, 'TI', 'en', 'old', [], NOW)).toBeNull();
  });
 
  it('single candidate is a trivial winner — does NOT mutate the registry', () => {
  const winners: WinnersFile = {};
- const out = resolveWinner(winners, 'en', 'old', [
+ const out = resolveWinner(winners, 'TI', 'en', 'old', [
  { jobIdentifier: 'job-a', canonicalSlug: 'old' },
  ], NOW);
  expect(out!.winnerJobIdentifier).toBe('job-a');
@@ -129,11 +129,11 @@ describe('previousSlugWinners', () => {
 
  it('multi-candidate first-time decision writes a registry entry', () => {
  const winners: WinnersFile = {};
- resolveWinner(winners, 'en', 'foo', [
+ resolveWinner(winners, 'TI', 'en', 'foo', [
  { jobIdentifier: 'job-a', canonicalSlug: 'foo-bar' },
  { jobIdentifier: 'job-b', canonicalSlug: 'foo' },
  ], NOW);
- const key = makeKey('en', 'foo');
+ const key = makeKey('TI', 'en', 'foo');
  expect(winners[key]).toBeDefined();
  expect(winners[key].winnerJobIdentifier).toBe('job-b');
  expect(winners[key].candidatesCount).toBe(2);
@@ -141,7 +141,7 @@ describe('previousSlugWinners', () => {
 
  it('reuses prior decision when the winner is still in the candidates list and TOUCHES lastSeenAt', () => {
  const winners: WinnersFile = {
- [makeKey('en', 'shared')]: {
+ [makeKey('TI', 'en', 'shared')]: {
  winnerJobIdentifier: 'job-aaa',
  winnerCanonical: 'shared-old',
  decidedAt: '2026-01-01T00:00:00.000Z',
@@ -150,7 +150,7 @@ describe('previousSlugWinners', () => {
  candidatesCount: 2,
  },
  };
- const out = resolveWinner(winners, 'en', 'shared', [
+ const out = resolveWinner(winners, 'TI', 'en', 'shared', [
  { jobIdentifier: 'job-aaa', canonicalSlug: 'shared-old' },
  { jobIdentifier: 'job-bbb', canonicalSlug: 'completely-different-slug' },
  ], NOW);
@@ -159,22 +159,23 @@ describe('previousSlugWinners', () => {
  expect(out!.decidedAt).toBe('2026-01-01T00:00:00.000Z');
  // lastSeenAt is bumped to NOW so the prune routine sees this entry as alive.
  expect(out!.lastSeenAt).toBe(NOW);
- expect(winners[makeKey('en', 'shared')].lastSeenAt).toBe(NOW);
+ expect(winners[makeKey('TI', 'en', 'shared')].lastSeenAt).toBe(NOW);
  });
 
- it('reuse: skips touch if lastSeenAt is already === now (idempotent)', () => {
+ it('reuse: skips touch if lastSeenAt is already === now AND canton stamped (idempotent)', () => {
  const winners: WinnersFile = {
- [makeKey('en', 'shared')]: {
+ [makeKey('TI', 'en', 'shared')]: {
  winnerJobIdentifier: 'job-aaa',
  winnerCanonical: 'shared-old',
  decidedAt: '2026-01-01T00:00:00.000Z',
  lastSeenAt: NOW,
  score: 1,
  candidatesCount: 2,
+ canton: 'TI',
  },
  };
- const before = winners[makeKey('en', 'shared')];
- const out = resolveWinner(winners, 'en', 'shared', [
+ const before = winners[makeKey('TI', 'en', 'shared')];
+ const out = resolveWinner(winners, 'TI', 'en', 'shared', [
  { jobIdentifier: 'job-aaa', canonicalSlug: 'shared-old' },
  { jobIdentifier: 'job-bbb', canonicalSlug: 'completely-different-slug' },
  ], NOW);
@@ -186,7 +187,7 @@ describe('previousSlugWinners', () => {
  // is no longer in candidates, we adopt whoever IS in candidates so the
  // file always reflects the current canonical (not a stale reference).
  const winners: WinnersFile = {
- [makeKey('en', 'shared')]: {
+ [makeKey('TI', 'en', 'shared')]: {
  winnerJobIdentifier: 'job-removed',
  winnerCanonical: 'shared-old',
  decidedAt: '2026-01-01T00:00:00.000Z',
@@ -195,7 +196,7 @@ describe('previousSlugWinners', () => {
  candidatesCount: 2,
  },
  };
- const out = resolveWinner(winners, 'en', 'shared', [
+ const out = resolveWinner(winners, 'TI', 'en', 'shared', [
  { jobIdentifier: 'job-still-here', canonicalSlug: 'shared-similar' },
  ], NOW);
  expect(out!.winnerJobIdentifier).toBe('job-still-here');
@@ -203,12 +204,12 @@ describe('previousSlugWinners', () => {
  expect(out!.lastSeenAt).toBe(NOW);
  // Registry IS updated even though only one candidate remained — keeps
  // the file consistent with the live state.
- expect(winners[makeKey('en', 'shared')].winnerJobIdentifier).toBe('job-still-here');
+ expect(winners[makeKey('TI', 'en', 'shared')].winnerJobIdentifier).toBe('job-still-here');
  });
 
  it('re-elects when prior winner removed AND multiple new candidates exist', () => {
  const winners: WinnersFile = {
- [makeKey('en', 'shared')]: {
+ [makeKey('TI', 'en', 'shared')]: {
  winnerJobIdentifier: 'job-removed',
  winnerCanonical: 'gone-slug',
  decidedAt: '2026-01-01T00:00:00.000Z',
@@ -217,7 +218,7 @@ describe('previousSlugWinners', () => {
  candidatesCount: 3,
  },
  };
- const out = resolveWinner(winners, 'en', 'shared', [
+ const out = resolveWinner(winners, 'TI', 'en', 'shared', [
  { jobIdentifier: 'job-aaa', canonicalSlug: 'shared-similar' },
  { jobIdentifier: 'job-bbb', canonicalSlug: 'totally-other' },
  ], NOW);
@@ -225,7 +226,7 @@ describe('previousSlugWinners', () => {
  expect(out!.decidedAt).toBe(NOW);
  expect(out!.lastSeenAt).toBe(NOW);
  // Registry updated.
- expect(winners[makeKey('en', 'shared')].winnerJobIdentifier).toBe('job-aaa');
+ expect(winners[makeKey('TI', 'en', 'shared')].winnerJobIdentifier).toBe('job-aaa');
  });
  });
 
@@ -238,7 +239,7 @@ describe('previousSlugWinners', () => {
 
  it('keeps entries whose lastSeenAt is within the TTL window', () => {
  const winners: WinnersFile = {
- [makeKey('en', 'fresh')]: {
+ [makeKey('TI', 'en', 'fresh')]: {
  winnerJobIdentifier: 'job', winnerCanonical: 'x', decidedAt: oneDayBefore,
  lastSeenAt: oneDayBefore, score: 0.5, candidatesCount: 2,
  },
@@ -250,11 +251,11 @@ describe('previousSlugWinners', () => {
 
  it('removes entries whose lastSeenAt is older than TTL', () => {
  const winners: WinnersFile = {
- [makeKey('en', 'stale')]: {
+ [makeKey('TI', 'en', 'stale')]: {
  winnerJobIdentifier: 'job', winnerCanonical: 'x', decidedAt: fortyDaysBefore,
  lastSeenAt: fortyDaysBefore, score: 0.5, candidatesCount: 2,
  },
- [makeKey('en', 'older')]: {
+ [makeKey('TI', 'en', 'older')]: {
  winnerJobIdentifier: 'job', winnerCanonical: 'x', decidedAt: fiftyDaysBefore,
  lastSeenAt: fiftyDaysBefore, score: 0.5, candidatesCount: 2,
  },
@@ -266,24 +267,24 @@ describe('previousSlugWinners', () => {
 
  it('mixed entries: keeps fresh, removes stale', () => {
  const winners: WinnersFile = {
- [makeKey('en', 'fresh')]: {
+ [makeKey('TI', 'en', 'fresh')]: {
  winnerJobIdentifier: 'a', winnerCanonical: 'x', decidedAt: oneDayBefore,
  lastSeenAt: oneDayBefore, score: 0, candidatesCount: 1,
  },
- [makeKey('en', 'stale')]: {
+ [makeKey('TI', 'en', 'stale')]: {
  winnerJobIdentifier: 'b', winnerCanonical: 'y', decidedAt: fortyDaysBefore,
  lastSeenAt: fortyDaysBefore, score: 0, candidatesCount: 1,
  },
  };
  const pruned = pruneStaleWinners(winners, TTL_MS, NOW_PRUNE);
  expect(pruned).toBe(1);
- expect(Object.keys(winners)).toEqual([makeKey('en', 'fresh')]);
+ expect(Object.keys(winners)).toEqual([makeKey('TI', 'en', 'fresh')]);
  });
 
  it('backward compat: entry without lastSeenAt falls back to decidedAt', () => {
  // Simulate an entry written before lastSeenAt was added — only decidedAt.
  const winners: WinnersFile = {
- [makeKey('en', 'old')]: {
+ [makeKey('TI', 'en', 'old')]: {
  winnerJobIdentifier: 'job', winnerCanonical: 'x', decidedAt: oneDayBefore,
  lastSeenAt: '', // empty — must fall back
  score: 0, candidatesCount: 1,
@@ -301,7 +302,7 @@ describe('previousSlugWinners', () => {
 
  it('returns 0 when `now` is unparseable (defensive — never purge on bad input)', () => {
  const winners: WinnersFile = {
- [makeKey('en', 'fresh')]: {
+ [makeKey('TI', 'en', 'fresh')]: {
  winnerJobIdentifier: 'job', winnerCanonical: 'x', decidedAt: oneDayBefore,
  lastSeenAt: oneDayBefore, score: 0, candidatesCount: 1,
  },
@@ -333,7 +334,7 @@ describe('previousSlugWinners', () => {
  it('saveWinners + loadWinners is a roundtrip', () => {
  const file = path.join(tmp, 'round.json');
  const data: WinnersFile = {
- [makeKey('en', 'foo')]: {
+ [makeKey('TI', 'en', 'foo')]: {
  winnerJobIdentifier: 'job-a',
  winnerCanonical: 'foo-bar',
  decidedAt: NOW,
@@ -349,16 +350,16 @@ describe('previousSlugWinners', () => {
  it('saveWinners sorts keys for stable diffs', () => {
  const file = path.join(tmp, 'sorted.json');
  saveWinners(file, {
- [makeKey('en', 'zzz')]: {
+ [makeKey('TI', 'en', 'zzz')]: {
  winnerJobIdentifier: 'job', winnerCanonical: 'zzz', decidedAt: NOW, lastSeenAt: NOW, score: 0, candidatesCount: 1,
  },
- [makeKey('en', 'aaa')]: {
+ [makeKey('TI', 'en', 'aaa')]: {
  winnerJobIdentifier: 'job', winnerCanonical: 'aaa', decidedAt: NOW, lastSeenAt: NOW, score: 0, candidatesCount: 1,
  },
  });
  const raw = fs.readFileSync(file, 'utf-8');
- const aaaPos = raw.indexOf('en::aaa');
- const zzzPos = raw.indexOf('en::zzz');
+ const aaaPos = raw.indexOf('TI::en::aaa');
+ const zzzPos = raw.indexOf('TI::en::zzz');
  expect(aaaPos).toBeGreaterThan(0);
  expect(zzzPos).toBeGreaterThan(aaaPos);
  });

--- a/tests/seo/cathedral-previous-slug-canton.test.ts
+++ b/tests/seo/cathedral-previous-slug-canton.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { makeKey } from '@/services/previousSlugWinners';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const DIST = path.join(REPO_ROOT, 'dist');
+
+describe('cathedral Phase 8b — previousSlugs bridges canton-aware', () => {
+  // ── Structural guard: makeKey() is canton-aware ───────────────────────
+  it('makeKey(canton, locale, oldSlug) returns the canton-prefixed key', () => {
+    expect(makeKey('ZH', 'de', 'old-slug')).toBe('ZH::de::old-slug');
+  });
+
+  it('makeKey() puts TI in the key for legacy entries', () => {
+    expect(makeKey('TI', 'it', 'old-slug')).toBe('TI::it::old-slug');
+  });
+
+  // ── Source-level guard: bridge emit + sitemap addEntry use the
+  //    canton-aware section helper instead of the TI-hardcoded sectionByLocale. ──
+  it('jobsSeoPagesPlugin.ts bridge emit derives section from buildCantonAwareSection', () => {
+    const src = fs.readFileSync(
+      path.join(REPO_ROOT, 'build-plugins', 'jobsSeoPagesPlugin.ts'),
+      'utf8',
+    );
+    const lines = src.split('\n');
+    // Look at the previousSlugs bridge emit region (~9650-9720). The
+    // bridge section variable must derive from buildCantonAwareSection,
+    // and the `oldPath = ...` builder must NOT reference sectionByLocale[locale].
+    const bridgeRegion = lines.slice(9560, 9720).join('\n');
+    expect(bridgeRegion).toMatch(/bridgeSection\s*=\s*buildCantonAwareSection\(locale,\s*jobCantonForBridge\)/);
+    const bridgeOldPathLines = bridgeRegion
+      .split('\n')
+      .filter((l) => /\boldPath\s*=/.test(l) && !/^\s*\/\//.test(l));
+    expect(bridgeOldPathLines.length, 'expected at least one oldPath assignment in bridge emit').toBeGreaterThan(0);
+    for (const l of bridgeOldPathLines) {
+      expect(l, `bridge oldPath still uses sectionByLocale: ${l}`).not.toMatch(
+        /sectionByLocale\[locale\]/,
+      );
+    }
+  });
+
+  it('jobsSeoPagesPlugin.ts sitemap addEntry for previousSlugs uses canton-aware section', () => {
+    const src = fs.readFileSync(
+      path.join(REPO_ROOT, 'build-plugins', 'jobsSeoPagesPlugin.ts'),
+      'utf8',
+    );
+    const lines = src.split('\n');
+    // Look at the sitemap previousSlugs addEntry region (~7385). The psRelPath
+    // builder must use buildCantonAwareSection, not sectionByLocale[locale].
+    const sitemapRegion = lines.slice(7355, 7410).join('\n');
+    expect(sitemapRegion).toMatch(/psRelPath\s*=\s*`\$\{localePrefix\[locale\]\}\/\$\{buildCantonAwareSection\(/);
+  });
+
+  // ── Behavioural: when dist/ is present, every bridge file's directory
+  //    should match its canonical's canton. Non-TI canton bridges must NOT
+  //    live under cerca-lavoro-ticino/. We sample a handful for speed. ──
+  it('non-TI canton bridges live under the canton path, not /cerca-lavoro-ticino/', () => {
+    if (!fs.existsSync(DIST)) return; // offline-skip
+    const jobsPath = path.join(REPO_ROOT, 'data', 'jobs.json');
+    if (!fs.existsSync(jobsPath)) return;
+    const jobs = JSON.parse(fs.readFileSync(jobsPath, 'utf8')) as Array<{
+      canton?: string;
+      location?: string;
+      slug?: string;
+      slugByLocale?: Record<string, string>;
+      previousSlugs?: string[];
+      previousSlugsByLocale?: Record<string, string[]>;
+    }>;
+    // Find a few non-TI jobs that have previousSlugs.
+    const samples = jobs
+      .filter((j) => j.canton && j.canton !== 'TI')
+      .filter((j) => {
+        const flat = Array.isArray(j.previousSlugs) ? j.previousSlugs.length : 0;
+        const byLoc = j.previousSlugsByLocale
+          ? Object.values(j.previousSlugsByLocale).flat().length
+          : 0;
+        return flat + byLoc > 0;
+      })
+      .slice(0, 3);
+    if (samples.length === 0) return; // no signal in dataset, skip
+
+    const mismatches: string[] = [];
+    for (const job of samples) {
+      const prev = [
+        ...(Array.isArray(job.previousSlugs) ? job.previousSlugs : []),
+        ...Object.values(job.previousSlugsByLocale || {}).flat(),
+      ];
+      for (const oldSlug of prev) {
+        const tiBridge = path.join(DIST, 'cerca-lavoro-ticino', oldSlug, 'index.html');
+        if (fs.existsSync(tiBridge)) {
+          // Verify it's actually the bridge for THIS non-TI job. The bridge file
+          // has the job's canonical slug in __BRIDGE_TARGET_SLUG__.
+          const html = fs.readFileSync(tiBridge, 'utf8');
+          const canonicalSlug = job.slugByLocale?.it || job.slug;
+          if (canonicalSlug && html.includes(canonicalSlug)) {
+            mismatches.push(
+              `non-TI job ${canonicalSlug} (canton=${job.canton}) bridge at TI path: cerca-lavoro-ticino/${oldSlug}/`,
+            );
+          }
+        }
+      }
+    }
+    expect(mismatches, mismatches.join('\n')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- `services/previousSlugWinners.ts`: storage key is now `\${canton}::\${locale}::\${oldSlug}` (was `\${locale}::\${oldSlug}`). `resolveWinner()` takes a `canton` parameter.
- Phase 8b makes bridges live under the winning job's canton path (e.g. `/cerca-lavoro-zurigo/...` for a ZH job). The registry key MUST include canton — two jobs in different cantons can legitimately share the same `(locale, oldSlug)` pair and emit at different bridge URLs.
- `scripts/migrate-previous-slug-winners-add-canton.mjs`: one-shot idempotent migration; resolves canton via `data/jobs.json` → `data/canton-municipalities.json` → fallback `'TI'`.
- `data/previous-slug-winners.json`: migrated in-place to the new shape.
- New `tests/seo/cathedral-previous-slug-canton.test.ts` locks the canton-aware key shape + asserts the bridge section in `jobsSeoPagesPlugin.ts` derives from `buildCantonAwareSection` (not the TI-hardcoded `sectionByLocale`).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run previous-slug-winners.test.ts cathedral-previous-slug-canton.test.ts\` — 33/33 verdi
- [ ] Full vitest + vite build delegated to CI (avoids local OOM with parallel worktrees)