### PR TITLE
fix(tests): unblock validate-dist by anchoring Phase 8b source guards

### DIFF
--- a/tests/seo/cathedral-previous-slug-canton.test.ts
+++ b/tests/seo/cathedral-previous-slug-canton.test.ts
@@ -24,11 +24,17 @@ describe('cathedral Phase 8b — previousSlugs bridges canton-aware', () => {
       path.join(REPO_ROOT, 'build-plugins', 'jobsSeoPagesPlugin.ts'),
       'utf8',
     );
+    // The bridge emit region floats as the plugin grows. Locate it by the
+    // unique `bridgeSection =` anchor and slice a window of surrounding lines.
+    // This survives Phase 8g (cathedral hub editorial helper) and future
+    // refactors that shift line numbers without changing the bridge logic.
     const lines = src.split('\n');
-    // Look at the previousSlugs bridge emit region (~9650-9720). The
-    // bridge section variable must derive from buildCantonAwareSection,
-    // and the `oldPath = ...` builder must NOT reference sectionByLocale[locale].
-    const bridgeRegion = lines.slice(9560, 9720).join('\n');
+    const bridgeAnchorIdx = lines.findIndex((l) => /\bbridgeSection\s*=\s*buildCantonAwareSection\(/.test(l));
+    expect(
+      bridgeAnchorIdx,
+      'expected to find `bridgeSection = buildCantonAwareSection(...)` anchor in jobsSeoPagesPlugin.ts',
+    ).toBeGreaterThan(-1);
+    const bridgeRegion = lines.slice(Math.max(0, bridgeAnchorIdx - 20), bridgeAnchorIdx + 80).join('\n');
     expect(bridgeRegion).toMatch(/bridgeSection\s*=\s*buildCantonAwareSection\(locale,\s*jobCantonForBridge\)/);
     const bridgeOldPathLines = bridgeRegion
       .split('\n')
@@ -46,10 +52,16 @@ describe('cathedral Phase 8b — previousSlugs bridges canton-aware', () => {
       path.join(REPO_ROOT, 'build-plugins', 'jobsSeoPagesPlugin.ts'),
       'utf8',
     );
+    // The sitemap addEntry region floats as the plugin grows. Locate it by
+    // the unique `psRelPath` builder anchor and verify the canton-aware
+    // section helper is used inline. Robust to Phase 8g+ line drift.
     const lines = src.split('\n');
-    // Look at the sitemap previousSlugs addEntry region (~7385). The psRelPath
-    // builder must use buildCantonAwareSection, not sectionByLocale[locale].
-    const sitemapRegion = lines.slice(7355, 7410).join('\n');
+    const psRelPathIdx = lines.findIndex((l) => /\bpsRelPath\s*=/.test(l));
+    expect(
+      psRelPathIdx,
+      'expected to find `psRelPath =` anchor in jobsSeoPagesPlugin.ts',
+    ).toBeGreaterThan(-1);
+    const sitemapRegion = lines.slice(Math.max(0, psRelPathIdx - 5), psRelPathIdx + 5).join('\n');
     expect(sitemapRegion).toMatch(/psRelPath\s*=\s*`\$\{localePrefix\[locale\]\}\/\$\{buildCantonAwareSection\(/);
   });
 


### PR DESCRIPTION
## Summary

Phase 8g (#118) shifted line numbers in \`build-plugins/jobsSeoPagesPlugin.ts\` by ~30 lines (added the cathedral canton-hub editorial helper). Two source-level guards in \`tests/seo/cathedral-previous-slug-canton.test.ts\` were sliced at hardcoded line ranges (7355-7410 and 9560-9720) and now miss the anchors they're supposed to verify — both tests fail on main.

Replace the brittle line-range slices with anchor-based lookups that locate \`psRelPath =\` and \`bridgeSection = buildCantonAwareSection(\` directly, then read a small surrounding window. The intent of the original tests is preserved (verify the patterns exist + use the canton-aware helper).

## Impact

- \`gate:seo-source\` (vitest run tests/seo/) was failing rc=1 on every deploy since Phase 8g landed
- \`validate-dist\` exited before the \`audit:max-bfs-depth\` gate could run, hiding the actual BFS-depth state on post-Phase-8 main
- Unblocks the full per-PR audit chain; the BFS-depth regression (~859 sitemap-jobs.xml URLs at depth > 4 in the pre-Phase-8d log) can finally be measured against the post-Phase-8d/8g dist output

## Test plan

- [x] \`npx vitest run tests/seo/cathedral-previous-slug-canton.test.ts\` → 5 pass
- [x] \`npx vitest run tests/seo/cathedral-phase8d-ti-invariance.test.ts tests/seo/cathedral-editorial-slug-tables.test.ts\` → 11 pass (no regression)
- [ ] CI \`gate:seo-source\` returns rc=0
- [ ] \`audit:max-bfs-depth\` runs and surfaces the current per-sitemap counts