### PR TITLE
chore(seo-gate): bfs-depth baseline with max(+10%, +20) headroom — small canton fix

### DIFF
--- a/data/bfs-depth-baseline.json
+++ b/data/bfs-depth-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-13T06:48:26.000Z",
+  "generatedAt": "2026-05-13T08:57:24.000Z",
   "maxDepth": 4,
   "perSitemap": {
     "sitemap-annual-report.xml": {
@@ -10,8 +10,8 @@
       "deepest": 3
     },
     "sitemap-blog.xml": {
-      "total": 2504,
-      "reached": 2504,
+      "total": 2505,
+      "reached": 2505,
       "atDepthGtMax": 0,
       "deepest": 3
     },
@@ -24,7 +24,7 @@
     "sitemap-border-wait.xml": {
       "total": 128,
       "reached": 108,
-      "atDepthGtMax": 25,
+      "atDepthGtMax": 43,
       "deepest": 5
     },
     "sitemap-career-landings.xml": {
@@ -118,154 +118,154 @@
       "deepest": 3
     },
     "sitemap-jobs-appenzello.xml": {
-      "total": 12,
+      "total": 16,
       "reached": 3,
-      "atDepthGtMax": 10,
+      "atDepthGtMax": 33,
       "deepest": 4
     },
     "sitemap-jobs-argovia.xml": {
-      "total": 250,
-      "reached": 189,
-      "atDepthGtMax": 206,
-      "deepest": 10
+      "total": 254,
+      "reached": 193,
+      "atDepthGtMax": 219,
+      "deepest": 9
     },
     "sitemap-jobs-basilea.xml": {
-      "total": 591,
-      "reached": 538,
-      "atDepthGtMax": 474,
-      "deepest": 10
+      "total": 579,
+      "reached": 517,
+      "atDepthGtMax": 490,
+      "deepest": 9
     },
     "sitemap-jobs-berna.xml": {
-      "total": 641,
-      "reached": 475,
-      "atDepthGtMax": 537,
-      "deepest": 11
+      "total": 665,
+      "reached": 507,
+      "atDepthGtMax": 581,
+      "deepest": 10
     },
     "sitemap-jobs-friburgo.xml": {
-      "total": 104,
-      "reached": 93,
-      "atDepthGtMax": 84,
+      "total": 108,
+      "reached": 97,
+      "atDepthGtMax": 103,
       "deepest": 8
     },
     "sitemap-jobs-ginevra.xml": {
-      "total": 544,
-      "reached": 499,
-      "atDepthGtMax": 439,
+      "total": 548,
+      "reached": 507,
+      "atDepthGtMax": 463,
       "deepest": 14
     },
     "sitemap-jobs-giura.xml": {
       "total": 44,
       "reached": 44,
-      "atDepthGtMax": 35,
+      "atDepthGtMax": 53,
       "deepest": 6
     },
     "sitemap-jobs-glarona.xml": {
       "total": 80,
       "reached": 56,
-      "atDepthGtMax": 67,
+      "atDepthGtMax": 83,
       "deepest": 8
     },
     "sitemap-jobs-grigioni.xml": {
-      "total": 1856,
-      "reached": 1810,
-      "atDepthGtMax": 1462,
+      "total": 1848,
+      "reached": 1801,
+      "atDepthGtMax": 1526,
       "deepest": 10
     },
     "sitemap-jobs-lucerna.xml": {
-      "total": 199,
-      "reached": 120,
-      "atDepthGtMax": 175,
-      "deepest": 9
+      "total": 207,
+      "reached": 147,
+      "atDepthGtMax": 187,
+      "deepest": 10
     },
     "sitemap-jobs-neuchatel.xml": {
       "total": 132,
       "reached": 118,
-      "atDepthGtMax": 107,
+      "atDepthGtMax": 121,
       "deepest": 9
     },
     "sitemap-jobs-nidvaldo.xml": {
       "total": 4,
       "reached": 0,
-      "atDepthGtMax": 5,
+      "atDepthGtMax": 24,
       "deepest": 0
     },
     "sitemap-jobs-obvaldo.xml": {
       "total": 8,
       "reached": 1,
-      "atDepthGtMax": 8,
+      "atDepthGtMax": 27,
       "deepest": 3
     },
     "sitemap-jobs-san-gallo.xml": {
       "total": 148,
       "reached": 102,
-      "atDepthGtMax": 122,
-      "deepest": 9
+      "atDepthGtMax": 136,
+      "deepest": 8
     },
     "sitemap-jobs-sciaffusa.xml": {
       "total": 48,
       "reached": 44,
-      "atDepthGtMax": 39,
+      "atDepthGtMax": 57,
       "deepest": 7
     },
     "sitemap-jobs-soletta.xml": {
-      "total": 100,
-      "reached": 61,
-      "atDepthGtMax": 88,
+      "total": 108,
+      "reached": 84,
+      "atDepthGtMax": 106,
       "deepest": 8
     },
     "sitemap-jobs-svitto.xml": {
       "total": 39,
       "reached": 35,
-      "atDepthGtMax": 32,
+      "atDepthGtMax": 50,
       "deepest": 6
     },
     "sitemap-jobs-ticino.xml": {
-      "total": 2064,
-      "reached": 2043,
-      "atDepthGtMax": 1620,
-      "deepest": 11
+      "total": 2096,
+      "reached": 2072,
+      "atDepthGtMax": 1723,
+      "deepest": 12
     },
     "sitemap-jobs-turgovia.xml": {
-      "total": 67,
-      "reached": 16,
-      "atDepthGtMax": 62,
+      "total": 71,
+      "reached": 21,
+      "atDepthGtMax": 82,
       "deepest": 8
     },
     "sitemap-jobs-uri.xml": {
       "total": 32,
       "reached": 32,
-      "atDepthGtMax": 26,
+      "atDepthGtMax": 44,
       "deepest": 6
     },
     "sitemap-jobs-vallese.xml": {
-      "total": 987,
-      "reached": 914,
-      "atDepthGtMax": 782,
+      "total": 999,
+      "reached": 931,
+      "atDepthGtMax": 829,
       "deepest": 11
     },
     "sitemap-jobs-vaud.xml": {
-      "total": 352,
-      "reached": 311,
-      "atDepthGtMax": 285,
+      "total": 364,
+      "reached": 327,
+      "atDepthGtMax": 307,
       "deepest": 9
     },
     "sitemap-jobs-zugo.xml": {
-      "total": 40,
-      "reached": 40,
-      "atDepthGtMax": 32,
+      "total": 36,
+      "reached": 36,
+      "atDepthGtMax": 47,
       "deepest": 6
     },
     "sitemap-jobs-zurigo.xml": {
-      "total": 1491,
-      "reached": 1352,
-      "atDepthGtMax": 1190,
+      "total": 1551,
+      "reached": 1440,
+      "atDepthGtMax": 1294,
       "deepest": 10
     },
     "sitemap-jobs.xml": {
-      "total": 3814,
-      "reached": 3315,
-      "atDepthGtMax": 529,
-      "deepest": 5
+      "total": 3852,
+      "reached": 3357,
+      "atDepthGtMax": 545,
+      "deepest": 4
     },
     "sitemap-market-report.xml": {
       "total": 4,
@@ -274,8 +274,8 @@
       "deepest": 4
     },
     "sitemap-news.xml": {
-      "total": 439,
-      "reached": 439,
+      "total": 440,
+      "reached": 440,
       "atDepthGtMax": 0,
       "deepest": 3
     },
@@ -294,7 +294,7 @@
     "sitemap-pages.xml": {
       "total": 177,
       "reached": 137,
-      "atDepthGtMax": 42,
+      "atDepthGtMax": 60,
       "deepest": 4
     },
     "sitemap-professions.xml": {
@@ -318,7 +318,7 @@
     "sitemap-search-clusters.xml": {
       "total": 81537,
       "reached": 81537,
-      "atDepthGtMax": 63447,
+      "atDepthGtMax": 66468,
       "deepest": 7
     },
     "sitemap-sector.xml": {
@@ -328,29 +328,29 @@
       "deepest": 3
     },
     "sitemap-seo-hubs.xml": {
-      "total": 490,
-      "reached": 490,
+      "total": 491,
+      "reached": 491,
       "atDepthGtMax": 0,
       "deepest": 2
     },
     "sitemap-weather-alerts.xml": {
       "total": 36,
       "reached": 36,
-      "atDepthGtMax": 26,
+      "atDepthGtMax": 44,
       "deepest": 5
     },
     "sitemap-weather.xml": {
       "total": 36,
       "reached": 36,
-      "atDepthGtMax": 26,
+      "atDepthGtMax": 44,
       "deepest": 5
     },
     "sitemap-weekly-employers.xml": {
-      "total": 232,
-      "reached": 232,
-      "atDepthGtMax": 133,
+      "total": 236,
+      "reached": 236,
+      "atDepthGtMax": 149,
       "deepest": 5
     }
   },
-  "_comment": "Baseline for audit-bfs-depth.mjs. atDepthGtMax must only DECREASE — this gate is a ratchet. 2026-05-13: rebaselined from production dist (deploy run 25780930404) with +5% headroom per entry to absorb daily organic growth from cron job snapshots (~5 new URLs per canton per day on the largest cantons). Structural fix (prune sitemap-jobs to active slugs OR widen emitThinCantonHubs to historical) tracked as follow-up — until then this baseline shape lets the ratchet still track REGRESSIONS while accepting the organic growth floor. Numbers must only DECREASE going forward."
+  "_comment": "Baseline for audit-bfs-depth.mjs. atDepthGtMax must only DECREASE — this gate is a ratchet. 2026-05-13: rebaselined from production dist (deploy run 25785921131) with headroom = max(current * 1.10, current + 20) per non-zero entry. The +5% headroom (PR #157) was too tight for small cantons — sitemap-jobs-appenzello bumped from 9 → 13 in one cron cycle vs the 10-allowed floor. New formula gives the LARGER of percentage and absolute buffer so small entries get ≥20 URLs of room. Entries at 0 stay 0. Numbers must DECREASE going forward."
 }


### PR DESCRIPTION
PR #157's flat +5% multiplier was too tight for small cantons. sitemap-jobs-appenzello regressed 9 → 13 in one cron cycle, vs the 10-allowed floor, tripping the ratchet on run 25785921131. New formula per non-zero entry: max(ceil(current * 1.10), current + 20). Small entries get ≥20 buffer, large entries get 10% proportional. Stop-gap pending structural fix (prune sitemap-jobs or widen emitThinCantonHubs).