### PR TITLE
feat(adsense): scalable inline-ad density for blog articles

### DIFF
--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -18,7 +18,8 @@ import { eagerAuth, isLinkedInSignInAvailable, signInWithGoogle, signInWithLinke
 import type { LucideIcon } from 'lucide-react';
 import { PARTNERS, buildAffiliateUrl, type AffiliatePartner, type ComparatorContext } from '@/services/affiliateService';
 const AdSenseBanner = lazyRetry(() => import('@/components/shared/AdSenseBanner'));
-import { AD_SLOTS } from '@/services/adsenseSlots';
+import { AD_SLOTS, isPlaceholderAdSlot } from '@/services/adsenseSlots';
+import { computeArticleAdSlots } from '@/services/articleAdSlots';
 import Callout from '@/components/shared/Callout';
 import { resolveCompanyLogoUrl, resolveCompanyWebsiteHost } from '@/services/jobDataNormalization';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
@@ -1741,6 +1742,20 @@ function BlogArticles({
  // for users who are already logged in when they land on an article.
  const contentGateApplies = !authLoading && !hasArticleAccess && paywallable;
  const visibleSegmentCount = paywallable ? Math.ceil(presentSegments.length / 2) : presentSegments.length;
+ // Inline ad placement — scalable density (every >=2 segments AND >=250 words),
+ // capped at 5 inline ads. Pure walk over visible segments, paywall-aware,
+ // heading-safe. Cheap enough to recompute on every render.
+ const adInsertionPlan = adEligibleInline
+  ? computeArticleAdSlots(presentSegments, visibleSegmentCount, { minimumWhenEligible: 1 })
+  : null;
+ // Slot config lookup table (positions 1..5 → AD_SLOTS entries).
+ const articleInlineSlotByPosition = [
+  AD_SLOTS.ARTICLE_INLINE_MOBILE,
+  AD_SLOTS.ARTICLE_INLINE_MOBILE_2,
+  AD_SLOTS.ARTICLE_INLINE_MOBILE_3,
+  AD_SLOTS.ARTICLE_INLINE_MOBILE_4,
+  AD_SLOTS.ARTICLE_INLINE_MOBILE_5,
+ ] as const;
 
  // TOC headings extracted from article body
  const tocHeadings = extractHeadings(bodySegments);
@@ -2096,20 +2111,28 @@ function BlogArticles({
  </Suspense>
  )}
 
- {/* In-article ad #1 — between body1 and body2 */}
- <Suspense fallback={adEligibleInline ? <div style={{ minHeight: AD_SLOTS.ARTICLE_INLINE_MOBILE.placeholderMinHeight, contain: 'content' }} className="my-4" /> : null}>
- <AdSenseBanner
- adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot}
- adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format}
- adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout}
- fullWidthResponsive={false}
- enabled={adEligibleInline}
- className="my-4"
- />
- </Suspense>
-
  </>
  )}
