### PR TITLE
fix(seo): revert tutti/page-N HTML emission — restore <2.2GB dist + text-html-ratio

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1192,16 +1192,17 @@ function emitThinCantonHubs(args: ThinCantonHubArgs): void {
       const localePrefix = locale === 'it' ? '' : `/${locale}`;
       const sectionRoot = `${localePrefix}/${section}`;
 
-      // ── tutti (all jobs) — full pagination ladder ──
-      // BFS-depth closure (2026-05-12): paginate `tutti/page-N/` so every
-      // canton job leaf is reachable at BFS depth ≤ 4 from `/`. Path is:
-      //   /  → TI canton hub (depth 1) → canton hub (depth 2)
-      //      → tutti/page-N (depth 3) → job-detail (depth 4)
-      // The canton-hub editorial (`buildCantonHubEditorial`) already links
-      // every `tutti/page-N/` from depth 2 via its archive navigator, so
-      // each page-N sits at depth 3. Without this loop the page-N HTML
-      // files don't exist → every linked anchor is a 404 and the leaves
-      // remain unreachable.
+      // ── tutti (all jobs) — page-1 only ──
+      // Reverted PR #141's full pagination ladder (2026-05-12): emitting
+      // every `tutti/page-N/` as static HTML × 26 cantons × 4 locales added
+      // ~170 MB to the dist (~2.19 GB → ~2.36 GB) which started tripping
+      // GitHub Pages' 1 GB soft cap on every deploy + regressed the
+      // text-html-ratio gate (page-N pages have ~6 % ratio vs ≥10 % needed —
+      // job cards are markup-heavy). Page-1 alone keeps the canton hub
+      // crawlable; deeper paginated views are served by the SPA via the
+      // `404.html` → `index.html` redirect (URL preserved). Sitemap only
+      // lists page-1 going forward — avoids advertising URLs whose static
+      // HTML doesn't exist (orphan-pages-in-sitemaps audit).
       //
       // Anchor URLs: prefer the per-locale URL from `all-known-job-slugs.json`
       // (cathedral-aware, points at `/{locale}/{section}/{slug}/`). Fall back
@@ -1210,46 +1211,36 @@ function emitThinCantonHubs(args: ThinCantonHubArgs): void {
       {
         const basePath = hubSlugFor(canton, locale, 'tutti');
         const tuttiPageSize = JOBS_PAGE_SIZE; // 100
-        const tuttiTotalPages = Math.max(1, Math.ceil(jobs.length / tuttiPageSize));
         const localeUrlMap = jobPerLocale[locale] ?? {};
         const itUrlMap = jobPerLocale.it ?? {};
-        for (let pageNum = 1; pageNum <= tuttiTotalPages; pageNum++) {
-          const startIdx = (pageNum - 1) * tuttiPageSize;
-          const pageJobs = jobs.slice(startIdx, startIdx + tuttiPageSize);
-          const items = pageJobs.map((j) => {
-            // 1) Try locale-specific path (cathedral-canton-aware).
-            // 2) Fall back to IT path (acceptable — same content, IT URL).
-            // 3) Last-resort legacy form `sectionRoot/slug/`.
-            const localePath = localeUrlMap[j.slug];
-            const itPath = itUrlMap[j.slug];
-            const href = (localePath && (localePath.endsWith('/') ? localePath : `${localePath}/`))
-              || (itPath && (itPath.endsWith('/') ? itPath : `${itPath}/`))
-              || `${sectionRoot}/${j.slug}/`;
-            return {
-              href,
-              label: j.role || humanizeSlug(j.slug),
-              sub: j.city || undefined,
-            };
-          });
-          const html = buildThinCantonHubHtml({
-            locale, hub: 'tutti', canton, cantonLabel, basePath,
-            totalItems: total, items, hasSpaBundle, entryJs, entryCss, dateStamp,
-            page: pageNum, totalPages: tuttiTotalPages,
-          });
-          const pageCanonical = pageNum === 1 ? basePath : paginatedPath(basePath, pageNum);
-          qw(np.join(distDir, pageCanonical.slice(1), 'index.html'), html);
-          onPageEmitted();
-          // Sitemap entries: keep the same shape as before — only IT locale
-          // contributes one entry per (canton, page) tuple. Page 1 keeps
-          // priority 0.6; paginated pages get 0.5 (mirrors the TI emitHub
-          // contract from line ~1311-1335).
-          if (locale === 'it') {
-            const url = `${BASE_URL}${pageCanonical}`;
-            const priority = pageNum === 1 ? '0.6' : '0.5';
-            sitemapEntries.push(
-              `  <url>\n    <loc>${url}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>${priority}</priority>\n  </url>`,
-            );
-          }
+        const pageJobs = jobs.slice(0, tuttiPageSize);
+        const items = pageJobs.map((j) => {
+          // 1) Try locale-specific path (cathedral-canton-aware).
+          // 2) Fall back to IT path (acceptable — same content, IT URL).
+          // 3) Last-resort legacy form `sectionRoot/slug/`.
+          const localePath = localeUrlMap[j.slug];
+          const itPath = itUrlMap[j.slug];
+          const href = (localePath && (localePath.endsWith('/') ? localePath : `${localePath}/`))
+            || (itPath && (itPath.endsWith('/') ? itPath : `${itPath}/`))
+            || `${sectionRoot}/${j.slug}/`;
+          return {
+            href,
+            label: j.role || humanizeSlug(j.slug),
+            sub: j.city || undefined,
+          };
+        });
+        const html = buildThinCantonHubHtml({
+          locale, hub: 'tutti', canton, cantonLabel, basePath,
+          totalItems: total, items, hasSpaBundle, entryJs, entryCss, dateStamp,
+          page: 1, totalPages: 1,
+        });
+        qw(np.join(distDir, basePath.slice(1), 'index.html'), html);
+        onPageEmitted();
+        if (locale === 'it') {
+          const url = `${BASE_URL}${basePath}`;
+          sitemapEntries.push(
+            `  <url>\n    <loc>${url}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.6</priority>\n  </url>`,
+          );
         }
       }
 

--- a/build-plugins/shared/cantonHubEditorial.ts
+++ b/build-plugins/shared/cantonHubEditorial.ts
@@ -90,10 +90,14 @@ export function buildCantonHubEditorial(opts: CantonHubEditorialOpts): string[] 
   }
 
   // ── 2. Deep-link archive navigator ────────────────────────────────────
-  // Same locale-aware labels as the TI hub. With ~30k slugs paginated at
-  // 100/page, totalPages can be in the hundreds — wrapped in <details>
-  // collapsible so the visible UX is a single "Sfoglia tutto l'archivio
-  // offerte per pagina (N pagine)" toggle.
+  // Only emitted for the TI hub. Non-TI canton hubs are page-1-only as
+  // static HTML (see seoHubsPlugin.emitThinCantonHubs — `tutti/page-N` for
+  // N>1 reverted 2026-05-12 to keep the dist under the 1 GB Pages cap +
+  // restore text-html-ratio on those leaves). Emitting page-N anchors
+  // here for non-TI cantons would produce 404 links since the static HTML
+  // doesn't exist (SPA shell would render, but the URL is not a canton
+  // listing). TI keeps the navigator because its master `emitHub`
+  // (`seoHubsPlugin`) still emits every page-N HTML.
   //
   // Page-weight guard: for very long archives (e.g. TI with ~400 pages)
   // emitting one anchor per page-N pushed the IT root over the 200 KB
@@ -105,7 +109,7 @@ export function buildCantonHubEditorial(opts: CantonHubEditorialOpts): string[] 
   // (totalPages <= PAGINATOR_HEAD + PAGINATOR_TAIL) we still emit every
   // page — byte-identical to the legacy output for cathedral cantons
   // (which all have small page counts).
-  if (totalPages > 1) {
+  if (isTi && totalPages > 1) {
     const jobsNavLabel = locale === 'it' ? 'Sfoglia tutto l\'archivio offerte per pagina'
       : locale === 'en' ? 'Browse the full job archive by page'
       : locale === 'de' ? 'Vollständiges Stellenarchiv nach Seite durchsuchen'

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -98,12 +98,16 @@ const ALLOWLIST = [
   // in emitThinCantonHubs), and once more on 2026-05-12 by the flat-ladder
   // navigator added inside renderPagination (BFS-depth closure run
   // 25753701178 — every page-N now lists every other page-N inside a
-  // collapsed <details>). The 4 literals all live on 2 paired template
-  // literals (sectors hub + companies hub), each spanning 2 lines.
-  'build-plugins/seoHubsPlugin.ts:1364',
-  'build-plugins/seoHubsPlugin.ts:1365',
-  'build-plugins/seoHubsPlugin.ts:1380',
-  'build-plugins/seoHubsPlugin.ts:1381',
+  // collapsed <details>). Then shifted back -10 on 2026-05-12 when the
+  // `tutti/page-N` pagination loop was reverted in emitThinCantonHubs
+  // (deploy artifact >1 GB Pages cap + text-html-ratio regression — only
+  // page-1 stays as static HTML for non-TI cantons). The 4 literals all
+  // live on 2 paired template literals (sectors hub + companies hub), each
+  // spanning 2 lines.
+  'build-plugins/seoHubsPlugin.ts:1354',
+  'build-plugins/seoHubsPlugin.ts:1355',
+  'build-plugins/seoHubsPlugin.ts:1370',
+  'build-plugins/seoHubsPlugin.ts:1371',
 
   // ── professionLandingsLinksPlugin: TI hub injection targets (intentional —
   //    the prose explicitly references "10 most-searched roles in Ticino"). ──


### PR DESCRIPTION
## Summary

Reverts PR #141's `tutti/page-N` static-HTML emission on non-TI canton hubs. PR #141 added ~170 MB to the github-pages artifact (2.19 → 2.36 GB), which started failing GitHub Pages' 1 GB soft cap on every deploy this morning. It also pushed the text-html-ratio gate from 471 → 1913 offenders (top offenders all `tutti/page-N` HTML — ratio ~6 %, well below the 10 % floor).

- `emitThinCantonHubs` (`build-plugins/seoHubsPlugin.ts`): drops the per-page loop and emits only page-1 per (canton, locale). Sitemap entry: page-1 only @ 0.6 priority.
- `buildCantonHubEditorial` (`build-plugins/shared/cantonHubEditorial.ts`): gates the page-N anchor navigator on `isTi`. TI's master `emitHub` still emits every page-N HTML so its archive nav stays valid; non-TI cantons no longer have page-N>1 static HTML, so emitting page-N anchors there would 404.
- `tests/seo/cathedral-no-ti-hardcodes.test.ts`: allowlist line numbers shifted -10 (1364/1365/1380/1381 → 1354/1355/1370/1371) by the removed loop.

**Trade-off**: non-TI paginated views (page-2..page-N) are no longer in the sitemap and no longer have static HTML. They remain reachable via SPA navigation (URL preserved → `404.html` → `index.html`). BFS-depth closure that PR #141 attempted is undone for non-TI cantons; whether that regresses the bfs ratchet depends on per-canton sitemap entries (currently not in `data/bfs-depth-baseline.json` — stale post-cathedral; separate follow-up via `seed-bfs-depth-baseline.yml` once this lands).

Pre-push skipped (`--no-verify`): per the user memory `feedback_verify_via_live_deploy.md`, local full builds are OOM-prone — verify via CI. Tests passed locally (`cathedral-no-ti-hardcodes`, `seo-hubs-pagination-bfs`, `cathedral-canton-hub-parity`).

Refs: deploy runs 25758779857 (a7f079a) + 25759348081 (045ccbe). Audit-reports artifact: text-html-ratio 471→1913 (+1442), page-weight gate already passed after PR #147.

## Test plan

- [ ] Build green on CI
- [ ] github-pages artifact size drops back toward ~2.2 GB
- [ ] text-html-ratio audit passes (job-board offenders back near baseline 328)
- [ ] Live verify: `https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/` still renders (TI keeps page-N — unaffected)
- [ ] Live verify: `https://frontaliereticino.ch/cerca-lavoro-grigioni/tutti/` page-1 still renders (non-TI page-1 only)
- [ ] Live verify: `https://frontaliereticino.ch/cerca-lavoro-grigioni/tutti/page-2/` SPA-rendered (no static HTML, falls through 404.html)