### PR TITLE
fix(ci): assemble jobs.json before build in adsense-prereview

### DIFF
--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Assemble jobs dataset from per-crawler slices
+        run: node scripts/assemble-jobs-dataset.mjs --stats
+
       - name: Build
         run: npm run build:prod
 


### PR DESCRIPTION
## Summary
- `data/jobs.json` is gitignored; on fresh CI checkout, two recent build plugins (`legacyRedirectsPlugin.ts`, `shared/slugCantonIndex.ts`) fail to load via ESM static import → vite config can't be loaded → adsense-prereview daily run fails on Build step.
- Fix: assemble `data/jobs.json` from per-crawler slices before `npm run build:prod`, matching the pattern used by `deploy.yml:215-216`.

## Validation
- Triggered workflow on this branch (run 25725742454) → `conclusion: success` ✓

https://claude.ai/code/session_017B9mhGUU2GVvHk6sUgefZX