### PR TITLE
feat(seo): long-form per-canton editorial slugs for all 24 cantons

### DIFF
--- a/build-plugins/cantonOrphanRedirectsPlugin.ts
+++ b/build-plugins/cantonOrphanRedirectsPlugin.ts
@@ -47,6 +47,7 @@ import {
  getJobNursesHubSlug,
  getJobPartTimeLandingSlug,
  getJobTodayLandingSlug,
+ LEGACY_SHORT_FORM_SLUGS_BY_SLOT,
  type JobCareClusterKey,
 } from './jobEditorialLanding';
 import { BASE_URL, buildCanonicalBridgePage } from './constants';
@@ -97,15 +98,24 @@ export function enumerateCantonOrphanRedirects(): OrphanRedirect[] {
  const prefix = LOCALE_PREFIX[locale];
  for (const slot of SLOT_KEYS) {
  const canonicalSlug = slugForSlot(slot, locale, canton);
- // Collect every other canton's canonical slug for this (slot, locale).
- // These are the "foreign" slugs that may appear under THIS canton's
- // section because of GSC discovery, external links, or historical
- // builds. Dedupe — multiple cantons share the short form ('oggi').
+ // Targeted orphan set — only the slug forms that actually leaked into
+ // production from historical code paths, NOT the full Cartesian
+ // product of 24 cantons (that exploded to ~16k files for ~672 real
+ // orphans). Sources covered:
+ //   1. TI/GR/VS canonical slugs: the original slug helpers defaulted
+ //      to `canton = 'TI'`, so internal navigators produced
+ //      /cerca-lavoro-basilea/offerte-di-lavoro-ticino-oggi/ etc.
+ //      GR/VS variants surfaced from the same default-arg bug for
+ //      pages that explicitly passed those cantons.
+ //   2. LEGACY_SHORT_FORM (`infermieri`, `oggi`, `cliniche`, …): the
+ //      pre-2026-05-18 Phase-8d canonical for every non-TI/GR/VS
+ //      canton. These are GSC-indexed and would 404 after the
+ //      long-form revert.
  const alternates = new Set<string>();
- for (const otherCanton of cantons) {
- if (otherCanton === canton) continue;
- alternates.add(slugForSlot(slot, locale, otherCanton));
+ for (const sourceCanton of ['TI', 'GR', 'VS']) {
+ alternates.add(slugForSlot(slot, locale, sourceCanton));
  }
+ alternates.add(LEGACY_SHORT_FORM_SLUGS_BY_SLOT[slot][locale]);
  alternates.delete(canonicalSlug);
  for (const orphanSlug of alternates) {
  const from = `${prefix}/${section}/${orphanSlug}/`.replace(/\/+/g, '/');

--- a/build-plugins/jobEditorialLanding.ts
+++ b/build-plugins/jobEditorialLanding.ts
@@ -95,12 +95,16 @@ export const EDITORIAL_CANTONS: readonly string[] = Object.freeze(
 // (Phase 5 P1-A — TI editorial URLs must stay invariant). Remaining cantons
 // auto-generated from CANTON_SLUG_LOCALE with locale-specific templates.
 
-// Phase 8 sub-PR (d): Non-TI/GR/VS cantons use a SHORT slug
-// (`oggi` / `today` / `heute` / `aujourdhui`) so the URL becomes
-// `/cerca-lavoro-{canton}/oggi/` instead of nesting a canton-named slug
-// under the TI section. TI/GR/VS legacy slugs are preserved byte-identical
-// (test suite locks these). Pair the short slug with the canton-aware
-// section produced by `buildCantonAwareSection(locale, canton)`.
+// Phase 8d revert (2026-05-18): every canton now uses a per-canton
+// long-form slug so the URL is `/cerca-lavoro-{canton}/{slug-with-canton-name}/`.
+// The earlier "short-form for non-TI/GR/VS" design saved a URL segment but
+// (a) made keyword matching weaker for SEO and (b) was inconsistent — TI
+// used `infermieri-in-ticino` while BASILEA used `infermieri`. The
+// long-form template is byte-identical to TI/GR/VS for the three legacy
+// cantons (CLAUDE.md non-negotiable preserves those URLs); the remaining
+// 21 cantons get the template `offerte-di-lavoro-{cantonSlug.locale}-oggi`
+// etc. Old short-form URLs (`infermieri`, `oggi`) remain reachable via
+// LEGACY_SHORT_FORM_SLUGS_BY_SLOT + cantonOrphanRedirectsPlugin.
 const JOB_TODAY_LANDING_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale, string>> = (() => {
  const out: Record<string, Record<JobLandingLocale, string>> = {
   TI: { it: 'offerte-di-lavoro-ticino-oggi', en: 'ticino-jobs-today', de: 'jobs-tessin-heute', fr: 'offres-emploi-tessin-aujourdhui' },
@@ -109,18 +113,17 @@ const JOB_TODAY_LANDING_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale,
  };
  for (const code of Object.keys(CANTON_SLUG_LOCALE)) {
   if (out[code]) continue;
+  const slugs = CANTON_SLUG_LOCALE[code];
   out[code] = {
-   it: 'oggi',
-   en: 'today',
-   de: 'heute',
-   fr: 'aujourdhui',
+   it: `offerte-di-lavoro-${slugs.it}-oggi`,
+   en: `${slugs.en}-jobs-today`,
+   de: `jobs-${slugs.de}-heute`,
+   fr: `offres-emploi-${slugs.fr}-aujourdhui`,
   };
  }
  return out;
 })();
 
-// Phase 8 sub-PR (d): non-TI/GR/VS cantons collapse to a short slug; the
-// canton is encoded in the section segment (`/cerca-lavoro-{canton}/`).
 const JOB_NURSES_HUB_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale, string>> = (() => {
  const out: Record<string, Record<JobLandingLocale, string>> = {
   TI: { it: 'infermieri-in-ticino', en: 'nurses-in-ticino', de: 'pflege-jobs-im-tessin', fr: 'infirmiers-au-tessin' },
@@ -129,18 +132,20 @@ const JOB_NURSES_HUB_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale, st
  };
  for (const code of Object.keys(CANTON_SLUG_LOCALE)) {
   if (out[code]) continue;
+  const slugs = CANTON_SLUG_LOCALE[code];
+  // DE preposition "in" matches the GR legacy (`pflege-jobs-in-graubunden`).
+  // FR preposition "a" is a safe default — TI/GR/VS keep their idiomatic
+  // au/aux/en variants above; new cantons use the simplest preposition.
   out[code] = {
-   it: 'infermieri',
-   en: 'nurses',
-   de: 'pflege-jobs',
-   fr: 'infirmiers',
+   it: `infermieri-in-${slugs.it}`,
+   en: `nurses-in-${slugs.en}`,
+   de: `pflege-jobs-in-${slugs.de}`,
+   fr: `infirmiers-a-${slugs.fr}`,
   };
  }
  return out;
 })();
 
-// Phase 8 sub-PR (d): non-TI/GR/VS cantons collapse to a short slug; the
-// canton is encoded in the section segment (`/cerca-lavoro-{canton}/`).
 const JOB_PART_TIME_LANDING_SLUGS_BY_CANTON: Record<string, Record<JobLandingLocale, string>> = (() => {
  const out: Record<string, Record<JobLandingLocale, string>> = {
   TI: { it: 'lavoro-part-time-ticino', en: 'part-time-jobs-ticino', de: 'teilzeit-jobs-tessin', fr: 'emploi-temps-partiel-tessin' },
@@ -149,11 +154,12 @@ const JOB_PART_TIME_LANDING_SLUGS_BY_CANTON: Record<string, Record<JobLandingLoc
  };
  for (const code of Object.keys(CANTON_SLUG_LOCALE)) {
   if (out[code]) continue;
+  const slugs = CANTON_SLUG_LOCALE[code];
   out[code] = {
-   it: 'lavoro-part-time',
-   en: 'part-time-jobs',
-   de: 'teilzeit-jobs',
-   fr: 'emploi-temps-partiel',
+   it: `lavoro-part-time-${slugs.it}`,
+   en: `part-time-jobs-${slugs.en}`,
+   de: `teilzeit-jobs-${slugs.de}`,
+   fr: `emploi-temps-partiel-${slugs.fr}`,
   };
  }
  return out;
@@ -893,9 +899,15 @@ const NURSES_HUB_COPY = makeNursesHubCopy('TI');
 // embedded in slug) for URL invariance — those URLs are locked by tests and
 // by the production index. For the other 21 cantons, the slug collapses to
 // the short form (e.g. `cliniche`) because the canton is already encoded in
-// the section segment via `buildCantonAwareSection(locale, canton)`. The
-// trailing `-jobs` suffix in EN/DE is preserved for TI/GR/VS only.
-const _LEGACY_CARE_CLUSTER_CANTONS = new Set(['TI', 'GR', 'VS']);
+// Phase 8d revert (2026-05-18): every canton now suffixes its display
+// slug onto the care-cluster base (e.g. `cliniche-basilea`,
+// `nurses-in-basel-jobs`) for keyword-rich URLs across the cathedral.
+// TI/GR/VS continue to use the legacy slugs (canton + `-jobs` suffix in
+// EN/DE) which are byte-identical because the template below resolves to
+// the same string for those three. The pre-revert short form (`cliniche`,
+// `clinics`, `kliniken`, `cliniques`) is kept as a legacy alias in
+// LEGACY_SHORT_FORM_SLUGS_BY_SLOT so previously-emitted URLs continue to
+// resolve via the canton-orphan-redirects plugin.
 export function careClusterSlug(key: JobCareClusterKey, cantonCode: string, locale: JobLandingLocale): string {
  const base: Record<JobCareClusterKey, Record<JobLandingLocale, string>> = {
  clinics: { it: 'cliniche', en: 'clinics', de: 'kliniken', fr: 'cliniques' },
@@ -903,11 +915,8 @@ export function careClusterSlug(key: JobCareClusterKey, cantonCode: string, loca
  oss: { it: 'oss', en: 'healthcare-assistants', de: 'pflegeassistenz', fr: 'oss' },
  educators: { it: 'educatori', en: 'educators', de: 'paedagogen', fr: 'educateurs' },
  };
- if (_LEGACY_CARE_CLUSTER_CANTONS.has(cantonCode)) {
-   const cantonSlug = CANTON_SLUG_LOCALE[cantonCode]?.[locale] || CANTON_SLUG_LOCALE['TI'][locale];
-   return `${base[key][locale]}-${cantonSlug}${locale === 'en' || locale === 'de' ? '-jobs' : ''}`;
- }
- return base[key][locale];
+ const cantonSlug = CANTON_SLUG_LOCALE[cantonCode]?.[locale] || CANTON_SLUG_LOCALE['TI'][locale];
+ return `${base[key][locale]}-${cantonSlug}${locale === 'en' || locale === 'de' ? '-jobs' : ''}`;
 }
 
 function careClusterLabel(key: JobCareClusterKey, cantonCode: string, locale: JobLandingLocale): string {
@@ -1423,10 +1432,23 @@ const CARE_CLUSTER_SHORT_SLUG_TO_KEY: Record<string, JobCareClusterKey> = {
 
 function findCareClusterKeyBySlug(slug: string): JobCareClusterKey | null {
  const clean = normalizeSpace(slug);
+ // CARE_CLUSTER_DEFS is built from TI slugs only; check first for the
+ // TI/GR/VS legacy long-form (kept byte-identical).
  const fromLegacy = (Object.keys(CARE_CLUSTER_DEFS) as JobCareClusterKey[]).find((key) =>
  Object.values(CARE_CLUSTER_DEFS[key].slug).includes(clean),
  );
  if (fromLegacy) return fromLegacy;
+ // 2026-05-18: scan all 24 cantons × 4 locales for long-form per-canton
+ // slugs (e.g. `cliniche-basilea`, `nurses-in-basel-jobs`). Without this
+ // the router would mis-route them to the job-detail view.
+ for (const key of Object.keys(CARE_CLUSTER_DEFS) as JobCareClusterKey[]) {
+ for (const canton of Object.keys(CANTON_SLUG_LOCALE)) {
+ for (const locale of ['it', 'en', 'de', 'fr'] as JobLandingLocale[]) {
+ if (careClusterSlug(key, canton, locale) === clean) return key;
+ }
+ }
+ }
+ // Pre-2026-05-18 short-form aliases (`cliniche`, `clinics`, …).
  return CARE_CLUSTER_SHORT_SLUG_TO_KEY[clean] || null;
 }
 
@@ -1590,11 +1612,32 @@ function resolveRecencyDescriptor(slug: string): { kind: 'recency'; variant: 'la
  return null;
 }
 
+/**
+ * Legacy short-form editorial slugs from the pre-2026-05-18 Phase-8d era,
+ * when non-TI/GR/VS cantons used canton-less slugs (`infermieri`, `oggi`,
+ * `cliniche`, …). These URLs were indexed by Google and may still appear
+ * as inbound traffic / GSC orphan reports. The descriptor matcher returns
+ * the same `kind` for them so the SPA router redirects to the canton's
+ * new long-form canonical, and the canton-orphan-redirects plugin emits
+ * a static HTML at the legacy path for the crawler.
+ */
+export const LEGACY_SHORT_FORM_SLUGS_BY_SLOT = {
+ today: { it: 'oggi', en: 'today', de: 'heute', fr: 'aujourdhui' },
+ nurses: { it: 'infermieri', en: 'nurses', de: 'pflege-jobs', fr: 'infirmiers' },
+ partTime: { it: 'lavoro-part-time', en: 'part-time-jobs', de: 'teilzeit-jobs', fr: 'emploi-temps-partiel' },
+ clinics: { it: 'cliniche', en: 'clinics', de: 'kliniken', fr: 'cliniques' },
+ careHomes: { it: 'case-anziani', en: 'care-homes', de: 'altersheime', fr: 'maisons-retraite' },
+ oss: { it: 'oss', en: 'healthcare-assistants', de: 'pflegeassistenz', fr: 'oss' },
+ educators: { it: 'educatori', en: 'educators', de: 'paedagogen', fr: 'educateurs' },
+} as const;
+
 export function isJobTodayLandingSlug(value: string): boolean {
  const slug = normalizeSpace(value);
  for (const cantonSlugs of Object.values(JOB_TODAY_LANDING_SLUGS_BY_CANTON)) {
  if (Object.values(cantonSlugs).includes(slug as JobLandingLocale)) return true;
  }
+ // Legacy short-form (pre-2026-05-18 Phase-8d-revert).
+ if (Object.values(LEGACY_SHORT_FORM_SLUGS_BY_SLOT.today).includes(slug as never)) return true;
  return false;
 }
 
@@ -1609,12 +1652,16 @@ export function resolveEditorialJobLandingDescriptor(value: string): EditorialLa
  if (Object.values(JOB_OFFICIAL_GAZETTE_LANDING_SLUGS).includes(slug as (typeof JOB_OFFICIAL_GAZETTE_LANDING_SLUGS)[JobLandingLocale])) {
  return { kind: 'official-gazette' };
  }
- // Phase 8 sub-PR (d): scan ALL canton variants for the nurses-hub and
- // part-time slugs (TI long-form + 21 short-form non-TI cantons).
+ // Scan ALL canton variants for the nurses-hub and part-time slugs
+ // (long-form per canton post-2026-05-18). The matcher also recognises
+ // legacy short-form aliases (`infermieri`, `lavoro-part-time`, …) so
+ // historical URLs continue to route through the SPA redirect → canton
+ // canonical → static page.
  const nursesSlugSet = new Set<string>();
  for (const cantonSlugs of Object.values(JOB_NURSES_HUB_SLUGS_BY_CANTON)) {
  for (const localeSlug of Object.values(cantonSlugs)) nursesSlugSet.add(localeSlug);
  }
+ for (const legacySlug of Object.values(LEGACY_SHORT_FORM_SLUGS_BY_SLOT.nurses)) nursesSlugSet.add(legacySlug);
  if (nursesSlugSet.has(slug) || slug === 'lavoro-infermieri') {
  return { kind: 'nurses-hub' };
  }
@@ -1622,6 +1669,7 @@ export function resolveEditorialJobLandingDescriptor(value: string): EditorialLa
  for (const cantonSlugs of Object.values(JOB_PART_TIME_LANDING_SLUGS_BY_CANTON)) {
  for (const localeSlug of Object.values(cantonSlugs)) partTimeSlugSet.add(localeSlug);
  }
+ for (const legacySlug of Object.values(LEGACY_SHORT_FORM_SLUGS_BY_SLOT.partTime)) partTimeSlugSet.add(legacySlug);
  if (partTimeSlugSet.has(slug)) {
  return { kind: 'part-time' };
  }

--- a/tests/canton-orphan-redirects.test.ts
+++ b/tests/canton-orphan-redirects.test.ts
@@ -6,10 +6,12 @@ describe('cantonOrphanRedirectsPlugin — enumerateCantonOrphanRedirects', () =>
  const redirects = enumerateCantonOrphanRedirects();
 
  it('emits a redirect for the originally reported URL', () => {
- // Real GSC orphan that surfaced this whole chain of bugs.
+ // Real GSC orphan that surfaced this whole chain of bugs. Post-revert
+ // the canonical for BASILEA is `offerte-di-lavoro-basilea-oggi`, so the
+ // foreign TI-form slug nested under BASILEA redirects to that.
  const hit = redirects.find((r) => r.from === '/cerca-lavoro-basilea/offerte-di-lavoro-ticino-oggi/');
  expect(hit).toBeDefined();
- expect(hit?.to).toBe('/cerca-lavoro-basilea/oggi/');
+ expect(hit?.to).toBe('/cerca-lavoro-basilea/offerte-di-lavoro-basilea-oggi/');
  expect(hit?.locale).toBe('it');
  expect(hit?.canton).toBe('BASILEA');
  expect(hit?.slot).toBe('today');
@@ -18,20 +20,35 @@ describe('cantonOrphanRedirectsPlugin — enumerateCantonOrphanRedirects', () =>
  it('emits the GR-form today slug under non-GR cantons', () => {
  const hit = redirects.find((r) => r.from === '/cerca-lavoro-zurigo/offerte-di-lavoro-grigioni-oggi/');
  expect(hit).toBeDefined();
- expect(hit?.to).toBe('/cerca-lavoro-zurigo/oggi/');
+ expect(hit?.to).toBe('/cerca-lavoro-zurigo/offerte-di-lavoro-zurigo-oggi/');
  });
 
- it('emits the short-form slug under TI section (TI long-form is canonical)', () => {
+ it('emits the legacy short-form slug under TI section as orphan → TI canonical', () => {
  const hit = redirects.find((r) => r.from === '/cerca-lavoro-ticino/oggi/');
  expect(hit).toBeDefined();
  expect(hit?.to).toBe('/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/');
  expect(hit?.slot).toBe('today');
  });
 
+ it('emits the legacy short-form slug under non-TI section as orphan → new long-form canonical', () => {
+ // Pre-2026-05-18 the canonical for BASILEA was `oggi`. Post-revert it
+ // becomes `offerte-di-lavoro-basilea-oggi`. The old URL must redirect.
+ const hit = redirects.find((r) => r.from === '/cerca-lavoro-basilea/oggi/');
+ expect(hit).toBeDefined();
+ expect(hit?.to).toBe('/cerca-lavoro-basilea/offerte-di-lavoro-basilea-oggi/');
+ });
+
+ it('emits the legacy short-form nurses slug as orphan → new long-form canonical', () => {
+ const hit = redirects.find((r) => r.from === '/cerca-lavoro-basilea/infermieri/');
+ expect(hit).toBeDefined();
+ expect(hit?.to).toBe('/cerca-lavoro-basilea/infermieri-in-basilea/');
+ expect(hit?.slot).toBe('nurses');
+ });
+
  it('emits care-cluster TI-form slugs under non-TI sections', () => {
  const clinicsHit = redirects.find((r) => r.from === '/cerca-lavoro-basilea/cliniche-ticino/');
  expect(clinicsHit).toBeDefined();
- expect(clinicsHit?.to).toBe('/cerca-lavoro-basilea/cliniche/');
+ expect(clinicsHit?.to).toBe('/cerca-lavoro-basilea/cliniche-basilea/');
  expect(clinicsHit?.slot).toBe('clinics');
 
  const ossHit = redirects.find((r) => r.from === '/cerca-lavoro-vallese/oss-ticino/');
@@ -42,15 +59,15 @@ describe('cantonOrphanRedirectsPlugin — enumerateCantonOrphanRedirects', () =>
  it('emits English / German / French locale variants', () => {
  const en = redirects.find((r) => r.from === '/en/find-jobs-basel/ticino-jobs-today/');
  expect(en).toBeDefined();
- expect(en?.to).toBe('/en/find-jobs-basel/today/');
+ expect(en?.to).toBe('/en/find-jobs-basel/basel-jobs-today/');
 
  const de = redirects.find((r) => r.from === '/de/jobs-in-basel/jobs-tessin-heute/');
  expect(de).toBeDefined();
- expect(de?.to).toBe('/de/jobs-in-basel/heute/');
+ expect(de?.to).toBe('/de/jobs-in-basel/jobs-basel-heute/');
 
  const fr = redirects.find((r) => r.from === '/fr/trouver-emploi-bale/offres-emploi-tessin-aujourdhui/');
  expect(fr).toBeDefined();
- expect(fr?.to).toBe('/fr/trouver-emploi-bale/aujourdhui/');
+ expect(fr?.to).toBe('/fr/trouver-emploi-bale/offres-emploi-bale-aujourdhui/');
  });
 
  it('never emits redirect to itself', () => {

--- a/tests/seo/cathedral-editorial-slug-tables.test.ts
+++ b/tests/seo/cathedral-editorial-slug-tables.test.ts
@@ -44,17 +44,20 @@ describe('editorial slug tables — all cantons covered', () => {
   expect(getJobTodayLandingSlug('fr', 'VS')).toBe('offres-emploi-valais-aujourdhui');
  });
 
- // Phase 8 sub-PR (d) — non-TI/GR/VS cantons collapse to a short slug.
- // The canton sits in the section segment, e.g. `/cerca-lavoro-zurigo/oggi/`.
- it('ZH today-landing slug uses the short Phase-8d form', () => {
-  expect(getJobTodayLandingSlug('it', 'ZH')).toBe('oggi');
-  expect(getJobTodayLandingSlug('en', 'ZH')).toBe('today');
-  expect(getJobTodayLandingSlug('de', 'ZH')).toBe('heute');
-  expect(getJobTodayLandingSlug('fr', 'ZH')).toBe('aujourdhui');
+ // 2026-05-18 Phase-8d revert — every canton uses a per-canton long-form
+ // slug so SEO keyword matching ("infermieri basilea", "offerte lavoro
+ // zurigo") is exact. URL becomes `/cerca-lavoro-zurigo/offerte-di-lavoro-
+ // zurigo-oggi/`. The old short form (`oggi`) remains reachable via the
+ // canton-orphan-redirects plugin emitting a 200 redirect HTML.
+ it('ZH today-landing slug uses the long-form per-canton pattern', () => {
+  expect(getJobTodayLandingSlug('it', 'ZH')).toBe('offerte-di-lavoro-zurigo-oggi');
+  expect(getJobTodayLandingSlug('en', 'ZH')).toBe('zurich-jobs-today');
+  expect(getJobTodayLandingSlug('de', 'ZH')).toBe('jobs-zurich-heute');
+  expect(getJobTodayLandingSlug('fr', 'ZH')).toBe('offres-emploi-zurich-aujourdhui');
  });
 
- it('AG today-landing slug uses the short Phase-8d form (no canton in slug)', () => {
-  expect(getJobTodayLandingSlug('it', 'AG')).toBe('oggi');
-  expect(getJobTodayLandingSlug('de', 'AG')).toBe('heute');
+ it('AG today-landing slug uses the long-form per-canton pattern', () => {
+  expect(getJobTodayLandingSlug('it', 'AG')).toBe('offerte-di-lavoro-argovia-oggi');
+  expect(getJobTodayLandingSlug('de', 'AG')).toBe('jobs-aargau-heute');
  });
 });


### PR DESCRIPTION
Reverts the Phase-8d short-form design that gave non-TI/GR/VS cantons
canton-less slugs (`infermieri`, `oggi`, `cliniche`). Every canton now
emits a fully qualified slug carrying the canton's display name in every
locale:

  BASILEA → infermieri-in-basilea / cliniche-basilea /
           offerte-di-lavoro-basilea-oggi / lavoro-part-time-basilea
  ZH      → nurses-in-zurich / clinics-zurich-jobs /
           zurich-jobs-today / part-time-jobs-zurich
  (… 19 other cantons)

Why:
 1. Keyword matching. "infermieri basilea" now matches the URL slug
    exactly, not just the section segment. SEO win across 21 cantons.
 2. Consistency. TI used `infermieri-in-ticino` while BASILEA used
    `infermieri` — a confusing split that obscured the URL grammar for
    crawlers and humans both.
 3. Surfaces the user-visible canton name in every URL slug, which
    flows through breadcrumbs, social-share previews, etc.

TI/GR/VS slugs remain byte-identical (CLAUDE.md NON-NEG #5 — never
break legacy indexed URLs). Pre-revert short forms (`infermieri`, `oggi`,
…) are kept as recognised aliases in LEGACY_SHORT_FORM_SLUGS_BY_SLOT so:
 - The SPA router still resolves them via resolveEditorialJobLandingDescriptor
   and redirects to the canton's new long-form canonical (PR #200 logic).
 - The cantonOrphanRedirectsPlugin (PR #207) emits a static 200-canonical-
   bridge HTML at every `/cerca-lavoro-{canton}/{legacy-short-form}/` so
   Google consolidates the legacy URL onto the new canonical without a
   404 in the index.

The orphan plugin's enumeration is narrowed to the three real orphan
sources (TI/GR/VS canonical leak from default args + legacy short-form)
to keep dist size sane: ~2.6k files instead of the ~16k Cartesian product.

Tests:
 - cathedral-editorial-slug-tables: updated to assert the new long-form
   for ZH/AG (TI/GR/VS invariance assertions unchanged).
 - canton-orphan-redirects: 9 cases incl. originally reported BASILEA URL,
   legacy short-form orphans, cross-canton historical leaks, 4 locales.
 - findCareClusterKeyBySlug extended to recognise per-canton long-form
   slugs (`cliniche-basilea` etc.) so the router descriptor matcher
   doesn't fall through to job-detail for valid editorial URLs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
