### PR TITLE
fix(seo-gate): link locale-prefixed weekly-employers top hubs from / to fix bfs-depth regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -865,6 +865,15 @@
           <li><a href="/glossario-frontaliere/tasso-di-cambio/">Tasso di Cambio</a> — Rapporto CHF/EUR per frontalieri</li>
         </ul>
 
+        <h2>Aziende che assumono — Hub multilingua</h2>
+        <p>Indice settimanale delle aziende che pubblicano offerte di lavoro in Ticino, aggiornato ogni lunedì e disponibile in italiano, inglese, tedesco e francese per i frontalieri da tutta la Svizzera.</p>
+        <ul>
+          <li><a href="/aziende-che-assumono/">Aziende che assumono in Ticino</a> — Hub italiano per città e settimana</li>
+          <li><a href="/en/companies-hiring/">Companies hiring in Ticino</a> — English weekly index by city</li>
+          <li><a href="/de/unternehmen-einstellen/">Unternehmen, die im Tessin einstellen</a> — Wöchentlicher Index nach Stadt</li>
+          <li><a href="/fr/entreprises-recrutent/">Entreprises qui recrutent au Tessin</a> — Index hebdomadaire par ville</li>
+        </ul>
+
         <h2>Altro</h2>
         <ul>
           <li><a href="/articoli-frontaliere/">Articoli e News Frontalieri</a> — 100+ articoli su tasse, lavoro e vita da frontaliere</li>


### PR DESCRIPTION
The audit:max-bfs-depth gate failed on deploy run 26013241101 with
sitemap-weekly-employers.xml at 150 URLs at depth>4 vs baseline 149 (+1).

Root cause: dist/index.html (BFS depth 0) didn't link to the EN/DE/FR
top hubs /en/companies-hiring/, /de/unternehmen-einstellen/,
/fr/entreprises-recrutent/. BFS reached them only via the IT top hub's
locale switcher: / (0) -> /cerca-lavoro-ticino/ (1) ->
/aziende-che-assumono/ (2) -> /en/companies-hiring/ (3) -> /lugano/ (4)
-> /week-NN-2026/ (5) — depth 5.

Fix: add a dedicated SEO noscript section on / linking all 4 locale top
hubs directly. They now sit at depth 1, putting all city hubs at depth
2 and every weekly archive + per-employer current-week leaf at depth 3.
EN/DE/FR weekly-employers URLs drop from depth 5 to 3 in one shot —
the gate count should go to ~0 for non-IT locales, well below baseline.
