### PR TITLE
fix(seo): drop non-IT page-N>1 from TI master jobs hub — restore <2.2GB dist

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1436,7 +1436,22 @@ export function emitSeoHubs(args: EmitArgs): { pagesEmitted: number; sitemapEntr
 
     const total = items.length;
     const totalPages = Math.max(1, Math.ceil(total / pageSize));
+    // Cap non-IT page-N>1 emission (2026-05-13): the master jobs hub has
+    // ~400 pages × 4 locales = ~1600 thin paginated HTML files at ~150 KB
+    // each = ~240 MB of dist — the dominant source of the deploy artifact
+    // crossing the 1 GB Pages cap + the text-html-ratio regression (471 →
+    // 1917 offenders, all `find-jobs-ticino/all/page-N` family). IT keeps
+    // every page-N as static HTML (canonical for search). Non-IT locales
+    // emit only page-1 — page-N>1 routes via the SPA shell.
+    //
+    // Hreflang impact: buildHtml only emits hreflang alternates on page-1
+    // (see line 661), so dropping non-IT page-N HTML doesn't break per-page
+    // hreflang signals. The sitemap entry for IT page-N>1 also drops its
+    // `xhtml:link` alternates (would 404 otherwise) — page-1 keeps the
+    // full 4-locale alternate set.
+    const emitNonItPageN = false;
     for (let page = 1; page <= totalPages; page++) {
+      if (page > 1 && locale !== 'it' && !emitNonItPageN) continue;
       const slice = items.slice((page - 1) * pageSize, page * pageSize);
       const html = buildHtml({
         locale, hubKey, basePath, page, totalPages,
@@ -1447,14 +1462,19 @@ export function emitSeoHubs(args: EmitArgs): { pagesEmitted: number; sitemapEntr
 
       // Sitemap: only emit IT entries (one per (hub, page) tuple), matches existing pattern
       if (locale === 'it') {
-        const altLinks = HUB_LOCALES.map((alt) => {
-          const altBase = alt === 'it' ? HUB_SLUGS.it[
-            hubKey === 'jobs' ? 'jobsAll' : hubKey === 'sectors' ? 'sectorsAll' : hubKey === 'companies' ? 'companiesAll' : 'articlesAll'
-          ] : HUB_SLUGS[alt][
-            hubKey === 'jobs' ? 'jobsAll' : hubKey === 'sectors' ? 'sectorsAll' : hubKey === 'companies' ? 'companiesAll' : 'articlesAll'
-          ];
-          return `    <xhtml:link rel="alternate" hreflang="${alt}" href="${BASE_URL}${page === 1 ? altBase : paginatedPath(altBase, page)}" />`;
-        }).join('\n');
+        // Hreflang alternates: page-1 ships the full 4-locale set; page-N>1
+        // ships IT-only (non-IT page-N HTML is no longer emitted, so listing
+        // those URLs as alternates would advertise 404s).
+        const altLinks = page === 1
+          ? HUB_LOCALES.map((alt) => {
+              const altBase = alt === 'it' ? HUB_SLUGS.it[
+                hubKey === 'jobs' ? 'jobsAll' : hubKey === 'sectors' ? 'sectorsAll' : hubKey === 'companies' ? 'companiesAll' : 'articlesAll'
+              ] : HUB_SLUGS[alt][
+                hubKey === 'jobs' ? 'jobsAll' : hubKey === 'sectors' ? 'sectorsAll' : hubKey === 'companies' ? 'companiesAll' : 'articlesAll'
+              ];
+              return `    <xhtml:link rel="alternate" hreflang="${alt}" href="${BASE_URL}${altBase}" />`;
+            }).join('\n')
+          : `    <xhtml:link rel="alternate" hreflang="it" href="${BASE_URL}${canonicalPath}" />`;
         const url = `${BASE_URL}${canonicalPath}`;
         const priority = page === 1 ? '0.7' : '0.5';
         sitemapEntries.push(


### PR DESCRIPTION
## Summary

The master jobs hub (`emitHub('jobs')` in `build-plugins/seoHubsPlugin.ts`) emits a paginated HTML page per (locale, page) tuple. With ~40k cumulative job slugs at 100/page that is ~400 pages × 4 locales = ~1600 thin paginated HTML files at ~150 KB each = **~240 MB of dist**. After PR #148 capped non-TI cantons, the master hub became the dominant remaining offender: every text-html-ratio offender in audit-reports artifact 25764199294 (1917 total, baseline 471) was a master-hub `find-jobs-ticino/all/page-N` family path, page-N up to 401.

### What this changes

- **Non-IT locales (EN/DE/FR): emit only page-1**. Page-N>1 routes through the SPA shell (`404.html` → `index.html` redirect → SPA picks up the URL).
- **IT canonical: keeps every page-N** (search canonical, indexed content).
- **Sitemap alternates for IT page-N>1** reduced from the 4-locale set to IT-self only (advertising non-existent non-IT page-N URLs would point Google at SPA-rendered pages without the master hub body — bad hreflang signal). Page-1 keeps the full alternate set.

### Expected impact

| Metric | Before | After (projected) |
|---|---|---|
| dist size | 2.37 GB | ~2.19 GB (yesterday's last green) |
| text-html-ratio offenders | 1917 | ~715 (IT-only page-N>1 left) |
| github-pages artifact | rejected by 1 GB cap | within tolerance |

### Hreflang handling

`buildHtml` already emits hreflang alternates only on page-1 (see line 661), so dropping non-IT page-N>1 HTML doesn't change the per-page hreflang signal. Page-N>1 sitemap entries point IT canonical to itself.

### Test plan

- [ ] Build green on CI
- [ ] github-pages artifact drops below ~2.2 GB
- [ ] `Reported success!` from `actions/deploy-pages@v5`
- [ ] text-html-ratio offenders count drops to ≤~750 (IT-only page-N>1)
- [ ] Live verify: `https://frontaliereticino.ch/cerca-lavoro-ticino/tutti/page-50/` renders (IT — has static HTML)
- [ ] Live verify: `https://frontaliereticino.ch/en/find-jobs-ticino/all/page-50/` renders via SPA (no static HTML, falls through `404.html`)

Pre-push skipped (`--no-verify`): per user memory `feedback_verify_via_live_deploy.md`, local full builds are OOM-prone — verify via CI. Tests passed locally (`cathedral-no-ti-hardcodes`, `seo-hubs-pagination-bfs`).

Refs: deploy runs 25758779857, 25759348081, 25764199294 (all failed with same artifact-rejection pattern + text-html-ratio regression). PR #148 capped non-TI cantons; this PR caps non-IT master.