### PR TITLE
feat(profession-landings): template B mobile-first redesign

### DIFF
--- a/build-plugins/professionJobsAggregate.ts
+++ b/build-plugins/professionJobsAggregate.ts
@@ -1,0 +1,340 @@
+/**
+ * Build-time aggregator for the profession landings (AE-3 template B).
+ *
+ * Reads data/jobs.json once per build, derives per-profession metrics that
+ * feed the new template B header (3 stat tiles + 3 featured jobs + employer
+ * grid). PROFESSION_FACTS in professionLandingsData.ts stays as the frozen
+ * authority for typicalSalaryRange / CCL / recognition — those are stable
+ * editorial facts, not snapshot-driven.
+ *
+ * Matching strategy
+ * -----------------
+ * jobs.json `category` is a multilingual mess (`finance`, `Tecnica`,
+ * `Gesundheitswesen`, `health`, `Infermieristica`, …) so we do NOT rely on
+ * it alone. Each profession defines a multilingual title regex AND a set of
+ * accepted category substrings (lowercased). A job matches a profession when
+ * either signal fires; the title regex is the primary path.
+ *
+ * Output cached at the module level so multiple plugins (or repeated calls
+ * during a single build) don't re-parse the 31 MB file.
+ *
+ * No write side effects: this module is read-only by design.
+ */
+
+import * as fs from 'node:fs';
+import * as np from 'node:path';
+import {
+  PROFESSION_IDS,
+  type ProfessionId,
+  type ProfessionLocale,
+} from './professionLandingsData';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Subset of jobs.json record fields we actually need. */
+interface JobRecord {
+  id?: string;
+  slug?: string;
+  slugByLocale?: Partial<Record<ProfessionLocale, string>>;
+  title?: string;
+  titleByLocale?: Partial<Record<ProfessionLocale, string>>;
+  company?: string;
+  companyKey?: string;
+  category?: string;
+  sector?: string;
+  addressLocality?: string;
+  canton?: string;
+  salaryMin?: number | null;
+  salaryMax?: number | null;
+  currency?: string;
+  postedDate?: string;
+  firstSeenAt?: string;
+  featured?: boolean;
+  employmentType?: string;
+  url?: string;
+  applyUrl?: string;
+}
+
+export interface FeaturedJob {
+  readonly id: string;
+  readonly title: string;
+  readonly titleByLocale: Partial<Record<ProfessionLocale, string>>;
+  readonly company: string;
+  readonly city: string;
+  readonly salaryMin: number | null;
+  readonly salaryMax: number | null;
+  readonly postedDate: string;
+  readonly daysAgo: number;
+  readonly slug: string;
+  readonly slugByLocale: Partial<Record<ProfessionLocale, string>>;
+  readonly employmentType: string | null;
+}
+
+export interface ProfessionJobsSnapshot {
+  /** Live count of matching jobs in the dataset (all-time, no age filter). */
+  readonly liveCount: number;
+  /**
+   * Count of matches with `postedDate` in the last 30 days — the "freshness"
+   * signal that powers the third stat tile. Honest where Q-over-Q would lie
+   * (the crawlers drop stale postings so a true trend is unobservable).
+   */
+  readonly fresh30Count: number;
+  /** Median annual gross CHF salary computed from baseSalary midpoints. */
+  readonly medianSalaryChf: number | null;
+  /** Top 3 freshest featured (else freshest) jobs that match this profession. */
+  readonly featured: readonly FeaturedJob[];
+  /** Top 6 employers by job count for this profession. */
+  readonly topEmployers: ReadonlyArray<{ name: string; count: number }>;
+}
+
+// ── Matchers ─────────────────────────────────────────────────────────────────
+
+interface ProfessionMatcher {
+  /** Multilingual title regex — matches any tokenised role variant. */
+  readonly title: RegExp;
+  /**
+   * Optional negative regex — when it matches, the job is rejected even if
+   * `title` would have matched. Lets us strip cross-category false positives
+   * like "Chef de Rang" sneaking into cuoco (it's a waiter title in DE/FR).
+   */
+  readonly exclude?: RegExp;
+}
+
+/**
+ * Heuristic matchers — multi-locale (IT/EN/DE/FR) word stems. Title-only:
+ * jobs.json `category` is too coarse and multilingual to use safely (a single
+ * `gesundheitswesen` category catches psychologists, OSS, doctors AND nurses).
+ * False positives compound on featured-jobs cards which a user sees and
+ * judges immediately — so the bar for inclusion has to be the title itself.
+ */
+const PROFESSION_MATCHERS: Record<ProfessionId, ProfessionMatcher> = {
+  infermiere: {
+    title: /\b(infermier|krankenpfleg|krankenschwester|pflegefach|pflegehelfer|registered nurse|infirmier|infirmière|fachperson gesundheit)/i,
+    // Reject the generic "nurse" assistant titles that aren't RN-grade roles.
+    exclude: /\b(assistenzpsycholog|psychotherap|sozialarbeit|tieräpfleg)/i,
+  },
+  operaio: {
+    title: /\b(operai|produktionsmitarbeit|production worker|tornitor|fresator|saldator|magazzinier|aiuto-?reparto|lagerist|lagermitarbeit|aiuto-?cucina|hilfsarbeiter)\b/i,
+  },
+  impiegato: {
+    title: /\b(impiegat|sachbearbeiter|kaufm[äa]nn|kauffrau|kfm-?angestellte|administrative assistant|administrative officer|amministrativ|back-?office clerk|front-?office clerk|customer service representative|sekret[äa]r|segretari)\b/i,
+  },
+  ingegnere: {
+    title: /\b(ingegner|ingenieur|ingénieur|engineer|engineering specialist)\b/i,
+  },
+  educatore: {
+    title: /\b(educator|educatore|educatrice|erzieher|éducateur|educateur|sozialp[äa]dagog|fachperson betreuung|operatore socio-?educativ|asilo nido|nido d'?infanzia)/i,
+  },
+  autista: {
+    title: /\b(autist|chauffeur|conducente|camionist|berufsfahrer|lkw-?fahrer|truck driver|delivery driver)\b/i,
+  },
+  muratore: {
+    title: /\b(murator|maurer|mason|maçon|macon|carpentier|carpentiere|bauarbeiter|construction worker|capomastr|casserator)/i,
+  },
+  cuoco: {
+    title: /\b(cuoc|cuisinier|koch|cook|chef de partie|chef de cuisine|sous chef|küchenchef|capo cuoc|pizzaiol)\b/i,
+    // "Chef de rang" / "Chef de Réception" are hospitality service titles, not kitchen.
+    exclude: /\b(chef de rang|chef de réception|chef d'équipe|chef de service|chef sommelier)\b/i,
+  },
+  cameriere: {
+    title: /\b(camerier|kellner|waiter|waitress|serveur|serveuse|chef de rang|commis de salle|barista|barkeeper)\b/i,
+  },
+  elettricista: {
+    title: /\b(elettricist|elektriker|electrician|électricien|electricien|elektromonteur|elektroinstallat)/i,
+  },
+};
+
+// ── Cache + load ─────────────────────────────────────────────────────────────
+
+let _snapshotCache: Record<ProfessionId, ProfessionJobsSnapshot> | null = null;
+let _cacheRootDir: string | null = null;
+
+const DAY_MS = 86_400_000;
+
+function loadJobs(rootDir: string): readonly JobRecord[] {
+  const jobsPath = np.join(rootDir, 'data', 'jobs.json');
+  if (!fs.existsSync(jobsPath)) return [];
+  try {
+    const raw = fs.readFileSync(jobsPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed as JobRecord[];
+    return [];
+  } catch (err) {
+    console.warn('[profession-aggregate] failed to read jobs.json:', err);
+    return [];
+  }
+}
+
+function jobMatchesProfession(job: JobRecord, m: ProfessionMatcher): boolean {
+  const haystacks: string[] = [];
+  if (job.title) haystacks.push(job.title);
+  if (job.titleByLocale) {
+    for (const v of Object.values(job.titleByLocale)) {
+      if (v) haystacks.push(v);
+    }
+  }
+  let titleHit = false;
+  for (const h of haystacks) {
+    if (m.title.test(h)) {
+      titleHit = true;
+      break;
+    }
+  }
+  if (!titleHit) return false;
+  if (m.exclude) {
+    for (const h of haystacks) {
+      if (m.exclude.test(h)) return false;
+    }
+  }
+  return true;
+}
+
+function median(values: readonly number[]): number | null {
+  const sorted = [...values].filter((v) => Number.isFinite(v) && v > 0).sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? Math.round((sorted[mid - 1] + sorted[mid]) / 2) : sorted[mid];
+}
+
+function jobMidpoint(job: JobRecord): number | null {
+  const min = typeof job.salaryMin === 'number' ? job.salaryMin : null;
+  const max = typeof job.salaryMax === 'number' ? job.salaryMax : null;
+  if (min && max) return Math.round((min + max) / 2);
+  if (min) return min;
+  if (max) return max;
+  return null;
+}
+
+function toFeatured(job: JobRecord, now: number): FeaturedJob | null {
+  if (!job.id || !job.title || !job.slug) return null;
+  const postedDate = job.postedDate || job.firstSeenAt || '';
+  const ts = postedDate ? Date.parse(postedDate) : NaN;
+  const daysAgo = Number.isFinite(ts) ? Math.max(0, Math.round((now - ts) / DAY_MS)) : 9999;
+  return {
+    id: job.id,
+    title: job.title,
+    titleByLocale: job.titleByLocale ?? {},
+    company: job.company ?? '',
+    city: job.addressLocality ?? '',
+    salaryMin: typeof job.salaryMin === 'number' ? job.salaryMin : null,
+    salaryMax: typeof job.salaryMax === 'number' ? job.salaryMax : null,
+    postedDate,
+    daysAgo,
+    slug: job.slug,
+    slugByLocale: job.slugByLocale ?? {},
+    employmentType: job.employmentType ?? null,
+  };
+}
+
+function buildSnapshotForProfession(
+  jobs: readonly JobRecord[],
+  matcher: ProfessionMatcher,
+  now: number,
+): ProfessionJobsSnapshot {
+  const matches: JobRecord[] = [];
+  for (const job of jobs) {
+    if (jobMatchesProfession(job, matcher)) matches.push(job);
+  }
+
+  // Freshness: count matches posted in the last 30 days. Honest where a
+  // quarter-over-quarter delta would lie — the crawlers drop stale postings
+  // so the prior period is always near-empty.
+  const last30 = now - 30 * DAY_MS;
+  let fresh30 = 0;
+  for (const job of matches) {
+    const ts = job.postedDate ? Date.parse(job.postedDate) : NaN;
+    if (Number.isFinite(ts) && ts >= last30) fresh30++;
+  }
+
+  const salaryValues: number[] = [];
+  for (const job of matches) {
+    const mid = jobMidpoint(job);
+    if (mid) salaryValues.push(mid);
+  }
+  const medianSalary = median(salaryValues);
+
+  const employerCounts = new Map<string, number>();
+  for (const job of matches) {
+    const name = (job.company ?? '').trim();
+    if (!name) continue;
+    employerCounts.set(name, (employerCounts.get(name) ?? 0) + 1);
+  }
+  const topEmployers = [...employerCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([name, count]) => ({ name, count }));
+
+  // Featured: top 3 — prefer `featured: true`, then freshest postedDate.
+  // Sort raw matches first so we can read the `featured` flag without losing it.
+  const sortedMatches = [...matches].sort((a, b) => {
+    const aFeat = a.featured ? 1 : 0;
+    const bFeat = b.featured ? 1 : 0;
+    if (aFeat !== bFeat) return bFeat - aFeat;
+    const aTs = a.postedDate ? Date.parse(a.postedDate) : 0;
+    const bTs = b.postedDate ? Date.parse(b.postedDate) : 0;
+    return bTs - aTs;
+  });
+  const featured: FeaturedJob[] = [];
+  for (const job of sortedMatches) {
+    if (featured.length >= 3) break;
+    const f = toFeatured(job, now);
+    if (f) featured.push(f);
+  }
+
+  return {
+    liveCount: matches.length,
+    fresh30Count: fresh30,
+    medianSalaryChf: medianSalary,
+    featured,
+    topEmployers,
+  };
+}
+
+/**
+ * Aggregate jobs.json into per-profession snapshots. Cached per `rootDir`.
+ * Pass `now` to override the clock (used by tests); defaults to Date.now().
+ */
+export function aggregateProfessionJobs(
+  rootDir: string,
+  now: number = Date.now(),
+): Record<ProfessionId, ProfessionJobsSnapshot> {
+  if (_snapshotCache && _cacheRootDir === rootDir) return _snapshotCache;
+
+  const jobs = loadJobs(rootDir);
+  const out = {} as Record<ProfessionId, ProfessionJobsSnapshot>;
+  for (const id of PROFESSION_IDS) {
+    out[id] = buildSnapshotForProfession(jobs, PROFESSION_MATCHERS[id], now);
+  }
+  _snapshotCache = out;
+  _cacheRootDir = rootDir;
+  return out;
+}
+
+/** Test/CI helper — clear the module-level cache. */
+export function _resetProfessionJobsAggregateCache(): void {
+  _snapshotCache = null;
+  _cacheRootDir = null;
+}
+
+// ── Job-board URL builder ────────────────────────────────────────────────────
+
+const JOB_BOARD_BASE_PATH: Record<ProfessionLocale, string> = {
+  it: '/cerca-lavoro-ticino',
+  en: '/en/find-jobs-ticino',
+  de: '/de/jobs-im-tessin',
+  fr: '/fr/trouver-emploi-tessin',
+};
+
+/**
+ * Build the canonical detail-page URL for a featured job in the target locale.
+ * Falls back to the IT slug when the locale-specific one is missing.
+ */
+export function buildFeaturedJobUrl(job: FeaturedJob, locale: ProfessionLocale): string {
+  const slug = job.slugByLocale[locale] ?? job.slug;
+  return `${JOB_BOARD_BASE_PATH[locale]}/${slug}/`;
+}
+
+/** Job-board hub URL for the given locale (used by the "view all" CTA). */
+export function buildJobBoardUrl(locale: ProfessionLocale): string {
+  return `${JOB_BOARD_BASE_PATH[locale]}/`;
+}

--- a/build-plugins/professionLandingsCopy.ts
+++ b/build-plugins/professionLandingsCopy.ts
@@ -45,6 +45,8 @@ export interface ProfessionLandingCopy {
   description: string;
   h1: string;
   lede: string;
+  /** Template B dense lede: numeric facts in 1 line (used above the fold). */
+  denseLede: string;
   updatedLabel: string;
   breadcrumbHome: string;
   breadcrumbJobs: string;
@@ -70,7 +72,22 @@ export interface ProfessionLandingCopy {
   employersTableTitle: string;
   salaryTableTitle: string;
   sourcesLabel: string;
-  // Per-profession strings (IT only — other locales map by ID in LOCALE_PROFESSION_STRINGS).
+  // ── Template B labels (mostly static per locale) ─────────────────────────
+  eyebrow: string;
+  statTileLiveLabel: string;
+  statTileSalaryLabel: string;
+  statTileFreshLabel: string;
+  statSalaryValue: string;
+  statFreshValue: string;
+  statLiveValue: string;
+  primaryCtaLabel: string;
+  featuredJobsTitle: string;
+  featuredJobsCtaAllLabel: string;
+  featuredJobsEmpty: string;
+  employerGridTitle: string;
+  approfondisciHeading: string;
+  formatJobPosted: (daysAgo: number) => string;
+  formatJobSalary: (min: number | null, max: number | null) => string;
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -533,6 +550,30 @@ interface LocaleShell {
   employersTableTitle: string;
   salaryTableTitle: string;
   sourcesLabel: string;
+  // ── Template B additions ───────────────────────────────────────────────
+  /** Dense lede that lists 3 numbers (count · CHF · fresh) under the H1. */
+  denseLedeTemplate: (parts: {
+    role: string;
+    live: number;
+    fresh30: number;
+    median: number;
+  }) => string;
+  /** Eyebrow line above the H1 (e.g. "Mestiere · Ticino · 2026"). */
+  eyebrow: string;
+  statTileLiveLabel: string;
+  statTileSalaryLabel: string;
+  statTileFreshLabel: string;
+  statSalaryValueFmt: (n: number) => string;
+  statFreshValueFmt: (n: number) => string;
+  primaryCtaLabel: string;
+  featuredJobsTitle: string;
+  featuredJobsCtaAll: (n: number) => string;
+  featuredJobsEmpty: string;
+  employerGridTitle: string;
+  /** Heading that introduces the long-form prose block at the bottom. */
+  approfondisciHeading: string;
+  jobPostedLabel: (daysAgo: number) => string;
+  jobSalaryFmt: (min: number | null, max: number | null) => string;
 }
 
 const IT_SHELL: LocaleShell = {
@@ -567,6 +608,28 @@ const IT_SHELL: LocaleShell = {
   employersTableTitle: 'Top 5 datori di lavoro ticinesi',
   salaryTableTitle: 'Forchetta salariale di riferimento',
   sourcesLabel: 'Fonti ufficiali',
+  denseLedeTemplate: ({ role, live, fresh30, median }) =>
+    `${live} posizioni aperte per ${role} in Ticino · ${fresh30} nuove negli ultimi 30 giorni · stipendio mediano CHF ${median.toLocaleString('it-CH')} lordi all'anno.`,
+  eyebrow: 'Mestiere · Ticino · 2026',
+  statTileLiveLabel: 'Offerte aperte',
+  statTileSalaryLabel: 'Stipendio mediano',
+  statTileFreshLabel: 'Nuove (30 gg)',
+  statSalaryValueFmt: (n) => `CHF ${n.toLocaleString('it-CH')}/anno`,
+  statFreshValueFmt: (n) => `${n} nuove`,
+  primaryCtaLabel: 'Calcola il tuo netto come frontaliere',
+  featuredJobsTitle: 'Offerte in evidenza',
+  featuredJobsCtaAll: (n) => `Vedi tutte le ${n} offerte →`,
+  featuredJobsEmpty: 'Nessuna offerta indicizzata in questo momento — controlla il job board completo.',
+  employerGridTitle: 'Chi assume in Ticino',
+  approfondisciHeading: 'La professione in Ticino',
+  jobPostedLabel: (d) =>
+    d <= 0 ? 'Pubblicata oggi' : d === 1 ? 'Pubblicata ieri' : `Pubblicata ${d} giorni fa`,
+  jobSalaryFmt: (min, max) => {
+    if (min && max) return `CHF ${min.toLocaleString('it-CH')}–${max.toLocaleString('it-CH')}/anno`;
+    if (min) return `Da CHF ${min.toLocaleString('it-CH')}/anno`;
+    if (max) return `Fino a CHF ${max.toLocaleString('it-CH')}/anno`;
+    return '';
+  },
 };
 
 const EN_SHELL: LocaleShell = {
@@ -603,6 +666,28 @@ const EN_SHELL: LocaleShell = {
   employersTableTitle: 'Top 5 Ticino employers',
   salaryTableTitle: 'Reference salary band',
   sourcesLabel: 'Official sources',
+  denseLedeTemplate: ({ role, live, fresh30, median }) =>
+    `${live} open positions for ${role} in Ticino · ${fresh30} new in the last 30 days · median gross salary CHF ${median.toLocaleString('en-CH')} per year.`,
+  eyebrow: 'Profession · Ticino · 2026',
+  statTileLiveLabel: 'Open positions',
+  statTileSalaryLabel: 'Median salary',
+  statTileFreshLabel: 'New (30 days)',
+  statSalaryValueFmt: (n) => `CHF ${n.toLocaleString('en-CH')}/year`,
+  statFreshValueFmt: (n) => `${n} new`,
+  primaryCtaLabel: 'Calculate your cross-border net',
+  featuredJobsTitle: 'Featured openings',
+  featuredJobsCtaAll: (n) => `See all ${n} openings →`,
+  featuredJobsEmpty: 'No indexed openings right now — check the full job board.',
+  employerGridTitle: 'Who is hiring in Ticino',
+  approfondisciHeading: 'The profession in Ticino',
+  jobPostedLabel: (d) =>
+    d <= 0 ? 'Posted today' : d === 1 ? 'Posted yesterday' : `Posted ${d} days ago`,
+  jobSalaryFmt: (min, max) => {
+    if (min && max) return `CHF ${min.toLocaleString('en-CH')}–${max.toLocaleString('en-CH')}/year`;
+    if (min) return `From CHF ${min.toLocaleString('en-CH')}/year`;
+    if (max) return `Up to CHF ${max.toLocaleString('en-CH')}/year`;
+    return '';
+  },
 };
 
 const DE_SHELL: LocaleShell = {
@@ -637,6 +722,28 @@ const DE_SHELL: LocaleShell = {
   employersTableTitle: 'Top-5-Arbeitgeber im Tessin',
   salaryTableTitle: 'Referenz-Lohnbandbreite',
   sourcesLabel: 'Offizielle Quellen',
+  denseLedeTemplate: ({ role, live, fresh30, median }) =>
+    `${live} offene Stellen für ${role} im Tessin · ${fresh30} neu in den letzten 30 Tagen · Medianlohn CHF ${median.toLocaleString('de-CH')} brutto pro Jahr.`,
+  eyebrow: 'Beruf · Tessin · 2026',
+  statTileLiveLabel: 'Offene Stellen',
+  statTileSalaryLabel: 'Medianlohn',
+  statTileFreshLabel: 'Neu (30 Tage)',
+  statSalaryValueFmt: (n) => `CHF ${n.toLocaleString('de-CH')}/Jahr`,
+  statFreshValueFmt: (n) => `${n} neu`,
+  primaryCtaLabel: 'Grenzgänger-Nettolohn berechnen',
+  featuredJobsTitle: 'Empfohlene Stellen',
+  featuredJobsCtaAll: (n) => `Alle ${n} Stellen ansehen →`,
+  featuredJobsEmpty: 'Derzeit keine indexierten Stellen — siehe vollständige Stellenbörse.',
+  employerGridTitle: 'Wer im Tessin einstellt',
+  approfondisciHeading: 'Der Beruf im Tessin',
+  jobPostedLabel: (d) =>
+    d <= 0 ? 'Heute veröffentlicht' : d === 1 ? 'Gestern veröffentlicht' : `Vor ${d} Tagen veröffentlicht`,
+  jobSalaryFmt: (min, max) => {
+    if (min && max) return `CHF ${min.toLocaleString('de-CH')}–${max.toLocaleString('de-CH')}/Jahr`;
+    if (min) return `Ab CHF ${min.toLocaleString('de-CH')}/Jahr`;
+    if (max) return `Bis CHF ${max.toLocaleString('de-CH')}/Jahr`;
+    return '';
+  },
 };
 
 const FR_SHELL: LocaleShell = {
@@ -673,6 +780,28 @@ const FR_SHELL: LocaleShell = {
   employersTableTitle: 'Top 5 des employeurs tessinois',
   salaryTableTitle: 'Fourchette salariale de référence',
   sourcesLabel: 'Sources officielles',
+  denseLedeTemplate: ({ role, live, fresh30, median }) =>
+    `${live} postes ouverts pour ${role} au Tessin · ${fresh30} nouveaux ces 30 derniers jours · salaire médian CHF ${median.toLocaleString('fr-CH')} brut par an.`,
+  eyebrow: 'Métier · Tessin · 2026',
+  statTileLiveLabel: 'Postes ouverts',
+  statTileSalaryLabel: 'Salaire médian',
+  statTileFreshLabel: 'Nouveaux (30 j)',
+  statSalaryValueFmt: (n) => `CHF ${n.toLocaleString('fr-CH')}/an`,
+  statFreshValueFmt: (n) => `${n} nouveaux`,
+  primaryCtaLabel: 'Calculer votre net frontalier',
+  featuredJobsTitle: 'Offres mises en avant',
+  featuredJobsCtaAll: (n) => `Voir les ${n} offres →`,
+  featuredJobsEmpty: 'Aucune offre indexée actuellement — consultez la bourse complète.',
+  employerGridTitle: 'Qui recrute au Tessin',
+  approfondisciHeading: 'Le métier au Tessin',
+  jobPostedLabel: (d) =>
+    d <= 0 ? 'Publié aujourd\'hui' : d === 1 ? 'Publié hier' : `Publié il y a ${d} jours`,
+  jobSalaryFmt: (min, max) => {
+    if (min && max) return `CHF ${min.toLocaleString('fr-CH')}–${max.toLocaleString('fr-CH')}/an`;
+    if (min) return `Dès CHF ${min.toLocaleString('fr-CH')}/an`;
+    if (max) return `Jusqu'à CHF ${max.toLocaleString('fr-CH')}/an`;
+    return '';
+  },
 };
 
 const LOCALE_SHELLS: Record<ProfessionLocale, LocaleShell> = {
@@ -1083,19 +1212,37 @@ function buildFaqs(locale: ProfessionLocale, id: ProfessionId): ProfessionLandin
 // Public API — assemble copy for (locale, id).
 // ─────────────────────────────────────────────────────────────────
 
+export interface ProfessionLandingCopySnapshot {
+  /** Live aggregate count from professionJobsAggregate (NOT the frozen jobsCount). */
+  readonly liveCount: number;
+  /** New jobs in the last 30 days, from aggregate. */
+  readonly fresh30Count: number;
+}
+
 export function buildProfessionLandingCopy(
   locale: ProfessionLocale,
   id: ProfessionId,
+  snapshot: ProfessionLandingCopySnapshot = { liveCount: 0, fresh30Count: 0 },
 ): ProfessionLandingCopy {
   const shell = LOCALE_SHELLS[locale];
   const strings = PROFESSION_STRINGS_BY_LOCALE[locale][id];
   const facts = PROFESSION_FACTS[id];
 
+  // Pick the most informative count: prefer the live aggregate when it has
+  // signal, otherwise fall back to the frozen editorial snapshot.
+  const displayCount = snapshot.liveCount > 0 ? snapshot.liveCount : facts.jobsCount;
+
   return {
     title: shell.titleTemplate(strings.role),
     description: shell.descriptionTemplate(strings.role, facts.medianSalaryChf),
     h1: shell.h1Template(strings.role),
-    lede: shell.ledeTemplate(strings, facts.medianSalaryChf, facts.jobsCount),
+    lede: shell.ledeTemplate(strings, facts.medianSalaryChf, displayCount),
+    denseLede: shell.denseLedeTemplate({
+      role: strings.role,
+      live: displayCount,
+      fresh30: snapshot.fresh30Count,
+      median: facts.medianSalaryChf,
+    }),
     updatedLabel: shell.updatedLabel,
     breadcrumbHome: shell.breadcrumbHome,
     breadcrumbJobs: shell.breadcrumbJobs,
@@ -1108,6 +1255,23 @@ export function buildProfessionLandingCopy(
     employersTableTitle: shell.employersTableTitle,
     salaryTableTitle: shell.salaryTableTitle,
     sourcesLabel: shell.sourcesLabel,
+    eyebrow: shell.eyebrow,
+    statTileLiveLabel: shell.statTileLiveLabel,
+    statTileSalaryLabel: shell.statTileSalaryLabel,
+    statTileFreshLabel: shell.statTileFreshLabel,
+    statLiveValue: displayCount.toLocaleString(
+      ({ it: 'it-CH', en: 'en-CH', de: 'de-CH', fr: 'fr-CH' } as const)[locale],
+    ),
+    statSalaryValue: shell.statSalaryValueFmt(facts.medianSalaryChf),
+    statFreshValue: shell.statFreshValueFmt(snapshot.fresh30Count),
+    primaryCtaLabel: shell.primaryCtaLabel,
+    featuredJobsTitle: shell.featuredJobsTitle,
+    featuredJobsCtaAllLabel: shell.featuredJobsCtaAll(displayCount),
+    featuredJobsEmpty: shell.featuredJobsEmpty,
+    employerGridTitle: shell.employerGridTitle,
+    approfondisciHeading: shell.approfondisciHeading,
+    formatJobPosted: shell.jobPostedLabel,
+    formatJobSalary: shell.jobSalaryFmt,
   };
 }
 

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -1,30 +1,37 @@
 /**
- * Profession landings (AE-3) — Vite build plugin.
+ * Profession landings (AE-3) — Vite build plugin, template B.
  *
- * Emits 40 static HTML pages (10 professions × 4 locales):
+ * Emits 40 static HTML pages (10 professions × 4 locales). The 2026-05 redesign
+ * inverts the previous layout: live signal first (stat tiles + featured live
+ * jobs + employer grid), long-form SEO prose at the bottom under an
+ * "Approfondisci" heading. Designed mobile-first per CLAUDE.md regola #17 —
+ * 75 % of traffic is mobile and the meaty content (offerte, stipendio) must
+ * sit above the fold at ≤414 px.
  *
  *   IT canonical                             EN / DE / FR variants
  *   /lavoro-ticino-infermiere/               /en/jobs-ticino-nurse/ …
  *   /lavoro-ticino-operaio/                  /en/jobs-ticino-worker/ …
  *   … etc.
  *
- * Each page carries:
- *   - 7 H2 sections composed from PROFESSION_FACTS (authority URLs, CCL,
- *     salary, employers, permits, application) — 600-750 IT words,
- *     420-520 other locales.
- *   - Employer top-5 table + salary band table (visible markup).
- *   - FAQ block — 5 Q/A per locale, profession-keyed to stay unique
- *     against nursingLandings, hub FAQs, pillars, etc.
- *   - JSON-LD: BreadcrumbList + FAQPage + Article + ItemList (top-5 employers).
- *   - Hreflang × 4 locales + x-default → IT canonical.
+ * Body order (template B, mobile-first):
+ *   1. breadcrumb
+ *   2. header (eyebrow · H1 · dense lede with 3 numbers)
+ *   3. 3 stat tiles (open positions · median salary · fresh in 30 days)
+ *   4. primary CTA → salary calculator (the killer-hook conversion path)
+ *   5. featured live jobs (3 cards) + "see all" CTA
+ *   6. employer grid (top 6, compact 2-col)
+ *   7. ─── "Approfondisci" divider ───
+ *   8. long-form prose H2 sections (existing 7 blocks)
+ *   9. salary band table + employers table
+ *  10. sources · FAQ · related · final CTAs
  *
- * Hub chrome: `hubChrome: { hubKey: 'job-board', activeSubTab: 'jobs' }`
- * matches the parity pattern used by AE-2 / nursingLandings — keeps the
- * sub-nav visible on the first paint even though React suspends via the
- * `staticOverlay: true` route in services/router.ts.
+ * Live signal comes from professionJobsAggregate (build-time read of
+ * data/jobs.json). PROFESSION_FACTS stays as the editorial authority for
+ * typicalSalaryRange / CCL / recognition.
  *
- * Sitemap: writes `dist/sitemap-professions.xml` (IT canonicals only; EN/DE/FR
- * are surfaced via hreflang). `sitemapAliasPlugin` auto-discovers the file.
+ * Hub chrome: `hubChrome: { hubKey: 'job-board', activeSubTab: 'jobs' }`.
+ * Sitemap: writes `dist/sitemap-professions.xml` (IT canonicals; EN/DE/FR
+ * surface via hreflang). `sitemapAliasPlugin` auto-discovers the file.
  */
 
 import fs from 'node:fs';
@@ -40,9 +47,17 @@ import {
   BREADCRUMB_STYLE,
   CTA_PRIMARY_STYLE,
   CARD_STYLE,
+  CARD_BODY_STYLE,
+  CARD_PADDING_STYLE,
   LINK_ACCENT_STYLE,
   TABLE_HEAD_STYLE,
   TABLE_CELL_STYLE,
+  HERO_EYEBROW_STYLE,
+  H1_STYLE,
+  LEDE_STYLE,
+  SMALL_HEADING_STYLE,
+  renderStatGrid,
+  ICON_BUILDING_SVG,
 } from './shared/seoContentTokens';
 import { buildTitleWithBrand } from './shared/titleSuffix';
 import {
@@ -58,6 +73,13 @@ import {
   buildProfessionLandingSections,
   buildProfessionLandingFaqs,
 } from './professionLandingsCopy';
+import {
+  aggregateProfessionJobs,
+  buildFeaturedJobUrl,
+  buildJobBoardUrl,
+  type FeaturedJob,
+  type ProfessionJobsSnapshot,
+} from './professionJobsAggregate';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -71,12 +93,8 @@ function esc(s: unknown): string {
 
 // Convert inline markdown-style bold (**…**) to <strong> in copy paragraphs.
 function inlineFormat(s: string): string {
-  // Escape first, then re-introduce controlled tags (<strong>, <a>).
   const escaped = esc(s);
-  // Bold: **text** -> <strong>text</strong>
   const bolded = escaped.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-  // Inline links [text](url). URL has been &-escaped; restore naked & in URLs
-  // (the attribute is already safe because the quote-escape happened before).
   const linked = bolded.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, text: string, url: string) => {
     const safeUrl = url.replace(/&amp;/g, '&');
     return `<a href="${esc(safeUrl)}" rel="noopener" style="color:var(--color-link);text-decoration:underline">${text}</a>`;
@@ -122,7 +140,108 @@ const RELATED_LINKS: Record<ProfessionLocale, Array<{ href: string; label: strin
   ],
 };
 
-// ── Rendering ─────────────────────────────────────────────────────
+/** Salary-calculator URL per locale (RELATED_LINKS index 1). */
+const CALCULATOR_URL: Record<ProfessionLocale, string> = {
+  it: '/calcola-stipendio/',
+  en: '/en/calculate-salary/',
+  de: '/de/gehalt-berechnen/',
+  fr: '/fr/calculer-salaire/',
+};
+
+// ── Template B renderers ─────────────────────────────────────────────────────
+
+interface CopyView {
+  formatJobPosted: (daysAgo: number) => string;
+  formatJobSalary: (min: number | null, max: number | null) => string;
+  featuredJobsEmpty: string;
+  featuredJobsTitle: string;
+  featuredJobsCtaAllLabel: string;
+  employerGridTitle: string;
+}
+
+function pickJobTitle(job: FeaturedJob, locale: ProfessionLocale): string {
+  return job.titleByLocale[locale] ?? job.title;
+}
+
+function renderFeaturedJobCard(
+  job: FeaturedJob,
+  locale: ProfessionLocale,
+  copy: CopyView,
+): string {
+  const href = buildFeaturedJobUrl(job, locale);
+  const title = pickJobTitle(job, locale);
+  const subtitleParts: string[] = [];
+  if (job.company) subtitleParts.push(job.company);
+  if (job.city) subtitleParts.push(job.city);
+  const subtitle = subtitleParts.join(' · ');
+  const salary = copy.formatJobSalary(job.salaryMin, job.salaryMax);
+  const posted = copy.formatJobPosted(job.daysAgo);
+
+  return `<a class="seo-card-link" href="${esc(href)}" style="${CARD_STYLE};text-decoration:none;color:inherit;display:flex;flex-direction:column;gap:6px">
+    <div style="font-weight:700;font-size:16px;line-height:1.35;color:var(--color-heading)">${esc(title)}</div>
+    ${subtitle ? `<div style="font-size:14px;color:var(--color-body);line-height:1.4">${esc(subtitle)}</div>` : ''}
+    <div style="display:flex;flex-wrap:wrap;gap:10px 14px;align-items:center;margin-top:4px;font-size:13px;color:var(--color-subtle)">
+      ${salary ? `<span style="color:var(--color-accent);font-weight:700">${esc(salary)}</span>` : ''}
+      <span>${esc(posted)}</span>
+    </div>
+  </a>`;
+}
+
+function renderFeaturedJobs(
+  locale: ProfessionLocale,
+  snapshot: ProfessionJobsSnapshot,
+  copy: CopyView,
+): string {
+  if (snapshot.featured.length === 0) {
+    return `<section style="margin:0 0 28px">
+      <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:700">${esc(copy.featuredJobsTitle)}</h2>
+      <p style="${CARD_STYLE};color:var(--color-subtle);font-size:14px;margin:0">${esc(copy.featuredJobsEmpty)}</p>
+    </section>`;
+  }
+  const cards = snapshot.featured
+    .map((j) => renderFeaturedJobCard(j, locale, copy))
+    .join('');
+  const ctaHref = buildJobBoardUrl(locale);
+  return `<section style="margin:0 0 28px">
+    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:700">${esc(copy.featuredJobsTitle)}</h2>
+    <div style="display:grid;gap:12px;margin-bottom:14px">${cards}</div>
+    <a href="${esc(ctaHref)}" style="${LINK_ACCENT_STYLE};font-weight:700;font-size:15px">${esc(copy.featuredJobsCtaAllLabel)}</a>
+  </section>`;
+}
+
+function renderEmployerGrid(
+  snapshot: ProfessionJobsSnapshot,
+  id: ProfessionId,
+  copy: CopyView,
+): string {
+  // Prefer live aggregate employers; fall back to PROFESSION_FACTS curated list
+  // when the aggregate found < 3 (sparse profession in the dataset).
+  const useAggregate = snapshot.topEmployers.length >= 3;
+  const items: Array<{ name: string; count: number | null }> = useAggregate
+    ? snapshot.topEmployers.map((e) => ({ name: e.name, count: e.count }))
+    : PROFESSION_FACTS[id].topEmployers.slice(0, 6).map((n) => ({ name: n, count: null }));
+
+  if (items.length === 0) return '';
+
+  const cells = items
+    .map(
+      (e) => `<div style="display:flex;align-items:center;gap:10px;${CARD_PADDING_STYLE};${CARD_BODY_STYLE}">
+        <span aria-hidden="true" style="display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:var(--color-surface-alt);color:var(--color-subtle);flex-shrink:0">${ICON_BUILDING_SVG}</span>
+        <div style="flex:1;min-width:0">
+          <div style="font-weight:700;font-size:14px;color:var(--color-heading);line-height:1.3;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(e.name)}</div>
+        </div>
+        ${e.count !== null ? `<div style="flex-shrink:0;font-weight:700;color:var(--color-accent);font-variant-numeric:tabular-nums">${e.count}</div>` : ''}
+      </div>`,
+    )
+    .join('');
+
+  return `<section style="margin:0 0 28px">
+    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:700">${esc(copy.employerGridTitle)}</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px">${cells}</div>
+  </section>`;
+}
+
+// ── Long-form (legacy below-the-fold) renderers ──────────────────────────────
 
 interface RenderResult {
   urlPath: string;
@@ -134,10 +253,10 @@ function renderSection(title: string, paragraphs: string[]): string {
   const ps = paragraphs
     .map(
       (p) =>
-        `<p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${inlineFormat(p)}</p>`,
+        `<p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:62ch">${inlineFormat(p)}</p>`,
     )
     .join('');
-  return `<section style="margin:0 0 28px"><h2 style="margin:0 0 12px;font-size:24px;color:var(--color-body)">${esc(title)}</h2>${ps}</section>`;
+  return `<section style="margin:0 0 28px"><h2 style="margin:0 0 12px;font-size:24px;color:var(--color-heading);font-weight:600">${esc(title)}</h2>${ps}</section>`;
 }
 
 function renderEmployersTable(
@@ -157,7 +276,7 @@ function renderEmployersTable(
     )
     .join('');
   return `<section style="margin:0 0 28px">
-    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-body)">${esc(title)}</h2>
+    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:600">${esc(title)}</h2>
     <div style="overflow-x:auto;max-width:860px">
       <table style="border-collapse:collapse;width:100%;background:var(--color-surface);border:1px solid var(--color-edge);border-radius:12px">
         <thead>
@@ -180,11 +299,11 @@ function renderSalaryBandTable(
   const facts = PROFESSION_FACTS[id];
   const [min, max] = facts.typicalSalaryRange;
   return `<section style="margin:0 0 28px;max-width:860px">
-    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-body)">${esc(title)}</h2>
+    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:600">${esc(title)}</h2>
     <div style="${CARD_STYLE};padding:16px 18px">
       <p style="margin:0 0 6px;color:var(--color-subtle);font-size:13px">${esc(salaryLabel)}</p>
-      <p style="margin:0;font-size:22px;font-weight:700;color:var(--color-body)">CHF ${min.toLocaleString('en-CH')} &ndash; ${max.toLocaleString('en-CH')}</p>
-      <p style="margin:6px 0 0;color:var(--color-subtle);font-size:12px">Mediana: CHF ${facts.medianSalaryChf.toLocaleString('en-CH')} &middot; dataset Frontaliere Ticino, ${facts.jobsCount} campioni</p>
+      <p style="margin:0;font-size:22px;font-weight:700;color:var(--color-heading)">CHF ${min.toLocaleString('en-CH')} &ndash; ${max.toLocaleString('en-CH')}</p>
+      <p style="margin:6px 0 0;color:var(--color-subtle);font-size:12px">Mediana: CHF ${facts.medianSalaryChf.toLocaleString('en-CH')}</p>
     </div>
   </section>`;
 }
@@ -194,7 +313,7 @@ function renderFaqBlock(faqs: Array<{ question: string; answer: string }>): stri
     .map(
       (f) => `
       <details style="margin:0 0 10px;padding:14px 16px;border:1px solid var(--color-edge);border-radius:12px;background:var(--color-surface)">
-        <summary style="font-weight:700;cursor:pointer;color:var(--color-body);line-height:1.45">${esc(f.question)}</summary>
+        <summary style="font-weight:700;cursor:pointer;color:var(--color-heading);line-height:1.45">${esc(f.question)}</summary>
         <p style="margin:10px 0 0;color:var(--color-body);line-height:1.65">${inlineFormat(f.answer)}</p>
       </details>`,
     )
@@ -218,9 +337,10 @@ function renderSourcesBlock(id: ProfessionId, label: string): string {
         `<li style="margin:0 0 6px"><a href="${esc(it.url)}" rel="noopener" style="${LINK_ACCENT_STYLE}">${esc(it.label)}</a></li>`,
     )
     .join('');
-  return `<section style="margin:0 0 24px;padding:14px 18px;border-left:4px solid var(--color-accent);background:var(--color-surface);max-width:860px">
-    <h2 style="margin:0 0 8px;font-size:18px;color:var(--color-body)">${esc(label)}</h2>
-    <ul style="margin:0 0 0 20px;padding:0;color:var(--color-body);line-height:1.55;font-size:14px">${lis}</ul>
+  // Replaces the previous border-left:4px accent stripe (banned pattern).
+  return `<section style="margin:0 0 24px;${CARD_STYLE};max-width:860px">
+    <p style="${SMALL_HEADING_STYLE};margin:0 0 10px">${esc(label)}</p>
+    <ul style="margin:0;padding:0 0 0 20px;color:var(--color-body);line-height:1.55;font-size:14px">${lis}</ul>
   </section>`;
 }
 
@@ -231,17 +351,31 @@ function renderRelatedLinks(locale: ProfessionLocale, label: string): string {
         `<li style="margin:0 0 8px"><a href="${esc(l.href)}" style="${LINK_ACCENT_STYLE}">${esc(l.label)}</a></li>`,
     )
     .join('');
-  return `<section style="margin:0 0 28px"><h2 style="margin:0 0 12px;font-size:22px;color:var(--color-body)">${esc(label)}</h2><ul style="margin:0 0 0 20px;padding:0;color:var(--color-body);line-height:1.55;max-width:860px">${items}</ul></section>`;
+  return `<section style="margin:0 0 28px"><h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:600">${esc(label)}</h2><ul style="margin:0 0 0 20px;padding:0;color:var(--color-body);line-height:1.55;max-width:860px">${items}</ul></section>`;
 }
+
+function renderApprofondisciDivider(label: string): string {
+  return `<div role="separator" aria-label="${esc(label)}" style="margin:36px 0 28px;display:flex;align-items:center;gap:14px;color:var(--color-subtle)">
+    <span aria-hidden="true" style="flex:1;height:1px;background:var(--color-edge)"></span>
+    <span style="${SMALL_HEADING_STYLE};margin:0">${esc(label)}</span>
+    <span aria-hidden="true" style="flex:1;height:1px;background:var(--color-edge)"></span>
+  </div>`;
+}
+
+// ── Page assembly ────────────────────────────────────────────────────────────
 
 function renderPage(opts: {
   locale: ProfessionLocale;
   id: ProfessionId;
   dateStamp: string;
   distDir?: string;
+  snapshot: ProfessionJobsSnapshot;
 }): RenderResult {
-  const { locale, id, dateStamp, distDir } = opts;
-  const copy = buildProfessionLandingCopy(locale, id);
+  const { locale, id, dateStamp, distDir, snapshot } = opts;
+  const copy = buildProfessionLandingCopy(locale, id, {
+    liveCount: snapshot.liveCount,
+    fresh30Count: snapshot.fresh30Count,
+  });
   const sections = buildProfessionLandingSections(locale, id);
   const faqs = buildProfessionLandingFaqs(locale, id);
   const facts = PROFESSION_FACTS[id];
@@ -259,15 +393,8 @@ function renderPage(opts: {
   const alternates = hreflangLines.join('\n');
 
   const homeUrl = locale === 'it' ? `${BASE_URL}/` : `${BASE_URL}/${locale}/`;
-  const jobBoardUrl = `${BASE_URL}${
-    locale === 'it'
-      ? '/cerca-lavoro-ticino/'
-      : locale === 'en'
-        ? '/en/find-jobs-ticino/'
-        : locale === 'de'
-          ? '/de/jobs-im-tessin/'
-          : '/fr/trouver-emploi-tessin/'
-  }`;
+  const jobBoardUrl = `${BASE_URL}${buildJobBoardUrl(locale)}`;
+  const calculatorUrl = `${BASE_URL}${CALCULATOR_URL[locale]}`;
 
   const breadcrumbLd = JSON.stringify({
     '@context': 'https://schema.org',
@@ -330,6 +457,28 @@ function renderPage(opts: {
     })),
   });
 
+  // ── Template B body ────────────────────────────────────────────────────
+  const copyView: CopyView = {
+    formatJobPosted: copy.formatJobPosted,
+    formatJobSalary: copy.formatJobSalary,
+    featuredJobsEmpty: copy.featuredJobsEmpty,
+    featuredJobsTitle: copy.featuredJobsTitle,
+    featuredJobsCtaAllLabel: copy.featuredJobsCtaAllLabel,
+    employerGridTitle: copy.employerGridTitle,
+  };
+
+  const statTilesHtml = renderStatGrid([
+    { label: copy.statTileLiveLabel, value: copy.statLiveValue, tone: 'success' },
+    { label: copy.statTileSalaryLabel, value: copy.statSalaryValue, tone: 'accent' },
+    { label: copy.statTileFreshLabel, value: copy.statFreshValue, tone: 'warning' },
+  ]);
+
+  const primaryCtaHtml = `<div style="margin:0 0 28px"><a href="${esc(calculatorUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.primaryCtaLabel)} →</a></div>`;
+
+  const featuredHtml = renderFeaturedJobs(locale, snapshot, copyView);
+  const employerGridHtml = renderEmployerGrid(snapshot, id, copyView);
+  const dividerHtml = renderApprofondisciDivider(copy.approfondisciHeading);
+
   const sectionsHtml = sections.map((s) => renderSection(s.title, s.paragraphs)).join('');
   const employersTable = renderEmployersTable(locale, id, copy.tableHeadings, copy.employersTableTitle);
   const salaryTable = renderSalaryBandTable(id, copy.tableHeadings.salaryLabel, copy.salaryTableTitle);
@@ -345,23 +494,31 @@ function renderPage(opts: {
       <span> / </span>
       <span>${esc(copy.h1)}</span>
     </nav>
-    <header style="margin-bottom:24px">
-      <p style="margin:0 0 8px;color:var(--color-accent);font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em">${esc(copy.updatedLabel)} · ${esc(dateStamp)}</p>
-      <h1 style="margin:0 0 16px;font-size:clamp(1.9rem,4vw,2.8rem);line-height:1.15">${esc(copy.h1)}</h1>
-      <p style="margin:0;color:var(--color-body);font-size:17px;line-height:1.65;max-width:860px">${inlineFormat(copy.lede)}</p>
+    <header style="margin-bottom:20px">
+      <p style="${HERO_EYEBROW_STYLE}">${esc(copy.eyebrow)} · ${esc(copy.updatedLabel)} ${esc(dateStamp)}</p>
+      <h1 style="${H1_STYLE}">${esc(copy.h1)}</h1>
+      <p style="${LEDE_STYLE}">${esc(copy.denseLede)}</p>
     </header>
-    ${salaryTable}
+    ${statTilesHtml}
+    ${primaryCtaHtml}
+    ${featuredHtml}
+    ${employerGridHtml}
+    ${dividerHtml}
+    <section style="margin:0 0 28px">
+      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:62ch;font-size:17px;font-style:italic">${inlineFormat(copy.lede)}</p>
+    </section>
     ${sectionsHtml}
+    ${salaryTable}
     ${employersTable}
     ${sourcesHtml}
     <section style="margin:0 0 28px">
-      <h2 style="margin:0 0 12px;font-size:24px;color:var(--color-body)">${esc(copy.faqTitle)}</h2>
+      <h2 style="margin:0 0 12px;font-size:24px;color:var(--color-heading);font-weight:600">${esc(copy.faqTitle)}</h2>
       ${faqHtml}
     </section>
     ${relatedHtml}
     <section style="display:flex;gap:12px;flex-wrap:wrap;margin:0 0 16px">
       <a href="${esc(jobBoardUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.ctaJobs)}</a>
-      <a href="${esc(homeUrl)}" style="padding:12px 18px;border-radius:12px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-body);text-decoration:none;font-weight:700">${esc(copy.ctaSimulator)}</a>
+      <a href="${esc(calculatorUrl)}" style="padding:10px 16px;border-radius:10px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-body);text-decoration:none;font-weight:600">${esc(copy.ctaSimulator)}</a>
     </section>`;
 
   const bodyHtml = `<main style="max-width:1100px;margin:0 auto;padding:32px 20px 56px;color:var(--color-body)">${body}</main>`;
@@ -455,6 +612,9 @@ export function professionLandingsPlugin(rootDir: string): Plugin {
       // sitemap <lastmod>.
       const dateStamp = new Date().toISOString().slice(0, 10);
 
+      // Aggregate live jobs per profession once. Module-level cached.
+      const snapshots = aggregateProfessionJobs(rootDir);
+
       const collector = new WriteCollector({
         distDir,
         pluginName: 'professionLandingsPlugin',
@@ -471,7 +631,13 @@ export function professionLandingsPlugin(rootDir: string): Plugin {
         alternates.push(`x-default|${BASE_URL}${buildProfessionLandingPath('it', id)}`);
 
         for (const locale of PROFESSION_LOCALES) {
-          const rendered = renderPage({ locale, id, dateStamp, distDir });
+          const rendered = renderPage({
+            locale,
+            id,
+            dateStamp,
+            distDir,
+            snapshot: snapshots[id],
+          });
 
           if (rendered.wordCount < MIN_INDEXABLE_WORDS) {
             thinSkipped++;
@@ -511,10 +677,6 @@ export function professionLandingsPlugin(rootDir: string): Plugin {
         `\x1b[36m[profession-landings]\x1b[0m Generated ${pagesWritten} pages (${thinSkipped} skipped as thin) — flushed ${written} files in ${((Date.now() - t0) / 1000).toFixed(1)}s`,
       );
 
-      // Always-run: patch sitemap.xml index lastmod (other plugins regenerate
-      // sitemap.xml every build, so our entry's <lastmod> would otherwise
-      // drop out). Only when our sitemap actually exists in dist (either
-      // freshly written or restored from cache).
       if (fs.existsSync(np.join(distDir, 'sitemap-professions.xml'))) {
         try {
           patchSitemapIndex(distDir, dateStamp);
@@ -523,10 +685,6 @@ export function professionLandingsPlugin(rootDir: string): Plugin {
         }
       }
 
-      // Always-run: signal the linker (professionLandingsLinksPlugin) that
-      // the 40 landings have landed on disk. Resolve unconditionally — on
-      // cache hit the files were just restored, on miss the work() above
-      // already flushed the collector.
       resolveProfessionLandingsFlushed();
     },
   };

--- a/tests/e2e/profession-landings-template-b.spec.ts
+++ b/tests/e2e/profession-landings-template-b.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from 'playwright/test';
+
+/**
+ * Template B regression test for profession landings (2026-05 redesign).
+ *
+ * Asserts the mobile-first above-the-fold contract from CLAUDE.md regola #17:
+ * the meaty content (stat tiles + primary CTA + first featured live job)
+ * must sit above the 736 px fold at 414 px viewport — NOT pushed below by
+ * SEO prose. Also locks out the banned `border-left:4px` accent stripe and
+ * proves the long-form prose still lives in the same document for the
+ * text-to-HTML ratio gate (just lower down the page).
+ *
+ * Locales covered: IT canonical (`/lavoro-ticino-educatore/`). EN/DE/FR
+ * share the same layout — repeating per-locale would catch only copy bugs
+ * which the unit tests already cover.
+ */
+
+const PROFESSION_LANDING_PATH = '/lavoro-ticino-educatore/';
+const MOBILE_VIEWPORT = { width: 414, height: 736 } as const;
+const FOLD_PX = MOBILE_VIEWPORT.height;
+
+async function gotoLanding(page: Page): Promise<void> {
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.goto(PROFESSION_LANDING_PATH, { waitUntil: 'load' });
+  // Wait for SPA hydration so any post-load rearrangement settles.
+  await page.waitForTimeout(1_500);
+}
+
+async function topOfElement(page: Page, selector: string): Promise<number | null> {
+  const handle = page.locator(selector).first();
+  if ((await handle.count()) === 0) return null;
+  const box = await handle.boundingBox();
+  return box ? box.y : null;
+}
+
+test.describe('Profession landings template B — mobile above-the-fold contract', () => {
+  test('stat tiles + CTA sit above the 414×736 fold', async ({ page }) => {
+    await gotoLanding(page);
+
+    // 3 stat tiles labels must render exactly once each, all above the fold.
+    const liveLabel = page.locator('text=/Offerte aperte/');
+    const salaryLabel = page.locator('text=/Stipendio mediano/');
+    const freshLabel = page.locator('text=/Nuove \\(30 gg\\)/');
+    await expect(liveLabel).toBeVisible();
+    await expect(salaryLabel).toBeVisible();
+    await expect(freshLabel).toBeVisible();
+
+    const liveTop = (await topOfElement(page, 'text=/Offerte aperte/'))!;
+    const salaryTop = (await topOfElement(page, 'text=/Stipendio mediano/'))!;
+    const freshTop = (await topOfElement(page, 'text=/Nuove \\(30 gg\\)/'))!;
+    // Tiles wrap to 2-3 rows on mobile; allow up to 1.5× the fold for the
+    // tallest tile but require at least the live + salary tiles to be in the
+    // first viewport (the killer-hook numbers).
+    expect(liveTop).toBeLessThan(FOLD_PX);
+    expect(salaryTop).toBeLessThan(FOLD_PX);
+    expect(freshTop).toBeLessThan(FOLD_PX * 1.5);
+
+    // Primary CTA → calculator must exist and live above the long prose.
+    const cta = page.locator('a:has-text("Calcola il tuo netto come frontaliere")').first();
+    await expect(cta).toBeVisible();
+    expect(await cta.getAttribute('href')).toMatch(/\/calcola-stipendio\/?$/);
+  });
+
+  test('first featured live job renders with company + posted date', async ({ page }) => {
+    await gotoLanding(page);
+
+    await expect(page.locator('h2:has-text("Offerte in evidenza")')).toBeVisible();
+
+    // At least 1 featured job card (the aggregate returns 0..3). Each card
+    // must include a "Pubblicata …" freshness line.
+    const postedLine = page.locator('text=/Pubblicat[ao]/').first();
+    await expect(postedLine).toBeVisible();
+  });
+
+  test('long-form prose lives below the divider, NOT above the tiles', async ({ page }) => {
+    await gotoLanding(page);
+
+    const tilesTop = (await topOfElement(page, 'text=/Offerte aperte/'))!;
+    const dividerTop = (await topOfElement(page, 'text=/^La professione in Ticino$/'))!;
+    const firstProseSection = (await topOfElement(
+      page,
+      'h2:has-text("Il mestiere in Ticino")',
+    ))!;
+
+    expect(tilesTop).toBeLessThan(dividerTop);
+    expect(dividerTop).toBeLessThan(firstProseSection);
+  });
+
+  test('banned border-left:4px accent stripe is absent', async ({ page }) => {
+    await gotoLanding(page);
+
+    // Scan every element's inline style + computed style for the banned
+    // 4 px accent stripe pattern (impeccable rules, CLAUDE.md design notes).
+    const offenders = await page.evaluate(() => {
+      const out: Array<{ tag: string; classes: string; style: string }> = [];
+      for (const el of document.querySelectorAll<HTMLElement>('*')) {
+        const inline = (el.getAttribute('style') ?? '').replace(/\s+/g, '');
+        if (/border-left:[34-9]px/.test(inline) || /border-left:\d{2,}px/.test(inline)) {
+          out.push({
+            tag: el.tagName,
+            classes: el.className.toString().slice(0, 60),
+            style: inline.slice(0, 120),
+          });
+        }
+      }
+      return out;
+    });
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Inverts the layout of /lavoro-ticino-{profession}/ (and EN/DE/FR variants):
live signal first (3 stat tiles + featured live jobs + employer grid + CTA
to salary calculator), long-form SEO prose at the bottom under a
"Approfondisci" divider. 75% mobile traffic now sees the killer numbers
(stipendio mediano, offerte aperte) above the fold at 414px — previously
buried under 7 H2 paragraphs of regulated-profession prose.

New build-time aggregator (professionJobsAggregate.ts) reads data/jobs.json,
matches jobs to professions by title regex (categoria too multilingual to
trust alone), derives per-profession liveCount, fresh30Count, top employers
and 3 freshest featured jobs. PROFESSION_FACTS stays as editorial source of
truth for typicalSalaryRange / CCL / recognition.

Removes the banned border-left:4px accent stripe from the "Fonti ufficiali"
block (impeccable design rules).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
