### PR TITLE
fix(audit): walk() iterative — unblock 5 audits crashing with RangeError

### DIFF
--- a/scripts/audit-h1-title-duplicates.mjs
+++ b/scripts/audit-h1-title-duplicates.mjs
@@ -75,22 +75,28 @@ const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 const H1_RE = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i;
 
 async function walk(dir) {
+  // Iterative — the cathedral expansion produced dist/ trees deep enough
+  // to blow the call stack via async recursion + array spread.
   const out = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch (err) {
-    if (err.code === 'ENOENT') return out;
-    throw err;
-  }
-  for (const e of entries) {
-    // Skip dot-prefixed dirs (debug artifacts, not deployed pages).
-    if (e.isDirectory() && e.name.startsWith('.')) continue;
-    const p = join(dir, e.name);
-    if (e.isDirectory()) {
-      out.push(...(await walk(p)));
-    } else if (e.isFile() && p.endsWith('.html')) {
-      out.push(p);
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = await readdir(cur, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    for (const e of entries) {
+      // Skip dot-prefixed dirs (debug artifacts, not deployed pages).
+      if (e.isDirectory() && e.name.startsWith('.')) continue;
+      const p = join(cur, e.name);
+      if (e.isDirectory()) {
+        stack.push(p);
+      } else if (e.isFile() && p.endsWith('.html')) {
+        out.push(p);
+      }
     }
   }
   return out;

--- a/scripts/audit-page-weight.mjs
+++ b/scripts/audit-page-weight.mjs
@@ -34,21 +34,28 @@ const MODE_JSON = args.has('--json');
 
 /** @param {string} dir */
 async function walk(dir) {
+  // Iterative — the cathedral expansion produced dist/ trees deep enough
+  // to blow the call stack via async recursion + array spread.
   /** @type {string[]} */
   const out = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch (err) {
-    if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') return out;
-    throw err;
-  }
-  for (const e of entries) {
-    const p = join(dir, e.name);
-    if (e.isDirectory()) {
-      out.push(...(await walk(p)));
-    } else if (e.isFile() && p.endsWith('.html')) {
-      out.push(p);
+  /** @type {string[]} */
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = /** @type {string} */ (stack.pop());
+    let entries;
+    try {
+      entries = await readdir(cur, { withFileTypes: true });
+    } catch (err) {
+      if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') continue;
+      throw err;
+    }
+    for (const e of entries) {
+      const p = join(cur, e.name);
+      if (e.isDirectory()) {
+        stack.push(p);
+      } else if (e.isFile() && p.endsWith('.html')) {
+        out.push(p);
+      }
     }
   }
   return out;

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -83,24 +83,31 @@ const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
 
 /** @param {string} dir */
 async function walk(dir) {
+  // Iterative — the cathedral expansion produced dist/ trees deep enough
+  // to blow the call stack via async recursion + array spread.
   /** @type {string[]} */
   const out = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch (err) {
-    if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') return out;
-    throw err;
-  }
-  for (const e of entries) {
-    // Skip dot-prefixed dirs (e.g. dist/.write-collisions-data/ — debug
-    // artifacts from writeRegistryLifecyclePlugin, not deployed pages).
-    if (e.isDirectory() && e.name.startsWith('.')) continue;
-    const p = join(dir, e.name);
-    if (e.isDirectory()) {
-      out.push(...(await walk(p)));
-    } else if (e.isFile() && p.endsWith('.html')) {
-      out.push(p);
+  /** @type {string[]} */
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = /** @type {string} */ (stack.pop());
+    let entries;
+    try {
+      entries = await readdir(cur, { withFileTypes: true });
+    } catch (err) {
+      if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') continue;
+      throw err;
+    }
+    for (const e of entries) {
+      // Skip dot-prefixed dirs (e.g. dist/.write-collisions-data/ — debug
+      // artifacts from writeRegistryLifecyclePlugin, not deployed pages).
+      if (e.isDirectory() && e.name.startsWith('.')) continue;
+      const p = join(cur, e.name);
+      if (e.isDirectory()) {
+        stack.push(p);
+      } else if (e.isFile() && p.endsWith('.html')) {
+        out.push(p);
+      }
     }
   }
   return out;

--- a/scripts/audit-title-length.mjs
+++ b/scripts/audit-title-length.mjs
@@ -73,23 +73,29 @@ const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 
 async function walk(dir) {
+  // Iterative — the cathedral expansion produced dist/ trees deep enough
+  // to blow the call stack via async recursion + array spread.
   const out = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch (err) {
-    if (err.code === 'ENOENT') return out;
-    throw err;
-  }
-  for (const e of entries) {
-    // Skip dot-prefixed dirs (e.g. dist/.write-collisions-data/ — debug
-    // artifacts from writeRegistryLifecyclePlugin, not deployed pages).
-    if (e.isDirectory() && e.name.startsWith('.')) continue;
-    const p = join(dir, e.name);
-    if (e.isDirectory()) {
-      out.push(...(await walk(p)));
-    } else if (e.isFile() && p.endsWith('.html')) {
-      out.push(p);
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = await readdir(cur, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    for (const e of entries) {
+      // Skip dot-prefixed dirs (e.g. dist/.write-collisions-data/ — debug
+      // artifacts from writeRegistryLifecyclePlugin, not deployed pages).
+      if (e.isDirectory() && e.name.startsWith('.')) continue;
+      const p = join(cur, e.name);
+      if (e.isDirectory()) {
+        stack.push(p);
+      } else if (e.isFile() && p.endsWith('.html')) {
+        out.push(p);
+      }
     }
   }
   return out;

--- a/scripts/audit-title-no-disambig-hash.mjs
+++ b/scripts/audit-title-no-disambig-hash.mjs
@@ -74,22 +74,28 @@ const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 const HASH_RE = /\(#[0-9a-f]{8}\)/;
 
 async function walk(dir) {
+  // Iterative — the cathedral expansion produced dist/ trees deep enough
+  // to blow the call stack via async recursion + array spread.
   const out = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch (err) {
-    if (err.code === 'ENOENT') return out;
-    throw err;
-  }
-  for (const e of entries) {
-    // Skip dot-prefixed dirs (debug artifacts, not deployed pages).
-    if (e.isDirectory() && e.name.startsWith('.')) continue;
-    const p = join(dir, e.name);
-    if (e.isDirectory()) {
-      out.push(...(await walk(p)));
-    } else if (e.isFile() && p.endsWith('.html')) {
-      out.push(p);
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = await readdir(cur, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    for (const e of entries) {
+      // Skip dot-prefixed dirs (debug artifacts, not deployed pages).
+      if (e.isDirectory() && e.name.startsWith('.')) continue;
+      const p = join(cur, e.name);
+      if (e.isDirectory()) {
+        stack.push(p);
+      } else if (e.isFile() && p.endsWith('.html')) {
+        out.push(p);
+      }
     }
   }
   return out;


### PR DESCRIPTION
## Summary
Phase 8 cathedral expansion produced \`dist/\` trees deep enough that the recursive \`walk()\` in five audit scripts overflowed the call stack (\`RangeError: Maximum call stack size exceeded\`). Two compounding causes:

1. Async recursion grows the stack one frame per directory level.
2. \`out.push(...(await walk(p)))\` spreads potentially huge arrays as function arguments — its own stack-frame ceiling.

Converted all five walkers to iterative DFS with an explicit stack array. Same files visited, same return shape, no behaviour change for shallow trees.

## Affected audits (all currently failing in deploy.yml post-build gates)
- \`audit:text-html-ratio\`
- \`audit:page-weight\`
- \`audit:h1-title-duplicates\`
- \`audit:title-no-disambig-hash\`
- \`audit:title-length\`

## Test plan
- [x] \`node --check\` on all 5 scripts — clean
- [x] Functional test of iterative walk on a 200-level synthetic fixture: 201 files found, no crash (the old recursive form crashed around ~100 levels)
- [ ] Full deploy.yml post-build gates delegated to CI