### PR TITLE
docs: refresh comment URLs after long-form canton-slug revert

### DIFF
--- a/build-plugins/cantonOrphanRedirectsPlugin.ts
+++ b/build-plugins/cantonOrphanRedirectsPlugin.ts
@@ -76,7 +76,7 @@ function slugForSlot(slot: SlotKey, locale: Locale, canton: string): string {
 export interface OrphanRedirect {
  /** Absolute path to emit, e.g. `/cerca-lavoro-basilea/offerte-di-lavoro-ticino-oggi/` */
  from: string;
- /** Absolute canonical path, e.g. `/cerca-lavoro-basilea/oggi/` */
+ /** Absolute canonical path, e.g. `/cerca-lavoro-basilea/offerte-di-lavoro-basilea-oggi/` */
  to: string;
  locale: Locale;
  canton: string;

--- a/build-plugins/jobEditorialLanding.ts
+++ b/build-plugins/jobEditorialLanding.ts
@@ -1915,8 +1915,8 @@ export function buildJobCareVariantLandingModel(options: {
  const baseUrl = options.baseUrl.replace(/\/+$/, '');
  // Per-canton scoping: care-variant pages (clinics / care-homes / OSS /
  // educators) previously bypassed the canton filter so per-canton URLs
- // like /cerca-lavoro-basilea/cliniche/ listed clinic jobs from across
- // Switzerland. Narrow to the requested canton — the partition is
+ // like /cerca-lavoro-basilea/cliniche-basilea/ listed clinic jobs from
+ // across Switzerland. Narrow to the requested canton — the partition is
  // canton-agnostic, so the filter is applied in both branches.
  const matchesPool: JobLike[] = options.partition
  ? [...options.partition.byCluster[clusterKey]]

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -1048,8 +1048,9 @@ export function staticPagesPlugin(rootDir: string): Plugin {
   *
   * The cathedral expansion to 26 cantons emits per-canton sector hubs
   * (`/cerca-lavoro-argovia/ingegneri/`), editorial slot pages
-  * (`/cerca-lavoro-giura/oggi/`), city hubs (`/cerca-lavoro-appenzello/herisau/`),
-  * and company-canton hubs (`/cerca-lavoro-basilea/azienda-tally-weijl-basel/`).
+  * (`/cerca-lavoro-giura/offerte-di-lavoro-giura-oggi/`), city hubs
+  * (`/cerca-lavoro-appenzello/herisau/`), and company-canton hubs
+  * (`/cerca-lavoro-basilea/azienda-tally-weijl-basel/`).
   * The non-TI canton hub already links its own leaves via the `data-canton-explore`
   * navigator in `jobsSeoPagesPlugin.ts`, BUT pages with `cantonCount <
   * MIN_JOBS_FOR_CANTON_PAGE` (5) are emitted as `noindex,follow`. The
@@ -3255,12 +3256,12 @@ export function staticPagesPlugin(rootDir: string): Plugin {
    .map((w: string) => w.length > 2 ? w.charAt(0).toUpperCase() + w.slice(1) : w)
    .join(' ');
  cantonAnchors.push(`<a href="${cantonHubHref}" style="display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:#eef2ff;color:#312e81;text-decoration:none;font-size:13px;font-weight:600;border:1px solid #c7d2fe">${esc(displayLabel)}</a>`);
- // Per-canton "today" landing lives under that canton's own section path
- // (`/cerca-lavoro-{canton}/{slug}/`), e.g. `/cerca-lavoro-basilea/oggi/`
- // or `/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/`. The earlier
+ // Per-canton "today" landing lives under that canton's own section
+ // with the canton's per-locale long-form slug, e.g.
+ // `/cerca-lavoro-basilea/offerte-di-lavoro-basilea-oggi/` or
+ // `/cerca-lavoro-ticino/offerte-di-lavoro-ticino-oggi/`. The earlier
  // implementation nested every canton's today slug under `tiSection`
- // (`/cerca-lavoro-ticino/oggi/` etc.) which 404s for non-TI cantons
- // because the actual emit target is `/cerca-lavoro-{canton}/oggi/`.
+ // (`/cerca-lavoro-ticino/<slug>/`) which 404s for non-TI cantons.
  if (code !== AGGREGATE_KEY) {
  const todaySlug = getJobTodayLandingSlug(cantonLocale, code);
  const cantonSectionForToday = resolveCantonSection(cantonLocale, code);


### PR DESCRIPTION
Four stale doc strings still referenced the pre-2026-05-18 Phase-8d short
slugs (`oggi`, `cliniche`, etc.) that were retired in PR #214. None of
them were functional — all four are comments — but they would mislead
future readers about what the canonical URL looks like today.

Refreshed:
 - jobEditorialLanding.ts buildJobCareVariantLandingModel comment
   (cliniche-basilea, not cliniche)
 - cantonOrphanRedirectsPlugin.ts OrphanRedirect.to docstring
 - staticPagesPlugin.ts BFS-depth-closure block (today URL example)
 - staticPagesPlugin.ts cross-canton today-link comment

Swept the codebase for any non-comment hardcoded short-form URL — none
found. All editorial URLs flow through getJobTodayLandingSlug /
getJobNursesHubSlug / getJobPartTimeLandingSlug / careClusterSlug so
sitemap, hreflang, breadcrumb and internal nav stay in sync with the
slug tables automatically.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
