### PR TITLE
feat(cathedral): link Phase 8a sub-pages from canton hub

### DIFF
--- a/build-plugins/jobEditorialLanding.ts
+++ b/build-plugins/jobEditorialLanding.ts
@@ -173,6 +173,22 @@ export function getJobTodayLandingSlug(locale: JobLandingLocale, canton: string 
  return slugs[locale];
 }
 
+// Phase 8 sub-PR (d) helper accessor — TI defaults preserved; non-TI/GR/VS
+// cantons return the short slug (`infermieri` / `nurses` / `pflege-jobs` /
+// `infirmiers`). Used by the canton-hub "Esplora" navigator to link the
+// Phase 8d editorial slot pages without rebuilding the lookup table.
+export function getJobNursesHubSlug(locale: JobLandingLocale, canton: string = 'TI'): string {
+ const slugs = JOB_NURSES_HUB_SLUGS_BY_CANTON[canton] || JOB_NURSES_HUB_SLUGS;
+ return slugs[locale];
+}
+
+// Phase 8 sub-PR (d) helper accessor — TI defaults preserved; non-TI/GR/VS
+// cantons return the short slug (`lavoro-part-time` / `part-time-jobs` / …).
+export function getJobPartTimeLandingSlug(locale: JobLandingLocale, canton: string = 'TI'): string {
+ const slugs = JOB_PART_TIME_LANDING_SLUGS_BY_CANTON[canton] || JOB_PART_TIME_LANDING_SLUGS_BY_CANTON['TI'];
+ return slugs[locale];
+}
+
 export const JOB_OFFICIAL_GAZETTE_LANDING_SLUGS: Record<JobLandingLocale, string> = {
  it: 'foglio-ufficiale-offerte-di-lavoro-ticino',
  en: 'official-gazette-ticino-jobs',
@@ -879,7 +895,7 @@ const NURSES_HUB_COPY = makeNursesHubCopy('TI');
 // the section segment via `buildCantonAwareSection(locale, canton)`. The
 // trailing `-jobs` suffix in EN/DE is preserved for TI/GR/VS only.
 const _LEGACY_CARE_CLUSTER_CANTONS = new Set(['TI', 'GR', 'VS']);
-function careClusterSlug(key: JobCareClusterKey, cantonCode: string, locale: JobLandingLocale): string {
+export function careClusterSlug(key: JobCareClusterKey, cantonCode: string, locale: JobLandingLocale): string {
  const base: Record<JobCareClusterKey, Record<JobLandingLocale, string>> = {
  clinics: { it: 'cliniche', en: 'clinics', de: 'kliniken', fr: 'cliniques' },
  careHomes: { it: 'case-anziani', en: 'care-homes', de: 'altersheime', fr: 'maisons-retraite' },

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -54,6 +54,9 @@ import {
  buildJobPartTimeLandingModel,
  buildJobTodayLandingModel,
  getJobTodayLandingSlug,
+ getJobNursesHubSlug,
+ getJobPartTimeLandingSlug,
+ careClusterSlug,
  EDITORIAL_CANTONS,
  partitionCareClusters,
  partitionByLocation,
@@ -8017,6 +8020,173 @@ ${alternates}
      const cantonEditorialSection =
        `<section data-canton-editorial style="max-width:860px;margin:32px 0 0;color:var(--color-body);font-size:15px">${editorialHtml}</section>`;
 
+     // ── BFS-depth closure (Group A2) — "Esplora" navigator ─────────────
+     // Phase 8a introduced ~250 sub-pages per canton (city hubs, category
+     // hubs, editorial slot pages) that the canton hub did NOT link to,
+     // pushing them to BFS depth>4 from `/`. This block surfaces:
+     //   - 5-8 top city hubs           → /{section}/{citySlug}/
+     //   - up to 6 category hubs       → /{section}/{catPrefix}-{slug}/
+     //   - 4 editorial slot pages      → today / nurses / part-time / clinics
+     // Emitted BELOW the listing grid (mobile-first per #16/#17). Gated on
+     // the same MIN_JOBS threshold used by the page itself (`meetsThreshold`)
+     // so thin pages don't sprout link farms. TI is filtered out at the
+     // cantonsToEmit loop entry (`code === 'TI' continue`), so this block
+     // never affects the byte-identical TI hub owned by staticPagesPlugin.
+     let exploreSection = '';
+     if (meetsThreshold && entry.key !== AGGREGATE_KEY) {
+       const exploreSectionBase = sectionBase; // already trailing-slashed canton-aware section
+       // Top cities by job count (max 8). Normalise via shared helper so the
+       // URL matches the citySlug emitted by the city-hub block earlier in
+       // this plugin (Phase 8a). Skip empty / "—" buckets.
+       const topCityHubs: Array<{ slug: string; label: string }> = [];
+       const seenCitySlugs = new Set<string>();
+       for (const [cityRaw, count] of [...cityCounts.entries()].sort((a, b) => b[1] - a[1])) {
+         if (topCityHubs.length >= 8) break;
+         if (!cityRaw || cityRaw === '—' || count < 1) continue;
+         const slug = normalizeCitySlug(cityRaw);
+         if (!slug || seenCitySlugs.has(slug)) continue;
+         seenCitySlugs.add(slug);
+         topCityHubs.push({ slug, label: cityRaw });
+       }
+       // Top categories by job count (max 6). Mirror the category slug
+       // tables from the category-listing block (~line 5742-5752); kept
+       // inline to avoid hoisting a nested scope across thousands of lines.
+       const categorySlugMap: Record<string, Record<'it' | 'en' | 'de' | 'fr', string>> = {
+         health: { it: 'sanita', en: 'health', de: 'gesundheit', fr: 'sante' },
+         finance: { it: 'finanza', en: 'finance', de: 'finanzen', fr: 'finance' },
+         tech: { it: 'informatica', en: 'tech', de: 'technik', fr: 'tech' },
+         engineering: { it: 'ingegneria', en: 'engineering', de: 'ingenieurwesen', fr: 'ingenierie' },
+         admin: { it: 'amministrazione', en: 'admin', de: 'verwaltung', fr: 'administration' },
+         hospitality: { it: 'ristorazione', en: 'hospitality', de: 'gastgewerbe', fr: 'hotellerie' },
+         sales: { it: 'vendita', en: 'sales', de: 'vertrieb', fr: 'vente' },
+         other: { it: 'altro', en: 'other', de: 'andere', fr: 'autre' },
+       };
+       const categoryPrefixMap: Record<'it' | 'en' | 'de' | 'fr', string> = {
+         it: 'categoria', en: 'category', de: 'kategorie', fr: 'categorie',
+       };
+       const categoryLabelMap: Record<string, Record<'it' | 'en' | 'de' | 'fr', string>> = {
+         health: { it: 'Sanità', en: 'Healthcare', de: 'Gesundheit', fr: 'Santé' },
+         finance: { it: 'Finanza', en: 'Finance', de: 'Finanzen', fr: 'Finance' },
+         tech: { it: 'Informatica', en: 'Technology', de: 'Technik', fr: 'Technologie' },
+         engineering: { it: 'Ingegneria', en: 'Engineering', de: 'Ingenieurwesen', fr: 'Ingénierie' },
+         admin: { it: 'Amministrazione', en: 'Administration', de: 'Verwaltung', fr: 'Administration' },
+         hospitality: { it: 'Ristorazione', en: 'Hospitality', de: 'Gastgewerbe', fr: 'Hôtellerie' },
+         sales: { it: 'Vendita', en: 'Sales', de: 'Vertrieb', fr: 'Vente' },
+         other: { it: 'Altro', en: 'Other', de: 'Andere', fr: 'Autre' },
+       };
+       // Job `sector` field uses Italian labels in many feeds; the canonical
+       // category key is derived elsewhere via the same lowercase compare.
+       // sectorCounts keys are the raw display labels; resolve to category
+       // keys with the same lowercase Italian alias table used by the
+       // category-listing block (best-effort: only emit a link when we
+       // actually have ≥3 jobs in that bucket — the same threshold used by
+       // the category-listing emit at line 5768).
+       const sectorAlias: Record<string, string> = {
+         sanita: 'health', salute: 'health',
+         finanza: 'finance', banca: 'finance',
+         informatica: 'tech', it: 'tech', tech: 'tech',
+         ingegneria: 'engineering',
+         amministrazione: 'admin', uffici: 'admin',
+         ristorazione: 'hospitality', alberghiero: 'hospitality',
+         vendita: 'sales', commerciale: 'sales',
+       };
+       const categoryCountAggregated = new Map<string, number>();
+       for (const [secRaw, count] of sectorCounts) {
+         const norm = String(secRaw).toLowerCase().trim();
+         const catKey = sectorAlias[norm] || (Object.keys(categorySlugMap).includes(norm) ? norm : 'other');
+         categoryCountAggregated.set(catKey, (categoryCountAggregated.get(catKey) ?? 0) + count);
+       }
+       const topCategoryHubs: Array<{ slug: string; label: string }> = [];
+       for (const [catKey, count] of [...categoryCountAggregated.entries()].sort((a, b) => b[1] - a[1])) {
+         if (topCategoryHubs.length >= 6) break;
+         if (count < 3) continue; // mirror the category-listing emit gate
+         const catSlug = categorySlugMap[catKey]?.[entry.locale];
+         const catLabel = categoryLabelMap[catKey]?.[entry.locale];
+         if (!catSlug || !catLabel) continue;
+         const slug = `${categoryPrefixMap[entry.locale]}-${catSlug}`;
+         topCategoryHubs.push({ slug, label: catLabel });
+       }
+       // Editorial slot pages (Phase 8d). Non-TI cantons collapse to short
+       // slugs (`oggi` / `infermieri` / `lavoro-part-time` / `cliniche`);
+       // TI is filtered out earlier so we don't worry about its long-form
+       // legacy URLs here.
+       const editorialSlotPages: Array<{ slug: string; label: string }> = [];
+       const todayLabels: Record<CantonLocale, string> = {
+         it: 'Offerte di oggi', en: 'Jobs posted today', de: 'Heute veröffentlicht', fr: "Offres d'aujourd'hui",
+       };
+       const nursesLabels: Record<CantonLocale, string> = {
+         it: 'Lavoro per infermieri', en: 'Nursing jobs', de: 'Pflegejobs', fr: 'Emplois en soins infirmiers',
+       };
+       const partTimeLabels: Record<CantonLocale, string> = {
+         it: 'Lavoro part-time', en: 'Part-time jobs', de: 'Teilzeitstellen', fr: 'Emplois à temps partiel',
+       };
+       const clinicsLabels: Record<CantonLocale, string> = {
+         it: 'Cliniche e ospedali', en: 'Clinics & hospitals', de: 'Kliniken & Spitäler', fr: 'Cliniques et hôpitaux',
+       };
+       editorialSlotPages.push({ slug: getJobTodayLandingSlug(entry.locale, entry.key), label: todayLabels[entry.locale] });
+       editorialSlotPages.push({ slug: getJobNursesHubSlug(entry.locale, entry.key), label: nursesLabels[entry.locale] });
+       editorialSlotPages.push({ slug: getJobPartTimeLandingSlug(entry.locale, entry.key), label: partTimeLabels[entry.locale] });
+       editorialSlotPages.push({ slug: careClusterSlug('clinics', entry.key, entry.locale), label: clinicsLabels[entry.locale] });
+
+       const exploreTitle = (() => {
+         switch (entry.locale) {
+           case 'en': return `Explore more jobs in ${display}`;
+           case 'de': return `Mehr Stellen in ${display}`;
+           case 'fr': return `Plus d'offres en ${display}`;
+           default: return `Esplora più offerte in ${display}`;
+         }
+       })();
+       const colByCityLabel = entry.locale === 'en' ? 'Top cities'
+         : entry.locale === 'de' ? 'Top-Städte'
+         : entry.locale === 'fr' ? 'Villes principales'
+         : 'Città principali';
+       const colByCategoryLabel = entry.locale === 'en' ? 'Top sectors'
+         : entry.locale === 'de' ? 'Top-Branchen'
+         : entry.locale === 'fr' ? 'Secteurs principaux'
+         : 'Settori principali';
+       const colEditorialLabel = entry.locale === 'en' ? 'Featured pages'
+         : entry.locale === 'de' ? 'Empfohlene Seiten'
+         : entry.locale === 'fr' ? 'Pages à la une'
+         : 'Pagine in evidenza';
+       const linkStyle = 'display:inline-block;padding:6px 12px;margin:0 6px 6px 0;border-radius:6px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-link);text-decoration:none;font-size:14px;line-height:1.3';
+       const renderLinks = (items: Array<{ slug: string; label: string }>): string =>
+         items
+           .map((it) => `<a href="${exploreSectionBase}${it.slug}/" style="${linkStyle}">${esc(it.label)}</a>`)
+           .join('');
+       const blocks: string[] = [];
+       if (topCityHubs.length > 0) {
+         blocks.push(
+           `<div data-explore-cities style="margin:0 0 12px">` +
+           `<h3 style="font-size:15px;margin:0 0 8px;color:var(--color-heading);font-weight:600">${esc(colByCityLabel)}</h3>` +
+           `<div>${renderLinks(topCityHubs)}</div>` +
+           `</div>`,
+         );
+       }
+       if (topCategoryHubs.length > 0) {
+         blocks.push(
+           `<div data-explore-categories style="margin:0 0 12px">` +
+           `<h3 style="font-size:15px;margin:0 0 8px;color:var(--color-heading);font-weight:600">${esc(colByCategoryLabel)}</h3>` +
+           `<div>${renderLinks(topCategoryHubs)}</div>` +
+           `</div>`,
+         );
+       }
+       if (editorialSlotPages.length > 0) {
+         blocks.push(
+           `<div data-explore-editorial style="margin:0 0 12px">` +
+           `<h3 style="font-size:15px;margin:0 0 8px;color:var(--color-heading);font-weight:600">${esc(colEditorialLabel)}</h3>` +
+           `<div>${renderLinks(editorialSlotPages)}</div>` +
+           `</div>`,
+         );
+       }
+       if (blocks.length > 0) {
+         exploreSection =
+           `<section data-canton-explore style="max-width:1080px;margin:24px 0 0">` +
+           `<h2 style="font-size:20px;margin:0 0 12px;color:var(--color-heading)">${esc(exploreTitle)}</h2>` +
+           blocks.join('') +
+           `</section>`;
+       }
+     }
+
      const bodyHtml = [
        `<main class="seo-static-content" style="max-width:1080px;margin:0 auto;padding:24px 16px">`,
        `<nav style="margin:0 0 16px;font-size:14px"><a href="${BASE_URL}/" style="color:var(--color-link);text-decoration:none;font-weight:600">${esc(homeLabel[entry.locale])}</a> &rarr; <span aria-current="page">${esc(display)}</span></nav>`,
@@ -8026,6 +8196,12 @@ ${alternates}
        subPageNav,
        cantonListSection,
        listingGrid,
+       // BFS-depth closure — link Phase 8a sub-pages from the canton hub
+       // (top cities, top categories, editorial slot pages). Empty string
+       // when meetsThreshold === false or canton === AGGREGATE_KEY. Sits
+       // ABOVE the prose so internal navigation stays close to the data
+       // area; the long filler stays after.
+       exploreSection,
        // Frontaliere context prose — placed BELOW the data area per CLAUDE.md
        // non-negotiable #16/#17 (mobile-first, filler below content). Ratio
        // uplift brings text/HTML from 1.7-2.2 % to ~12 % so

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -23,13 +23,14 @@ const ALLOWLIST = [
   'build-plugins/shared/cantonSection.ts',
 
   // ── jobsSeoPagesPlugin: sectionByLocale legacy preservation (TI default) ──
-  // Lines shifted +1 by the Phase 8(g) imports added at the top of the
-  // file (HUB_JOBS_PAGE_SIZE / hubSlugFor / buildCantonHubEditorial).
-  'build-plugins/jobsSeoPagesPlugin.ts:781',
-  'build-plugins/jobsSeoPagesPlugin.ts:782',
-  'build-plugins/jobsSeoPagesPlugin.ts:783',
+  // Lines shifted +3 by the BFS-depth Explore navigator imports added at
+  // the top of the file (getJobNursesHubSlug / getJobPartTimeLandingSlug /
+  // careClusterSlug). Previous +1 shift from Phase 8(g) imports is included.
   'build-plugins/jobsSeoPagesPlugin.ts:784',
-  'build-plugins/jobsSeoPagesPlugin.ts:789',          // jsdoc reference to the legacy slugs
+  'build-plugins/jobsSeoPagesPlugin.ts:785',
+  'build-plugins/jobsSeoPagesPlugin.ts:786',
+  'build-plugins/jobsSeoPagesPlugin.ts:787',
+  'build-plugins/jobsSeoPagesPlugin.ts:792',          // jsdoc reference to the legacy slugs
 
   // ── jobBoardSeo: TI legacy job-board landing paths (kept for legacy entry) ──
   'build-plugins/jobBoardSeo.ts:38',


### PR DESCRIPTION
## Summary

Closes the Group A2 BFS-depth regression introduced by Phase 8a/d: ~250 sub-pages per non-TI canton were unreachable at depth ≤ 4 because the canton hub `/cerca-lavoro-{canton}/` did not link them.

Adds an "Esplora più offerte in {canton}" navigator in the canton-emit loop of `jobsSeoPagesPlugin.ts`, placed BELOW the listing grid (mobile-first per CLAUDE.md #16/#17) and ABOVE the long-prose filler. Three columns:

- **Top 8 city hubs** → `/{section}/{citySlug}/` (Phase 8a city pages)
- **Top 6 category hubs** → `/{section}/{categoria-X}/` (≥ 3 jobs threshold, mirrors the category-listing emit gate)
- **4 editorial slot pages** → `oggi` / `infermieri` / `lavoro-part-time` / `cliniche` (Phase 8d short-slug pages)

Gated on `meetsThreshold` (`MIN_JOBS_FOR_CANTON_PAGE`) so thin canton pages never sprout link farms. `AGGREGATE_KEY` (`/cerca-lavoro-svizzera/`) keeps its own canton-list section and skips the navigator. **TI is filtered out at `cantonsToEmit` loop entry** (`code === 'TI' continue`) so the legacy `/cerca-lavoro-ticino/` hub owned by `staticPagesPlugin` stays byte-identical — Phase 8d TI invariance test still passes.

Implementation notes:
- `export careClusterSlug` + new helpers `getJobNursesHubSlug` / `getJobPartTimeLandingSlug` in `jobEditorialLanding.ts` (mirrors the existing `getJobTodayLandingSlug` accessor pattern).
- `catSlugsMap` / `catPrefix` / `catLabels` duplicated inline in the canton-emit scope (mirrors lines 5742-5762 — kept local to avoid hoisting across a 9k-line file).
- HTML uses only semantic OKLCH tokens (`--color-edge`, `--color-link`, `--color-heading`, `--color-surface`) — no new colour values, no `dark:` prefixes.
- 4 locales (it/en/de/fr).
- `cathedral-no-ti-hardcodes` allowlist shifted +3 lines for the new imports.

## Out of scope (follow-up)

Phase 8a company×city URLs (`/cerca-lavoro-{canton}/azienda-{empKey}-{city}/`) are NOT linked from the hub here — they live in a different plugin emit path (likely `weeklyEmployersPlugin` or `companyHubBridgePlugin`). Worth a separate PR once their emit loop is audited; the `aziende/` sub-hub already linked `/azienda-{empKey}/` (without `-{city}` suffix) so the absolute count of remaining orphans is bounded.

## Test plan

- [x] `npx tsc --noEmit` clean (pre-existing `jobs.json` module errors are unrelated)
- [x] `cathedral-phase8d-ti-invariance` — 4/4 pass
- [x] `cathedral-editorial-slug-tables` — 7/7 pass
- [x] `cathedral-canton-hub-parity` — 4/4 pass
- [x] `cathedral-no-ti-hardcodes` — 5/5 pass
- [x] All `tests/seo/cathedral-*` (17 files, 107 tests) green
- [ ] CI build green
- [ ] Post-deploy: `npm run audit:max-bfs-depth` confirms ~250 URLs flipped to depth ≤ 4