### PR TITLE
fix(ci): bump deploy-pages error_count 10 → 100 — defensive (timeout already at 30min)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -791,6 +791,7 @@ jobs:
         continue-on-error: true
         with:
           timeout: 1800000
+          error_count: 100
 
       - name: Wait for previous Pages deployment to finish
         if: steps.deployment_first.outcome == 'failure'
@@ -804,6 +805,7 @@ jobs:
         uses: actions/deploy-pages@v5
         with:
           timeout: 1800000
+          error_count: 100
 
       - name: Fail if both deploy attempts failed
         if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome != 'success'
@@ -1103,6 +1105,7 @@ jobs:
         uses: actions/deploy-pages@v5
         with:
           timeout: 1800000
+          error_count: 100
 
       - name: Report rollback to Linear
         if: always()


### PR DESCRIPTION
PR #163 set timeout: 1800000 (30 min) but recent runs (25789842656, 25791219337) abort exactly at 10 min. Either v5 has an internal cap OR error_count: 10 (default) is the limiter (transient API errors accumulating). Bump error_count to 100 to remove that variable. If still aborts at 10 min, downgrade to @v4 or custom polling.