### PR TITLE
fix(crawlers): apply stable-id matchKey to remaining 57 crawlers + CLAUDE.md rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,13 @@ These directives have the highest priority. No exceptions, workarounds, or "temp
 
     **Reference commits** for the canonical implementation: `2f845817eb` (border-wait), `74866f13b4` (health-premiums leaf), `cfde4aca6c` (weekly-employers city), `26421ccb6c` (fuel-daily root). Read those diffs before adding a new SEO landing.
 
+18. **Every dedicated crawler MUST key its merge on stable-id, not the source URL.** Vendor APIs (PwC / Workday / Prospective.ch / Greenhouse) rewrite the slug-portion of a job's URL when titles change while keeping the underlying UUID stable. A URL-keyed `jobMatchKey` treats the rename as delete+add: the old slug falls out of the per-crawler slice without a `previousSlugs` trail, and the soft-landing emitter takes over the canton-aware URL on the next deploy — turning a live position into "Offerta non più disponibile".
+
+    - Use `extractStableJobId(job.url)` from `scripts/lib/job-match-key.mjs` (matches UUID → long numeric ID → 10+ char hex → URL fallback).
+    - When the merge updates an existing job whose slug/slugByLocale differs from the previous run, push every prior slug into `previousSlugs` (and per-locale `previousSlugsByLocale`) so the build emits a bridge page (canonical → new URL) instead of an expired soft-landing.
+    - Truncate slug-output through `truncateSlugAtWordBoundary` from `scripts/lib/slug-truncate.mjs`, never `.slice(0, MAX)` raw — chopping mid-token produces unrouted slugs (e.g. `...switzerland-genev` from `...switzerland-geneve`).
+    - Reference fix: PR #161 (2026-05-13) + follow-up — `scripts/lib/job-match-key.mjs`, `scripts/lib/slug-truncate.mjs`, `scripts/backfill-renamed-slugs-from-history.mjs`. Backfill repaired 358 historical rename-drift cases across 56 crawler slices. Incident: 2.591 slugs dropped in 7 days, 1.987 still live on source side. Full context: `project_seo_rename_drift_may13.md` memory.
+
 ---
 
 # Project Overview

--- a/scripts/update-a-plus-plus-group-jobs.mjs
+++ b/scripts/update-a-plus-plus-group-jobs.mjs
@@ -49,6 +49,7 @@ import {
   buildAplusLocalizedContent,
 } from './lib/a-plus-plus-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -234,7 +235,7 @@ async function buildAplusJob(listing) {
 /* ── Merge & write ─────────────────────────────────────────── */
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-afry-jobs.mjs
+++ b/scripts/update-afry-jobs.mjs
@@ -13,6 +13,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -256,7 +257,7 @@ function buildAfryJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-agie-charmilles-jobs.mjs
+++ b/scripts/update-agie-charmilles-jobs.mjs
@@ -16,6 +16,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -185,7 +186,7 @@ function buildAgieCharmillesJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-agroscope-jobs.mjs
+++ b/scripts/update-agroscope-jobs.mjs
@@ -14,6 +14,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -191,7 +192,7 @@ function buildAgroscopeJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-allianz-jobs.mjs
+++ b/scripts/update-allianz-jobs.mjs
@@ -43,6 +43,7 @@ import {
   inferAllianzCanton,
 } from './lib/allianz-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -291,7 +292,7 @@ function buildAllianzJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-alten-jobs.mjs
