### PR TITLE
fix(ci): bump deploy-pages timeout 10min → 30min (1.84 GB dist slow at Pages backend)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -789,6 +789,8 @@ jobs:
         id: deployment_first
         uses: actions/deploy-pages@v5
         continue-on-error: true
+        with:
+          timeout: 1800000
 
       - name: Wait for previous Pages deployment to finish
         if: steps.deployment_first.outcome == 'failure'
@@ -800,6 +802,8 @@ jobs:
         id: deployment
         if: steps.deployment_first.outcome == 'failure'
         uses: actions/deploy-pages@v5
+        with:
+          timeout: 1800000
 
       - name: Fail if both deploy attempts failed
         if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome != 'success'
@@ -1097,6 +1101,8 @@ jobs:
         if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != '' && steps.last-good-artifact.outputs.id != ''
         id: rollback_deploy
         uses: actions/deploy-pages@v5
+        with:
+          timeout: 1800000
 
       - name: Report rollback to Linear
         if: always()


### PR DESCRIPTION
## Summary

Run 25784642450 — `validate-dist` PASSED (text-html-ratio + bfs-depth both green post #154+#157+#159 stack) but `deploy` step hit `Timeout reached, aborting!` on BOTH attempts (first + retry). The default `actions/deploy-pages@v5` timeout is 600000 ms (10 min); the dist is ~1.84 GB and Pages backend ingestion is taking longer than that today.

This bumps the timeout to 1800000 ms (30 min) on all three call sites in `deploy.yml`:
- first attempt
- retry attempt
- rollback deploy

Doesn't widen failure mode — a 30 min wait in `deployment_in_progress` is still a Pages backend issue. But at this dist size, 10 min is too tight (yesterday's 2.19 GB green deploy took 7 min; today's 1.84 GB exceeds 10 min — variance is normal).

### Test plan

- [ ] CI green — first deploy on this branch should complete within 30 min

Pre-push skipped per user memory.

**This should be the last red gate.** All audit gates green post-#157, deploy step was the structural blocker.