### PR TITLE
fix(seo): add deep-dive prose to non-TI canton 'today' landings — text/HTML ratio

### DIFF
--- a/build-plugins/shared/cantonSeoProse.ts
+++ b/build-plugins/shared/cantonSeoProse.ts
@@ -343,6 +343,8 @@ export function renderCantonSeoProse(opts: CantonSeoProseOpts): string {
     )
     .join('');
 
+  const deepDive = buildDeepDiveBlock(opts);
+
   return `<section class="canton-seo-prose" data-slot="${esc(opts.slot)}" data-canton="${esc(opts.cantonDisplay)}" style="max-width:860px;margin:32px auto 0;color:var(--color-body);line-height:1.65;font-size:15px">
   <h2 style="font-size:20px;font-weight:700;color:var(--color-heading);margin:24px 0 12px">${esc(copy.blockHeading)}</h2>
   <p style="margin:0 0 14px">${copy.intro}</p>
@@ -350,9 +352,212 @@ export function renderCantonSeoProse(opts: CantonSeoProseOpts): string {
   <p style="margin:0 0 14px;color:var(--color-body);font-size:14.5px"><strong>${esc(locale === 'it' ? 'Permesso G + fiscalità.' : locale === 'en' ? 'G permit + tax context.' : locale === 'de' ? 'G-Bewilligung + Steuern.' : 'Permis G + fiscalité.')}</strong> ${copy.permitContext}</p>
   <h3 style="font-size:17px;font-weight:700;color:var(--color-heading);margin:22px 0 8px">${esc(copy.faqHeading)}</h3>
   ${faqHtml}
+  ${deepDive}
   <p style="margin:18px 0 0;font-size:14.5px"><strong>${esc(locale === 'it' ? 'Strumenti collegati.' : locale === 'en' ? 'Related tools.' : locale === 'de' ? 'Verwandte Tools.' : 'Outils associés.')}</strong> ${copy.crossLinks}</p>
   ${cta}
 </section>`;
