### PR TITLE
feat(calcola-stipendio): salaryHubPlugin uses mobile-first shell + 4 new orphan hubs

### DIFF
--- a/build-plugins/salaryHubContent.ts
+++ b/build-plugins/salaryHubContent.ts
@@ -15,6 +15,11 @@ import { AD_CLIENT, AD_SLOTS } from '../services/adsenseSlots';
 import { BASE_URL } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { renderHreflangTags } from './shared/hreflang';
+import {
+  renderSalaryLandingShell,
+  type SalaryLandingData,
+  type SalaryLocale,
+} from './shared/salaryLandingShell';
 
 type Locale = 'it' | 'en' | 'de' | 'fr';
 
@@ -473,6 +478,106 @@ function resultsTableHtml(result: SimulationResult, l: Labels): string {
     </div>`;
 }
 
+// Per-locale strings the new mobile-first SEO-landing shell needs that aren't
+// already in `Labels`. Kept tight on purpose — only the bits that the shell
+// renders (eyebrow, 4 tile labels, advice template, secondary CTA copy).
+interface ShellPack {
+  readonly eyebrow: (scenario: SalaryHubScenario) => string;
+  readonly tileNetCh: string;
+  readonly tileNetIt: string;
+  readonly tileSavings: string;
+  readonly tileExchange: string;
+  readonly advice: (result: SimulationResult) => string;
+  readonly ctaSecondary: string;
+}
+
+const SHELL_PACK: Record<Locale, ShellPack> = {
+  it: {
+    eyebrow: (s) => `Simulazione netto · ${s.frontierType === 'NEW' ? 'Nuovo' : 'Vecchio'} frontaliere · ${s.distanceZone === 'WITHIN_20KM' ? 'Entro 20 km' : 'Oltre 20 km'}`,
+    tileNetCh: 'Netto Permesso B',
+    tileNetIt: 'Netto Permesso G',
+    tileSavings: 'Differenza',
+    tileExchange: 'Cambio CHF/EUR',
+    advice: (r) => r.savingsCHF > 0
+      ? `Il permesso B (residente CH) rende ~CHF ${fmtCHF(r.savingsCHF)} netti in più all'anno rispetto al permesso G (frontaliere). Valuta cambio residenza se l'affitto Lugano + LAMal non erodono la differenza.`
+      : `Il permesso G (frontaliere) resta più conveniente di ~CHF ${fmtCHF(Math.abs(r.savingsCHF))} netti/anno rispetto al permesso B. Mantieni la residenza italiana finché la soglia non si inverte.`,
+    ctaSecondary: 'Confronta scenari simili',
+  },
+  en: {
+    eyebrow: (s) => `Net simulation · ${s.frontierType === 'NEW' ? 'New' : 'Existing'} cross-border worker · ${s.distanceZone === 'WITHIN_20KM' ? 'Within 20 km' : 'Over 20 km'}`,
+    tileNetCh: 'Net Permit B',
+    tileNetIt: 'Net Permit G',
+    tileSavings: 'Difference',
+    tileExchange: 'CHF/EUR rate',
+    advice: (r) => r.savingsCHF > 0
+      ? `Permit B (Swiss resident) takes home ~CHF ${fmtCHF(r.savingsCHF)} more per year than Permit G (cross-border). Consider residence change if Lugano rent + LAMal do not erode the gap.`
+      : `Permit G (cross-border) stays more convenient by ~CHF ${fmtCHF(Math.abs(r.savingsCHF))} net/year vs Permit B. Keep Italian residence until the threshold inverts.`,
+    ctaSecondary: 'Compare similar scenarios',
+  },
+  de: {
+    eyebrow: (s) => `Netto-Simulation · ${s.frontierType === 'NEW' ? 'Neuer' : 'Alter'} Grenzgänger · ${s.distanceZone === 'WITHIN_20KM' ? 'Bis 20 km' : 'Über 20 km'}`,
+    tileNetCh: 'Netto B-Bewilligung',
+    tileNetIt: 'Netto G-Bewilligung',
+    tileSavings: 'Differenz',
+    tileExchange: 'CHF/EUR-Kurs',
+    advice: (r) => r.savingsCHF > 0
+      ? `B-Bewilligung (CH-Resident) erhält ~CHF ${fmtCHF(r.savingsCHF)} netto/Jahr mehr als G-Bewilligung. Wohnsitzwechsel erwägen, falls Lugano-Miete + LAMal die Differenz nicht aufzehren.`
+      : `G-Bewilligung (Grenzgänger) bleibt um ~CHF ${fmtCHF(Math.abs(r.savingsCHF))} netto/Jahr günstiger als B-Bewilligung. Italienischen Wohnsitz behalten, bis sich die Schwelle umkehrt.`,
+    ctaSecondary: 'Ähnliche Szenarien vergleichen',
+  },
+  fr: {
+    eyebrow: (s) => `Simulation net · ${s.frontierType === 'NEW' ? 'Nouveau' : 'Ancien'} frontalier · ${s.distanceZone === 'WITHIN_20KM' ? 'Moins 20 km' : 'Plus 20 km'}`,
+    tileNetCh: 'Net Permis B',
+    tileNetIt: 'Net Permis G',
+    tileSavings: 'Différence',
+    tileExchange: 'Taux CHF/EUR',
+    advice: (r) => r.savingsCHF > 0
+      ? `Le permis B (résident CH) touche ~CHF ${fmtCHF(r.savingsCHF)} nets/an de plus que le permis G (frontalier). Envisagez un changement de résidence si le loyer Lugano + LAMal n'érodent pas l'écart.`
+      : `Le permis G (frontalier) reste plus avantageux de ~CHF ${fmtCHF(Math.abs(r.savingsCHF))} nets/an vs le permis B. Gardez la résidence italienne jusqu'à inversion du seuil.`,
+    ctaSecondary: 'Comparer des scénarios similaires',
+  },
+};
+
+/**
+ * Map `SalaryLocale` (used by shared/salaryLandingShell) to our local
+ * `Locale` alias — they share members, just narrowed differently.
+ */
+function asShellLocale(l: Locale): SalaryLocale {
+  return l;
+}
+
+function buildHubSalaryLandingData(
+  scenario: SalaryHubScenario,
+  result: SimulationResult,
+  locale: Locale,
+  l: Labels,
+): SalaryLandingData {
+  const pack = SHELL_PACK[locale];
+  const ch = result.chResident.netIncomeAnnual;
+  const it = result.itResident.netIncomeAnnual;
+  return {
+    eyebrow: pack.eyebrow(scenario),
+    tagline: l.subtitle(scenario, result),
+    tiles: [
+      { label: pack.tileNetCh, value: `CHF ${fmtCHF(ch)}`, tone: 'accent' },
+      { label: pack.tileNetIt, value: `CHF ${fmtCHF(it)}`, tone: 'success' },
+      {
+        label: pack.tileSavings,
+        value: `${result.savingsCHF >= 0 ? '+' : '-'}CHF ${fmtCHF(Math.abs(result.savingsCHF))}/a`,
+        tone: result.savingsCHF >= 0 ? 'success' : 'warning',
+      },
+      { label: pack.tileExchange, value: result.exchangeRate.toFixed(4), tone: 'neutral' },
+    ],
+    advice: pack.advice(result),
+    ctaPrimary: {
+      label: l.personalizeBtn,
+      href: `${LOCALE_CALC_PREFIX[locale]}/?reddito=${scenario.salary}&tipo=${scenario.frontierType}&stato=${scenario.maritalStatus}&figli=${scenario.children}&zona=${scenario.distanceZone}`,
+    },
+    ctaSecondary: { label: pack.ctaSecondary, href: `${LOCALE_CALC_PREFIX[locale]}/` },
+    faqs: l.faqItems(scenario, result),
+  };
+}
+
 export function generatePageHtml(
   scenario: SalaryHubScenario,
   result: SimulationResult,
@@ -518,62 +623,36 @@ export function generatePageHtml(
     return `<a href="${path}" class="related-card"><strong>CHF ${fmtCHF(s.salary)}</strong><br>${scenarioDesc(s, l)}</a>`;
   }).join('\n');
 