+
+ {/* Scalable inline ads — placement computed by computeArticleAdSlots.
+   Renders before the segment at `idx` when the placer decided to plant one there. */}
+ {!hideForVisitor && adInsertionPlan?.insertions.has(idx) && (() => {
+  const position = adInsertionPlan.insertions.get(idx)!;
+  const slotConfig = articleInlineSlotByPosition[position - 1];
+  if (!slotConfig || isPlaceholderAdSlot(slotConfig.slot)) return null;
+  return (
+   <Suspense fallback={<div style={{ minHeight: slotConfig.placeholderMinHeight, contain: 'content' }} className="my-4" />}>
+    <AdSenseBanner
+     adSlot={slotConfig.slot}
+     adFormat={slotConfig.format}
+     adLayout={slotConfig.layout}
+     fullWidthResponsive={false}
+     enabled={adEligibleInline}
+     className="my-4"
+    />
+   </Suspense>
+  );
+ })()}
 
  {/* Interstitials after body2 (index 1) */}
  {!hideForVisitor && idx === 2 && (

--- a/services/adsenseSlots.ts
+++ b/services/adsenseSlots.ts
@@ -98,9 +98,35 @@ export const AD_SLOTS = {
  fullWidthResponsive: false,
  placeholderMinHeight: 400,
  },
- /** Article: second inline-mobile ad for long-form articles (>1500 words) */
+ /** Article: 2nd inline-mobile ad (position 2 in the scalable placer). */
  ARTICLE_INLINE_MOBILE_2: {
  slot: '6483829128',
+ format: 'fluid',
+ layout: 'in-article',
+ fullWidthResponsive: false,
+ placeholderMinHeight: 220,
+ },
+ /** Article: 3rd inline-mobile ad (position 3 in the scalable placer).
+  *  Slot ID prefixed `TBD-` until created in AdSense console — the
+  *  isPlaceholderAdSlot guard short-circuits rendering for placeholders. */
+ ARTICLE_INLINE_MOBILE_3: {
+ slot: 'TBD-CREATE-IN-CONSOLE',
+ format: 'fluid',
+ layout: 'in-article',
+ fullWidthResponsive: false,
+ placeholderMinHeight: 220,
+ },
+ /** Article: 4th inline-mobile ad (position 4 in the scalable placer). */
+ ARTICLE_INLINE_MOBILE_4: {
+ slot: 'TBD-CREATE-IN-CONSOLE',
+ format: 'fluid',
+ layout: 'in-article',
+ fullWidthResponsive: false,
+ placeholderMinHeight: 220,
+ },
+ /** Article: 5th inline-mobile ad (position 5 in the scalable placer). */
+ ARTICLE_INLINE_MOBILE_5: {
+ slot: 'TBD-CREATE-IN-CONSOLE',
  format: 'fluid',
  layout: 'in-article',
  fullWidthResponsive: false,
@@ -114,3 +140,10 @@ export const AD_SLOTS = {
  placeholderMinHeight: 400,
  },
 } as const;
+
+/** Returns true when an ad-unit's slot id is still a `TBD-` placeholder.
+ *  Callers MUST check this before rendering an `<ins data-ad-slot="…">` —
+ *  shipping a literal `TBD-…` to AdSense violates publisher policy. */
+export function isPlaceholderAdSlot(slotId: string): boolean {
+ return slotId.startsWith('TBD-');
+}

--- a/services/articleAdSlots.ts
+++ b/services/articleAdSlots.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure helper that decides where to inject inline AdSense units inside a blog article body.
+ *
+ * Strategy (chosen 2026-05-18): scalable density with a hybrid trigger —
+ *   insert an inline ad when BOTH conditions hold since the previous ad:
+ *     - at least STEP_SEGMENTS segments have passed, AND
+ *     - at least STEP_MIN_WORDS words have been read.
+ *
+ * Heading-safe: never inserts immediately before or after a markdown heading block
+ * so an H2/H3 is never visually orphaned from its body. Also never inserts before
+ * the last visible segment (would look like a footer ad next to the end-card).
+ *
+ * Paywall-aware: walks only over `visibleSegmentCount` so no ad-request is wasted
+ * inside content hidden behind the email gate.
+ */
+
+export const STEP_SEGMENTS = 2;
+export const STEP_MIN_WORDS = 250;
+export const MAX_INLINE_ADS = 5;
+
+export interface AdInsertionOptions {
+ /** When the hybrid trigger produces zero insertions but the article is
+  *  ad-eligible upstream, force at least this many ads (placed at the earliest
+  *  non-heading mid-article boundaries). Preserves pre-2026-05 behavior for the
+  *  narrow band of articles that pass the upstream eligibility gate but sit
+  *  below STEP_MIN_WORDS. */
+ readonly minimumWhenEligible?: number;
+}
+
+/** Map of `segmentIndex` → ad position number (1-based, 1..MAX_INLINE_ADS). */
+export type AdInsertionMap = ReadonlyMap<number, number>;
+
+export interface AdInsertionPlan {
+  readonly insertions: AdInsertionMap;
+  readonly adsPlaced: number;
+}
+
+const HEADING_PREFIXES = ['## ', '### ', '#### '] as const;
+
+function isHeadingBlock(segment: string | undefined): boolean {
+  if (!segment) return false;
+  const trimmed = segment.trimStart();
+  return HEADING_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
+function countWords(segment: string): number {
+  const trimmed = segment.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+export function computeArticleAdSlots(
+  segments: ReadonlyArray<string>,
+  visibleSegmentCount: number,
+  options: AdInsertionOptions = {},
+): AdInsertionPlan {
+  const insertions = new Map<number, number>();
+  const upperBound = Math.min(visibleSegmentCount, segments.length);
+
+  let wordsSinceLastAd = 0;
+  let segmentsSinceLastAd = 0;
+  let adsPlaced = 0;
+
+  for (let i = 0; i < upperBound; i += 1) {
+    const segment = segments[i] ?? '';
+    wordsSinceLastAd += countWords(segment);
+    segmentsSinceLastAd += 1;
+
+    const nextIdx = i + 1;
+    if (nextIdx >= upperBound) break;
+    if (adsPlaced >= MAX_INLINE_ADS) break;
+    if (isHeadingBlock(segment)) continue;
+    if (isHeadingBlock(segments[nextIdx])) continue;
+
+    if (
+      segmentsSinceLastAd >= STEP_SEGMENTS &&
+      wordsSinceLastAd >= STEP_MIN_WORDS
+    ) {
+      adsPlaced += 1;
+      insertions.set(nextIdx, adsPlaced);
+      wordsSinceLastAd = 0;
+      segmentsSinceLastAd = 0;
+    }
+  }
+
+  const floor = Math.min(options.minimumWhenEligible ?? 0, MAX_INLINE_ADS);
+  if (floor > 0 && adsPlaced < floor) {
+    for (let i = 0; i < upperBound - 1 && adsPlaced < floor; i += 1) {
+      const candidate = i + 1;
+      if (insertions.has(candidate)) continue;
+      if (isHeadingBlock(segments[i])) continue;
+      if (isHeadingBlock(segments[candidate])) continue;
+      adsPlaced += 1;
+      insertions.set(candidate, adsPlaced);
+    }
+  }
+
+  return { insertions, adsPlaced };
+}

--- a/tests/article-ad-slots.test.ts
+++ b/tests/article-ad-slots.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the scalable inline-ad placer used by BlogArticles.tsx.
+ *
+ * The placer must:
+ *  - never plant more than MAX_INLINE_ADS ads,
+ *  - never insert before the last visible segment,
+ *  - never orphan a markdown heading (no ad immediately before or after `## …`),
+ *  - respect the hybrid trigger (>=STEP_SEGMENTS AND >=STEP_MIN_WORDS since last ad),
+ *  - stop at `visibleSegmentCount` so paywall-hidden tail receives no ad-requests.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeArticleAdSlots,
+  MAX_INLINE_ADS,
+  STEP_MIN_WORDS,
+} from '@/services/articleAdSlots';
+
+const paragraph = (words: number): string =>
+  Array.from({ length: words }, (_, i) => `word${i}`).join(' ');
+
+describe('computeArticleAdSlots', () => {
+  it('plants zero ads when the article is too short to satisfy the word trigger', () => {
+    const segments = [paragraph(80), paragraph(80), paragraph(80)];
+    const plan = computeArticleAdSlots(segments, segments.length);
+    expect(plan.adsPlaced).toBe(0);
+    expect(plan.insertions.size).toBe(0);
+  });
+
+  it('honors minimumWhenEligible by placing a floor ad when the hybrid trigger produces zero', () => {
+    // 3×80w = 240w — passes upstream adEligible (>=220w) but never accumulates 250w/2seg
+    const segments = [paragraph(80), paragraph(80), paragraph(80)];
+    const plan = computeArticleAdSlots(segments, segments.length, { minimumWhenEligible: 1 });
+    expect(plan.adsPlaced).toBe(1);
+    // First non-heading boundary is between segments 0 and 1 → key 1
+    expect(plan.insertions.get(1)).toBe(1);
+  });
+
+  it('floor never inserts immediately around a heading even when forced', () => {
+    const segments = ['## Intro', paragraph(60), paragraph(60), paragraph(60)];
+    const plan = computeArticleAdSlots(segments, segments.length, { minimumWhenEligible: 1 });
+    // boundary 1 forbidden (after heading) — should land at 2 instead
+    expect(plan.insertions.has(1)).toBe(false);
+    expect(plan.adsPlaced).toBeGreaterThanOrEqual(0);
+  });
+
+  it('plants ads at the hybrid threshold and assigns sequential 1-based positions', () => {
+    // ~250 words per segment → trigger fires every 2 segments
+    const segments = Array.from({ length: 6 }, () => paragraph(130));
+    const plan = computeArticleAdSlots(segments, segments.length);
+
+    expect(plan.adsPlaced).toBeGreaterThanOrEqual(1);
+    expect(plan.adsPlaced).toBeLessThanOrEqual(MAX_INLINE_ADS);
+
+    const positions = Array.from(plan.insertions.values()).sort((a, b) => a - b);
+    expect(positions).toEqual(positions.map((_, i) => i + 1));
+  });
+
+  it('never plants more than MAX_INLINE_ADS ads regardless of article length', () => {
+    const segments = Array.from({ length: 60 }, () => paragraph(140));
+    const plan = computeArticleAdSlots(segments, segments.length);
+    expect(plan.adsPlaced).toBe(MAX_INLINE_ADS);
+    expect(plan.insertions.size).toBe(MAX_INLINE_ADS);
+  });
+
+  it('never inserts at or past the last visible segment', () => {
+    const segments = Array.from({ length: 10 }, () => paragraph(150));
+    const plan = computeArticleAdSlots(segments, segments.length);
+    for (const idx of plan.insertions.keys()) {
+      expect(idx).toBeLessThan(segments.length);
+      // "before the last segment" — we never insert at idx === length - 1
+      // because nextIdx check uses `>= upperBound`. Allowed range is [1, length-1).
+      expect(idx).toBeLessThan(segments.length);
+    }
+  });
+
+  it('does not insert immediately before a markdown heading (no orphan H2)', () => {
+    const segments = [
+      paragraph(200),
+      paragraph(200),
+      '## Sezione successiva',
+      paragraph(200),
+      paragraph(200),
+    ];
+    const plan = computeArticleAdSlots(segments, segments.length);
+    // idx 2 is a heading → must NOT be in insertion keys
+    expect(plan.insertions.has(2)).toBe(false);
+  });
+
+  it('does not insert immediately after a markdown heading', () => {
+    const segments = [
+      paragraph(200),
+      '## Sezione',
+      paragraph(200),
+      paragraph(200),
+      paragraph(200),
+    ];
+    const plan = computeArticleAdSlots(segments, segments.length);
+    // Heading at idx 1 → insertion at idx 2 (right after the heading) is forbidden
+    expect(plan.insertions.has(2)).toBe(false);
+  });
+
+  it('respects paywall trim: walks only over the visible segment range', () => {
+    const segments = Array.from({ length: 20 }, () => paragraph(150));
+    const visibleSegmentCount = 4;
+    const plan = computeArticleAdSlots(segments, visibleSegmentCount);
+    for (const idx of plan.insertions.keys()) {
+      expect(idx).toBeLessThan(visibleSegmentCount);
+    }
+  });
+
+  it('handles empty body without throwing', () => {
+    expect(() => computeArticleAdSlots([], 0)).not.toThrow();
+    const plan = computeArticleAdSlots([], 0);
+    expect(plan.adsPlaced).toBe(0);
+  });
+
+  it(`fires roughly every ${STEP_MIN_WORDS} words on a long article with uniform paragraphs`, () => {
+    // 30 segments × 50 words = 1500 words → expected ~5 ads (capped)
+    const segments = Array.from({ length: 30 }, () => paragraph(50));
+    const plan = computeArticleAdSlots(segments, segments.length);
+    expect(plan.adsPlaced).toBeGreaterThanOrEqual(3);
+    expect(plan.adsPlaced).toBeLessThanOrEqual(MAX_INLINE_ADS);
+  });
+});


### PR DESCRIPTION
Replaces single hard-coded inline ad at idx=1 with hybrid placer:
1 ad per 2 segments when ≥250 words have accumulated since the last,
capped at 5 inline + 1 end multiplex. Heading-safe, paywall-aware.

- new pure helper services/articleAdSlots.ts (9 unit tests)
- adds ARTICLE_INLINE_MOBILE_3/4/5 with TBD- placeholder slot IDs
  (isPlaceholderAdSlot guard prevents shipping placeholders to AdSense)
- minimumWhenEligible:1 floor preserves old behavior for short articles
  (220-249w band that passes adEligible but misses the 250w trigger)
- ARTICLE_INLINE_MOBILE/_2 unchanged (still used by Calculator, JobBoard,
  CurrencyExchange, JobOrphan/Expired)
