### PR TITLE
fix(cathedral): close spa-locale text-to-html offenders — EN/DE/FR canton prose

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -5468,7 +5468,7 @@ ${alternates}
  if (locale === 'de') return `<p>Derzeit sind <strong>${cityJobs.length} Stellenangebote</strong> in ${esc(cityDisplay)} (Kanton ${esc(cDisplay)}) verfügbar. Die Anzeigen werden täglich von unserem automatischen Crawler aktualisiert. Für Grenzgänger mit G-Bewilligung erhebt der Kanton ${esc(cDisplay)} eine Quellensteuer auf das Bruttoeinkommen: nutzen Sie unseren <a href="${BASE_URL}/de/">kostenlosen Steuersimulator</a>.</p>`;
  return `<p>${cityJobs.length} <strong>offres d'emploi</strong> sont actuellement disponibles à ${esc(cityDisplay)} (Canton de ${esc(cDisplay)}). Les annonces sont mises à jour quotidiennement. Pour les frontaliers avec un permis G, le Canton de ${esc(cDisplay)} applique un impôt à la source sur le revenu brut : utilisez notre <a href="${BASE_URL}/fr/">simulateur fiscal gratuit</a>.</p>`;
  })();
- const bodyHtml = `<h1>${esc(cityHubSeo.h1)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(backLabel)}</a></p>\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay }))}`;
+ const bodyHtml = `<h1>${esc(cityHubSeo.h1)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(backLabel)}</a></p>\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'city-landing', cantonEntityName: cityDisplay }))}`;
  const html = buildSimplePage({
  locale,
  title: pageTitle,
@@ -5716,7 +5716,7 @@ ${alternates}
  jsonLdScripts: [pgCollLd, pgItemLd, pgBreadcrumbLd],
  entryJs: hasSpaBundle ? entryJs : undefined,
  entryCss: hasSpaBundle ? entryCss : undefined,
- bodyHtml: `<h1>${esc(pgHeading)}</h1>\n <p>${esc(pgDesc)}</p>\n <ul style="list-style:none;padding:0;margin:16px 0">${pgListHtml}</ul>\n <nav style="margin:24px 0;text-align:center;font-size:14px">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true }))}`,
+ bodyHtml: `<h1>${esc(pgHeading)}</h1>\n <p>${esc(pgDesc)}</p>\n <ul style="list-style:none;padding:0;margin:16px 0">${pgListHtml}</ul>\n <nav style="margin:24px 0;text-align:center;font-size:14px">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, cantonDisplay: cDisplay, cantonSlot: 'canton-hub' }))}`,
  });
  const pgOutDir = np.join(distDir, pgCanonicalPath.slice(1));
  activeJobDirs.add(pgCanonicalPath.slice(1).replace(/\/+$/, ''));
@@ -6004,7 +6004,7 @@ ${alternates}
  title: catTitle,
  };
  const catH1 = formatSeoH1(catLocaleParts) + (catPage > 1 ? (locale === 'it' ? ` — Pagina ${catPage}` : locale === 'de' ? ` — Seite ${catPage}` : locale === 'fr' ? ` — Page ${catPage}` : ` — Page ${catPage}`) : '');
- return `<h1>${esc(catH1)}</h1>\n <p>${esc(catDescription)}</p>\n ${catIntro}\n <ul style="list-style:none;padding:0;margin:16px 0">${catListHtml}</ul>\n <p><a href="${catSectionUrl}">${esc(catOpenAllLabel)}</a></p>\n ${catMarketSection}\n <nav style="margin:20px 0;font-size:14px">${catNavLabel}: ${catOtherLinks.join(' · ')}</nav>\n ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: catLabel }))}`;
+ return `<h1>${esc(catH1)}</h1>\n <p>${esc(catDescription)}</p>\n ${catIntro}\n <ul style="list-style:none;padding:0;margin:16px 0">${catListHtml}</ul>\n <p><a href="${catSectionUrl}">${esc(catOpenAllLabel)}</a></p>\n ${catMarketSection}\n <nav style="margin:20px 0;font-size:14px">${catNavLabel}: ${catOtherLinks.join(' · ')}</nav>\n ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: catLabel, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
  })(),
  });
  const catOutDir = np.join(distDir, catCanonicalPath.slice(1));
@@ -6173,7 +6173,7 @@ ${alternates}
  })();
  const openAllLabel = locale === 'it' ? `Apri tutte le offerte in ${cDisplay}` : locale === 'en' ? `View all jobs in ${cDisplay}` : locale === 'de' ? `Alle Stellen ${cDisplay}` : `Voir toutes les offres à ${cDisplay}`;
  const listHtml = cappedJobs.map((job: any) => renderJobCardLi(job, locale)).join('');
- const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: sectorDisplay }))}`;
+ const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: sectorDisplay, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
  const html = buildSimplePage({
  locale,
  title: pageTitle,
@@ -6386,7 +6386,7 @@ ${alternates}
  return `<section style="margin-top:20px"><h2>Travailler chez ${esc(companyName)} à ${esc(cDisplay)}</h2><p>${esc(companyName)} fait partie des entreprises qui recrutent à ${esc(cDisplay)}. Pour les frontaliers avec un permis G, la Suisse applique un impôt à la source. Utilisez notre <a href="${BASE_URL}/fr/">simulateur fiscal gratuit</a>.</p></section>`;
  })();
  const openAllLabel = locale === 'it' ? `Apri tutte le offerte in ${cDisplay}` : locale === 'en' ? `View all jobs in ${cDisplay}` : locale === 'de' ? `Alle Stellen ${cDisplay}` : `Voir toutes les offres à ${cDisplay}`;
