### PR TITLE
fix(seo/jsonld): canton page BreadcrumbList — human label + aggregator parent

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -7835,15 +7835,27 @@ ${alternates}
      const legacyJobBoardHref = `${BASE_URL}${withSlash(`${localePrefix[entry.locale]}/${entry.section}`.replace(/\/+/g, '/'))}`;
      // BreadcrumbList JSON-LD: required by tests/seo/breadcrumb-coverage.test.ts
      // (D.2 — every non-exempt dist/ HTML page must include a BreadcrumbList).
-     // Three-level chain: Home → Job Board (locale legacy section) → canton.
+     // Per-canton: Home → "Cerca lavoro in Svizzera" (aggregator) → canton.
+     // Aggregator page itself: Home → "Svizzera" (skip dupe parent).
+     // Prior bug (GSC "Unparsable structured data", 2026-05-13): position 2
+     // used `sectionByLocale[locale]` — a URL slug like "cerca-lavoro-ticino" —
+     // as the human `name`, and `legacyJobBoardHref` resolved to the same URL
+     // as the canton page itself (e.g. /cerca-lavoro-argovia/ on the AG page),
+     // producing a malformed breadcrumb that Google rejected as invalid.
+     const homeItem = { '@type': 'ListItem', position: 1, name: homeLabel[entry.locale], item: `${BASE_URL}${entry.locale === 'it' ? '/' : `/${entry.locale}/`}` };
+     const currentItem = { '@type': 'ListItem', position: entry.key === AGGREGATE_KEY ? 2 : 3, name: display, item: canonicalUrl };
+     const aggregatorBreadcrumbItem = (() => {
+       const aggregatorDisplay = getCantonDisplayLabel(AGGREGATE_KEY, entry.locale);
+       const aggregatorSection = buildCantonAwareSection(entry.locale, AGGREGATE_KEY);
+       const aggregatorHref = `${BASE_URL}${withSlash(`${localePrefix[entry.locale]}/${aggregatorSection}`.replace(/\/+/g, '/'))}`;
+       return { '@type': 'ListItem', position: 2, name: cantonSectionName(entry.locale, aggregatorDisplay), item: aggregatorHref };
+     })();
      const cantonBreadcrumbLd = `<script type="application/ld+json">${JSON.stringify({
        '@context': 'https://schema.org',
        '@type': 'BreadcrumbList',
-       itemListElement: [
-         { '@type': 'ListItem', position: 1, name: homeLabel[entry.locale], item: `${BASE_URL}${entry.locale === 'it' ? '/' : `/${entry.locale}/`}` },
-         { '@type': 'ListItem', position: 2, name: sectionByLocale[entry.locale], item: legacyJobBoardHref },
-         { '@type': 'ListItem', position: 3, name: display, item: canonicalUrl },
-       ],
+       itemListElement: entry.key === AGGREGATE_KEY
+         ? [homeItem, currentItem]
+         : [homeItem, aggregatorBreadcrumbItem, currentItem],
      })}</script>`;
 
      // ── P4: rich canton-landing body ────────────────────────────────────


### PR DESCRIPTION
## Summary

GSC report "Dati strutturati non analizzabili" (2026-05-13) flagged canton job pages (`/cerca-lavoro-{canton}/`) emitting malformed `BreadcrumbList`:

- `position 2.name` was a URL slug (`"cerca-lavoro-ticino"`), not a human label.
- `position 2.item` resolved to the same URL as `position 3.item` (the canton page itself), because `legacyJobBoardHref` was computed from `entry.section` — the canton-aware segment.

Google's parser rejected this as "Tipo di valore non corretto".

## Fix

`build-plugins/jobsSeoPagesPlugin.ts` canton emit (~L7836):

- Per-canton: `Home → "Cerca lavoro in Svizzera" (/cerca-lavoro-svizzera/) → Canton`.
- Aggregator page (`_AGGREGATE_`): 2-level `Home → "Svizzera"` (skips the would-be duplicate parent).
- Labels via existing helpers (`cantonSectionName`, `getCantonDisplayLabel`) so IT/EN/DE/FR are all localized properly (`Find jobs in Switzerland`, `Jobs in Schweiz`, `Trouver un emploi en Suisse`).

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] Verified rendered JSON-LD locally for AG/IT, ZH/EN, AG/DE, and aggregator — all breadcrumbs have distinct URLs and human-readable names
- [ ] CI deploy pipeline green
- [ ] Post-deploy: `curl https://frontaliereticino.ch/cerca-lavoro-argovia/ | grep BreadcrumbList` shows new shape
- [ ] GSC re-validation request after deploy