### PR TITLE
fix(seo/bfs-depth): static lang-switcher anchors on home — ROOT cause fix (no baseline workaround)

### DIFF
--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -476,7 +476,50 @@ function injectHomepageSeoContent(html: string, locale: HpSeoLocale): string {
  // not touched by React hydration. Falls back to no-op if no </body>.
  if (!html.includes('</body>')) return html;
  const cantonNav = buildHomepageCantonNavHtml(locale);
- return html.replace('</body>', `${block}\n${cantonNav}\n</body>`);
+ const langSwitch = buildHomepageLangSwitchHtml(locale);
+ return html.replace('</body>', `${block}\n${langSwitch}\n${cantonNav}\n</body>`);
+}
+
+/**
+ * Language switcher anchors emitted as static `<a>` on every locale's
+ * home page. ROOT-CAUSE FIX for bfs-depth regression on
+ * sitemap-jobs-{canton}.xml (run 25954025410 — Ginevra 465/608 URLs
+ * at depth > 4, deepest=13).
+ *
+ * The audit's BFS walker follows `<a href>` only — `<link rel="alternate"
+ * hreflang>` tags in `<head>` are ignored. Before this fix, the IT home
+ * `/` had ZERO `<a>` anchors to `/en/`, `/de/`, `/fr/`, so the entire
+ * non-IT URL tree (per-canton hubs + their job-detail leaves) was
+ * orphan to static BFS. Audit reached them via indirect chains that
+ * accumulated 5-13 hops.
+ *
+ * With the switcher in place, every locale home is at depth 1 from
+ * every other locale home → non-IT canton hubs at depth 2 → tutti at
+ * depth 3 → job detail at depth 4. ✓
+ *
+ * Rendered as a compact pill row (mobile-friendly) so it's
+ * visible-not-collapsed for BFS reliability AND user UX.
+ */
+function buildHomepageLangSwitchHtml(currentLocale: HpSeoLocale): string {
+ const langs: Array<{ code: HpSeoLocale; label: string; href: string }> = [
+   { code: 'it', label: 'Italiano', href: '/' },
+   { code: 'en', label: 'English', href: '/en/' },
+   { code: 'de', label: 'Deutsch', href: '/de/' },
+   { code: 'fr', label: 'Français', href: '/fr/' },
+ ];
+ const navLabel = currentLocale === 'en' ? 'Language switcher'
+   : currentLocale === 'de' ? 'Sprachumschalter'
+   : currentLocale === 'fr' ? 'Sélecteur de langue'
+   : 'Cambia lingua';
+ const pillStyle = 'display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:#f8fafc;color:#1e293b;text-decoration:none;font-size:13px;font-weight:600;border:1px solid #cbd5e1';
+ const activeStyle = 'display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:#1e293b;color:#fff;font-size:13px;font-weight:600;border:1px solid #1e293b';
+ const items = langs
+   .map(({ code, label, href }) => code === currentLocale
+     ? `<span style="${activeStyle}" aria-current="page">${label}</span>`
+     : `<a href="${href}" hreflang="${code}" style="${pillStyle}">${label}</a>`,
+   )
+   .join('');
+ return `<nav id="hp-lang-switch" aria-label="${navLabel}" style="max-width:1100px;margin:16px auto 0;padding:0 20px;line-height:1.9">${items}</nav>`;
 }
 
 /**

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -137,16 +137,16 @@ const ALLOWLIST = [
   //    for sitemap-jobs.xml — pulls per-company azienda-* leaves from BFS
   //    depth 5 to depth 4 by anchoring /aziende-che-assumono/tutte/ + the
   //    locale variants directly off `/`).
-  'build-plugins/staticPagesPlugin.ts:1212',
-  'build-plugins/staticPagesPlugin.ts:1213',
-  'build-plugins/staticPagesPlugin.ts:1214',
-  'build-plugins/staticPagesPlugin.ts:1215',
-  'build-plugins/staticPagesPlugin.ts:1234',
-  'build-plugins/staticPagesPlugin.ts:1235',
-  'build-plugins/staticPagesPlugin.ts:1769',
-  'build-plugins/staticPagesPlugin.ts:1794',
-  'build-plugins/staticPagesPlugin.ts:1819',
-  'build-plugins/staticPagesPlugin.ts:2087',
+  'build-plugins/staticPagesPlugin.ts:1255',
+  'build-plugins/staticPagesPlugin.ts:1256',
+  'build-plugins/staticPagesPlugin.ts:1257',
+  'build-plugins/staticPagesPlugin.ts:1258',
+  'build-plugins/staticPagesPlugin.ts:1277',
+  'build-plugins/staticPagesPlugin.ts:1278',
+  'build-plugins/staticPagesPlugin.ts:1812',
+  'build-plugins/staticPagesPlugin.ts:1837',
+  'build-plugins/staticPagesPlugin.ts:1862',
+  'build-plugins/staticPagesPlugin.ts:2130',
   // ── Cross-section hub anchors emitted inside buildHomepageCantonNavHtml
   //    (2026-05-13 BFS-depth fix for sitemap-jobs.xml azienda-* leaves).
   //    Per-locale URL constants reference the TI section slug; the audit


### PR DESCRIPTION
Home / has zero <a href> to /en/, /de/, /fr/. BFS walker follows <a> only — <link rel='alternate' hreflang> is ignored. All non-IT canton URLs were orphan, only reachable via 5-13 hop indirect chains. With visible lang-pill nav: / → /en/ → /en/find-jobs-{canton}/ → tutti → job = depth 4 ✓. Eliminates the ratchet flap (not band-aid baseline buffer). Audit run 25954025410 ginevra: 465 vs 463 → expected 0 after fix.