- const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true }))}`;
+ const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, cantonDisplay: cDisplay, cantonSlot: 'company-landing', cantonEntityName: companyName }))}`;
  const html = buildSimplePage({
  locale,
  title: pageTitle,
@@ -6592,7 +6592,7 @@ ${alternates}
  return `<p>${ccJobs.length} <strong>offres d'emploi</strong> sont actuellement disponibles chez ${esc(companyName)} à ${esc(cityDisplay)} (Canton de ${esc(cDisplay)}). Mises à jour quotidiennement.</p>`;
  })();
  const openAllLabel = locale === 'it' ? `Vedi tutte le offerte presso ${companyName}` : locale === 'en' ? `View all jobs at ${companyName}` : locale === 'de' ? `Alle Stellen bei ${companyName}` : `Voir toutes les offres chez ${companyName}`;
- const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${companyHubUrl}">${esc(openAllLabel)}</a></p>\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay }))}`;
+ const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${companyHubUrl}">${esc(openAllLabel)}</a></p>\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'company-landing', cantonEntityName: `${companyName} — ${cityDisplay}` }))}`;
  const html = buildSimplePage({
  locale,
  title: pageTitle,

--- a/build-plugins/shared/jobBoardCommuterContext.ts
+++ b/build-plugins/shared/jobBoardCommuterContext.ts
@@ -398,11 +398,19 @@ export interface JobBoardCommuterContextOpts {
    * read when `cantonDisplay` is set. Defaults to `'canton-hub'` for safety.
    */
   cantonSlot?: CantonSeoSlot | null;
+  /**
+   * Optional entity name (city display for `city-landing`, company name for
+   * `company-landing`). When set, the canton prose helper substitutes the
+   * entity into its intro + FAQ wording, making per-page strings unique and
+   * avoiding cross-page boilerplate duplication. Only read when
+   * `cantonDisplay` is set AND `cantonSlot` is an entity-aware slot.
+   */
+  cantonEntityName?: string | null;
 }
 
 // Memo cache for the appended canton-prose block. Each non-TI editorial page
-// re-emits the same (canton × locale × slot) combination identically, so
-// caching avoids ~400 redundant string builds across the build. Key fields
+// re-emits the same (canton × locale × slot × entity) combination identically,
+// so caching avoids ~400 redundant string builds across the build. Key fields
 // are the only inputs that drive the helper output.
 const cantonProseCache = new Map<string, string>();
 
@@ -410,15 +418,17 @@ function getCantonProseBlock(
   locale: CommuterLocale,
   cantonDisplay: string,
   slot: CantonSeoSlot,
+  entityName: string | null,
 ): string {
-  const key = `${locale}::${cantonDisplay}::${slot}`;
+  const entityKey = entityName ? entityName.trim() : '';
+  const key = `${locale}::${cantonDisplay}::${slot}::${entityKey}`;
   const cached = cantonProseCache.get(key);
   if (cached !== undefined) return cached;
   const html = renderCantonSeoProse({
     locale,
     cantonDisplay,
     slot,
-    entityName: null,
+    entityName: entityKey || null,
     countHint: null,
     ctaHref: null,
     ctaLabel: null,
@@ -450,6 +460,7 @@ export function renderJobBoardCommuterContext(
     omitCommute = false,
     cantonDisplay = null,
     cantonSlot = null,
+    cantonEntityName = null,
   } = opts;
   const row = omitCommute ? null : resolveCommuteRow(location);
   const copy = COPY[locale];
@@ -487,7 +498,12 @@ export function renderJobBoardCommuterContext(
     const isTicino = displayLower === 'ticino' || displayLower === 'tessin';
     if (!isTicino) {
       const slot: CantonSeoSlot = cantonSlot || 'canton-hub';
-      cantonBlock = getCantonProseBlock(locale, cantonDisplay.trim(), slot);
+      cantonBlock = getCantonProseBlock(
+        locale,
+        cantonDisplay.trim(),
+        slot,
+        cantonEntityName,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

The `audit:text-html-ratio` gate was failing on `validate-dist` run 25739076601 with **798 offenders vs baseline 471** (+327 regression). The bulk was in `spa-locale` (368 vs baseline 10, +358) — almost entirely non-TI canton pages emitted by `jobsSeoPagesPlugin.ts` for the EN/DE/FR locales.

PR #130 had introduced canton-aware SEO prose on 4 editorial slots (today/nursing/clinics/part-time). The same plugin emits 6 other family of per-canton pages (city/paginated/category/sector/company/company×city) for the 23 non-TI cantons across all 4 locales — those never received the prose hook.

## What changed

- `build-plugins/jobsSeoPagesPlugin.ts` — added `cantonDisplay` + `cantonSlot` + (where relevant) `cantonEntityName` arguments to the 6 untouched `renderJobBoardCommuterContext` call sites. Each is guarded by an `if (canton === 'TI') continue` upstream, so TI output stays byte-identical (CLAUDE.md non-negotiable invariant #1, #5, #6).
- `build-plugins/shared/jobBoardCommuterContext.ts` — extended the helper with a `cantonEntityName` opt forwarded to `renderCantonSeoProse`. Memo-cache key is extended to `locale::canton::slot::entity` so company/city pages get entity-aware copy without losing the per-build cache benefit.

## Why this passes the non-negotiable rules

- **No baseline widened.** Local clean build now reports `ratchet OK: 103 offenders ≤ baseline 471 (−368)` — audit exits 0.
- **No `noindex` toggled.** Real cross-border-relevant content (methodology, Permit G context, fiscal regime, 4-FAQ, cross-tool links) is appended **below** the data area — never above the mobile fold.
- **No threshold lowered.** `scripts/audit-text-html-ratio.mjs` stays at 10 %.
- **TI invariance preserved.** Helper still guards `displayLower === 'ticino' || 'tessin'`, and the 6 patched call sites are all inside non-TI loop bodies.

## Local audit before/after

| Bucket | Before (CI 25739076601) | After (local clean build) | Baseline |
|---|---|---|---|
| spa-locale | 368 | 3 | 10 |
| spa-other  | 115 | 32 | 62 |
| job-board  | 250 | 65 | 328 |
| **Total**  | **798** | **103** | **471** |

## Test plan

- [x] `npx tsc --noEmit` clean for both modified files (only pre-existing JobBoard.tsx errors remain on main)
- [x] `npx vitest run tests/seo/canton-seo-prose tests/seo/cathedral-phase8d-ti-invariance tests/seo/cathedral-canton-hub-parity tests/seo/bridge-page-prose tests/seo/job-board-text-ratio-regression` → 59/59 pass
- [x] Full local audit: `node scripts/audit-text-html-ratio.mjs --baseline=data/text-html-ratio-baseline.json` exits 0
- [ ] CI validate-dist passes the text-to-html-ratio gate on a real (production-sized) dist with all 26 cantons populated
- [ ] BFS-depth audit still passes (separate concern, being handled in another worktree)

## Out of scope

- The 4 failing tests (`cathedral-job-detail-canton`, `cathedral-sector-hubs`, `cathedral-sitemap-emit-consistency`) are pre-existing fixture-data failures on `main` — verified by stashing this diff and re-running. Unrelated to this change.
- The `find-jobs-{canton}/sectors/`, `/companies/`, `/all/` index pages emitted by `seoHubsPlugin` already use `renderCantonSeoProse` (since PR #129). Those weren't part of the regression CI flagged.
- The few `clinics-{canton}-jobs/` pages at 9.94-10.00 % (already using `editorial-clinics` prose) are right at the threshold — within baseline tolerance.

Do **not** merge — leave for review.