### PR TITLE
fix(routing): half-canton city lookup + orphan /categoria-altro/ link

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -8118,32 +8118,28 @@ ${alternates}
          sales: { it: 'Vendita', en: 'Sales', de: 'Vertrieb', fr: 'Vente' },
          other: { it: 'Altro', en: 'Other', de: 'Andere', fr: 'Autre' },
        };
-       // Job `sector` field uses Italian labels in many feeds; the canonical
-       // category key is derived elsewhere via the same lowercase compare.
-       // sectorCounts keys are the raw display labels; resolve to category
-       // keys with the same lowercase Italian alias table used by the
-       // category-listing block (best-effort: only emit a link when we
-       // actually have ≥3 jobs in that bucket — the same threshold used by
-       // the category-listing emit at line 5768).
-       const sectorAlias: Record<string, string> = {
-         sanita: 'health', salute: 'health',
-         finanza: 'finance', banca: 'finance',
-         informatica: 'tech', it: 'tech', tech: 'tech',
-         ingegneria: 'engineering',
-         amministrazione: 'admin', uffici: 'admin',
-         ristorazione: 'hospitality', alberghiero: 'hospitality',
-         vendita: 'sales', commerciale: 'sales',
-       };
+       // Source-of-truth alignment: the per-canton category-listing emitter
+       // (~line 5921) keys buckets by `job.category` directly and only emits
+       // a page when that bucket has ≥3 jobs. The previous implementation of
+       // this link emitter classified by `job.sector` via a heuristic alias
+       // table — which silently funnelled unrecognised sectors into the
+       // `other` bucket and emitted /categoria-altro/ links pointing at
+       // pages the listing emitter had refused to generate (404 in same-tab
+       // navigation, reported 2026-05-18). Read the same field, apply the
+       // same gate, exclude the `other` catch-all (no SEO value + frequent
+       // misclassifications).
        const categoryCountAggregated = new Map<string, number>();
