### PR TITLE
perf(jobs-seo): slim __EXPIRED_JOB_DATA__ + fix locale-variant indexing

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -8683,6 +8683,17 @@ ${alternates}
  // Was unconditional `set` previously, which let the LAST entry (oldest
  // after sort, but arbitrary order before sort) overwrite the winner.
  if (ej.slug && !expiredBySlug.has(ej.slug)) expiredBySlug.set(ej.slug, ej);
+ // Index current-locale slug variants so DE/EN/FR soft-landing URLs
+ // (e.g. /de/jobs-im-tessin/{de-slug}/) resolve to the same ejData as
+ // the IT primary. Without this, expiredBySlug.get(de-slug) returns
+ // undefined → emitter ships descriptionByLocale:{} on those variants,
+ // forcing the SPA to fetch /data/expired-jobs.json (4.5 MB) just to
+ // render the description post-hydration.
+ if (ej.slugByLocale && typeof ej.slugByLocale === 'object') {
+ for (const ls of Object.values(ej.slugByLocale)) {
+ if (ls && typeof ls === 'string' && !expiredBySlug.has(ls)) expiredBySlug.set(ls, ej);
+ }
+ }
  // Also index previousSlugs so renamed-then-deleted jobs get enriched soft-landing pages
  if (Array.isArray(ej.previousSlugs)) {
  for (const ps of ej.previousSlugs) {
@@ -9460,14 +9471,25 @@ ${hreflangLinks}
  // Seed expired job data as window global so the SPA can render
  // rich content (title, company, description) without depending on
  // the runtime expired-jobs.json fetch (which only has recently expired jobs).
+ //
+ // Multi-locale stripping: the SPA reads only `[locale]` entries from
+ // titleByLocale / descriptionByLocale (JobExpiredView.tsx:174-175). The
+ // other 3 locales' entries are dead bytes on the wire — ~6 KB per
+ // IT-primary expired page (de+en+fr descriptions). slugByLocale stays
+ // full because seededJobMatchesSlug + hooks/useExpiredJob match the
+ // URL slug against any locale entry.
+ const pickLocaleEntry = <T,>(src: Record<string, T> | undefined, l: string): Record<string, T> => {
+  if (!src || src[l] == null) return {};
+  return { [l]: src[l] };
+ };
  const expiredWindowData = JSON.stringify({
  slug,
  title: ejData?.title || gscInfo?.title || slugInfo?.title || '',
- titleByLocale: ejData?.titleByLocale || gscInfo?.titleByLocale || {},
+ titleByLocale: pickLocaleEntry(ejData?.titleByLocale || gscInfo?.titleByLocale, locale),
  company: ejData?.company || gscInfo?.company || slugInfo?.company || '',
  companyKey: ejData?.companyKey || gscInfo?.companyKey || slugInfo?.companyKey || '',
  location: ejData?.location || ejData?.addressLocality || gscInfo?.location || slugInfo?.location || '',
- descriptionByLocale: ejData?.descriptionByLocale || gscInfo?.descriptionByLocale || {},
+ descriptionByLocale: pickLocaleEntry(ejData?.descriptionByLocale || gscInfo?.descriptionByLocale, locale),
  slugByLocale: ejData?.slugByLocale || gscInfo?.slugByLocale || {},
  sector: ejData?.sector || gscInfo?.sector || '',
  expiredAt: ejData?.expiredAt || '',


### PR DESCRIPTION
## Cosa

Due fix combinati al payload \`window.__EXPIRED_JOB_DATA__\` emesso da \`build-plugins/jobsSeoPagesPlugin.ts\` per ~70k pagine expired/soft-landing in 4 lingue.

### 1. Strip multi-locale dead data (IT primary)

\`JobExpiredView.tsx:174-175\` (e \`useExpiredJob\` hook) leggono SOLO \`descriptionByLocale[currentLocale]\` e \`titleByLocale[currentLocale]\`. Le entries delle altre 3 lingue sono dead bytes.

Wrap con \`pickLocaleEntry(src, locale)\`:
- IT primary expired page payload: \`8,435 B → ~2,500 B\` (saving 5,935 B/pagina)
- 1,158 pagine impattate → **-6.9 MB**

### 2. Fix \`expiredBySlug\` indexing per locale-variant URLs

\`expiredBySlug\` indicizzava \`ej.slug\` + \`previousSlugs\` + \`previousSlugsByLocale\` ma **NON** \`ej.slugByLocale[*]\`. Quando il plugin emette \`/de/jobs-im-tessin/{de-slug}/\`, \`expiredBySlug.get(de-slug)\` ritornava \`undefined\` → pagine DE/EN/FR con \`descriptionByLocale: {}\` vuoto. La SPA doveva fetchare \`/data/expired-jobs.json\` (4.5 MB) a runtime per riempire la descrizione post-hydration → **flash of empty description**.

Aggiungendo \`slugByLocale[*]\` al populate, le 3 locale variants ora ricevono il payload arricchito direttamente dal seed (+~2 KB/pagina × ~3,500 pagine = +7 MB).

### Net change

| | Before | After | Δ |
|---|---:|---:|---:|
| IT-primary pages | 8,435 B EJD | 2,500 B EJD | **-5,935 B/pagina** × 1,158 = -6.9 MB |
| DE/EN/FR variants | 215-223 B EJD (empty) | ~2,500 B EJD (current locale) | **+2,300 B/pagina** × 3,474 = +8.0 MB |
| **Net artifact size** | | | **~+1 MB** (saving compensato) |

Il fix prioritario qui è **UX/performance**, non size:
- DE/EN/FR expired soft-landing renderizzano descrizione istantanea
- Eliminato il fetch runtime di \`expired-jobs.json\` (4.5 MB!) come dipendenza pre-render
- Ratio: +1 MB statico vs -4.5 MB runtime fetch per ~3,500 pagine

## Cosa NON cambia

- \`slugByLocale\` resta intero (~200 B/pagina) — usato da \`seededJobMatchesSlug\` e \`useExpiredJob.matchExpiredSlug\` per match URL→qualsiasi locale entry
- \`__STATIC_BODY_HTML__\` invariato — testo SEO per crawler resta identico
- IT primary hydration: comportamento identico (descrizione visibile post-mount, no flash)
- DE/EN/FR hydration: **MIGLIORATO** (descrizione visibile istantaneamente, era vuoto)

## Test plan

- [x] \`npx tsc --noEmit\`: solo errori pre-existing (data/jobs.json gitignored, JobBoard typing) — non toccati dal diff
- [x] \`tests/regression/company-filter-vs-job-slug.test.ts\`: 15/15 ✅
- [x] \`tests/soft-landing-seo.test.ts\`: 9/9 ✅
- [ ] CI post-merge: verificare un sample expired page in 4 locali via curl per confermare payload shape

Closes P0-2 + bonus F nell'analisi artifact ottimizzazione.