+++ b/scripts/update-alten-jobs.mjs
@@ -33,6 +33,7 @@ import {
 } from './lib/alten-job-parser.mjs';
 import { inferSwissTargetCanton, inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -243,7 +244,7 @@ async function buildJobs(listings) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-amag-jobs.mjs
+++ b/scripts/update-amag-jobs.mjs
@@ -44,6 +44,7 @@ import {
   inferAmagCanton,
 } from './lib/amag-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -314,7 +315,7 @@ function buildAmagJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-ariston-jobs.mjs
+++ b/scripts/update-ariston-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -188,7 +189,7 @@ async function buildAristonJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-artificialy-jobs.mjs
+++ b/scripts/update-artificialy-jobs.mjs
@@ -15,6 +15,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -223,7 +224,7 @@ function buildArtificialyJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-artisa-jobs.mjs
+++ b/scripts/update-artisa-jobs.mjs
@@ -3,6 +3,7 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -187,7 +188,7 @@ async function buildArtisaJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-avaloq-jobs.mjs
+++ b/scripts/update-avaloq-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -184,7 +185,7 @@ async function buildAvaloqJobs() {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-axpo-jobs.mjs
+++ b/scripts/update-axpo-jobs.mjs
@@ -31,6 +31,7 @@ import {
   validateAxpoDescription,
 } from './lib/axpo-job-parser.mjs';
 import { isTargetSwissLocation, inferAnyCanton } from './lib/target-swiss-locations.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -88,7 +89,7 @@ function isTargetJob(job) {
 }
 
 function jobMatchKey(job) {
-  return job.url || job.slug || '';
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function isGrCity(city = '') {

--- a/scripts/update-bancastato-jobs.mjs
+++ b/scripts/update-bancastato-jobs.mjs
@@ -45,6 +45,7 @@ import {
 mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { parseListingPage, parseDetailPage, buildJob, stripHtml } from './lib/bancastato-job-parser.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -155,7 +156,7 @@ function writeJson(filePath, value) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase().replace(/\/+$/, '') || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-baronie-jobs.mjs
+++ b/scripts/update-baronie-jobs.mjs
@@ -52,6 +52,7 @@ import {
   isSwissJob,
 } from './lib/baronie-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -175,7 +176,7 @@ function buildBaronieJob(url, detail) {
 
 /* ── Merge ─────────────────────────────────────────────────── */
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-board-jobs.mjs
+++ b/scripts/update-board-jobs.mjs
@@ -26,6 +26,7 @@ import {
   mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { JSDOM } from 'jsdom';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   parseBoardListings,
   isBoardTargetLocation,
@@ -208,7 +209,7 @@ async function buildBoardJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-boggi-jobs.mjs
+++ b/scripts/update-boggi-jobs.mjs
@@ -46,6 +46,7 @@ import {
 } from './lib/boggi-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -177,7 +178,7 @@ function buildBoggiJob(offer) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-bosch-jobs.mjs
+++ b/scripts/update-bosch-jobs.mjs
@@ -34,6 +34,7 @@ import {
   inferBoschCategory,
 } from './lib/bosch-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -190,7 +191,7 @@ async function buildBoschJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-bps-suisse-jobs.mjs
+++ b/scripts/update-bps-suisse-jobs.mjs
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -263,7 +264,7 @@ function writeJson(filePath, value) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase().replace(/\/+$/, '') || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-burkhalter-jobs.mjs
+++ b/scripts/update-burkhalter-jobs.mjs
@@ -47,6 +47,7 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { isTargetCanton, getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -107,7 +108,7 @@ function isRelevantCanton(rawCanton = '', cityHint = '') {
 }
 
 function jobMatchKey(job) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function slugify(text = '') {

--- a/scripts/update-centiel-jobs.mjs
+++ b/scripts/update-centiel-jobs.mjs
@@ -19,6 +19,7 @@ import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -283,7 +284,7 @@ function buildJob(row) {
 
 /* ── Merge ─────────────────────────────────────────────────── */
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-cerbios-pharma-jobs.mjs
+++ b/scripts/update-cerbios-pharma-jobs.mjs
@@ -45,6 +45,7 @@ import {
 mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { parseListingPage, parseDetailPage, buildJob, stripHtml } from './lib/cerbios-pharma-job-parser.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -131,7 +132,7 @@ function writeJson(filePath, value) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase().replace(/\/+$/, '') || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-citta-di-lugano-jobs.mjs
+++ b/scripts/update-citta-di-lugano-jobs.mjs
@@ -45,6 +45,7 @@ import {
 mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { parseListingPage, parseDetailPage, buildJob, stripHtml } from './lib/citta-di-lugano-job-parser.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   buildPdfBackedDescription,
   extractPdfJobContentFromUrl,
@@ -161,7 +162,7 @@ function writeJson(filePath, value) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase().replace(/\/+$/, '') || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-cler-jobs.mjs
+++ b/scripts/update-cler-jobs.mjs
@@ -36,6 +36,7 @@ import {
   validateClerDescription,
 } from './lib/cler-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -98,7 +99,7 @@ function isTargetJob(job) {
 }
 
 function jobMatchKey(job) {
-  return job.url || job.slug || '';
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function todayIso() {

--- a/scripts/update-colin-cie-jobs.mjs
+++ b/scripts/update-colin-cie-jobs.mjs
@@ -24,6 +24,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -340,7 +341,7 @@ function buildJob(row, description) {
 
 /* ── Merge ─────────────────────────────────────────────────── */
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-convit-jobs.mjs
+++ b/scripts/update-convit-jobs.mjs
@@ -46,6 +46,7 @@ import {
   inferConvitCanton,
 } from './lib/convit-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -252,7 +253,7 @@ function buildConvitJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-damiani-jobs.mjs
+++ b/scripts/update-damiani-jobs.mjs
@@ -34,6 +34,7 @@ import {
   inferDamianiCategory,
 } from './lib/damiani-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -188,7 +189,7 @@ async function buildDamianiJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-delvitech-jobs.mjs
+++ b/scripts/update-delvitech-jobs.mjs
@@ -37,6 +37,7 @@ import {
   buildDelvitechLocalizedContent,
 } from './lib/delvitech-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -275,7 +276,7 @@ async function buildDelvitechJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-dot-life-jobs.mjs
+++ b/scripts/update-dot-life-jobs.mjs
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -312,7 +313,7 @@ async function buildDotLifeJob(card, playwrightPage) {
 function jobMatchKey(job = {}) {
   // Deduplicate by LinkedIn job ID when present, else by URL
   if (job.linkedInJobId) return `linkedin:${job.linkedInJobId}`;
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-ems-chemie-jobs.mjs
+++ b/scripts/update-ems-chemie-jobs.mjs
@@ -45,6 +45,7 @@ import {
 mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { parseListingPage, parseDetailPage, buildJob, stripHtml } from './lib/ems-chemie-job-parser.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -154,7 +155,7 @@ function writeJson(filePath, value) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase().replace(/\/+$/, '') || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-engelvoelkers-jobs.mjs
+++ b/scripts/update-engelvoelkers-jobs.mjs
@@ -48,6 +48,7 @@ import {
   inferEngelvoelkersCanton,
 } from './lib/engelvoelkers-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -269,7 +270,7 @@ function buildJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-ferrovia-retica-jobs.mjs
+++ b/scripts/update-ferrovia-retica-jobs.mjs
@@ -45,6 +45,7 @@ import {
 mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { parseListingPage, parseDetailPage, buildJob, buildFallbackDescription, stripHtml } from './lib/ferrovia-retica-job-parser.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -153,7 +154,7 @@ function writeJson(filePath, value) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase().replace(/\/+$/, '') || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-fincons-jobs.mjs
+++ b/scripts/update-fincons-jobs.mjs
@@ -31,6 +31,7 @@ import {
   buildFinconsLocalizedContent,
 } from './lib/fincons-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -189,7 +190,7 @@ async function buildFinconsJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-grace-jobs.mjs
+++ b/scripts/update-grace-jobs.mjs
@@ -28,6 +28,7 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { selectGraceDescription } from './lib/grace-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -81,7 +82,7 @@ function stripHtml(html = '') {
 }
 
 function jobMatchKey(job) {
-  return job.url || job.slug || '';
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function isTargetJob(job) {

--- a/scripts/update-hamilton-jobs.mjs
+++ b/scripts/update-hamilton-jobs.mjs
@@ -27,6 +27,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -106,7 +107,7 @@ function isTargetJob(job = {}) {
 }
 
 function jobMatchKey(job) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function slugify(text = '') {

--- a/scripts/update-hitachi-energy-jobs.mjs
+++ b/scripts/update-hitachi-energy-jobs.mjs
@@ -13,6 +13,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -299,7 +300,7 @@ function buildHitachiJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-hoval-jobs.mjs
+++ b/scripts/update-hoval-jobs.mjs
@@ -13,6 +13,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -250,7 +251,7 @@ function buildHovalJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-kempinski-jobs.mjs
+++ b/scripts/update-kempinski-jobs.mjs
@@ -26,6 +26,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -98,7 +99,7 @@ function isTargetJob(job = {}) {
 }
 
 function jobMatchKey(job) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function slugify(text = '') {

--- a/scripts/update-knowledge-lab-jobs.mjs
+++ b/scripts/update-knowledge-lab-jobs.mjs
@@ -14,6 +14,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -191,7 +192,7 @@ function buildKnowledgeLabJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-kronenhof-jobs.mjs
+++ b/scripts/update-kronenhof-jobs.mjs
@@ -45,6 +45,7 @@ import {
   mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -93,7 +94,7 @@ function isTargetJob(job = {}) {
 }
 
 function jobMatchKey(job) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function slugify(text = '') {

--- a/scripts/update-lombardi-jobs.mjs
+++ b/scripts/update-lombardi-jobs.mjs
@@ -44,6 +44,7 @@ import {
   titleOverlap,
 } from './lib/lombardi-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -187,7 +188,7 @@ function buildLombardiJob(raw, detail) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-lwphr-jobs.mjs
+++ b/scripts/update-lwphr-jobs.mjs
@@ -24,6 +24,7 @@ import { translateMissingJobLocales, validateDedicatedLocaleCoverage, detectLang
 import { buildPdfBackedDescription, extractPdfJobContentFromUrl } from './lib/pdf-job-content.mjs';
 import { parseLwphrOpenJobs, inferLwphrLocation, inferLwphrCategory, buildLwphrLocalizedPayload, extractTitleFromPdfText, reconcilePdfTitle } from './lib/lwphr-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -100,7 +101,7 @@ function isTrustedDomain(rawUrl = '') {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || job.slug || '').toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function buildJob({ title, pdfUrl, pdfText }) {

--- a/scripts/update-mkspamp-jobs.mjs
+++ b/scripts/update-mkspamp-jobs.mjs
@@ -43,6 +43,7 @@ import {
   buildMksPampLocalizedContent,
 } from './lib/mkspamp-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -187,7 +188,7 @@ function buildMksPampJob(rssItem, location) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-mtic-jobs.mjs
+++ b/scripts/update-mtic-jobs.mjs
@@ -43,6 +43,7 @@ import {
   isMticTicinoRelevant,
 } from './lib/mtic-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -279,7 +280,7 @@ function buildMticJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-pemsa-jobs.mjs
+++ b/scripts/update-pemsa-jobs.mjs
@@ -42,6 +42,7 @@ import {
   buildPemsaLocalizedContent,
 } from './lib/pemsa-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -168,7 +169,7 @@ function buildPemsaJob(detail, url) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-pizzarotti-jobs.mjs
+++ b/scripts/update-pizzarotti-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -199,7 +200,7 @@ async function buildPizzarottiJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-relewant-jobs.mjs
+++ b/scripts/update-relewant-jobs.mjs
@@ -43,6 +43,7 @@ import {
   isRelewantTicinoRelevant,
 } from './lib/relewant-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -148,7 +149,7 @@ function buildRelewantJob(parsed) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 async function mergeJobs(discoveredJobs) {

--- a/scripts/update-rittmeyer-jobs.mjs
+++ b/scripts/update-rittmeyer-jobs.mjs
@@ -32,6 +32,7 @@ import {
   buildRittmeyerLocalizedContent,
 } from './lib/rittmeyer-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -170,7 +171,7 @@ async function buildRittmeyerJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-ruag-jobs.mjs
+++ b/scripts/update-ruag-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -259,7 +260,7 @@ function buildRuagJob(detail) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-skyguide-jobs.mjs
+++ b/scripts/update-skyguide-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -218,7 +219,7 @@ async function buildSkyguideJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-stadt-chur-jobs.mjs
+++ b/scripts/update-stadt-chur-jobs.mjs
@@ -43,6 +43,7 @@ import {
   mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -119,7 +120,7 @@ function isTargetJob(job) {
 }
 
 function jobMatchKey(job) {
-  return job.url || job.slug || '';
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function todayIso() {

--- a/scripts/update-sunrise-jobs.mjs
+++ b/scripts/update-sunrise-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -211,7 +212,7 @@ async function buildSunriseJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-tarchini-group-jobs.mjs
+++ b/scripts/update-tarchini-group-jobs.mjs
@@ -13,6 +13,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -224,7 +225,7 @@ function buildTarchiniJob(row) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-tinext-jobs.mjs
+++ b/scripts/update-tinext-jobs.mjs
@@ -41,6 +41,7 @@ import {
   mergeLocaleTextMap,
 } from './lib/dedicated-crawler-common.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -320,7 +321,7 @@ async function buildJobs(positions) {
 
 /* ── Merge ─────────────────────────────────────────────────── */
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-trumpf-jobs.mjs
+++ b/scripts/update-trumpf-jobs.mjs
@@ -40,6 +40,7 @@ import {
 } from './lib/dedicated-crawler-common.mjs';
 import { isTargetSwissLocation, inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { isTargetCanton, getCompanyDefaults, getCantonDisplayName } from './lib/crawler-location-config.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -119,7 +120,7 @@ function isTargetJob(job) {
 }
 
 function jobMatchKey(job) {
-  return job.url || job.slug || '';
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function isSwissLocation(locationText = '') {

--- a/scripts/update-tsmg-jobs.mjs
+++ b/scripts/update-tsmg-jobs.mjs
@@ -20,6 +20,7 @@ import {
   readExistingCrawlerJobs,
 } from './assemble-jobs-dataset.mjs';
 import { validateJobUrls } from './lib/validate-job-url.mjs';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   translateMissingJobLocales,
   validateDedicatedLocaleCoverage,
@@ -174,7 +175,7 @@ function buildJob(job) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {

--- a/scripts/update-volg-jobs.mjs
+++ b/scripts/update-volg-jobs.mjs
@@ -24,6 +24,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -101,7 +102,7 @@ function isTargetJob(job = {}) {
 }
 
 function jobMatchKey(job) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function slugify(text = '') {

--- a/scripts/update-zucchetti-jobs.mjs
+++ b/scripts/update-zucchetti-jobs.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   printPublishedJobUrls,
   writeJobsSummary,
@@ -174,7 +175,7 @@ async function buildZucchettiJob(listing) {
 }
 
 function jobMatchKey(job = {}) {
-  return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
+  return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
 function mergeJobs(discoveredJobs) {


### PR DESCRIPTION
## Summary

Follow-up a PR #161. Coverage completa del fix vendor-URL-rename su tutti i 250 crawler dedicati + regola CLAUDE.md per i futuri crawler.

## Coverage map

| Pattern | Count | Status |
|---|---:|---|
| Migrato in questo PR (bespoke `jobMatchKey` → `extractStableJobId`) | 57 | ✅ |
| Già coperto (PwC bespoke fix in #161) | 1 | ✅ |
| Usa `mergePreserveLocaleData` (default matchKey fixato in #161) | 18 | ✅ |
| Usa `runStandardCrawlerPipeline` → passa dallo shared helper | ~167 | ✅ |

Tutti i 250 crawler ora keyer su stable-id (UUID / numeric / hex) con fallback URL.

## Migrazione

Sostituzione meccanica conservativa:
```
return String(job.url || '').trim().toLowerCase() || String(job.slug || '').trim().toLowerCase();
```
→
```
return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
```
+ import shared helper.

Per crawler senza stable token nell'URL, `extractStableJobId` ritorna `url:<u>` — comportamento identico al codice precedente, zero regressione.

## CLAUDE.md

Aggiunta non-negotiable #18 che documenta:
- `extractStableJobId` come matchKey obbligatorio
- `truncateSlugAtWordBoundary` come truncation obbligatoria
- previousSlugs preservation pattern per renames
- Cross-ref al memory `project_seo_rename_drift_may13.md`

## Test plan

- [x] 16 vitest fail pre-esistenti su main (errorReporter mock, i18n missing keys jobAlert.postAuthPromptError\*, useSeoPageTracking, chatbot/searchJobs, footer-position regression). Nessuno tocca crawler matchKey / slug truncation — non causati da questo PR.
- [x] 14 test nuovi (slug-truncate + job-match-key) da PR #161 ancora verdi.
- [ ] Post-merge: il prossimo run di un crawler con URL rename (PwC sicuro) deve preservare il vecchio slug in `previousSlugs`.