### PR TITLE
fix(seo): truncate 401-page paginator on TI hub — page-weight

### DIFF
--- a/build-plugins/shared/cantonHubEditorial.ts
+++ b/build-plugins/shared/cantonHubEditorial.ts
@@ -94,16 +94,36 @@ export function buildCantonHubEditorial(opts: CantonHubEditorialOpts): string[] 
   // 100/page, totalPages can be in the hundreds — wrapped in <details>
   // collapsible so the visible UX is a single "Sfoglia tutto l'archivio
   // offerte per pagina (N pagine)" toggle.
+  //
+  // Page-weight guard: for very long archives (e.g. TI with ~400 pages)
+  // emitting one anchor per page-N pushed the IT root over the 200 KB
+  // audit:page-weight budget (~93 KB just for this nav). Crawler reach
+  // is preserved by the sequential prev/next/first/last links emitted on
+  // every `/tutti/page-N/` page itself, so we only need head+tail anchors
+  // here. We render pages 1..PAGINATOR_HEAD + last PAGINATOR_TAIL pages
+  // with a non-link ellipsis between them. For small archives
+  // (totalPages <= PAGINATOR_HEAD + PAGINATOR_TAIL) we still emit every
+  // page — byte-identical to the legacy output for cathedral cantons
+  // (which all have small page counts).
   if (totalPages > 1) {
     const jobsNavLabel = locale === 'it' ? 'Sfoglia tutto l\'archivio offerte per pagina'
       : locale === 'en' ? 'Browse the full job archive by page'
       : locale === 'de' ? 'Vollständiges Stellenarchiv nach Seite durchsuchen'
       : 'Parcourir toutes les offres par page';
     const jobsPageWord = locale === 'it' ? 'Pagina' : locale === 'en' ? 'Page' : locale === 'de' ? 'Seite' : 'Page';
-    const jobsAnchors: string[] = [];
-    for (let p = 1; p <= totalPages; p++) {
+    const PAGINATOR_HEAD = 20;
+    const PAGINATOR_TAIL = 5;
+    const anchorFor = (p: number): string => {
       const href = paginatedPath(archiveBaseHref, p);
-      jobsAnchors.push(`<a href="${href}" style="display:inline-block;padding:3px 8px;margin:1px;border-radius:4px;background:#f1f5f9;color:#1e293b;text-decoration:none;font-size:12px;border:1px solid #e2e8f0">${jobsPageWord}&nbsp;${p}</a>`);
+      return `<a href="${href}" style="display:inline-block;padding:3px 8px;margin:1px;border-radius:4px;background:#f1f5f9;color:#1e293b;text-decoration:none;font-size:12px;border:1px solid #e2e8f0">${jobsPageWord}&nbsp;${p}</a>`;
+    };
+    const jobsAnchors: string[] = [];
+    if (totalPages <= PAGINATOR_HEAD + PAGINATOR_TAIL) {
+      for (let p = 1; p <= totalPages; p++) jobsAnchors.push(anchorFor(p));
+    } else {
+      for (let p = 1; p <= PAGINATOR_HEAD; p++) jobsAnchors.push(anchorFor(p));
+      jobsAnchors.push('<span aria-hidden="true" style="display:inline-block;padding:3px 4px;margin:1px;font-size:12px;color:#64748b">…</span>');
+      for (let p = totalPages - PAGINATOR_TAIL + 1; p <= totalPages; p++) jobsAnchors.push(anchorFor(p));
     }
     out.push(
       `<details style="margin:.75rem 0;border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem"><summary style="cursor:pointer;font-weight:600;font-size:.95rem;color:#1e293b;padding:.25rem 0">${esc(jobsNavLabel)} (${totalPages} pagine)</summary><nav aria-label="${esc(jobsNavLabel)}" style="margin-top:.5rem;line-height:1.8">${jobsAnchors.join('')}</nav></details>`,

--- a/tests/seo/cathedral-canton-hub-parity.test.ts
+++ b/tests/seo/cathedral-canton-hub-parity.test.ts
@@ -39,12 +39,23 @@ describe('Phase 8(g) — canton hub editorial parity with TI', () => {
     // Intro paragraph mentions Ticino + "oltre 1.500 offerte" (legacy copy).
     expect(blocks[1]).toMatch(/lavoro in Ticino/);
     expect(blocks[1]).toMatch(/oltre 1\.500/);
-    // Archive navigator is a single <details> collapsible with one anchor
-    // per page-N (1..304).
+    // Archive navigator is a single <details> collapsible. For long archives
+    // (> 25 pages) the paginator emits head pages 1..20 + ellipsis + tail
+    // pages (N-4)..N to stay under the 200 KB audit:page-weight budget.
+    // Crawler reach is preserved by sequential prev/next/first/last links
+    // on each `/tutti/page-N/` page itself. Small archives (cathedral
+    // cantons with ≤ 25 pages) still emit every page anchor.
     expect(blocks[2].startsWith('<details ')).toBe(true);
     expect(blocks[2]).toMatch(/Sfoglia tutto l'archivio offerte per pagina \(304 pagine\)/);
     expect(blocks[2]).toMatch(/Pagina&nbsp;1/);
     expect(blocks[2]).toMatch(/Pagina&nbsp;304/);
+    // Head pages 1..20 + tail pages 300..304 must be present; middle pages
+    // (e.g. Pagina 150) must NOT be present in the truncated paginator.
+    expect(blocks[2]).toMatch(/Pagina&nbsp;20/);
+    expect(blocks[2]).toMatch(/Pagina&nbsp;300/);
+    expect(blocks[2]).not.toMatch(/Pagina&nbsp;150[^0-9]/);
+    // Ellipsis separator between head and tail (non-link span).
+    expect(blocks[2]).toMatch(/aria-hidden="true"[^>]*>…</);
     // Prose paragraph 1 mentions the canonical canton labels.
     expect(blocks[3]).toMatch(/offerte lavoro Ticino/);
     expect(blocks[3]).toMatch(/oltre 100 aziende ticinesi/);


### PR DESCRIPTION
## Summary
- `cantonHubEditorial.ts buildCantonHubEditorial`: for totalPages > 25, emit head 1..20 + ellipsis + tail (N-4)..N (was: 401 inline-styled anchors = ~93 KB on TI hub)
- Cathedral cantons (totalPages ≤ 25) unchanged — byte-identical
- Crawler reach preserved via existing prev/next/first/last sequential links on each page-N
- Projected `/cerca-lavoro-ticino/` size: 265.3 KB → ~179.6 KB

## Test plan
- [x] 491/491 SEO+perf tests pass
- [x] Pinned regex assertions on cathedral-canton-hub-parity still pass; head/tail/ellipsis assertions added
- [x] No threshold lowered, no real content removed
- [ ] CI audit:page-weight confirms < 200 KB