### PR TITLE
fix(cathedral): close spa-locale text-to-html offenders (PR2/4)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -4073,7 +4073,7 @@ ${alternates}
  <h2 style="margin:0 0 14px;font-size:24px">${esc(model.sections.partTime.label)}</h2>
  ${renderJobList(model.sections.partTime.jobs)}
  </section>
- ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true }))}
+ ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true, cantonDisplay: CANTON_DISPLAY[editorialCanton] || editorialCanton, cantonSlot: 'editorial-today' }))}
  </main>
  <div id="footer-root"></div>${hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
  </body>
@@ -4396,7 +4396,7 @@ ${alternates}
  <h2 style="margin:0 0 14px;font-size:24px">${locale === 'it' ? 'Domande frequenti' : locale === 'en' ? 'Frequently asked questions' : locale === 'de' ? 'Haufige Fragen' : 'Questions frequentes'}</h2>
  <div style="display:grid;gap:12px">${faqHtml}</div>
  </section>
- ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true }))}
+ ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true, cantonDisplay: CANTON_DISPLAY[editorialCanton] || editorialCanton, cantonSlot: 'editorial-nursing' }))}
  </main>
  <div id="footer-root"></div>${hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
  </body>
@@ -4568,7 +4568,7 @@ ${alternates}
  <h2 style="margin:0 0 14px;font-size:24px">${locale === 'it' ? 'Domande frequenti' : locale === 'en' ? 'Frequently asked questions' : locale === 'de' ? 'Haufige Fragen' : 'Questions frequentes'}</h2>
  <div style="display:grid;gap:12px">${faqHtml}</div>
  </section>
- ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true }))}
+ ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true, cantonDisplay: CANTON_DISPLAY[editorialCanton] || editorialCanton, cantonSlot: 'editorial-part-time' }))}
  </main>
  <div id="footer-root"></div>${hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
  </body>
@@ -4733,7 +4733,7 @@ ${alternates}
  <h2 style="margin:0 0 14px;font-size:24px">${esc(locale === 'it' ? 'Altri percorsi sanitari' : locale === 'en' ? 'Other care paths' : locale === 'de' ? 'Weitere Pflegepfade' : 'Autres parcours sante')}</h2>
  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px">${siblingLinks}</div>
  </section>
- ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true, sectorOrType: locale === 'it' ? 'sanità' : locale === 'en' ? 'healthcare' : locale === 'de' ? 'Gesundheitswesen' : 'santé' }))}
+ ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: CANTON_DISPLAY[editorialCanton] || editorialCanton, omitCommute: true, sectorOrType: locale === 'it' ? 'sanità' : locale === 'en' ? 'healthcare' : locale === 'de' ? 'Gesundheitswesen' : 'santé', cantonDisplay: CANTON_DISPLAY[editorialCanton] || editorialCanton, cantonSlot: 'editorial-clinics' }))}
  </main>
  <div id="footer-root"></div>${hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
  </body>

--- a/build-plugins/shared/jobBoardCommuterContext.ts
+++ b/build-plugins/shared/jobBoardCommuterContext.ts
@@ -29,6 +29,11 @@
  *  - Cross-references to calculator / FX / health-insurance comparator
  */
 
+import {
+  renderCantonSeoProse,
+  type CantonSeoSlot,
+} from './cantonSeoProse';
+
 export type CommuterLocale = 'it' | 'en' | 'de' | 'fr';
 
 interface CityCommuteRow {
@@ -378,6 +383,48 @@ export interface JobBoardCommuterContextOpts {
   sectorOrType?: string | null;
   /** When true, omits the commute table (used for non-city pages like "today"). */
   omitCommute?: boolean;
+  /**
+   * Optional canton display name (e.g. 'Zurigo', 'Vallese', 'Argovia'). When
+   * provided AND the canton is NOT Ticino, the helper appends a second
+   * canton-aware prose block via `renderCantonSeoProse`, lifting the visible
+   * text by ~5 KB on the heavy non-TI editorial host pages (find-jobs-{canton}/
+   * today, /nurses, /clinics, /part-time) that otherwise tripped Semrush's
+   * 10 % text-to-HTML threshold. For TI the legacy commuter block is enough
+   * and adding the canton block would shift TI HTML — non-TI only.
+   */
+  cantonDisplay?: string | null;
+  /**
+   * Editorial slot label, used to pick the right canton-prose flavour. Only
+   * read when `cantonDisplay` is set. Defaults to `'canton-hub'` for safety.
+   */
+  cantonSlot?: CantonSeoSlot | null;
+}
+
+// Memo cache for the appended canton-prose block. Each non-TI editorial page
+// re-emits the same (canton × locale × slot) combination identically, so
+// caching avoids ~400 redundant string builds across the build. Key fields
+// are the only inputs that drive the helper output.
+const cantonProseCache = new Map<string, string>();
+
+function getCantonProseBlock(
+  locale: CommuterLocale,
+  cantonDisplay: string,
+  slot: CantonSeoSlot,
+): string {
+  const key = `${locale}::${cantonDisplay}::${slot}`;
+  const cached = cantonProseCache.get(key);
+  if (cached !== undefined) return cached;
+  const html = renderCantonSeoProse({
+    locale,
+    cantonDisplay,
+    slot,
+    entityName: null,
+    countHint: null,
+    ctaHref: null,
+    ctaLabel: null,
+  });
+  cantonProseCache.set(key, html);
+  return html;
 }
 
 /**
@@ -396,7 +443,14 @@ export interface JobBoardCommuterContextOpts {
 export function renderJobBoardCommuterContext(
   opts: JobBoardCommuterContextOpts,
 ): string {
-  const { locale, location, sectorOrType = null, omitCommute = false } = opts;
+  const {
+    locale,
+    location,
+    sectorOrType = null,
+    omitCommute = false,
+    cantonDisplay = null,
+    cantonSlot = null,
+  } = opts;
   const row = omitCommute ? null : resolveCommuteRow(location);
   const copy = COPY[locale];
 
@@ -421,6 +475,22 @@ export function renderJobBoardCommuterContext(
     )
     .join('');
 
+  // Optional canton-aware prose appended ONLY for non-TI canton editorial
+  // pages. Adds ~5 KB of canton-specific intro/methodology/permit/FAQ/links
+  // so the heavy host page (~95-145 KB) clears the 10 % Semrush text/HTML
+  // gate that the legacy block alone could not reach for non-TI cantons.
+  // TI keeps its byte-identical output (HARD INVARIANT per CLAUDE.md
+  // non-negotiables #1, #5, #6).
+  let cantonBlock = '';
+  if (cantonDisplay && cantonDisplay.trim()) {
+    const displayLower = cantonDisplay.trim().toLowerCase();
+    const isTicino = displayLower === 'ticino' || displayLower === 'tessin';
+    if (!isTicino) {
+      const slot: CantonSeoSlot = cantonSlot || 'canton-hub';
+      cantonBlock = getCantonProseBlock(locale, cantonDisplay.trim(), slot);
+    }
+  }
+
   return `<section class="job-board-commuter-context" style="max-width:860px;margin:32px auto 0;color:var(--color-body);line-height:1.65;font-size:15px">
   <h2 style="font-size:22px;font-weight:700;color:var(--color-heading);margin:24px 0 12px">${escAttr(copy.methodologyH)}</h2>
   <p style="margin:0 0 14px">${copy.methodology}</p>
@@ -433,6 +503,7 @@ export function renderJobBoardCommuterContext(
   ${faqHtml}
   <h2 style="font-size:20px;font-weight:700;color:var(--color-heading);margin:24px 0 12px">${escAttr(copy.ctaH)}</h2>
   <p style="margin:0 0 14px">${crossLinks}</p>
+${cantonBlock}
 </section>`;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #129. Closes the **spa-locale** offender group (~441 pages, the
biggest of the 4 remaining groups) on the `audit:text-html-ratio` Semrush
gate by appending memoized canton-aware prose to the non-TI canton editorial
emit sites.

## What changed

- **`build-plugins/shared/jobBoardCommuterContext.ts`** — extends the helper
  with `cantonDisplay?: string | null` + `cantonSlot?: CantonSeoSlot | null`
  parameters. When `cantonDisplay` is set AND it's NOT Ticino, the helper
  appends a memoized `renderCantonSeoProse` block (~5 KB visible text per
  call). Map cache keyed by `locale::canton::slot` avoids ~400 redundant
  renders per build.
- **`build-plugins/jobsSeoPagesPlugin.ts`** — 4 editorial emit sites now pass
  the new params:
  - editorial-jobs-today → `cantonSlot: 'editorial-today'`
  - editorial-nurses → `cantonSlot: 'editorial-nursing'`
  - editorial-parttime → `cantonSlot: 'editorial-part-time'`
  - editorial-care-variant → `cantonSlot: 'editorial-clinics'`

## TI HARD INVARIANT preserved

The helper checks `displayLower === 'ticino' || displayLower === 'tessin'`
case-insensitively. TI emits remain byte-identical (cathedral-phase8d-ti-invariance
test still passes).

## Expected gate impact

spa-locale offenders: ~451 → ~10 (≈ -441 / 98 %). Total gate offenders should
drop from ~1243 (last seen on this group) back below the 471 baseline.

## Follow-ups (not in this PR — declared as PR3)

- **job-board (+61)**: TI section per-job detail thin templates
- **blog (+15)**: short articles + hub index
- **fuel-daily (+7)**: IT-cities index + new stations

## Test plan

- [x] `npx tsc --noEmit` — only pre-existing errors (data/jobs.json gitignored, unrelated JobBoard.tsx)
- [x] `npx vitest run tests/seo/canton-seo-prose tests/seo/job-board-text-ratio-regression tests/seo/cathedral-phase8d-ti-invariance tests/seo/cathedral-canton-hub-parity tests/seo/cathedral-no-ti-hardcodes` → 59 passed
- [x] `npx vitest run tests/seo/` → 480 passed, 22 skipped, 0 failed
- [x] `npx vitest run tests/build-plugins/ tests/services/` → 146 passed
- [ ] Live deploy: confirm spa-locale offender count drops in post-deploy audit