### PR TITLE
fix(cathedral): Phase 8g — canton-hub editorial helper

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -79,7 +79,8 @@ import {
  jobMatchesSector,
  type SectorHubKey,
 } from './jobSectorLanding';
-import { SEO_HUB_RESERVED_SLUGS } from './seoHubsData';
+import { SEO_HUB_RESERVED_SLUGS, JOBS_PAGE_SIZE as HUB_JOBS_PAGE_SIZE, hubSlugFor } from './seoHubsData';
+import { buildCantonHubEditorial } from './shared/cantonHubEditorial';
 // F3a — Job Page CTR Optimization: shared 50-60 char title templates and
 // 140-160 char meta-description templates that drive SERP CTR on the
 // top-20 job listing pages. See services/seo/job-board-titles.ts and
@@ -7959,6 +7960,41 @@ ${alternates}
          `</ul>` +
          `</section>`;
      }
+     // Phase 8(g) cathedral parity — bring every /cerca-lavoro-{canton}/
+     // landing up to the TI hub's editorial richness: H2 definition block
+     // for AI extraction, deep-link archive navigator (one anchor per
+     // page-N), 4 frontaliere-context prose paragraphs, sources line, and
+     // a collapsible FAQ. Placed BELOW the data area per CLAUDE.md
+     // non-negotiables #16/#17 (mobile-first, filler below content). The
+     // helper is the same one used by staticPagesPlugin for TI byte
+     // identity. The archive navigator base path is derived per-canton
+     // via `hubSlugFor(entry.key, entry.locale, 'tutti')` so cathedral
+     // cantons paginate from their own `/cerca-lavoro-{canton}/tutti/`
+     // root instead of the TI default.
+     const archiveBaseHref = entry.key === AGGREGATE_KEY
+       ? hubSlugFor(AGGREGATE_KEY, entry.locale, 'tutti')
+       : hubSlugFor(entry.key, entry.locale, 'tutti');
+     const cantonTotalPages = Math.max(1, Math.ceil(totalJobs / HUB_JOBS_PAGE_SIZE));
+     const editorialEntries = buildCantonHubEditorial({
+       canton: entry.key,
+       locale: entry.locale,
+       display,
+       jobsCount: totalJobs,
+       totalPages: cantonTotalPages,
+       archiveBaseHref,
+     });
+     // Mirror the staticPagesPlugin auto-`<p>`-wrap regex so plain-text
+     // prose paragraphs (entries 3-6 in the non-TI helper output) become
+     // proper paragraphs instead of leaking into a flat string. Block-level
+     // entries (h2/p/details/...) pass through untouched.
+     const editorialHtml = editorialEntries
+       .map((b) => /^<(h[1-6]|p|nav|div|details|section|ul|ol|table|figure|aside|blockquote)\b/.test(b)
+         ? b
+         : `<p style="margin:.5rem 0;line-height:1.65;color:var(--color-body)">${b}</p>`)
+       .join('');
+     const cantonEditorialSection =
+       `<section data-canton-editorial style="max-width:860px;margin:32px 0 0;color:var(--color-body);font-size:15px">${editorialHtml}</section>`;
+
      const bodyHtml = [
        `<main class="seo-static-content" style="max-width:1080px;margin:0 auto;padding:24px 16px">`,
        `<nav style="margin:0 0 16px;font-size:14px"><a href="${BASE_URL}/" style="color:var(--color-link);text-decoration:none;font-weight:600">${esc(homeLabel[entry.locale])}</a> &rarr; <span aria-current="page">${esc(display)}</span></nav>`,
@@ -7973,6 +8009,9 @@ ${alternates}
        // uplift brings text/HTML from 1.7-2.2 % to ~12 % so
        // audit:text-html-ratio accepts these pages.
        buildCantonContextProse(entry.locale, display),
+       // Phase 8(g) — TI-parity editorial package (H2, archive navigator,
+       // prose, sources, FAQ). Below the data area per #16/#17.
+       cantonEditorialSection,
        `</main>`,
      ].join('\n');
      const html = buildSeoPageHtml({

--- a/build-plugins/shared/cantonHubEditorial.ts
+++ b/build-plugins/shared/cantonHubEditorial.ts
@@ -1,0 +1,168 @@
+/**
+ * Shared editorial blocks for cathedral canton landing pages.
+ *
+ * The Ticino hub (`/cerca-lavoro-ticino/`) has shipped since launch with a
+ * rich editorial body: H2 definition block for AI extraction, deep-link
+ * archive navigator, frontaliere context prose, and a collapsible FAQ.
+ *
+ * Phase 8(g) of the cathedral-canton-aware rewrite brings the same
+ * editorial richness to every cathedral canton landing — `/cerca-lavoro-zurigo/`,
+ * `/cerca-lavoro-svizzera/`, etc. Until this helper landed, those pages
+ * shipped only with tiles + CTA + listing grid + `buildCantonContextProse`,
+ * a thin set that struggled to clear the text/HTML 10 % ratio gate and
+ * gave neither AI extractors nor crawlers the same definition surface as
+ * the TI hub.
+ *
+ * **TI byte-identity contract.** When called with `{canton: 'TI', display:
+ * 'Ticino', locale: 'it', ...}`, this helper emits the exact same set of
+ * strings that `staticPagesPlugin.ts` previously inlined for its TI
+ * `isJobsIndex` branch — same characters, same order, same array length.
+ * The `cathedral-canton-hub-parity.test.ts` snapshot test enforces this
+ * invariance. The TI canton navigator (`<details>` listing every other
+ * canton) is intentionally NOT part of this helper because it is unique
+ * to the TI hub; it stays inline in `staticPagesPlugin.ts`.
+ *
+ * **Per-canton commuter prose** (Como → Brogeda etc.) is NOT emitted by
+ * this helper. The legacy TI prose mentions Lugano, Bellinzona, Locarno,
+ * Mendrisio and the Como/Varese border crossings — content that makes
+ * no sense on `/cerca-lavoro-zurigo/`. For non-TI cantons the helper
+ * emits a canton-agnostic parametric variant that name-drops `display`
+ * instead of TI-specific cities; per-canton commuter copy is a Phase 9
+ * follow-up.
+ */
+
+import { paginatedPath } from '../seoHubsData';
+import type { HubLocale as ArchiveHubLocale } from '../seoHubsData';
+
+export interface CantonHubEditorialOpts {
+  /** Canton code, e.g. 'TI', 'ZH', 'GE', or AGGREGATE_KEY for the federal hub. */
+  canton: string;
+  /** Locale of the page being emitted. */
+  locale: ArchiveHubLocale;
+  /** Display label, e.g. 'Ticino', 'Zurigo', 'Svizzera'. */
+  display: string;
+  /** Total jobs counted for this canton (used in intro copy). */
+  jobsCount: number;
+  /** Total number of paginated archive pages (`Math.ceil(jobsCount / JOBS_PAGE_SIZE)`). */
+  totalPages: number;
+  /** Base path for the paginated archive, e.g. '/cerca-lavoro-zurigo/tutti/'. */
+  archiveBaseHref: string;
+}
+
+// Local escape helper. Matches the staticPagesPlugin / jobsSeoPages
+// implementations so a shared move stays byte-identical.
+const esc = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+/**
+ * Build the canton-hub editorial blocks. Returns an array of HTML strings
+ * suitable for `editorialBlocks.push(...buildCantonHubEditorial(...))`
+ * (staticPagesPlugin), or for joining into a single string before
+ * concatenation into the canton-landing `bodyHtml` (jobsSeoPagesPlugin).
+ *
+ * Each returned entry already begins with a block-level HTML element so
+ * the staticPagesPlugin auto-`<p>`-wrap regex (`/^<(h[1-6]|p|nav|div|details|section|ul|ol|table|figure|aside|blockquote)\b/`)
+ * leaves them untouched.
+ */
+export function buildCantonHubEditorial(opts: CantonHubEditorialOpts): string[] {
+  const { canton, locale, display, jobsCount, totalPages, archiveBaseHref } = opts;
+  const isTi = canton === 'TI';
+  const out: string[] = [];
+
+  // ── 1. H2 + intro paragraph (definition block for AI extraction) ────────
+  if (isTi) {
+    // Byte-identical TI strings (Italian). Other locales served the same
+    // Italian filler historically — preserved for byte-identity even though
+    // it is not idiomatic for EN/DE/FR pages.
+    out.push(
+      `<h2 style="font-size:1.05rem;font-weight:700;margin:1rem 0 .5rem">Offerte di Lavoro in Ticino — Bacheca Lavoro per Frontalieri</h2>`,
+      `<p style="margin:.5rem 0;font-weight:500;font-size:1rem;line-height:1.7">Cerchi <strong>lavoro in Ticino</strong>? Questa bacheca raccoglie oltre 1.500 <strong>offerte di lavoro</strong> attive da più di 100 aziende del Canton Ticino, aggiornate ogni 12 ore. Le posizioni coprono tutti i principali settori — banca, pharma, IT, edilizia, sanità, logistica — e sono disponibili in italiano, inglese, tedesco e francese. Ogni annuncio è collegato direttamente al sito ufficiale dell’azienda per la candidatura.</p>`,
+    );
+  } else {
+    // Canton-agnostic intro. Uses `display` so it reads naturally for
+    // ZH/GE/VD/etc. and avoids any TI-specific city or border-crossing
+    // reference (those are Phase 9 follow-up).
+    out.push(
+      `<h2 style="font-size:1.05rem;font-weight:700;margin:1rem 0 .5rem">${esc(`Offerte di Lavoro ${display === 'Svizzera' ? 'in Svizzera' : `nel Canton ${display}`} — Bacheca Lavoro per Frontalieri`)}</h2>`,
+      `<p style="margin:.5rem 0;font-weight:500;font-size:1rem;line-height:1.7">${esc(`Cerchi lavoro ${display === 'Svizzera' ? 'in Svizzera' : `nel Canton ${display}`}?`)} Questa bacheca raccoglie <strong>${jobsCount.toLocaleString('de-CH')}</strong> <strong>offerte di lavoro</strong> ${display === 'Svizzera' ? 'attive in tutta la Svizzera' : `attive nel Canton ${esc(display)}`}, aggiornate ogni 12 ore. Le posizioni coprono tutti i principali settori — banca, pharma, IT, edilizia, sanità, logistica — e sono disponibili in italiano, inglese, tedesco e francese. Ogni annuncio è collegato direttamente al sito ufficiale dell’azienda per la candidatura.</p>`,
+    );
+  }
+
+  // ── 2. Deep-link archive navigator ────────────────────────────────────
+  // Same locale-aware labels as the TI hub. With ~30k slugs paginated at
+  // 100/page, totalPages can be in the hundreds — wrapped in <details>
+  // collapsible so the visible UX is a single "Sfoglia tutto l'archivio
+  // offerte per pagina (N pagine)" toggle.
+  if (totalPages > 1) {
+    const jobsNavLabel = locale === 'it' ? 'Sfoglia tutto l\'archivio offerte per pagina'
+      : locale === 'en' ? 'Browse the full job archive by page'
+      : locale === 'de' ? 'Vollständiges Stellenarchiv nach Seite durchsuchen'
+      : 'Parcourir toutes les offres par page';
+    const jobsPageWord = locale === 'it' ? 'Pagina' : locale === 'en' ? 'Page' : locale === 'de' ? 'Seite' : 'Page';
+    const jobsAnchors: string[] = [];
+    for (let p = 1; p <= totalPages; p++) {
+      const href = paginatedPath(archiveBaseHref, p);
+      jobsAnchors.push(`<a href="${href}" style="display:inline-block;padding:3px 8px;margin:1px;border-radius:4px;background:#f1f5f9;color:#1e293b;text-decoration:none;font-size:12px;border:1px solid #e2e8f0">${jobsPageWord}&nbsp;${p}</a>`);
+    }
+    out.push(
+      `<details style="margin:.75rem 0;border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem"><summary style="cursor:pointer;font-weight:600;font-size:.95rem;color:#1e293b;padding:.25rem 0">${esc(jobsNavLabel)} (${totalPages} pagine)</summary><nav aria-label="${esc(jobsNavLabel)}" style="margin-top:.5rem;line-height:1.8">${jobsAnchors.join('')}</nav></details>`,
+    );
+  }
+
+  // ── 3. Frontaliere context prose (4 paragraphs) + sources line ────────
+  // TODO: per-canton commuter prose (Phase 9). The TI variant references
+  // Lugano/Bellinzona/Locarno/Mendrisio and the Como/Varese crossings;
+  // non-TI cantons get a canton-agnostic variant that name-drops `display`
+  // and otherwise sticks to generic G-permit + filter-tool messaging.
+  if (isTi) {
+    out.push(
+      `La sezione <strong>offerte lavoro Ticino</strong> raccoglie annunci pubblicati su fonti aziendali ufficiali, con normalizzazione dei dati principali per facilitare il confronto tra ruolo, sede, contratto e coerenza con il proprio profilo professionale. Gli annunci provengono da oltre 100 aziende ticinesi monitorate quotidianamente da crawler dedicati.`,
+      `Per ogni posizione vengono mantenuti metadati utili alla valutazione: data di pubblicazione, azienda, località, requisiti richiesti e collegamento diretto alla candidatura sul sito originale del datore di lavoro. Le offerte sono filtrate per il Canton Ticino e vengono aggiornate ogni 12 ore.`,
+      `I frontalieri con permesso G hanno diritto a candidarsi a posizioni in tutta la Svizzera; la guida inclusa nella sezione lavoro spiega la procedura per richiedere un permesso di lavoro, i settori con maggiore domanda e i salari mediani per categoria professionale nel mercato del lavoro ticinese.`,
+      `Il motore di ricerca integrato permette di filtrare per settore, tipo di contratto (tempo indeterminato, determinato, part-time), località e data di pubblicazione. La funzione di allerta e-mail notifica automaticamente le nuove offerte che corrispondono ai criteri salvati, così non si perde nessuna opportunità.`,
+      `<p style="color:#64748b;font-size:0.8rem;margin-top:4px;">Fonte: <a href="https://www.seco.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">SECO - Segretariato di Stato dell'economia</a></p>`,
+    );
+  } else {
+    const cantonOrCh = display === 'Svizzera' ? 'in Svizzera' : `nel Canton ${display}`;
+    const cantonOrSwiss = display === 'Svizzera' ? 'svizzera' : `del Canton ${display}`;
+    out.push(
+      `La sezione <strong>offerte lavoro ${esc(cantonOrSwiss)}</strong> raccoglie annunci pubblicati su fonti aziendali ufficiali, con normalizzazione dei dati principali per facilitare il confronto tra ruolo, sede, contratto e coerenza con il proprio profilo professionale. Gli annunci provengono da aziende ${esc(cantonOrSwiss)} monitorate quotidianamente da crawler dedicati.`,
+      `Per ogni posizione vengono mantenuti metadati utili alla valutazione: data di pubblicazione, azienda, località, requisiti richiesti e collegamento diretto alla candidatura sul sito originale del datore di lavoro. Le offerte sono filtrate ${esc(cantonOrCh)} e vengono aggiornate ogni 12 ore.`,
+      `I frontalieri con permesso G hanno diritto a candidarsi a posizioni in tutta la Svizzera; la guida inclusa nella sezione lavoro spiega la procedura per richiedere un permesso di lavoro, i settori con maggiore domanda e i salari mediani per categoria professionale nel mercato del lavoro ${esc(cantonOrSwiss)}.`,
+      `Il motore di ricerca integrato permette di filtrare per settore, tipo di contratto (tempo indeterminato, determinato, part-time), località e data di pubblicazione. La funzione di allerta e-mail notifica automaticamente le nuove offerte che corrispondono ai criteri salvati, così non si perde nessuna opportunità.`,
+      `<p style="color:#64748b;font-size:0.8rem;margin-top:4px;">Fonte: <a href="https://www.seco.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">SECO - Segretariato di Stato dell'economia</a></p>`,
+    );
+  }
+
+  // ── 4. FAQ block (collapsible, AI-extractable) ────────────────────────
+  if (isTi) {
+    out.push(
+      `<details style="margin:.75rem 0;border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem"><summary style="cursor:pointer;font-weight:700;font-size:1rem;color:#1e293b;padding:.25rem 0">Domande frequenti sulla ricerca lavoro in Ticino</summary><div style="margin-top:.5rem">` +
+      `<p style="margin:.5rem 0"><strong>Quante offerte di lavoro sono disponibili?</strong> La sezione lavoro Ticino raccoglie oltre 1.500 offerte attive da più di 100 aziende ticinesi, aggiornate ogni 12 ore tramite crawler automatici che monitorano i siti ufficiali delle aziende.</p>` +
+      `<p style="margin:.5rem 0"><strong>Come posso cercare lavoro in Ticino come frontaliere?</strong> Usa il motore di ricerca integrato per filtrare le posizioni per settore (banca, pharma, IT, edilizia, sanità), tipo di contratto (tempo indeterminato, determinato, part-time), località (Lugano, Bellinzona, Locarno, Mendrisio) e data di pubblicazione. Ogni annuncio include il collegamento diretto alla candidatura sul sito aziendale.</p>` +
+      `<p style="margin:.5rem 0"><strong>Serve il permesso G per candidarsi?</strong> I frontalieri con permesso G (Grenzgängerbewilligung) possono candidarsi a qualsiasi posizione in Svizzera. Il permesso viene richiesto dal datore di lavoro dopo l'assunzione. Per i dettagli, consulta la <a href="/guida-frontaliere/permessi-di-lavoro/" style="color:#2563eb;text-decoration:none;">guida permessi di lavoro</a>.</p>` +
+      `<p style="margin:.5rem 0"><strong>Quali sono i settori con più domanda in Ticino?</strong> I settori con maggiore domanda per frontalieri nel 2026 sono: servizi finanziari e bancari, farmaceutico e chimico, IT e software, edilizia e impiantistica, sanità e assistenza, ristorazione e turismo, logistica e trasporti.</p>` +
+      `<p style="margin:.5rem 0"><strong>Qual è lo stipendio medio per un frontaliere in Ticino?</strong> Lo stipendio mediano lordo in Canton Ticino è di circa CHF 62.000-68.000 annui, variabile per settore: IT/Software CHF 95.000, Banca/Finanza CHF 110.000, Pharma CHF 105.000, Commercio CHF 55.000. Usa il <a href="/calcola-stipendio/" style="color:#2563eb;text-decoration:none;">simulatore fiscale</a> per calcolare il netto.</p>` +
+      `<p style="margin:.5rem 0"><strong>Come attivare le notifiche per nuove offerte?</strong> Imposta i tuoi criteri di ricerca (settore, località, parole chiave) e attiva le allerte e-mail: riceverai una notifica automatica quando vengono pubblicate nuove posizioni corrispondenti.</p>` +
+      `<p style="color:#64748b;font-size:0.8rem;margin-top:.5rem;">Fonte: <a href="https://www.bfs.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">UST/BFS</a> · <a href="https://www.seco.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">SECO</a> · Dati Frontaliere Ticino</p>` +
+      `</div></details>`,
+    );
+  } else {
+    const cantonOrCh = display === 'Svizzera' ? 'in Svizzera' : `nel Canton ${display}`;
+    const summary = `Domande frequenti sulla ricerca lavoro ${cantonOrCh}`;
+    out.push(
+      `<details style="margin:.75rem 0;border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem"><summary style="cursor:pointer;font-weight:700;font-size:1rem;color:#1e293b;padding:.25rem 0">${esc(summary)}</summary><div style="margin-top:.5rem">` +
+      `<p style="margin:.5rem 0"><strong>${esc(`Quante offerte di lavoro sono disponibili ${cantonOrCh}?`)}</strong> ${esc(`La sezione lavoro ${cantonOrCh} raccoglie ${jobsCount.toLocaleString('de-CH')} offerte attive, aggiornate ogni 12 ore tramite crawler automatici che monitorano i siti ufficiali delle aziende.`)}</p>` +
+      `<p style="margin:.5rem 0"><strong>${esc(`Come posso cercare lavoro ${cantonOrCh} come frontaliere?`)}</strong> Usa il motore di ricerca integrato per filtrare le posizioni per settore (banca, pharma, IT, edilizia, sanità), tipo di contratto (tempo indeterminato, determinato, part-time), località e data di pubblicazione. Ogni annuncio include il collegamento diretto alla candidatura sul sito aziendale.</p>` +
+      `<p style="margin:.5rem 0"><strong>Serve il permesso G per candidarsi?</strong> I frontalieri con permesso G (Grenzgängerbewilligung) possono candidarsi a qualsiasi posizione in Svizzera. Il permesso viene richiesto dal datore di lavoro dopo l'assunzione. Per i dettagli, consulta la <a href="/guida-frontaliere/permessi-di-lavoro/" style="color:#2563eb;text-decoration:none;">guida permessi di lavoro</a>.</p>` +
+      `<p style="margin:.5rem 0"><strong>${esc(`Quali sono i settori con più domanda ${cantonOrCh}?`)}</strong> I settori con maggiore domanda per frontalieri nel 2026 sono: servizi finanziari e bancari, farmaceutico e chimico, IT e software, edilizia e impiantistica, sanità e assistenza, ristorazione e turismo, logistica e trasporti.</p>` +
+      `<p style="margin:.5rem 0"><strong>${esc(`Qual è lo stipendio medio per un frontaliere ${cantonOrCh}?`)}</strong> Lo stipendio mediano lordo svizzero è di circa CHF 78.000-85.000 annui, variabile per settore e cantone: IT/Software CHF 95.000+, Banca/Finanza CHF 110.000+, Pharma CHF 105.000+, Commercio CHF 55.000. Usa il <a href="/calcola-stipendio/" style="color:#2563eb;text-decoration:none;">simulatore fiscale</a> per calcolare il netto.</p>` +
+      `<p style="margin:.5rem 0"><strong>Come attivare le notifiche per nuove offerte?</strong> Imposta i tuoi criteri di ricerca (settore, località, parole chiave) e attiva le allerte e-mail: riceverai una notifica automatica quando vengono pubblicate nuove posizioni corrispondenti.</p>` +
+      `<p style="color:#64748b;font-size:0.8rem;margin-top:.5rem;">Fonte: <a href="https://www.bfs.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">UST/BFS</a> · <a href="https://www.seco.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">SECO</a> · Dati Frontaliere Ticino</p>` +
+      `</div></details>`,
+    );
+  }
+
+  return out;
+}

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -25,6 +25,7 @@ import {
 } from './jobBoardSeo';
 import { emitSeoHubs } from './seoHubsPlugin';
 import { ARTICLES_PAGE_SIZE, JOBS_PAGE_SIZE, HUB_SLUGS, paginatedPath, type HubLocale as ArchiveHubLocale } from './seoHubsData';
+import { buildCantonHubEditorial } from './shared/cantonHubEditorial';
 import { ALL_CANTON_CODES, AGGREGATE_KEY, resolveCantonSection, type CantonLocale } from './shared/cantonSection';
 import cantonSlugFile from '../data/canton-url-slugs.json';
 import { getJobTodayLandingSlug } from './jobEditorialLanding';
@@ -2657,35 +2658,29 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  `La piattaforma è pensata per essere consultata anche da mobile durante i tempi di viaggio: ogni blocco ha un obiettivo preciso, con contenuti sintetici in ingresso e approfondimenti completi nelle pagine dedicate.`,
  );
  } else if (isJobsIndex) {
- // Definition block for AI extraction — self-contained answer to "offerte di lavoro ticino"
- editorialBlocks.push(
- `<h2 style="font-size:1.05rem;font-weight:700;margin:1rem 0 .5rem">Offerte di Lavoro in Ticino \u2014 Bacheca Lavoro per Frontalieri</h2>`,
- `<p style="margin:.5rem 0;font-weight:500;font-size:1rem;line-height:1.7">Cerchi <strong>lavoro in Ticino</strong>? Questa bacheca raccoglie oltre 1.500 <strong>offerte di lavoro</strong> attive da pi\u00f9 di 100 aziende del Canton Ticino, aggiornate ogni 12 ore. Le posizioni coprono tutti i principali settori \u2014 banca, pharma, IT, edilizia, sanit\u00e0, logistica \u2014 e sono disponibili in italiano, inglese, tedesco e francese. Ogni annuncio \u00e8 collegato direttamente al sito ufficiale dell\u2019azienda per la candidatura.</p>`,
- );
- // Deep-link archive navigator \u2014 same methodology as the blog fix
- // (commit f53d7fea5c). With ~30k job slugs paginated at 100/page,
- // totalPages is ~304 \u2014 too many for a flat visible list, so the anchors
- // are wrapped in a <details> collapsible. Visually a single "Sfoglia
- // tutto l'archivio per pagina" toggle; semantically every /tutti/page-K/
- // archive sits at depth 2 from `/`, putting every company/job listed
- // there at depth 3. Closes the bulk of sitemap-jobs.xml (1030 offenders)
- // and sitemap-seo-hubs.xml (302 offenders) in the May-2026 baseline.
- if (jobsTotalPages > 1) {
- const jobsArchiveBase = HUB_SLUGS[locale as ArchiveHubLocale]?.jobsAll ?? '/cerca-lavoro-ticino/tutti/';
- const jobsNavLabel = locale === 'it' ? 'Sfoglia tutto l\'archivio offerte per pagina'
-   : locale === 'en' ? 'Browse the full job archive by page'
-   : locale === 'de' ? 'Vollst\u00e4ndiges Stellenarchiv nach Seite durchsuchen'
-   : 'Parcourir toutes les offres par page';
- const jobsPageWord = locale === 'it' ? 'Pagina' : locale === 'en' ? 'Page' : locale === 'de' ? 'Seite' : 'Page';
- const jobsAnchors: string[] = [];
- for (let p = 1; p <= jobsTotalPages; p++) {
- const href = paginatedPath(jobsArchiveBase, p);
- jobsAnchors.push(`<a href="${href}" style="display:inline-block;padding:3px 8px;margin:1px;border-radius:4px;background:#f1f5f9;color:#1e293b;text-decoration:none;font-size:12px;border:1px solid #e2e8f0">${jobsPageWord}&nbsp;${p}</a>`);
- }
- editorialBlocks.push(
- `<details style="margin:.75rem 0;border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem"><summary style="cursor:pointer;font-weight:600;font-size:.95rem;color:#1e293b;padding:.25rem 0">${esc(jobsNavLabel)} (${jobsTotalPages} pagine)</summary><nav aria-label="${esc(jobsNavLabel)}" style="margin-top:.5rem;line-height:1.8">${jobsAnchors.join('')}</nav></details>`,
- );
- }
+ // Phase 8(g) cathedral parity — H2 + intro + archive navigator are now
+ // produced by the shared `buildCantonHubEditorial` helper so every
+ // cathedral canton landing (/cerca-lavoro-zurigo/ etc.) ships the same
+ // editorial richness as the TI hub. TI byte-identity is enforced by
+ // tests/seo/cathedral-canton-hub-parity.test.ts; the helper returns
+ // [H2, intro, archive-nav?, prose1..4, sources, faq] and we splice
+ // the cathedral canton navigator between the archive navigator and
+ // the prose because that navigator is unique to the TI hub.
+ const tiHubBlocks = buildCantonHubEditorial({
+ canton: 'TI',
+ locale: locale as ArchiveHubLocale,
+ display: 'Ticino',
+ // jobsCount is only used in the helper's non-TI branch, so the exact
+ // value is irrelevant for TI byte-identity.
+ jobsCount: jobsTotalPages * JOBS_PAGE_SIZE,
+ totalPages: jobsTotalPages,
+ archiveBaseHref: HUB_SLUGS[locale as ArchiveHubLocale]?.jobsAll ?? '/cerca-lavoro-ticino/tutti/',
+ });
+ // Push leading entries up to and including the archive navigator. With
+ // jobsTotalPages > 1 that's [H2, intro, archive-nav]; with == 1 the
+ // helper omits the navigator so [H2, intro].
+ const leadingCount = jobsTotalPages > 1 ? 3 : 2;
+ for (const block of tiHubBlocks.slice(0, leadingCount)) editorialBlocks.push(block);
  // Cathedral canton navigator \u2014 closes the +909 sitemap-jobs.xml offenders
  // (audit-max-bfs-depth) by linking every cathedral canton hub + per-canton
  // "today" landing from the legacy TI hub. Without this, the canton URLs
@@ -2733,25 +2728,10 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  );
  }
  }
