### PR TITLE
fix(article-gen): repairJson tolera separatori `***` markdown

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -3060,8 +3060,20 @@ async function translateArticle(data) {
       if (ch === '"') { inStr = !inStr; out += ch; continue; }
       if (inStr && ch === '\n') { out += '\\n'; continue; }
       if (inStr && ch === '\r') { continue; }
+      // Some models emit markdown bold markers (`**` / `***`) between JSON
+      // properties instead of commas — collapse a run of stray `*` outside
+      // strings into a single comma so the structure stays valid.
+      if (!inStr && ch === '*') {
+        while (i + 1 < c.length && c[i + 1] === '*') i++;
+        out += ',';
+        continue;
+      }
       out += ch;
     }
+    // Normalize accidental double commas introduced by the `***` → `,` swap
+    // when a comma already separated the properties, and trim trailing commas
+    // before closers.
+    out = out.replace(/,(\s*,)+/g, ',').replace(/,(\s*[}\]])/g, '$1');
     return out;
   };
 


### PR DESCRIPTION
## Summary
- Alcuni LLM (osservato su Ministral-3B, llama-3.3-70b cf) emettono `***` come separatore di proprietà JSON anziché `,`, causando `Expected ',' or '}'` su `fr:b2` dopo 2 retry → workflow generate-article fallisce.
- `repairJson` ora collassa run di `*` outside-string in una singola `,` e normalizza virgole doppie/finali. Markdown bold dentro le stringhe resta intatto.

## Test
Verificato su 4 casi sintetici (`***` come separatore, `**` prima di `}`, bold dentro stringa, `,` già presente + `***` extra): tutti parsano correttamente.

https://claude.ai/code/session_017B9mhGUU2GVvHk6sUgefZX