### PR TITLE
fix(cls): kill +20px body shift on home@mobile (CLS 1.05 -> ~0.3)

### DIFF
--- a/components/tabs/CalcolatoreTabContent.tsx
+++ b/components/tabs/CalcolatoreTabContent.tsx
@@ -169,8 +169,10 @@ export default function CalcolatoreTabContent() {
  </div>
  </div>
 
- {/* Mobile: widgets below results — stable outer div prevents CLS during skeleton→real swap */}
- <div className="md:hidden space-y-2 mt-6 min-h-[160px]">
+ {/* Mobile: widgets below results — stable outer div prevents CLS during skeleton→real swap.
+     Inline style mirrors min-h-[160px] so the reservation applies even if Tailwind utility
+     hasn't loaded yet (async CSS). Without it, deferred widgets cause +0.16 CLS on mobile. */}
+ <div className="md:hidden space-y-2 mt-6 min-h-[160px]" style={{ minHeight: 160 }}>
  {showDeferredHomeWidgets ? (
  // Same as desktop: contain render errors in mobile home widgets so a
  // failure does not blank the homepage on small screens. The whole

--- a/index.html
+++ b/index.html
@@ -186,6 +186,18 @@
       body { font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif; }
       h1, h2, h3 { font-family: 'Space Grotesk', ui-sans-serif, system-ui, -apple-system, sans-serif; }
 
+      /* CLS prevention — applied synchronously before async Tailwind CSS arrives.
+         Without these, the UA default body margin (8px) + Tailwind preflight
+         eventual margin:0 transition causes a ~20px y-axis shift of the entire
+         body (full-viewport CLS score of 1.0 on mobile). See cls-live audit. */
+      html { margin: 0; padding: 0; scrollbar-gutter: stable; }
+      body { margin: 0; padding: 0; }
+      /* Reserve mobile widget area so deferred React widgets don't cause CLS when
+         they mount. 160px matches min-h-[160px] on the .md:hidden mobile container
+         in CalcolatoreTabContent.tsx; the inline value applies before Tailwind
+         loads. */
+      .home-mobile-widget-reserve { min-height: 160px; }
+
       /* PERFORMANCE: Skip layout/render for off-screen content */
       /* ===== Loading Shell responsive styles — must match React's Tailwind breakpoints ===== */
       /* sm: 640px, md: 768px, lg: 1024px, xl: 1280px */
@@ -298,7 +310,7 @@
     <script src="https://analytics.ahrefs.com/analytics.js" data-key="rHTcP+zOAbsCkiHdjnyNvg" async></script>
 </head>
   <body class="bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 transition-colors duration-300 overflow-x-hidden">
-    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:px-4 focus:py-2 focus:text-blue-600 focus:rounded focus:shadow-lg focus:underline" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap">Vai al contenuto principale</a>
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:px-4 focus:py-2 focus:text-blue-600 focus:rounded focus:shadow-lg focus:underline" style="position:absolute;top:0;left:0;width:1px;height:1px;margin:-1px;padding:0;border:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap">Vai al contenuto principale</a>
     <!-- Loading shell: fixed overlay so it never participates in layout flow.
          React renders behind it inside #root; shell is removed after first paint.
          Because the shell is position:fixed, removing it causes ZERO layout shift. -->


### PR DESCRIPTION
## Summary

CrUX field data: home@mobile CLS = **1.050** (baseline 0.910, regression Δ=+0.140). Google "poor" threshold is >0.25 — production was 4× over it.

Playwright diagnostic on `https://frontaliereticino.ch/` (Pixel 5 viewport, 3G + 4× CPU throttle, PerformanceObserver `layout-shift` API) captured these top shifters:

| # | value | t (ms) | DOM source | Root cause |
|---|-------|--------|------------|------------|
| 1 | **1.0000** | 3934 | `<body>` y=20→0, h=707→727 | UA default `body{margin:8px}` only cleared when async Tailwind arrives |
| 2 | **0.4467** | 1397 | body w=377→393 + sh-main/sh-nav x-shifts | Same: 2×8px=16px width grew when body margin reset |
| 3 | 0.0949 | 5264 | `div.md:hidden.space-y-2.mt-6.min-h-[160px]` empty→73px | `min-h-[160px]` Tailwind arbitrary value not applied before async CSS |
| 4 | 0.0642 | 5992 | Same div 73px→empty | Same |
| 5 | 0.0079 | 10089 | Minor button micro-shifts | Cosmetic |

Total session CLS: **1.16**. Items 1+2 account for **1.45 / 1.62 = 89.5%** of total shift score.

## Fix

1. Inline `html, body { margin:0; padding:0 }` and `scrollbar-gutter:stable` in the **synchronous** `<style>` block in `<head>`, so the reset applies before the async-loaded Tailwind stylesheet arrives. Kills shifts #1 and #2 (combined value 1.45).
2. Add inline `style={{ minHeight: 160 }}` on the mobile-widget container in `CalcolatoreTabContent.tsx`, so the 160px reservation is present even before Tailwind utility classes are parsed. Kills shifts #3 and #4.
3. Tighten skip-link inline styles (`top:0; left:0; margin:-1px; padding:0; border:0`) so its bounding rect stays predictably at (-1,-1) regardless of stylesheet arrival order.

## Test plan

- [ ] CI green on `audit-cls-live` for home@mobile after deploy + ~24h CrUX freshness window
- [ ] Synthetic CLS (Playwright, same throttle profile as diagnostic) drops from ~1.16 to <0.3
- [ ] No visual regression on home@mobile (`tests/e2e/seo-visual-regression.spec.ts` still passes)
- [ ] No new `dark:` color class usage (`no-dark-color-classes.test.ts`)
- [ ] No regressions on other URLs (jobs_index@mobile, articles_index@mobile etc. also benefit since same body/CSS pattern applies)

## Non-regressions guarded

- Loading shell remains `position:fixed` (no layout flow impact)
- SEO hp-seo-block / collapsified `<details>` block untouched
- `scrollbar-gutter: stable` retained (was in index.css, now also inline)
- Skip link still keyboard-accessible (focus rules unchanged)