### PR TITLE
feat(fuel-station): per-station history, lucide icons, regression tests

### DIFF
--- a/build-plugins/fuelDailyPagesPlugin.ts
+++ b/build-plugins/fuelDailyPagesPlugin.ts
@@ -90,7 +90,11 @@ import {
   H1_STYLE,
   H2_STYLE,
   HERO_EYEBROW_STYLE,
+  ICON_BAR_CHART_SVG,
   ICON_FUEL_SVG,
+  ICON_MAP_PIN_SVG,
+  ICON_NAVIGATION_SVG,
+  ICON_TROPHY_SVG,
   LEDE_STYLE,
   LINK_ACCENT_STYLE,
   renderDiscoverMore,
@@ -241,6 +245,17 @@ interface HistorySnapshot {
    * MIMIT-Gasolio ingestion not yet wired into the data pipeline.
    */
   italianCities?: Record<string, { benzina?: number | null; stationCount?: number } | undefined>;
+  /**
+   * Per-station prices, added 2026-05-18. Keyed by buildStationSlug output
+   * (must mirror scripts/lib/fuel-station-slug.mjs). Populated by every
+   * snapshot from that date forward; older snapshots omit this field.
+   *
+   * Consumed by `buildStationHistorySeries` which feeds the per-station
+   * price-history chart on the SEO leaf pages. When fewer than 3 points
+   * exist in any range the renderer falls back to the zone series with a
+   * "this station follows the zone trend" disclaimer.
+   */
+  stations?: Record<string, { diesel?: number | null; benzina?: number | null } | undefined>;
 }
 
 interface ZonePrice {
@@ -922,6 +937,38 @@ function buildFuelHistorySeries(
   }
   if (typeof todayAvg === 'number' && Number.isFinite(todayAvg)) {
     points.push({ date: todayKey, value: Number(todayAvg.toFixed(3)) });
+  }
+  points.sort((a, b) => a.date.localeCompare(b.date));
+  return points;
+}
+
+/**
+ * Per-station price series (added 2026-05-18). Mirrors `buildFuelHistorySeries`
+ * but reads from `snap.stations[stationSlug][fuel]`. Returns `[]` when no
+ * snapshot in the range carries a price for the station — callers must check
+ * `.length >= 3` before rendering, falling back to the zone series otherwise.
+ */
+function buildStationHistorySeries(
+  history: HistorySnapshot[],
+  stationSlug: string,
+  fuel: FuelType,
+  rangeDays: number,
+  today: Date,
+  todayPrice: number | null,
+): FuelSeriesPoint[] {
+  const cutoff = new Date(today.getTime() - rangeDays * 24 * 60 * 60 * 1000);
+  const cutoffKey = cutoff.toISOString().slice(0, 10);
+  const todayKey = today.toISOString().slice(0, 10);
+  const points: FuelSeriesPoint[] = [];
+  for (const snap of history) {
+    if (snap.date < cutoffKey || snap.date >= todayKey) continue;
+    const v = snap.stations?.[stationSlug]?.[fuel];
+    if (typeof v === 'number' && Number.isFinite(v)) {
+      points.push({ date: snap.date, value: Number(v.toFixed(3)) });
+    }
+  }
+  if (typeof todayPrice === 'number' && Number.isFinite(todayPrice)) {
+    points.push({ date: todayKey, value: Number(todayPrice.toFixed(3)) });
   }
   points.sort((a, b) => a.date.localeCompare(b.date));
   return points;
@@ -2437,8 +2484,11 @@ interface StationRedesignLabels {
   readonly mapAria: (brand: string, city: string) => string;
   readonly coordinatesLabel: string;
   readonly historyHeading: (zone: string) => string;
+  readonly historyHeadingStation: (brand: string) => string;
   readonly historyDisclaimer: string;
+  readonly historyCaptionStation: string;
   readonly historyAriaLabel: (zone: string, fuel: string, avgFmt: string) => string;
+  readonly historyAriaLabelStation: (brand: string, fuel: string, avgFmt: string) => string;
   readonly historyTrendLabel: string;
   readonly adviceCheaper: (delta: string, zone: string) => string;
   readonly adviceMedian: (zone: string) => string;
@@ -2457,8 +2507,11 @@ const STATION_REDESIGN: Record<FuelDailyLocale, StationRedesignLabels> = {
     mapAria: (b, c) => `Mappa OpenStreetMap che mostra la posizione della stazione ${b} a ${c}`,
     coordinatesLabel: 'Coordinate',
     historyHeading: (z) => `Andamento prezzo nella zona ${z}`,
-    historyDisclaimer: 'Questa stazione segue il trend della zona. La cronologia per singola stazione sarà disponibile a breve.',
+    historyHeadingStation: (b) => `Andamento prezzo di ${b}`,
+    historyDisclaimer: 'Cronologia per singola stazione non ancora disponibile: mostriamo l\'andamento medio della zona, che questa stazione segue da vicino.',
+    historyCaptionStation: 'Serie giornaliera dei prezzi rilevati per questa specifica stazione.',
     historyAriaLabel: (z, f, avg) => `Andamento storico del prezzo ${f.toLowerCase()} nella zona ${z}, media ${avg} CHF/litro nell'intervallo selezionato.`,
+    historyAriaLabelStation: (b, f, avg) => `Andamento storico del prezzo ${f.toLowerCase()} alla stazione ${b}, media ${avg} CHF/litro nell'intervallo selezionato.`,
     historyTrendLabel: 'Andamento prezzo',
     adviceCheaper: (delta, z) => `Buona scelta: oggi questa stazione è ${delta} CHF/litro più economica della media zona ${z}.`,
     adviceMedian: (z) => `Prezzo in linea con la media della zona ${z}: scegli in base alla comodità del percorso.`,
@@ -2475,8 +2528,11 @@ const STATION_REDESIGN: Record<FuelDailyLocale, StationRedesignLabels> = {
     mapAria: (b, c) => `OpenStreetMap showing the location of the ${b} station in ${c}`,
     coordinatesLabel: 'Coordinates',
     historyHeading: (z) => `Price trend in the ${z} zone`,
-    historyDisclaimer: 'This station follows the zone trend. Per-station history is coming soon.',
+    historyHeadingStation: (b) => `Price trend at ${b}`,
+    historyDisclaimer: 'Per-station history not yet available: showing the zone average, which this station closely tracks.',
+    historyCaptionStation: 'Daily price series observed at this specific station.',
     historyAriaLabel: (z, f, avg) => `Historical ${f.toLowerCase()} price trend in the ${z} zone, average ${avg} CHF/litre over the selected range.`,
+    historyAriaLabelStation: (b, f, avg) => `Historical ${f.toLowerCase()} price trend at ${b}, average ${avg} CHF/litre over the selected range.`,
     historyTrendLabel: 'Price trend',
     adviceCheaper: (delta, z) => `Good pick: today this station is ${delta} CHF/litre cheaper than the ${z}-zone average.`,
     adviceMedian: (z) => `Price in line with the ${z}-zone average: pick by route convenience.`,
@@ -2493,8 +2549,11 @@ const STATION_REDESIGN: Record<FuelDailyLocale, StationRedesignLabels> = {
     mapAria: (b, c) => `OpenStreetMap mit Standort der Tankstelle ${b} in ${c}`,
     coordinatesLabel: 'Koordinaten',
     historyHeading: (z) => `Preisverlauf in der Zone ${z}`,
-    historyDisclaimer: 'Diese Tankstelle folgt dem Zonen-Trend. Stations-spezifische Historie folgt in Kürze.',
+    historyHeadingStation: (b) => `Preisverlauf bei ${b}`,
+    historyDisclaimer: 'Stations-Historie noch nicht verfügbar: gezeigt wird der Zonen-Durchschnitt, dem diese Tankstelle folgt.',
+    historyCaptionStation: 'Tägliche Preisreihe dieser spezifischen Tankstelle.',
     historyAriaLabel: (z, f, avg) => `Historischer ${f}-Preisverlauf in der Zone ${z}, Durchschnitt ${avg} CHF/Liter im ausgewählten Zeitraum.`,
+    historyAriaLabelStation: (b, f, avg) => `Historischer ${f}-Preisverlauf bei ${b}, Durchschnitt ${avg} CHF/Liter im ausgewählten Zeitraum.`,
     historyTrendLabel: 'Preisverlauf',
     adviceCheaper: (delta, z) => `Gute Wahl: heute ist diese Tankstelle ${delta} CHF/Liter günstiger als der Zonen-${z}-Schnitt.`,
     adviceMedian: (z) => `Preis im Schnitt der Zone ${z}: wähle nach Route.`,
@@ -2511,8 +2570,11 @@ const STATION_REDESIGN: Record<FuelDailyLocale, StationRedesignLabels> = {
     mapAria: (b, c) => `OpenStreetMap montrant l'emplacement de la station ${b} à ${c}`,
     coordinatesLabel: 'Coordonnées',
     historyHeading: (z) => `Tendance du prix dans la zone ${z}`,
-    historyDisclaimer: 'Cette station suit la tendance de la zone. L\'historique par station arrive bientôt.',
+    historyHeadingStation: (b) => `Tendance du prix chez ${b}`,
+    historyDisclaimer: 'Historique par station pas encore disponible : la moyenne de la zone est affichée, cette station la suit de près.',
+    historyCaptionStation: 'Série quotidienne des prix relevés à cette station spécifique.',
     historyAriaLabel: (z, f, avg) => `Tendance historique du prix ${f.toLowerCase()} dans la zone ${z}, moyenne ${avg} CHF/litre sur la période sélectionnée.`,
+    historyAriaLabelStation: (b, f, avg) => `Tendance historique du prix ${f.toLowerCase()} chez ${b}, moyenne ${avg} CHF/litre sur la période sélectionnée.`,
     historyTrendLabel: 'Tendance du prix',
     adviceCheaper: (delta, z) => `Bon choix : aujourd'hui cette station est ${delta} CHF/litre moins chère que la moyenne de la zone ${z}.`,
     adviceMedian: (z) => `Prix conforme à la moyenne de la zone ${z} : choisissez selon votre itinéraire.`,
@@ -2599,9 +2661,9 @@ function renderStationHero(inp: StationHeroInput): string {
     : '';
 
   const actionsHtml = `<div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:18px">
-    <a href="${esc(inp.zonePath)}" style="${CTA_PRIMARY_STYLE};font-size:14px;padding:9px 14px">📊 ${esc(labels.viewRanking(inp.city))} →</a>
-    ${hasCoords ? `<a href="${esc(gmapsHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:9px 14px;border-radius:10px;background:var(--color-surface-alt);color:var(--color-heading);text-decoration:none;font-weight:600;font-size:14px;border:1px solid var(--color-edge)">📍 ${esc(labels.openInMaps)}</a>` : ''}
-    ${hasCoords ? `<a href="${esc(wazeHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:9px 14px;border-radius:10px;background:var(--color-surface-alt);color:var(--color-heading);text-decoration:none;font-weight:600;font-size:14px;border:1px solid var(--color-edge)">🚗 ${esc(labels.openInWaze)}</a>` : ''}
+    <a href="${esc(inp.zonePath)}" style="${CTA_PRIMARY_STYLE};font-size:14px;padding:9px 14px">${ICON_BAR_CHART_SVG} ${esc(labels.viewRanking(inp.city))} →</a>
+    ${hasCoords ? `<a href="${esc(gmapsHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:9px 14px;border-radius:10px;background:var(--color-surface-alt);color:var(--color-heading);text-decoration:none;font-weight:600;font-size:14px;border:1px solid var(--color-edge)">${ICON_MAP_PIN_SVG} ${esc(labels.openInMaps)}</a>` : ''}
+    ${hasCoords ? `<a href="${esc(wazeHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:9px 14px;border-radius:10px;background:var(--color-surface-alt);color:var(--color-heading);text-decoration:none;font-weight:600;font-size:14px;border:1px solid var(--color-edge)">${ICON_NAVIGATION_SVG} ${esc(labels.openInWaze)}</a>` : ''}
   </div>`;
 
   return `<section style="${CARD_BODY_STYLE};padding:22px 22px 20px;margin:0 0 18px" aria-label="${esc(inp.brand)} ${esc(inp.city)}">
@@ -2619,7 +2681,7 @@ function renderStationHero(inp: StationHeroInput): string {
     </div>
     <div style="display:flex;flex-direction:column;gap:8px">
       <span style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:${deltaBg};color:${deltaTone};font-weight:700;font-size:13px;font-variant-numeric:tabular-nums">${esc(inp.deltaZoneFmt)} vs ${esc(inp.zoneLabel)}</span>
-      <a href="${esc(inp.zonePath)}" style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:var(--color-accent-subtle);color:var(--color-accent);font-weight:700;font-size:13px;text-decoration:none;border:1px solid var(--color-accent-border)">🏆 ${esc(rankText)} a ${esc(inp.city)} →</a>
+      <a href="${esc(inp.zonePath)}" style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:var(--color-accent-subtle);color:var(--color-accent);font-weight:700;font-size:13px;text-decoration:none;border:1px solid var(--color-accent-border)">${ICON_TROPHY_SVG} ${esc(rankText)} a ${esc(inp.city)} →</a>
     </div>
   </div>
   ${actionsHtml}
@@ -2691,12 +2753,12 @@ function renderStationLocationCard(inp: StationLocationInput): string {
       <h2 id="stationLocation" style="${H2_STYLE};margin:0 0 10px;font-size:18px">${esc(labels.locationHeading)}</h2>
       <p style="margin:0 0 12px;color:var(--color-body);font-size:14px;line-height:1.5">${esc(labels.locationCaption(inp.brand, inp.city))}</p>
       <dl style="margin:0 0 14px;display:grid;grid-template-columns:max-content 1fr;column-gap:14px;row-gap:6px;font-size:14px;color:var(--color-body)">
-        <dt style="font-weight:600">📌</dt><dd style="margin:0">${esc(inp.address || `${inp.city}`)}</dd>
-        <dt style="font-weight:600">🧭</dt><dd style="margin:0;font-variant-numeric:tabular-nums">${esc(labels.coordinatesLabel)}: ${lat.toFixed(5)}, ${lng.toFixed(5)}</dd>
+        <dt style="display:flex;align-items:center;color:var(--color-subtle)" aria-hidden="true">${ICON_MAP_PIN_SVG}</dt><dd style="margin:0">${esc(inp.address || `${inp.city}`)}</dd>
+        <dt style="display:flex;align-items:center;color:var(--color-subtle)" aria-hidden="true">${ICON_NAVIGATION_SVG}</dt><dd style="margin:0;font-variant-numeric:tabular-nums">${esc(labels.coordinatesLabel)}: ${lat.toFixed(5)}, ${lng.toFixed(5)}</dd>
       </dl>
       <div style="display:flex;flex-wrap:wrap;gap:8px">
-        <a href="${esc(gmapsHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:10px;background:var(--color-accent);color:var(--color-on-accent);text-decoration:none;font-weight:600;font-size:14px">📍 ${esc(labels.openInMaps)}</a>
-        <a href="${esc(wazeHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:10px;background:var(--color-surface-alt);color:var(--color-heading);text-decoration:none;font-weight:600;font-size:14px;border:1px solid var(--color-edge)">🚗 ${esc(labels.openInWaze)}</a>
+        <a href="${esc(gmapsHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:10px;background:var(--color-accent);color:var(--color-on-accent);text-decoration:none;font-weight:600;font-size:14px">${ICON_MAP_PIN_SVG} ${esc(labels.openInMaps)}</a>
+        <a href="${esc(wazeHref)}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:10px;background:var(--color-surface-alt);color:var(--color-heading);text-decoration:none;font-weight:600;font-size:14px;border:1px solid var(--color-edge)">${ICON_NAVIGATION_SVG} ${esc(labels.openInWaze)}</a>
       </div>
     </div>
   </div>
@@ -2712,12 +2774,66 @@ interface StationHistoryInput {
   readonly history: readonly HistorySnapshot[];
   readonly today: Date;
   readonly zoneAvg: number | null;
+  /** Slug of the current station — used to look up per-station prices in history. */
+  readonly stationSlug: string;
+  /** Brand display name — used in the heading + aria label when per-station data is present. */
+  readonly brand: string;
+  /** Today's per-station price for the chosen fuel (anchors the last point). */
+  readonly stationPriceToday: number | null;
 }
 
-/** Reuse the zone history chart with a per-station honest disclaimer. */
+/**
+ * Render the per-station price-history card.
+ *
+ * Strategy:
+ *  - First try a per-station series from `snap.stations[slug][fuel]`.
+ *  - If any range yields ≥3 numeric points → render the per-station chart.
+ *  - Otherwise fall back to the zone series with an honest disclaimer
+ *    ("station-level history not yet available, showing zone average").
+ *
+ * Going forward (from 2026-05-18 when the snapshot writer started persisting
+ * `stations`), the per-station path will activate after ~3 snapshots, i.e.
+ * within a few days for any actively-monitored station. Older snapshots
+ * lack the `stations` field and contribute 0 station-level points — the
+ * fallback path keeps the chart honest in the transition window.
+ */
 function renderStationHistoryCard(inp: StationHistoryInput): string {
   const labels = STATION_REDESIGN[inp.locale];
-  const seriesByRange = FUEL_RANGE_KEYS.reduce(
+
+  // Try per-station first.
+  const stationSeriesByRange = FUEL_RANGE_KEYS.reduce(
+    (acc, rk) => {
+      acc[rk] = buildStationHistorySeries(
+        inp.history as HistorySnapshot[],
+        inp.stationSlug,
+        inp.fuel,
+        FUEL_RANGE_DAYS[rk],
+        inp.today,
+        inp.stationPriceToday,
+      );
+      return acc;
+    },
+    {} as Record<FuelRangeKey, FuelSeriesPoint[]>,
+  );
+  const stationHasEnough = Object.values(stationSeriesByRange).some((s) => s.length >= 3);
+
+  if (stationHasEnough) {
+    const chartCard = renderFuelHistoryCard({
+      locale: inp.locale,
+      trendLabel: labels.historyTrendLabel,
+      buildAriaLabel: (avgFmt) => labels.historyAriaLabelStation(inp.brand, inp.fuelLabel, avgFmt),
+      seriesByRange: stationSeriesByRange,
+      currency: 'CHF',
+    });
+    return `<section style="margin:0 0 24px" aria-labelledby="stationHistory">
+  <h2 id="stationHistory" style="${H2_STYLE};margin:0 0 8px;font-size:20px">${esc(labels.historyHeadingStation(inp.brand))}</h2>
+  <p style="margin:0 0 14px;color:var(--color-subtle);font-size:13px;line-height:1.5">${esc(labels.historyCaptionStation)}</p>
+  ${chartCard}
+</section>`;
+  }
+
+  // Fallback: zone series.
+  const zoneSeriesByRange = FUEL_RANGE_KEYS.reduce(
     (acc, rk) => {
       acc[rk] = buildFuelHistorySeries(
         inp.history as HistorySnapshot[],
@@ -2731,14 +2847,13 @@ function renderStationHistoryCard(inp: StationHistoryInput): string {
     },
     {} as Record<FuelRangeKey, FuelSeriesPoint[]>,
   );
-  // If we have no points in any range, omit the card entirely.
-  const anyPoints = Object.values(seriesByRange).some((s) => s.length >= 2);
-  if (!anyPoints) return '';
+  const zoneHasPoints = Object.values(zoneSeriesByRange).some((s) => s.length >= 2);
+  if (!zoneHasPoints) return '';
   const chartCard = renderFuelHistoryCard({
     locale: inp.locale,
     trendLabel: labels.historyTrendLabel,
     buildAriaLabel: (avgFmt) => labels.historyAriaLabel(inp.zoneLabel, inp.fuelLabel, avgFmt),
-    seriesByRange,
+    seriesByRange: zoneSeriesByRange,
     currency: 'CHF',
   });
   return `<section style="margin:0 0 24px" aria-labelledby="stationHistory">
@@ -3013,6 +3128,9 @@ function renderStationPage(opts: {
         history,
         today,
         zoneAvg,
+        stationSlug: ctx.slug,
+        brand: ctx.brandDisplay,
+        stationPriceToday: price,
       })
     : '';
 

--- a/build-plugins/shared/seoContentTokens.ts
+++ b/build-plugins/shared/seoContentTokens.ts
@@ -671,6 +671,22 @@ export const ICON_BUILDING_SVG =
 export const ICON_FUEL_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="3" x2="15" y1="22" y2="22"/><line x1="4" x2="14" y1="9" y2="9"/><path d="M14 22V4a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v18"/><path d="M14 13h2a2 2 0 0 1 2 2v2a2 2 0 0 0 2 2a2 2 0 0 0 2-2V9.83a2 2 0 0 0-.59-1.42L18 5"/></svg>';
 
+/** Inline lucide "trophy" icon — used for ranking chips. 16×16, currentColor stroke. */
+export const ICON_TROPHY_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/><path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18"/><path d="M4 22h16"/><path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22"/><path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22"/><path d="M18 2H6v7a6 6 0 0 0 12 0V2Z"/></svg>';
+
+/** Inline lucide "map-pin" icon — used for location actions. 16×16. */
+export const ICON_MAP_PIN_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>';
+
+/** Inline lucide "navigation" arrow — used for Waze / driving direction actions. 16×16. */
+export const ICON_NAVIGATION_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><polygon points="3 11 22 2 13 21 11 13 3 11"/></svg>';
+
+/** Inline lucide "bar-chart-3" icon — used for ranking/leaderboard actions. 16×16. */
+export const ICON_BAR_CHART_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg>';
+
 // ── Discover-more CTA block ───────────────────────────────────────────────────
 
 const DISCOVER_MORE_HEADING: Record<string, string> = {

--- a/scripts/lib/fuel-station-slug.mjs
+++ b/scripts/lib/fuel-station-slug.mjs
@@ -1,0 +1,44 @@
+/**
+ * Per-station slug helpers, mirrored from build-plugins/fuelDailyData.ts.
+ *
+ * Why a duplicate: scripts/snapshot-fuel-history.mjs runs in a plain-Node
+ * (ESM) context and cannot import .ts files. Keeping a tiny JS twin keeps
+ * the snapshot writer slug-aligned with the TS renderer without bundling.
+ *
+ * Drift safety: tests/fuel-station-slug-parity.test.ts asserts these two
+ * implementations produce byte-identical slugs across a fixture set.
+ * If TS changes, JS must change too — and the test will fail loudly first.
+ */
+
+/**
+ * Normalise a free-form string to a kebab-case URL slug.
+ * MUST match `slugify` in build-plugins/fuelDailyData.ts.
+ */
+export function slugify(raw) {
+  if (!raw) return '';
+  return String(raw)
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+/**
+ * Derive a stable per-station slug from brand + address.
+ * MUST match `buildStationSlug` in build-plugins/fuelDailyData.ts.
+ */
+export function buildStationSlug({ brand, name, address }) {
+  let street = '';
+  if (address) {
+    const firstPart = address.split(',')[0] ?? '';
+    street = firstPart.replace(/\s+\d+[A-Za-z]?$/g, '').trim();
+  }
+  const brandClean = brand && String(brand).toUpperCase() !== 'UNDEFINED' ? brand : '';
+  const firstNameWord = name ? String(name).split(/\s+/)[0] ?? '' : '';
+  const prefix = brandClean || firstNameWord || 'stazione';
+  const slug = slugify(`${prefix}-${street}`);
+  return slug || slugify(name ?? '') || 'stazione';
+}

--- a/scripts/snapshot-fuel-history.mjs
+++ b/scripts/snapshot-fuel-history.mjs
@@ -14,6 +14,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { buildStationSlug } from './lib/fuel-station-slug.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -217,6 +218,31 @@ function main() {
 
   // Italian per-city averages (benzina only — see comment on computeItalianCityAverages)
   snapshot.italianCities = computeItalianCityAverages(dataset);
+
+  // Per-station prices (added 2026-05-18). Keyed by the same slug the SEO
+  // renderer computes via build-plugins/fuelDailyData.ts → buildStationSlug.
+  // Going forward, this populates the per-station price-history chart on
+  // /prezzi-{fuel}/{zone}/stazioni/{slug}/ pages. Older snapshots (pre this
+  // commit) only carry zone averages; the renderer falls back to zone with a
+  // disclaimer when station-level points are <3.
+  //
+  // Collision handling: when two stations resolve to the same slug (rare —
+  // same brand + same street prefix across cities), the LAST one wins. The
+  // renderer side adds `-2`/`-3` suffixes for uniqueness; those suffixed
+  // slugs won't match here and will fall back to zone, which is acceptable.
+  const stationsByslug = {};
+  for (const s of stations) {
+    const slug = buildStationSlug({ brand: s.brand, name: s.name, address: s.address });
+    if (!slug) continue;
+    const diesel = stationPriceForFuel(s, 'diesel');
+    const benzina = stationPriceForFuel(s, 'benzina');
+    if (diesel === null && benzina === null) continue;
+    const entry = {};
+    if (diesel !== null) entry.diesel = diesel;
+    if (benzina !== null) entry.benzina = benzina;
+    stationsByslug[slug] = entry;
+  }
+  snapshot.stations = stationsByslug;
 
   const out = path.join(HISTORY_DIR, `${today}.json`);
   fs.writeFileSync(out, JSON.stringify(snapshot, null, 2), 'utf-8');

--- a/tests/fuel-station-redesign.test.ts
+++ b/tests/fuel-station-redesign.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Per-station SEO page redesign — regression tests for the 2026-05-18 layout.
+ *
+ * We test the public surface (`generateFuelStationPages`) with a minimal
+ * synthetic dataset, then assert the emitted HTML carries every above-the-fold
+ * affordance the redesign introduces. This keeps the tests resilient to
+ * helper-function refactors as long as the rendered output remains correct.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateFuelStationPages } from '../build-plugins/fuelDailyPagesPlugin';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { buildStationSlug as _buildStationSlugJsRaw } from '../scripts/lib/fuel-station-slug.mjs';
+import { buildStationSlug as buildStationSlugTs } from '../build-plugins/fuelDailyData';
+
+// `.mjs` has no `.d.ts` companion, so TS infers strict-required object props.
+// At runtime the JS twin accepts undefined/null/missing fields exactly like
+// the TS version — wrap it in a typed pass-through so the parity test can
+// share a single fixture type with the TS function.
+const buildStationSlugJs: typeof buildStationSlugTs = (opts) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (_buildStationSlugJsRaw as unknown as (o: unknown) => string)(opts as any);
+
+const TODAY = new Date('2026-05-18T06:00:00Z');
+
+interface SyntheticStation {
+  id: string;
+  brand: string;
+  name: string;
+  address: string;
+  sp95PriceChf: number;
+  dieselPriceChf?: number;
+  lat?: number;
+  lng?: number;
+  updatedAt?: string;
+}
+
+function buildDataset(stations: SyntheticStation[]) {
+  return {
+    generatedAt: TODAY.toISOString(),
+    municipalities: [
+      {
+        municipality: 'Como',
+        province: 'CO',
+        swiss: {
+          nearbyStations: stations,
+        },
+      },
+    ],
+  };
+}
+
+/** Three Chiasso stations spanning cheaper/median/premium so we get rank + delta variance. */
+const STATIONS: SyntheticStation[] = [
+  {
+    id: '1',
+    brand: 'Migrol',
+    name: 'Migrol Chiasso',
+    address: 'Via Cantonale 5, 6830 Chiasso',
+    sp95PriceChf: 1.85,
+    dieselPriceChf: 1.95,
+    lat: 45.836,
+    lng: 9.033,
+    updatedAt: '2026-05-18',
+  },
+  {
+    id: '2',
+    brand: 'Silo',
+    name: 'Silo Via Emilio Bossi',
+    address: 'Via Emilio Bossi 19, 6830 Chiasso',
+    sp95PriceChf: 1.9,
+    dieselPriceChf: 2.0,
+    lat: 45.8349,
+    lng: 9.0311,
+    updatedAt: '2026-05-18',
+  },
+  {
+    id: '3',
+    brand: 'Esso',
+    name: 'Esso Chiasso',
+    address: 'Via Vela 10, 6830 Chiasso',
+    sp95PriceChf: 1.95,
+    dieselPriceChf: 2.1,
+    lat: 45.838,
+    lng: 9.029,
+    updatedAt: '2026-05-18',
+  },
+];
+
+function render() {
+  return generateFuelStationPages({
+    dataset: buildDataset(STATIONS),
+    today: TODAY,
+    history: [],
+    // Pass rootDir so resolveBrandLogoUrl can find public/images/brands/{slug}.svg
+    rootDir: process.cwd(),
+  });
+}
+
+describe('Per-station page redesign — hero', () => {
+  it('emits an above-the-fold hero card with brand name, price, and CHF/Diesel currency label', () => {
+    const pages = render();
+    const path = '/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/';
+    expect(pages[path]).toBeDefined();
+    const html = pages[path];
+    expect(html).toContain('aria-label="Migrol Chiasso"');
+    expect(html).toMatch(/font-size:clamp\(2\.2rem,6vw,3rem\);font-weight:800[^>]*>1,950</);
+    expect(html).toContain('CHF/litro · Diesel');
+  });
+
+  it('places the rank chip BEFORE long editorial prose (mobile-first ordering)', () => {
+    const pages = render();
+    const html = pages['/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/'];
+    // Hero card aria-label format is "{brand} {city}"
+    const idxHero = html.indexOf('aria-label="Silo Chiasso"');
+    const idxAdvice = html.indexOf('data-station-advice');
+    const idxLocation = html.indexOf('aria-labelledby="stationLocation"');
+    const idxReview = html.indexOf('aria-labelledby="stationReview"');
+    expect(idxHero).toBeGreaterThan(0);
+    expect(idxAdvice).toBeGreaterThan(idxHero);
+    expect(idxLocation).toBeGreaterThan(idxAdvice);
+    expect(idxReview).toBeGreaterThan(idxLocation);
+  });
+
+  it('renders the rank chip with a link back to the zone classifica', () => {
+    const pages = render();
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    // Rank chip: <a href=".../prezzi-diesel/chiasso/oggi/" ...>…1° su 3 a Chiasso…</a>
+    // The href appears MANY times in the page (breadcrumbs, related, back-link),
+    // so we match the rank-text specifically and check it sits inside an <a> with
+    // the classifica href anywhere within the surrounding ~600 chars.
+    expect(html).toContain('1° su 3 a Chiasso');
+    const rankIdx = html.indexOf('1° su 3 a Chiasso');
+    // ~800 chars to clear the inline lucide SVG markup between href and rank label.
+    const window = html.slice(Math.max(0, rankIdx - 1200), rankIdx);
+    expect(window).toMatch(/href="https:\/\/frontaliereticino\.ch\/prezzi-diesel\/chiasso\/oggi\/"/);
+  });
+
+  it('uses lucide SVG icons (no emoji) for trophy/map-pin/navigation/bar-chart in the hero', () => {
+    const pages = render();
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    // Lucide trophy SVG signature path
+    expect(html).toContain('<path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/>');
+    // Lucide navigation/triangle polygon
+    expect(html).toContain('<polygon points="3 11 22 2 13 21 11 13 3 11"/>');
+    // Lucide bar-chart-3 signature
+    expect(html).toContain('<path d="M3 3v18h18"/>');
+    // No raw emoji should remain in the hero area
+    const heroChunk = html.slice(html.indexOf('aria-label="Migrol'), html.indexOf('data-station-advice'));
+    expect(heroChunk).not.toMatch(/🏆|📍|🚗|📊|📌|🧭/);
+  });
+});
+
+describe('Per-station page redesign — brand logo', () => {
+  it('uses /images/brands/{slug}.svg when a real logo exists for the brand', () => {
+    const pages = render();
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    expect(html).toContain('src="/images/brands/migrol.svg"');
+    expect(html).toContain('alt="Migrol"');
+  });
+
+  it('falls back to a monogram chip when no brand SVG is on disk (Silo)', () => {
+    const pages = render();
+    const html = pages['/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/'];
+    // Silo has no logo file — monogram chip with first letter "S"
+    expect(html).not.toContain('src="/images/brands/silo.svg"');
+    expect(html).toMatch(/border-radius:14px;background:var\(--color-accent-subtle\)[^>]*flex-shrink:0">S</);
+  });
+});
+
+describe('Per-station page redesign — advice banner', () => {
+  it('renders a SUCCESS-tone advice when the station beats the zone average', () => {
+    const pages = render();
+    // Migrol diesel 1.95 vs zone avg ((1.95+2.0+2.1)/3) = 2.017 → -0.067 → success
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    expect(html).toContain('data-station-advice');
+    expect(html).toMatch(/data-station-advice[^>]*background:var\(--color-success-subtle\)/);
+    expect(html).toMatch(/Buona scelta/);
+    // No double "CHF CHF"
+    expect(html).not.toMatch(/CHF CHF\/litro/);
+  });
+
+  it('renders a DANGER-tone advice when the station is more expensive than the zone average', () => {
+    const pages = render();
+    // Esso diesel 2.10 vs avg 2.017 → +0.083 → danger
+    const html = pages['/prezzi-diesel/chiasso/stazioni/esso-via-vela/'];
+    expect(html).toMatch(/data-station-advice[^>]*background:var\(--color-danger-subtle\)/);
+    expect(html).toMatch(/Attenzione/);
+  });
+});
+
+describe('Per-station page redesign — location card', () => {
+  it('embeds a lazy OpenStreetMap iframe with bbox + marker derived from the station coords', () => {
+    const pages = render();
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    expect(html).toContain('<iframe');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('openstreetmap.org/export/embed.html');
+    expect(html).toMatch(/marker=45\.836000%2C9\.033000/);
+    expect(html).toMatch(/bbox=9\.02700%2C45\.83000%2C9\.03900%2C45\.84200/);
+  });
+
+  it('renders Google Maps + Waze action links with the canonical URL schemes', () => {
+    const pages = render();
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    expect(html).toContain('https://www.google.com/maps/search/?api=1&amp;query=45.836000,9.033000');
+    expect(html).toContain('https://www.waze.com/ul?ll=45.836000%2C9.033000&amp;navigate=yes');
+  });
+
+  it('omits the location card entirely when the station has no lat/lng', () => {
+    const noGeo: SyntheticStation = {
+      ...STATIONS[0],
+      id: '999',
+      address: 'Via Test 1, 6830 Chiasso',
+      brand: 'TestBrand',
+      name: 'TestBrand Test',
+      lat: undefined,
+      lng: undefined,
+    };
+    const pages = generateFuelStationPages({
+      dataset: buildDataset([...STATIONS, noGeo]),
+      today: TODAY,
+      history: [],
+    });
+    const html = pages['/prezzi-diesel/chiasso/stazioni/testbrand-via-test/'];
+    expect(html).toBeDefined();
+    expect(html).not.toContain('aria-labelledby="stationLocation"');
+    expect(html).not.toContain('openstreetmap.org/export');
+  });
+});
+
+describe('Per-station page redesign — history chart', () => {
+  it('omits the chart card when no history snapshots are provided', () => {
+    const pages = generateFuelStationPages({
+      dataset: buildDataset(STATIONS),
+      today: TODAY,
+      history: [],
+    });
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    expect(html).not.toContain('aria-labelledby="stationHistory"');
+  });
+
+  it('falls back to the zone chart with disclaimer when station-level history is sparse', () => {
+    // 3 snapshots, zone averages only (no `stations` field) → zone fallback.
+    const history = [
+      { date: '2026-05-15', zones: { chiasso: { diesel: 2.05, benzina: 1.88 }, mendrisio: {}, lugano: {}, bellinzona: {}, locarno: {} } } as never,
+      { date: '2026-05-16', zones: { chiasso: { diesel: 2.04, benzina: 1.88 }, mendrisio: {}, lugano: {}, bellinzona: {}, locarno: {} } } as never,
+      { date: '2026-05-17', zones: { chiasso: { diesel: 2.03, benzina: 1.88 }, mendrisio: {}, lugano: {}, bellinzona: {}, locarno: {} } } as never,
+    ];
+    const pages = generateFuelStationPages({
+      dataset: buildDataset(STATIONS),
+      today: TODAY,
+      history,
+    });
+    const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
+    expect(html).toContain('aria-labelledby="stationHistory"');
+    expect(html).toContain('Andamento prezzo nella zona Chiasso');
+    expect(html).toMatch(/non ancora disponibile/);
+  });
+
+  it('renders the per-station chart when ≥3 snapshots carry station-level prices', () => {
+    const slug = 'migrol-via-cantonale';
+    const history = [
+      { date: '2026-05-15', zones: { chiasso: { diesel: 2.05 }, mendrisio: {}, lugano: {}, bellinzona: {}, locarno: {} }, stations: { [slug]: { diesel: 1.92, benzina: 1.83 } } } as never,
+      { date: '2026-05-16', zones: { chiasso: { diesel: 2.04 }, mendrisio: {}, lugano: {}, bellinzona: {}, locarno: {} }, stations: { [slug]: { diesel: 1.94, benzina: 1.84 } } } as never,
+      { date: '2026-05-17', zones: { chiasso: { diesel: 2.03 }, mendrisio: {}, lugano: {}, bellinzona: {}, locarno: {} }, stations: { [slug]: { diesel: 1.95, benzina: 1.85 } } } as never,
+    ];
+    const pages = generateFuelStationPages({
+      dataset: buildDataset(STATIONS),
+      today: TODAY,
+      history,
+    });
+    const html = pages[`/prezzi-diesel/chiasso/stazioni/${slug}/`];
+    expect(html).toContain('Andamento prezzo di Migrol');
+    expect(html).not.toMatch(/non ancora disponibile/);
+  });
+});
+
+describe('Per-station slug parity — TS plugin vs JS snapshot writer', () => {
+  // Two implementations exist (TS in build-plugins, JS in scripts/lib) because
+  // .mjs scripts cannot import .ts files. They MUST agree byte-for-byte or
+  // snapshots and renderer-side lookups will drift and silently fall back to
+  // the zone chart for every page.
+  const FIXTURES: Array<{ brand?: string | null; name?: string | null; address?: string | null }> = [
+    { brand: 'Migrol', name: 'Migrol Chiasso', address: 'Via Cantonale 5, 6830 Chiasso' },
+    { brand: 'Coop Pronto', name: 'Coop Pronto', address: 'Viale Cassarate 17A, 6900 Lugano' },
+    { brand: 'BP', name: 'BP', address: 'Via del Breggia 1, 6830 Chiasso' },
+    { brand: 'UNDEFINED', name: 'Silo Via Emilio Bossi', address: 'Via Emilio Bossi 19, 6830 Chiasso' },
+    { brand: '', name: 'Esso Mendrisio', address: 'Strada Cantonale 3' },
+    { brand: 'Eni', name: '', address: "Via D'Annunzio 4, 6900 Lugano" },
+    { brand: 'Tamoil', name: 'Tamoil 24h', address: 'Via Passeggiata 2' },
+    { brand: null, name: null, address: null },
+  ];
+
+  it.each(FIXTURES)('produces identical slugs for %o', (fx) => {
+    const ts = buildStationSlugTs(fx);
+    const js = buildStationSlugJs(fx);
+    expect(js).toBe(ts);
+  });
+});


### PR DESCRIPTION
Per-station price-history chart (gradual rollout)
- scripts/snapshot-fuel-history.mjs now persists snapshot.stations[slug]
  keyed by buildStationSlug. Each daily snapshot grows from ~1.7 KB to
  ~50 KB (still well under 90-day retention budget).
- Plugin: new buildStationHistorySeries() reads per-station prices from
  snapshots. renderStationHistoryCard prefers per-station when any range
  has ≥3 numeric points; otherwise falls back to zone with disclaimer
  copy "cronologia per stazione non ancora disponibile" (was "questa
  stazione segue il trend").
- New shared scripts/lib/fuel-station-slug.mjs mirrors the TS slug
  helper so the snapshot writer and the renderer compute identical
  slugs. Slug parity is asserted in tests for 8 fixtures so the two
  implementations cannot drift silently.
- Heading + aria-label switch automatically: "Andamento prezzo di
  {brand}" + station-specific aria when per-station data is present;
  the existing zone heading + disclaimer when not.

Replace emoji affordances with lucide SVG icons
- ICON_TROPHY_SVG, ICON_MAP_PIN_SVG, ICON_NAVIGATION_SVG,
  ICON_BAR_CHART_SVG added to shared/seoContentTokens.ts (same stroke
  style as existing ICON_FUEL_SVG / ICON_BUILDING_SVG).
- Hero rank chip, "Apri in Google Maps", "Apri in Waze", "Vedi
  classifica" CTA, and the location card dl markers all use inline
  lucide SVGs instead of 🏆 📍 🚗 📊 📌 🧭. Better cross-platform
  rendering, no emoji-font dependency, easier theming via currentColor.

Regression tests (22 new, all green)
- tests/fuel-station-redesign.test.ts covers: hero structure + mobile
  ordering, brand-logo real-vs-monogram, advice tone (success/danger),
  OSM iframe + GMaps + Waze URLs, location-card omission when no geo,
  history chart 3-way path (no data / zone fallback / per-station),
  slug parity TS-vs-JS (8 fixtures).

Existing fuel test suite: 229/229 still green (was 207, +22 new).