-  const ctaUrl = `${LOCALE_CALC_PREFIX[locale]}/?reddito=${scenario.salary}&tipo=${scenario.frontierType}&stato=${scenario.maritalStatus}&figli=${scenario.children}&zona=${scenario.distanceZone}`;
-
   const title = l.metaTitle(scenario);
   const description = l.metaDesc(scenario, result);
 
-  const bodyHtml = `<article class="salary-hub-page">
-    <div class="hub-grid">
-      <div class="content">
-        <nav class="breadcrumb">
-          <a href="/">${l.home}</a> &rsaquo;
-          <a href="${LOCALE_CALC_PREFIX[locale]}/">${l.breadcrumbCalc}</a> &rsaquo;
-          ${l.h1(scenario)}
-        </nav>
+  // 1. The simulation results table (the meat) stays in the data-area slot
+  //    of the new SEO-landing shell — instead of below the H1 as before.
+  const dataAreaHtmlOverride = `<section class="salary-hub-page">${resultsTableHtml(result, l)}<div class="ad-unit">${adSlotHtml('ARTICLE_INLINE_MOBILE')}</div></section>`;
 
-        <h1>${l.h1(scenario)}</h1>
-        <p class="subtitle">${l.subtitle(scenario, result)}</p>
+  // 2. The 5 long-form explanations + related grid + tail AdSense slot
+  //    become the "long prose" block rendered at the bottom of the shell
+  //    (CLAUDE.md rule 16 — filler below the data area, never above the fold).
+  const editorialHtml = `<section class="salary-hub-page">
+    <h2>${l.howToCalcTitle}</h2><p>${l.howToCalc(scenario.salary, scenario, result)}</p>
+    <h2>${l.regimeTitle}</h2><p>${l.regimeExplain(scenario, result)}</p>
+    <h2>${l.familyTitle}</h2><p>${l.familyExplain(scenario, result)}</p>
+    <h2>${l.distanceTitle}</h2><p>${l.distanceExplain(scenario, result)}</p>
+    <h2>${l.budgetTitle}</h2><p>${l.budgetExplain(scenario, result)}</p>
+    <h2>${l.tipsTitle}</h2><p>${l.tipsExplain(scenario, result)}</p>
+    <h2>${l.relatedTitle}</h2><div class="related-grid">${relatedHtml}</div>
+    <div class="ad-unit">${adSlotHtml('ARTICLE_END_MULTIPLEX')}</div>
+  </section>`;
 
-        ${resultsTableHtml(result, l)}
-
-        <div class="ad-unit">${adSlotHtml('ARTICLE_INLINE_MOBILE')}</div>
-
-        <h2>${l.howToCalcTitle}</h2>
-        <p>${l.howToCalc(scenario.salary, scenario, result)}</p>
-
-        <h2>${l.regimeTitle}</h2>
-        <p>${l.regimeExplain(scenario, result)}</p>
-
-        <h2>${l.familyTitle}</h2>
-        <p>${l.familyExplain(scenario, result)}</p>
-
-        <h2>${l.distanceTitle}</h2>
-        <p>${l.distanceExplain(scenario, result)}</p>
-
-        <h2>${l.budgetTitle}</h2>
-        <p>${l.budgetExplain(scenario, result)}</p>
-
-        <h2>${l.tipsTitle}</h2>
-        <p>${l.tipsExplain(scenario, result)}</p>
-
-        <div class="cta-box">
-          <p>${l.personalizeBtn}</p>
-          <a href="${ctaUrl}">${l.personalizeBtn} &rarr;</a>
-        </div>
-
-        <h2>${l.relatedTitle}</h2>
-        <div class="related-grid">${relatedHtml}</div>
-
-        <div class="faq-section">
-          <h2>${l.faqTitle}</h2>
-          ${faqs.map(f => `<div class="faq-item"><div class="faq-q">${f.q}</div><div class="faq-a">${f.a}</div></div>`).join('\n')}
-        </div>
-
-        <div class="ad-unit">${adSlotHtml('ARTICLE_END_MULTIPLEX')}</div>
-      </div>
-    </div>
-  </article>`;
+  // 3. Render the shell. H1 + tiles + advice + CTA + data table + FAQ (from
+  //    landingData) + editorial prose (above). Breadcrumb + navHtml left to
+  //    the shell defaults (`buildSeoPageHtml` wraps the body in the SPA shell).
+  const landingData = buildHubSalaryLandingData(scenario, result, locale, l);
+  const bodyHtml = renderSalaryLandingShell(landingData, asShellLocale(locale), {
+    h1Text: l.h1(scenario),
+    dataAreaHtmlOverride,
+    editorialHtml,
+  });
 
   return buildSeoPageHtml({
     locale,

--- a/build-plugins/shared/salaryLandingShell.ts
+++ b/build-plugins/shared/salaryLandingShell.ts
@@ -146,10 +146,19 @@ type HubKey =
   | 'simula-busta-paga'
   | 'cosa-cambia-se'
   | 'confronta-stipendi'
-  | 'quiz-stipendio'
-  | 'confronta-retribuzione-ral';
+  | 'quanto-guadagneresti-in-svizzera'
+  | 'confronta-retribuzione-ral'
+  | 'simula-cambio-residenza'
+  | 'stima-bonus-frontaliere'
+  | 'verifica-congedo-parentale';
 
-const HUB_SCENARIOS: Record<HubKey, Record<SalaryLocale, SalaryLandingData>> = {
+// Note: EN/DE/FR keys are kept for legacy `nuovi-frontalieri-oltre-20-km`,
+// `simula-busta-paga`, `cosa-cambia-se`, `quiz-stipendio` (now
+// `quanto-guadagneresti-in-svizzera`), `confronta-stipendi` and
+// `confronta-retribuzione-ral` — currently unreachable via HUB_PATH_TO_KEY
+// but preserved for future expansion. New hubs (`simula-cambio-residenza`,
+// `stima-bonus-frontaliere`, `verifica-congedo-parentale`) are IT-only.
+const HUB_SCENARIOS: Record<HubKey, Partial<Record<SalaryLocale, SalaryLandingData>>> = {
   'nuovi-frontalieri-oltre-20-km': {
     it: {
       eyebrow: 'Nuovo Accordo 2024 · Oltre 20 km',
@@ -634,7 +643,7 @@ const HUB_SCENARIOS: Record<HubKey, Record<SalaryLocale, SalaryLandingData>> = {
     },
   },
 
-  'quiz-stipendio': {
+  'quanto-guadagneresti-in-svizzera': {
     it: {
       eyebrow: 'Quiz fiscale settimanale',
       tagline: '5 domande, 8 minuti: testa quanto sai davvero su tasse, contributi e franchigia.',
@@ -871,6 +880,102 @@ const HUB_SCENARIOS: Record<HubKey, Record<SalaryLocale, SalaryLandingData>> = {
       ],
     },
   },
+
+  // ── IT-only orphan hubs (URL exists only in IT sitemap-pages.xml) ─────────
+
+  'simula-cambio-residenza': {
+    it: {
+      eyebrow: 'Simulatore residenza · Frontaliere',
+      tagline: 'Stima il delta netto annuo se ti trasferisci in Svizzera (permesso B) o resti in Italia (permesso G).',
+      tiles: [
+        { label: 'Permit G → B', value: '+CHF 3-7k/anno', tone: 'success' },
+        { label: 'Costo LAMal', value: '200-600 CHF/mese', tone: 'warning' },
+        { label: 'Soggiorno richiesto', value: '>183 gg/anno CH', tone: 'accent' },
+        { label: 'Cassa malati', value: 'LAMal obbligatoria', tone: 'danger' },
+      ],
+      advice: 'Il cambio residenza CH conviene sopra CHF 80k di RAL: il risparmio fiscale supera i costi extra (affitto Lugano, LAMal). Verifica disponibilità abitativa prima di firmare.',
+      ctaPrimary: { label: 'Apri il simulatore', href: '/calcola-stipendio/' },
+      ctaSecondary: { label: 'Confronto permesso G vs B', href: '/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km/' },
+      table: {
+        caption: 'Delta netto annuo · trasferimento da Italia a Svizzera (single, A0N)',
+        headers: ['RAL CHF', 'Permit G (Italia)', 'Permit B (CH)', 'Δ a favore B'],
+        rows: [
+          { cells: ['60.000', '~CHF 44.000', '~CHF 45.500', '+CHF 1.500'] },
+          { cells: ['80.000', '~CHF 55.000', '~CHF 58.000', '+CHF 3.000'], emphasized: true },
+          { cells: ['100.000', '~CHF 67.000', '~CHF 71.000', '+CHF 4.000'] },
+        ],
+        footnote: 'Stime al netto di trasporto frontaliere (G) e LAMal CHF 4.800/anno (B). Considera anche costo affitto Lugano (~+CHF 1.200/mese vs Como).',
+      },
+      faqs: [
+        { q: 'Quali sono i requisiti per il permesso B?', a: 'Contratto di lavoro CH valido, alloggio a tuo nome, dimostrazione di mezzi sufficienti, iscrizione anagrafica al Comune CH (entro 14 giorni dall\'arrivo). Variabile per cantone.' },
+        { q: 'Cosa cambia nella mia tassazione cambiando residenza?', a: 'Passi dal regime frontaliere (tassazione concorrente CH+IT) a residente CH (solo tassazione svizzera). Risparmi tipicamente CHF 3-7k/anno ma assumi LAMal obbligatoria.' },
+        { q: 'Posso mantenere casa in Italia?', a: 'Sì, ma il fisco italiano potrebbe contestare la residenza fiscale: serve dimostrare che il centro vitale è in CH (>183 gg/anno, contratto, conti bancari, vita sociale).' },
+      ],
+    },
+  },
+
+  'stima-bonus-frontaliere': {
+    it: {
+      eyebrow: 'Bonus & 13ª · Frontaliere Ticino',
+      tagline: 'Stima il valore reale del bonus annuo + 13ª mensilità nel tuo netto, dopo tasse e contributi.',
+      tiles: [
+        { label: '13ª obbligatoria', value: 'Standard CCL', tone: 'success' },
+        { label: 'Tassazione bonus', value: 'Stessa fonte', tone: 'warning' },
+        { label: 'Trattenuta CH', value: '~25-30% del lordo', tone: 'danger' },
+        { label: 'Netto in tasca', value: '~70-75%', tone: 'accent' },
+      ],
+      advice: 'Un bonus lordo di CHF 10.000 vale ~CHF 7.200 netti in tasca (single A0). Il datore può ottimizzare versandolo come pilastro 3a se non hai ancora raggiunto il tetto annuo deducibile.',
+      ctaPrimary: { label: 'Calcola il netto con bonus', href: '/calcola-stipendio/' },
+      ctaSecondary: { label: 'Cosa cambia se… (what-if)', href: '/calcola-stipendio/cosa-cambia-se/' },
+      table: {
+        caption: 'Netto stimato di un bonus annuo CHF 10.000 (Lugano, A0N)',
+        headers: ['Voce', 'Importo lordo', 'Trattenute', 'Netto in tasca'],
+        rows: [
+          { cells: ['Bonus puro', 'CHF 10.000', '-CHF 2.800', 'CHF 7.200'], emphasized: true },
+          { cells: ['Bonus → pilastro 3a', 'CHF 10.000', '-CHF 0 (deducibile)', 'CHF 10.000 in pensione'] },
+          { cells: ['13ª su lordo 80k', 'CHF 6.150', '-CHF 1.720', 'CHF 4.430'] },
+        ],
+        footnote: 'Versare bonus al pilastro 3a azzera la tassazione immediata fino al massimo deducibile annuo (CHF 7.258 nel 2026 per affiliati LPP).',
+      },
+      faqs: [
+        { q: 'La 13ª è obbligatoria?', a: 'Dipende dal CCL settoriale. In Ticino la maggior parte dei settori la prevede (industria, banche, sanità, retail). Verifica sempre il contratto firmato.' },
+        { q: 'Posso versare il bonus al pilastro 3a?', a: 'Sì, se non hai ancora raggiunto il massimo deducibile annuo. Versando CHF 7.258 al pilastro 3a deduci l\'intero importo dal reddito imponibile.' },
+        { q: 'Bonus target e variable: come si tassano?', a: 'Esattamente come il salario fisso, all\'imposta alla fonte cantonale + contributi sociali. Non c\'è regime agevolato in Svizzera.' },
+      ],
+    },
+  },
+
+  'verifica-congedo-parentale': {
+    it: {
+      eyebrow: 'Congedo parentale · Frontaliere',
+      tagline: 'Diritti, durata e indennità del congedo parentale per frontaliere: cosa offre la Svizzera vs l\'Italia.',
+      tiles: [
+        { label: 'Maternità CH', value: '14 settimane (80%)', tone: 'accent' },
+        { label: 'Paternità CH', value: '2 settimane (80%)', tone: 'accent' },
+        { label: 'Maternità IT', value: '5 mesi (80%)', tone: 'success' },
+        { label: 'Frontaliere applica', value: 'Legge svizzera', tone: 'warning' },
+      ],
+      advice: 'Il frontaliere segue la legge svizzera: 14 settimane di maternità (80% salario) + 2 settimane di paternità. Per congedi più lunghi serve trattativa col datore o aspettare il rientro definitivo in IT.',
+      ctaPrimary: { label: 'Calcola impatto netto', href: '/calcola-stipendio/' },
+      ctaSecondary: { label: 'Cosa cambia se… (figli)', href: '/calcola-stipendio/cosa-cambia-se/' },
+      table: {
+        caption: 'Congedo parentale: Svizzera (frontaliere) vs Italia',
+        headers: ['Voce', 'Svizzera (frontaliere)', 'Italia (residente)'],
+        rows: [
+          { cells: ['Maternità', '14 settimane × 80%', '5 mesi × 80%'], emphasized: true },
+          { cells: ['Paternità', '2 settimane × 80%', '10 giorni × 100%'] },
+          { cells: ['Parentale aggiuntivo', 'No (solo trattativa)', '6 mesi × 30%'] },
+          { cells: ['Tetto giornaliero', 'CHF 220/giorno', '~EUR 100/giorno'] },
+        ],
+        footnote: 'Il frontaliere applica la legge svizzera (Loi sur les allocations pour perte de gain — LAPG). Verifica eventuali CCL settoriali per condizioni migliorative.',
+      },
+      faqs: [
+        { q: 'Posso usare il congedo parentale italiano se sono frontaliere?', a: 'No. Il frontaliere è assicurato in Svizzera (LAPG) e segue le regole svizzere: 14 settimane di maternità + 2 di paternità con tetto giornaliero CHF 220.' },
+        { q: 'Come cambia il netto durante il congedo?', a: 'Ricevi l\'80% del salario fino al tetto CHF 220/giorno. Per stipendi sopra CHF 88.000/anno c\'è un taglio: usa il simulatore per stimare il netto durante il periodo.' },
+        { q: 'Posso chiedere parental leave non retribuito?', a: 'Sì, ma dipende dal CCL e dal contratto. Senza obbligo legale, è una trattativa col datore. Alcune aziende offrono fino a 6 mesi non retribuiti su richiesta.' },
+      ],
+    },
+  },
 };
 
 // ── Salary-tier generator ───────────────────────────────────────────────────
@@ -1101,36 +1206,22 @@ function buildSalaryTierData(cfg: TierConfig, locale: SalaryLocale): SalaryLandi
 // paths return both a key and the parsed `ral` + `variant` so the caller
 // can hand them to the generator. Hub paths return only the key + locale.
 
+// Per live `sitemap-pages.xml`, all hub URLs under /calcola-stipendio/* are
+// IT-only. EN/DE/FR siblings are not emitted by the static-pages plugin
+// (the salaryHub plugin owns the salary-tier slugs in all 4 locales — see
+// `salaryHubContent.generatePageHtml` which already handles its own
+// localisation). Adding EN/DE/FR keys here is dead code.
 const HUB_PATH_TO_KEY: Record<string, { key: HubKey; locale: SalaryLocale }> = {
   '/calcola-stipendio/nuovi-frontalieri-oltre-20-km': { key: 'nuovi-frontalieri-oltre-20-km', locale: 'it' },
-  '/en/calculate-salary/new-cross-border-workers-over-20km': { key: 'nuovi-frontalieri-oltre-20-km', locale: 'en' },
-  '/de/gehalt-berechnen/neue-grenzgaenger-ueber-20-km': { key: 'nuovi-frontalieri-oltre-20-km', locale: 'de' },
-  '/fr/calculer-salaire/nouveaux-frontaliers-plus-20-km': { key: 'nuovi-frontalieri-oltre-20-km', locale: 'fr' },
-
   '/calcola-stipendio/simula-busta-paga': { key: 'simula-busta-paga', locale: 'it' },
-  '/en/calculate-salary/simulate-payslip': { key: 'simula-busta-paga', locale: 'en' },
-  '/de/gehalt-berechnen/lohnabrechnung-simulieren': { key: 'simula-busta-paga', locale: 'de' },
-  '/fr/calculer-salaire/simuler-fiche-paie': { key: 'simula-busta-paga', locale: 'fr' },
-
   '/calcola-stipendio/cosa-cambia-se': { key: 'cosa-cambia-se', locale: 'it' },
-  '/en/calculate-salary/what-if': { key: 'cosa-cambia-se', locale: 'en' },
-  '/de/gehalt-berechnen/was-waere-wenn': { key: 'cosa-cambia-se', locale: 'de' },
-  '/fr/calculer-salaire/et-si': { key: 'cosa-cambia-se', locale: 'fr' },
-
-  '/calcola-stipendio/confronta-stipendi': { key: 'confronta-stipendi', locale: 'it' },
-  '/en/calculate-salary/compare-salaries': { key: 'confronta-stipendi', locale: 'en' },
-  '/de/gehalt-berechnen/gehaelter-vergleichen': { key: 'confronta-stipendi', locale: 'de' },
-  '/fr/calculer-salaire/comparer-salaires': { key: 'confronta-stipendi', locale: 'fr' },
-
-  '/calcola-stipendio/quiz-stipendio': { key: 'quiz-stipendio', locale: 'it' },
-  '/en/calculate-salary/salary-quiz': { key: 'quiz-stipendio', locale: 'en' },
-  '/de/gehalt-berechnen/gehaltsquiz': { key: 'quiz-stipendio', locale: 'de' },
-  '/fr/calculer-salaire/quiz-salaire': { key: 'quiz-stipendio', locale: 'fr' },
-
   '/calcola-stipendio/confronta-retribuzione-ral': { key: 'confronta-retribuzione-ral', locale: 'it' },
-  '/en/calculate-salary/compare-gross-net': { key: 'confronta-retribuzione-ral', locale: 'en' },
-  '/de/gehalt-berechnen/brutto-netto-vergleich': { key: 'confronta-retribuzione-ral', locale: 'de' },
-  '/fr/calculer-salaire/comparer-brut-net': { key: 'confronta-retribuzione-ral', locale: 'fr' },
+  // Quiz: live slug is `quanto-guadagneresti-in-svizzera`, not `quiz-stipendio`.
+  '/calcola-stipendio/quanto-guadagneresti-in-svizzera': { key: 'quanto-guadagneresti-in-svizzera', locale: 'it' },
+  // 3 hubs missed by the previous round (all IT-only, all in sitemap-pages.xml).
+  '/calcola-stipendio/simula-cambio-residenza': { key: 'simula-cambio-residenza', locale: 'it' },
+  '/calcola-stipendio/stima-bonus-frontaliere': { key: 'stima-bonus-frontaliere', locale: 'it' },
+  '/calcola-stipendio/verifica-congedo-parentale': { key: 'verifica-congedo-parentale', locale: 'it' },
 };
 
 /**
@@ -1668,24 +1759,8 @@ function parseNetComparisonPath(canonicalPath: string): { key: NetComparisonKey;
   for (const { slug, key } of itSlugs) {
     if (stripped === slug) return { key, locale: 'it' };
   }
-  // EN / DE / FR variants (per services/router.ts SEO_LANDING_SLUGS lines 316-373)
-  const localeSlugs: Array<{ slug: string; key: NetComparisonKey; locale: SalaryLocale }> = [
-    { slug: '/en/calculate-salary/net-comparison-2025-2026-within-20km', key: 'confronto-netto-2025-2026-entro-20km', locale: 'en' },
-    { slug: '/en/calculate-salary/net-comparison-2025-2026-over-20km', key: 'confronto-netto-2025-2026-oltre-20km', locale: 'en' },
-    { slug: '/en/calculate-salary/permit-g-vs-b-comparison-within-20km', key: 'confronto-permesso-g-vs-b-entro-20km', locale: 'en' },
-    { slug: '/en/calculate-salary/permit-g-vs-b-comparison-over-20km', key: 'confronto-permesso-g-vs-b-oltre-20km', locale: 'en' },
-    { slug: '/de/gehalt-berechnen/nettovergleich-2025-2026-bis-20km', key: 'confronto-netto-2025-2026-entro-20km', locale: 'de' },
-    { slug: '/de/gehalt-berechnen/nettovergleich-2025-2026-ueber-20km', key: 'confronto-netto-2025-2026-oltre-20km', locale: 'de' },
-    { slug: '/de/gehalt-berechnen/vergleich-bewilligung-g-vs-b-bis-20km', key: 'confronto-permesso-g-vs-b-entro-20km', locale: 'de' },
-    { slug: '/de/gehalt-berechnen/vergleich-bewilligung-g-vs-b-ueber-20km', key: 'confronto-permesso-g-vs-b-oltre-20km', locale: 'de' },
-    { slug: '/fr/calculer-salaire/comparaison-net-2025-2026-moins-20km', key: 'confronto-netto-2025-2026-entro-20km', locale: 'fr' },
-    { slug: '/fr/calculer-salaire/comparaison-net-2025-2026-plus-20km', key: 'confronto-netto-2025-2026-oltre-20km', locale: 'fr' },
-    { slug: '/fr/calculer-salaire/comparaison-permis-g-vs-b-moins-20km', key: 'confronto-permesso-g-vs-b-entro-20km', locale: 'fr' },
-    { slug: '/fr/calculer-salaire/comparaison-permis-g-vs-b-plus-20km', key: 'confronto-permesso-g-vs-b-oltre-20km', locale: 'fr' },
-  ];
-  for (const { slug, key, locale } of localeSlugs) {
-    if (stripped === slug) return { key, locale };
-  }
+  // Per live sitemap-pages.xml the net-comparison URLs are IT-only.
+  // EN/DE/FR were never emitted as static landings — no mapping needed.
   return null;
 }
 
@@ -1694,7 +1769,10 @@ function resolveScenarioData(canonicalPath: string): { data: SalaryLandingData; 
   // 1. Hub lookup
   const hubHit = HUB_PATH_TO_KEY[stripped];
   if (hubHit) {
-    return { data: HUB_SCENARIOS[hubHit.key][hubHit.locale], locale: hubHit.locale };
+    // HUB_SCENARIOS[key][locale] may be undefined for hubs that only ship
+    // an IT dataset; fall back to IT when the requested locale is missing.
+    const localeData = HUB_SCENARIOS[hubHit.key][hubHit.locale] ?? HUB_SCENARIOS[hubHit.key].it;
+    if (localeData) return { data: localeData, locale: hubHit.locale };
   }
   // 2. Salary-tier pattern
   const tierHit = parseSalaryTierPath(canonicalPath);
@@ -1791,8 +1869,27 @@ export interface BuildSalaryLandingArgs {
   readonly navHtml: string;
 }
 
-export function buildSalaryLandingBody(args: BuildSalaryLandingArgs): string {
-  const { data, locale } = resolveScenarioData(args.canonicalPath);
+export interface RenderShellArgs {
+  readonly h1Text: string;
+  /** Optional rich HTML to render in the data-area slot (replaces auto-rendered table from data.table). */
+  readonly dataAreaHtmlOverride?: string;
+  /** Long prose block (5+ paragraph editorial, related-grid, AdSense) rendered at the bottom. */
+  readonly editorialHtml?: string;
+  /** Footer nav block (raw HTML). */
+  readonly navHtml?: string;
+}
+
+/**
+ * Render the mobile-first SEO-landing shell from explicit data + locale.
+ * Used directly by salaryHubPlugin (which computes per-scenario data from
+ * `SalaryHubScenario` + `SimulationResult`). `buildSalaryLandingBody` is
+ * a thin wrapper that first resolves data from a canonical path.
+ */
+export function renderSalaryLandingShell(
+  data: SalaryLandingData,
+  locale: SalaryLocale,
+  args: RenderShellArgs,
+): string {
   const pack = LOCALE_PACKS[locale];
 
   const breadcrumb = renderBreadcrumb([
@@ -1808,14 +1905,27 @@ export function buildSalaryLandingBody(args: BuildSalaryLandingArgs): string {
   const tilesHtml = renderStatGrid(data.tiles);
   const adviceHtml = data.advice ? renderAdvice(pack.adviceLabel, data.advice) : '';
   const ctaHtml = renderCtaBlock(data.ctaPrimary, data.ctaSecondary);
-  const tableHtml = data.table ? renderTable(data.table) : '';
+  const dataAreaHtml = args.dataAreaHtmlOverride ?? (data.table ? renderTable(data.table) : '');
   const faqsHtml = data.faqs ? renderFaqs(pack.faqsLabel, data.faqs) : '';
 
   const prose = args.editorialHtml
     ? `<section style="margin:32px 0 0;border-top:1px solid var(--color-edge);padding-top:24px">${args.editorialHtml}</section>`
     : '';
 
-  return `<div style="max-width:64rem;margin:0 auto;padding:16px 16px 32px;font-family:inherit">${breadcrumb}<header style="margin:0 0 20px">${eyebrow}${h1}${lede}</header>${tilesHtml}${adviceHtml}${ctaHtml}${tableHtml}${faqsHtml}${prose}<nav aria-label="${esc(pack.navLabel)}" style="margin-top:32px;padding-top:20px;border-top:1px solid var(--color-edge);font-size:13px;color:var(--color-subtle);line-height:1.9">${args.navHtml}</nav></div>`;
+  const navHtml = args.navHtml
+    ? `<nav aria-label="${esc(pack.navLabel)}" style="margin-top:32px;padding-top:20px;border-top:1px solid var(--color-edge);font-size:13px;color:var(--color-subtle);line-height:1.9">${args.navHtml}</nav>`
+    : '';
+
+  return `<div style="max-width:64rem;margin:0 auto;padding:16px 16px 32px;font-family:inherit">${breadcrumb}<header style="margin:0 0 20px">${eyebrow}${h1}${lede}</header>${tilesHtml}${adviceHtml}${ctaHtml}${dataAreaHtml}${faqsHtml}${prose}${navHtml}</div>`;
+}
+
+export function buildSalaryLandingBody(args: BuildSalaryLandingArgs): string {
+  const { data, locale } = resolveScenarioData(args.canonicalPath);
+  return renderSalaryLandingShell(data, locale, {
+    h1Text: args.h1Text,
+    editorialHtml: args.editorialHtml,
+    navHtml: args.navHtml,
+  });
 }
 
 // ── Test helpers (exported for unit tests) ──────────────────────────────────

--- a/tests/build-plugins/salaryLandingShell.test.ts
+++ b/tests/build-plugins/salaryLandingShell.test.ts
@@ -6,54 +6,55 @@ import {
 } from '../../build-plugins/shared/salaryLandingShell';
 
 describe('salaryLandingShell · resolver', () => {
-  it('matches all hub paths across IT/EN/DE/FR', () => {
-    const cases: Array<{ path: string; locale: SalaryLocale; eyebrowSubstr: string }> = [
-      { path: '/calcola-stipendio/nuovi-frontalieri-oltre-20-km', locale: 'it', eyebrowSubstr: 'Oltre 20 km' },
-      { path: '/en/calculate-salary/new-cross-border-workers-over-20km', locale: 'en', eyebrowSubstr: 'Over 20 km' },
-      { path: '/de/gehalt-berechnen/neue-grenzgaenger-ueber-20-km', locale: 'de', eyebrowSubstr: 'Über 20 km' },
-      { path: '/fr/calculer-salaire/nouveaux-frontaliers-plus-20-km', locale: 'fr', eyebrowSubstr: 'Plus de 20 km' },
-      { path: '/calcola-stipendio/simula-busta-paga', locale: 'it', eyebrowSubstr: 'Busta paga' },
-      { path: '/calcola-stipendio/cosa-cambia-se', locale: 'it', eyebrowSubstr: 'What-if' },
-      { path: '/calcola-stipendio/quiz-stipendio', locale: 'it', eyebrowSubstr: 'Quiz' },
+  it('matches every IT hub path emitted under /calcola-stipendio/* (per sitemap-pages.xml)', () => {
+    const cases: Array<{ path: string; eyebrowSubstr: string }> = [
+      { path: '/calcola-stipendio/nuovi-frontalieri-oltre-20-km', eyebrowSubstr: 'Oltre 20 km' },
+      { path: '/calcola-stipendio/simula-busta-paga', eyebrowSubstr: 'Busta paga' },
+      { path: '/calcola-stipendio/cosa-cambia-se', eyebrowSubstr: 'What-if' },
+      { path: '/calcola-stipendio/confronta-retribuzione-ral', eyebrowSubstr: 'Da RAL' },
+      { path: '/calcola-stipendio/quanto-guadagneresti-in-svizzera', eyebrowSubstr: 'Quiz' },
+      { path: '/calcola-stipendio/simula-cambio-residenza', eyebrowSubstr: 'Simulatore residenza' },
+      { path: '/calcola-stipendio/stima-bonus-frontaliere', eyebrowSubstr: 'Bonus' },
+      { path: '/calcola-stipendio/verifica-congedo-parentale', eyebrowSubstr: 'Congedo parentale' },
     ];
     for (const c of cases) {
       const r = _internal.resolveScenarioData(c.path);
-      expect(r.locale).toBe(c.locale);
+      expect(r.locale).toBe('it');
       expect(r.data.eyebrow).toContain(c.eyebrowSubstr);
     }
   });
 
-  it('parses salary-tier paths with all variants', () => {
-    const cases: Array<{ path: string; ral: number; variant: string }> = [
-      { path: '/calcola-stipendio/stipendio-netto-60000-chf', ral: 60, variant: 'base' },
-      { path: '/calcola-stipendio/stipendio-netto-80000-chf-nuovo-frontaliere-2026', ral: 80, variant: 'new' },
-      { path: '/calcola-stipendio/stipendio-netto-100000-chf-vecchio-frontaliere', ral: 100, variant: 'old' },
-      { path: '/calcola-stipendio/stipendio-netto-60000-chf-sposato-2-figli', ral: 60, variant: 'married' },
-      { path: '/calcola-stipendio/stipendio-netto-80000-chf-residenza-entro-20km', ral: 80, variant: 'within20' },
-      { path: '/calcola-stipendio/stipendio-netto-100000-chf-residenza-oltre-20km', ral: 100, variant: 'over20' },
+  it('parses salary-tier paths with all variants (IT) and 4-locale prefixes', () => {
+    const cases: Array<{ path: string; ral: number; variant: string; locale: SalaryLocale }> = [
+      { path: '/calcola-stipendio/stipendio-netto-60000-chf', ral: 60, variant: 'base', locale: 'it' },
+      { path: '/calcola-stipendio/stipendio-netto-80000-chf-nuovo-frontaliere-2026', ral: 80, variant: 'new', locale: 'it' },
+      { path: '/calcola-stipendio/stipendio-netto-100000-chf-vecchio-frontaliere', ral: 100, variant: 'old', locale: 'it' },
+      { path: '/calcola-stipendio/stipendio-netto-60000-chf-sposato-2-figli', ral: 60, variant: 'married', locale: 'it' },
+      { path: '/calcola-stipendio/stipendio-netto-80000-chf-residenza-entro-20km', ral: 80, variant: 'within20', locale: 'it' },
+      { path: '/calcola-stipendio/stipendio-netto-100000-chf-residenza-oltre-20km', ral: 100, variant: 'over20', locale: 'it' },
+      { path: '/en/calculate-salary/net-salary-80000-chf-married-2-children', ral: 80, variant: 'married', locale: 'en' },
+      { path: '/de/gehalt-berechnen/nettogehalt-100000-chf-wohnsitz-bis-20km', ral: 100, variant: 'within20', locale: 'de' },
+      { path: '/fr/calculer-salaire/salaire-net-60000-chf-ancien-frontalier', ral: 60, variant: 'old', locale: 'fr' },
     ];
     for (const c of cases) {
       const parsed = _internal.parseSalaryTierPath(c.path);
       expect(parsed).not.toBeNull();
       expect(parsed!.ral).toBe(c.ral);
       expect(parsed!.variant).toBe(c.variant);
-      expect(parsed!.locale).toBe('it');
+      expect(parsed!.locale).toBe(c.locale);
     }
   });
 
-  it('resolves all 4 net-comparison scenarios in IT/EN/DE/FR', () => {
-    const cases: Array<{ path: string; locale: SalaryLocale; eyebrowSubstr: string }> = [
-      { path: '/calcola-stipendio/confronto-netto-2025-2026-entro-20km', locale: 'it', eyebrowSubstr: 'Entro 20 km' },
-      { path: '/calcola-stipendio/confronto-netto-2025-2026-oltre-20km', locale: 'it', eyebrowSubstr: 'Oltre 20 km' },
-      { path: '/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km', locale: 'it', eyebrowSubstr: 'Permesso G vs B' },
-      { path: '/calcola-stipendio/confronto-permesso-g-vs-b-oltre-20km', locale: 'it', eyebrowSubstr: 'Permesso G vs B' },
-      { path: '/en/calculate-salary/net-comparison-2025-2026-within-20km', locale: 'en', eyebrowSubstr: 'Within 20 km' },
-      { path: '/de/gehalt-berechnen/nettovergleich-2025-2026-ueber-20km', locale: 'de', eyebrowSubstr: 'Über 20 km' },
-      { path: '/fr/calculer-salaire/comparaison-permis-g-vs-b-plus-20km', locale: 'fr', eyebrowSubstr: 'Plus 20 km' },
+  it('resolves all 4 IT net-comparison scenarios (URLs only emitted in IT)', () => {
+    const cases: Array<{ path: string; eyebrowSubstr: string }> = [
+      { path: '/calcola-stipendio/confronto-netto-2025-2026-entro-20km', eyebrowSubstr: 'Entro 20 km' },
+      { path: '/calcola-stipendio/confronto-netto-2025-2026-oltre-20km', eyebrowSubstr: 'Oltre 20 km' },
+      { path: '/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km', eyebrowSubstr: 'Permesso G vs B' },
+      { path: '/calcola-stipendio/confronto-permesso-g-vs-b-oltre-20km', eyebrowSubstr: 'Permesso G vs B' },
     ];
     for (const c of cases) {
       const r = _internal.resolveScenarioData(c.path);
-      expect(r.locale).toBe(c.locale);
+      expect(r.locale).toBe('it');
       expect(r.data.eyebrow).toContain(c.eyebrowSubstr);
       expect(r.data.table?.headers.length).toBe(4);
       expect(r.data.tiles.length).toBe(4);
@@ -117,20 +118,7 @@ describe('salaryLandingShell · buildSalaryLandingBody', () => {
     expect(html).toContain('var(--color-');
   });
 
-  it('renders English content for the EN locale variant', () => {
-    const html = buildSalaryLandingBody({
-      canonicalPath: '/en/calculate-salary/simulate-payslip',
-      h1Text: 'Simulate Payslip',
-      seoDesc: '',
-      editorialHtml: '',
-      navHtml: '',
-    });
-    expect(html).toContain('Cross-border payslip');
-    expect(html).toContain('Open the simulator');
-    expect(html).toContain('Frequently asked');
-  });
-
-  it('generates a coherent salary-tier table with deterministic numbers', () => {
+  it('generates a coherent salary-tier table with deterministic numbers (IT)', () => {
     const html = buildSalaryLandingBody({
       canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf',
       h1Text: 'Stipendio netto 80.000 CHF',
@@ -138,9 +126,24 @@ describe('salaryLandingShell · buildSalaryLandingBody', () => {
       editorialHtml: '',
       navHtml: '',
     });
-    // Gross row
-    expect(html).toMatch(/80['. \s]?000/);
-    // Net row (gross - social - source ≈ 60k)
-    expect(html).toMatch(/59['. \s]?(840|800|912)/);
+    expect(html).toMatch(/80['. \s]?000/);
+    expect(html).toMatch(/59['. \s]?(840|800|912)/);
+  });
+
+  it('shipsh bespoke data for the 4 new orphan hubs', () => {
+    for (const slug of ['simula-cambio-residenza', 'stima-bonus-frontaliere', 'verifica-congedo-parentale', 'quanto-guadagneresti-in-svizzera']) {
+      const html = buildSalaryLandingBody({
+        canonicalPath: `/calcola-stipendio/${slug}`,
+        h1Text: slug,
+        seoDesc: '',
+        editorialHtml: '',
+        navHtml: '',
+      });
+      expect(html).toContain('aria-label="breadcrumb"');
+      expect(html).toContain('clamp(1.8rem');
+      expect(html).toContain('minmax(180px,1fr)');
+      expect(html).toContain('<table');
+      expect(html).toContain('<details');
+    }
   });
 });


### PR DESCRIPTION
Phase A — Cleanup dead mappings (per live sitemap-pages.xml):
- Remove 20 EN/DE/FR entries from HUB_PATH_TO_KEY (URLs never emitted by
  staticPagesPlugin; only IT hubs exist as static pages)
- Remove 12 EN/DE/FR entries from parseNetComparisonPath (same reason)
- Drop dead quiz-stipendio key (real slug is `quanto-guadagneresti-in-svizzera`)

Phase B — Bespoke for 4 IT orphan hubs from sitemap (previously
fallback-generic):
- /calcola-stipendio/quanto-guadagneresti-in-svizzera/ (was wrongly mapped
  as `quiz-stipendio` — slug never existed on live)
- /calcola-stipendio/simula-cambio-residenza/
- /calcola-stipendio/stima-bonus-frontaliere/
- /calcola-stipendio/verifica-congedo-parentale/

Phase C — salaryHubPlugin uses renderSalaryLandingShell:
- Extract `renderSalaryLandingShell(data, locale, opts)` from
  `buildSalaryLandingBody` so external callers can supply explicit data +
  inject a `dataAreaHtmlOverride`
- Refactor `salaryHubContent.generatePageHtml` to:
  * compute SalaryLandingData per scenario (eyebrow with variant info,
    4 tiles from result.chResident/itResident/savingsCHF/exchangeRate,
    derived advice based on savings sign, prefilled-calculator CTA)
  * pass the existing rich `resultsTableHtml` as dataAreaHtmlOverride
  * pass the 5 H2 explanations + related-grid + tail AdSense as
    editorialHtml (long prose, slot 7)
  * delegate H1, breadcrumb, tiles, advice, CTA, FAQ rendering to the
    shared shell
- Net effect: ~500 salary-hub pages × 4 locales now ship with the same
  mobile-first SEO-landing template as the staticPages hubs

HUB_SCENARIOS type loosened to Partial<Record<SalaryLocale, ...>> so
IT-only hubs don't need empty EN/DE/FR stubs; resolveScenarioData falls
back to `.it` when a requested locale is missing.

Tests: 9 unit tests cover all 8 IT hubs + 9 salary-tier variants across
4 locales + 4 net-comparison + generic locale-aware fallback + new orphan
hubs. Full build-plugin suite (78 tests) passes.