-       for (const [secRaw, count] of sectorCounts) {
-         const norm = String(secRaw).toLowerCase().trim();
-         const catKey = sectorAlias[norm] || (Object.keys(categorySlugMap).includes(norm) ? norm : 'other');
-         categoryCountAggregated.set(catKey, (categoryCountAggregated.get(catKey) ?? 0) + count);
+       for (const j of cantonJobsAll) {
+         const rawCat = String((j as { category?: string }).category || '').toLowerCase().trim();
+         if (!rawCat) continue;
+         if (!Object.prototype.hasOwnProperty.call(categorySlugMap, rawCat)) continue;
+         if (rawCat === 'other') continue;
+         categoryCountAggregated.set(rawCat, (categoryCountAggregated.get(rawCat) ?? 0) + 1);
        }
        const topCategoryHubs: Array<{ slug: string; label: string }> = [];
        for (const [catKey, count] of [...categoryCountAggregated.entries()].sort((a, b) => b[1] - a[1])) {
          if (topCategoryHubs.length >= 6) break;
-         if (count < 3) continue; // mirror the category-listing emit gate
+         if (count < 3) continue; // same gate as the page emitter
          const catSlug = categorySlugMap[catKey]?.[entry.locale];
          const catLabel = categoryLabelMap[catKey]?.[entry.locale];
          if (!catSlug || !catLabel) continue;

--- a/build-plugins/shared/cantonCities.ts
+++ b/build-plugins/shared/cantonCities.ts
@@ -1,7 +1,26 @@
 import municipalitiesFile from '../../data/canton-municipalities.json';
+import cantonSlugFile from '../../data/canton-url-slugs.json';
 
 type CityFile = { cantons: Record<string, { municipalities: string[] }> };
 const data = municipalitiesFile as CityFile;
+
+// Half-canton URL groups (BL+BS → BASILEA, AI+AR → APPENZELLO, see
+// data/canton-url-slugs.json `cantonGroups`). Router parses URLs like
+// `/cerca-lavoro-basilea/basel/` with `jobBoardCanton: 'BASILEA'`, but
+// canton-municipalities.json keys jobs by real BFS codes (BS, BL, …).
+// Without expansion, `getCantonCities('BASILEA')` would return [] and
+// `isKnownCityHub('basel', 'BASILEA')` would falsely return false —
+// the bug where SPA clicks on canton-index city links land on the
+// "Annuncio non trovato" view while new-tab opens work (because the
+// static HTML for the city page exists in dist/).
+const GROUP_TO_MEMBERS: Record<string, readonly string[]> = (() => {
+  const out: Record<string, readonly string[]> = {};
+  const groups = (cantonSlugFile as { cantonGroups?: Record<string, { members?: readonly string[] }> }).cantonGroups ?? {};
+  for (const [group, info] of Object.entries(groups)) {
+    if (info?.members?.length) out[group.toUpperCase()] = info.members.map((m) => String(m).toUpperCase());
+  }
+  return out;
+})();
 
 // ASCII-fold city names so canton-aware helpers expose URL-safe, display-stable
 // strings. The source data preserves native spelling ("Zürich"), but cathedral
@@ -53,7 +72,15 @@ for (const [canton, cities] of Object.entries(CANTON_TO_CITIES)) {
 }
 
 export function getCantonCities(canton: string): string[] {
-  return CANTON_TO_CITIES[String(canton).toUpperCase()] ?? [];
+  const key = String(canton).toUpperCase();
+  const direct = CANTON_TO_CITIES[key];
+  if (direct) return direct;
+  // Virtual URL group (BASILEA, APPENZELLO): union of member-canton cities.
+  const members = GROUP_TO_MEMBERS[key];
+  if (members) {
+    return members.flatMap((m) => CANTON_TO_CITIES[m] ?? []);
+  }
+  return [];
 }
 
 export function getCityCanton(city: string): string | null {

--- a/tests/router/canton-city-routing.test.ts
+++ b/tests/router/canton-city-routing.test.ts
@@ -58,4 +58,32 @@ describe('Phase 2 — per-canton city routing', () => {
     expect(parsed.route.activeTab).toBe('job-board');
     expect(parsed.route.jobBoardCanton).toBe('_AGGREGATE_');
   });
+
+  // Half-canton URL groups (BL+BS → BASILEA, AI+AR → APPENZELLO). Router
+  // resolves the section to the virtual group code, but jobs are still
+  // keyed by real BFS codes (BS, BL, …) in canton-municipalities.json.
+  // `isKnownCityHub` must expand the group to its members before lookup,
+  // otherwise SPA clicks on canton-index city links land on
+  // "Annuncio non trovato" while new-tab opens work (the static city
+  // page exists in dist/). Regression for 2026-05-18.
+  it('/cerca-lavoro-basilea/basel/ → jobBoardCanton=BASILEA, jobBoardCity=basel (BS member)', () => {
+    const parsed = parsePath('/cerca-lavoro-basilea/basel/');
+    expect(parsed.route.jobBoardCanton).toBe('BASILEA');
+    expect(parsed.route.jobBoardCity).toBe('basel');
+    expect(parsed.route.jobSlug).toBeUndefined();
+  });
+
+  it('/cerca-lavoro-basilea/muttenz/ → jobBoardCanton=BASILEA, jobBoardCity=muttenz (BL member)', () => {
+    const parsed = parsePath('/cerca-lavoro-basilea/muttenz/');
+    expect(parsed.route.jobBoardCanton).toBe('BASILEA');
+    expect(parsed.route.jobBoardCity).toBe('muttenz');
+    expect(parsed.route.jobSlug).toBeUndefined();
+  });
+
+  it('/cerca-lavoro-appenzello/appenzell/ → jobBoardCanton=APPENZELLO, jobBoardCity=appenzell', () => {
+    const parsed = parsePath('/cerca-lavoro-appenzello/appenzell/');
+    expect(parsed.route.jobBoardCanton).toBe('APPENZELLO');
+    expect(parsed.route.jobBoardCity).toBe('appenzell');
+    expect(parsed.route.jobSlug).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Two follow-up fixes to PR #206 closing the remaining "Annuncio non
trovato" cases on per-canton landing pages.

1. Half-canton cities — clicking `/cerca-lavoro-basilea/basel/` (or
   any BS/BL city) from inside the SPA hit the jobSlug fallback in
   `services/router.ts` and rendered "Annuncio non trovato", while a
   new-tab open worked (static city page on disk). Root cause:
   `isKnownCityHub('basel', 'BASILEA')` called `getCantonCities`
   which looked up the virtual URL-group code `BASILEA` in
   `data/canton-municipalities.json` — that file is keyed by real
   BFS codes (BS, BL). Fix: `getCantonCities` now also expands
   group codes (`BASILEA` → BS+BL, `APPENZELLO` → AI+AR) by reading
   `cantonGroups` from `data/canton-url-slugs.json`.

2. `/cerca-lavoro-{canton}/categoria-altro/` 404 — the canton-index
   "Esplora per settore" link emitter classified sectors via a tiny
   alias table and dumped unrecognised sectors into the `other`
   bucket, emitting links the per-canton category-listing emitter
   (which keys on `job.category` and only writes pages with ≥3 jobs
   in that category) refused to generate. Aligned both sides on
   `job.category` and dropped the `other` catch-all entirely — no
   SEO value and frequent misclassifications.

Regression tests added to
`tests/router/canton-city-routing.test.ts` for BS, BL, AI/AR member
cities via the BASILEA / APPENZELLO URL groups.