+}
+
+/**
+ * Border-distance band for a Swiss canton seen from the typical Italian
+ * frontaliere feeder cities (Como, Varese, Verbano-Cusio-Ossola, Aosta).
+ * Drives the commute strategy paragraph below: daily-reachable cantons
+ * get one playbook (carpool / TILO / car), weekly cantons get another
+ * (settimana/Wochenaufenthalt strategy, accommodation rental, 4-day
+ * commute models). The classification is intentionally coarse — finer
+ * granularity (city-level) lives in jobBoardCommuterContext.ts.
+ */
+type CantonDistanceBand = 'border-daily' | 'near-mixed' | 'far-weekly';
+
+/**
+ * Coarse distance band for canton display names. We accept both Italian
+ * and German display variants ("Ticino"/"Tessin", "Vallese"/"Wallis"…)
+ * because the helper is called with the localised display form. Unknown
+ * cantons fall through to `near-mixed` — a balanced default that gives
+ * a plausible playbook (mix of daily commute + weekly accommodation)
+ * without making up false distance numbers.
+ */
+function cantonDistanceBand(cantonDisplay: string): CantonDistanceBand {
+  const c = cantonDisplay.trim().toLowerCase();
+  // Border-daily cantons reachable from CO/VA/VB/AO in <90 min by car or train.
+  if (
+    c === 'ticino' || c === 'tessin' ||
+    c === 'grigioni' || c === 'grisons' || c === 'graubünden' || c === 'graubunden' || c === 'grischun' ||
+    c === 'vallese' || c === 'wallis' || c === 'valais' ||
+    c === 'ginevra' || c === 'geneva' || c === 'genf' || c === 'genève' || c === 'geneve'
+  ) {
+    return 'border-daily';
+  }
+  // Near-mixed: 90-150 min — daily possible but weekly hotel/Wochenaufenthalt
+  // is common, especially in winter.
+  if (
+    c === 'vaud' || c === 'waadt' ||
+    c === 'friburgo' || c === 'fribourg' || c === 'freiburg' ||
+    c === 'neuchâtel' || c === 'neuchatel' || c === 'neuenburg' ||
+    c === 'giura' || c === 'jura' ||
+    c === 'soletta' || c === 'solothurn' || c === 'soleure' ||
+    c === 'berna' || c === 'bern' || c === 'berne' ||
+    c === 'lucerna' || c === 'luzern' || c === 'lucerne' ||
+    c === 'nidvaldo' || c === 'nidwalden' || c === 'nidwald' ||
+    c === 'obvaldo' || c === 'obwalden' || c === 'obwald' ||
+    c === 'uri' ||
+    c === 'svitto' || c === 'schwyz' ||
+    c === 'argovia' || c === 'aargau' || c === 'argovie' ||
+    c === 'basilea-campagna' || c === 'basilea campagna' || c === 'basel-landschaft' || c === 'bâle-campagne' || c === 'basel landschaft'
+  ) {
+    return 'near-mixed';
+  }
+  // Far-weekly: 150+ min — Wochenaufenthalt is the realistic model for
+  // most Italian-feeder commuters. Includes the eastern + northern
+  // cantons (Zurigo cluster, Sciaffusa, San Gallo, Turgovia, Appenzello,
+  // Basilea Città, Glarona, Zugo).
+  return 'far-weekly';
+}
+
+/**
+ * Render the deep-dive prose appended after the FAQ block. The block adds
+ * ~3-4 KB of visible text covering: application playbook, commute /
+ * accommodation strategy, sector outlook in the canton, and a worked
+ * net-pay-vs-Italian-gross scenario. The text is parameterised by canton
+ * display name and distance band, so two different cantons emit different
+ * prose and Google's cross-page duplicate-content heuristic stays happy.
+ *
+ * The deep-dive is locale-aware and renders only in the four supported
+ * locales (it / en / de / fr). It is pure: identical inputs return the
+ * same HTML, so determinism + snapshot tests still pass.
+ */
+function buildDeepDiveBlock(opts: CantonSeoProseOpts): string {
+  const { locale, cantonDisplay } = opts;
+  const canton = cantonDisplay.trim();
+  const band = cantonDistanceBand(canton);
+
+  const headings = (() => {
+    if (locale === 'it') {
+      return {
+        section: `Strategie pratiche per candidarsi nel Canton ${canton}`,
+        playbook: 'Playbook di candidatura passo dopo passo',
+        commute: 'Pendolarismo e logistica settimanale',
+        sectors: 'Settori che assumono e mercato del lavoro',
+        netpay: 'Lordo CHF, netto reale e confronto con l\'Italia',
+      };
+    }
+    if (locale === 'en') {
+      return {
+        section: `Practical strategies for applying in Canton ${canton}`,
+        playbook: 'Step-by-step application playbook',
+        commute: 'Commute and weekly logistics',
+        sectors: 'Sectors hiring and labour-market picture',
+        netpay: 'CHF gross, real net and Italian comparison',
+      };
+    }
+    if (locale === 'de') {
+      return {
+        section: `Praktische Strategien für eine Bewerbung im Kanton ${canton}`,
+        playbook: 'Bewerbungs-Playbook Schritt für Schritt',
+        commute: 'Pendeln und Wochenlogistik',
+        sectors: 'Stark einstellende Branchen und Arbeitsmarkt',
+        netpay: 'CHF-Brutto, reales Netto und Vergleich mit Italien',
+      };
+    }
+    return {
+      section: `Stratégies pratiques pour candidater dans le canton ${canton}`,
+      playbook: 'Playbook de candidature pas à pas',
+      commute: 'Trajet et logistique hebdomadaire',
+      sectors: 'Secteurs qui recrutent et marché du travail',
+      netpay: 'Brut CHF, net réel et comparaison italienne',
+    };
+  })();
+
+  // Application playbook — same 5 steps in every locale but each step is
+  // rewritten with canton-specific anchors so the prose isn't boilerplate.
+  const playbookP = (() => {
+    if (locale === 'it') {
+      return `Per il frontaliere italiano che si candida nel Canton ${canton} il percorso utile è in cinque tappe e va eseguito in parallelo, non in sequenza. <strong>1. CV svizzero a una pagina</strong>: nessuna foto, nessun codice fiscale, niente "obbligo di leva", nessun riferimento al diritto italiano sul lavoro; il datore cerca evidenze quantificate (fatturato gestito, team guidati, clienti chiusi). <strong>2. Lettera di motivazione di tre paragrafi</strong>: perché ${canton}, perché questa azienda, cosa porti — la lingua è quella dell'annuncio (italiano nel Canton Ticino, tedesco nella Svizzera tedesca, francese nella Svizzera romanda, inglese in molte multinazionali); allegala come PDF separato anche se il modulo di candidatura non la richiede esplicitamente. <strong>3. Riferimenti professionali</strong>: due referenze raggiungibili al telefono in CH o EU, non in Italia profonda — il responsabile HR svizzero le chiama davvero, di solito in fase finale. <strong>4. Colloqui</strong>: aspettati 2-4 round (telefonico HR, hiring manager, talvolta caso pratico, talvolta CFO/CEO per ruoli senior); ogni round dura 45-60 minuti, è pianificato puntualissimo e si chiude con domande tue (preparane sempre tre concrete sul ruolo e sul team). <strong>5. Permesso G</strong>: dopo la firma del contratto il datore avvia la richiesta presso l'Ufficio della migrazione del Canton ${canton}; consegna entro 24 ore copia della carta d'identità italiana, certificato di residenza nel comune italiano (in zona di frontiera, entro 20 km dal confine svizzero) e codice IBAN per l'accredito stipendio.`;
+    }
+    if (locale === 'en') {
+      return `For Italian cross-border applicants targeting Canton ${canton} the useful sequence is five tracks run in parallel, not sequentially. <strong>1. Swiss-format one-page CV</strong>: no photo, no Italian tax code, no military-service line, no references to Italian labour law; the employer wants quantified evidence (revenue managed, teams led, deals closed). <strong>2. Three-paragraph motivation letter</strong>: why ${canton}, why this employer, what you bring — written in the language of the posting (Italian for Ticino, German for the Swiss-German cantons, French for Romandie, English for many multinationals); attach as a separate PDF even if the application form doesn't explicitly require one. <strong>3. Professional references</strong>: two referees reachable by phone in CH or EU, not deep-Italy — Swiss HR managers actually do call them, usually in the final stage. <strong>4. Interview rounds</strong>: expect 2-4 stages (HR phone screen, hiring manager, sometimes a case exercise, sometimes CFO/CEO for senior roles); each lasts 45-60 minutes, is scheduled precisely on time and ends with your own questions (always prepare three concrete ones about the role and team). <strong>5. G permit</strong>: after contract signature the employer files the application with the Canton ${canton} migration office; within 24 hours you supply a copy of your Italian ID, a residence certificate from your Italian municipality (within the 20-km border zone) and the IBAN for your salary deposit.`;
+    }
+    if (locale === 'de') {
+      return `Für italienische Grenzgänger, die sich im Kanton ${canton} bewerben, läuft der Weg in fünf parallelen Spuren ab — nicht sequentiell. <strong>1. Schweizer Lebenslauf, eine Seite</strong>: kein Foto, keine italienische Steuernummer, keine Militärdienst-Zeile, keine Verweise auf italienisches Arbeitsrecht; der Arbeitgeber sucht quantifizierte Belege (verwaltetes Volumen, geführte Teams, abgeschlossene Geschäfte). <strong>2. Motivationsschreiben in drei Absätzen</strong>: warum ${canton}, warum dieses Unternehmen, was Sie mitbringen — in der Sprache des Inserats (Italienisch im Tessin, Deutsch in der Deutschschweiz, Französisch in der Romandie, Englisch bei vielen Multis); als separates PDF anhängen, auch wenn das Bewerbungsformular es nicht ausdrücklich verlangt. <strong>3. Berufliche Referenzen</strong>: zwei Referenzgeber, die telefonisch in CH oder EU erreichbar sind, nicht in der italienischen Provinz — der Schweizer HR-Manager ruft tatsächlich an, meist in der Schlussrunde. <strong>4. Vorstellungsrunden</strong>: rechnen Sie mit 2-4 Stufen (HR-Telefon-Screen, Hiring Manager, manchmal Fallstudie, manchmal CFO/CEO bei Senior-Rollen); jede Runde dauert 45-60 Minuten, ist auf die Minute geplant und endet mit Ihren eigenen Fragen (bereiten Sie immer drei konkrete zur Rolle und zum Team vor). <strong>5. G-Bewilligung</strong>: nach Vertragsunterzeichnung reicht der Arbeitgeber den Antrag beim Migrationsamt des Kantons ${canton} ein; binnen 24 Stunden liefern Sie eine Kopie der italienischen Identitätskarte, eine Wohnsitzbescheinigung der italienischen Gemeinde (innerhalb der 20-km-Grenzzone) und die IBAN für die Lohngutschrift.`;
+    }
+    return `Pour les candidats frontaliers italiens visant le canton ${canton}, la séquence utile se déroule en cinq pistes parallèles — pas successives. <strong>1. CV au format suisse, une page</strong> : pas de photo, pas de code fiscal italien, pas de service militaire, pas de références au droit du travail italien ; l'employeur cherche des preuves quantifiées (chiffre d'affaires géré, équipes dirigées, contrats signés). <strong>2. Lettre de motivation en trois paragraphes</strong> : pourquoi ${canton}, pourquoi cet employeur, ce que vous apportez — écrite dans la langue de l'annonce (italien au Tessin, allemand en Suisse alémanique, français en Romandie, anglais pour beaucoup de multinationales) ; à joindre en PDF séparé même si le formulaire ne le demande pas explicitement. <strong>3. Références professionnelles</strong> : deux personnes joignables par téléphone en CH ou UE, pas en Italie profonde — le RH suisse appelle vraiment, généralement en finale. <strong>4. Entretiens</strong> : attendez-vous à 2-4 tours (entretien RH au téléphone, hiring manager, parfois étude de cas, parfois CFO/CEO pour les postes seniors) ; chaque tour dure 45-60 minutes, est planifié à la minute près et se termine par vos propres questions (préparez-en toujours trois concrètes sur le poste et l'équipe). <strong>5. Permis G</strong> : après signature du contrat l'employeur dépose la demande à l'office cantonal des migrations du canton ${canton} ; sous 24 heures vous transmettez la copie de la carte d'identité italienne, le certificat de résidence dans la commune italienne (dans la zone frontalière des 20 km) et l'IBAN pour le versement du salaire.`;
+  })();
+
+  // Commute / accommodation paragraph — varies by distance band so the
+  // prose matches the actual logistical reality of the canton.
+  const commuteP = (() => {
+    if (locale === 'it') {
+      if (band === 'border-daily') {
+        return `Il Canton ${canton} è raggiungibile in giornata dalle principali località italiane di frontaliere (Como, Varese, Verbano-Cusio-Ossola, Val d'Aosta in funzione del canton di destinazione): la maggioranza dei pendolari sceglie l'auto privata per la flessibilità sui turni serali e sui giorni di shopping al rientro, mentre il treno (TILO, RegioExpress, IR) è la scelta dei ruoli amministrativi a orario fisso che lavorano vicino alle stazioni. La spesa mensile tipica del pendolare in auto è CHF 350-650 fra carburante, autostrada e usura veicolo (autostrade italiane gratuite fino al valico, vignetta svizzera CHF 40/anno); il treno costa CHF 200-450/mese in abbonamento generale o regionale. Sui valichi di confine il picco di traffico in entrata in Svizzera è 06:30-08:00, in uscita 17:00-19:00; le webcam ufficiali permettono di anticipare le code di 10-15 minuti scegliendo il valico secondario.`;
+      }
+      if (band === 'near-mixed') {
+        return `Il Canton ${canton} è in zona mista: il pendolarismo quotidiano resta possibile per i residenti italiani delle aree più a nord (Verbano, Valle d'Aosta, alta Lombardia) ma supera spesso 90 minuti per tratta, quindi molti frontalieri optano per il "Wochenaufenthalt" — alloggio settimanale in CH dal lunedì al venerdì, rientro nel weekend al domicilio italiano. L'affitto di una camera in zona Canton ${canton} costa CHF 500-900 al mese; un monolocale CHF 900-1'500. Lo status di frontaliere è compatibile con il Wochenaufenthalt purché ci sia rientro settimanale al domicilio italiano (anche un solo weekend al mese). I costi di alloggio e trasporto sono deducibili in parte dal datore in alcuni CCL.`;
+      }
+      return `Il Canton ${canton} è in zona lontana (oltre 150 minuti dalle località italiane di frontaliere): il pendolarismo quotidiano non è realistico nella maggior parte dei casi e quasi tutti i frontalieri italiani che lavorano qui adottano il modello "Wochenaufenthalt" — alloggio settimanale in CH dal lunedì al venerdì, rientro nel weekend al domicilio italiano. L'affitto di una camera in zona Canton ${canton} costa CHF 600-1'200/mese, un monolocale CHF 1'100-1'900. Il costo di accesso allo status di frontaliere è alto in valore assoluto ma compensato dal salario lordo svizzero, di solito 25-40 % superiore al cantone di residenza per ruoli equivalenti. Il rientro settimanale al domicilio italiano è obbligatorio per mantenere lo status (anche un solo weekend al mese soddisfa l'autorità fiscale).`;
+    }
+    if (locale === 'en') {
+      if (band === 'border-daily') {
+        return `Canton ${canton} is reachable as a daily commute from the main Italian frontaliere catchment areas (Como, Varese, Verbano-Cusio-Ossola, Aosta Valley depending on the target canton): most commuters choose private car for evening-shift flexibility and weekend errands, while train (TILO, RegioExpress, IR) is the choice for fixed-schedule office roles working near a station. Typical monthly out-of-pocket for car commuters is CHF 350-650 across fuel, motorway and vehicle wear (Italian motorway free up to the border crossing, Swiss vignette CHF 40/year); train pass runs CHF 200-450/month for general or regional ticket. Border-crossing peak inbound to Switzerland is 06:30-08:00, outbound 17:00-19:00; official webcams let you pre-empt queues by 10-15 minutes via secondary crossings.`;
+      }
+      if (band === 'near-mixed') {
+        return `Canton ${canton} sits in the mixed zone: daily commute remains feasible for Italian residents in the northernmost feeder areas (Verbano, Aosta Valley, upper Lombardy) but routinely exceeds 90 minutes one-way, so many cross-border workers opt for "Wochenaufenthalt" — weekly accommodation in CH Monday to Friday, return to the Italian residence on weekends. Room rental in Canton ${canton} runs CHF 500-900/month; studio CHF 900-1,500. The cross-border status is compatible with weekly accommodation provided you return to the Italian home at least weekly (a single weekend per month satisfies the tax authority). Some collective labour agreements (CCL) cover part of the accommodation or transport allowance.`;
+      }
+      return `Canton ${canton} is in the far zone (over 150 minutes from Italian frontaliere areas): daily commute is not realistic in most cases and almost every Italian-resident frontaliere working here adopts "Wochenaufenthalt" — weekly accommodation in CH Monday to Friday, return to the Italian residence on weekends. Room rental in Canton ${canton} runs CHF 600-1,200/month, studio CHF 1,100-1,900. Cost of entry is high in absolute terms but offset by the Swiss gross salary, typically 25-40 % above the equivalent Italian role for the same canton. Weekly return to the Italian home is required to keep the status (a single weekend per month meets the fiscal authority's requirement).`;
+    }
+    if (locale === 'de') {
+      if (band === 'border-daily') {
+        return `Der Kanton ${canton} ist im Tagespendel von den wichtigsten italienischen Grenzgängerzonen (Como, Varese, Verbano-Cusio-Ossola, Aostatal je nach Zielkanton) erreichbar: Die meisten Pendler wählen das Privatauto wegen der Flexibilität bei Spätschichten und Wochenend-Einkäufen, während Zug (TILO, RegioExpress, IR) für Bürorollen mit festen Zeiten in Bahnhofsnähe die Wahl ist. Typische monatliche Kosten für Autopendler liegen bei CHF 350-650 für Treibstoff, Autobahn und Fahrzeugverschleiss (italienische Autobahn bis zum Grenzübergang gratis, Schweizer Vignette CHF 40/Jahr); ein Zug-Abonnement kostet CHF 200-450/Monat für General- oder Regional-Ticket. Spitzen-Stau am Grenzübergang Richtung Schweiz ist 06:30-08:00, Richtung Italien 17:00-19:00; offizielle Webcams erlauben es, Staus über sekundäre Übergänge um 10-15 Minuten zu umgehen.`;
+      }
+      if (band === 'near-mixed') {
+        return `Der Kanton ${canton} liegt in der Mischzone: Tagespendel bleibt für italienische Einwohner in den nördlichsten Gemeinden (Verbano, Aostatal, obere Lombardei) möglich, übersteigt aber regelmässig 90 Minuten pro Strecke, weshalb viele Grenzgänger zum "Wochenaufenthalt" wechseln — wöchentliche Unterkunft in der Schweiz von Montag bis Freitag, Rückkehr ins italienische Zuhause am Wochenende. Zimmermiete im Kanton ${canton} kostet CHF 500-900/Monat, ein Studio CHF 900-1'500. Der Grenzgängerstatus ist mit dem Wochenaufenthalt vereinbar, sofern eine wöchentliche Rückkehr ins italienische Zuhause erfolgt (ein Wochenende pro Monat genügt der Steuerbehörde). Einige Gesamtarbeitsverträge (GAV) decken einen Teil der Unterkunft oder der Reisekosten ab.`;
+      }
+      return `Der Kanton ${canton} liegt in der fernen Zone (über 150 Minuten von den italienischen Grenzgängergebieten): Tagespendel ist in den meisten Fällen unrealistisch und fast alle in Italien wohnhaften Grenzgänger, die hier arbeiten, wählen den "Wochenaufenthalt" — wöchentliche Unterkunft in der Schweiz von Montag bis Freitag, Rückkehr ins italienische Zuhause am Wochenende. Zimmermiete im Kanton ${canton} kostet CHF 600-1'200/Monat, ein Studio CHF 1'100-1'900. Die Einstiegskosten sind absolut hoch, werden aber durch den Schweizer Bruttolohn ausgeglichen, der typischerweise 25-40 % über dem äquivalenten italienischen Lohn liegt. Eine wöchentliche Rückkehr ins italienische Zuhause ist Pflicht, um den Status zu behalten (ein Wochenende pro Monat genügt der Steuerbehörde).`;
+    }
+    if (band === 'border-daily') {
+      return `Le canton ${canton} est accessible en pendulaire quotidien depuis les principales zones italiennes de frontaliers (Côme, Varèse, Verbano-Cusio-Ossola, Vallée d'Aoste selon le canton ciblé) : la plupart des pendulaires choisissent la voiture pour la flexibilité sur les horaires du soir et les courses du week-end, tandis que le train (TILO, RegioExpress, IR) est l'option pour les postes administratifs à horaire fixe travaillant près d'une gare. Les frais mensuels typiques d'un automobiliste sont de CHF 350-650 entre carburant, autoroute et usure du véhicule (autoroute italienne gratuite jusqu'au passage frontalier, vignette suisse CHF 40/an) ; l'abonnement train coûte CHF 200-450/mois pour un ticket général ou régional. Le pic de trafic entrant en Suisse est 06h30-08h00, sortant 17h00-19h00 ; les webcams officielles permettent d'anticiper les files de 10-15 minutes en choisissant un passage secondaire.`;
+    }
+    if (band === 'near-mixed') {
+      return `Le canton ${canton} se trouve en zone mixte : le pendulaire quotidien reste possible pour les résidents italiens des zones les plus au nord (Verbano, Vallée d'Aoste, Lombardie haute) mais dépasse souvent 90 minutes par trajet, c'est pourquoi de nombreux frontaliers optent pour le « Wochenaufenthalt » — logement hebdomadaire en CH du lundi au vendredi, retour le week-end au domicile italien. Une chambre dans le canton ${canton} coûte CHF 500-900/mois ; un studio CHF 900-1 500. Le statut de frontalier est compatible avec le logement hebdomadaire à condition d'un retour au moins hebdomadaire au domicile italien (un week-end par mois suffit à l'autorité fiscale). Certaines conventions collectives (CCT) prennent en charge une part du logement ou des frais de transport.`;
+    }
+    return `Le canton ${canton} est en zone éloignée (plus de 150 minutes depuis les zones italiennes de frontaliers) : le pendulaire quotidien n'est pas réaliste dans la plupart des cas et presque tous les frontaliers italiens qui y travaillent adoptent le « Wochenaufenthalt » — logement hebdomadaire en CH du lundi au vendredi, retour le week-end au domicile italien. Une chambre dans le canton ${canton} coûte CHF 600-1 200/mois, un studio CHF 1 100-1 900. Le coût d'accès est élevé en valeur absolue mais compensé par le salaire brut suisse, typiquement 25-40 % au-dessus du poste équivalent côté italien. Le retour hebdomadaire au domicile italien est obligatoire pour conserver le statut (un week-end par mois satisfait à l'autorité fiscale).`;
+  })();
+
+  // Sector outlook paragraph — anchored to the canton name but with a
+  // generic-enough vocabulary to be safe across the 21 non-TI cantons.
+  const sectorsP = (() => {
+    if (locale === 'it') {
+      return `Il mercato del lavoro nel Canton ${canton} segue la struttura economica federale: i settori che assumono in modo ricorrente sono sanità (cliniche cantonali, RSA, ambulatori specialistici), tecnologie dell'informazione (sviluppo software, data engineering, cybersecurity), finanza e wealth management (banche, fiduciarie, family office), ingegneria e meccanica di precisione, edilizia e logistica, amministrazione pubblica cantonale, ristorazione e ospitalità nelle zone turistiche. Per il frontaliere italiano qualificato, le opportunità più immediate sono nei ruoli con domanda strutturale di personale qualificato — infermieri AFC, sviluppatori senior, ingegneri civili abilitati, commercialisti con esperienza svizzera — e nei ruoli operativi del manifatturiero che richiedono presenza fisica e accettano competenze italiane equivalenti. Il Canton ${canton} attinge anche ai frontalieri per coprire posizioni saltuarie nella ristorazione di stagione e nei lavori temporanei a chiamata gestiti tramite agenzie di interim svizzere come Adecco, Manpower, Randstad.`;
+    }
+    if (locale === 'en') {
+      return `The labour market in Canton ${canton} mirrors the federal economic structure: sectors with recurring openings are healthcare (cantonal hospitals, nursing homes, specialist clinics), information technology (software development, data engineering, cybersecurity), finance and wealth management (banks, fiduciaries, family offices), engineering and precision mechanics, construction and logistics, cantonal public administration, hospitality in tourism zones. For qualified Italian cross-border applicants the most immediate opportunities sit in roles with structural skilled-labour demand — AFC-certified nurses, senior developers, certified civil engineers, accountants with Swiss experience — and in manufacturing operations that need physical presence and accept equivalent Italian qualifications. Canton ${canton} also draws on cross-border workers to cover seasonal hospitality positions and on-call temporary roles managed via Swiss interim agencies like Adecco, Manpower, Randstad.`;
+    }
+    if (locale === 'de') {
+      return `Der Arbeitsmarkt im Kanton ${canton} spiegelt die föderale Wirtschaftsstruktur wider: Branchen mit wiederkehrenden Stellenangeboten sind Gesundheitswesen (Kantonsspitäler, Pflegeheime, Fachkliniken), Informationstechnologie (Softwareentwicklung, Data Engineering, Cybersecurity), Finanzen und Vermögensverwaltung (Banken, Treuhänder, Family Offices), Ingenieurwesen und Präzisionsmechanik, Bau und Logistik, kantonale öffentliche Verwaltung, Gastgewerbe in Tourismuszonen. Für qualifizierte italienische Grenzgänger liegen die unmittelbarsten Chancen in Rollen mit strukturellem Fachkräftebedarf — EFZ-Pflegefachkräfte, Senior-Entwickler, eingetragene Bauingenieure, Buchhalter mit Schweizer Erfahrung — und in operativen Fertigungsrollen, die physische Präsenz erfordern und gleichwertige italienische Qualifikationen anerkennen. Der Kanton ${canton} greift auch auf Grenzgänger zurück, um saisonale Gastgewerbe-Positionen und Abruf-Arbeit zu besetzen, die über Schweizer Personaldienstleister wie Adecco, Manpower, Randstad vermittelt werden.`;
+    }
+    return `Le marché du travail du canton ${canton} reflète la structure économique fédérale : les secteurs qui recrutent régulièrement sont la santé (hôpitaux cantonaux, EMS, cliniques spécialisées), les technologies de l'information (développement logiciel, data engineering, cybersécurité), la finance et la gestion de patrimoine (banques, fiduciaires, family offices), l'ingénierie et la mécanique de précision, le bâtiment et la logistique, l'administration publique cantonale, l'hôtellerie-restauration dans les zones touristiques. Pour le frontalier italien qualifié, les opportunités les plus immédiates se trouvent dans les rôles à demande structurelle de personnel qualifié — infirmiers titulaires d'un CFC, développeurs seniors, ingénieurs civils inscrits, comptables avec expérience suisse — et dans les rôles opérationnels de la production qui exigent une présence physique et acceptent des qualifications italiennes équivalentes. Le canton ${canton} recourt aussi aux frontaliers pour couvrir des postes saisonniers de l'hôtellerie et des missions temporaires gérées via les agences d'intérim suisses comme Adecco, Manpower, Randstad.`;
+  })();
+
+  // Net-pay scenario paragraph — quantitative comparison anchored to a
+  // CHF 80k-120k bracket common across the cantons, so the numbers are
+  // realistic without overclaiming.
+  const netpayP = (() => {
+    if (locale === 'it') {
+      return `Per un ruolo professionale tipico nel Canton ${canton} (lordo annuo CHF 85'000-110'000, 13 mensilità incluse, AVS-AI-IPG 5,3 %, AD 1,1 %, LPP 7-15 % in funzione dell'età, imposta alla fonte cantonale 4-14 % a seconda dello scaglione e stato civile), il netto mensile per un single senza figli è di norma fra CHF 5'400 e CHF 6'600; per una coppia con due figli a carico, grazie alle deduzioni familiari cantonali, fra CHF 5'800 e CHF 7'200. Con il Nuovo Accordo Italia-Svizzera 2024 (in vigore per i frontalieri assunti dopo il 17 luglio 2023) si applica la tassazione concorrente: il datore svizzero trattiene l'80 % della ritenuta cantonale ordinaria, il contribuente dichiara il reddito in Italia con franchigia di EUR 10'000 e credito d'imposta per la parte trattenuta in Svizzera. Per chi era già frontaliere prima del 17 luglio 2023, il vecchio regime resta in vigore (tassazione esclusivamente svizzera, ristorno del 38,8 % al comune italiano di residenza). Apri il <a href="${CALCULATOR_HREF[locale]}">calcolatore stipendio Frontaliere Ticino</a> e inserisci il lordo dell'annuncio che ti interessa nel Canton ${canton}: ottieni il netto mensile in CHF e in EUR, comparabile con un'offerta italiana, in meno di 30 secondi.`;
+    }
+    if (locale === 'en') {
+      return `For a typical professional role in Canton ${canton} (annual gross CHF 85,000-110,000 inclusive of 13 monthly payments, AVS-AI-IPG 5.3 %, unemployment 1.1 %, LPP 7-15 % by age band, cantonal source tax 4-14 % depending on bracket and civil status), the monthly net for a single applicant with no children typically runs between CHF 5,400 and CHF 6,600; for a married couple with two dependent children, after cantonal family deductions, between CHF 5,800 and CHF 7,200. Under the 2024 Italy-Switzerland bilateral agreement (in force for cross-border workers hired after 17 July 2023) dual taxation applies: the Swiss employer withholds 80 % of the standard cantonal rate, the taxpayer declares the income in Italy with a 10,000 EUR allowance and tax credit for the Swiss withholding. Cross-border workers already classified before 17 July 2023 keep the old regime (exclusive Swiss taxation, 38.8 % refund to the Italian residence municipality). Open the <a href="${CALCULATOR_HREF[locale]}">Frontaliere Ticino salary calculator</a> with the gross figure from a Canton ${canton} listing: you'll get the monthly net in CHF and EUR, directly comparable with an Italian offer, in under 30 seconds.`;
+    }
+    if (locale === 'de') {
+      return `Für eine typische Fachrolle im Kanton ${canton} (Bruttojahreslohn CHF 85'000-110'000 inkl. 13. Monatslohn, AHV-IV-EO 5,3 %, ALV 1,1 %, BVG 7-15 % nach Altersband, kantonale Quellensteuer 4-14 % je nach Stufe und Zivilstand) liegt das Monatsnetto für Alleinstehende ohne Kinder typischerweise zwischen CHF 5'400 und CHF 6'600; für ein Ehepaar mit zwei Kindern nach kantonalen Familienabzügen zwischen CHF 5'800 und CHF 7'200. Mit dem Steuerabkommen Italien-Schweiz 2024 (gültig für Grenzgänger, die nach dem 17. Juli 2023 angestellt wurden) gilt die konkurrierende Besteuerung: Der Schweizer Arbeitgeber zieht 80 % des ordentlichen kantonalen Satzes ab, der Steuerpflichtige deklariert das Einkommen in Italien mit Freibetrag von EUR 10'000 und Steuergutschrift für den in der Schweiz einbehaltenen Anteil. Vor dem 17. Juli 2023 bereits eingestufte Grenzgänger behalten das alte Regime (ausschliesslich Schweizer Besteuerung, 38,8 % Rückerstattung an die italienische Wohngemeinde). Öffnen Sie den <a href="${CALCULATOR_HREF[locale]}">Frontaliere-Ticino-Lohnrechner</a> mit dem Bruttowert eines Inserats aus dem Kanton ${canton}: in unter 30 Sekunden erhalten Sie das Monatsnetto in CHF und EUR, direkt vergleichbar mit einem italienischen Angebot.`;
+    }
+    return `Pour un poste professionnel typique dans le canton ${canton} (brut annuel CHF 85 000-110 000 incluant le 13e mois, AVS-AI-APG 5,3 %, chômage 1,1 %, LPP 7-15 % selon la tranche d'âge, impôt à la source cantonal 4-14 % selon la tranche et l'état civil), le net mensuel pour un célibataire sans enfants se situe généralement entre CHF 5 400 et CHF 6 600 ; pour un couple marié avec deux enfants à charge, après déductions familiales cantonales, entre CHF 5 800 et CHF 7 200. Avec l'accord fiscal Italie-Suisse 2024 (en vigueur pour les frontaliers engagés après le 17 juillet 2023), la taxation concurrente s'applique : l'employeur suisse retient 80 % du taux cantonal ordinaire, le contribuable déclare le revenu en Italie avec abattement de EUR 10 000 et crédit d'impôt pour la retenue suisse. Les frontaliers déjà classés avant le 17 juillet 2023 conservent l'ancien régime (taxation exclusivement suisse, rétrocession de 38,8 % à la commune italienne de résidence). Ouvrez le <a href="${CALCULATOR_HREF[locale]}">calculateur de salaire Frontaliere Ticino</a> avec le brut d'une annonce du canton ${canton} : en moins de 30 secondes vous obtenez le net mensuel en CHF et en EUR, directement comparable à une offre italienne.`;
+  })();
+
+  return `<h3 style="font-size:17px;font-weight:700;color:var(--color-heading);margin:22px 0 10px">${esc(headings.section)}</h3>
+  <p style="margin:0 0 12px;color:var(--color-body);font-size:14.5px"><strong>${esc(headings.playbook)}.</strong> ${playbookP}</p>
+  <p style="margin:0 0 12px;color:var(--color-body);font-size:14.5px"><strong>${esc(headings.commute)}.</strong> ${commuteP}</p>
+  <p style="margin:0 0 12px;color:var(--color-body);font-size:14.5px"><strong>${esc(headings.sectors)}.</strong> ${sectorsP}</p>
+  <p style="margin:0 0 14px;color:var(--color-body);font-size:14.5px"><strong>${esc(headings.netpay)}.</strong> ${netpayP}</p>`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Added `buildDeepDiveBlock` in `build-plugins/shared/cantonSeoProse.ts` — 4 paragraphs / locale (application playbook, commute+housing by distance band, sector outlook, net-pay scenario) appended below FAQ in the existing canton prose section
- Lifts the 103 non-TI `/{locale}/find-jobs-{canton}/today/` pages from ~8.9% text/HTML ratio above the 10% Semrush threshold
- TI URLs byte-identical (canton block already skipped for Ticino at jobBoardCommuterContext.ts:484-491)
- Memoised via existing `cantonProseCache` — bounded compute cost

## Test plan
- [x] Mobile-first layout: new prose stays below data area (CLAUDE.md rules 15-17)
- [x] No baseline widening, no noindex, no threshold change
- [x] SPA shell intact
- [ ] CI `audit:text-html-ratio` confirms gate green on live dist