### PR TITLE
fix(cathedral): emit full-content bridge at legacy TI URL for non-TI jobs

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2821,6 +2821,38 @@ ${hreflangHtml}
  }
  recordEmit('active-job-legacy-bridge', __tLegacyBridge);
  }
+
+ // Cross-canton legacy TI bridge: when the job's resolved canton is NOT
+ // TI, the pre-cathedral URL was under the legacy TI section
+ // (/cerca-lavoro-ticino/, /de/jobs-im-tessin/, /en/find-jobs-ticino/,
+ // /fr/trouver-emploi-tessin/). The active emit and the same-section
+ // legacy bridge above both write only to the new canton-aware section,
+ // leaving the indexed legacy TI URL uncovered and the self-healing
+ // safety net (jobsSeoPagesPlugin.ts:10184+) to render a noindex
+ // tombstone there. Emit the same full-content bridge at the legacy TI
+ // path so visitors and Google see the real job page; the canonical
+ // inside `html` already points to the canton-aware URL, so Google
+ // consolidates link equity to the new section.
+ //
+ // Slug is `job.slug` (master/IT slug) because pre-cathedral
+ // `all-known-job-slugs.json` keyed every locale path to the master
+ // slug under the TI section.
+ if (jobCanton !== 'TI') {
+ const __tCrossCantonLegacy = startTimer();
+ const legacyTIRel = `${localePrefix[locale]}/${buildCantonAwareSection(locale, 'TI')}/${job.slug}`.replace(/\/+/g, '/').replace(/^\//, '');
+ if (!activeJobDirs.has(legacyTIRel.replace(/\/+$/, ''))) {
+ const bridgeScript = `<script>window.__BRIDGE_TARGET_SLUG__=${JSON.stringify(perLocaleSlug[locale])};</script>`;
+ const legacyTIIndexHtml = html.replace('</head>', ` ${bridgeScript}\n </head>`);
+ const legacyTIFlatHtml = legacyTIIndexHtml.replace(SPA_ACTION_REDIRECT_SCRIPT, '');
+ const legacyTIDir = np.join(distDir, legacyTIRel);
+ _md(legacyTIDir);
+ _qw(np.join(legacyTIDir, 'index.html'), legacyTIIndexHtml);
+ const legacyTIFlat = np.join(distDir, legacyTIRel + '.html');
+ _md(np.dirname(legacyTIFlat));
+ _qw(legacyTIFlat, legacyTIFlatHtml);
+ }
+ recordEmit('active-job-cross-canton-legacy', __tCrossCantonLegacy);
+ }
  }
  }
 


### PR DESCRIPTION
## Problem

Pre-cathedral, every job was indexed under the legacy TI section (`/cerca-lavoro-ticino/`, `/de/jobs-im-tessin/`, `/en/find-jobs-ticino/`, `/fr/trouver-emploi-tessin/`). Post-cathedral expansion (2026-05-10, CH-wide canton sections), jobs whose resolved canton is NOT TI emit only at their canton-aware section (e.g. `/cerca-lavoro-grigioni/`). The legacy TI URL was left uncovered and the self-healing safety net at `jobsSeoPagesPlugin.ts:10184+` rendered a `noindex,follow` tombstone with canonical pointing to the listing index.

**Example** — `/cerca-lavoro-ticino/venditore-in-molkerei-genossenschaft-migros-ostschweiz-bellinzona/`:
- Job is alive (`company-jlrzns`, Migros, canton GR after slice refresh)
- Live URL canton-aware: `/cerca-lavoro-grigioni/venditore-in-molkerei-genossenschaft-migros-ostschweiz-chur/` → HTTP 200, full content
- Legacy TI URL: tombstone — `<title>Offerta di lavoro aggiornata</title>`, `<meta name="robots" content="noindex,follow">`, canonical to `/cerca-lavoro-ticino/`

Affected scope: ~1,395 active non-TI jobs × 4 locales ≈ 5,580 pages.

## Fix

Extend the existing locale-mismatch legacy bridge (lines 2808-2823) with a parallel **canton-mismatch** emit. When `jobCanton !== 'TI'`, emit the same full-content HTML bytes at the legacy TI section path using `job.slug` (the master/IT slug — `all-known-job-slugs.json` keyed every locale path to it pre-cathedral).

The HTML's `<link rel="canonical">` already points to the canton-aware URL, so Google consolidates link equity to the new section. The URL bar stays on the legacy TI path; the SPA hydrates in place via the existing `__BRIDGE_TARGET_SLUG__` signal.

## UX & SEO

- **Visitor**: full job page (h1, description, requirements, JSON-LD, breadcrumbs), no redirect, bookmarkable URL.
- **Google**: full content + explicit canonical → consolidates to the canton-aware URL. No duplicate-content penalty.

## Test plan

- [x] TypeScript check: 0 new errors in `jobsSeoPagesPlugin.ts`
- [ ] CI build pipeline exits 0
- [ ] Post-deploy: `curl -sL https://frontaliereticino.ch/cerca-lavoro-ticino/venditore-in-molkerei-genossenschaft-migros-ostschweiz-bellinzona/` returns full job content + canonical to `/cerca-lavoro-grigioni/...`
- [ ] All 6 SEO content gates pass