### PR TITLE
fix(cathedral): close 2 validate-dist gates — title-length + BFS depth

### DIFF
--- a/build-plugins/jobEditorialLanding.ts
+++ b/build-plugins/jobEditorialLanding.ts
@@ -575,7 +575,7 @@ function makeTodayCopy(cantonCode: string): Record<JobLandingLocale, {
  internalLinks: ['Neue Jobs in den letzten 24 Stunden', 'Jobs der letzten 3 Tage', `Teilzeitjobs ${germanCantonPrep(cd.de)}`],
  },
  fr: {
- title: `Offres d'emploi ${frenchCantonPrep(cd.fr)} aujourd'hui | 24h + 3 jours`,
+ title: `Emplois ${frenchCantonPrep(cd.fr)} aujourd'hui | 24h + 3 jours`,
  heading: `Offres d'emploi ${frenchCantonPrep(cd.fr)} aujourd'hui`,
  description: `Consultez les offres d'emploi ${frenchCantonPrep(cd.fr)} publiees aujourd'hui ou ces 3 derniers jours, avec blocs 24h, temps partiel et villes.`,
  intro: `Cette landing page regroupe les offres les plus recentes de notre job board ${frenchCantonPrep(cd.fr)} et les organise en blocs utiles pour lire rapidement le marche.`,
@@ -610,7 +610,7 @@ const OFFICIAL_GAZETTE_COPY: Record<JobLandingLocale, {
  faq: Array<{ question: string; answer: string }>;
 }> = {
  it: {
- title: 'Foglio ufficiale offerte di lavoro Ticino | Concorsi pubblici e fonti ufficiali',
+ title: 'Foglio ufficiale lavoro Ticino | Concorsi pubblici',
  heading: 'Foglio ufficiale offerte di lavoro Ticino',
  description: (count) => `Consulta ${count} concorsi pubblici e offerte dal Foglio ufficiale del Ticino indicizzati da Frontaliere Ticino, con spiegazione su concorsi, job board e fonti.`,
  intro: 'Questa pagina ti aiuta a distinguere tra concorsi pubblici, annunci del nostro job board e fonti ufficiali cantonali. Qui trovi soprattutto concorsi pubblici indicizzati da fonti ufficiali come concorsi.ti.ch, con link interni alle schede gia pulite e leggibili.',
@@ -652,7 +652,7 @@ const OFFICIAL_GAZETTE_COPY: Record<JobLandingLocale, {
  ],
  },
  en: {
- title: 'Official Gazette Ticino jobs | Public competitions and official sources',
+ title: 'Official Gazette Ticino jobs | Public competitions',
  heading: 'Official Gazette jobs in Ticino',
  description: (count) => `Browse ${count} public competitions and jobs from the Ticino Official Gazette indexed by Frontaliere Ticino, with public vs job board vs official sources explained.`,
  intro: 'This page helps you understand the difference between public competitions, our broader job board and official canton sources. It focuses on public-sector listings already indexed from official sources such as concorsi.ti.ch.',
@@ -694,7 +694,7 @@ const OFFICIAL_GAZETTE_COPY: Record<JobLandingLocale, {
  ],
  },
  de: {
- title: 'Amtsblatt Stellen Tessin | Offentliche Ausschreibungen und offizielle Quellen',
+ title: 'Amtsblatt Stellen Tessin | Offentliche Ausschreibungen',
  heading: 'Amtsblatt-Stellen im Tessin',
  description: (count) => `Entdecken Sie ${count} offentliche Ausschreibungen aus offiziellen Tessiner Quellen, indexiert von Frontaliere Ticino, mit Erklarung zu Wettbewerb und Quellen.`,
  intro: 'Diese Seite hilft bei der Unterscheidung zwischen offentlichen Ausschreibungen, unserem umfassenderen Job Board und offiziellen kantonalen Quellen. Im Fokus stehen bereits indexierte Ausschreibungen aus offiziellen Quellen wie concorsi.ti.ch.',
@@ -736,7 +736,7 @@ const OFFICIAL_GAZETTE_COPY: Record<JobLandingLocale, {
  ],
  },
  fr: {
- title: "Feuille officielle emplois Tessin | Concours publics et sources officielles",
+ title: "Feuille officielle emplois Tessin | Concours publics",
  heading: "Emplois de la Feuille officielle au Tessin",
  description: (count) => `Consultez ${count} concours publics et offres de sources officielles du Tessin indexes par Frontaliere Ticino, avec explication concours, job board et sources.`,
  intro: "Cette page vous aide a distinguer les concours publics, notre job board plus large et les sources officielles cantonales. Elle se concentre sur les offres publiques deja indexees depuis des sources officielles comme concorsi.ti.ch.",
@@ -796,7 +796,7 @@ function makeNursesHubCopy(cantonCode: string): Record<JobLandingLocale, {
  const cd = CANTON_DISPLAY_LOCALE[cantonCode] || CANTON_DISPLAY_LOCALE['TI'];
  return {
  it: {
- title: `Infermieri in ${cd.it} | Cliniche, case anziani, OSS ed educatori`,
+ title: `Infermieri ${cd.it} | Cliniche, case anziani e OSS`,
  heading: `Infermieri e sanita in ${cd.it}`,
  description: (count) => `Scopri ${count} offerte per infermieri, OSS, educatori e ruoli nelle cliniche o case anziani in ${cd.it}, con pagine dedicate ai cluster che convertono meglio.`,
  intro: `Questo hub raccoglie i lavori sanita e care che intercettano piu domanda: infermieri, OSS, educatori, cliniche private e case anziani. Serve per trovare piu velocemente le opportunita davvero vicine al tuo profilo.`,
@@ -818,7 +818,7 @@ function makeNursesHubCopy(cantonCode: string): Record<JobLandingLocale, {
  openAll: `Vedi tutte le offerte in ${cd.it}`,
  },
  en: {
- title: `Nurses in ${cd.en} | Clinics, care homes, healthcare assistants and educators`,
+ title: `Nurses in ${cd.en} | Clinics, care homes and OSS`,
  heading: `Nurses and healthcare jobs in ${cd.en}`,
  description: (count) => `Browse ${count} nursing, healthcare assistant, educator and clinic or care home jobs in ${cd.en}, with dedicated pages for top converting clusters.`,
  intro: 'This hub groups together the healthcare and care jobs that attract the strongest demand: nurses, healthcare assistants, educators, private clinics and care homes.',
@@ -840,7 +840,7 @@ function makeNursesHubCopy(cantonCode: string): Record<JobLandingLocale, {
  openAll: `See all jobs in ${cd.en}`,
  },
  de: {
- title: `Pflege Jobs ${germanCantonPrep(cd.de)} | Kliniken, Altersheime, OSS und Erzieher`,
+ title: `Pflege Jobs ${germanCantonPrep(cd.de)} | Kliniken & OSS`,
  heading: `Pflege- und Gesundheitsjobs ${germanCantonPrep(cd.de)}`,
  description: (count) => `Entdecken Sie ${count} Pflege-, OSS-, Erzieher- und Klinikstellen ${germanCantonPrep(cd.de)}, mit eigenen Seiten fur die relevantesten Cluster.`,
  intro: 'Dieser Hub bundelt die Gesundheits- und Care-Jobs mit hoher Nachfrage: Pflege, Betreuung, Erziehung, Kliniken und Altersheime.',
@@ -862,7 +862,7 @@ function makeNursesHubCopy(cantonCode: string): Record<JobLandingLocale, {
  openAll: `Alle Jobs ${germanCantonPrep(cd.de)} ansehen`,
  },
  fr: {
- title: `Infirmiers ${frenchCantonPrep(cd.fr)} | Cliniques, EMS, OSS et educateurs`,
+ title: `Infirmiers ${frenchCantonPrep(cd.fr)} | Cliniques & EMS`,
  heading: `Infirmiers et sante ${frenchCantonPrep(cd.fr)}`,
  description: (count) => `Consultez ${count} offres infirmiers, OSS, educateurs et cliniques ou EMS ${frenchCantonPrep(cd.fr)}, avec pages dediees aux sous-clusters performants.`,
  intro: `Ce hub regroupe les offres sante et care qui attirent le plus de demande: infirmiers, OSS, educateurs, cliniques privees et maisons de retraite.`,
@@ -1820,15 +1820,21 @@ export function buildJobCareVariantLandingModel(options: {
  const label = careClusterLabel(clusterKey, cantonCode, locale);
  const cd = CANTON_DISPLAY_LOCALE[cantonCode] || CANTON_DISPLAY_LOCALE['TI'];
  const isEducators = clusterKey === 'educators';
+ // Title: the `label` already contains the canton display + preposition
+ // (e.g. "Maisons de retraite dans le canton de Schaffhouse"). The trailing
+ // suffix MUST NOT repeat the canton — duplicating it pushed FR/EN titles
+ // past 80-104 chars and tanked the audit:title-length ratchet (Phase 8a
+ // canton expansion). Short suffix only; brand dropped by titleSuffix.ts
+ // when total exceeds the 66-char cap.
  const title = locale === 'it'
  ? isEducators
- ? `Concorso Educatore ${cd.it} | Offerte lavoro educatori`
- : `${label} | Offerte di lavoro aggiornate in ${cd.it}`
+ ? `Concorso Educatore ${cd.it} | Offerte aggiornate`
+ : `${label} | Offerte aggiornate`
  : locale === 'en'
- ? `${label} | Updated job offers in ${cd.en}`
+ ? `${label} | Updated job offers`
  : locale === 'de'
- ? `${label} | Aktuelle Jobangebote ${germanCantonPrep(cd.de)}`
- : `${label} | Offres d'emploi a jour ${frenchCantonPrep(cd.fr)}`;
+ ? `${label} | Aktuelle Jobangebote`
+ : `${label} | Offres a jour`;
  const description = locale === 'it'
  ? isEducators
  ? `Concorso educatore ${cd.it}: ${matches.length} offerte di lavoro per educatori dell'infanzia, educatrici e pedagoghi con candidature dirette.`
@@ -2140,7 +2146,7 @@ function makeSectorRegionCopy(cantonCode: string): Record<JobLandingLocale, {
  },
  fr: {
  heading: (label) => `Emplois ${label} ${frenchCantonPrep(cd.fr)}`,
- title: (label) => `Emplois ${label} ${frenchCantonPrep(cd.fr)} | Offres a jour`,
+ title: (label) => `Emplois ${label} ${frenchCantonPrep(cd.fr)}`,
  description: (label, count) => `Decouvrez ${count} offres d'emploi dans le secteur ${label.toLowerCase()} ${frenchCantonPrep(cd.fr)}. Mises a jour quotidiennement pour les frontaliers.`,
  intro: (label) => `Toutes les offres dans le secteur ${label.toLowerCase()} disponibles ${frenchCantonPrep(cd.fr)} pour les frontaliers.`,
  countsLabel: 'annonces actives',
@@ -2230,7 +2236,7 @@ function makePartTimeCopy(cantonCode: string): Record<JobLandingLocale, {
  const cd = CANTON_DISPLAY_LOCALE[cantonCode] || CANTON_DISPLAY_LOCALE['TI'];
  return {
  it: {
- title: `Lavoro part-time in ${cd.it} | Offerte a tempo parziale per frontalieri`,
+ title: `Lavoro part-time ${cd.it} | Posti flessibili frontalieri`,
  heading: `Lavoro part-time in ${cd.it}`,
  description: (count) => `Scopri ${count} offerte part-time in ${cd.it} per frontalieri. Posizioni a tempo parziale aggiornate da aziende svizzere, con filtri per citta e settore.`,
  intro: `Questa landing raccoglie tutte le offerte a tempo parziale disponibili nel Canton ${cd.it}, ideale per chi cerca flessibilita lavorativa come frontaliere. Le posizioni spaziano da contratti al 20% fino al 80% e coprono tutti i principali settori.`,
@@ -2256,7 +2262,7 @@ function makePartTimeCopy(cantonCode: string): Record<JobLandingLocale, {
  ],
  },
  en: {
- title: `Part-time jobs in ${cd.en} | Flexible positions for cross-border workers`,
+ title: `Part-time jobs in ${cd.en} | Flexible cross-border roles`,
  heading: `Part-time jobs in ${cd.en}`,
  description: (count) => `Browse ${count} part-time jobs in ${cd.en} for cross-border workers. Flexible positions updated daily, filterable by city, sector and employment percentage.`,
  intro: `This page collects all part-time positions available in Canton ${cd.en}, ideal for cross-border workers seeking flexibility. Roles range from 20% to 80% contracts across all major sectors.`,
@@ -2282,7 +2288,7 @@ function makePartTimeCopy(cantonCode: string): Record<JobLandingLocale, {
  ],
  },
  de: {
- title: `Teilzeitjobs ${germanCantonPrep(cd.de)} | Flexible Stellen fur Grenzganger`,
+ title: `Teilzeitjobs ${germanCantonPrep(cd.de)} | Flexible Stellen`,
  heading: `Teilzeitjobs ${germanCantonPrep(cd.de)}`,
  description: (count) => `Entdecken Sie ${count} Teilzeitstellen ${germanCantonPrep(cd.de)} fur Grenzganger. Flexible Positionen taglich aktualisiert, filterbar nach Stadt und Branche.`,
  intro: `Diese Seite sammelt alle Teilzeitstellen im Kanton ${cd.de}, ideal fur Grenzganger auf der Suche nach flexibler Arbeit. Die Positionen reichen von 20%- bis 80%-Vertragen in allen wichtigen Branchen.`,
@@ -2308,7 +2314,7 @@ function makePartTimeCopy(cantonCode: string): Record<JobLandingLocale, {
  ],
  },
  fr: {
- title: `Emploi temps partiel ${frenchCantonPrep(cd.fr)} | Postes flexibles pour frontaliers`,
+ title: `Temps partiel ${frenchCantonPrep(cd.fr)} | Postes flexibles`,
  heading: `Emploi temps partiel ${frenchCantonPrep(cd.fr)}`,
  description: (count) => `Consultez ${count} offres a temps partiel ${frenchCantonPrep(cd.fr)} pour frontaliers. Postes flexibles mis a jour quotidiennement, filtrables par ville et secteur.`,
  intro: `Cette page regroupe toutes les offres a temps partiel disponibles dans le canton ${cd.fr}, ideales pour les frontaliers a la recherche de flexibilite. Les postes vont de contrats a 20% jusqu'a 80% dans tous les secteurs majeurs.`,

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -8127,6 +8127,77 @@ ${alternates}
        editorialSlotPages.push({ slug: getJobNursesHubSlug(entry.locale, entry.key), label: nursesLabels[entry.locale] });
        editorialSlotPages.push({ slug: getJobPartTimeLandingSlug(entry.locale, entry.key), label: partTimeLabels[entry.locale] });
        editorialSlotPages.push({ slug: careClusterSlug('clinics', entry.key, entry.locale), label: clinicsLabels[entry.locale] });
+       // BFS-depth closure (Phase 8a follow-up — May 2026): non-cliniche care
+       // clusters (case anziani, OSS, educatori) were emitted by
+       // `buildJobCareVariantLandingModel` but unreachable from the canton
+       // hub, leaving ~250 orphan URLs in sitemap-jobs.xml. Add the 3
+       // remaining cluster slots so every care leaf is at BFS depth ≤ 3.
+       const careHomesLabels: Record<CantonLocale, string> = {
+         it: 'Case anziani', en: 'Care homes', de: 'Altersheime', fr: 'Maisons de retraite',
+       };
+       const ossLabels: Record<CantonLocale, string> = {
+         it: 'OSS e assistenza', en: 'Healthcare assistants', de: 'Pflegeassistenz', fr: 'OSS et assistance',
+       };
+       const educatorsLabels: Record<CantonLocale, string> = {
+         it: 'Educatori', en: 'Educators', de: 'Erzieher', fr: 'Educateurs',
+       };
+       editorialSlotPages.push({ slug: careClusterSlug('careHomes', entry.key, entry.locale), label: careHomesLabels[entry.locale] });
+       editorialSlotPages.push({ slug: careClusterSlug('oss', entry.key, entry.locale), label: ossLabels[entry.locale] });
+       editorialSlotPages.push({ slug: careClusterSlug('educators', entry.key, entry.locale), label: educatorsLabels[entry.locale] });
+
+       // BFS-depth closure (Phase 8a follow-up — May 2026): top company hubs
+       // (`/cerca-lavoro-{canton}/azienda-{empKey}/`) are emitted by the
+       // per-canton company-hub block (~line 6275-6400) using
+       // `canonicalCompanySlugBuild`, gated MIN_JOBS_PER_CANTON_COMPANY=3.
+       // Re-derive the slug here using the SAME `canonicalCompanySlugBuild`
+       // helper so the hrefs exactly match what's emitted. Top 6 by job
+       // count keeps the navigator focused; ties broken by slug for
+       // determinism.
+       const companyHubs: Array<{ slug: string; label: string }> = [];
+       if (entry.key !== AGGREGATE_KEY) {
+         const companyCounts = new Map<string, { name: string; count: number }>();
+         for (const j of cantonJobsAll) {
+           const jc = j as { company?: string; companyKey?: string };
+           const cSlug = canonicalCompanySlugBuild(jc.company || '', jc.companyKey);
+           if (!cSlug) continue;
+           const cur = companyCounts.get(cSlug);
+           if (cur) { cur.count++; }
+           else { companyCounts.set(cSlug, { name: String(jc.company || cSlug), count: 1 }); }
+         }
+         const sorted = [...companyCounts.entries()]
+           .filter(([, v]) => v.count >= 3) // mirror MIN_JOBS_PER_CANTON_COMPANY
+           .sort((a, b) => b[1].count - a[1].count || a[0].localeCompare(b[0]))
+           .slice(0, 6);
+         const compPrefix = companyRoutePrefix[entry.locale];
+         for (const [cSlug, v] of sorted) {
+           companyHubs.push({ slug: `${compPrefix}-${cSlug}`, label: v.name });
+         }
+       }
+
+       // BFS-depth closure (Phase 8a follow-up — May 2026): full pagination
+       // ladder. The per-canton paginated listing emit (`/cerca-lavoro-
+       // {canton}/pagina-N/`, ~line 5622) only emits when canton has
+       // ≥ 2 × JOBS_PER_LISTING_PAGE = 40 jobs and caps at MAX_LISTING_PAGES.
+       // Mirror that gate here so we only link pages that actually exist.
+       // Linking ALL pages (not just neighbours) brings every paginated leaf
+       // to BFS depth 3 from `/`.
+       const paginationLinks: Array<{ slug: string; label: string }> = [];
+       if (entry.key !== AGGREGATE_KEY) {
+         const JOBS_PER_LISTING_PAGE_NAV = 20;
+         const MAX_LISTING_PAGES_NAV = 25;
+         const cantonJobCount = cantonJobsAll.length;
+         if (cantonJobCount >= 2 * JOBS_PER_LISTING_PAGE_NAV) {
+           const paginationSlugsNav: Record<CantonLocale, string> = { it: 'pagina', en: 'page', de: 'seite', fr: 'page' };
+           const cTotalPages = Math.min(MAX_LISTING_PAGES_NAV, Math.ceil(cantonJobCount / JOBS_PER_LISTING_PAGE_NAV));
+           const pagLabel = entry.locale === 'en' || entry.locale === 'fr' ? 'p.' : entry.locale === 'de' ? 'S.' : 'p.';
+           for (let p = 2; p <= cTotalPages; p++) {
+             paginationLinks.push({
+               slug: `${paginationSlugsNav[entry.locale]}-${p}`,
+               label: `${pagLabel} ${p}`,
+             });
+           }
+         }
+       }
 
        const exploreTitle = (() => {
          switch (entry.locale) {
@@ -8148,6 +8219,14 @@ ${alternates}
          : entry.locale === 'de' ? 'Empfohlene Seiten'
          : entry.locale === 'fr' ? 'Pages à la une'
          : 'Pagine in evidenza';
+       const colCompaniesLabel = entry.locale === 'en' ? 'Top employers'
+         : entry.locale === 'de' ? 'Top-Arbeitgeber'
+         : entry.locale === 'fr' ? 'Employeurs principaux'
+         : 'Aziende che assumono';
+       const colPaginationLabel = entry.locale === 'en' ? 'Browse by page'
+         : entry.locale === 'de' ? 'Weitere Seiten'
+         : entry.locale === 'fr' ? 'Plus de pages'
+         : 'Altre pagine';
        const linkStyle = 'display:inline-block;padding:6px 12px;margin:0 6px 6px 0;border-radius:6px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-link);text-decoration:none;font-size:14px;line-height:1.3';
        const renderLinks = (items: Array<{ slug: string; label: string }>): string =>
          items
@@ -8175,6 +8254,22 @@ ${alternates}
            `<div data-explore-editorial style="margin:0 0 12px">` +
            `<h3 style="font-size:15px;margin:0 0 8px;color:var(--color-heading);font-weight:600">${esc(colEditorialLabel)}</h3>` +
            `<div>${renderLinks(editorialSlotPages)}</div>` +
+           `</div>`,
+         );
+       }
+       if (companyHubs.length > 0) {
+         blocks.push(
+           `<div data-explore-companies style="margin:0 0 12px">` +
+           `<h3 style="font-size:15px;margin:0 0 8px;color:var(--color-heading);font-weight:600">${esc(colCompaniesLabel)}</h3>` +
+           `<div>${renderLinks(companyHubs)}</div>` +
+           `</div>`,
+         );
+       }
+       if (paginationLinks.length > 0) {
+         blocks.push(
+           `<div data-explore-pagination style="margin:0 0 12px">` +
+           `<h3 style="font-size:15px;margin:0 0 8px;color:var(--color-heading);font-weight:600">${esc(colPaginationLabel)}</h3>` +
+           `<div>${renderLinks(paginationLinks)}</div>` +
            `</div>`,
          );
        }


### PR DESCRIPTION
## Summary

Phase 8a (cathedral expansion to 26 cantons) introduced canton-aware titles and sub-pages that overflowed the SEO ratchets. This PR closes **2 of 3** broken `validate-dist` gates.

### Gate 1 — `audit:title-length` (272 offenders → expected ≤25)

Worst offenders were FR care-variant titles where the canton was duplicated in both the label and the suffix:
- Before: `Maisons de retraite dans le canton de Schaffhouse | Offres d'emploi a jour dans le canton de Schaffhouse` = **104 chars**
- After: `Maisons de retraite dans le canton de Schaffhouse | Offres a jour` = **65 chars** ✓

Shortened title templates in `build-plugins/jobEditorialLanding.ts`:
- `TODAY_COPY` (FR) — drop `"Offres d'emploi"` prefix
- `NURSES_HUB_COPY` (4 locales) — collapse explainer to a short suffix
- `PART_TIME_COPY` (4 locales) — shorter functional tagline
- `CARE_VARIANT` title (4 locales) — drop the duplicate `… in/dans le canton de ${cd}` tail (label already includes it)
- `SECTOR_REGION_COPY` (FR) — drop ` | Offres a jour` suffix that pushed Hotellerie+canton over 80 chars
- `OFFICIAL_GAZETTE_COPY` (4 locales, TI-only) — trim descriptive tail

All new titles stay ≤66 chars for the worst-case canton display in each locale.

### Gate 3 — `audit:max-bfs-depth` (748 offenders → expected ≤118)

PR #123 closed depth>4 leaves for city hubs + 1 care cluster (cliniche) + categoria hubs + 3 editorial slots. Remaining orphans were:
- 3 care-cluster slots (`case-anziani`, `oss`, `educatori`) × 21 non-TI cantons × 4 locales (~250 URLs)
- Per-canton company hubs (`/cerca-lavoro-{canton}/azienda-{X}/`) for every canton×company bucket with ≥3 jobs
- Paginated listing pages (`/cerca-lavoro-{canton}/pagina-N/`)

Extended Esplora navigator in `build-plugins/jobsSeoPagesPlugin.ts` (~line 8023-8230):
1. `editorialSlotPages` now includes **all 4 care-cluster slots**, not just clinics
2. **New 'Top employers' block** — re-derives top 6 companies per canton via the same `canonicalCompanySlugBuild` used by the per-canton company-hub emit, gated on the same `MIN_JOBS_PER_CANTON_COMPANY=3` threshold so no broken hrefs
3. **New 'Browse by page' block** — full pagination ladder gated on ≥40 jobs/canton (matching the Phase 3.5 emit gate), capped at `MAX_LISTING_PAGES=25`

Placed BELOW the listing grid and ABOVE the prose per CLAUDE.md non-negotiable #16/#17 (mobile-first, filler below data, internal nav close to content).

### Gate 2 deferred — `audit:text-html-ratio` (1243 offenders → expected ≤471)

This gate needs prose additions across 5+ plugins (jobsSeoPagesPlugin canton city/category/company hubs, weeklyEmployersPlugin canton hub, careerLandings, blog article generator, jobMarketSnapshot per-canton). The scope is large and orthogonal to Gates 1+3, so splitting into a follow-up PR keeps this one reviewable.

## TI URL Invariance (CLAUDE.md non-negotiable)

The `cathedral-phase8d-ti-invariance` test only checks URL slugs, never titles. Titles for TI are allowed to change; URLs are byte-locked. Both invariants verified green.

## Test plan

- [x] `npx tsc --noEmit` — clean (pre-existing `JobBoard` / `jobs.json` errors only)
- [x] `npx vitest run tests/seo/` — **440 passed**, 22 skipped, 0 failed
- [x] `cathedral-phase8d-ti-invariance` — 4/4
- [x] `cathedral-canton-hub-parity` — 4/4
- [x] `cathedral-no-ti-hardcodes` — 5/5
- [x] `cathedral-editorial-slug-tables` — 7/7
- [x] `cathedral-previous-slug-canton` — 5/5
- [x] `title-uniqueness` — 21/21
- [ ] Deploy and confirm `audit:title-length` count drops below the spa-locale baseline of 25
- [ ] Deploy and confirm `audit:max-bfs-depth` `sitemap-jobs.xml.atDepthGtMax` drops below 118
- [ ] After verification, rebaseline both gates with `npm run audit:title-length:rebaseline` and `npm run audit:max-bfs-depth:rebaseline` in a follow-up housekeeping commit
- [ ] Follow-up PR for Gate 2 (text-html-ratio prose across 5 plugins)

## No baselines widened

Per CLAUDE.md non-negotiable #1, baselines can only DECREASE. CI will tighten them automatically after this deploy verifies the new offender counts.