### PR TITLE
fix(test): cathedral-previous-slug-canton — relax over-specified regex

### DIFF
--- a/tests/seo/cathedral-previous-slug-canton.test.ts
+++ b/tests/seo/cathedral-previous-slug-canton.test.ts
@@ -19,17 +19,41 @@ describe('cathedral Phase 8b — previousSlugs bridges canton-aware', () => {
 
   // ── Source-level guard: bridge emit + sitemap addEntry use the
   //    canton-aware section helper instead of the TI-hardcoded sectionByLocale. ──
+  //
+  // These tests are intent-based, not name-based: they locate the code region
+  // by stable anchor comments (so refactors that rename local variables don't
+  // break the gate) and then assert that
+  //   1. `buildCantonAwareSection(...)` is invoked in the region, and
+  //   2. the call's second argument is a canton-derived variable (matches
+  //      /[Jj]obCanton/ — covers `jobCantonForBridge`, `jobCantonForSitemapPrevSlugs`,
+  //      and any future name that still derives the canton from the job), and
+  //   3. the `oldPath` / `psRelPath` builder does NOT reference
+  //      `sectionByLocale[locale]` (the legacy TI-hardcoded path — the bug
+  //      this test was originally written to prevent).
   it('jobsSeoPagesPlugin.ts bridge emit derives section from buildCantonAwareSection', () => {
     const src = fs.readFileSync(
       path.join(REPO_ROOT, 'build-plugins', 'jobsSeoPagesPlugin.ts'),
       'utf8',
     );
-    const lines = src.split('\n');
-    // Look at the previousSlugs bridge emit region (~9650-9720). The
-    // bridge section variable must derive from buildCantonAwareSection,
-    // and the `oldPath = ...` builder must NOT reference sectionByLocale[locale].
-    const bridgeRegion = lines.slice(9560, 9720).join('\n');
-    expect(bridgeRegion).toMatch(/bridgeSection\s*=\s*buildCantonAwareSection\(locale,\s*jobCantonForBridge\)/);
+    // Anchor the region by the bridge emit comment block. The body of the
+    // bridge generator (the `for (const job of validJobs) { ... }` loop that
+    // emits bridge HTML to dist/<canton-section>/<oldSlug>/index.html) lives
+    // between this anchor and the next major section header.
+    const bridgeAnchor = '/* ── Full-content pages for previousSlugs of active jobs';
+    const anchorIdx = src.indexOf(bridgeAnchor);
+    expect(anchorIdx, `bridge anchor comment missing in jobsSeoPagesPlugin.ts`).toBeGreaterThan(0);
+    // End the region at the next ── header (next phase of closeBundle), e.g.
+    // `/* ── Cross-locale reconciliation bridge pages ─`.
+    const nextAnchorIdx = src.indexOf('/* ──', anchorIdx + bridgeAnchor.length);
+    expect(nextAnchorIdx, 'expected a following ── section header to bound the bridge region').toBeGreaterThan(anchorIdx);
+    const bridgeRegion = src.slice(anchorIdx, nextAnchorIdx);
+
+    // (1) The bridge region must invoke buildCantonAwareSection with a
+    // canton variable derived from the job (any name containing "JobCanton"
+    // / "jobCanton"). This is the canton-aware section path.
+    expect(bridgeRegion).toMatch(/buildCantonAwareSection\s*\(\s*locale\s*,\s*\w*[Jj]obCanton\w*\s*\)/);
+    // (2) The oldPath builder must not fall back to the legacy TI-hardcoded
+    // sectionByLocale lookup keyed by locale.
     const bridgeOldPathLines = bridgeRegion
       .split('\n')
       .filter((l) => /\boldPath\s*=/.test(l) && !/^\s*\/\//.test(l));
@@ -37,6 +61,14 @@ describe('cathedral Phase 8b — previousSlugs bridges canton-aware', () => {
     for (const l of bridgeOldPathLines) {
       expect(l, `bridge oldPath still uses sectionByLocale: ${l}`).not.toMatch(
         /sectionByLocale\[locale\]/,
+      );
+      // The line that builds oldPath must reference the canton-aware section —
+      // either directly (`buildCantonAwareSection(...)`) or via a hoisted
+      // variable name that itself derived from the canton-aware helper
+      // (anything containing "Section" works as a heuristic so long as
+      // sectionByLocale was excluded above).
+      expect(l, `bridge oldPath does not appear canton-aware: ${l}`).toMatch(
+        /buildCantonAwareSection|\w*[Ss]ection\b/,
       );
     }
   });
@@ -46,11 +78,29 @@ describe('cathedral Phase 8b — previousSlugs bridges canton-aware', () => {
       path.join(REPO_ROOT, 'build-plugins', 'jobsSeoPagesPlugin.ts'),
       'utf8',
     );
-    const lines = src.split('\n');
-    // Look at the sitemap previousSlugs addEntry region (~7385). The psRelPath
-    // builder must use buildCantonAwareSection, not sectionByLocale[locale].
-    const sitemapRegion = lines.slice(7355, 7410).join('\n');
-    expect(sitemapRegion).toMatch(/psRelPath\s*=\s*`\$\{localePrefix\[locale\]\}\/\$\{buildCantonAwareSection\(/);
+    // Anchor the sitemap previousSlugs region by the FRO-SEO comment that
+    // introduces the bridge-sitemap-entry generation loop. The addEntry
+    // closure that builds psRelPath lives within ~80 lines of this anchor.
+    const sitemapAnchor = 'FRO-SEO / seo/sitemap-crawl-budget: previousSlugs bridge pages';
+    const anchorIdx = src.indexOf(sitemapAnchor);
+    expect(anchorIdx, `sitemap previousSlugs anchor comment missing in jobsSeoPagesPlugin.ts`).toBeGreaterThan(0);
+    // Bound the region at the closing of the for-loop that hosts addEntry.
+    // Use the "Legacy flat previousSlugs" comment which closes the block.
+    const endMarker = 'Legacy flat previousSlugs';
+    const endIdx = src.indexOf(endMarker, anchorIdx);
+    expect(endIdx, 'expected "Legacy flat previousSlugs" marker after the sitemap anchor').toBeGreaterThan(anchorIdx);
+    const sitemapRegion = src.slice(anchorIdx, endIdx);
+
+    // (1) The psRelPath builder (or its functional equivalent under another
+    // local name) must call buildCantonAwareSection with the job-derived
+    // canton variable as the second argument.
+    expect(sitemapRegion).toMatch(
+      /\w*Path\s*=\s*`\$\{localePrefix\[locale\]\}\/\$\{buildCantonAwareSection\(\s*locale\s*,\s*\w*[Jj]obCanton\w*\s*\)\}\/\$\{[^`]+`/,
+    );
+    // (2) Defence-in-depth: no occurrence of sectionByLocale[locale] inside
+    // the sitemap previousSlugs region — that's the legacy TI-hardcode the
+    // canton-aware refactor replaced.
+    expect(sitemapRegion).not.toMatch(/sectionByLocale\[locale\]/);
   });
 
   // ── Behavioural: when dist/ is present, every bridge file's directory


### PR DESCRIPTION
## Summary

The 2 source-level guards in `tests/seo/cathedral-previous-slug-canton.test.ts` (introduced by PR #117 Phase 8b) were brittle / over-specified and failing in `gate:seo-source`:

- They sliced `build-plugins/jobsSeoPagesPlugin.ts` by hard-coded line numbers (`9560..9720` for bridge, `7355..7410` for sitemap). The actual canton-aware code lives at lines 9748-9772 (bridge `bridgeSection = buildCantonAwareSection(locale, jobCantonForBridge)`) and line 7412 (sitemap `psRelPath = ...buildCantonAwareSection(locale, jobCantonForSitemapPrevSlugs)...`) — both **outside** the slices.
- They pinned exact local-variable names (`bridgeSection`, `psRelPath`, `jobCantonForBridge`) which no longer all exist in the source.

The **source code is correct** — it derives the bridge / sitemap section from `buildCantonAwareSection(locale, <job-derived canton>)` and never falls back to the legacy `sectionByLocale[locale]`. The tests were the only thing broken.

## What changed

- Locate each code region by **stable anchor comments** (the Phase 8b "Full-content pages for previousSlugs of active jobs" header, and the "FRO-SEO / seo/sitemap-crawl-budget: previousSlugs bridge pages" comment) instead of absolute line offsets — refactors that move code around no longer break this gate.
- Assert the **intent**:
  1. `buildCantonAwareSection(locale, …)` is invoked with a job-derived canton variable (regex: `\w*[Jj]obCanton\w*`),
  2. `sectionByLocale[locale]` is NOT used to build the bridge/sitemap path for the previousSlug — this is the legacy TI hardcode the Phase 8b refactor was designed to remove.
- Exact local-variable names (`bridgeSection`, `psRelPath`, …) are no longer load-bearing.

## Bug-catching power preserved

Reverting `jobsSeoPagesPlugin.ts` to use `sectionByLocale[locale]` for the bridge or sitemap path of a previousSlug would still re-fail this suite — that's the regression the tests were originally written to catch.

## Test plan

- [x] `npx vitest run tests/seo/cathedral-previous-slug-canton.test.ts` → 5/5 green
- [x] `npx vitest run tests/seo/cathedral-no-ti-hardcodes.test.ts` → 5/5 green (correlated TI-invariance gate)
- [x] No source-code edits — only the test file was relaxed
- [ ] Full `gate:seo-source` CI run after merge confirms the gate is now green