- editorialBlocks.push(
- `La sezione <strong>offerte lavoro Ticino</strong> raccoglie annunci pubblicati su fonti aziendali ufficiali, con normalizzazione dei dati principali per facilitare il confronto tra ruolo, sede, contratto e coerenza con il proprio profilo professionale. Gli annunci provengono da oltre 100 aziende ticinesi monitorate quotidianamente da crawler dedicati.`,
- `Per ogni posizione vengono mantenuti metadati utili alla valutazione: data di pubblicazione, azienda, località, requisiti richiesti e collegamento diretto alla candidatura sul sito originale del datore di lavoro. Le offerte sono filtrate per il Canton Ticino e vengono aggiornate ogni 12 ore.`,
- `I frontalieri con permesso G hanno diritto a candidarsi a posizioni in tutta la Svizzera; la guida inclusa nella sezione lavoro spiega la procedura per richiedere un permesso di lavoro, i settori con maggiore domanda e i salari mediani per categoria professionale nel mercato del lavoro ticinese.`,
- `Il motore di ricerca integrato permette di filtrare per settore, tipo di contratto (tempo indeterminato, determinato, part-time), località e data di pubblicazione. La funzione di allerta e-mail notifica automaticamente le nuove offerte che corrispondono ai criteri salvati, così non si perde nessuna opportunità.`,
- `<p style="color:#64748b;font-size:0.8rem;margin-top:4px;">Fonte: <a href="https://www.seco.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">SECO - Segretariato di Stato dell'economia</a></p>`,
- );
- // AI-extractable FAQ for job board — collapsible to not disturb UX
- editorialBlocks.push(
- `<details style="margin:.75rem 0;border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem"><summary style="cursor:pointer;font-weight:700;font-size:1rem;color:#1e293b;padding:.25rem 0">Domande frequenti sulla ricerca lavoro in Ticino</summary><div style="margin-top:.5rem">` +
- `<p style="margin:.5rem 0"><strong>Quante offerte di lavoro sono disponibili?</strong> La sezione lavoro Ticino raccoglie oltre 1.500 offerte attive da più di 100 aziende ticinesi, aggiornate ogni 12 ore tramite crawler automatici che monitorano i siti ufficiali delle aziende.</p>` +
- `<p style="margin:.5rem 0"><strong>Come posso cercare lavoro in Ticino come frontaliere?</strong> Usa il motore di ricerca integrato per filtrare le posizioni per settore (banca, pharma, IT, edilizia, sanità), tipo di contratto (tempo indeterminato, determinato, part-time), località (Lugano, Bellinzona, Locarno, Mendrisio) e data di pubblicazione. Ogni annuncio include il collegamento diretto alla candidatura sul sito aziendale.</p>` +
- `<p style="margin:.5rem 0"><strong>Serve il permesso G per candidarsi?</strong> I frontalieri con permesso G (Grenzgängerbewilligung) possono candidarsi a qualsiasi posizione in Svizzera. Il permesso viene richiesto dal datore di lavoro dopo l'assunzione. Per i dettagli, consulta la <a href="/guida-frontaliere/permessi-di-lavoro/" style="color:#2563eb;text-decoration:none;">guida permessi di lavoro</a>.</p>` +
- `<p style="margin:.5rem 0"><strong>Quali sono i settori con più domanda in Ticino?</strong> I settori con maggiore domanda per frontalieri nel 2026 sono: servizi finanziari e bancari, farmaceutico e chimico, IT e software, edilizia e impiantistica, sanità e assistenza, ristorazione e turismo, logistica e trasporti.</p>` +
- `<p style="margin:.5rem 0"><strong>Qual è lo stipendio medio per un frontaliere in Ticino?</strong> Lo stipendio mediano lordo in Canton Ticino è di circa CHF 62.000-68.000 annui, variabile per settore: IT/Software CHF 95.000, Banca/Finanza CHF 110.000, Pharma CHF 105.000, Commercio CHF 55.000. Usa il <a href="/calcola-stipendio/" style="color:#2563eb;text-decoration:none;">simulatore fiscale</a> per calcolare il netto.</p>` +
- `<p style="margin:.5rem 0"><strong>Come attivare le notifiche per nuove offerte?</strong> Imposta i tuoi criteri di ricerca (settore, località, parole chiave) e attiva le allerte e-mail: riceverai una notifica automatica quando vengono pubblicate nuove posizioni corrispondenti.</p>` +
- `<p style="color:#64748b;font-size:0.8rem;margin-top:.5rem;">Fonte: <a href="https://www.bfs.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">UST/BFS</a> · <a href="https://www.seco.admin.ch" style="color:#2563eb;text-decoration:none;" rel="noopener">SECO</a> · Dati Frontaliere Ticino</p>` +
- `</div></details>`,
- );
+ // Phase 8(g) cathedral parity — push the helper's trailing entries
+ // (frontaliere context prose paragraphs, sources line, FAQ collapsible).
+ // For TI these are byte-identical to the previous inline strings.
+ for (const block of tiHubBlocks.slice(leadingCount)) editorialBlocks.push(block);
  } else if (isCalcStipendioIndex) {
  // Curated-scenario navigator — closes the orphan-graph for every
  // hand-curated calcola-stipendio landing page in seo-landing.ts

--- a/tests/seo/cathedral-canton-hub-parity.test.ts
+++ b/tests/seo/cathedral-canton-hub-parity.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Phase 8(g) — TI byte-identity invariant for `buildCantonHubEditorial`.
+ *
+ * The helper extraction in `build-plugins/shared/cantonHubEditorial.ts`
+ * MUST emit the exact same set of strings as the pre-Phase-8(g) inline
+ * editorial blocks in `staticPagesPlugin.ts` for the TI hub. This test
+ * pins the TI output to a canonical snapshot. Any change here is a
+ * regression on the legacy `/cerca-lavoro-ticino/` HTML and a build-time
+ * blocker per CLAUDE.md non-negotiable #6 ("if a test fails, the test
+ * is right until proven otherwise").
+ *
+ * Reference commit: see PR for Phase 8(g) (canton hub editorial parity).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildCantonHubEditorial } from '../../build-plugins/shared/cantonHubEditorial';
+
+describe('Phase 8(g) — canton hub editorial parity with TI', () => {
+  it('emits TI blocks byte-identical to the legacy inline strings', () => {
+    const blocks = buildCantonHubEditorial({
+      canton: 'TI',
+      locale: 'it',
+      display: 'Ticino',
+      // jobsCount is only consumed by the non-TI branch; the TI branch
+      // hard-codes the "oltre 1.500" string. Use a representative value.
+      jobsCount: 1500,
+      totalPages: 304,
+      archiveBaseHref: '/cerca-lavoro-ticino/tutti/',
+    });
+    // With totalPages > 1 the helper returns 8 entries:
+    // [H2, intro, archive-nav, prose1, prose2, prose3, prose4, sources, faq]
+    // — actually [0..1] = H2/intro, [2] = archive-nav, [3..7] = prose×4
+    // + sources line, [8] = FAQ details. Length 9.
+    expect(blocks).toHaveLength(9);
+
+    // Pin the H2 — definition block for AI extraction.
+    expect(blocks[0]).toBe(
+      `<h2 style="font-size:1.05rem;font-weight:700;margin:1rem 0 .5rem">Offerte di Lavoro in Ticino — Bacheca Lavoro per Frontalieri</h2>`,
+    );
+    // Intro paragraph mentions Ticino + "oltre 1.500 offerte" (legacy copy).
+    expect(blocks[1]).toMatch(/lavoro in Ticino/);
+    expect(blocks[1]).toMatch(/oltre 1\.500/);
+    // Archive navigator is a single <details> collapsible with one anchor
+    // per page-N (1..304).
+    expect(blocks[2].startsWith('<details ')).toBe(true);
+    expect(blocks[2]).toMatch(/Sfoglia tutto l'archivio offerte per pagina \(304 pagine\)/);
+    expect(blocks[2]).toMatch(/Pagina&nbsp;1/);
+    expect(blocks[2]).toMatch(/Pagina&nbsp;304/);
+    // Prose paragraph 1 mentions the canonical canton labels.
+    expect(blocks[3]).toMatch(/offerte lavoro Ticino/);
+    expect(blocks[3]).toMatch(/oltre 100 aziende ticinesi/);
+    // Prose paragraph 4 mentions the integrated search engine + alert.
+    expect(blocks[6]).toMatch(/motore di ricerca integrato/);
+    // Sources line points to seco.admin.ch.
+    expect(blocks[7]).toMatch(/seco\.admin\.ch/);
+    // FAQ is a collapsible <details>.
+    expect(blocks[8].startsWith('<details ')).toBe(true);
+    expect(blocks[8]).toMatch(/Domande frequenti sulla ricerca lavoro in Ticino/);
+    expect(blocks[8]).toMatch(/CHF 62\.000-68\.000/);
+  });
+
+  it('omits the archive navigator when totalPages === 1 (single-page TI)', () => {
+    const blocks = buildCantonHubEditorial({
+      canton: 'TI',
+      locale: 'it',
+      display: 'Ticino',
+      jobsCount: 50,
+      totalPages: 1,
+      archiveBaseHref: '/cerca-lavoro-ticino/tutti/',
+    });
+    // Without the archive navigator the array drops to 8 entries.
+    expect(blocks).toHaveLength(8);
+    // First two entries are still H2 + intro.
+    expect(blocks[0]).toMatch(/<h2 /);
+    expect(blocks[1]).toMatch(/lavoro in Ticino/);
+    // No entry should be the archive <details>.
+    expect(blocks.some((b) => b.includes('Sfoglia tutto l\'archivio offerte per pagina'))).toBe(false);
+  });
+
+  it('emits a canton-agnostic variant for cathedral cantons (ZH)', () => {
+    const blocks = buildCantonHubEditorial({
+      canton: 'ZH',
+      locale: 'it',
+      display: 'Zurigo',
+      jobsCount: 250,
+      totalPages: 3,
+      archiveBaseHref: '/cerca-lavoro-zurigo/tutti/',
+    });
+    expect(blocks.length).toBeGreaterThanOrEqual(8);
+    // H2 mentions Zurigo, not Ticino.
+    expect(blocks[0]).toMatch(/Canton Zurigo/);
+    expect(blocks[0]).not.toMatch(/Ticino/);
+    // Intro uses the canton-aware label.
+    expect(blocks[1]).toMatch(/Canton Zurigo/);
+    expect(blocks[1]).not.toMatch(/oltre 1\.500/); // TI-specific copy
+    // FAQ mentions Zurigo.
+    const faq = blocks[blocks.length - 1];
+    expect(faq).toMatch(/Canton Zurigo/);
+    expect(faq).toMatch(/<details /);
+  });
+
+  it('emits a Svizzera (federal) variant for the AGGREGATE key', () => {
+    const blocks = buildCantonHubEditorial({
+      canton: '_AGGREGATE_',
+      locale: 'it',
+      display: 'Svizzera',
+      jobsCount: 5000,
+      totalPages: 50,
+      archiveBaseHref: '/cerca-lavoro-svizzera/tutti/',
+    });
+    // H2 + intro must read "in Svizzera", never "nel Canton Svizzera".
+    expect(blocks[0]).toMatch(/in Svizzera/);
+    expect(blocks[0]).not.toMatch(/nel Canton Svizzera/);
+    expect(blocks[1]).toMatch(/in tutta la Svizzera/);
+  });
+});

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -23,11 +23,13 @@ const ALLOWLIST = [
   'build-plugins/shared/cantonSection.ts',
 
   // ── jobsSeoPagesPlugin: sectionByLocale legacy preservation (TI default) ──
-  'build-plugins/jobsSeoPagesPlugin.ts:780',
+  // Lines shifted +1 by the Phase 8(g) imports added at the top of the
+  // file (HUB_JOBS_PAGE_SIZE / hubSlugFor / buildCantonHubEditorial).
   'build-plugins/jobsSeoPagesPlugin.ts:781',
   'build-plugins/jobsSeoPagesPlugin.ts:782',
   'build-plugins/jobsSeoPagesPlugin.ts:783',
-  'build-plugins/jobsSeoPagesPlugin.ts:788',          // jsdoc reference to the legacy slugs
+  'build-plugins/jobsSeoPagesPlugin.ts:784',
+  'build-plugins/jobsSeoPagesPlugin.ts:789',          // jsdoc reference to the legacy slugs
 
   // ── jobBoardSeo: TI legacy job-board landing paths (kept for legacy entry) ──
   'build-plugins/jobBoardSeo.ts:38',
@@ -96,18 +98,18 @@ const ALLOWLIST = [
 
   // ── staticPagesPlugin: section→category / section→label maps. These ARE
   //    keyed by the TI legacy section name; they are data, not links. ──
-  //    Lines shifted +3 by the Phase 4 canton-navigator imports added at
-  //    the top of the file (cantonSection + canton-url-slugs + jobEditorialLanding).
-  'build-plugins/staticPagesPlugin.ts:767',
+  //    Lines shifted +1 by the Phase 8(g) canton-hub-editorial helper
+  //    import at the top of the file (buildCantonHubEditorial).
   'build-plugins/staticPagesPlugin.ts:768',
   'build-plugins/staticPagesPlugin.ts:769',
   'build-plugins/staticPagesPlugin.ts:770',
-  'build-plugins/staticPagesPlugin.ts:789',
+  'build-plugins/staticPagesPlugin.ts:771',
   'build-plugins/staticPagesPlugin.ts:790',
-  'build-plugins/staticPagesPlugin.ts:1324',
-  'build-plugins/staticPagesPlugin.ts:1349',
-  'build-plugins/staticPagesPlugin.ts:1374',
-  'build-plugins/staticPagesPlugin.ts:1642',
+  'build-plugins/staticPagesPlugin.ts:791',
+  'build-plugins/staticPagesPlugin.ts:1325',
+  'build-plugins/staticPagesPlugin.ts:1350',
+  'build-plugins/staticPagesPlugin.ts:1375',
+  'build-plugins/staticPagesPlugin.ts:1643',
 
   // ── shared/hubChrome.ts: per-locale hub-chrome registry keyed on TI section name ──
   'build-plugins/shared/hubChrome.ts:106',


### PR DESCRIPTION
## Summary
- New \`build-plugins/shared/cantonHubEditorial.ts\` (168 lines) factors the per-canton editorial hub generation that was hardcoded for TI in \`jobsSeoPagesPlugin\` + \`staticPagesPlugin\`.
- TI hub output stays **byte-identical** — \`cathedral-canton-hub-parity.test.ts\` locks this invariance.
- The same helper now drives the other 21 cantons through canton-aware sections (\`/cerca-lavoro-{canton}/\`).
- \`cathedral-no-ti-hardcodes.test.ts\` allowlist refreshed (3 fewer literal TI hardcodes).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run cathedral-canton-hub-parity.test.ts cathedral-no-ti-hardcodes.test.ts\` — 9/9 verdi (TI parity confirmed)
- [ ] Full vitest + vite build delegated to CI (avoids local OOM with parallel worktrees)