### PR TITLE
feat(career-landings): template B (full + ridotto) per topic landings

### DIFF
--- a/build-plugins/careerJobsAggregate.ts
+++ b/build-plugins/careerJobsAggregate.ts
@@ -1,0 +1,516 @@
+/**
+ * Build-time aggregator for the 4 career-landing topic pages (template B).
+ *
+ * Unlike `professionJobsAggregate` (clean per-mestiere title matching), the
+ * career landings target topic-level concepts:
+ *
+ *   - agenzie-del-lavoro-lugano      → SECO-authorised staffing agencies
+ *   - concorsi-pubblici-lugano       → cantonal/communal/parastatale jobs
+ *   - stage-lugano                   → internships in Lugano area
+ *   - contratti-lavoro-frontalieri   → editorial (G-permit contracts)
+ *
+ * Each aggregator returns a shape that mirrors `ProfessionJobsSnapshot` so
+ * the renderer can reuse the template-B primitives (stat tiles + featured
+ * cards + employer grid). When a topic has no jobs in `data/jobs.json` (e.g.
+ * staffing agencies aren't crawled), the aggregator returns a snapshot with
+ * empty featured/employer fields — the renderer then either suppresses the
+ * section or falls back to a curated authority list (SECO registry,
+ * concorsi-ti snapshot).
+ *
+ * Module-level cache keyed by `rootDir`. Read-only by design.
+ */
+
+import * as fs from 'node:fs';
+import * as np from 'node:path';
+import {
+  CAREER_LOCALES,
+  type CareerLocale,
+} from './careerLandingsData';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Subset of jobs.json record fields used by the aggregators. */
+interface JobRecord {
+  id?: string;
+  slug?: string;
+  slugByLocale?: Partial<Record<CareerLocale, string>>;
+  title?: string;
+  titleByLocale?: Partial<Record<CareerLocale, string>>;
+  company?: string;
+  companyKey?: string;
+  category?: string;
+  sector?: string;
+  addressLocality?: string;
+  canton?: string;
+  salaryMin?: number | null;
+  salaryMax?: number | null;
+  currency?: string;
+  postedDate?: string;
+  firstSeenAt?: string;
+  featured?: boolean;
+  employmentType?: string;
+  url?: string;
+  applyUrl?: string;
+}
+
+export interface CareerFeaturedJob {
+  readonly id: string;
+  readonly title: string;
+  readonly titleByLocale: Partial<Record<CareerLocale, string>>;
+  readonly company: string;
+  readonly city: string;
+  readonly salaryMin: number | null;
+  readonly salaryMax: number | null;
+  readonly postedDate: string;
+  readonly daysAgo: number;
+  readonly slug: string;
+  readonly slugByLocale: Partial<Record<CareerLocale, string>>;
+  readonly employmentType: string | null;
+}
+
+export interface CareerEmployer {
+  readonly name: string;
+  /** Live job count when sourced from jobs.json; null when from a curated registry. */
+  readonly count: number | null;
+}
+
+export interface CareerJobsSnapshot {
+  /** Primary count for the stat-tile headline (matching jobs or curated entries). */
+  readonly liveCount: number;
+  /** Jobs first seen / posted in the last 30 days (NaN-safe: 0 when unknown). */
+  readonly fresh30Count: number;
+  /** Median annual gross CHF salary from baseSalary midpoints — null when sparse. */
+  readonly medianSalaryChf: number | null;
+  /** Top 3 freshest jobs (featured first), max 3. Empty when the topic isn't crawled. */
+  readonly featured: readonly CareerFeaturedJob[];
+  /** Top 6 employers — sourced live or from a curated registry. */
+  readonly topEmployers: readonly CareerEmployer[];
+  /** Number of top cities (used by the contracts landing). */
+  readonly topCities: readonly string[];
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Lugano-area city regex — matches the city name in `addressLocality` and
+ * common variants. Used to scope the public-sector and intern aggregators
+ * (the keyword cluster targets Lugano specifically, not all of Ticino).
+ */
+const LUGANO_AREA_REGEX =
+  /\b(lugano|paradiso|massagno|breganzona|viganello|pregassona|sorengo|savosa|porza|cureggia|cassarate|pambio|carona|gandria)\b/i;
+
+/** Public-sector employer matcher — covers cantonal, communal, parastatal entities. */
+const PUBLIC_SECTOR_COMPANY_REGEX =
+  /\b(comune di|cantone|amministrazione cantonale|cancelleria|repubblica e cantone|eoc|ente ospedaliero|supsi|usi\b|università della svizzera|aet|ses(?:\s|$)|polizia|polcantonale|polizia cantonale|ffs|tilo|tpl|trasporti pubblici luganesi|aziende industriali|cardiocentro|istituto cantonale|fondazione cantonale|swissmedic|confederazione svizzera)\b/i;
+
+/** Internship matcher — covers IT/EN/DE/FR title variants + INTERN employment type. */
+const INTERN_TITLE_REGEX =
+  /\b(stage(?:\s|$|s)|stagiaire|stagista|tirocini|tirocinio|praktikum|praktikant|internship|intern(?:\s|$)|trainee|tirocinant)/i;
+
+// ── Cache + load ─────────────────────────────────────────────────────────────
+
+let _cache: {
+  rootDir: string;
+  staffing: CareerJobsSnapshot;
+  publicSector: CareerJobsSnapshot;
+  internship: CareerJobsSnapshot;
+  frontaliereContract: CareerJobsSnapshot;
+} | null = null;
+
+function loadJobs(rootDir: string): readonly JobRecord[] {
+  const jobsPath = np.join(rootDir, 'data', 'jobs.json');
+  if (!fs.existsSync(jobsPath)) return [];
+  try {
+    const raw = fs.readFileSync(jobsPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed as JobRecord[];
+    return [];
+  } catch (err) {
+    console.warn('[career-aggregate] failed to read jobs.json:', err);
+    return [];
+  }
+}
+
+interface SecoAgency {
+  name: string;
+  city: string;
+  type?: string;
+  notes?: string;
+}
+
+interface SecoRegistry {
+  source?: string;
+  sourceLabel?: string;
+  fetchedAt?: string;
+  count?: number;
+  agencies: readonly SecoAgency[];
+}
+
+function loadSecoRegistry(rootDir: string): SecoRegistry | null {
+  const p = np.join(rootDir, 'data', 'seco-staffing-registry.json');
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8')) as SecoRegistry;
+  } catch (err) {
+    console.warn('[career-aggregate] failed to read seco-staffing-registry.json:', err);
+    return null;
+  }
+}
+
+interface ConcorsiEntry {
+  ref?: string;
+  title?: string;
+  organization?: string | null;
+  location?: string | null;
+  deadline?: string | null;
+  url?: string;
+}
+
+interface ConcorsiSnapshot {
+  source?: string;
+  fetchedAt?: string;
+  count?: number;
+  concorsi: readonly ConcorsiEntry[];
+}
+
+function loadConcorsi(rootDir: string): ConcorsiSnapshot | null {
+  const p = np.join(rootDir, 'data', 'seo', 'concorsi-ti.json');
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8')) as ConcorsiSnapshot;
+  } catch (err) {
+    console.warn('[career-aggregate] failed to read concorsi-ti.json:', err);
+    return null;
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function jobTitleHaystack(job: JobRecord): string {
+  const parts: string[] = [];
+  if (job.title) parts.push(job.title);
+  if (job.titleByLocale) {
+    for (const v of Object.values(job.titleByLocale)) {
+      if (v) parts.push(v);
+    }
+  }
+  return parts.join(' ');
+}
+
+function jobCityString(job: JobRecord): string {
+  return `${job.addressLocality ?? ''} ${job.canton ?? ''}`;
+}
+
+function median(values: readonly number[]): number | null {
+  const sorted = [...values].filter((v) => Number.isFinite(v) && v > 0).sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? Math.round((sorted[mid - 1] + sorted[mid]) / 2) : sorted[mid];
+}
+
+function jobMidpoint(job: JobRecord): number | null {
+  const min = typeof job.salaryMin === 'number' ? job.salaryMin : null;
+  const max = typeof job.salaryMax === 'number' ? job.salaryMax : null;
+  if (min && max) return Math.round((min + max) / 2);
+  if (min) return min;
+  if (max) return max;
+  return null;
+}
+
+function toFeatured(job: JobRecord, now: number): CareerFeaturedJob | null {
+  if (!job.id || !job.title || !job.slug) return null;
+  const postedDate = job.postedDate || job.firstSeenAt || '';
+  const ts = postedDate ? Date.parse(postedDate) : NaN;
+  const daysAgo = Number.isFinite(ts) ? Math.max(0, Math.round((now - ts) / DAY_MS)) : 9999;
+  // Type-safe slugByLocale: jobs.json keys are arbitrary 2-char strings, but at
+  // build-time we only need the CareerLocale subset — drop anything else.
+  const slugByLocale: Partial<Record<CareerLocale, string>> = {};
+  const titleByLocale: Partial<Record<CareerLocale, string>> = {};
+  for (const loc of CAREER_LOCALES) {
+    const s = job.slugByLocale?.[loc];
+    if (typeof s === 'string') slugByLocale[loc] = s;
+    const t = job.titleByLocale?.[loc];
+    if (typeof t === 'string') titleByLocale[loc] = t;
+  }
+  return {
+    id: job.id,
+    title: job.title,
+    titleByLocale,
+    company: job.company ?? '',
+    city: job.addressLocality ?? '',
+    salaryMin: typeof job.salaryMin === 'number' ? job.salaryMin : null,
+    salaryMax: typeof job.salaryMax === 'number' ? job.salaryMax : null,
+    postedDate,
+    daysAgo,
+    slug: job.slug,
+    slugByLocale,
+    employmentType: job.employmentType ?? null,
+  };
+}
+
+function pickFeatured(matches: readonly JobRecord[], now: number, limit: number): CareerFeaturedJob[] {
+  const sorted = [...matches].sort((a, b) => {
+    const aFeat = a.featured ? 1 : 0;
+    const bFeat = b.featured ? 1 : 0;
+    if (aFeat !== bFeat) return bFeat - aFeat;
+    const aTs = a.postedDate ? Date.parse(a.postedDate) : 0;
+    const bTs = b.postedDate ? Date.parse(b.postedDate) : 0;
+    return bTs - aTs;
+  });
+  const out: CareerFeaturedJob[] = [];
+  for (const job of sorted) {
+    if (out.length >= limit) break;
+    const f = toFeatured(job, now);
+    if (f) out.push(f);
+  }
+  return out;
+}
+
+function fresh30Count(matches: readonly JobRecord[], now: number): number {
+  const cutoff = now - 30 * DAY_MS;
+  let n = 0;
+  for (const job of matches) {
+    const ts = job.postedDate ? Date.parse(job.postedDate) : NaN;
+    if (Number.isFinite(ts) && ts >= cutoff) n++;
+  }
+  return n;
+}
+
+function topEmployersFromJobs(matches: readonly JobRecord[], limit = 6): CareerEmployer[] {
+  const counts = new Map<string, number>();
+  for (const job of matches) {
+    const name = (job.company ?? '').trim();
+    if (!name) continue;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([name, count]) => ({ name, count }));
+}
+
+function topCitiesFromJobs(matches: readonly JobRecord[], limit = 5): string[] {
+  const counts = new Map<string, number>();
+  for (const job of matches) {
+    const c = (job.addressLocality ?? '').trim();
+    if (!c) continue;
+    counts.set(c, (counts.get(c) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([name]) => name);
+}
+
+// ── Aggregators ──────────────────────────────────────────────────────────────
+
+/**
+ * Agenzie del lavoro (staffing agencies) — Lugano.
+ *
+ * Vendor crawlers don't ingest staffing-agency jobs as such (Adecco etc. post
+ * their assignments under client brands), so `data/jobs.json` returns ~0
+ * matches by company. The aggregator therefore sources the live signal from
+ * the SECO registry snapshot (`data/seco-staffing-registry.json`) — that's
+ * the authoritative count of AVG-authorised agencies the page is built around.
+ * Featured is intentionally empty; the employer grid uses the SECO list.
+ */
+function buildStaffingSnapshot(rootDir: string): CareerJobsSnapshot {
+  const registry = loadSecoRegistry(rootDir);
+  const agencies = registry?.agencies ?? [];
+  const topEmployers: CareerEmployer[] = agencies
+    .slice(0, 6)
+    .map((a) => ({ name: a.name, count: null }));
+  return {
+    liveCount: agencies.length,
+    fresh30Count: 0,
+    medianSalaryChf: null,
+    featured: [],
+    topEmployers,
+    topCities: ['Lugano'],
+  };
+}
+
+/**
+ * Concorsi pubblici / public-sector jobs — Lugano area.
+ *
+ * Combines two sources:
+ *   - `data/seo/concorsi-ti.json` snapshot — cantonal concorsi (the canonical
+ *     count for the headline tile).
+ *   - `data/jobs.json` filtered by company regex matching cantonal/communal/
+ *     parastatal entities + Lugano-area locality — for featured cards and
+ *     a richer employer grid.
+ */
+function buildPublicSectorSnapshot(
+  rootDir: string,
+  jobs: readonly JobRecord[],
+  now: number,
+): CareerJobsSnapshot {
+  const concorsi = loadConcorsi(rootDir);
+  const concorsiCount = concorsi?.concorsi.length ?? 0;
+
+  const matches: JobRecord[] = [];
+  for (const job of jobs) {
+    const company = `${job.company ?? ''} ${job.companyKey ?? ''}`;
+    if (!PUBLIC_SECTOR_COMPANY_REGEX.test(company)) continue;
+    const city = jobCityString(job);
+    if (city && !LUGANO_AREA_REGEX.test(city)) {
+      // Also accept jobs that don't have city info but DO match canton TI —
+      // the company regex is strict enough that EOC/Cantone TI is on-topic.
+      const isTicino = (job.canton ?? '').toLowerCase() === 'ti';
+      if (!isTicino) continue;
+    }
+    matches.push(job);
+  }
+
+  const liveCount = Math.max(concorsiCount, matches.length);
+  const salaryValues: number[] = [];
+  for (const job of matches) {
+    const mid = jobMidpoint(job);
+    if (mid) salaryValues.push(mid);
+  }
+
+  return {
+    liveCount,
+    fresh30Count: fresh30Count(matches, now),
+    medianSalaryChf: median(salaryValues),
+    featured: pickFeatured(matches, now, 3),
+    topEmployers: topEmployersFromJobs(matches, 6),
+    topCities: topCitiesFromJobs(matches, 5),
+  };
+}
+
+/**
+ * Stage / internships — Lugano area.
+ *
+ * Matches on `employmentType === 'INTERN'` (case-insensitive) OR title regex
+ * across the 4 locale variants. Scopes to Lugano locality.
+ */
+function buildInternshipSnapshot(jobs: readonly JobRecord[], now: number): CareerJobsSnapshot {
+  const matches: JobRecord[] = [];
+  for (const job of jobs) {
+    const et = (job.employmentType ?? '').toUpperCase();
+    const isIntern = et === 'INTERN' || INTERN_TITLE_REGEX.test(jobTitleHaystack(job));
+    if (!isIntern) continue;
+    const city = jobCityString(job);
+    if (!LUGANO_AREA_REGEX.test(city)) continue;
+    matches.push(job);
+  }
+  const salaryValues: number[] = [];
+  for (const job of matches) {
+    const mid = jobMidpoint(job);
+    if (mid) salaryValues.push(mid);
+  }
+  return {
+    liveCount: matches.length,
+    fresh30Count: fresh30Count(matches, now),
+    medianSalaryChf: median(salaryValues),
+    featured: pickFeatured(matches, now, 3),
+    // No employer grid for stage — the curated copy carries that signal.
+    topEmployers: [],
+    topCities: topCitiesFromJobs(matches, 3),
+  };
+}
+
+/**
+ * Contratti lavoro frontalieri — purely editorial.
+ *
+ * Surfaces total CH-side jobs + median salary + top cities to give the page
+ * concrete numbers in the stat tiles, but does NOT pick featured jobs (the
+ * topic is about contract types, not specific positions).
+ */
+function buildFrontaliereContractSnapshot(
+  jobs: readonly JobRecord[],
+  now: number,
+): CareerJobsSnapshot {
+  // Use every job in the dataset (all are CH-side, suitable for permesso G).
+  const salaryValues: number[] = [];
+  for (const job of jobs) {
+    const mid = jobMidpoint(job);
+    if (mid) salaryValues.push(mid);
+  }
+  return {
+    liveCount: jobs.length,
+    fresh30Count: fresh30Count(jobs, now),
+    medianSalaryChf: median(salaryValues),
+    featured: [],
+    topEmployers: [],
+    topCities: topCitiesFromJobs(jobs, 5),
+  };
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export interface CareerLandingSnapshots {
+  readonly 'agenzie-lavoro-lugano': CareerJobsSnapshot;
+  readonly 'concorsi-pubblici-lugano': CareerJobsSnapshot;
+  readonly 'stage-lugano': CareerJobsSnapshot;
+  readonly 'contratti-lavoro-frontalieri': CareerJobsSnapshot;
+}
+
+/**
+ * Aggregate every career landing's snapshot in a single pass. Module-level
+ * cached per `rootDir` so multiple plugins (or repeated calls during a build)
+ * don't re-parse the 30 MB jobs.json file.
+ */
+export function aggregateCareerLandings(
+  rootDir: string,
+  now: number = Date.now(),
+): CareerLandingSnapshots {
+  if (_cache && _cache.rootDir === rootDir) {
+    return {
+      'agenzie-lavoro-lugano': _cache.staffing,
+      'concorsi-pubblici-lugano': _cache.publicSector,
+      'stage-lugano': _cache.internship,
+      'contratti-lavoro-frontalieri': _cache.frontaliereContract,
+    };
+  }
+
+  const jobs = loadJobs(rootDir);
+  const staffing = buildStaffingSnapshot(rootDir);
+  const publicSector = buildPublicSectorSnapshot(rootDir, jobs, now);
+  const internship = buildInternshipSnapshot(jobs, now);
+  const frontaliereContract = buildFrontaliereContractSnapshot(jobs, now);
+
+  _cache = {
+    rootDir,
+    staffing,
+    publicSector,
+    internship,
+    frontaliereContract,
+  };
+
+  return {
+    'agenzie-lavoro-lugano': staffing,
+    'concorsi-pubblici-lugano': publicSector,
+    'stage-lugano': internship,
+    'contratti-lavoro-frontalieri': frontaliereContract,
+  };
+}
+
+/** Test/CI helper — clear the module-level cache. */
+export function _resetCareerJobsAggregateCache(): void {
+  _cache = null;
+}
+
+// ── Job-board URL builder ────────────────────────────────────────────────────
+
+const JOB_BOARD_BASE_PATH: Record<CareerLocale, string> = {
+  it: '/cerca-lavoro-ticino',
+  en: '/en/find-jobs-ticino',
+  de: '/de/jobs-im-tessin',
+  fr: '/fr/trouver-emploi-tessin',
+};
+
+export function buildCareerFeaturedJobUrl(
+  job: CareerFeaturedJob,
+  locale: CareerLocale,
+): string {
+  const slug = job.slugByLocale[locale] ?? job.slug;
+  return `${JOB_BOARD_BASE_PATH[locale]}/${slug}/`;
+}
+
+export function buildCareerJobBoardUrl(locale: CareerLocale): string {
+  return `${JOB_BOARD_BASE_PATH[locale]}/`;
+}

--- a/build-plugins/careerLandingsCopy.ts
+++ b/build-plugins/careerLandingsCopy.ts
@@ -32,6 +32,7 @@ export interface CareerLandingCopy {
   title: string;
   description: string;
   h1: string;
+  /** Long-form intro paragraph — pushed below the divider under template B. */
   lede: string;
   updatedLabel: string;
   breadcrumbHome: string;
@@ -45,6 +46,62 @@ export interface CareerLandingCopy {
   sources: Array<{ label: string; href: string }>;
   sections: CareerLandingSection[];
   faqs: CareerLandingFaq[];
+}
+
+/**
+ * Template B labels — shared across all 4 career landings in a given locale.
+ * Per-id divergence (e.g. "Concorsi aperti" vs "Agenzie SECO") is handled by
+ * the `buildCareerTemplateBCopy` helper that splices a per-id label set on
+ * top of the locale shell.
+ */
+export interface CareerTemplateBShell {
+  eyebrow: string;
+  updatedLabel: string;
+  approfondisciHeading: string;
+  featuredJobsTitle: string;
+  featuredJobsEmpty: string;
+  /** Builds the "see all N openings" CTA when featured.length > 0. */
+  featuredJobsCtaAll: (n: number) => string;
+  employerGridTitle: string;
+  jobPostedLabel: (daysAgo: number) => string;
+  jobSalaryFmt: (min: number | null, max: number | null) => string;
+  /** "Nessuna offerta indicizzata" — used when featured + jobs are 0. */
+  noSalaryLabel: string;
+}
+
+/**
+ * Per-id template-B copy. `denseLede` is the 1-line tagline (≤120 chars),
+ * `statTile*` are the 3 stat-tile triplets the renderer feeds into
+ * `renderStatGrid`. `primaryCtaLabel` + `primaryCtaHref` describe the killer
+ * CTA above the fold; the renderer wraps them in `CTA_PRIMARY_STYLE`.
+ *
+ * Tiles are `null` when the underlying data is not meaningful for the id
+ * (e.g. stage doesn't ship an employer grid; agenzie doesn't ship featured
+ * jobs; contratti doesn't ship either).
+ */
+export interface CareerTemplateBCopy {
+  /** Per-id eyebrow (overrides shell when set, defaults to shell). */
+  eyebrow: string;
+  /** ≤120-char tagline shown directly under the H1. */
+  denseLede: string;
+  /** 3 stat tiles — labels are static copy, values come from the snapshot. */
+  statTile1: { label: string; valueFromCount: (count: number) => string; tone: 'success' | 'accent' | 'warning' | 'danger' | 'neutral' };
+  statTile2: { label: string; value: string | ((snapshot: { medianSalary: number | null; liveCount: number }) => string); tone: 'success' | 'accent' | 'warning' | 'danger' | 'neutral' };
+  statTile3: { label: string; valueFromFresh: (fresh: number) => string; tone: 'success' | 'accent' | 'warning' | 'danger' | 'neutral' };
+  /** Primary CTA copy — links to the calculator or job-board. */
+  primaryCtaLabel: string;
+  /** Path-relative href for the primary CTA. */
+  primaryCtaHref: string;
+  /** When false the renderer skips the featured-jobs section entirely. */
+  showFeaturedJobs: boolean;
+  /** When false the renderer skips the employer grid; some pages show curated copy instead. */
+  showEmployerGrid: boolean;
+  /** Optional editorial replacement when the employer grid is suppressed (stage / contratti). */
+  employerGridReplacement?: string;
+  /** Section title for the featured jobs (defaults to shell). */
+  featuredJobsTitle?: string;
+  /** Section title for the employer grid (defaults to shell). */
+  employerGridTitle?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -1227,3 +1284,472 @@ export const CAREER_LANDING_COPY: Record<
     'contratti-lavoro-frontalieri': condenseFor('fr', 'contratti-lavoro-frontalieri'),
   },
 };
+
+// ─────────────────────────────────────────────────────────────────
+// Template B — per-locale shell + per-id copy.
+// ─────────────────────────────────────────────────────────────────
+
+const TEMPLATE_B_SHELL: Record<CareerLocale, CareerTemplateBShell> = {
+  it: {
+    eyebrow: 'Lavoro · Lugano · 2026',
+    updatedLabel: 'Aggiornato',
+    approfondisciHeading: 'Approfondisci',
+    featuredJobsTitle: 'Offerte in evidenza',
+    featuredJobsEmpty:
+      'Nessuna offerta indicizzata in questo momento — controlla il job board completo.',
+    featuredJobsCtaAll: (n) => `Vedi tutte le ${n} offerte →`,
+    employerGridTitle: 'Chi assume',
+    jobPostedLabel: (d) =>
+      d <= 0 ? 'Pubblicata oggi' : d === 1 ? 'Pubblicata ieri' : `Pubblicata ${d} giorni fa`,
+    jobSalaryFmt: (min, max) => {
+      if (min && max) return `CHF ${min.toLocaleString('it-CH')}–${max.toLocaleString('it-CH')}/anno`;
+      if (min) return `Da CHF ${min.toLocaleString('it-CH')}/anno`;
+      if (max) return `Fino a CHF ${max.toLocaleString('it-CH')}/anno`;
+      return '';
+    },
+    noSalaryLabel: 'salario non dichiarato',
+  },
+  en: {
+    eyebrow: 'Jobs · Lugano · 2026',
+    updatedLabel: 'Updated',
+    approfondisciHeading: 'Read more',
+    featuredJobsTitle: 'Featured openings',
+    featuredJobsEmpty: 'No indexed openings right now — check the full job board.',
+    featuredJobsCtaAll: (n) => `See all ${n} openings →`,
+    employerGridTitle: 'Who is hiring',
+    jobPostedLabel: (d) =>
+      d <= 0 ? 'Posted today' : d === 1 ? 'Posted yesterday' : `Posted ${d} days ago`,
+    jobSalaryFmt: (min, max) => {
+      if (min && max) return `CHF ${min.toLocaleString('en-CH')}–${max.toLocaleString('en-CH')}/year`;
+      if (min) return `From CHF ${min.toLocaleString('en-CH')}/year`;
+      if (max) return `Up to CHF ${max.toLocaleString('en-CH')}/year`;
+      return '';
+    },
+    noSalaryLabel: 'salary not disclosed',
+  },
+  de: {
+    eyebrow: 'Jobs · Lugano · 2026',
+    updatedLabel: 'Aktualisiert',
+    approfondisciHeading: 'Mehr erfahren',
+    featuredJobsTitle: 'Empfohlene Stellen',
+    featuredJobsEmpty: 'Derzeit keine indexierten Stellen — siehe vollständige Stellenbörse.',
+    featuredJobsCtaAll: (n) => `Alle ${n} Stellen ansehen →`,
+    employerGridTitle: 'Wer einstellt',
+    jobPostedLabel: (d) =>
+      d <= 0 ? 'Heute veröffentlicht' : d === 1 ? 'Gestern veröffentlicht' : `Vor ${d} Tagen veröffentlicht`,
+    jobSalaryFmt: (min, max) => {
+      if (min && max) return `CHF ${min.toLocaleString('de-CH')}–${max.toLocaleString('de-CH')}/Jahr`;
+      if (min) return `Ab CHF ${min.toLocaleString('de-CH')}/Jahr`;
+      if (max) return `Bis CHF ${max.toLocaleString('de-CH')}/Jahr`;
+      return '';
+    },
+    noSalaryLabel: 'Lohn nicht angegeben',
+  },
+  fr: {
+    eyebrow: 'Emploi · Lugano · 2026',
+    updatedLabel: 'Mis à jour',
+    approfondisciHeading: 'Pour aller plus loin',
+    featuredJobsTitle: 'Offres mises en avant',
+    featuredJobsEmpty: 'Aucune offre indexée actuellement — consultez la bourse complète.',
+    featuredJobsCtaAll: (n) => `Voir les ${n} offres →`,
+    employerGridTitle: 'Qui recrute',
+    jobPostedLabel: (d) =>
+      d <= 0 ? "Publié aujourd'hui" : d === 1 ? 'Publié hier' : `Publié il y a ${d} jours`,
+    jobSalaryFmt: (min, max) => {
+      if (min && max) return `CHF ${min.toLocaleString('fr-CH')}–${max.toLocaleString('fr-CH')}/an`;
+      if (min) return `Dès CHF ${min.toLocaleString('fr-CH')}/an`;
+      if (max) return `Jusqu'à CHF ${max.toLocaleString('fr-CH')}/an`;
+      return '';
+    },
+    noSalaryLabel: 'salaire non communiqué',
+  },
+};
+
+// Salary-calculator URL per locale (template-B primary CTA target — pages
+// without a calculator hook (agenzie) fall back to the job-board).
+const CALCULATOR_URL: Record<CareerLocale, string> = {
+  it: '/calcola-stipendio/',
+  en: '/en/calculate-salary/',
+  de: '/de/gehalt-berechnen/',
+  fr: '/fr/calculer-salaire/',
+};
+
+const JOB_BOARD_URL: Record<CareerLocale, string> = {
+  it: '/cerca-lavoro-ticino/',
+  en: '/en/find-jobs-ticino/',
+  de: '/de/jobs-im-tessin/',
+  fr: '/fr/trouver-emploi-tessin/',
+};
+
+function fmtIntLocale(n: number, locale: CareerLocale): string {
+  const tag = { it: 'it-CH', en: 'en-CH', de: 'de-CH', fr: 'fr-CH' }[locale];
+  return n.toLocaleString(tag);
+}
+
+function fmtChfLocale(n: number, locale: CareerLocale): string {
+  return `CHF ${fmtIntLocale(n, locale)}`;
+}
+
+// ── Per-id × per-locale dense lede ───────────────────────────────────────────
+
+interface DenseLedeInputs {
+  liveCount: number;
+  fresh30Count: number;
+  medianSalary: number | null;
+  agencyCount: number;
+  concorsiCount: number;
+}
+
+const DENSE_LEDE: Record<CareerLandingId, Record<CareerLocale, (i: DenseLedeInputs) => string>> = {
+  'agenzie-lavoro-lugano': {
+    it: (i) =>
+      `${i.agencyCount} agenzie SECO autorizzate a Lugano · interinale coperto da CCL · permesso G full rights.`,
+    en: (i) =>
+      `${i.agencyCount} SECO-licensed staffing agencies in Lugano · CLA-covered interim work · full G-permit rights.`,
+    de: (i) =>
+      `${i.agencyCount} SECO-bewilligte Personalvermittler in Lugano · GAV-geregelte Temporärarbeit · volle G-Bewilligungs-Rechte.`,
+    fr: (i) =>
+      `${i.agencyCount} agences agréées SECO à Lugano · intérim couvert par CCT · droits complets du permis G.`,
+  },
+  'concorsi-pubblici-lugano': {
+    it: (i) =>
+      `${i.concorsiCount} concorsi pubblici aperti in Ticino · ${i.fresh30Count} nuove offerte pubbliche negli ultimi 30 giorni · stipendi cantonali su tabella ufficiale.`,
+    en: (i) =>
+      `${i.concorsiCount} open public-sector competitions in Ticino · ${i.fresh30Count} new public jobs in the last 30 days · cantonal pay scale.`,
+    de: (i) =>
+      `${i.concorsiCount} offene öffentliche Wettbewerbe im Tessin · ${i.fresh30Count} neue öffentliche Stellen in 30 Tagen · kantonaler Lohnraster.`,
+    fr: (i) =>
+      `${i.concorsiCount} concours publics ouverts au Tessin · ${i.fresh30Count} nouveaux postes publics ces 30 derniers jours · grille salariale cantonale.`,
+  },
+  'stage-lugano': {
+    it: (i) =>
+      `${i.liveCount} stage attivi a Lugano · ${i.fresh30Count} nuovi negli ultimi 30 giorni · CCL e copertura LAINF garantite anche per stagisti frontalieri.`,
+    en: (i) =>
+      `${i.liveCount} active internships in Lugano · ${i.fresh30Count} new in the last 30 days · CLA and accident insurance covered for cross-border interns.`,
+    de: (i) =>
+      `${i.liveCount} aktive Praktika in Lugano · ${i.fresh30Count} neu in 30 Tagen · GAV und UVG-Deckung auch für Grenzgänger-Praktikanten.`,
+    fr: (i) =>
+      `${i.liveCount} stages actifs à Lugano · ${i.fresh30Count} nouveaux ces 30 derniers jours · CCT et LAA garanties pour les stagiaires frontaliers.`,
+  },
+  'contratti-lavoro-frontalieri': {
+    it: (i) =>
+      `${fmtIntLocale(i.liveCount, 'it')} offerte aperte in Svizzera per permesso G · ${i.fresh30Count} nuove in 30 giorni · stipendio mediano CHF ${i.medianSalary ? fmtIntLocale(i.medianSalary, 'it') : '—'}/anno.`,
+    en: (i) =>
+      `${fmtIntLocale(i.liveCount, 'en')} G-permit openings across Switzerland · ${i.fresh30Count} new in 30 days · median gross salary CHF ${i.medianSalary ? fmtIntLocale(i.medianSalary, 'en') : '—'}/year.`,
+    de: (i) =>
+      `${fmtIntLocale(i.liveCount, 'de')} offene Stellen für G-Bewilligung in der Schweiz · ${i.fresh30Count} neu in 30 Tagen · Medianlohn CHF ${i.medianSalary ? fmtIntLocale(i.medianSalary, 'de') : '—'}/Jahr.`,
+    fr: (i) =>
+      `${fmtIntLocale(i.liveCount, 'fr')} offres ouvertes en Suisse pour permis G · ${i.fresh30Count} nouveaux en 30 jours · salaire médian CHF ${i.medianSalary ? fmtIntLocale(i.medianSalary, 'fr') : '—'}/an.`,
+  },
+};
+
+// ── Per-id × per-locale stat-tile + CTA copy ────────────────────────────────
+
+interface CareerStatLabels {
+  tile1Label: string;
+  tile2Label: string;
+  tile3Label: string;
+  primaryCtaLabel: string;
+  employerGridTitle?: string;
+  featuredJobsTitle?: string;
+  employerGridReplacement?: string;
+}
+
+const STAT_LABELS: Record<CareerLandingId, Record<CareerLocale, CareerStatLabels>> = {
+  'agenzie-lavoro-lugano': {
+    it: {
+      tile1Label: 'Agenzie SECO a Lugano',
+      tile2Label: 'Autorizzazione SECO',
+      tile3Label: 'Diritto frontalieri',
+      primaryCtaLabel: 'Calcola il netto da interinale',
+      employerGridTitle: 'Agenzie SECO autorizzate a Lugano',
+    },
+    en: {
+      tile1Label: 'SECO agencies in Lugano',
+      tile2Label: 'SECO licence required',
+      tile3Label: 'Cross-border rights',
+      primaryCtaLabel: 'Calculate net interim salary',
+      employerGridTitle: 'SECO-licensed staffing agencies in Lugano',
+    },
+    de: {
+      tile1Label: 'SECO-Agenturen in Lugano',
+      tile2Label: 'SECO-Bewilligung Pflicht',
+      tile3Label: 'Grenzgänger-Rechte',
+      primaryCtaLabel: 'Temporär-Nettolohn berechnen',
+      employerGridTitle: 'SECO-bewilligte Personalvermittler in Lugano',
+    },
+    fr: {
+      tile1Label: 'Agences SECO à Lugano',
+      tile2Label: 'Autorisation SECO',
+      tile3Label: 'Droits frontaliers',
+      primaryCtaLabel: 'Calculer le net en intérim',
+      employerGridTitle: 'Agences agréées SECO à Lugano',
+    },
+  },
+  'concorsi-pubblici-lugano': {
+    it: {
+      tile1Label: 'Concorsi aperti (TI)',
+      tile2Label: 'Offerte settore pubblico',
+      tile3Label: 'Nuovi negli ultimi 30 gg',
+      primaryCtaLabel: 'Calcola il netto cantonale',
+      employerGridTitle: 'Principali enti pubblici che assumono',
+      featuredJobsTitle: 'Offerte settore pubblico Lugano',
+    },
+    en: {
+      tile1Label: 'Open competitions (TI)',
+      tile2Label: 'Public-sector openings',
+      tile3Label: 'New in last 30 days',
+      primaryCtaLabel: 'Calculate cantonal net salary',
+      employerGridTitle: 'Main public employers',
+      featuredJobsTitle: 'Public-sector openings — Lugano',
+    },
+    de: {
+      tile1Label: 'Offene Wettbewerbe (TI)',
+      tile2Label: 'Stellen öffentl. Sektor',
+      tile3Label: 'Neu in 30 Tagen',
+      primaryCtaLabel: 'Kantonalen Nettolohn berechnen',
+      employerGridTitle: 'Wichtigste öffentliche Arbeitgeber',
+      featuredJobsTitle: 'Öffentliche Stellen — Lugano',
+    },
+    fr: {
+      tile1Label: 'Concours ouverts (TI)',
+      tile2Label: 'Offres secteur public',
+      tile3Label: 'Nouveaux en 30 j',
+      primaryCtaLabel: 'Calculer le net cantonal',
+      employerGridTitle: 'Principaux employeurs publics',
+      featuredJobsTitle: 'Offres secteur public — Lugano',
+    },
+  },
+  'stage-lugano': {
+    it: {
+      tile1Label: 'Stage attivi a Lugano',
+      tile2Label: 'Indennità mediana',
+      tile3Label: 'Nuovi negli ultimi 30 gg',
+      primaryCtaLabel: 'Calcola netto da stagista frontaliere',
+      featuredJobsTitle: 'Stage in evidenza a Lugano',
+      employerGridReplacement:
+        'I principali sbocchi per stage a Lugano sono USI, SUPSI, EOC, Tether/Lugano crypto-valley, gruppo BancaStato e fondazioni cantonali. Lo stage frontaliere richiede permesso G ridotto (durata pari al contratto) ed è coperto dal CCL del settore di riferimento.',
+    },
+    en: {
+      tile1Label: 'Active internships in Lugano',
+      tile2Label: 'Median allowance',
+      tile3Label: 'New in last 30 days',
+      primaryCtaLabel: 'Calculate cross-border intern net pay',
+      featuredJobsTitle: 'Featured internships — Lugano',
+      employerGridReplacement:
+        'Main destinations for internships in Lugano: USI, SUPSI, EOC, Tether / Lugano crypto-valley, BancaStato group and cantonal foundations. Cross-border internships use a short-term G-permit (term-matched) and are covered by the sector CLA.',
+    },
+    de: {
+      tile1Label: 'Aktive Praktika in Lugano',
+      tile2Label: 'Median-Entschädigung',
+      tile3Label: 'Neu in 30 Tagen',
+      primaryCtaLabel: 'Grenzgänger-Praktikum-Nettolohn berechnen',
+      featuredJobsTitle: 'Empfohlene Praktika — Lugano',
+      employerGridReplacement:
+        'Hauptanbieter für Praktika in Lugano: USI, SUPSI, EOC, Tether / Lugano crypto-valley, BancaStato-Gruppe und kantonale Stiftungen. Grenzgänger-Praktika nutzen eine kurze G-Bewilligung (vertragslänge-gebunden) und sind durch den Sektor-GAV gedeckt.',
+    },
+    fr: {
+      tile1Label: 'Stages actifs à Lugano',
+      tile2Label: 'Indemnité médiane',
+      tile3Label: 'Nouveaux en 30 j',
+      primaryCtaLabel: 'Calculer net stagiaire frontalier',
+      featuredJobsTitle: 'Stages mis en avant — Lugano',
+      employerGridReplacement:
+        'Principaux débouchés pour les stages à Lugano : USI, SUPSI, EOC, Tether / Lugano crypto-valley, groupe BancaStato et fondations cantonales. Le stage frontalier utilise un permis G court (durée du contrat) et est couvert par la CCT sectorielle.',
+    },
+  },
+  'contratti-lavoro-frontalieri': {
+    it: {
+      tile1Label: 'Offerte CH per permesso G',
+      tile2Label: 'Stipendio mediano',
+      tile3Label: 'Nuove negli ultimi 30 gg',
+      primaryCtaLabel: 'Simula il tuo netto frontaliere',
+      employerGridReplacement:
+        'Il contratto del frontaliere ricalca il diritto svizzero: CCL applicabile per settore, periodo di prova 1-3 mesi (art. 335b CO), 5 settimane di vacanza minime (6 dopo i 50 anni), assicurazioni sociali svizzere (AVS/AI/IPG, LAINF, LPP) trattenute alla fonte. Per l\'imposizione vale l\'Accordo 2020 (nuovi frontalieri ≥ 17/07/2023: 80 % imposta CH + dichiarazione IT).',
+    },
+    en: {
+      tile1Label: 'Swiss openings (G-permit)',
+      tile2Label: 'Median salary',
+      tile3Label: 'New in last 30 days',
+      primaryCtaLabel: 'Simulate your cross-border net',
+      employerGridReplacement:
+        'A cross-border employment contract follows Swiss law: sector CLA applies, 1-3 month probation (art. 335b CO), minimum 5 weeks of paid leave (6 after age 50), Swiss social insurance (AVS/AI/IPG, LAINF, LPP) withheld at source. Taxation follows the 2020 bilateral accord (new cross-borderers ≥ 17/07/2023: 80 % CH source tax + Italian declaration).',
+    },
+    de: {
+      tile1Label: 'CH-Stellen (G-Bewilligung)',
+      tile2Label: 'Medianlohn',
+      tile3Label: 'Neu in 30 Tagen',
+      primaryCtaLabel: 'Grenzgänger-Nettolohn simulieren',
+      employerGridReplacement:
+        'Der Grenzgänger-Vertrag folgt dem Schweizer Recht: GAV nach Branche, Probezeit 1-3 Monate (Art. 335b OR), mindestens 5 Wochen Ferien (6 ab 50), Schweizer Sozialversicherungen (AHV/IV/EO, UVG, BVG) an der Quelle einbehalten. Besteuerung nach Abkommen 2020 (neue Grenzgänger ≥ 17.07.2023: 80 % CH-Quellensteuer + italienische Deklaration).',
+    },
+    fr: {
+      tile1Label: 'Offres CH (permis G)',
+      tile2Label: 'Salaire médian',
+      tile3Label: 'Nouveaux en 30 j',
+      primaryCtaLabel: 'Simuler votre net frontalier',
+      employerGridReplacement:
+        'Le contrat frontalier suit le droit suisse : CCT sectorielle, période d\'essai 1-3 mois (art. 335b CO), 5 semaines de vacances minimum (6 après 50 ans), assurances sociales suisses (AVS/AI/APG, LAA, LPP) prélevées à la source. Fiscalité selon l\'accord 2020 (nouveaux frontaliers ≥ 17/07/2023 : 80 % impôt source CH + déclaration italienne).',
+    },
+  },
+};
+
+// ── Public API: build per-(locale, id) template B copy ──────────────────────
+
+export interface CareerTemplateBSnapshotInputs {
+  /** Live count from aggregateCareerLandings (jobs or curated registry). */
+  liveCount: number;
+  /** Jobs first-seen/posted in the last 30 days. */
+  fresh30Count: number;
+  /** Median annual gross CHF salary — null when the topic doesn't ship one. */
+  medianSalary: number | null;
+  /** Curated counts that override `liveCount` for the headline tile. */
+  agencyCount: number;
+  concorsiCount: number;
+}
+
+export function buildCareerTemplateBCopy(
+  locale: CareerLocale,
+  id: CareerLandingId,
+  snapshot: CareerTemplateBSnapshotInputs,
+): CareerTemplateBCopy {
+  const shell = TEMPLATE_B_SHELL[locale];
+  const labels = STAT_LABELS[id][locale];
+  const denseLede = DENSE_LEDE[id][locale](snapshot);
+
+  // Per-id stat-tile composition: each id binds the 3 tiles to the snapshot
+  // fields that make sense for the topic.
+  if (id === 'agenzie-lavoro-lugano') {
+    return {
+      eyebrow: shell.eyebrow,
+      denseLede,
+      statTile1: {
+        label: labels.tile1Label,
+        valueFromCount: (c) => fmtIntLocale(c, locale),
+        tone: 'accent',
+      },
+      statTile2: {
+        label: labels.tile2Label,
+        value: { it: 'Obbligatoria', en: 'Mandatory', de: 'Pflicht', fr: 'Obligatoire' }[locale],
+        tone: 'warning',
+      },
+      statTile3: {
+        label: labels.tile3Label,
+        valueFromFresh: () =>
+          ({ it: 'CCL pieno', en: 'Full CLA', de: 'Voller GAV', fr: 'CCT complète' }[locale]),
+        tone: 'success',
+      },
+      primaryCtaLabel: labels.primaryCtaLabel,
+      primaryCtaHref: CALCULATOR_URL[locale],
+      showFeaturedJobs: false,
+      showEmployerGrid: true,
+      employerGridTitle: labels.employerGridTitle,
+    };
+  }
+
+  if (id === 'concorsi-pubblici-lugano') {
+    return {
+      eyebrow: shell.eyebrow,
+      denseLede,
+      statTile1: {
+        label: labels.tile1Label,
+        valueFromCount: (c) => fmtIntLocale(c, locale),
+        tone: 'accent',
+      },
+      statTile2: {
+        label: labels.tile2Label,
+        value: (snap) => fmtIntLocale(snap.liveCount, locale),
+        tone: 'success',
+      },
+      statTile3: {
+        label: labels.tile3Label,
+        valueFromFresh: (f) => `+${fmtIntLocale(f, locale)}`,
+        tone: 'warning',
+      },
+      primaryCtaLabel: labels.primaryCtaLabel,
+      primaryCtaHref: CALCULATOR_URL[locale],
+      showFeaturedJobs: true,
+      showEmployerGrid: true,
+      featuredJobsTitle: labels.featuredJobsTitle,
+      employerGridTitle: labels.employerGridTitle,
+    };
+  }
+
+  if (id === 'stage-lugano') {
+    const indemnitaLabel: Record<CareerLocale, string> = {
+      it: 'Stage non pagato / variabile',
+      en: 'Unpaid / variable',
+      de: 'Unbezahlt / variabel',
+      fr: 'Non rémunéré / variable',
+    };
+    return {
+      eyebrow: shell.eyebrow,
+      denseLede,
+      statTile1: {
+        label: labels.tile1Label,
+        valueFromCount: (c) => fmtIntLocale(c, locale),
+        tone: 'accent',
+      },
+      statTile2: {
+        label: labels.tile2Label,
+        value: (snap) =>
+          snap.medianSalary && snap.medianSalary > 0
+            ? `${fmtChfLocale(snap.medianSalary, locale)}/${{ it: 'anno', en: 'year', de: 'Jahr', fr: 'an' }[locale]}`
+            : indemnitaLabel[locale],
+        tone: 'warning',
+      },
+      statTile3: {
+        label: labels.tile3Label,
+        valueFromFresh: (f) => `+${fmtIntLocale(f, locale)}`,
+        tone: 'success',
+      },
+      primaryCtaLabel: labels.primaryCtaLabel,
+      primaryCtaHref: CALCULATOR_URL[locale],
+      showFeaturedJobs: true,
+      showEmployerGrid: false,
+      employerGridReplacement: labels.employerGridReplacement,
+      featuredJobsTitle: labels.featuredJobsTitle,
+    };
+  }
+
+  // contratti-lavoro-frontalieri (editorial)
+  return {
+    eyebrow: shell.eyebrow,
+    denseLede,
+    statTile1: {
+      label: labels.tile1Label,
+      valueFromCount: (c) => fmtIntLocale(c, locale),
+      tone: 'accent',
+    },
+    statTile2: {
+      label: labels.tile2Label,
+      value: (snap) =>
+        snap.medianSalary && snap.medianSalary > 0
+          ? `${fmtChfLocale(snap.medianSalary, locale)}/${{ it: 'anno', en: 'year', de: 'Jahr', fr: 'an' }[locale]}`
+          : '—',
+      tone: 'success',
+    },
+    statTile3: {
+      label: labels.tile3Label,
+      valueFromFresh: (f) => `+${fmtIntLocale(f, locale)}`,
+      tone: 'warning',
+    },
+    primaryCtaLabel: labels.primaryCtaLabel,
+    primaryCtaHref: CALCULATOR_URL[locale],
+    showFeaturedJobs: false,
+    showEmployerGrid: false,
+    employerGridReplacement: labels.employerGridReplacement,
+  };
+}
+
+export function getCareerTemplateBShell(locale: CareerLocale): CareerTemplateBShell {
+  return TEMPLATE_B_SHELL[locale];
+}
+
+export function getCareerJobBoardUrl(locale: CareerLocale): string {
+  return JOB_BOARD_URL[locale];
+}
+
+export function getCareerCalculatorUrl(locale: CareerLocale): string {
+  return CALCULATOR_URL[locale];
+}

--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -1,7 +1,20 @@
 /**
- * Career quick-win SEO landings — Vite build plugin (AE-2).
+ * Career quick-win SEO landings (AE-2) — Vite build plugin, template B.
  *
- * Emits 16 static HTML pages (4 IT canonicals × 4 locales):
+ * Emits 16 static HTML pages (4 IT canonicals × 4 locales). The 2026-05
+ * redesign inverts the previous layout to match the mobile-first contract in
+ * CLAUDE.md regola #17 (75% of traffic is mobile):
+ *
+ *   1. breadcrumb
+ *   2. header (eyebrow · H1 · 1-line denseLede ≤120 chars)
+ *   3. 3 stat tiles (per-id labels + snapshot-driven values)
+ *   4. primary CTA → calculator / job-board
+ *   5. featured live jobs (when applicable — concorsi + stage)
+ *   6. employer grid (when applicable — agenzie + concorsi)
+ *      OR curated editorial replacement (stage + contratti)
+ *   7. ─── "Approfondisci" divider ───
+ *   8. long-form lede + 7 H2 prose sections (existing copy)
+ *   9. sources · FAQ · related · final CTAs
  *
  *   IT canonical                        EN / DE / FR variants
  *   /agenzie-del-lavoro-lugano/         /en/staffing-agencies-lugano/ …
@@ -9,31 +22,18 @@
  *   /stage-lugano/                      /en/internships-lugano/ …
  *   /contratti-lavoro-frontalieri/      /en/cross-border-work-contracts/ …
  *
- * Each IT page is ≥800 words and covers the quick-win keyword cluster with
- * real cited data from concorsi.ti.ch (snapshot in `data/seo/concorsi-ti.json`)
- * and the SECO AVG agency registry (`data/seco-staffing-registry.json`).
- * EN/DE/FR variants are ≥400 words and follow the same structure with inline
- * citations to the primary sources.
+ * Live signal comes from `careerJobsAggregate` (build-time read of
+ * `data/jobs.json` + `data/seco-staffing-registry.json` +
+ * `data/seo/concorsi-ti.json`). The editorial copy in `careerLandingsCopy`
+ * stays unchanged — the long-form prose just moves below the divider.
  *
- * JSON-LD emitted: BreadcrumbList + FAQPage + Article (Article carries
- * `inLanguage` so Google indexes the correct locale variant).
+ * JSON-LD: BreadcrumbList + FAQPage + Article (locale-tagged).
+ * Hub chrome: `{ hubKey: 'job-board', activeSubTab: 'jobs' }`.
+ * Sitemap: writes `dist/sitemap-career-landings.xml`; `sitemapAliasPlugin`
+ * auto-discovers it.
  *
- * Routing: paths are registered as `staticOverlay` routes in
- * `services/router.ts` so the SPA doesn't replace the SEO content with a
- * NotFoundSuggestions UI on hydrate (content lives outside `#root` via
- * `seoContentOutsideRoot: true`, same trick used by nursing + F2-F8 plugins).
- *
- * Hub chrome: every page wraps its body in the canonical job-board sub-nav
- * via `hubChrome: { hubKey: 'job-board', activeSubTab: 'jobs' }`, so the
- * first-paint static HTML matches the SPA chrome of the rest of the site
- * (same contract enforced by BUG-2 / tests/e2e/hub-chrome-parity.spec.ts).
- *
- * Sitemap: writes `dist/sitemap-career-landings.xml` and patches
- * `sitemap.xml` index. `sitemapAliasPlugin` auto-discovers the file so no
- * extra wiring is needed in `sitemapAliasPlugin.ts`.
- *
- * Gate: SKIP_CAREER_LANDINGS=1 fast-exits the plugin for local builds only.
- * CI (`npm run build:ci`) always exercises it — exit 0 required.
+ * Gate: `SKIP_CAREER_LANDINGS=1` fast-exits for local builds only. CI
+ * (`npm run build:ci`) always exercises this plugin — exit 0 required.
  */
 
 import fs from 'node:fs';
@@ -52,8 +52,19 @@ import {
 } from './careerLandingsData';
 import {
   CAREER_LANDING_COPY,
+  buildCareerTemplateBCopy,
+  getCareerTemplateBShell,
+  getCareerCalculatorUrl,
   type CareerLandingCopy,
+  type CareerTemplateBCopy,
 } from './careerLandingsCopy';
+import {
+  aggregateCareerLandings,
+  buildCareerFeaturedJobUrl,
+  buildCareerJobBoardUrl,
+  type CareerJobsSnapshot,
+  type CareerFeaturedJob,
+} from './careerJobsAggregate';
 import {
   BREADCRUMB_STYLE,
   BREADCRUMB_LINK_STYLE,
@@ -62,9 +73,20 @@ import {
   BODY_STYLE,
   H2_STYLE,
   CARD_STYLE,
+  CARD_BODY_STYLE,
+  CARD_PADDING_STYLE,
   LINK_ACCENT_STYLE,
   CTA_PRIMARY_STYLE,
   HERO_EYEBROW_STYLE,
+  SMALL_HEADING_STYLE,
+  STAT_TILE_ACCENT,
+  STAT_TILE_SUCCESS,
+  STAT_TILE_WARNING,
+  STAT_TILE_DANGER,
+  STAT_TILE_BASE,
+  STAT_TILE_LABEL,
+  STAT_TILE_VALUE,
+  ICON_BUILDING_SVG,
 } from './shared/seoContentTokens';
 import { buildTitleWithBrand } from './shared/titleSuffix';
 
@@ -87,9 +109,9 @@ const OG_LOCALE: Record<CareerLocale, string> = {
 
 /**
  * Related internal links per locale. IT canonicals verified against
- * services/router.ts slug tables. Keeps every career landing connected to
- * the main job-board hub + salary calculator + existing nursing landings
- * (inter-vertical link equity).
+ * `services/router.ts` slug tables. Keeps every career landing connected to
+ * the main job-board hub + salary calculator + nursing landings (cross-
+ * vertical link equity).
  */
 const RELATED_LINKS: Record<
   CareerLocale,
@@ -137,7 +159,159 @@ const RELATED_LINKS: Record<
   ],
 };
 
-// ── Rendering ─────────────────────────────────────────────────────
+// ── Template B renderers ─────────────────────────────────────────────────────
+
+function toneToStyle(tone: CareerTemplateBCopy['statTile1']['tone']): string {
+  switch (tone) {
+    case 'success':
+      return STAT_TILE_SUCCESS;
+    case 'warning':
+      return STAT_TILE_WARNING;
+    case 'danger':
+      return STAT_TILE_DANGER;
+    case 'neutral':
+      return STAT_TILE_BASE;
+    case 'accent':
+    default:
+      return STAT_TILE_ACCENT;
+  }
+}
+
+function renderTile(label: string, value: string, tone: CareerTemplateBCopy['statTile1']['tone']): string {
+  return `<div style="${toneToStyle(tone)}">
+    <div style="${STAT_TILE_LABEL}">${esc(label)}</div>
+    <div style="${STAT_TILE_VALUE}">${esc(value)}</div>
+  </div>`;
+}
+
+function renderStatTiles(
+  id: CareerLandingId,
+  templateB: CareerTemplateBCopy,
+  snapshot: CareerJobsSnapshot,
+  agencyCount: number,
+  concorsiCount: number,
+): string {
+  // Tile 1 count source is id-deterministic — agenzie uses the SECO registry,
+  // concorsi uses the cantonal snapshot, the rest use the live jobs aggregate.
+  const tile1Count =
+    id === 'agenzie-lavoro-lugano'
+      ? agencyCount
+      : id === 'concorsi-pubblici-lugano'
+        ? concorsiCount
+        : snapshot.liveCount;
+
+  const tile2Value =
+    typeof templateB.statTile2.value === 'string'
+      ? templateB.statTile2.value
+      : templateB.statTile2.value({
+          medianSalary: snapshot.medianSalaryChf,
+          liveCount: snapshot.liveCount,
+        });
+
+  const tile1 = renderTile(
+    templateB.statTile1.label,
+    templateB.statTile1.valueFromCount(tile1Count),
+    templateB.statTile1.tone,
+  );
+  const tile2 = renderTile(templateB.statTile2.label, tile2Value, templateB.statTile2.tone);
+  const tile3 = renderTile(
+    templateB.statTile3.label,
+    templateB.statTile3.valueFromFresh(snapshot.fresh30Count),
+    templateB.statTile3.tone,
+  );
+
+  return `<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px;margin:0 0 24px">${tile1}${tile2}${tile3}</div>`;
+}
+
+function renderFeaturedJobCard(
+  job: CareerFeaturedJob,
+  locale: CareerLocale,
+  formatPosted: (d: number) => string,
+  formatSalary: (min: number | null, max: number | null) => string,
+): string {
+  const href = buildCareerFeaturedJobUrl(job, locale);
+  const title = job.titleByLocale[locale] ?? job.title;
+  const subtitleParts: string[] = [];
+  if (job.company) subtitleParts.push(job.company);
+  if (job.city) subtitleParts.push(job.city);
+  const subtitle = subtitleParts.join(' · ');
+  const salary = formatSalary(job.salaryMin, job.salaryMax);
+  const posted = formatPosted(job.daysAgo);
+  return `<a class="seo-card-link" href="${esc(href)}" style="${CARD_STYLE};text-decoration:none;color:inherit;display:flex;flex-direction:column;gap:6px">
+    <div style="font-weight:700;font-size:16px;line-height:1.35;color:var(--color-heading)">${esc(title)}</div>
+    ${subtitle ? `<div style="font-size:14px;color:var(--color-body);line-height:1.4">${esc(subtitle)}</div>` : ''}
+    <div style="display:flex;flex-wrap:wrap;gap:10px 14px;align-items:center;margin-top:4px;font-size:13px;color:var(--color-subtle)">
+      ${salary ? `<span style="color:var(--color-accent);font-weight:700">${esc(salary)}</span>` : ''}
+      <span>${esc(posted)}</span>
+    </div>
+  </a>`;
+}
+
+function renderFeaturedJobs(
+  locale: CareerLocale,
+  snapshot: CareerJobsSnapshot,
+  templateB: CareerTemplateBCopy,
+): string {
+  const shell = getCareerTemplateBShell(locale);
+  const title = templateB.featuredJobsTitle ?? shell.featuredJobsTitle;
+  if (snapshot.featured.length === 0) {
+    return `<section style="margin:0 0 28px">
+      <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:700">${esc(title)}</h2>
+      <p style="${CARD_STYLE};color:var(--color-subtle);font-size:14px;margin:0">${esc(shell.featuredJobsEmpty)}</p>
+    </section>`;
+  }
+  const cards = snapshot.featured
+    .map((j) => renderFeaturedJobCard(j, locale, shell.jobPostedLabel, shell.jobSalaryFmt))
+    .join('');
+  const ctaHref = buildCareerJobBoardUrl(locale);
+  return `<section style="margin:0 0 28px">
+    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:700">${esc(title)}</h2>
+    <div style="display:grid;gap:12px;margin-bottom:14px">${cards}</div>
+    <a href="${esc(ctaHref)}" style="${LINK_ACCENT_STYLE};font-weight:700;font-size:15px">${esc(shell.featuredJobsCtaAll(snapshot.liveCount))}</a>
+  </section>`;
+}
+
+function renderEmployerGrid(
+  snapshot: CareerJobsSnapshot,
+  templateB: CareerTemplateBCopy,
+  locale: CareerLocale,
+): string {
+  const employers = snapshot.topEmployers;
+  if (employers.length === 0) return '';
+  const shell = getCareerTemplateBShell(locale);
+  const title = templateB.employerGridTitle ?? shell.employerGridTitle;
+  const cells = employers
+    .map(
+      (e) => `<div style="display:flex;align-items:center;gap:10px;${CARD_PADDING_STYLE};${CARD_BODY_STYLE}">
+        <span aria-hidden="true" style="display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:var(--color-surface-alt);color:var(--color-subtle);flex-shrink:0">${ICON_BUILDING_SVG}</span>
+        <div style="flex:1;min-width:0">
+          <div style="font-weight:700;font-size:14px;color:var(--color-heading);line-height:1.3;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(e.name)}</div>
+        </div>
+        ${e.count !== null ? `<div style="flex-shrink:0;font-weight:700;color:var(--color-accent);font-variant-numeric:tabular-nums">${e.count}</div>` : ''}
+      </div>`,
+    )
+    .join('');
+  return `<section style="margin:0 0 28px">
+    <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:700">${esc(title)}</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px">${cells}</div>
+  </section>`;
+}
+
+function renderEmployerGridReplacement(text: string): string {
+  return `<section style="margin:0 0 28px;${CARD_STYLE};max-width:860px">
+    <p style="margin:0;color:var(--color-body);line-height:1.65">${esc(text)}</p>
+  </section>`;
+}
+
+function renderApprofondisciDivider(label: string): string {
+  return `<div role="separator" aria-label="${esc(label)}" style="margin:36px 0 28px;display:flex;align-items:center;gap:14px;color:var(--color-subtle)">
+    <span aria-hidden="true" style="flex:1;height:1px;background:var(--color-edge)"></span>
+    <span style="${SMALL_HEADING_STYLE};margin:0">${esc(label)}</span>
+    <span aria-hidden="true" style="flex:1;height:1px;background:var(--color-edge)"></span>
+  </div>`;
+}
+
+// ── Long-form (below-the-fold) renderers ─────────────────────────────────────
 
 interface RenderResult {
   urlPath: string;
@@ -147,10 +321,7 @@ interface RenderResult {
 
 function renderSection(title: string, paragraphs: string[]): string {
   const ps = paragraphs
-    .map(
-      (p) =>
-        `<p style="${BODY_STYLE};max-width:860px">${esc(p)}</p>`,
-    )
+    .map((p) => `<p style="${BODY_STYLE}">${esc(p)}</p>`)
     .join('');
   return `<section style="margin:0 0 28px"><h2 style="${H2_STYLE}">${esc(title)}</h2>${ps}</section>`;
 }
@@ -187,18 +358,31 @@ function renderSources(sources: CareerLandingCopy['sources'], label: string): st
   return `<section style="margin:0 0 28px"><h2 style="${H2_STYLE}">${esc(label)}</h2><ul style="margin:0 0 0 20px;padding:0;color:var(--color-subtle);line-height:1.55;max-width:860px;font-size:14px">${items}</ul></section>`;
 }
 
+// ── Page assembly ────────────────────────────────────────────────────────────
+
 function renderPage(opts: {
   locale: CareerLocale;
   id: CareerLandingId;
   dateStamp: string;
   distDir?: string;
+  snapshot: CareerJobsSnapshot;
+  agencyCount: number;
+  concorsiCount: number;
 }): RenderResult {
-  const { locale, id, dateStamp, distDir } = opts;
+  const { locale, id, dateStamp, distDir, snapshot, agencyCount, concorsiCount } = opts;
   const copy = CAREER_LANDING_COPY[locale][id];
+  const shell = getCareerTemplateBShell(locale);
+  const templateB = buildCareerTemplateBCopy(locale, id, {
+    liveCount: snapshot.liveCount,
+    fresh30Count: snapshot.fresh30Count,
+    medianSalary: snapshot.medianSalaryChf,
+    agencyCount,
+    concorsiCount,
+  });
   const urlPath = buildCareerLandingPath(locale, id);
   const canonicalUrl = `${BASE_URL}${urlPath}`;
 
-  // Hreflang — all 4 locales + x-default → IT canonical.
+  // Hreflang
   const hreflangLines = CAREER_LOCALES.map((alt) => {
     const altPath = buildCareerLandingPath(alt, id);
     return `    <link rel="alternate" hreflang="${alt}" href="${BASE_URL}${altPath}">`;
@@ -209,32 +393,18 @@ function renderPage(opts: {
   const alternates = hreflangLines.join('\n');
 
   const homeUrl = locale === 'it' ? `${BASE_URL}/` : `${BASE_URL}/${locale}/`;
-  const jobBoardUrl = `${BASE_URL}${
-    locale === 'it'
-      ? '/cerca-lavoro-ticino/'
-      : locale === 'en'
-        ? '/en/find-jobs-ticino/'
-        : locale === 'de'
-          ? '/de/jobs-im-tessin/'
-          : '/fr/trouver-emploi-tessin/'
-  }`;
+  const jobBoardUrl = `${BASE_URL}${buildCareerJobBoardUrl(locale)}`;
+  const primaryCtaUrl = `${BASE_URL}${templateB.primaryCtaHref}`;
+
+  // The simulator / calculator URL is also referenced by the bottom CTAs.
+  const calculatorUrl = `${BASE_URL}${getCareerCalculatorUrl(locale)}`;
 
   const breadcrumbLd = JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
-      {
-        '@type': 'ListItem',
-        position: 1,
-        name: copy.breadcrumbHome,
-        item: homeUrl,
-      },
-      {
-        '@type': 'ListItem',
-        position: 2,
-        name: copy.breadcrumbJobs,
-        item: jobBoardUrl,
-      },
+      { '@type': 'ListItem', position: 1, name: copy.breadcrumbHome, item: homeUrl },
+      { '@type': 'ListItem', position: 2, name: copy.breadcrumbJobs, item: jobBoardUrl },
       { '@type': 'ListItem', position: 3, name: copy.h1, item: canonicalUrl },
     ],
   });
@@ -246,10 +416,7 @@ function renderPage(opts: {
     mainEntity: copy.faqs.map((f) => ({
       '@type': 'Question',
       name: f.question,
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: f.answer,
-      },
+      acceptedAnswer: { '@type': 'Answer', text: f.answer },
     })),
   });
 
@@ -262,11 +429,7 @@ function renderPage(opts: {
     url: canonicalUrl,
     datePublished: dateStamp,
     dateModified: dateStamp,
-    author: {
-      '@type': 'Organization',
-      name: 'Frontaliere Ticino',
-      url: BASE_URL,
-    },
+    author: { '@type': 'Organization', name: 'Frontaliere Ticino', url: BASE_URL },
     publisher: {
       '@type': 'Organization',
       name: 'Frontaliere Ticino',
@@ -280,7 +443,27 @@ function renderPage(opts: {
     mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl },
   });
 
-  const sections = copy.sections.map((s) => renderSection(s.title, s.paragraphs)).join('');
+  // ── Template B header → above-the-fold ─────────────────────────────────
+  const statTilesHtml = renderStatTiles(id, templateB, snapshot, agencyCount, concorsiCount);
+
+  const primaryCtaHtml = `<div style="margin:0 0 28px"><a href="${esc(primaryCtaUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(templateB.primaryCtaLabel)} →</a></div>`;
+
+  const featuredHtml = templateB.showFeaturedJobs
+    ? renderFeaturedJobs(locale, snapshot, templateB)
+    : '';
+
+  const employerHtml = templateB.showEmployerGrid
+    ? renderEmployerGrid(snapshot, templateB, locale)
+    : templateB.employerGridReplacement
+      ? renderEmployerGridReplacement(templateB.employerGridReplacement)
+      : '';
+
+  const dividerHtml = renderApprofondisciDivider(shell.approfondisciHeading);
+
+  // ── Below-the-fold prose (legacy) ──────────────────────────────────────
+  const sectionsHtml = copy.sections
+    .map((s) => renderSection(s.title, s.paragraphs))
+    .join('');
   const faqHtml = renderFaqBlock(copy.faqs);
   const relatedHtml = renderRelatedLinks(locale, copy.relatedLabel);
   const sourcesHtml = renderSources(copy.sources, copy.sourcesLabel);
@@ -293,12 +476,20 @@ function renderPage(opts: {
       <span> / </span>
       <span>${esc(copy.h1)}</span>
     </nav>
-    <header style="margin-bottom:24px">
-      <p style="${HERO_EYEBROW_STYLE}">${esc(copy.updatedLabel)} · ${esc(dateStamp)}</p>
+    <header style="margin-bottom:20px">
+      <p style="${HERO_EYEBROW_STYLE}">${esc(templateB.eyebrow)} · ${esc(shell.updatedLabel)} ${esc(dateStamp)}</p>
       <h1 style="${H1_STYLE}">${esc(copy.h1)}</h1>
-      <p style="${LEDE_STYLE};max-width:860px">${esc(copy.lede)}</p>
+      <p style="${LEDE_STYLE}">${esc(templateB.denseLede)}</p>
     </header>
-    ${sections}
+    ${statTilesHtml}
+    ${primaryCtaHtml}
+    ${featuredHtml}
+    ${employerHtml}
+    ${dividerHtml}
+    <section style="margin:0 0 28px">
+      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:62ch;font-size:17px;font-style:italic">${esc(copy.lede)}</p>
+    </section>
+    ${sectionsHtml}
     <section style="margin:0 0 28px">
       <h2 style="${H2_STYLE}">${esc(copy.faqTitle)}</h2>
       ${faqHtml}
@@ -307,7 +498,7 @@ function renderPage(opts: {
     ${relatedHtml}
     <section style="display:flex;gap:12px;flex-wrap:wrap;margin:0 0 16px">
       <a href="${esc(jobBoardUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.ctaJobs)}</a>
-      <a href="${esc(homeUrl)}" style="${CARD_STYLE};padding:12px 18px;border-radius:12px;text-decoration:none;font-weight:700">${esc(copy.ctaSimulator)}</a>
+      <a href="${esc(calculatorUrl)}" style="padding:10px 16px;border-radius:10px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-body);text-decoration:none;font-weight:600">${esc(copy.ctaSimulator)}</a>
     </section>`;
 
   const bodyHtml = `<main class="seo-static-content" style="max-width:1100px;margin:0 auto;padding:32px 20px 56px">${body}</main>`;
@@ -401,6 +592,11 @@ export function careerLandingsPlugin(rootDir: string): Plugin {
 
       const dateStamp = new Date().toISOString().slice(0, 10);
 
+      // Aggregate live signal once per build (module-level cached).
+      const snapshots = aggregateCareerLandings(rootDir);
+      const agencyCount = snapshots['agenzie-lavoro-lugano'].liveCount;
+      const concorsiCount = snapshots['concorsi-pubblici-lugano'].liveCount;
+
       const collector = new WriteCollector({
         distDir,
         pluginName: 'careerLandingsPlugin',
@@ -422,7 +618,15 @@ export function careerLandingsPlugin(rootDir: string): Plugin {
         );
 
         for (const locale of CAREER_LOCALES) {
-          const rendered = renderPage({ locale, id, dateStamp, distDir });
+          const rendered = renderPage({
+            locale,
+            id,
+            dateStamp,
+            distDir,
+            snapshot: snapshots[id],
+            agencyCount,
+            concorsiCount,
+          });
 
           if (rendered.wordCount < MIN_INDEXABLE_WORDS) {
             thinSkipped++;

--- a/tests/e2e/career-landings-template-b.spec.ts
+++ b/tests/e2e/career-landings-template-b.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from 'playwright/test';
+
+/**
+ * Template B regression test for career landings (2026-05 redesign — AE-2).
+ *
+ * Targets the richest of the 4 career landings,
+ * `/agenzie-del-lavoro-lugano/`, because:
+ *   - it ships the SECO-registry-backed employer grid (8 agencies)
+ *   - it covers the no-featured-jobs path (vendors don't crawl staffing
+ *     agencies — the renderer must NOT crash + must NOT show an empty
+ *     featured section)
+ *   - it has the typical 3-tile + CTA + employer-grid + divider + prose
+ *     structure that the other 3 landings share.
+ *
+ * Asserts the mobile-first above-the-fold contract from CLAUDE.md regola #17
+ * (75 % traffic is mobile, 414 × 736 viewport). EN/DE/FR variants reuse the
+ * exact same layout — per-locale coverage stays in unit tests.
+ */
+
+const CAREER_LANDING_PATH = '/agenzie-del-lavoro-lugano/';
+const MOBILE_VIEWPORT = { width: 414, height: 736 } as const;
+const FOLD_PX = MOBILE_VIEWPORT.height;
+
+async function gotoLanding(page: Page): Promise<void> {
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.goto(CAREER_LANDING_PATH, { waitUntil: 'load' });
+  // Wait for SPA hydration so any post-load rearrangement settles.
+  await page.waitForTimeout(1_500);
+}
+
+async function topOfElement(page: Page, selector: string): Promise<number | null> {
+  const handle = page.locator(selector).first();
+  if ((await handle.count()) === 0) return null;
+  const box = await handle.boundingBox();
+  return box ? box.y : null;
+}
+
+test.describe('Career landings template B — mobile above-the-fold contract', () => {
+  test('stat tiles + primary CTA sit above the 414×736 fold', async ({ page }) => {
+    await gotoLanding(page);
+
+    const liveLabel = page.locator('text=/Agenzie SECO a Lugano/');
+    const requirementLabel = page.locator('text=/Autorizzazione SECO/');
+    const rightsLabel = page.locator('text=/Diritto frontalieri/');
+    await expect(liveLabel).toBeVisible();
+    await expect(requirementLabel).toBeVisible();
+    await expect(rightsLabel).toBeVisible();
+
+    const liveTop = (await topOfElement(page, 'text=/Agenzie SECO a Lugano/'))!;
+    const reqTop = (await topOfElement(page, 'text=/Autorizzazione SECO/'))!;
+    const rightsTop = (await topOfElement(page, 'text=/Diritto frontalieri/'))!;
+    // Tiles may wrap to 2 rows at 414 px — first 2 must be in the viewport,
+    // the third within 1.5× the fold.
+    expect(liveTop).toBeLessThan(FOLD_PX);
+    expect(reqTop).toBeLessThan(FOLD_PX);
+    expect(rightsTop).toBeLessThan(FOLD_PX * 1.5);
+
+    // Primary CTA → calculator must exist and live above the long prose.
+    const cta = page.locator('a:has-text("Calcola il netto da interinale")').first();
+    await expect(cta).toBeVisible();
+    expect(await cta.getAttribute('href')).toMatch(/\/calcola-stipendio\/?$/);
+  });
+
+  test('employer grid shows ≥1 SECO-registered agency above the divider', async ({ page }) => {
+    await gotoLanding(page);
+
+    await expect(
+      page.locator('h2:has-text("Agenzie SECO autorizzate a Lugano")'),
+    ).toBeVisible();
+
+    // The SECO registry curates 8 brands; assert at least one well-known
+    // brand renders in the grid as a sanity check that the loader works.
+    const adecco = page.locator('text=/Adecco/').first();
+    await expect(adecco).toBeVisible();
+  });
+
+  test('long-form prose lives below the divider, NOT above the tiles', async ({ page }) => {
+    await gotoLanding(page);
+
+    const tilesTop = (await topOfElement(page, 'text=/Agenzie SECO a Lugano/'))!;
+    const dividerTop = (await topOfElement(page, 'text=/^Approfondisci$/'))!;
+    // The first long-form H2 on the agenzie page is hand-written copy in IT.
+    const firstProseSection = (await topOfElement(
+      page,
+      'h2:has-text("Come riconoscere un\'agenzia autorizzata SECO")',
+    ))!;
+
+    expect(tilesTop).toBeLessThan(dividerTop);
+    expect(dividerTop).toBeLessThan(firstProseSection);
+  });
+
+  test('banned border-left:4px accent stripe is absent', async ({ page }) => {
+    await gotoLanding(page);
+
+    // Scan every element's inline style for the banned 4+ px accent stripe
+    // pattern (impeccable rules, CLAUDE.md design notes).
+    const offenders = await page.evaluate(() => {
+      const out: Array<{ tag: string; classes: string; style: string }> = [];
+      for (const el of document.querySelectorAll<HTMLElement>('*')) {
+        const inline = (el.getAttribute('style') ?? '').replace(/\s+/g, '');
+        if (/border-left:[34-9]px/.test(inline) || /border-left:\d{2,}px/.test(inline)) {
+          out.push({
+            tag: el.tagName,
+            classes: el.className.toString().slice(0, 60),
+            style: inline.slice(0, 120),
+          });
+        }
+      }
+      return out;
+    });
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Inverts the layout of the 4 career topic landings (/agenzie-del-lavoro-lugano/,
/concorsi-pubblici-lugano/, /stage-lugano/, /contratti-lavoro-frontalieri/)
× 4 locales = 16 pages, following the mobile-first contract shipped in
PR #197 for profession landings (CLAUDE.md regola #17).

Above the fold (mobile 414 px): eyebrow · H1 · 1-line denseLede ≤120 chars,
3 stat tiles, primary CTA → calculator. Below the divider: long-form prose
+ FAQ + sources + related (unchanged copy, just moved down).

Per-id template variants — full vs ridotto — based on what the data supports:
  agenzie-del-lavoro-lugano    employer grid (SECO registry, 8 brands), no featured jobs
  concorsi-pubblici-lugano     employer grid + featured (public-sector jobs in Lugano)
  stage-lugano                 featured INTERN jobs + curated copy (no employer grid)
  contratti-lavoro-frontalieri editorial only + curated copy (no featured, no grid)

New build-time aggregator (careerJobsAggregate.ts) reads data/jobs.json once
per build and derives per-topic liveCount/fresh30/median/featured/employers:
  - staffing → SECO registry (vendors don't crawl agencies)
  - public-sector → company regex (Comune/Cantone/EOC/USI/SUPSI/AET/SES/FFS/TPL...) + Lugano area
  - internship → employmentType=INTERN OR title regex stage|praktikum|stagiaire|internship + Lugano
  - contracts → all jobs (median CHF + top cities for the stat tiles)

Module-level cached per rootDir. Test/CI helper `_resetCareerJobsAggregateCache`.

Preserves: hreflang × 4 locales + x-default, JSON-LD (BreadcrumbList + FAQPage
+ Article inLanguage), hubChrome { job-board / jobs }, sitemap-career-landings.xml,
MIN_INDEXABLE_WORDS gate. Removes the previous border-left:4px accent stripe
(impeccable design rules).

E2E spec covers /agenzie-del-lavoro-lugano/ (the densest case): stat tiles +
CTA above fold, SECO agency in employer grid, prose below divider, zero
border-left:4px.
