### PR TITLE
fix(canton): scope editorial pages to their canton + redirect mis-routed URLs

### DIFF
--- a/build-plugins/jobEditorialLanding.ts
+++ b/build-plugins/jobEditorialLanding.ts
@@ -5,6 +5,7 @@ export type JobCareClusterKey = 'clinics' | 'careHomes' | 'oss' | 'educators';
 
 import cantonSlugFile from '../data/canton-url-slugs.json';
 import municipalitiesFile from '../data/canton-municipalities.json';
+import { resolveJobCanton } from './shared/cantonSection';
 
 type CantonSlugEntry = { it: string; en: string; de: string; fr: string; dePrefix?: string };
 type CantonMunicipalitiesFile = {
@@ -1257,9 +1258,15 @@ function isInLast3Days(jobDate: Date | null, now: Date): boolean {
  return calendarDiff >= 0 && calendarDiff <= 2;
 }
 
+// Canton scoping for per-canton editorial pages. Routes through
+// resolveJobCanton so URL groups (BASILEA = BS+BL, APPENZELLO = AI+AR)
+// match their member cantons, and jobs without an explicit `canton` field
+// fall back to the location-derived canton (defaulting to TI). The previous
+// `!canton || canton === cantonCode` check failed in two ways:
+//   1. BASILEA matched zero jobs (BS/BL never equal "BASILEA")
+//   2. Jobs with no canton field leaked into every canton's page
 function isCantonScoped(job: JobLike, cantonCode: string): boolean {
- const canton = normalizeSpace(job.canton || '').toUpperCase();
- return !canton || canton === cantonCode;
+ return resolveJobCanton(job) === cantonCode;
 }
 
 function isTicinoScoped(job: JobLike): boolean {
@@ -1750,17 +1757,26 @@ function buildCareVariantLinks(options: {
  localePrefix: string;
  sectionSlug: string;
  partition?: CareClusterPartition;
+ // Optional canton scope. When provided, sibling-variant counts are
+ // restricted to jobs in that canton so badges on /cerca-lavoro-{canton}/
+ // pages reflect that canton's supply, not Switzerland-wide totals.
+ canton?: string;
 }): CareVariantLink[] {
  const partition = options.partition;
- const nursing: readonly JobLike[] = partition
+ const nursingRaw: readonly JobLike[] = partition
  ? partition.nursing
  : options.jobs.filter((job) => isNursingHubJob(job));
+ const nursing = options.canton
+ ? nursingRaw.filter((job) => isCantonScoped(job, options.canton as string))
+ : nursingRaw;
  return (Object.keys(CARE_CLUSTER_DEFS) as JobCareClusterKey[])
  .map((key) => {
  const def = getCareClusterDef(key);
- const count = partition
- ? partition.byCluster[key].length
- : nursing.filter((job) => def.matcher(job)).length;
+ const count = options.canton
+ ? nursing.filter((job) => def.matcher(job)).length
+ : partition
+   ? partition.byCluster[key].length
+   : nursing.filter((job) => def.matcher(job)).length;
  return {
  key,
  label: def.label[options.locale],
@@ -1793,9 +1809,15 @@ export function buildJobNursesHubLandingModel(options: {
  const copy = makeNursesHubCopy(cantonCode)[locale];
  const now = options.now instanceof Date ? options.now : new Date(options.now || new Date().toISOString());
  const baseUrl = options.baseUrl.replace(/\/+$/, '');
- const matches: JobLike[] = options.partition
+ // Per-canton scoping: nurses-hub previously bypassed the canton filter so
+ // every cathedral canton's `/cerca-lavoro-{canton}/infermieri/` page
+ // surfaced all Swiss nursing jobs (mostly TI). When the caller supplies a
+ // pre-computed partition we still need to narrow the nursing set to the
+ // requested canton — the partition is canton-agnostic.
+ const nursingPool: JobLike[] = options.partition
  ? [...options.partition.nursing]
  : options.jobs.filter((job) => isNursingHubJob(job));
+ const matches: JobLike[] = nursingPool.filter((job) => isCantonScoped(job, cantonCode));
  const latestJobs = matches.filter((job) => isInLast3Days(getJobFreshnessDate(job), now));
  const feedJobs = toLinkedJobs(matches, now, locale, { ...options, baseUrl }, 18);
  const latestJobsLinked = dedupeAgainst(toLinkedJobs(latestJobs, now, locale, { ...options, baseUrl }, 12), feedJobs);
@@ -1813,7 +1835,7 @@ export function buildJobNursesHubLandingModel(options: {
  latestLabel: copy.latestLabel,
  latestJobs: latestJobsLinked,
  variantTitle: copy.variantTitle,
- variants: buildCareVariantLinks({ jobs: options.jobs, locale, now, baseUrl, localePrefix: options.localePrefix, sectionSlug: options.sectionSlug, partition: options.partition }),
+ variants: buildCareVariantLinks({ jobs: options.jobs, locale, now, baseUrl, localePrefix: options.localePrefix, sectionSlug: options.sectionSlug, partition: options.partition, canton: cantonCode }),
  explainerCards: copy.explainerCards,
  faq: copy.faq,
  openAllLabel: copy.openAll,
@@ -1843,9 +1865,15 @@ export function buildJobCareVariantLandingModel(options: {
  const def = getCareClusterDef(clusterKey);
  const now = options.now instanceof Date ? options.now : new Date(options.now || new Date().toISOString());
  const baseUrl = options.baseUrl.replace(/\/+$/, '');
- const matches: JobLike[] = options.partition
+ // Per-canton scoping: care-variant pages (clinics / care-homes / OSS /
+ // educators) previously bypassed the canton filter so per-canton URLs
+ // like /cerca-lavoro-basilea/cliniche/ listed clinic jobs from across
+ // Switzerland. Narrow to the requested canton — the partition is
+ // canton-agnostic, so the filter is applied in both branches.
+ const matchesPool: JobLike[] = options.partition
  ? [...options.partition.byCluster[clusterKey]]
  : options.jobs.filter((job) => isNursingHubJob(job) && def.matcher(job));
+ const matches: JobLike[] = matchesPool.filter((job) => isCantonScoped(job, cantonCode));
  const latestJobs = matches.filter((job) => isInLast3Days(getJobFreshnessDate(job), now));
  const label = careClusterLabel(clusterKey, cantonCode, locale);
  const cd = CANTON_DISPLAY_LOCALE[cantonCode] || CANTON_DISPLAY_LOCALE['TI'];
@@ -1881,7 +1909,7 @@ export function buildJobCareVariantLandingModel(options: {
  : locale === 'de'
  ? `Diese Seite fokussiert den Gesundheits-Hub auf ${label.toLowerCase()}, damit Sie die relevantesten Stellen schneller sehen.`
  : `Cette page resserre le hub sante sur les roles ${label.toLowerCase()} pour aller directement aux offres les plus pertinentes.`;
- const siblingLinks = buildCareVariantLinks({ jobs: options.jobs, locale, now, baseUrl, localePrefix: options.localePrefix, sectionSlug: options.sectionSlug, partition: options.partition }).filter((entry) => entry.key !== clusterKey);
+ const siblingLinks = buildCareVariantLinks({ jobs: options.jobs, locale, now, baseUrl, localePrefix: options.localePrefix, sectionSlug: options.sectionSlug, partition: options.partition, canton: cantonCode }).filter((entry) => entry.key !== clusterKey);
  const feedJobs = toLinkedJobs(matches, now, locale, { ...options, baseUrl }, 18);
  const latestJobsLinked = dedupeAgainst(toLinkedJobs(latestJobs, now, locale, { ...options, baseUrl }, 12), feedJobs);
  return {
@@ -1924,12 +1952,16 @@ export function buildJobTodayLandingModel(options: {
  const baseUrl = options.baseUrl.replace(/\/+$/, '');
  const todaySlugs = JOB_TODAY_LANDING_SLUGS_BY_CANTON[cantonCode] || JOB_TODAY_LANDING_SLUGS;
  const landingHref = ensureTrailingSlash(`${baseUrl}${`${options.localePrefix}/${options.sectionSlug}/${todaySlugs[locale]}`.replace(/\/+/g, '/')}`);
- const recent24h = options.jobs.filter((job) => isInLast24Hours(getJobFreshnessDate(job), now));
- const recent3d = options.jobs.filter((job) => isInLast3Days(getJobFreshnessDate(job), now));
- const partTime = options.jobs.filter((job) => isPartTime(job));
- const citySourceJobs = options.jobs.some((job) => normalizeSpace(job.canton || ''))
- ? options.jobs.filter((job) => isCantonScoped(job, cantonCode))
- : options.jobs;
+ // Per-canton scoping: the recent24h/recent3d/partTime feeds previously
+ // skipped any canton filter, so /cerca-lavoro-{canton}/{today-slug}/
+ // pages on every non-TI canton listed jobs from across Switzerland
+ // (mostly TI). Restrict to the canton — `isCantonScoped` routes through
+ // resolveJobCanton, so BASILEA matches BS+BL and APPENZELLO matches AI+AR.
+ const cantonJobs = options.jobs.filter((job) => isCantonScoped(job, cantonCode));
+ const recent24h = cantonJobs.filter((job) => isInLast24Hours(getJobFreshnessDate(job), now));
+ const recent3d = cantonJobs.filter((job) => isInLast3Days(getJobFreshnessDate(job), now));
+ const partTime = cantonJobs.filter((job) => isPartTime(job));
+ const citySourceJobs = cantonJobs;
  const cityLeaders = Array.from(
  citySourceJobs.reduce<Map<string, number>>((map, job) => {
  const location = normalizeSpace(job.location || '');
@@ -1960,7 +1992,7 @@ export function buildJobTodayLandingModel(options: {
  intro: copy.intro,
  updatedLabel: copy.updatedLabel,
  countsLabel: copy.countsLabel,
- totalJobs: options.jobs.length,
+ totalJobs: cantonJobs.length,
  sections: {
  last24Hours: { label: copy.fresh24h, jobs: toLinkedJobs(recent24h, now, locale, { ...options, baseUrl }) },
  last3Days: { label: copy.fresh3d, jobs: toLinkedJobs(recent3d, now, locale, { ...options, baseUrl }) },

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -3246,12 +3246,16 @@ export function staticPagesPlugin(rootDir: string): Plugin {
    .map((w: string) => w.length > 2 ? w.charAt(0).toUpperCase() + w.slice(1) : w)
    .join(' ');
  cantonAnchors.push(`<a href="${cantonHubHref}" style="display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:#eef2ff;color:#312e81;text-decoration:none;font-size:13px;font-weight:600;border:1px solid #c7d2fe">${esc(displayLabel)}</a>`);
- // Per-canton "today" landing lives under the legacy TI section path
- // (`/cerca-lavoro-ticino/offerte-di-lavoro-{slug}-oggi/`).
- // Use the canonical slug helper so it always matches the emitter.
+ // Per-canton "today" landing lives under that canton's own section path
+ // (`/cerca-lavoro-{canton}/{slug}/`), e.g. `/cerca-lavoro-basilea/oggi/`
+ // or `/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/`. The earlier
+ // implementation nested every canton's today slug under `tiSection`
+ // (`/cerca-lavoro-ticino/oggi/` etc.) which 404s for non-TI cantons
+ // because the actual emit target is `/cerca-lavoro-{canton}/oggi/`.
  if (code !== AGGREGATE_KEY) {
  const todaySlug = getJobTodayLandingSlug(cantonLocale, code);
- const todayHref = `/${(locale === 'it' ? '' : `${locale}/`)}${tiSection}/${todaySlug}/`.replace(/\/+/g, '/');
+ const cantonSectionForToday = resolveCantonSection(cantonLocale, code);
+ const todayHref = `/${(locale === 'it' ? '' : `${locale}/`)}${cantonSectionForToday}/${todaySlug}/`.replace(/\/+/g, '/');
  cantonAnchors.push(`<a href="${todayHref}" style="display:inline-block;padding:3px 8px;margin:2px;border-radius:6px;background:#f0fdf4;color:#166534;text-decoration:none;font-size:12px;border:1px solid #bbf7d0">${esc(displayLabel)} &mdash; ${esc(todayLabel)}</a>`);
  }
  }

--- a/hooks/useNavigationState.ts
+++ b/hooks/useNavigationState.ts
@@ -93,7 +93,18 @@ export interface NavigationState {
 }
 
 export function useNavigationState(): NavigationState {
- // Read initial route from URL path
+ // Read initial route from URL path. If parsePath flagged the URL as a
+ // non-canonical variant of a known canton editorial-landing page
+ // (e.g. `/cerca-lavoro-basilea/offerte-di-lavoro-ticino-oggi/` → the
+ // canton's own `/cerca-lavoro-basilea/oggi/`), replace the URL before
+ // any rendering so the browser lands on the real static HTML and Google
+ // eventually drops the orphan.
+ if (typeof window !== 'undefined') {
+ const initialParsed = parsePath(window.location.pathname);
+ if (initialParsed.redirectTo && initialParsed.redirectTo !== window.location.pathname) {
+ window.location.replace(initialParsed.redirectTo + window.location.search + window.location.hash);
+ }
+ }
  const [initialRoute] = useState(() => {
  const parsed = parsePath(window.location.pathname);
  return { route: parsed.route, locale: parsed.locale };
@@ -184,7 +195,14 @@ export function useNavigationState(): NavigationState {
  // Shared route application — used by popstate AND global click interceptor
  const applyRoute = useCallback((pathname: string) => {
  enableRuntimeSeo();
- const { route, locale: urlLocale, notFoundPath: parsedNotFoundPath } = parsePath(pathname);
+ const { route, locale: urlLocale, notFoundPath: parsedNotFoundPath, redirectTo } = parsePath(pathname);
+ // Non-canonical canton editorial-landing URLs (e.g. a TI-form slug
+ // nested under a non-TI canton section) parse to a redirectTo target.
+ // Replace the URL so the browser fetches the canonical static HTML.
+ if (redirectTo && redirectTo !== pathname) {
+   window.location.replace(redirectTo + window.location.search + window.location.hash);
+   return;
+ }
  // Static SEO routes own their full HTML (rendered outside `#root`). When
  // navigating BACK into one (popstate) from elsewhere in the SPA, the
  // static content is no longer in the DOM and we cannot reconstruct it

--- a/services/router.ts
+++ b/services/router.ts
@@ -37,6 +37,10 @@ import {
  buildJobPartTimeLandingModel,
  buildJobSectorRegionLandingModel,
  buildJobTodayLandingModel,
+ careClusterSlug,
+ getJobNursesHubSlug,
+ getJobPartTimeLandingSlug,
+ getJobTodayLandingSlug,
  resolveEditorialJobLandingDescriptor,
 } from '../build-plugins/jobEditorialLanding';
 import { JOB_RECENCY_LANDING_SLUGS as RECENCY_LANDING_SLUGS } from '../build-plugins/jobRecencyLanding';
@@ -2018,6 +2022,14 @@ export interface ParseResult {
  locale: Locale;
  /** Set when the URL could not be matched to any known route */
  notFoundPath?: string;
+ /**
+  * Set when the URL is a recognisable variant of a canonical route but
+  * lives at a non-canonical path (e.g. a TI-form editorial slug nested
+  * under a non-TI canton section). App.tsx should `window.location.replace`
+  * to this canonical URL so the user lands on the real page (and Google
+  * eventually drops the orphan from its index).
+  */
+ redirectTo?: string;
 }
 
 export function parsePath(pathname: string): ParseResult {
@@ -2387,6 +2399,47 @@ export function parsePath(pathname: string): ParseResult {
              jobBoardCanton: cantonCode,
              jobBoardCity: rawSecond,
            },
+           locale,
+         };
+       }
+       // Editorial-landing slugs (today / nurses-hub / part-time / care-
+       // variant / official-gazette). The descriptor resolver accepts
+       // every canton variant — TI long-form (`offerte-di-lavoro-ticino-
+       // oggi`) and the short non-TI form (`oggi`). If the URL nests a
+       // foreign canton's slug under this canton's section (e.g.
+       // `/cerca-lavoro-basilea/offerte-di-lavoro-ticino-oggi/`), no
+       // static HTML exists at that path, so the SPA would otherwise
+       // fall through to the empty job-detail view. Redirect to this
+       // canton's own canonical slug — the build emits that page.
+       const editorialDescriptor = cantonCode !== '_AGGREGATE_'
+         ? resolveEditorialJobLandingDescriptor(rawSecond)
+         : null;
+       if (editorialDescriptor) {
+         const canonicalSlug: string | null = (() => {
+           if (editorialDescriptor.kind === 'today') return getJobTodayLandingSlug(locale, cantonCode);
+           if (editorialDescriptor.kind === 'nurses-hub') return getJobNursesHubSlug(locale, cantonCode);
+           if (editorialDescriptor.kind === 'part-time') return getJobPartTimeLandingSlug(locale, cantonCode);
+           if (editorialDescriptor.kind === 'care-variant') return careClusterSlug(editorialDescriptor.clusterKey, cantonCode, locale);
+           // official-gazette only emitted for TI; recency variants don't
+           // have per-canton slug variants. Let these fall through to the
+           // static-overlay branch so the existing handler renders the
+           // build-time HTML if present.
+           return null;
+         })();
+         if (canonicalSlug && canonicalSlug !== rawSecond) {
+           const sectionForRedirect = first;
+           const localePref = locale === 'it' ? '' : `/${locale}`;
+           const redirectTo = `${localePref}/${sectionForRedirect}/${canonicalSlug}/`.replace(/\/+/g, '/');
+           return {
+             route: { activeTab: 'job-board', jobBoardCanton: cantonCode, staticOverlay: true },
+             locale,
+             redirectTo,
+           };
+         }
+         // Canonical slug for this canton — render the static overlay
+         // (the build emits the HTML at this exact path).
+         return {
+           route: { activeTab: 'job-board', jobBoardCanton: cantonCode, staticOverlay: true },
            locale,
          };
        }

--- a/tests/job-editorial-landing.test.ts
+++ b/tests/job-editorial-landing.test.ts
@@ -478,4 +478,91 @@ describe('jobEditorialLanding', () => {
     expect(model.siblingSectorLinks.every((l) => l.key !== 'health')).toBe(true);
     expect(model.siblingSectorLinks.find((l) => l.key === 'finance')).toBeTruthy();
   });
+
+  it('scopes the today landing to the requested canton (BASILEA = BS + BL)', () => {
+    // Regression: per-canton today pages used to surface jobs from every
+    // canton (recent24h/recent3d/partTime did not filter by canton). For
+    // BASILEA the URL-group key never matched any job's canton field, so
+    // naive equality would have produced 0 jobs.
+    const now = '2026-05-15T10:00:00.000+02:00';
+    const mixed = [
+      job({ slug: 'bs-1', title: 'Pflegefachperson Basel', location: 'Basel', canton: 'BS', postedDate: '2026-05-15' }),
+      job({ slug: 'bl-1', title: 'Sachbearbeiter Liestal', location: 'Liestal', canton: 'BL', postedDate: '2026-05-14' }),
+      job({ slug: 'bs-2', title: 'Disponent 60%', location: 'Allschwil', canton: 'BS', contract: 'Part-time', postedDate: '2026-05-13' }),
+      job({ slug: 'ti-1', title: 'Backend Developer', location: 'Lugano', canton: 'TI', postedDate: '2026-05-15' }),
+      job({ slug: 'zh-1', title: 'UX Designer', location: 'Zurich', canton: 'ZH', postedDate: '2026-05-15' }),
+    ];
+
+    const basilea = buildJobTodayLandingModel({
+      jobs: mixed,
+      locale: 'it',
+      now,
+      localizedSlug: (j) => String(j.slug),
+      baseUrl: 'https://frontaliereticino.ch',
+      sectionSlug: 'cerca-lavoro-basilea',
+      localePrefix: '',
+      canton: 'BASILEA',
+    });
+    expect(basilea.totalJobs).toBe(3);
+    const allFeedSlugs = [
+      ...basilea.sections.last24Hours.jobs,
+      ...basilea.sections.last3Days.jobs,
+      ...basilea.sections.partTime.jobs,
+    ].map((j) => j.href);
+    expect(allFeedSlugs.every((href) => !href.includes('/ti-1/'))).toBe(true);
+    expect(allFeedSlugs.every((href) => !href.includes('/zh-1/'))).toBe(true);
+    expect(basilea.sections.partTime.jobs.some((j) => j.href.includes('/bs-2/'))).toBe(true);
+    expect(basilea.sections.cities.length).toBeGreaterThan(0);
+    expect(basilea.sections.cities.every((c) => ['Basel', 'Liestal', 'Allschwil'].includes(c.name))).toBe(true);
+
+    const ti = buildJobTodayLandingModel({
+      jobs: mixed,
+      locale: 'it',
+      now,
+      localizedSlug: (j) => String(j.slug),
+      baseUrl: 'https://frontaliereticino.ch',
+      sectionSlug: 'cerca-lavoro-ticino',
+      localePrefix: '',
+      canton: 'TI',
+    });
+    expect(ti.totalJobs).toBe(1);
+  });
+
+  it('scopes nurses-hub and care-variant to the requested canton', () => {
+    // Job titles must match HEALTHCARE_TITLE_ROLE_REGEX inside
+    // `isNursingHubJob`; `Pflegefachperson` alone does not (the regex covers
+    // `nurse`, `infermier*`, `oss`, etc.). Use roles that the regex matches.
+    const now = '2026-05-15T10:00:00.000+02:00';
+    const nursing = [
+      job({ slug: 'bs-pflege-1', title: 'Nurse clinic Basel Universitätsspital', location: 'Basel', canton: 'BS', category: 'health', description: 'Hospital ward in Basel clinic', postedDate: '2026-05-15' }),
+      job({ slug: 'ti-infermiere-1', title: 'Infermiere reparto medicina ospedale Lugano', location: 'Lugano', canton: 'TI', category: 'health', description: 'Clinica e ospedale Lugano', postedDate: '2026-05-14' }),
+      job({ slug: 'ti-infermiere-2', title: 'Infermiera diplomata clinica Bellinzona', location: 'Bellinzona', canton: 'TI', category: 'health', description: 'Clinica e ospedale Bellinzona', postedDate: '2026-05-13' }),
+    ];
+
+    const basileaNurses = buildJobNursesHubLandingModel({
+      jobs: nursing,
+      locale: 'it',
+      now,
+      localizedSlug: (j) => String(j.slug),
+      baseUrl: 'https://frontaliereticino.ch',
+      sectionSlug: 'cerca-lavoro-basilea',
+      localePrefix: '',
+      canton: 'BASILEA',
+    });
+    expect(basileaNurses.totalJobs).toBe(1);
+    expect(basileaNurses.feed.jobs.every((j) => !j.href.includes('/ti-'))).toBe(true);
+
+    const basileaClinics = buildJobCareVariantLandingModel({
+      jobs: nursing,
+      locale: 'it',
+      clusterKey: 'clinics',
+      now,
+      localizedSlug: (j) => String(j.slug),
+      baseUrl: 'https://frontaliereticino.ch',
+      sectionSlug: 'cerca-lavoro-basilea',
+      localePrefix: '',
+      canton: 'BASILEA',
+    });
+    expect(basileaClinics.feed.jobs.every((j) => !j.href.includes('/ti-'))).toBe(true);
+  });
 });


### PR DESCRIPTION
Three related bugs surfaced from the orphan URL
/cerca-lavoro-basilea/offerte-di-lavoro-ticino-oggi/:

1. The today / nurses-hub / care-variant editorial models built the
   per-canton pages from `validJobs` without applying any canton filter,
   so every non-TI canton's /cerca-lavoro-{canton}/{slot}/ page surfaced
   jobs from across Switzerland (mostly TI). The pre-existing
   `isCantonScoped` helper compared raw upper-case codes and never
   matched URL-group keys (BASILEA, APPENZELLO), so BASILEA part-time
   pages also showed 0 jobs. Route the check through `resolveJobCanton`
   so half-cantons (BS+BL → BASILEA, AI+AR → APPENZELLO) collapse to
   their URL group, and apply the filter in the three models that were
   missing it. Per-canton sibling-variant counts on nurses-hub /
   care-variant now also reflect the canton's own supply.

2. The cross-canton "today" navigator in staticPagesPlugin
   (`tiSection` + per-canton short slug) produced links like
   /cerca-lavoro-ticino/oggi/ for every non-TI canton, all 404s. Build
   the link against the canton's own section so it matches the actual
   emit target /cerca-lavoro-{canton}/{slug}/.

3. The SPA router only handled editorial-landing slugs under the legacy
   TI section. Nested combinations like the originally reported orphan
   URL fell through to the empty job-detail view. Detect when the URL
   parses to a known editorial descriptor but at a non-canonical canton
   path, and emit `redirectTo` so useNavigationState replaces the URL
   with the canton's canonical equivalent on first paint and on popstate.

Regression tests cover the BASILEA scoping bug + a smoke test against
real jobs.json data confirms BASILEA now lists 48 BS/BL jobs (was
1,800+ Swiss-wide), ZH shows 190 ZH jobs, VS shows 254 VS jobs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
