### PR TITLE
fix(seo/bfs): homepage canton nav + flat page-N ladder — BFS depth ≤ 4

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -808,7 +808,21 @@ function updatedLabel(locale: HubLocale): string {
 }
 
 function renderPagination(locale: HubLocale, basePath: string, current: number, total: number): string {
-  // Compact pagination: prev, 1, current-1, current, current+1, last, next
+  // Compact pagination (visible): prev, 1, current-1, current, current+1, last, next.
+  // Plus a FLAT crawler-facing navigator inside a collapsed <details> linking
+  // every page-N (BFS-depth closure 2026-05-12 run 25753701178 — without
+  // every page-N anchor on every page, leaves on page-3..N regress past BFS
+  // depth 4 since the compact nav only links 1, n-1, n+1, last from any
+  // given page — page-2 ↔ page-3 is a single hop, but page-1 → page-50 is a
+  // chain of length ~25 via the compact ladder, pushing leaves on page-25+
+  // to BFS depth > 4). The flat ladder collapses every page-N to a single
+  // hop from any other page-N, so every job leaf sits at depth 4 from `/`:
+  //   /  → /cerca-lavoro-ticino/tutti/   (page 1, depth 1)
+  //      → /cerca-lavoro-ticino/tutti/page-N/ (depth 2 via flat nav)
+  //      → /cerca-lavoro-{canton}/{slug}/  (depth 3, anchor on page-N)
+  // The <details> stays collapsed by default — mobile fold is preserved
+  // (CLAUDE.md #15/#16), and the BFS walker / crawlers parse every `<a>`
+  // inside `<details>` regardless of `open` state.
   const pages = new Set<number>();
   pages.add(1);
   pages.add(total);
@@ -839,7 +853,33 @@ function renderPagination(locale: HubLocale, basePath: string, current: number, 
   if (current < total) {
     parts.push(`<a href="${BASE_URL}${paginatedPath(basePath, current + 1)}" style="${baseStyle}" rel="next">${nextLabel}</a>`);
   }
-  return `<nav aria-label="Pagination" style="margin-top:32px;text-align:center">${parts.join('')}</nav>`;
+  const compactNav = `<nav aria-label="Pagination" style="margin-top:32px;text-align:center">${parts.join('')}</nav>`;
+
+  // Flat ladder — every page-N anchor, collapsed for mobile.
+  // Skip when totalPages ≤ 1 (no pagination needed) or ≤ 5 (compact nav
+  // already shows all pages, ladder would be redundant).
+  if (total <= 5) return compactNav;
+  const flatLabel = {
+    it: "Sfoglia tutto l'archivio per pagina",
+    en: 'Browse the full archive by page',
+    de: 'Vollständiges Archiv nach Seite durchsuchen',
+    fr: 'Parcourir toutes les archives par page',
+  }[locale];
+  const pageWord = locale === 'de' ? 'Seite' : locale === 'fr' || locale === 'en' ? 'Page' : 'Pagina';
+  const flatPillStyle = 'display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:var(--color-surface);color:var(--color-link);text-decoration:none;font-size:13px;border:1px solid var(--color-edge)';
+  const flatActiveStyle = 'display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:var(--color-accent);color:var(--color-on-accent);font-size:13px;font-weight:700';
+  const flatAnchors: string[] = [];
+  for (let p = 1; p <= total; p++) {
+    const href = `${BASE_URL}${paginatedPath(basePath, p)}`;
+    if (p === current) {
+      flatAnchors.push(`<strong style="${flatActiveStyle}" aria-current="page">${pageWord}&nbsp;${p}</strong>`);
+    } else {
+      flatAnchors.push(`<a href="${href}" style="${flatPillStyle}">${pageWord}&nbsp;${p}</a>`);
+    }
+  }
+  const flatNav = `<nav aria-label="${flatLabel}" style="margin-top:16px;max-width:1080px"><details style="border:1px solid var(--color-edge);border-radius:8px;padding:.5rem .75rem;background:var(--color-surface-alt)"><summary style="cursor:pointer;font-weight:600;font-size:14px;color:var(--color-heading);padding:.25rem 0">${flatLabel} (${total})</summary><div style="margin-top:.5rem;line-height:1.9">${flatAnchors.join('')}</div></details></nav>`;
+
+  return `${compactNav}${flatNav}`;
 }
 
 interface EmitArgs {

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -475,7 +475,81 @@ function injectHomepageSeoContent(html: string, locale: HpSeoLocale): string {
  // Place the block before </body> so it sits as a sibling of #root and is
  // not touched by React hydration. Falls back to no-op if no </body>.
  if (!html.includes('</body>')) return html;
- return html.replace('</body>', `${block}\n</body>`);
+ const cantonNav = buildHomepageCantonNavHtml(locale);
+ return html.replace('</body>', `${block}\n${cantonNav}\n</body>`);
+}
+
+/**
+ * Homepage canton navigator — closes the +395 BFS-depth regression on
+ * `sitemap-jobs.xml` (run 25753701178). Without this block, the chain from
+ * `/` to a canton job leaf is:
+ *
+ *   /  → /cerca-lavoro-ticino/{tutti,…}  (depth 1)
+ *      → /cerca-lavoro-ticino/         (TI hub, depth 2)
+ *      → /cerca-lavoro-{canton}/       (canton hub, depth 3, via TI's
+ *                                       nonTiCantonNavEntries block)
+ *      → /cerca-lavoro-{canton}/tutti/page-N/   (depth 4, via canton
+ *                                       hub editorial flat archive nav)
+ *      → /cerca-lavoro-{canton}/{slug}/         (job leaf, depth 5 — over
+ *                                       the audit-max-bfs-depth cap of 4)
+ *
+ * This block lifts every non-TI canton hub to BFS depth 1 from `/`. Combined
+ * with the canton-hub editorial flat archive nav (cantonHubEditorial.ts), it
+ * collapses the chain to:
+ *
+ *   /  → /cerca-lavoro-{canton}/       (depth 1, this block)
+ *      → /cerca-lavoro-{canton}/tutti/page-N/   (depth 2)
+ *      → /cerca-lavoro-{canton}/{slug}/         (depth 3) ✓
+ *
+ * The `sitemap-jobs.xml` `<loc>` always uses the IT canton-aware path
+ * (jobsSeoPagesPlugin.ts:7350-7352), so for the failing gate the IT block
+ * alone suffices. EN/DE/FR home pages get their own locale-aware block via
+ * the same helper so the per-canton sitemap shards (sitemap-jobs-aargau.xml,
+ * etc.) also see shorter chains for their non-IT URLs.
+ *
+ * Layout: a collapsed `<details>` so the mobile fold stays clear (CLAUDE.md
+ * #15/#16). Inside, one row per canton with anchors:
+ *   <canton-hub>  ·  <tutti/>  ·  <today landing>
+ * The `tutti/` anchor explicitly creates a flat depth-1 → depth-2 hop for
+ * the `tutti/page-N` ladder owned by buildCantonHubEditorial.
+ */
+function buildHomepageCantonNavHtml(locale: HpSeoLocale): string {
+ const cantonDataAny = (cantonSlugFile as { cantons: Record<string, Record<string, string>>; aggregate?: Record<string, string> });
+ const cantonLocale = locale as CantonLocale;
+ const navLabel = locale === 'en' ? 'Browse jobs by Swiss canton'
+   : locale === 'de' ? 'Stellen nach Schweizer Kanton durchsuchen'
+   : locale === 'fr' ? 'Parcourir les offres par canton suisse'
+   : 'Sfoglia le offerte per cantone svizzero';
+ const allJobsLabel = locale === 'en' ? 'All' : locale === 'de' ? 'Alle' : locale === 'fr' ? 'Toutes' : 'Tutte';
+ // Cathedral canton-aware section + URL builders.
+ const codes = [...ALL_CANTON_CODES, AGGREGATE_KEY];
+ const TUTTI_SLUG: Record<HpSeoLocale, string> = { it: 'tutti', en: 'all', de: 'alle', fr: 'tous' };
+ const cantonRows: string[] = [];
+ for (const code of codes) {
+   // Display label = the URL slug humanised; matches the existing TI-hub
+   // nonTiCantonNavEntries pattern (no extra translation table needed —
+   // the per-canton hub itself emits a localized H1).
+   const slugForLabel = code === AGGREGATE_KEY
+     ? cantonDataAny.aggregate?.[locale]
+     : cantonDataAny.cantons?.[code]?.[locale] ?? cantonDataAny.cantons?.[code]?.it;
+   if (!slugForLabel) continue;
+   const cantonSection = resolveCantonSection(cantonLocale, code);
+   const cantonHubHref = `/${(locale === 'it' ? '' : `${locale}/`)}${cantonSection}/`.replace(/\/+/g, '/');
+   const tuttiHref = `${cantonHubHref}${TUTTI_SLUG[locale]}/`;
+   const displayLabel = slugForLabel
+     .split('-')
+     .map((w: string) => (w.length > 2 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+     .join(' ');
+   const hubPillStyle = 'display:inline-block;padding:3px 9px;margin:2px;border-radius:6px;background:#eef2ff;color:#312e81;text-decoration:none;font-size:12px;font-weight:600;border:1px solid #c7d2fe';
+   const tuttiPillStyle = 'display:inline-block;padding:3px 9px;margin:2px;border-radius:6px;background:#f0fdf4;color:#166534;text-decoration:none;font-size:12px;border:1px solid #bbf7d0';
+   cantonRows.push(
+     `<span style="display:inline-flex;align-items:center;gap:4px;margin:2px"><a href="${cantonHubHref}" style="${hubPillStyle}">${displayLabel}</a><a href="${tuttiHref}" style="${tuttiPillStyle}" aria-label="${displayLabel} — ${allJobsLabel}">${allJobsLabel}</a></span>`,
+   );
+ }
+ if (cantonRows.length === 0) return '';
+ // Collapsed <details> — BFS walker reads <a> tags regardless of `open`
+ // state, mobile fold stays clear.
+ return `<aside id="hp-canton-nav" aria-label="${navLabel}" style="max-width:1100px;margin:24px auto 56px;padding:0 20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#334155;line-height:1.65"><details style="border:1px solid #e2e8f0;border-radius:8px;padding:.5rem .75rem;background:#f8fafc"><summary style="cursor:pointer;font-weight:600;font-size:.95rem;color:#1e293b;padding:.25rem 0">${navLabel} (${cantonRows.length})</summary><nav aria-label="${navLabel}" style="margin-top:.5rem;line-height:1.9">${cantonRows.join('')}</nav></details></aside>`;
 }
 
 // ── Calculator landing SEO block ─────────────────────────────────────

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -95,12 +95,15 @@ const ALLOWLIST = [
   // buildThinCantonHubHtml (May 2026 — text-to-html-ratio gate fix). Lines
   // shifted again on 2026-05-12 by the BFS-depth `tutti` pagination fix
   // (paginationHtml block in buildThinCantonHubHtml + jobPerLocale plumbing
-  // in emitThinCantonHubs). The 4 literals all live on 2 paired template
+  // in emitThinCantonHubs), and once more on 2026-05-12 by the flat-ladder
+  // navigator added inside renderPagination (BFS-depth closure run
+  // 25753701178 — every page-N now lists every other page-N inside a
+  // collapsed <details>). The 4 literals all live on 2 paired template
   // literals (sectors hub + companies hub), each spanning 2 lines.
-  'build-plugins/seoHubsPlugin.ts:1323',
-  'build-plugins/seoHubsPlugin.ts:1324',
-  'build-plugins/seoHubsPlugin.ts:1339',
-  'build-plugins/seoHubsPlugin.ts:1340',
+  'build-plugins/seoHubsPlugin.ts:1364',
+  'build-plugins/seoHubsPlugin.ts:1365',
+  'build-plugins/seoHubsPlugin.ts:1380',
+  'build-plugins/seoHubsPlugin.ts:1381',
 
   // ── professionLandingsLinksPlugin: TI hub injection targets (intentional —
   //    the prose explicitly references "10 most-searched roles in Ticino"). ──
@@ -115,16 +118,20 @@ const ALLOWLIST = [
   //    data-prep block added in closeBundle (May 2026, run 25739076601 —
   //    bfs-depth gate fix for the 23 non-TI cathedral cantons). The previous
   //    +129 shift from PR #133 TI hub deep-navigator data-prep is included.
-  'build-plugins/staticPagesPlugin.ts:1094',
-  'build-plugins/staticPagesPlugin.ts:1095',
-  'build-plugins/staticPagesPlugin.ts:1096',
-  'build-plugins/staticPagesPlugin.ts:1097',
-  'build-plugins/staticPagesPlugin.ts:1116',
-  'build-plugins/staticPagesPlugin.ts:1117',
-  'build-plugins/staticPagesPlugin.ts:1651',
-  'build-plugins/staticPagesPlugin.ts:1676',
-  'build-plugins/staticPagesPlugin.ts:1701',
-  'build-plugins/staticPagesPlugin.ts:1969',
+  //    Lines shifted again on 2026-05-12 by the homepage canton-nav helper
+  //    (`buildHomepageCantonNavHtml`) added between `injectHomepageSeoContent`
+  //    and `injectCalculatorSeoContent` — BFS-depth closure run 25753701178.
+  //    Every entry shifts by the same +74 lines (helper block size).
+  'build-plugins/staticPagesPlugin.ts:1168',
+  'build-plugins/staticPagesPlugin.ts:1169',
+  'build-plugins/staticPagesPlugin.ts:1170',
+  'build-plugins/staticPagesPlugin.ts:1171',
+  'build-plugins/staticPagesPlugin.ts:1190',
+  'build-plugins/staticPagesPlugin.ts:1191',
+  'build-plugins/staticPagesPlugin.ts:1725',
+  'build-plugins/staticPagesPlugin.ts:1750',
+  'build-plugins/staticPagesPlugin.ts:1775',
+  'build-plugins/staticPagesPlugin.ts:2043',
 
   // ── shared/hubChrome.ts: per-locale hub-chrome registry keyed on TI section name ──
   'build-plugins/shared/hubChrome.ts:106',


### PR DESCRIPTION
## Summary
- Root cause: chain was `/ → TI tutti → TI hub → canton hub → page-N → leaf` = depth 5+. Per-canton tutti/page-N anchors only reached via sequential prev/next chain.
- `staticPagesPlugin.ts buildHomepageCantonNavHtml`: collapsed `<details>` on every locale homepage linking every non-TI canton hub + tutti/ entry → canton hubs at depth 1
- `seoHubsPlugin.ts renderPagination`: secondary `<details>` lists every page-N anchor (flat ladder) — page-1 ↔ page-50 in one hop
- 485 SEO tests pass; cathedral-no-ti-hardcodes line numbers updated for the line shifts

## Test plan
- [x] 485/485 SEO tests pass
- [x] No baseline widening, no noindex
- [x] TI hub byte-identical
- [ ] CI audit:max-bfs-depth confirms ≤ baseline 118