### PR TITLE
fix(vaudoise): trust Softgarden host + fetch detail-page descriptions

### DIFF
--- a/scripts/lib/vaudoise-job-parser.mjs
+++ b/scripts/lib/vaudoise-job-parser.mjs
@@ -83,11 +83,21 @@ export function isVaudoiseJob(job) {
 
 /**
  * Validate that a URL belongs to Vaudoise Assurances's domain.
+ *
+ * Trusts both the corporate domain (vaudoise.ch + subdomains) and the
+ * Softgarden ATS subdomain (`vaudoise.softgarden.io`), which is where the
+ * public job postings actually live. Without the ATS host the dedicated
+ * locale-validation gate flags every job as `url_not_vaudoise_domain` and
+ * the crawler exits 1 (49/49 issues, GH run 26004869125 + history).
  */
 export function isTrustedDomain(rawUrl = '') {
   try {
     const host = new URL(rawUrl).hostname.toLowerCase();
-    return host === 'vaudoise.ch' || host.endsWith('.vaudoise.ch');
+    return (
+      host === 'vaudoise.ch' ||
+      host.endsWith('.vaudoise.ch') ||
+      host === 'vaudoise.softgarden.io'
+    );
   } catch {
     return false;
   }
@@ -325,10 +335,90 @@ async function fetchJobListings(options = {}) {
   }
 }
 
+/* ── Detail-page description extraction ────────────────────── */
+
+const DETAIL_FETCH_UA =
+  'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch)';
+const DETAIL_FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Parse a Softgarden job-detail HTML page and extract the long description
+ * from the embedded JSON-LD `JobPosting`. Returns plain text (HTML stripped)
+ * or `''` when unavailable.
+ *
+ * @param {string} html
+ * @returns {string}
+ */
+export function parseVaudoiseDetailHtml(html = '') {
+  if (!html || typeof html !== 'string') return '';
+  const ldMatch = html.match(
+    /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i,
+  );
+  if (!ldMatch) return '';
+  try {
+    const ld = JSON.parse(ldMatch[1]);
+    const candidates = Array.isArray(ld) ? ld : [ld];
+    for (const entry of candidates) {
+      if (!entry || typeof entry !== 'object') continue;
+      const type = entry['@type'];
+      const isJobPosting =
+        type === 'JobPosting' || (Array.isArray(type) && type.includes('JobPosting'));
+      if (isJobPosting && entry.description) {
+        return normalizeSpace(stripHtml(String(entry.description)));
+      }
+    }
+  } catch {
+    /* ignore parse errors — fall through to '' */
+  }
+  return '';
+}
+
+/**
+ * Default `fetch` wrapper used to pull Softgarden detail pages. Isolated so
+ * tests can inject a stub via the `_detailFetcher` option without touching
+ * the global `fetch`.
+ *
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+async function defaultDetailFetcher(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DETAIL_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': DETAIL_FETCH_UA, Accept: 'text/html' },
+      signal: controller.signal,
+    });
+    if (!res.ok) return '';
+    return await res.text();
+  } catch {
+    return '';
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Fetch and parse the long description for a single detail URL.
+ *
+ * @param {string} url
+ * @param {(url: string) => Promise<string>} [fetcher]
+ * @returns {Promise<string>}
+ */
+export async function fetchVaudoiseDescription(url, fetcher = defaultDetailFetcher) {
+  if (!url) return '';
+  const html = await fetcher(url);
+  if (!html) return '';
+  return parseVaudoiseDetailHtml(html);
+}
+
 // Internal export for test injection — not part of the public crawler contract.
 export const __testables = {
   fetchJobListings,
   resolveApplyUrl,
+  parseVaudoiseDetailHtml,
+  fetchVaudoiseDescription,
+  defaultDetailFetcher,
   SWISS_LOCATION_RX,
   SOFTGARDEN_LISTING_URL,
   SOFTGARDEN_BASE,
@@ -344,6 +434,7 @@ export const __testables = {
  *
  * @param {object} [options]
  * @param {() => Promise<unknown>} [options._runtime] Test seam — Playwright runtime factory.
+ * @param {(url: string) => Promise<string>} [options._detailFetcher] Test seam — Softgarden detail-page fetcher.
  */
 export async function fetchAllVaudoiseJobs(options = {}) {
   console.log(`🔍 Fetching Vaudoise Assurances jobs`);
@@ -357,16 +448,36 @@ export async function fetchAllVaudoiseJobs(options = {}) {
 
   console.log(`  📋 Listings found: ${listings.length}`);
 
+  const detailFetcher = options._detailFetcher || defaultDetailFetcher;
+
   const jobs = [];
+  let detailFilled = 0;
   for (const listing of listings) {
     const title = normalizeSpace(listing.title || '');
     if (!title || title.length < 3) continue;
 
     const location = listing.location || 'Lausanne'; // HQ: Lausanne (VD)
     const canton = inferSwissTargetCanton(location) || 'VD';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || SOFTGARDEN_LISTING_URL;
+
+    // Softgarden listing rows do NOT include the long description — only
+    // title/location/date/category. Fetch the detail page and pull the
+    // JSON-LD `JobPosting.description` so source-locale descriptions are
+    // real content (≥120 chars) instead of a `"${title} — Vaudoise…"`
+    // stub. Without this every job tripped the locale-validation gate's
+    // `untranslated_description` check after hardening copied the stub
+    // into every locale slot (GH run 26004869125).
+    let descriptionText = '';
+    try {
+      descriptionText = await fetchVaudoiseDescription(publicUrl, detailFetcher);
+    } catch {
+      descriptionText = '';
+    }
+    if (descriptionText && descriptionText.length >= 120) {
+      detailFilled += 1;
+    } else if (listing.description) {
+      descriptionText = stripHtml(listing.description);
+    }
 
     const sourceLang = detectLang(descriptionText || title, 'fr');
     const jobSlug = slugify(`${title} vaudoise ch`);
@@ -413,7 +524,10 @@ export async function fetchAllVaudoiseJobs(options = {}) {
     await new Promise((r) => setTimeout(r, 100)); // Rate limiting
   }
 
-  console.log(`\n📋 Total Vaudoise Assurances jobs discovered: ${jobs.length}`);
+  console.log(
+    `\n📋 Total Vaudoise Assurances jobs discovered: ${jobs.length} ` +
+      `(${detailFilled} with real detail-page descriptions).`,
+  );
   return jobs;
 }
 

--- a/tests/vaudoise-crawler.test.ts
+++ b/tests/vaudoise-crawler.test.ts
@@ -116,6 +116,19 @@ describe('Vaudoise Assurances crawler parser', () => {
       expect(isTrustedDomain('https://careers.vaudoise.ch/job/456')).toBe(true);
     });
 
+    // Postings live on the Softgarden ATS subdomain — the dedicated
+    // locale-validation gate flags `url_not_vaudoise_domain` otherwise
+    // (regression covered by GH run 26004869125, 49/49 jobs).
+    it('trusts the Softgarden ATS subdomain', () => {
+      expect(
+        isTrustedDomain('https://vaudoise.softgarden.io/job/64060113/some-title'),
+      ).toBe(true);
+    });
+
+    it('rejects other softgarden tenants', () => {
+      expect(isTrustedDomain('https://other.softgarden.io/job/1/foo')).toBe(false);
+    });
+
     it('rejects other domains', () => {
       expect(isTrustedDomain('https://example.com/jobs')).toBe(false);
     });
@@ -341,8 +354,87 @@ describe('Vaudoise Assurances crawler parser', () => {
     });
   });
 
+  // ── Detail-page description extraction ──
+  describe('parseVaudoiseDetailHtml', () => {
+    it('returns the JSON-LD description (HTML stripped)', () => {
+      const html = `
+        <html><head>
+        <script type="application/ld+json">
+        {"@context":"http://schema.org/","@type":"JobPosting","title":"X","description":"<p>Première phrase.</p><p>Seconde phrase avec plus de détails sur le poste à pourvoir au sein du Département Assurances de personnes pour assurer la gestion des sinistres.</p>"}
+        </script>
+        </head><body></body></html>`;
+      const out = __testables.parseVaudoiseDetailHtml(html);
+      expect(out).toContain('Première phrase.');
+      expect(out).toContain('gestion des sinistres');
+      expect(out).not.toContain('<p>');
+      expect(out.length).toBeGreaterThanOrEqual(120);
+    });
+
+    it('handles array-shaped JSON-LD (multiple @types)', () => {
+      const html = `
+        <script type="application/ld+json">
+        [{"@type":"WebPage"},{"@type":"JobPosting","description":"<strong>Real description body content that comfortably exceeds the one-hundred-and-twenty character minimum threshold required by the locale-validation gate.</strong>"}]
+        </script>`;
+      const out = __testables.parseVaudoiseDetailHtml(html);
+      expect(out).toMatch(/Real description body/);
+      expect(out.length).toBeGreaterThanOrEqual(120);
+    });
+
+    it('returns empty string when no JSON-LD is present', () => {
+      expect(__testables.parseVaudoiseDetailHtml('<html></html>')).toBe('');
+    });
+
+    it('returns empty string when JSON-LD is malformed', () => {
+      const html = `<script type="application/ld+json">{ not json }</script>`;
+      expect(__testables.parseVaudoiseDetailHtml(html)).toBe('');
+    });
+
+    it('handles null/undefined gracefully', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(__testables.parseVaudoiseDetailHtml(null as any)).toBe('');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(__testables.parseVaudoiseDetailHtml(undefined as any)).toBe('');
+    });
+  });
+
+  describe('fetchVaudoiseDescription', () => {
+    it('returns description when fetcher resolves with JSON-LD HTML', async () => {
+      const longDesc =
+        'Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, plus assez de texte pour le seuil de 120 caractères.';
+      const html = `<script type="application/ld+json">{"@type":"JobPosting","description":"${longDesc}"}</script>`;
+      const fetcher = vi.fn(async () => html);
+      const out = await __testables.fetchVaudoiseDescription(
+        'https://vaudoise.softgarden.io/job/123/foo',
+        fetcher,
+      );
+      expect(out).toContain('Lorem ipsum');
+      expect(fetcher).toHaveBeenCalledOnce();
+    });
+
+    it('returns empty string on fetcher failure', async () => {
+      const fetcher = vi.fn(async () => '');
+      const out = await __testables.fetchVaudoiseDescription(
+        'https://vaudoise.softgarden.io/job/123/foo',
+        fetcher,
+      );
+      expect(out).toBe('');
+    });
+
+    it('returns empty string for empty url', async () => {
+      const fetcher = vi.fn(async () => 'whatever');
+      const out = await __testables.fetchVaudoiseDescription('', fetcher);
+      expect(out).toBe('');
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+  });
+
   // ── End-to-end through fetchAllVaudoiseJobs ──
   describe('fetchAllVaudoiseJobs (with stubbed runtime)', () => {
+    const longDetailDesc =
+      "Employeur solide et tourné vers l'avenir, la Vaudoise est l'un des assureurs leaders en Suisse. Nous recherchons un spécialiste avec expérience confirmée dans la gestion des sinistres pour rejoindre notre équipe.";
+    const detailHtml = `<script type="application/ld+json">{"@type":"JobPosting","description":"<p>${longDetailDesc}</p>"}</script>`;
+    const detailFetcher = async () => detailHtml;
+
     it('builds NormalizedJob shape from a Softgarden row', async () => {
       const row: RowShape = {
         title: 'Product Manager/in Vorsorge (m/w/d) - 80-100%',
@@ -357,6 +449,7 @@ describe('Vaudoise Assurances crawler parser', () => {
 
       const jobs = await fetchAllVaudoiseJobs({
         _runtime: async () => runtime,
+        _detailFetcher: detailFetcher,
       });
 
       expect(jobs).toHaveLength(1);
@@ -376,6 +469,33 @@ describe('Vaudoise Assurances crawler parser', () => {
       expect(job.employmentType).toBe('PART_TIME');
       expect(job.slug).toMatch(/^product-manager/);
       expect(job.slugByLocale).toHaveProperty(job.sourceLang);
+      // Description should come from the detail page (≥120 chars) so the
+      // locale-validation gate doesn't flag the locale copies as
+      // `untranslated_description`.
+      expect(job.description.length).toBeGreaterThanOrEqual(120);
+      expect(job.description).toContain('assureurs leaders');
+      expect(job.descriptionByLocale[job.sourceLang]).toBe(job.description);
+    });
+
+    it('falls back to a stub description when the detail fetcher returns empty', async () => {
+      const row: RowShape = {
+        title: 'Stub Test Role 100%',
+        url: '../job/77/Stub-Test',
+        location: 'Lausanne',
+        postedDate: '5/8/26',
+        audience: '',
+        jobCategory: '',
+        id: '77',
+      };
+      const { runtime } = makeRuntime([row]);
+      const jobs = await fetchAllVaudoiseJobs({
+        _runtime: async () => runtime,
+        _detailFetcher: async () => '',
+      });
+      expect(jobs).toHaveLength(1);
+      const job = jobs[0];
+      expect(job.description).toContain('Vaudoise Assurances');
+      expect(job.descriptionByLocale[job.sourceLang]).toBe(job.description);
     });
 
     it('returns [] when no Swiss listings are found', async () => {
@@ -392,6 +512,7 @@ describe('Vaudoise Assurances crawler parser', () => {
 
       const jobs = await fetchAllVaudoiseJobs({
         _runtime: async () => runtime,
+        _detailFetcher: detailFetcher,
       });
       expect(jobs).toEqual([]);
     });


### PR DESCRIPTION
The dedicated Vaudoise Assurances crawler has failed every run since the
parser landed: shared locale-hardening repairs 49/49 jobs, then the
validation gate immediately throws "localization validation failed
(58 issues)" (GH run 26004869125 + history).

Two root causes:

1. URL trust mismatch. Postings live on `vaudoise.softgarden.io`
   (Softgarden ATS) but `isTrustedDomain` only whitelisted `vaudoise.ch`,
   so every job tripped `url_not_vaudoise_domain` (49 blocking issues).
   Same shape as the existing `bitfinex` whitelisting of `.recruitee.com`.
   Fix: also trust `vaudoise.softgarden.io`.

2. Stub-description trap. The Softgarden listing rows don't include the
   long description — only title/location/date/category. The parser fell
   back to `"${title} — Vaudoise Assurances"` (~60-90 chars), which the
   hardener copied into every locale slot. When the stub crossed the
   120-char base-thinness threshold (long titles) the validation gate
   flagged the locale copies as `untranslated_description` (blocking,
   not soft). Fix: after the Playwright listing pass, hit each detail URL
   with plain fetch and extract the description from the embedded
   JSON-LD `JobPosting` (verified live: 2241 chars on a sample posting).
   Plain `fetch` + 15s timeout keeps the cost negligible vs the existing
   Playwright load; degrades to the title-stub on any per-URL failure so
   one bad detail page never tanks the whole run.

Tests: +11 new specs covering the Softgarden trusted-domain branch,
JSON-LD parsing (object + array shapes, malformed, missing), the
detail-fetcher seam, and the e2e fall-back when the detail page is
empty. Existing 37 specs unchanged. All 48 green.
