### PR TITLE
fix(seo): trim CollectionPage itemListElement 50 → 25 — page-weight gate (1 offender)

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -998,7 +998,7 @@ function buildHtml(args: BuildHtmlArgs): string {
     mainEntity: {
       '@type': 'ItemList',
       numberOfItems: totalItems,
-      itemListElement: pageItems.slice(0, 50).map((it, idx) => ({
+      itemListElement: pageItems.slice(0, 25).map((it, idx) => ({
         '@type': 'ListItem',
         position: (page - 1) * 100 + idx + 1,
         name: it.label,


### PR DESCRIPTION
Only 1 offender on run 25797411387: page-365 of TI master jobs hub at 205,918 bytes vs 204,800 limit (+1118 bytes). Trimming the inlined CollectionPage structured-data from 50 → 25 ListItem entries shaves ~3.7 KB — clears the gate with margin.