### PR TITLE
fix(crawlers): emit structured bullets in msc-cargo + posta-svizzera descriptions

### DIFF
--- a/data/jobs/by-crawler/msc-cargo.json
+++ b/data/jobs/by-crawler/msc-cargo.json
@@ -1,1091 +1,1087 @@
-{
-  "crawlerKey": "msc-cargo",
-  "assembledAt": "2026-05-17T22:15:36.563Z",
-  "jobs": [
-    {
-      "id": "msc-cargo-f1ddd87c1987",
-      "slug": "shore-excursions-product-development-manager-msc-geneva",
-      "slugByLocale": {
-        "it": "shore-excursions-product-development-manager-msc-geneva",
-        "en": "shore-excursions-product-development-manager-msc-geneva",
-        "de": "shore-excursions-product-development-manager-msc-geneva",
-        "fr": "shore-excursions-product-development-manager-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Shore Excursions Product Development Manager",
-      "titleByLocale": {
-        "it": "Shore Excursions Product Development Manager",
-        "en": "Shore Excursions Product Development Manager",
-        "de": "Shore Excursions Product Development Manager",
-        "fr": "Shore Excursions Product Development Manager"
-      },
-      "description": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!",
-      "descriptionByLocale": {
-        "it": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!",
-        "en": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!",
-        "de": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!",
-        "fr": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15739EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.785Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "IT",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-02-16",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15739EXTERNALENGB",
-      "jobReqId": "15739",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.314Z",
-      "salaryMin": 79500,
-      "salaryMax": 135000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 79500,
-          "maxValue": 135000,
-          "unitText": "YEAR"
-        }
-      }
+[
+  {
+    "id": "msc-cargo-f1ddd87c1987",
+    "slug": "shore-excursions-product-development-manager-msc-geneva",
+    "slugByLocale": {
+      "it": "shore-excursions-product-development-manager-msc-geneva",
+      "en": "shore-excursions-product-development-manager-msc-geneva",
+      "de": "shore-excursions-product-development-manager-msc-geneva",
+      "fr": "shore-excursions-product-development-manager-msc-geneva"
     },
-    {
-      "id": "msc-cargo-82745a9429a3",
-      "slug": "destinations-experience-manager-msc-geneva",
-      "slugByLocale": {
-        "it": "destinations-experience-manager-msc-geneva",
-        "en": "destinations-experience-manager-msc-geneva",
-        "de": "destinations-experience-manager-msc-geneva",
-        "fr": "destinations-experience-manager-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Destinations Experience Manager",
-      "titleByLocale": {
-        "it": "Destinations Experience Manager",
-        "en": "Destinations Experience Manager",
-        "de": "Destinations Experience Manager",
-        "fr": "Destinations Experience Manager"
-      },
-      "description": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!",
-      "descriptionByLocale": {
-        "it": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!",
-        "en": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!",
-        "de": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!",
-        "fr": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16487EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.784Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Produzione",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-02-23",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16487EXTERNALENGB",
-      "jobReqId": "16487",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.314Z",
-      "salaryMin": 68000,
-      "salaryMax": 103000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 68000,
-          "maxValue": 103000,
-          "unitText": "YEAR"
-        }
-      }
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Shore Excursions Product Development Manager",
+    "titleByLocale": {
+      "it": "Shore Excursions Product Development Manager",
+      "en": "Shore Excursions Product Development Manager",
+      "de": "Shore Excursions Product Development Manager",
+      "fr": "Shore Excursions Product Development Manager"
     },
-    {
-      "id": "msc-cargo-be64fb5540f0",
-      "slug": "f-b-service-manager-msc-geneva",
-      "slugByLocale": {
-        "it": "f-b-service-manager-msc-geneva",
-        "en": "f-b-service-manager-msc-geneva",
-        "de": "f-b-service-manager-msc-geneva",
-        "fr": "f-b-service-manager-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "F&B Service Manager",
-      "titleByLocale": {
-        "it": "F&B Service Manager",
-        "en": "F&B Service Manager",
-        "de": "F&B Service Manager",
-        "fr": "F&B Service Manager"
-      },
-      "description": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the...",
-      "descriptionByLocale": {
-        "it": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the...",
-        "en": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the...",
-        "de": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the...",
-        "fr": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the..."
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16384EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.784Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Altro",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-01-30",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16384EXTERNALENGB",
-      "jobReqId": "16384",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.312Z",
-      "salaryMin": 68000,
-      "salaryMax": 103000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 68000,
-          "maxValue": 103000,
-          "unitText": "YEAR"
-        }
-      }
+    "description": "Your Purpose\n\nIn line with current and future tourism trends, the Shore Excursions Product Development Manager oversees product content and delivery, negotiates costs, and develops new tours to grow revenue and enhance guest satisfaction in specific geographical regions.\n\nYour Impact\n\n- Lead the development of innovative shore excursion products and manage the tour program for assigned regions.\n\n- Source and procure high-quality excursions in line with seasonal demand and company standards.\n\n- Monitor market trends, guest preferences, and potential risks to develop effective action and improvement plans.\n\n- Analyze guest feedback and satisfaction scores to drive continuous product and service enhancements.\n\n- Build and maintain relationships with up to 100 tour operators, overseeing a portfolio of 1,000+ tours.\n\n- Negotiate contracts with suppliers, manage large-scale bids, and optimize costs to ensure profitability and efficiency.\n\n- Collaborate cross-functionally with Legal, Insurance, and Operations teams to ensure compliance and risk mitigation.\n\n- Oversee product creation, feedback analysis, and product revamping to maintain competitive and engaging offerings.\n\n- Ensure inventory accuracy and perform regular site inspections within assigned destinations.\n\n- Represent the company at government meetings, industry events, and travel conventions to strengthen partnerships and brand presence.\n\nYour Journey so far\n\n- 10 years of experience in the Shore Excursions Department within the cruise industry (either onboard or ashore) is preferred. Experience in shore excursion operations within the hospitality industry or with a global tour operator may also be considered.\n\n- 5–10+ years of proven experience in global shore excursion operations is required, including product development, bid management, and cross-functional collaboration with legal, insurance, and operations stakeholders.\n\n- A bachelor’s degree in tourism and proficiency in multiple languages are highly preferred.\n\nYour Essentials\n\n- Flexibility and strong analytical skills.\n\n- Excellent communication and collaboration abilities.\n\n- IT-savvy; experience with Fidelio is highly advantageous.\n\n- Advanced proficiency in Microsoft Office applications (Excel, Word, PowerPoint, Publisher).\n\n- Extensive knowledge of shore excursion products and operational delivery.\n\n- Fluent in English with a good command of Italian; additional languages are an asset.\n\n- Willingness to travel up to 25% of the time.\n\n- Must hold an EU passport or have the legal right to work in Switzerland.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!",
+      "en": "Your Purpose\n\nIn line with current and future tourism trends, the Shore Excursions Product Development Manager oversees product content and delivery, negotiates costs, and develops new tours to grow revenue and enhance guest satisfaction in specific geographical regions.\n\nYour Impact\n\n- Lead the development of innovative shore excursion products and manage the tour program for assigned regions.\n\n- Source and procure high-quality excursions in line with seasonal demand and company standards.\n\n- Monitor market trends, guest preferences, and potential risks to develop effective action and improvement plans.\n\n- Analyze guest feedback and satisfaction scores to drive continuous product and service enhancements.\n\n- Build and maintain relationships with up to 100 tour operators, overseeing a portfolio of 1,000+ tours.\n\n- Negotiate contracts with suppliers, manage large-scale bids, and optimize costs to ensure profitability and efficiency.\n\n- Collaborate cross-functionally with Legal, Insurance, and Operations teams to ensure compliance and risk mitigation.\n\n- Oversee product creation, feedback analysis, and product revamping to maintain competitive and engaging offerings.\n\n- Ensure inventory accuracy and perform regular site inspections within assigned destinations.\n\n- Represent the company at government meetings, industry events, and travel conventions to strengthen partnerships and brand presence.\n\nYour Journey so far\n\n- 10 years of experience in the Shore Excursions Department within the cruise industry (either onboard or ashore) is preferred. Experience in shore excursion operations within the hospitality industry or with a global tour operator may also be considered.\n\n- 5–10+ years of proven experience in global shore excursion operations is required, including product development, bid management, and cross-functional collaboration with legal, insurance, and operations stakeholders.\n\n- A bachelor’s degree in tourism and proficiency in multiple languages are highly preferred.\n\nYour Essentials\n\n- Flexibility and strong analytical skills.\n\n- Excellent communication and collaboration abilities.\n\n- IT-savvy; experience with Fidelio is highly advantageous.\n\n- Advanced proficiency in Microsoft Office applications (Excel, Word, PowerPoint, Publisher).\n\n- Extensive knowledge of shore excursion products and operational delivery.\n\n- Fluent in English with a good command of Italian; additional languages are an asset.\n\n- Willingness to travel up to 25% of the time.\n\n- Must hold an EU passport or have the legal right to work in Switzerland.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!",
+      "fr": "Join our team as a Shore Excursions Product Development Manager, where you will lead the creation of innovative tour products, negotiate contracts, and enhance guest satisfaction. If you have a passion for travel and a knack for collaboration, we want to hear from you!"
     },
-    {
-      "id": "msc-cargo-8fd1f556af0a",
-      "slug": "brand-manager-brand-product-msc-geneva",
-      "slugByLocale": {
-        "it": "brand-manager-brand-product-msc-geneva",
-        "en": "brand-manager-brand-product-msc-geneva",
-        "de": "brand-manager-brand-product-msc-geneva",
-        "fr": "brand-manager-brand-product-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Brand Manager - Brand & Product",
-      "titleByLocale": {
-        "it": "Brand Manager - Brand & Product",
-        "en": "Brand Manager - Brand & Product",
-        "de": "Brand Manager - Brand & Product",
-        "fr": "Brand Manager - Brand & Product"
-      },
-      "description": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!",
-      "descriptionByLocale": {
-        "it": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!",
-        "en": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!",
-        "de": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!",
-        "fr": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16918EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.783Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Marketing",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15739EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.785Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "IT",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-02-16",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15739EXTERNALENGB",
+    "jobReqId": "15739",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.314Z",
+    "salaryMin": 79500,
+    "salaryMax": 135000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
       "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-04-20",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16918EXTERNALENGB",
-      "jobReqId": "16918",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.313Z",
-      "salaryMin": 75500,
-      "salaryMax": 133000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 75500,
-          "maxValue": 133000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-9469e7860b49",
-      "slug": "multimedia-and-av-manager-msc-geneva",
-      "slugByLocale": {
-        "it": "multimedia-and-av-manager-msc-geneva",
-        "en": "multimedia-and-av-manager-msc-geneva",
-        "de": "multimedia-and-av-manager-msc-geneva",
-        "fr": "multimedia-and-av-manager-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Multimedia and AV Manager",
-      "titleByLocale": {
-        "it": "Multimedia and AV Manager",
-        "en": "Multimedia and AV Manager",
-        "de": "Multimedia and AV Manager",
-        "fr": "Multimedia and AV Manager"
-      },
-      "description": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!",
-      "descriptionByLocale": {
-        "it": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!",
-        "en": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!",
-        "de": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!",
-        "fr": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16952EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.782Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Hospitality",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-05-07",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16952EXTERNALENGB",
-      "jobReqId": "16952",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.307Z",
-      "salaryMin": 72000,
-      "salaryMax": 90500,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 72000,
-          "maxValue": 90500,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-6a5b336e6a54",
-      "slug": "digital-platforms-manager-msc-geneva",
-      "slugByLocale": {
-        "it": "digital-platforms-manager-msc-geneva",
-        "en": "digital-platforms-manager-msc-geneva",
-        "de": "digital-platforms-manager-msc-geneva",
-        "fr": "digital-platforms-manager-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Digital Platforms Manager",
-      "titleByLocale": {
-        "it": "Digital Platforms Manager",
-        "en": "Digital Platforms Manager",
-        "de": "Digital Platforms Manager",
-        "fr": "Digital Platforms Manager"
-      },
-      "description": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry.",
-      "descriptionByLocale": {
-        "it": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry.",
-        "en": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry.",
-        "de": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry.",
-        "fr": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry."
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16921EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.782Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Marketing",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-04-28",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16921EXTERNALENGB",
-      "jobReqId": "16921",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.313Z",
-      "salaryMin": 75500,
-      "salaryMax": 133000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 75500,
-          "maxValue": 133000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-b4cb66b778c0",
-      "slug": "senior-hr-business-partner-msc-geneva",
-      "slugByLocale": {
-        "it": "senior-hr-business-partner-msc-geneva",
-        "en": "senior-hr-business-partner-msc-geneva",
-        "de": "senior-hr-business-partner-msc-geneva",
-        "fr": "senior-hr-business-partner-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Senior HR Business Partner",
-      "titleByLocale": {
-        "it": "Senior Risorse Umane Business Partner",
-        "en": "Senior HR Business Partner",
-        "de": "Senior Personalwesen Business Partner",
-        "fr": "Senior HR Business Partner"
-      },
-      "description": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness.",
-      "descriptionByLocale": {
-        "it": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness.",
-        "en": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness.",
-        "de": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness.",
-        "fr": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness."
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16316EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.781Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Risorse Umane",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-01-19",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16316EXTERNALENGB",
-      "jobReqId": "16316",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.309Z",
-      "salaryMin": 68000,
-      "salaryMax": 103000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 68000,
-          "maxValue": 103000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-b8db6c0698ca",
-      "slug": "direttore-of-operations-hospitality-infrastructure-msc-group-geneva",
-      "slugByLocale": {
-        "it": "direttore-of-operations-hospitality-infrastructure-msc-group-geneva",
-        "en": "director-of-operations-hospitality-infrastructure-msc-geneva",
-        "de": "direktor-of-operations-hospitality-infrastructure-msc-group-geneva",
-        "fr": "directeur-of-operations-hospitality-infrastructure-msc-group-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Director of Operations - Hospitality Infrastructure",
-      "titleByLocale": {
-        "it": "Direttore of Operations - Hospitality Infrastructure",
-        "en": "Director of Operations - Hospitality Infrastructure",
-        "de": "Direktor of Operations - Hospitality Infrastructure",
-        "fr": "Directeur of Operations - Hospitality Infrastructure"
-      },
-      "description": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,...",
-      "descriptionByLocale": {
-        "it": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,...",
-        "en": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,...",
-        "de": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,...",
-        "fr": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,..."
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16422EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.780Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Produzione",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-02-13",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16422EXTERNALENGB",
-      "jobReqId": "16422",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.305Z",
-      "previousSlugsByLocale": {
-        "it": [
-          "director-of-operations-hospitality-infrastructure-msc-geneva"
-        ],
-        "de": [
-          "director-of-operations-hospitality-infrastructure-msc-geneva"
-        ],
-        "fr": [
-          "director-of-operations-hospitality-infrastructure-msc-geneva"
-        ]
-      },
-      "previousSlugs": [
-        "director-of-operations-hospitality-infrastructure-msc-geneva"
-      ],
-      "salaryMin": 68000,
-      "salaryMax": 103000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 68000,
-          "maxValue": 103000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-57f045d85699",
-      "slug": "senior-project-manager-investimenti-in-infrastrutture-caribico-msc-group-geneva",
-      "slugByLocale": {
-        "it": "senior-project-manager-investimenti-in-infrastrutture-caribico-msc-group-geneva",
-        "en": "senior-project-manager-infrastructure-investments-caribbean-msc-geneva",
-        "de": "senior-projektmanager-infrastrukturinvestitionen-karibik-msc-group-geneva",
-        "fr": "responsable-de-projet-senior-investissements-en-infrastructures-caraibes-msc-group-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Senior Project Manager - Infrastructure Investments (Caribbean)",
-      "titleByLocale": {
-        "it": "Senior Project Manager - Investimenti in Infrastrutture (Caribico)",
-        "en": "Senior Project Manager - Infrastructure Investments (Caribbean)",
-        "de": "Senior Projektmanager - Infrastrukturinvestitionen (Karibik)",
-        "fr": "Responsable de Projet Senior - Investissements en Infrastructures (Caraïbes)"
-      },
-      "description": "This role carries full accountability for project delivery, spanning finance, construction, commercial, operational, HR, regulatory, and stakeholder dimensions. Establish and lead a Project Management...",
-      "descriptionByLocale": {
-        "it": "Descrizione - Questo ruolo comporta la piena responsabilità per la consegna del progetto, che abbraccia le dimensioni finanziarie, costruttive, commerciali, operative, HR, regolamentari e degli stakeholder - Stabilire e guidare un Project Management...",
-        "en": "This role carries full accountability for project delivery, spanning finance, construction, commercial, operational, HR, regulatory, and stakeholder dimensions. Establish and lead a Project Management...",
-        "de": "Beschreibung - Diese Rolle trägt die volle Verantwortung für die Projektlieferung, die Finanz-, Bau-, Handels-, Betriebs-, HR-, Regulierungs- und Stakeholder-Dimensionen umfasst - Etablieren und leiten eines Projektmanagements...",
-        "fr": "Description - Ce rôle implique une responsabilité totale pour la livraison du projet, couvrant les dimensions financières, de construction, commerciales, opérationnelles, RH, réglementaires et des parties prenantes - Établir et diriger une gestion de projet..."
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16283EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.780Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "IT",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-02-02",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16283EXTERNALENGB",
-      "jobReqId": "16283",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "previousSlugs": [
-        "senior-project-manager-infrastructure-investments-caribbean-msc-geneva"
-      ],
-      "previousSlugsByLocale": {
-        "it": [
-          "senior-project-manager-infrastructure-investments-caribbean-msc-geneva"
-        ]
-      },
-      "firstSeenAt": "2026-05-11T12:59:30.064Z",
-      "salaryMin": 79500,
-      "salaryMax": 135000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 79500,
-          "maxValue": 135000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-a231a60627cc",
-      "slug": "responsabile-acquisizione-digitale-msc-group-geneva",
-      "slugByLocale": {
-        "it": "responsabile-acquisizione-digitale-msc-group-geneva",
-        "en": "digital-acquisition-manager-msc-geneva",
-        "de": "digitaler-akquisitionsmanager-msc-group-geneva",
-        "fr": "responsable-de-l-acquisition-numerique-msc-group-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Digital Acquisition Manager",
-      "titleByLocale": {
-        "it": "Responsabile Acquisizione Digitale",
-        "en": "Digital Acquisition Manager",
-        "de": "Digitaler Akquisitionsmanager",
-        "fr": "Responsable de l'acquisition numérique"
-      },
-      "description": "Are you experienced in driving digital marketing strategies? Join us as a Senior Digital Acquisition Manager to lead innovative campaigns, optimize performance, and enhance customer engagement across multiple channels. Your expertise will help shape our digital landscape and drive direct sales growth. Apply now!",
-      "descriptionByLocale": {
-        "it": "Descrizione - Hai esperienza nella gestione di strategie di marketing digitale? - Unisciti a noi come Senior Digital Acquisition Manager per guidare campagne innovative, ottimizzare le performance e migliorare l'engagement dei clienti su più canali - La tua esperienza aiuterà a plasmare il nostro panorama digitale e a incrementare le vendite dirette",
-        "en": "Are you experienced in driving digital marketing strategies? Join us as a Senior Digital Acquisition Manager to lead innovative campaigns, optimize performance, and enhance customer engagement across multiple channels. Your expertise will help shape our digital landscape and drive direct sales growth. Apply now!",
-        "de": "Beschreibung - Haben Sie Erfahrung in der Gestaltung von Digitalmarketing-Strategien? - Treten Sie uns als Senior Digital Acquisition Manager bei, um innovative Kampagnen zu leiten, die Leistung zu optimieren und die Kundenbindung über mehrere Kanäle hinweg zu verbessern - Ihre Expertise wird helfen, unsere digitale Landschaft zu gestalten und den direkten Verkaufswachstum zu steigern - Bewerben Sie sich jetzt!",
-        "fr": "Description - Avez-vous de l'expérience dans la gestion de stratégies de marketing numérique? - Rejoignez-nous en tant que Senior Digital Acquisition Manager pour diriger des campagnes innovantes, optimiser les performances et améliorer l'engagement des clients sur plusieurs canaux - Votre expertise aidera à façonner notre paysage numérique et à stimuler la croissance des ventes directes - Postulez maintenant!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB11987EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.779Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Marketing",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-02-19",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB11987EXTERNALENGB",
-      "jobReqId": "11987",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "previousSlugs": [
-        "digital-acquisition-manager-msc-geneva"
-      ],
-      "previousSlugsByLocale": {
-        "it": [
-          "digital-acquisition-manager-msc-geneva"
-        ]
-      },
-      "firstSeenAt": "2026-05-11T12:59:30.062Z",
-      "salaryMin": 75500,
-      "salaryMax": 133000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 75500,
-          "maxValue": 133000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-d7e4d37de431",
-      "slug": "vice-president-global-spa-and-wellness-msc-geneva",
-      "slugByLocale": {
-        "it": "vice-president-global-spa-and-wellness-msc-geneva",
-        "en": "vice-president-global-spa-and-wellness-msc-geneva",
-        "de": "vice-president-global-spa-and-wellness-msc-geneva",
-        "fr": "vice-president-global-spa-and-wellness-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Vice President Global SPA and Wellness",
-      "titleByLocale": {
-        "it": "Vice President Global SPA and Wellness",
-        "en": "Vice President Global SPA and Wellness",
-        "de": "Vice President Global SPA and Wellness",
-        "fr": "Vice President Global SPA and Wellness"
-      },
-      "description": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!",
-      "descriptionByLocale": {
-        "it": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!",
-        "en": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!",
-        "de": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!",
-        "fr": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15903EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.778Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Marketing",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "mid",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-03-11",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15903EXTERNALENGB",
-      "jobReqId": "15903",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.298Z",
-      "salaryMin": 75500,
-      "salaryMax": 133000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 75500,
-          "maxValue": 133000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-027165218aff",
-      "slug": "crm-direttore-msc-group-geneva",
-      "slugByLocale": {
-        "it": "crm-direttore-msc-group-geneva",
-        "en": "crm-director-msc-geneva",
-        "de": "crm-direktor-msc-group-geneva",
-        "fr": "crm-director-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "CRM Director",
-      "titleByLocale": {
-        "it": "CRM Direttore",
-        "en": "CRM Director",
-        "de": "CRM Direktor",
-        "fr": "CRM Director"
-      },
-      "description": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!",
-      "descriptionByLocale": {
-        "it": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!",
-        "en": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!",
-        "de": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!",
-        "fr": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16545EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.778Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Marketing",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-03-05",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16545EXTERNALENGB",
-      "jobReqId": "16545",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.299Z",
-      "previousSlugsByLocale": {
-        "it": [
-          "crm-director-msc-geneva"
-        ],
-        "de": [
-          "crm-director-msc-geneva"
-        ]
-      },
-      "previousSlugs": [
-        "crm-director-msc-geneva"
-      ],
-      "salaryMin": 75500,
-      "salaryMax": 133000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 75500,
-          "maxValue": 133000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-32cf9574722c",
-      "slug": "culinary-operations-manager-msc-geneva",
-      "slugByLocale": {
-        "it": "culinary-operations-manager-msc-geneva",
-        "en": "culinary-operations-manager-msc-geneva",
-        "de": "culinary-operations-manager-msc-geneva",
-        "fr": "culinary-operations-manager-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Culinary Operations Manager",
-      "titleByLocale": {
-        "it": "Culinary Operations Manager",
-        "en": "Culinary Operations Manager",
-        "de": "Culinary Operations Manager",
-        "fr": "Culinary Operations Manager"
-      },
-      "description": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia...",
-      "descriptionByLocale": {
-        "it": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia...",
-        "en": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia...",
-        "de": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia...",
-        "fr": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia..."
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16385EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.777Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Produzione",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-01-30",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16385EXTERNALENGB",
-      "jobReqId": "16385",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.299Z",
-      "salaryMin": 68000,
-      "salaryMax": 103000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 68000,
-          "maxValue": 103000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-72e4b16fc7fa",
-      "slug": "mobile-app-product-specialista-msc-group-geneva",
-      "slugByLocale": {
-        "it": "mobile-app-product-specialista-msc-group-geneva",
-        "en": "mobile-app-product-specialist-msc-geneva",
-        "de": "mobile-app-product-spezialist-msc-group-geneva",
-        "fr": "mobile-app-product-specialiste-msc-group-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Mobile App Product Specialist",
-      "titleByLocale": {
-        "it": "Mobile App Product Specialista",
-        "en": "Mobile App Product Specialist",
-        "de": "Mobile App Product Spezialist",
-        "fr": "Mobile App Product Spécialiste"
-      },
-      "description": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications.",
-      "descriptionByLocale": {
-        "it": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications.",
-        "en": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications.",
-        "de": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications.",
-        "fr": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications."
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16552EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.775Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Marketing",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "mid",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-03-10",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16552EXTERNALENGB",
-      "jobReqId": "16552",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.297Z",
-      "previousSlugsByLocale": {
-        "it": [
-          "mobile-app-product-specialist-msc-geneva"
-        ],
-        "de": [
-          "mobile-app-product-specialist-msc-geneva"
-        ],
-        "fr": [
-          "mobile-app-product-specialist-msc-geneva"
-        ]
-      },
-      "previousSlugs": [
-        "mobile-app-product-specialist-msc-geneva"
-      ],
-      "salaryMin": 50500,
-      "salaryMax": 89000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 50500,
-          "maxValue": 89000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-620a4e378a97",
-      "slug": "finanza-and-accounting-manager-new-investments-msc-group-geneva",
-      "slugByLocale": {
-        "it": "finanza-and-accounting-manager-new-investments-msc-group-geneva",
-        "en": "finance-and-accounting-manager-new-investments-msc-geneva",
-        "de": "finanzen-and-accounting-manager-new-investments-msc-group-geneva",
-        "fr": "finance-and-accounting-manager-new-investments-msc-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Finance and Accounting Manager - New Investments",
-      "titleByLocale": {
-        "it": "Finanza and Accounting Manager - New Investments",
-        "en": "Finance and Accounting Manager - New Investments",
-        "de": "Finanzen and Accounting Manager - New Investments",
-        "fr": "Finance and Accounting Manager - New Investments"
-      },
-      "description": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!",
-      "descriptionByLocale": {
-        "it": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!",
-        "en": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!",
-        "de": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!",
-        "fr": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16550EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.774Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "Finanza",
-      "contract": "full-time",
-      "employmentType": "OTHER",
-      "experienceLevel": "senior",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-03-09",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16550EXTERNALENGB",
-      "jobReqId": "16550",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "needsRetranslation": true,
-      "firstSeenAt": "2026-05-17T10:50:48.295Z",
-      "previousSlugsByLocale": {
-        "it": [
-          "finance-and-accounting-manager-new-investments-msc-geneva"
-        ],
-        "de": [
-          "finance-and-accounting-manager-new-investments-msc-geneva"
-        ]
-      },
-      "previousSlugs": [
-        "finance-and-accounting-manager-new-investments-msc-geneva"
-      ],
-      "salaryMin": 68000,
-      "salaryMax": 103000,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 68000,
-          "maxValue": 103000,
-          "unitText": "YEAR"
-        }
-      }
-    },
-    {
-      "id": "msc-cargo-1850ab808b78",
-      "slug": "junior-architetto-port-development-intern-msc-group-geneva",
-      "slugByLocale": {
-        "it": "junior-architetto-port-development-intern-msc-group-geneva",
-        "en": "junior-architect-port-development-intern-msc-geneva",
-        "de": "junior-architect-port-development-praktikant-msc-group-geneva",
-        "fr": "junior-architecte-port-development-stagiaire-msc-group-geneva"
-      },
-      "company": "MSC Group",
-      "companyKey": "msc-cargo",
-      "companyDomain": "msc.com",
-      "title": "Junior Architect Port Development Intern",
-      "titleByLocale": {
-        "it": "Junior Architetto Port Development Tirocinante",
-        "en": "Junior Architect Port Development Intern",
-        "de": "Junior Architect Port Development Praktikant",
-        "fr": "Junior Architecte Port Development Stagiaire"
-      },
-      "description": "Kickstart your architecture career as a Junior Architect Port Development Intern! Support innovative port and infrastructure projects, create technical drawings, and develop 3D models using AutoCAD, SketchUp, and real-time rendering tools. Collaborate on spatial studies and presentations while gaining hands-on experience in a dynamic, international environment. Join us and shape the future of port development!",
-      "descriptionByLocale": {
-        "it": "Descrizione - Inizia la tua carriera di architetto junior Port Development Intern! - Sostenere progetti innovativi di porto e infrastrutture - Creare disegni tecnici - Sviluppare modelli 3D utilizzando strumenti di rendering AutoCAD, SketchUp e in tempo reale - Collaborare su studi e presentazioni spaziali - Ottieni esperienza pratica in un ambiente dinamico e internazionale - Unisciti a noi e modella il futuro dello sviluppo portuale!",
-        "en": "Kickstart your architecture career as a Junior Architect Port Development Intern! Support innovative port and infrastructure projects, create technical drawings, and develop 3D models using AutoCAD, SketchUp, and real-time rendering tools. Collaborate on spatial studies and presentations while gaining hands-on experience in a dynamic, international environment. Join us and shape the future of port development!",
-        "de": "Beschreibung - Starten Sie Ihre Architekturkarriere als Junior Architect Port Development Intern! - Unterstützung innovativer Hafen- und Infrastrukturprojekte - technische Zeichnungen erstellen - Entwickeln Sie 3D-Modelle mit AutoCAD, SketchUp und Echtzeit-Rendering-Tools - Zusammenarbeit bei Raumstudien und Präsentationen - Erfahrung in einem dynamischen, internationalen Umfeld sammeln - Mitmachen und die Zukunft der Hafenentwicklung gestalten!",
-        "fr": "Descrizione - Commencez votre carrière d'architecte junior en tant que stagiaire en développement portuaire ! - Soutenir des projets portuaires et d'infrastructure innovants - Créer des dessins techniques - Développer des modèles 3D en utilisant AutoCAD, SketchUp et des outils de rendu en temps réel - Collaborer à des études et des présentations spatiales - Acquérir une expérience pratique dans un environnement international dynamique - Rejoignez-nous et façonnez l'avenir du développement portuaire !"
-      },
-      "location": "Geneva",
-      "canton": "GE",
-      "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16951EXTERNALENGB",
-      "source": "MSC Group Dedicated Parser (Phenom careers portal)",
-      "sourceLang": "en",
-      "crawledAt": "2026-05-17T22:15:34.764Z",
-      "addressLocality": "Geneva",
-      "addressRegion": "GE",
-      "addressCountry": "CH",
-      "country": "CH",
-      "category": "IT",
-      "contract": "full-time",
-      "employmentType": "INTERN",
-      "experienceLevel": "intern",
-      "sector": "Logistica e crocieristica",
-      "currency": "CHF",
-      "featured": false,
-      "postedDate": "2026-05-05",
-      "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16951EXTERNALENGB",
-      "jobReqId": "16951",
-      "requirements": [],
-      "requirementsByLocale": {},
-      "previousSlugs": [
-        "junior-architect-port-development-intern-msc-geneva"
-      ],
-      "previousSlugsByLocale": {
-        "it": [
-          "junior-architect-port-development-intern-msc-geneva"
-        ],
-        "de": [
-          "junior-architect-port-development-intern-msc-geneva"
-        ],
-        "fr": [
-          "junior-architect-port-development-intern-msc-geneva"
-        ]
-      },
-      "firstSeenAt": "2026-05-13T22:48:16.135Z",
-      "salaryMin": 46000,
-      "salaryMax": 78500,
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 46000,
-          "maxValue": 78500,
-          "unitText": "YEAR"
-        }
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 79500,
+        "maxValue": 135000,
+        "unitText": "YEAR"
       }
     }
-  ]
-}
+  },
+  {
+    "id": "msc-cargo-82745a9429a3",
+    "slug": "destinations-experience-manager-msc-geneva",
+    "slugByLocale": {
+      "it": "destinations-experience-manager-msc-geneva",
+      "en": "destinations-experience-manager-msc-geneva",
+      "de": "destinations-experience-manager-msc-geneva",
+      "fr": "destinations-experience-manager-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Destinations Experience Manager",
+    "titleByLocale": {
+      "it": "Destinations Experience Manager",
+      "en": "Destinations Experience Manager",
+      "de": "Destinations Experience Manager",
+      "fr": "Destinations Experience Manager"
+    },
+    "description": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nThe Destination Experience Manager is fully responsible for the performance, development, and operational excellence of assigned regions.\nThis role requires strong cruise shore excursion experience, deep knowledge of ports and destination logistics, and a solid understanding of onboard operations. The Manager oversees the full lifecycle of destination experiences — from sourcing and contracting to onboard delivery and financial performance.\n\nYour Impact\n\nDestination & Product Management\n•    Develop and manage destination experiences across assigned regions\n•    Scout and contract TOs/DMCs through structured bidding and negotiation\n•    Ensure experiences are operationally feasible and aligned with luxury brand standards\n•    Manage pricing, ROI, and capacity planning\n•    Oversee content coordination with Marketing and system loading (Seaware, Otalio, etc.)\n\nOnboard & Operational Support\n•    Ensure products reflect onboard realities (timings, guest demographics, mobility considerations)\n•    Train and support onboard Destination teams\n•    Assist with escalations, refunds, and service recovery when required\n•    Monitor guest feedback and implement corrective actions\n\nFinancial & Performance Management\n•    Own budgeting and revenue performance for assigned regions\n•    Monitor margins, refund trends, and voyage-level contribution\n•    Identify underperforming ports and optimize offerings accordingly\n•    Partner with Finance and Analytics on reporting and dashboards\n\n \n\nYour Journey so far\n\n- 7–10+ years in cruise shore excursions, destination management, or luxury travel\n\n- Bachelor’s degree in Hospitality, Tourism, Business, or equivalent experience preferred.\n\nYour Essentials\n\n- Strong onboard cruise experience and operational understanding\n\n- Deep knowledge of ports and destination infrastructure\n\n- Knowledge of Alaska, Caribbean, South America, or Asia regions is a strong advantage\n\n- Proven negotiation and financial management skills\n\n- Strong analytical and communication abilities\n\n- Fluent in English; additional languages are an asset\n\n- Valid Swiss work permit or eligibility to work in Switzerland / US permit for Miami position \n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+    "descriptionByLocale": {
+      "it": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!",
+      "en": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nThe Destination Experience Manager is fully responsible for the performance, development, and operational excellence of assigned regions.\nThis role requires strong cruise shore excursion experience, deep knowledge of ports and destination logistics, and a solid understanding of onboard operations. The Manager oversees the full lifecycle of destination experiences — from sourcing and contracting to onboard delivery and financial performance.\n\nYour Impact\n\nDestination & Product Management\n•    Develop and manage destination experiences across assigned regions\n•    Scout and contract TOs/DMCs through structured bidding and negotiation\n•    Ensure experiences are operationally feasible and aligned with luxury brand standards\n•    Manage pricing, ROI, and capacity planning\n•    Oversee content coordination with Marketing and system loading (Seaware, Otalio, etc.)\n\nOnboard & Operational Support\n•    Ensure products reflect onboard realities (timings, guest demographics, mobility considerations)\n•    Train and support onboard Destination teams\n•    Assist with escalations, refunds, and service recovery when required\n•    Monitor guest feedback and implement corrective actions\n\nFinancial & Performance Management\n•    Own budgeting and revenue performance for assigned regions\n•    Monitor margins, refund trends, and voyage-level contribution\n•    Identify underperforming ports and optimize offerings accordingly\n•    Partner with Finance and Analytics on reporting and dashboards\n\n \n\nYour Journey so far\n\n- 7–10+ years in cruise shore excursions, destination management, or luxury travel\n\n- Bachelor’s degree in Hospitality, Tourism, Business, or equivalent experience preferred.\n\nYour Essentials\n\n- Strong onboard cruise experience and operational understanding\n\n- Deep knowledge of ports and destination infrastructure\n\n- Knowledge of Alaska, Caribbean, South America, or Asia regions is a strong advantage\n\n- Proven negotiation and financial management skills\n\n- Strong analytical and communication abilities\n\n- Fluent in English; additional languages are an asset\n\n- Valid Swiss work permit or eligibility to work in Switzerland / US permit for Miami position \n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+      "de": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!",
+      "fr": "Join our team as a Destination Experience Manager, where your passion for luxury travel meets operational excellence. Leverage your expertise in cruise shore excursions and destination management to create unforgettable experiences. If you have strong negotiation skills and a deep understanding of destination logistics, we want to hear from you!"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16487EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.784Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Produzione",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-02-23",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16487EXTERNALENGB",
+    "jobReqId": "16487",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.314Z",
+    "salaryMin": 68000,
+    "salaryMax": 103000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 68000,
+        "maxValue": 103000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-be64fb5540f0",
+    "slug": "f-b-service-manager-msc-geneva",
+    "slugByLocale": {
+      "it": "f-b-service-manager-msc-geneva",
+      "en": "f-b-service-manager-msc-geneva",
+      "de": "f-b-service-manager-msc-geneva",
+      "fr": "f-b-service-manager-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "F&B Service Manager",
+    "titleByLocale": {
+      "it": "F&B Service Manager",
+      "en": "F&B Service Manager",
+      "de": "F&B Service Manager",
+      "fr": "F&B Service Manager"
+    },
+    "description": "Your Purpose\n\nThe F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. This role ensures service excellence, consistency in guest experience, and alignment with corporate standards. Acting as the primary liaison between shipboard teams and corporate leadership, the Manager of F&B Service drives quality, innovation, compliance, and talent development across all F&B operations. This role reports directly to the Vice President of F&B.\n\nYour Impact\n\nStrategic Operations & Standards\n\n- Define, implement, and maintain fleet-wide F&B service standards and best practices.\n\n- Develop and oversee strategic initiatives to enhance guest experience and operational efficiency across all vessels.\n\n- Coordinate with shipboard teams to ensure compliance with corporate policies, procedures, and brand standards.\n\n- Conduct remote audits, operational reviews, and assessments to maintain service excellence.\n\nGuest Experience & Quality Assurance\n\n- Monitor guest satisfaction and F&B performance metrics, analyze trends, and recommend improvements.\n\n- Collaborate with culinary and beverage teams to innovate and elevate the onboard F&B offering.\n\n- Ensure alignment with global health, safety, and hygiene protocols through corporate-led programs.\n\nTraining & Leadership Development\n\n- Design and oversee training programs for F&B teams to ensure consistency with the brand’s service philosophy.\n\n- Mentor and develop shipboard F&B leaders to support career progression and succession planning.\n\nHuman Resources & Leadership Oversight\n\n- Collaborate with HR on performance reviews, promotions, rotations, and career pathing for F&B personnel.\n\n- Promote a high-performance culture rooted in recognition, development, and fairness.\n\nFleet Support & Headquarters Coordination\n\n- Serve as the principal corporate liaison for all F&B service matters across the fleet.\n\n- Coordinate F&B equipment planning, material sourcing, and integration of brand standards.\n\n- Compile and analyze operational reports, voyage summaries, and performance metrics for corporate leadership.\n\n- Participate in key shipboard meetings remotely or in person as required.\n\nFinancial Oversight\n\n- Support financial sustainability and profitability of F&B operations across the fleet.\n\n- Implement continuous improvement programs to achieve operational and financial targets.\n\n- Oversee cost control, inventory planning, and resource allocation in coordination with shipboard teams.\n\nYour Journey so far\n\n- Minimum 15 years in high-end Food & Beverage operations.\n\n- At least 5 years in senior leadership roles within luxury hospitality or cruise operations.\n\n- Proven experience in multi-site operational oversight.\n\nYour Essentials\n\nLeadership & Communication\n\n- Strategic, dynamic leader with experience managing multicultural teams.\n\n- Excellent communication skills, fluent in English; additional languages an asset.\n\nTechnical & Operational Knowledge\n\n- Proficient in Microsoft Office and industry-specific systems.\n\n- Strong understanding of HR protocols, labor regulations, and compliance standards.\n\n- Expert knowledge of F&B operations, beverage programming, and luxury hospitality standards.\n\nProfessional Competencies\n\n- Strategic thinker with operational agility and strong business acumen.\n\n- Results-driven, detail-oriented, and highly collaborative.\n\n- Capable of working cross-functionally across corporate and shipboard teams.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the...",
+      "en": "Your Purpose\n\nThe F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. This role ensures service excellence, consistency in guest experience, and alignment with corporate standards. Acting as the primary liaison between shipboard teams and corporate leadership, the Manager of F&B Service drives quality, innovation, compliance, and talent development across all F&B operations. This role reports directly to the Vice President of F&B.\n\nYour Impact\n\nStrategic Operations & Standards\n\n- Define, implement, and maintain fleet-wide F&B service standards and best practices.\n\n- Develop and oversee strategic initiatives to enhance guest experience and operational efficiency across all vessels.\n\n- Coordinate with shipboard teams to ensure compliance with corporate policies, procedures, and brand standards.\n\n- Conduct remote audits, operational reviews, and assessments to maintain service excellence.\n\nGuest Experience & Quality Assurance\n\n- Monitor guest satisfaction and F&B performance metrics, analyze trends, and recommend improvements.\n\n- Collaborate with culinary and beverage teams to innovate and elevate the onboard F&B offering.\n\n- Ensure alignment with global health, safety, and hygiene protocols through corporate-led programs.\n\nTraining & Leadership Development\n\n- Design and oversee training programs for F&B teams to ensure consistency with the brand’s service philosophy.\n\n- Mentor and develop shipboard F&B leaders to support career progression and succession planning.\n\nHuman Resources & Leadership Oversight\n\n- Collaborate with HR on performance reviews, promotions, rotations, and career pathing for F&B personnel.\n\n- Promote a high-performance culture rooted in recognition, development, and fairness.\n\nFleet Support & Headquarters Coordination\n\n- Serve as the principal corporate liaison for all F&B service matters across the fleet.\n\n- Coordinate F&B equipment planning, material sourcing, and integration of brand standards.\n\n- Compile and analyze operational reports, voyage summaries, and performance metrics for corporate leadership.\n\n- Participate in key shipboard meetings remotely or in person as required.\n\nFinancial Oversight\n\n- Support financial sustainability and profitability of F&B operations across the fleet.\n\n- Implement continuous improvement programs to achieve operational and financial targets.\n\n- Oversee cost control, inventory planning, and resource allocation in coordination with shipboard teams.\n\nYour Journey so far\n\n- Minimum 15 years in high-end Food & Beverage operations.\n\n- At least 5 years in senior leadership roles within luxury hospitality or cruise operations.\n\n- Proven experience in multi-site operational oversight.\n\nYour Essentials\n\nLeadership & Communication\n\n- Strategic, dynamic leader with experience managing multicultural teams.\n\n- Excellent communication skills, fluent in English; additional languages an asset.\n\nTechnical & Operational Knowledge\n\n- Proficient in Microsoft Office and industry-specific systems.\n\n- Strong understanding of HR protocols, labor regulations, and compliance standards.\n\n- Expert knowledge of F&B operations, beverage programming, and luxury hospitality standards.\n\nProfessional Competencies\n\n- Strategic thinker with operational agility and strong business acumen.\n\n- Results-driven, detail-oriented, and highly collaborative.\n\n- Capable of working cross-functionally across corporate and shipboard teams.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the...",
+      "fr": "The F&B Service Manager is a strategic headquarters-based role responsible for providing leadership, oversight, and guidance for all Food & Beverage service operations across the fleet. Acting as the..."
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16384EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.784Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Altro",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-01-30",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16384EXTERNALENGB",
+    "jobReqId": "16384",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.312Z",
+    "salaryMin": 68000,
+    "salaryMax": 103000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 68000,
+        "maxValue": 103000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-8fd1f556af0a",
+    "slug": "brand-manager-brand-product-msc-geneva",
+    "slugByLocale": {
+      "it": "brand-manager-brand-product-msc-geneva",
+      "en": "brand-manager-brand-product-msc-geneva",
+      "de": "brand-manager-brand-product-msc-geneva",
+      "fr": "brand-manager-brand-product-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Brand Manager - Brand & Product",
+    "titleByLocale": {
+      "it": "Brand Manager - Brand & Product",
+      "en": "Brand Manager - Brand & Product",
+      "de": "Brand Manager - Brand & Product",
+      "fr": "Brand Manager - Brand & Product"
+    },
+    "description": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nDiscover your journey into the extraordinary.\n\nExplora Journeys is a vibrant, cosmopolitan, European luxury brand, imagined in the heart of Swiss hospitality in Geneva. Leveraging our parent company MSC Group’s hundreds of years of maritime expertise, our fleet of six luxury ships (four currently in the pipeline) are being built and designed in a totally different and unique way that will transform and redefine the cruise experience, creating a category of its own, appealing to the next generation of luxury travellers. \n\nPart of the global Marketing team and reporting directly to the Brand Director, this role plays a central role in safeguarding, shaping and activating the Explora Journeys brand across all touchpoints, with a particular focus on brand campaigns, the fleet and new brand developments.\n\nBased at our headquarters in Geneva, this role sits at the intersection of brand strategy, product storytelling, and execution, working closely with Product, Design, Hotel Operations, Commercial, PR, Media, and Digital teams to bring the brand to life with clarity, consistency and emotional depth, across markets.\n\n \n\nYour Impact\n\nBrand Management & Governance\n\n- Act as a core guardian of the Explora Journeys brand, supporting the Brand Director in the day to day management, development, and evolution of the brand.\n\n- Ensure consistent application of brand identity, tone of voice, messaging, and visual language across all touchpoints, channels, and guest journeys.\n\n- Lead the development, evolution and maintenance of brand guidelines, frameworks, and master toolkits, ensuring relevance, clarity, and scalability globally.\n\n- Monitor brand execution across markets and partners, proactively identifying inconsistencies and working collaboratively with stakeholders to safeguard luxury and hospitality standards.\n\n- Contribute to brand strategy initiatives, brand evolution projects, and internal brand education, strengthening brand understanding and alignment across the organisation.\n\nCampaigns, Content & Brand Activation\n\n- Lead the development and delivery of master brand and product campaigns, in line with brand strategy and commercial priorities.\n\n- Oversee the creation of hero brand and product assets, including key visuals, copy frameworks, brochures, photography, and videography.\n\n- Work closely with Media, Digital, and PR teams to ensure a coherent  and premium brand expression across paid, owned, and earned channels.\n\n- Manage and curate brand, product and fleet content within DAM and PIM systems, ensuring accuracy, ease of use and global market adoption.\n\nProduct Marketing – Fleet & Onboard Experience\n\n- Own and articulate the brand and product narrative for the Explora Journeys fleet, translating ship design, onboard experiences and service philosophy into compelling, clear, and guest-centric storytelling.\n\n- Act as a key brand partner to Product, New Builds and Hotel Operations teams, supporting projects throughout the ship lifecycle; from early concept through delivery, launch and in-service evolution.\n\n- Define and activate ship level propositions and concepts, onboard experiences, suite concepts, culinary, wellness and retail pillars, and service rituals.\n\n- Ensure alignment between the onboard guest experience and the brand promise communicated to market.\n\nLaunch & Go to Market Coordination\n\n- Support brand and product readiness for new brand initiatives, campaigns, ship launches, major milestones, and onboard innovations.\n\n- Develop master launch toolkits to equip channels, markets, Sales, and PR with clear narratives, positioning and assets.\n\n- Ensure consistency, clarity and brand alignment across all internal and external communications related to brand, fleet and product evolution.\n\nCross Functional Collaboration & Operational Excellence\n\n- Act as a trusted brand partner across functions, fostering alignment between brand, product, commercial, and operational teams\n\n- Coordinate budgets, suppliers, forecasting, purchase orders, and invoicing related to brand initiatives.\n\n- Balance strategic brand thinking with hands on execution in a fast paced environment.\n\n \n\nYour Journey so far\n\n- Master’s degree in Marketing, Brand Management, Product Marketing, or a related field.\n\n- 8+ years’ experience in brand management and campaign building.\n\n- Prior experience within luxury, premium or high-end travel, hospitality or consumer brands strongly preferred.\n\n- Proven experience operating in a global headquarters environment, managing brand frameworks and master assets across markets.\n\n- Experience managing agencies and external creative partners.\n\nYour Essentials\n\n- Exposure to product marketing and physical experience‑based products (ships, hotels, resorts, or complex premium environments highly desirable).\n\n- Strong creative sensibility combined with operational rigour, attention to detail and stakeholder management skills.\n\n- Comfortable moving between strategic brand thinking and detailed execution.\n\n- Fluent in English; additional European languages are a strong advantage.\n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+    "descriptionByLocale": {
+      "it": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!",
+      "en": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nDiscover your journey into the extraordinary.\n\nExplora Journeys is a vibrant, cosmopolitan, European luxury brand, imagined in the heart of Swiss hospitality in Geneva. Leveraging our parent company MSC Group’s hundreds of years of maritime expertise, our fleet of six luxury ships (four currently in the pipeline) are being built and designed in a totally different and unique way that will transform and redefine the cruise experience, creating a category of its own, appealing to the next generation of luxury travellers. \n\nPart of the global Marketing team and reporting directly to the Brand Director, this role plays a central role in safeguarding, shaping and activating the Explora Journeys brand across all touchpoints, with a particular focus on brand campaigns, the fleet and new brand developments.\n\nBased at our headquarters in Geneva, this role sits at the intersection of brand strategy, product storytelling, and execution, working closely with Product, Design, Hotel Operations, Commercial, PR, Media, and Digital teams to bring the brand to life with clarity, consistency and emotional depth, across markets.\n\n \n\nYour Impact\n\nBrand Management & Governance\n\n- Act as a core guardian of the Explora Journeys brand, supporting the Brand Director in the day to day management, development, and evolution of the brand.\n\n- Ensure consistent application of brand identity, tone of voice, messaging, and visual language across all touchpoints, channels, and guest journeys.\n\n- Lead the development, evolution and maintenance of brand guidelines, frameworks, and master toolkits, ensuring relevance, clarity, and scalability globally.\n\n- Monitor brand execution across markets and partners, proactively identifying inconsistencies and working collaboratively with stakeholders to safeguard luxury and hospitality standards.\n\n- Contribute to brand strategy initiatives, brand evolution projects, and internal brand education, strengthening brand understanding and alignment across the organisation.\n\nCampaigns, Content & Brand Activation\n\n- Lead the development and delivery of master brand and product campaigns, in line with brand strategy and commercial priorities.\n\n- Oversee the creation of hero brand and product assets, including key visuals, copy frameworks, brochures, photography, and videography.\n\n- Work closely with Media, Digital, and PR teams to ensure a coherent  and premium brand expression across paid, owned, and earned channels.\n\n- Manage and curate brand, product and fleet content within DAM and PIM systems, ensuring accuracy, ease of use and global market adoption.\n\nProduct Marketing – Fleet & Onboard Experience\n\n- Own and articulate the brand and product narrative for the Explora Journeys fleet, translating ship design, onboard experiences and service philosophy into compelling, clear, and guest-centric storytelling.\n\n- Act as a key brand partner to Product, New Builds and Hotel Operations teams, supporting projects throughout the ship lifecycle; from early concept through delivery, launch and in-service evolution.\n\n- Define and activate ship level propositions and concepts, onboard experiences, suite concepts, culinary, wellness and retail pillars, and service rituals.\n\n- Ensure alignment between the onboard guest experience and the brand promise communicated to market.\n\nLaunch & Go to Market Coordination\n\n- Support brand and product readiness for new brand initiatives, campaigns, ship launches, major milestones, and onboard innovations.\n\n- Develop master launch toolkits to equip channels, markets, Sales, and PR with clear narratives, positioning and assets.\n\n- Ensure consistency, clarity and brand alignment across all internal and external communications related to brand, fleet and product evolution.\n\nCross Functional Collaboration & Operational Excellence\n\n- Act as a trusted brand partner across functions, fostering alignment between brand, product, commercial, and operational teams\n\n- Coordinate budgets, suppliers, forecasting, purchase orders, and invoicing related to brand initiatives.\n\n- Balance strategic brand thinking with hands on execution in a fast paced environment.\n\n \n\nYour Journey so far\n\n- Master’s degree in Marketing, Brand Management, Product Marketing, or a related field.\n\n- 8+ years’ experience in brand management and campaign building.\n\n- Prior experience within luxury, premium or high-end travel, hospitality or consumer brands strongly preferred.\n\n- Proven experience operating in a global headquarters environment, managing brand frameworks and master assets across markets.\n\n- Experience managing agencies and external creative partners.\n\nYour Essentials\n\n- Exposure to product marketing and physical experience‑based products (ships, hotels, resorts, or complex premium environments highly desirable).\n\n- Strong creative sensibility combined with operational rigour, attention to detail and stakeholder management skills.\n\n- Comfortable moving between strategic brand thinking and detailed execution.\n\n- Fluent in English; additional European languages are a strong advantage.\n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+      "de": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!",
+      "fr": "We are looking for a passionate Brand Manager to join Explora Journeys, where you will safeguard and activate our luxury brand across all touchpoints. Collaborate with cross-functional teams to deliver compelling brand narratives and campaigns that resonate with our guests. Join us in redefining luxury ocean travel!"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16918EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.783Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Marketing",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-04-20",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16918EXTERNALENGB",
+    "jobReqId": "16918",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.313Z",
+    "salaryMin": 75500,
+    "salaryMax": 133000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 75500,
+        "maxValue": 133000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-9469e7860b49",
+    "slug": "multimedia-and-av-manager-msc-geneva",
+    "slugByLocale": {
+      "it": "multimedia-and-av-manager-msc-geneva",
+      "en": "multimedia-and-av-manager-msc-geneva",
+      "de": "multimedia-and-av-manager-msc-geneva",
+      "fr": "multimedia-and-av-manager-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Multimedia and AV Manager",
+    "titleByLocale": {
+      "it": "Multimedia and AV Manager",
+      "en": "Multimedia and AV Manager",
+      "de": "Multimedia and AV Manager",
+      "fr": "Multimedia and AV Manager"
+    },
+    "description": "Your Purpose\n\nLead and define the strategic planning, deployment, and operational management of the Multimedia Department while supporting audiovisual (AV) systems across fleet and corporate infrastructure. Oversee fleet multimedia content, technology innovation, and AV operations to maximise guest experience and maintain consistent brand standards. Working closely with global teams, new build projects, and external stakeholders, drive collaboration across Entertainment, Marketing, IT, Digital, Production, and technical functions to deliver seamless digital experiences. The AV scope expands beyond traditional multimedia, supporting wider technical initiatives across the Entertainment division — including theatrical and guest activities — and acting as a key bridge between operational entertainment needs and technical delivery teams.\n\nYour Impact\n\n- Manage multimedia and AV operations, including the design, implementation, optimisation, and lifecycle management of audio, video, broadcast, digital signage, and content delivery systems.\n\n- Partner with shoreside and onboard technical teams to ensure equipment reliability, structured maintenance planning, operational scheduling, and agreed repair strategies across the fleet.\n\n- Lead cross-functional initiatives with Entertainment, Marketing, IT, Digital, Production, and technical stakeholders to deliver innovative onboard and shoreside guest experiences.\n\n- Act as the primary liaison between Entertainment, Production vendors, external contractors, and the Show and Multimedia department, translating creative and operational requirements into scalable technical solutions.\n\n- Advise and support New Build projects on multimedia and AV technical requirements, ensuring future-proof, sustainable technology integration.\n\n- Collaborate with Brand, Marketing, and content providers to develop, brief, and implement new ship-based media content strategies and onboard marketing initiatives.\n\n- Define and project manage operational workflows and delivery plans for Entertainment and onboard marketing content across shipboard screens and digital platforms.\n\n- Oversee vendor relationships, procurement activities, and associated budgets to maintain cost efficiency while ensuring technical excellence.\n\n- Monitor and evaluate global technology trends to keep fleet systems innovative, competitive, and aligned with evolving guest expectations.\n\n- Develop, maintain, and continuously improve standard operating procedures and technical standards, ensuring fleetwide consistency, safety, and operational efficiency in line with corporate Entertainment guidelines.\n\n- Supervise, appraise, and mentor ship-based and touring technicians globally, ensuring compliance with safety, maritime, and corporate policies.\n\n- Support live events, broadcasting, corporate communications, and multimedia initiatives through strategic planning combined with hands-on technical leadership.\n\n- Manage and govern visual content provided by internal and external partners for broadcast across onboard platforms.\n\nYour Journey so far\n\n- Extensive experience within cruise environments is a must.\n\n- Senior operational and managerial experience within the Entertainment industry.\n\n- Mother tongue English; Italian, German, or Spanish advantageous.\n\n- Strong background in broadcasting, web, TV, theatrical production, or digital media operations with managerial responsibility.\n\n- Knowledge of enterprise Content Management Systems and digital platforms.\n\n- Solid IT literacy with understanding of systems architecture and AV integration.\n\n- Full understanding of LES systems within the maritime industry.\n\n- Advanced computer literacy (Microsoft Office, Adobe Creative Suite, and CAD software).\n\n- Strong project management and stakeholder coordination skills.\n\n- Proven ability to work autonomously, solve complex operational challenges, and manage global teams.\n\n- International mindset with experience supporting mixed-nationality audiences and global operations.\n\n- Willingness to travel extensively.\n\nYour Essentials\n\n- SWISS Resident or Visa Holder\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!",
+      "en": "Your Purpose\n\nLead and define the strategic planning, deployment, and operational management of the Multimedia Department while supporting audiovisual (AV) systems across fleet and corporate infrastructure. Oversee fleet multimedia content, technology innovation, and AV operations to maximise guest experience and maintain consistent brand standards. Working closely with global teams, new build projects, and external stakeholders, drive collaboration across Entertainment, Marketing, IT, Digital, Production, and technical functions to deliver seamless digital experiences. The AV scope expands beyond traditional multimedia, supporting wider technical initiatives across the Entertainment division — including theatrical and guest activities — and acting as a key bridge between operational entertainment needs and technical delivery teams.\n\nYour Impact\n\n- Manage multimedia and AV operations, including the design, implementation, optimisation, and lifecycle management of audio, video, broadcast, digital signage, and content delivery systems.\n\n- Partner with shoreside and onboard technical teams to ensure equipment reliability, structured maintenance planning, operational scheduling, and agreed repair strategies across the fleet.\n\n- Lead cross-functional initiatives with Entertainment, Marketing, IT, Digital, Production, and technical stakeholders to deliver innovative onboard and shoreside guest experiences.\n\n- Act as the primary liaison between Entertainment, Production vendors, external contractors, and the Show and Multimedia department, translating creative and operational requirements into scalable technical solutions.\n\n- Advise and support New Build projects on multimedia and AV technical requirements, ensuring future-proof, sustainable technology integration.\n\n- Collaborate with Brand, Marketing, and content providers to develop, brief, and implement new ship-based media content strategies and onboard marketing initiatives.\n\n- Define and project manage operational workflows and delivery plans for Entertainment and onboard marketing content across shipboard screens and digital platforms.\n\n- Oversee vendor relationships, procurement activities, and associated budgets to maintain cost efficiency while ensuring technical excellence.\n\n- Monitor and evaluate global technology trends to keep fleet systems innovative, competitive, and aligned with evolving guest expectations.\n\n- Develop, maintain, and continuously improve standard operating procedures and technical standards, ensuring fleetwide consistency, safety, and operational efficiency in line with corporate Entertainment guidelines.\n\n- Supervise, appraise, and mentor ship-based and touring technicians globally, ensuring compliance with safety, maritime, and corporate policies.\n\n- Support live events, broadcasting, corporate communications, and multimedia initiatives through strategic planning combined with hands-on technical leadership.\n\n- Manage and govern visual content provided by internal and external partners for broadcast across onboard platforms.\n\nYour Journey so far\n\n- Extensive experience within cruise environments is a must.\n\n- Senior operational and managerial experience within the Entertainment industry.\n\n- Mother tongue English; Italian, German, or Spanish advantageous.\n\n- Strong background in broadcasting, web, TV, theatrical production, or digital media operations with managerial responsibility.\n\n- Knowledge of enterprise Content Management Systems and digital platforms.\n\n- Solid IT literacy with understanding of systems architecture and AV integration.\n\n- Full understanding of LES systems within the maritime industry.\n\n- Advanced computer literacy (Microsoft Office, Adobe Creative Suite, and CAD software).\n\n- Strong project management and stakeholder coordination skills.\n\n- Proven ability to work autonomously, solve complex operational challenges, and manage global teams.\n\n- International mindset with experience supporting mixed-nationality audiences and global operations.\n\n- Willingness to travel extensively.\n\nYour Essentials\n\n- SWISS Resident or Visa Holder\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!",
+      "fr": "Join us as a Multimedia and AV Manager and lead the strategic planning, deployment, and operational management of cutting-edge AV systems across our fleet and corporate infrastructure. Drive innovation, collaborate globally, and deliver seamless digital experiences in a dynamic, international environment. Shape the future of entertainment technology with us!"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16952EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.782Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Hospitality",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-05-07",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16952EXTERNALENGB",
+    "jobReqId": "16952",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.307Z",
+    "salaryMin": 72000,
+    "salaryMax": 90500,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 72000,
+        "maxValue": 90500,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-6a5b336e6a54",
+    "slug": "digital-platforms-manager-msc-geneva",
+    "slugByLocale": {
+      "it": "digital-platforms-manager-msc-geneva",
+      "en": "digital-platforms-manager-msc-geneva",
+      "de": "digital-platforms-manager-msc-geneva",
+      "fr": "digital-platforms-manager-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Digital Platforms Manager",
+    "titleByLocale": {
+      "it": "Digital Platforms Manager",
+      "en": "Digital Platforms Manager",
+      "de": "Digital Platforms Manager",
+      "fr": "Digital Platforms Manager"
+    },
+    "description": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nExplora Journeys is a vibrant, cosmopolitan, European luxury brand, imagined in the heart of Swiss hospitality in Geneva. Leveraging our parent company MSC Group’s hundreds of years of maritime expertise, our fleet of six luxury ships (four currently in the pipeline) are being built and designed in a totally different and unique way that will transform and redefine the cruise experience, creating a category of its own, appealing to the next generation of luxury travellers.An exciting opportunity exists for a talented Digital Professional to join our newly created luxury travel brand Explora Journeys. This role is based in the office in Geneva.The Digital Platforms Manager will lead the strategy, development and deployment of our travel App.\n\nYour Impact\n\nThe Digital platforms Manager will:\n\n- Lead the strategy of the EJ guest Area including My Explora and our travel App\n\n- Design and lead the development of the new App\n\n- Define and maintain the Guest Area strategy and roadmap aligned with business goals.\n\n- Establish governance frameworks, standards, and best practices for platform management.\n\n- Identify opportunities for platforms innovation, optimization, and new capabilities.\n\n- Document product features and create user stories\n\n- Lead the creation and maintenance of platforms roadmap\n\n- Translate complex technical requirements into actionable product specifications\n\n- Communicate with cross-functional teams, including developers, designers, and business stakeholders\n\n- Support the testing and release processes for new product updates\n\n- Spot, report and follow the resolution & correction of bugs\n\n- Monitor product performance metrics and making data-driven decisions\n\n- Define KPIs and dashboards to track platform success.\n\nYour Journey so far\n\n- You have minimum of 8/10 years’ experience in a similar Role preferably in the Luxury or Luxury Hospitality/Travel Industry\n\n- Bachelor’s or Master’s degree in Business, Computer Science, Digital Marketing, or related field.\n\n- Experience managing web platforms, mobile apps, or enterprise digital ecosystems.\n\nYour Essentials\n\n- You set yourself apart through your personal accountability to deliver with excellence\n\n- You are structured, well organized and know how to navigate in a matrix organisation\n\n- Strong knowledge on the Digital projects lifecycle, particularly on complex or highly technical products\n\n- You are a fast learner and tech savvy\n\n- Knowledge in Adobe Experience Manager is a plus\n\n- Fluent in English\n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+    "descriptionByLocale": {
+      "it": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry.",
+      "en": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nExplora Journeys is a vibrant, cosmopolitan, European luxury brand, imagined in the heart of Swiss hospitality in Geneva. Leveraging our parent company MSC Group’s hundreds of years of maritime expertise, our fleet of six luxury ships (four currently in the pipeline) are being built and designed in a totally different and unique way that will transform and redefine the cruise experience, creating a category of its own, appealing to the next generation of luxury travellers.An exciting opportunity exists for a talented Digital Professional to join our newly created luxury travel brand Explora Journeys. This role is based in the office in Geneva.The Digital Platforms Manager will lead the strategy, development and deployment of our travel App.\n\nYour Impact\n\nThe Digital platforms Manager will:\n\n- Lead the strategy of the EJ guest Area including My Explora and our travel App\n\n- Design and lead the development of the new App\n\n- Define and maintain the Guest Area strategy and roadmap aligned with business goals.\n\n- Establish governance frameworks, standards, and best practices for platform management.\n\n- Identify opportunities for platforms innovation, optimization, and new capabilities.\n\n- Document product features and create user stories\n\n- Lead the creation and maintenance of platforms roadmap\n\n- Translate complex technical requirements into actionable product specifications\n\n- Communicate with cross-functional teams, including developers, designers, and business stakeholders\n\n- Support the testing and release processes for new product updates\n\n- Spot, report and follow the resolution & correction of bugs\n\n- Monitor product performance metrics and making data-driven decisions\n\n- Define KPIs and dashboards to track platform success.\n\nYour Journey so far\n\n- You have minimum of 8/10 years’ experience in a similar Role preferably in the Luxury or Luxury Hospitality/Travel Industry\n\n- Bachelor’s or Master’s degree in Business, Computer Science, Digital Marketing, or related field.\n\n- Experience managing web platforms, mobile apps, or enterprise digital ecosystems.\n\nYour Essentials\n\n- You set yourself apart through your personal accountability to deliver with excellence\n\n- You are structured, well organized and know how to navigate in a matrix organisation\n\n- Strong knowledge on the Digital projects lifecycle, particularly on complex or highly technical products\n\n- You are a fast learner and tech savvy\n\n- Knowledge in Adobe Experience Manager is a plus\n\n- Fluent in English\n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+      "de": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry.",
+      "fr": "We are looking for a talented Digital Platforms Manager to lead the strategy and development of our travel app at Explora Journeys. Join us in redefining luxury ocean travel and make a significant impact in the luxury hospitality industry."
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16921EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.782Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Marketing",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-04-28",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16921EXTERNALENGB",
+    "jobReqId": "16921",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.313Z",
+    "salaryMin": 75500,
+    "salaryMax": 133000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 75500,
+        "maxValue": 133000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-b4cb66b778c0",
+    "slug": "senior-hr-business-partner-msc-geneva",
+    "slugByLocale": {
+      "it": "senior-hr-business-partner-msc-geneva",
+      "en": "senior-hr-business-partner-msc-geneva",
+      "de": "senior-hr-business-partner-msc-geneva",
+      "fr": "senior-hr-business-partner-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Senior HR Business Partner",
+    "titleByLocale": {
+      "it": "Senior Risorse Umane Business Partner",
+      "en": "Senior HR Business Partner",
+      "de": "Senior Personalwesen Business Partner",
+      "fr": "Senior HR Business Partner"
+    },
+    "description": "Your Purpose\n\nWorking at the heart of the business and in close partnership with the Corporate HR team, the Senior HR Business Partner provides strategic and hands-on HR support to assigned corporate functions and offices worldwide, within a fast-paced, service-driven hospitality environment.\n\n \n\nReporting to the Head of HR, this role partners with senior leaders to translate business priorities into effective people solutions, while ensuring consistent application of Group HR policies, processes, and standards. The Senior HRBP plays a key role in driving performance, engagement, and organisational effectiveness in a complex, international organisation where operational excellence, agility, and customer focus are critical.\n\nYour Impact\n\n- Act as the primary HR partner for assigned corporate functions, providing strategic advice and operational HR support aligned with business objectives;\n\n- Equip leaders with the tools, frameworks, and guidance required to effectively manage their teams in line with Group values and people policies;\n\n- Partner with senior leaders to support workforce planning and organisational needs, ensuring capabilities and capacity are aligned with current and future business requirements;\n\n- Collaborate closely with Talent Acquisition and hiring managers to define recruitment needs and support delivery of hiring plans in line with agreed KPIs;\n\n- Drive performance and accountability by supporting the implementation of the Group performance management framework, including goal setting, evaluation cycles, and manager capability building;\n\n- Support talent management processes within the business perimeter, including talent reviews, identification of high-potential employees, succession discussions, and development actions, in coordination with the Head of HR and relevant Centers of Expertise;\n\n- Advise managers on employee relations matters, ensuring fair, consistent, and compliant people decisions;\n\n- Support change management and organisational initiatives by assessing people impact, supporting leaders through transitions, and ensuring clear and effective communication;\n\n- Contribute to key HR cycles such as annual compensation reviews, talent reviews, and employee engagement initiatives;\n\n- Work closely with HR Operations, Payroll, and HRIS teams to ensure smooth execution of HR processes and digital tools;\n\n- Participate in global HR projects and initiatives, contributing business insight and supporting effective local implementation;\n\n- Conduct exit interviews, analyse turnover trends, and contribute to retention and engagement actions within the business perimeter.\n\nYour Journey so far\n\n- Master’s degree in Human Resources, Business Administration, or a related field;\n\n- Minimum 10 years of progressive HR experience in a matrixed, multinational environment, including at least 5 -7 years in a Senior HR Business Partner or equivalent role;\n\n- Proven HR experience within the hospitality, cruise, travel or customer-centric industry, with a strong understanding of service culture;\n\n- Demonstrated experience partnering with senior leaders in a corporate or headquarters environment;\n\n- Strong project management skills, with the ability to plan, coordinate, and deliver HR initiatives involving multiple stakeholders and tight timelines;\n\n- Solid exposure to performance management, talent processes, employee relations, and organisational support;\n\n- Experience working with global HR policies, frameworks, and HR systems (HRIS);\n\n- Knowledge of Swiss Labour Law is an advantage;\n\n- Fluent in English; French is an advantage.\n\nYour Essentials\n\n- Strong business acumen with the ability to translate strategy into pragmatic HR solutions;\n\n- Credible and confident advisor, able to influence, challenge, and build trust with senior stakeholders;\n\n- Strong understanding of hospitality and service excellence cultures, with the ability to balance people care, performance, and operational demands;\n\n- Ability to balance strategic thinking with hands-on delivery in a fast-paced, high-expectation environment.\n\n- Structured, reliable, and comfortable operating across multiple priorities;\n\n- Collaborative mindset, with the ability to work effectively across HR functions and with diverse stakeholders;\n\n- High standards of integrity, discretion, and professional judgment;\n\n- Flexible, resilient, and solution-oriented, with a continuous improvement mindset.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness.",
+      "en": "Your Purpose\n\nWorking at the heart of the business and in close partnership with the Corporate HR team, the Senior HR Business Partner provides strategic and hands-on HR support to assigned corporate functions and offices worldwide, within a fast-paced, service-driven hospitality environment.\n\n \n\nReporting to the Head of HR, this role partners with senior leaders to translate business priorities into effective people solutions, while ensuring consistent application of Group HR policies, processes, and standards. The Senior HRBP plays a key role in driving performance, engagement, and organisational effectiveness in a complex, international organisation where operational excellence, agility, and customer focus are critical.\n\nYour Impact\n\n- Act as the primary HR partner for assigned corporate functions, providing strategic advice and operational HR support aligned with business objectives;\n\n- Equip leaders with the tools, frameworks, and guidance required to effectively manage their teams in line with Group values and people policies;\n\n- Partner with senior leaders to support workforce planning and organisational needs, ensuring capabilities and capacity are aligned with current and future business requirements;\n\n- Collaborate closely with Talent Acquisition and hiring managers to define recruitment needs and support delivery of hiring plans in line with agreed KPIs;\n\n- Drive performance and accountability by supporting the implementation of the Group performance management framework, including goal setting, evaluation cycles, and manager capability building;\n\n- Support talent management processes within the business perimeter, including talent reviews, identification of high-potential employees, succession discussions, and development actions, in coordination with the Head of HR and relevant Centers of Expertise;\n\n- Advise managers on employee relations matters, ensuring fair, consistent, and compliant people decisions;\n\n- Support change management and organisational initiatives by assessing people impact, supporting leaders through transitions, and ensuring clear and effective communication;\n\n- Contribute to key HR cycles such as annual compensation reviews, talent reviews, and employee engagement initiatives;\n\n- Work closely with HR Operations, Payroll, and HRIS teams to ensure smooth execution of HR processes and digital tools;\n\n- Participate in global HR projects and initiatives, contributing business insight and supporting effective local implementation;\n\n- Conduct exit interviews, analyse turnover trends, and contribute to retention and engagement actions within the business perimeter.\n\nYour Journey so far\n\n- Master’s degree in Human Resources, Business Administration, or a related field;\n\n- Minimum 10 years of progressive HR experience in a matrixed, multinational environment, including at least 5 -7 years in a Senior HR Business Partner or equivalent role;\n\n- Proven HR experience within the hospitality, cruise, travel or customer-centric industry, with a strong understanding of service culture;\n\n- Demonstrated experience partnering with senior leaders in a corporate or headquarters environment;\n\n- Strong project management skills, with the ability to plan, coordinate, and deliver HR initiatives involving multiple stakeholders and tight timelines;\n\n- Solid exposure to performance management, talent processes, employee relations, and organisational support;\n\n- Experience working with global HR policies, frameworks, and HR systems (HRIS);\n\n- Knowledge of Swiss Labour Law is an advantage;\n\n- Fluent in English; French is an advantage.\n\nYour Essentials\n\n- Strong business acumen with the ability to translate strategy into pragmatic HR solutions;\n\n- Credible and confident advisor, able to influence, challenge, and build trust with senior stakeholders;\n\n- Strong understanding of hospitality and service excellence cultures, with the ability to balance people care, performance, and operational demands;\n\n- Ability to balance strategic thinking with hands-on delivery in a fast-paced, high-expectation environment.\n\n- Structured, reliable, and comfortable operating across multiple priorities;\n\n- Collaborative mindset, with the ability to work effectively across HR functions and with diverse stakeholders;\n\n- High standards of integrity, discretion, and professional judgment;\n\n- Flexible, resilient, and solution-oriented, with a continuous improvement mindset.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness.",
+      "fr": "Are you experienced in strategic HR management? Join us as a Senior HR Business Partner, where you will provide hands-on HR support and drive performance in a dynamic hospitality environment. Collaborate with senior leaders to translate business priorities into effective people solutions and make a significant impact on organizational effectiveness."
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16316EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.781Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Risorse Umane",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-01-19",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16316EXTERNALENGB",
+    "jobReqId": "16316",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.309Z",
+    "salaryMin": 68000,
+    "salaryMax": 103000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 68000,
+        "maxValue": 103000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-b8db6c0698ca",
+    "slug": "direttore-of-operations-hospitality-infrastructure-msc-group-geneva",
+    "slugByLocale": {
+      "it": "direttore-of-operations-hospitality-infrastructure-msc-group-geneva",
+      "en": "director-of-operations-hospitality-infrastructure-msc-geneva",
+      "de": "direktor-of-operations-hospitality-infrastructure-msc-group-geneva",
+      "fr": "directeur-of-operations-hospitality-infrastructure-msc-group-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Director of Operations - Hospitality Infrastructure",
+    "titleByLocale": {
+      "it": "Direttore of Operations - Hospitality Infrastructure",
+      "en": "Director of Operations - Hospitality Infrastructure",
+      "de": "Direktor of Operations - Hospitality Infrastructure",
+      "fr": "Directeur of Operations - Hospitality Infrastructure"
+    },
+    "description": "Your Purpose\n\nThe Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets.\nThe role ensures continuity from development through steady-state operations, acting as the operational owner from early construction phases through long-term performance.\nWorking in parallel with Development, Construction and Guest Experience, the Director of Operations guarantees that assets are operable by design, fully ready at opening, and sustainably efficient, safe and profitable thereafter.\n\nYour Impact\n\n1. Operational Leadership Across the Asset Lifecycle\nOwn end-to-end operational responsibility from pre-opening through live operations.\nDefine the long-term operating vision, KPIs and service standards.\nEnsure continuity of design, culture and systems from project phase into steady-state operations.\n\n2. Pre-Opening & Mobilization (Parallel to Construction)\nLead the operational readiness program aligned with construction milestones.\nIn coordination with Corporate Guest Services (F&B, HK, Entertainment etc.), define Procurements needs and implement it. FFE/OWS. \nInfluence design decisions to ensure operational efficiency, safety and maintainability.\nEstablish operating structures, SOPs and governance well ahead of opening.\nManage handovers from construction to operations, including phased turnovers.\nFor each project, identify personnel need and -in conjunction with HR- ensure the operational ability of new assets. Establish Training Programs for operational readiness.\n\n3. Post-Opening Operations Management\nDirect daily operations across all departments (hospitality, F&B, retail, attractions, marine, security, maintenance, guest services).\nEnsure delivery of guest experience, safety, service quality and brand standards.\nDrive operational stability during ramp-up and maturity phases.\nLead continuous improvement initiatives across the asset.\n\n4. Workforce, Training & Culture\nBuild, lead and retain a high-performing, multi-national workforce.\nMaintain and evolve training programs post-opening.\nEmbed a safety-first, service-oriented and performance-driven culture.\n\n5. Financial & Commercial Performance\nOwn operational P&L, cost controls and productivity metrics.\nManage operating budgets, capex planning and lifecycle reserves.\nCollaborate with commercial teams to optimize revenue (F&B, retail, experiences, shore excursions where applicable).\n\n6. Compliance, Safety & Risk Management\nEnsure ongoing compliance with all regulatory, maritime, health, safety and environmental standards.\nLead emergency preparedness, crisis management and business continuity planning.\nServe as the accountable executive for audits and inspections.\n\nYour Journey so far\n\n- 15+ years senior operations leadership in hospitality, cruise destinations, resorts, ports, theme parks or large hospitality assets.\n\n- Demonstrated ownership of both pre-opening and long-term operations.\n\n- Strong background working alongside development, construction and technical services teams.\n\n- Experience in Caribbean or island environments strongly preferred.\n\nYour Essentials\n\n- Operational readiness & lifecycle operations\n\n- Large-scale workforce leadership\n\n- Financial & P&L accountability\n\n- Asset lifecycle & maintenance management\n\n- Multi-operator and concession management\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,...",
+      "en": "Your Purpose\n\nThe Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets.\nThe role ensures continuity from development through steady-state operations, acting as the operational owner from early construction phases through long-term performance.\nWorking in parallel with Development, Construction and Guest Experience, the Director of Operations guarantees that assets are operable by design, fully ready at opening, and sustainably efficient, safe and profitable thereafter.\n\nYour Impact\n\n1. Operational Leadership Across the Asset Lifecycle\nOwn end-to-end operational responsibility from pre-opening through live operations.\nDefine the long-term operating vision, KPIs and service standards.\nEnsure continuity of design, culture and systems from project phase into steady-state operations.\n\n2. Pre-Opening & Mobilization (Parallel to Construction)\nLead the operational readiness program aligned with construction milestones.\nIn coordination with Corporate Guest Services (F&B, HK, Entertainment etc.), define Procurements needs and implement it. FFE/OWS. \nInfluence design decisions to ensure operational efficiency, safety and maintainability.\nEstablish operating structures, SOPs and governance well ahead of opening.\nManage handovers from construction to operations, including phased turnovers.\nFor each project, identify personnel need and -in conjunction with HR- ensure the operational ability of new assets. Establish Training Programs for operational readiness.\n\n3. Post-Opening Operations Management\nDirect daily operations across all departments (hospitality, F&B, retail, attractions, marine, security, maintenance, guest services).\nEnsure delivery of guest experience, safety, service quality and brand standards.\nDrive operational stability during ramp-up and maturity phases.\nLead continuous improvement initiatives across the asset.\n\n4. Workforce, Training & Culture\nBuild, lead and retain a high-performing, multi-national workforce.\nMaintain and evolve training programs post-opening.\nEmbed a safety-first, service-oriented and performance-driven culture.\n\n5. Financial & Commercial Performance\nOwn operational P&L, cost controls and productivity metrics.\nManage operating budgets, capex planning and lifecycle reserves.\nCollaborate with commercial teams to optimize revenue (F&B, retail, experiences, shore excursions where applicable).\n\n6. Compliance, Safety & Risk Management\nEnsure ongoing compliance with all regulatory, maritime, health, safety and environmental standards.\nLead emergency preparedness, crisis management and business continuity planning.\nServe as the accountable executive for audits and inspections.\n\nYour Journey so far\n\n- 15+ years senior operations leadership in hospitality, cruise destinations, resorts, ports, theme parks or large hospitality assets.\n\n- Demonstrated ownership of both pre-opening and long-term operations.\n\n- Strong background working alongside development, construction and technical services teams.\n\n- Experience in Caribbean or island environments strongly preferred.\n\nYour Essentials\n\n- Operational readiness & lifecycle operations\n\n- Large-scale workforce leadership\n\n- Financial & P&L accountability\n\n- Asset lifecycle & maintenance management\n\n- Multi-operator and concession management\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,...",
+      "fr": "The Director of Operations is accountable for the design, mobilization, opening and ongoing operation of large-scale cruise and hospitality infrastructure assets. Working in parallel with Development,..."
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16422EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.780Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Produzione",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-02-13",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16422EXTERNALENGB",
+    "jobReqId": "16422",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.305Z",
+    "previousSlugsByLocale": {
+      "it": [
+        "director-of-operations-hospitality-infrastructure-msc-geneva"
+      ],
+      "de": [
+        "director-of-operations-hospitality-infrastructure-msc-geneva"
+      ],
+      "fr": [
+        "director-of-operations-hospitality-infrastructure-msc-geneva"
+      ]
+    },
+    "previousSlugs": [
+      "director-of-operations-hospitality-infrastructure-msc-geneva"
+    ],
+    "salaryMin": 68000,
+    "salaryMax": 103000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 68000,
+        "maxValue": 103000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-57f045d85699",
+    "slug": "senior-project-manager-investimenti-in-infrastrutture-caribico-msc-group-geneva",
+    "slugByLocale": {
+      "it": "senior-project-manager-investimenti-in-infrastrutture-caribico-msc-group-geneva",
+      "en": "senior-project-manager-infrastructure-investments-caribbean-msc-geneva",
+      "de": "senior-projektmanager-infrastrukturinvestitionen-karibik-msc-group-geneva",
+      "fr": "responsable-de-projet-senior-investissements-en-infrastructures-caraibes-msc-group-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Senior Project Manager - Infrastructure Investments (Caribbean)",
+    "titleByLocale": {
+      "it": "Senior Project Manager - Investimenti in Infrastrutture (Caribico)",
+      "en": "Senior Project Manager - Infrastructure Investments (Caribbean)",
+      "de": "Senior Projektmanager - Infrastrukturinvestitionen (Karibik)",
+      "fr": "Responsable de Projet Senior - Investissements en Infrastructures (Caraïbes)"
+    },
+    "description": "Your Purpose\n\nWe are seeking a high-caliber, dedicated PMO Lead / Senior Project Manager to oversee a strategic infrastructure investment project in the Caribbean, while establishing governance and execution discipline across current and future projects in the investment pipeline.\nThis role carries full accountability for project delivery, spanning finance, construction, commercial, operational, HR, regulatory, and stakeholder dimensions. The successful candidate will act as the single point of coordination and control between investors, contractors, operators, lenders, and government stakeholders.\n\nYour Impact\n\n• Establish and lead a Project Management System, including governance, reporting, controls, and KPIs.\n• Drive end-to-end execution of major infrastructure projects, from development through construction and into operations.\n• Oversees construction delivery and project financials, including budgets, cash flow, CAPEX/OPEX tracking, lender requirements, and reporting.\n• Lead commercial and contract management, supplier, and concession PPP agreements.\n• Ensure operational readiness and handover, including systems, staffing, and procedures.\n• Coordinate HR and workforce planning, ensuring compliance with local labor laws and effective contractor management.\n• Identify and manage project risks across technical, financial, regulatory, ESG, and political dimensions.\n• Provide PMO oversight and execution support for additional projects in the development funnel.\n\nYour Journey so far\n\n• Bachelor’s degree in Engineering, Finance, Business, or related field; Master’s degree preferred.\n• 15+ years of experience in large-scale infrastructure or real asset projects.\n• Demonstrated leadership of complex, capital-intensive projects with multiple stakeholders.\n• Strong experience across construction, project finance, commercial contracts, and operations.\n• Experience in emerging markets and/or the Caribbean region strongly preferred.\n• PMP / PRINCE2 or equivalent certification preferred.\n\nYour Essentials\n\n• Hands-on, structured, and highly accountable\n• Executive presence and credibility with senior stakeholders\n• Comfortable working in complex, multi-jurisdictional environments\n• Willing to travel and be on-site as required\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Descrizione - Questo ruolo comporta la piena responsabilità per la consegna del progetto, che abbraccia le dimensioni finanziarie, costruttive, commerciali, operative, HR, regolamentari e degli stakeholder - Stabilire e guidare un Project Management...",
+      "en": "Your Purpose\n\nWe are seeking a high-caliber, dedicated PMO Lead / Senior Project Manager to oversee a strategic infrastructure investment project in the Caribbean, while establishing governance and execution discipline across current and future projects in the investment pipeline.\nThis role carries full accountability for project delivery, spanning finance, construction, commercial, operational, HR, regulatory, and stakeholder dimensions. The successful candidate will act as the single point of coordination and control between investors, contractors, operators, lenders, and government stakeholders.\n\nYour Impact\n\n• Establish and lead a Project Management System, including governance, reporting, controls, and KPIs.\n• Drive end-to-end execution of major infrastructure projects, from development through construction and into operations.\n• Oversees construction delivery and project financials, including budgets, cash flow, CAPEX/OPEX tracking, lender requirements, and reporting.\n• Lead commercial and contract management, supplier, and concession PPP agreements.\n• Ensure operational readiness and handover, including systems, staffing, and procedures.\n• Coordinate HR and workforce planning, ensuring compliance with local labor laws and effective contractor management.\n• Identify and manage project risks across technical, financial, regulatory, ESG, and political dimensions.\n• Provide PMO oversight and execution support for additional projects in the development funnel.\n\nYour Journey so far\n\n• Bachelor’s degree in Engineering, Finance, Business, or related field; Master’s degree preferred.\n• 15+ years of experience in large-scale infrastructure or real asset projects.\n• Demonstrated leadership of complex, capital-intensive projects with multiple stakeholders.\n• Strong experience across construction, project finance, commercial contracts, and operations.\n• Experience in emerging markets and/or the Caribbean region strongly preferred.\n• PMP / PRINCE2 or equivalent certification preferred.\n\nYour Essentials\n\n• Hands-on, structured, and highly accountable\n• Executive presence and credibility with senior stakeholders\n• Comfortable working in complex, multi-jurisdictional environments\n• Willing to travel and be on-site as required\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Beschreibung - Diese Rolle trägt die volle Verantwortung für die Projektlieferung, die Finanz-, Bau-, Handels-, Betriebs-, HR-, Regulierungs- und Stakeholder-Dimensionen umfasst - Etablieren und leiten eines Projektmanagements...",
+      "fr": "Description - Ce rôle implique une responsabilité totale pour la livraison du projet, couvrant les dimensions financières, de construction, commerciales, opérationnelles, RH, réglementaires et des parties prenantes - Établir et diriger une gestion de projet..."
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16283EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.780Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "IT",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-02-02",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16283EXTERNALENGB",
+    "jobReqId": "16283",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "previousSlugs": [
+      "senior-project-manager-infrastructure-investments-caribbean-msc-geneva"
+    ],
+    "previousSlugsByLocale": {
+      "it": [
+        "senior-project-manager-infrastructure-investments-caribbean-msc-geneva"
+      ]
+    },
+    "firstSeenAt": "2026-05-11T12:59:30.064Z",
+    "salaryMin": 79500,
+    "salaryMax": 135000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 79500,
+        "maxValue": 135000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-a231a60627cc",
+    "slug": "responsabile-acquisizione-digitale-msc-group-geneva",
+    "slugByLocale": {
+      "it": "responsabile-acquisizione-digitale-msc-group-geneva",
+      "en": "digital-acquisition-manager-msc-geneva",
+      "de": "digitaler-akquisitionsmanager-msc-group-geneva",
+      "fr": "responsable-de-l-acquisition-numerique-msc-group-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Digital Acquisition Manager",
+    "titleByLocale": {
+      "it": "Responsabile Acquisizione Digitale",
+      "en": "Digital Acquisition Manager",
+      "de": "Digitaler Akquisitionsmanager",
+      "fr": "Responsable de l'acquisition numérique"
+    },
+    "description": "Your Purpose\n\nThe Senior Digital Acquisition Manager will be responsible for leading the digital marketing strategy across all MSC Cruises markets, with a focus on driving direct sales through digital advertising levers, setting and achieving KPIs, and developing innovative digital campaigns across multiple channels. The successful candidate will have a proven track record in performance marketing and digital sales development at a positive ROAS, along with strong expertise in digital advertising campaign strategy, paid media planning and implementation, and team leadership. Additionally, the role will involve developing affiliation and partnership programs as part of an integrated digital engagement strategy to broaden reach, drive qualified traffic, and support long-term customer value.\n\nYour Impact\n\n• Develop and maintain strong relationships with MSC stakeholders across various markets, with a deep understanding of their business needs, challenges, and opportunities—while balancing the global objectives set by headquarters.\n\n• Set and achieve KPIs for online sales through digital advertising levers, ensuring the media agency delivers against targets and contractual obligations.\n\n• Lead internal meetings, QBRs, and annual reviews by providing strategic insights and recommendations based on campaign performance, website analytics, market trends, and the competitive landscape.\n\n• Plan and implement innovative performance marketing campaigns across Paid Search, Display, Social, Native, Digital Audio, and Video channels—tailored to business goals and market dynamics.\n\n• Collaborate with internal teams—including Creative, Social Media, Data & Analytics, SEO, Content, Product, and agency partners—to ensure the timely delivery of high-quality assets aligned with annual digital sales targets.\n\n• Identify and pursue opportunities to enhance revenue streams through existing and new digital strategies, while improving campaign ROAS and experimenting with innovations in the adtech and martech ecosystem.\n\n• Develop and manage lead generation strategies, ensuring effective customer acquisition flows and nurturing tactics are in place across all paid media touchpoints.\n\n• Maintain oversight of account resourcing and profitability to ensure HQ and local markets are managed efficiently and profitably.\n\n• Serve as the main escalation point for concerns raised by internal teams or local market stakeholders.\n\n• Continuously review and optimize operational workflows, proposing and implementing process improvements where relevant.\n\n• Collaborate with country and HQ stakeholders to prepare and manage the annual digital marketing budget, aligned with MSC Cruises’ B2C revenue goals.\n\n• Lead and optimize affiliate and partnership programs to drive qualified traffic and conversions, ensuring alignment with digital acquisition strategy and performance goals.\n\n• Manage key partners and co-branded initiatives, coordinating with internal teams to ensure seamless execution and tracking.\n \n\nYour Journey so far\n\n• 7+ years of experience in a similar role.\n• Hands-on experience with analytics and ad server tools such as GA4, Adobe Analytics, Campaign Manager and their relevant reporting frameworks.\n• Proven experience in managing, mentoring, and upskilling team members.\n• Past experience in lead generation strategy and execution is a strong plus.\n• Solid experience in budget ownership and cost control.\n\nYour Essentials\n\n• Fluent in English (additional languages are a plus).\n• Strong analytical skills and the ability to leverage data for informed decision-making.\n• Proven track record of driving direct sales growth and improving ROAS through high-performing digital advertising campaigns.\n• Passion for digital marketing, performance media, and innovative digital solutions.\n• Deep knowledge of Google and Meta ad platforms, including setup auditing, implementation, and performance analysis with actionable insights.\n• Excellent organizational, project management, and problem-solving skills.\n• Proficient in Microsoft Office and data visualization tools such as Datorama.\n• Strong collaboration and communication skills, with the ability to work effectively across cross-functional teams and external partners.\n• Ability to identify trends in data and transform insights into actionable strategic recommendations.\n• Self-starter with the ability to work independently and take initiative.\n• Confident, articulate presenter—comfortable engaging with senior stakeholders and internal teams.\n• Strong strategic thinking, capable of acting as a ‘Trusted Advisor’ to senior leadership.\n• High attention to detail and ability to manage multiple priorities in a fast-paced, dynamic environment.\n• Positive attitude, proactive mindset, and a drive to embrace new challenges.\n• Knowledge of affiliate platforms such as Awin, Kwanko, and similar tools. Strong network of industry contacts to initiate partnership opportunities and brand collaborations.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Descrizione - Hai esperienza nella gestione di strategie di marketing digitale? - Unisciti a noi come Senior Digital Acquisition Manager per guidare campagne innovative, ottimizzare le performance e migliorare l'engagement dei clienti su più canali - La tua esperienza aiuterà a plasmare il nostro panorama digitale e a incrementare le vendite dirette",
+      "en": "Your Purpose\n\nThe Senior Digital Acquisition Manager will be responsible for leading the digital marketing strategy across all MSC Cruises markets, with a focus on driving direct sales through digital advertising levers, setting and achieving KPIs, and developing innovative digital campaigns across multiple channels. The successful candidate will have a proven track record in performance marketing and digital sales development at a positive ROAS, along with strong expertise in digital advertising campaign strategy, paid media planning and implementation, and team leadership. Additionally, the role will involve developing affiliation and partnership programs as part of an integrated digital engagement strategy to broaden reach, drive qualified traffic, and support long-term customer value.\n\nYour Impact\n\n• Develop and maintain strong relationships with MSC stakeholders across various markets, with a deep understanding of their business needs, challenges, and opportunities—while balancing the global objectives set by headquarters.\n\n• Set and achieve KPIs for online sales through digital advertising levers, ensuring the media agency delivers against targets and contractual obligations.\n\n• Lead internal meetings, QBRs, and annual reviews by providing strategic insights and recommendations based on campaign performance, website analytics, market trends, and the competitive landscape.\n\n• Plan and implement innovative performance marketing campaigns across Paid Search, Display, Social, Native, Digital Audio, and Video channels—tailored to business goals and market dynamics.\n\n• Collaborate with internal teams—including Creative, Social Media, Data & Analytics, SEO, Content, Product, and agency partners—to ensure the timely delivery of high-quality assets aligned with annual digital sales targets.\n\n• Identify and pursue opportunities to enhance revenue streams through existing and new digital strategies, while improving campaign ROAS and experimenting with innovations in the adtech and martech ecosystem.\n\n• Develop and manage lead generation strategies, ensuring effective customer acquisition flows and nurturing tactics are in place across all paid media touchpoints.\n\n• Maintain oversight of account resourcing and profitability to ensure HQ and local markets are managed efficiently and profitably.\n\n• Serve as the main escalation point for concerns raised by internal teams or local market stakeholders.\n\n• Continuously review and optimize operational workflows, proposing and implementing process improvements where relevant.\n\n• Collaborate with country and HQ stakeholders to prepare and manage the annual digital marketing budget, aligned with MSC Cruises’ B2C revenue goals.\n\n• Lead and optimize affiliate and partnership programs to drive qualified traffic and conversions, ensuring alignment with digital acquisition strategy and performance goals.\n\n• Manage key partners and co-branded initiatives, coordinating with internal teams to ensure seamless execution and tracking.\n \n\nYour Journey so far\n\n• 7+ years of experience in a similar role.\n• Hands-on experience with analytics and ad server tools such as GA4, Adobe Analytics, Campaign Manager and their relevant reporting frameworks.\n• Proven experience in managing, mentoring, and upskilling team members.\n• Past experience in lead generation strategy and execution is a strong plus.\n• Solid experience in budget ownership and cost control.\n\nYour Essentials\n\n• Fluent in English (additional languages are a plus).\n• Strong analytical skills and the ability to leverage data for informed decision-making.\n• Proven track record of driving direct sales growth and improving ROAS through high-performing digital advertising campaigns.\n• Passion for digital marketing, performance media, and innovative digital solutions.\n• Deep knowledge of Google and Meta ad platforms, including setup auditing, implementation, and performance analysis with actionable insights.\n• Excellent organizational, project management, and problem-solving skills.\n• Proficient in Microsoft Office and data visualization tools such as Datorama.\n• Strong collaboration and communication skills, with the ability to work effectively across cross-functional teams and external partners.\n• Ability to identify trends in data and transform insights into actionable strategic recommendations.\n• Self-starter with the ability to work independently and take initiative.\n• Confident, articulate presenter—comfortable engaging with senior stakeholders and internal teams.\n• Strong strategic thinking, capable of acting as a ‘Trusted Advisor’ to senior leadership.\n• High attention to detail and ability to manage multiple priorities in a fast-paced, dynamic environment.\n• Positive attitude, proactive mindset, and a drive to embrace new challenges.\n• Knowledge of affiliate platforms such as Awin, Kwanko, and similar tools. Strong network of industry contacts to initiate partnership opportunities and brand collaborations.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Beschreibung - Haben Sie Erfahrung in der Gestaltung von Digitalmarketing-Strategien? - Treten Sie uns als Senior Digital Acquisition Manager bei, um innovative Kampagnen zu leiten, die Leistung zu optimieren und die Kundenbindung über mehrere Kanäle hinweg zu verbessern - Ihre Expertise wird helfen, unsere digitale Landschaft zu gestalten und den direkten Verkaufswachstum zu steigern - Bewerben Sie sich jetzt!",
+      "fr": "Description - Avez-vous de l'expérience dans la gestion de stratégies de marketing numérique? - Rejoignez-nous en tant que Senior Digital Acquisition Manager pour diriger des campagnes innovantes, optimiser les performances et améliorer l'engagement des clients sur plusieurs canaux - Votre expertise aidera à façonner notre paysage numérique et à stimuler la croissance des ventes directes - Postulez maintenant!"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB11987EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.779Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Marketing",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-02-19",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB11987EXTERNALENGB",
+    "jobReqId": "11987",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "previousSlugs": [
+      "digital-acquisition-manager-msc-geneva"
+    ],
+    "previousSlugsByLocale": {
+      "it": [
+        "digital-acquisition-manager-msc-geneva"
+      ]
+    },
+    "firstSeenAt": "2026-05-11T12:59:30.062Z",
+    "salaryMin": 75500,
+    "salaryMax": 133000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 75500,
+        "maxValue": 133000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-d7e4d37de431",
+    "slug": "vice-president-global-spa-and-wellness-msc-geneva",
+    "slugByLocale": {
+      "it": "vice-president-global-spa-and-wellness-msc-geneva",
+      "en": "vice-president-global-spa-and-wellness-msc-geneva",
+      "de": "vice-president-global-spa-and-wellness-msc-geneva",
+      "fr": "vice-president-global-spa-and-wellness-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Vice President Global SPA and Wellness",
+    "titleByLocale": {
+      "it": "Vice President Global SPA and Wellness",
+      "en": "Vice President Global SPA and Wellness",
+      "de": "Vice President Global SPA and Wellness",
+      "fr": "Vice President Global SPA and Wellness"
+    },
+    "description": "Your Purpose\n\nThe Vice President Global SPA and Wellness is the global business owner for all onboard SPA, wellness, beauty, and fitness operations across the Cruise Division of MSC Group, spanning MSC Cruises (Contemporary & Premium) and Explora Journeys (Luxury).\n\nThe role has full accountability for SPA and treatment programs, fitness and thermal areas, salon services, wellness retail, medical aesthetics (where applicable), and future digital wellness offerings.\n\nThis position ensures that luxury wellness standards, service rituals, therapeutic excellence, and holistic wellbeing philosophies are fully embedded—particularly for Explora Journeys—while maintaining scalable, brand-differentiated wellness frameworks across the fleet.\n\nThe VP defines the long-term global SPA and wellness vision, drives commercial performance, elevates guest satisfaction, and evolves wellness concepts that differentiate MSC Group’s Cruise Division across contemporary, premium, and luxury segments. \n\nYour Impact\n\nStrategic & Commercial Leadership\n\n- Define and lead the global SPA and wellness strategy across contemporary, premium, and luxury brands, aligned with differentiated guest profiles and brand positioning.\n\n- Act as business owner for Global SPA and Wellness, with explicit accountability for luxury wellness concepts and standards.\n\n- Own the end-to-end commercial roadmap, including treatment architecture, pricing strategy, promotions, capacity optimisation, and end-to-end guest journey design.\n\n- Lead strategic negotiations with SPA operators, wellness partners, medical aesthetics providers (where permitted), product brands, and equipment suppliers.\n\n- Drive growth in high-margin and premium wellness categories, including signature treatments, medical aesthetics, fitness and longevity programs, wellness retail, and personalised wellbeing journeys.\n\n- Develop scalable yet brand-distinct SPA and wellness frameworks, enabling selective deployment of premium and luxury concepts across MSC Cruises and Explora Journeys.\n\nOperational and Brand Excellence\n\n- Oversee SPA operations fleet-wide, ensuring consistent service delivery, treatment quality, hygiene standards, and guest satisfaction.\n\n- Define service standards, therapist certification requirements, training programs, and performance benchmarks across all SPA formats.\n\n- Ensure luxury wellness excellence for Explora Journeys, including service rituals, therapist conduct, holistic programming, privacy standards, and immersive wellness environments.\n\n- Introduce tier-specific wellness concepts, signature and luxury rituals, experiential programming, and destination-inspired treatments.\n\n- Ensure fleet readiness for newbuilds and dry docks, including SPA layout design, equipment selection, CAPEX planning, and concept activation.\n\nFinancial Management\n\n- Own the full P&L for SPA and Wellness across all Cruise Division brands, including annual budgets, revenue targets, margin improvement, and cost control.\n\n- Optimise therapist productivity, treatment mix, pricing discipline, retail attachment rates, staffing models, and concession economics.\n\n- Leverage advanced analytics to drive demand forecasting, yield management, guest segmentation, booking optimisation, and treatment performance.\n\nCross-Functional Collaboration\n\n- Partner closely with Hotel Operations, Medical, Fitness, Retail, F&B, Shorex, Digital, Finance, and Newbuild teams to integrate wellness into the overall guest experience.\n\n- Collaborate with CRM and Digital teams on pre-cruise wellness engagement, onboard booking optimisation, and personalised wellness journeys.\n\n- Align SPA offerings with itinerary, destination, and onboard programming to maximise relevance differentiation, and revenue.\n\nLeadership & Organisational Development\n\n- Lead a global HQ and fleet SPA and wellness organisation, including strategy, operations, training, and partner management teams.\n\n- Build a culture of guest-centric service excellence, luxury wellness stewardship, commercial discipline, and continuous innovation.\n\n- Mentor senior leaders and strengthen capabilities across SPA operations, luxury wellness concept development, and data-driven performance management.\n\nYour Journey so far\n\n- 15+ years senior leadership experience in SPA, wellness, hospitality, cruise, or multi-site service businesses.\n\n- Proven success owning complex P&Ls and driving profitability in service-led environments.\n\n- Deep expertise in SPA operations, wellness programming, service quality management, and luxury guest experience standards.\n\n- Strong experience managing third-party operators, concession models, or global vendor partnerships.\n\nYour Essentials\n\n- Excellent leadership, negotiation, and cross-functional stakeholder management skills.\n\n- Willingness to travel extensively and operate in a fast-paced international environment.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!",
+      "en": "Your Purpose\n\nThe Vice President Global SPA and Wellness is the global business owner for all onboard SPA, wellness, beauty, and fitness operations across the Cruise Division of MSC Group, spanning MSC Cruises (Contemporary & Premium) and Explora Journeys (Luxury).\n\nThe role has full accountability for SPA and treatment programs, fitness and thermal areas, salon services, wellness retail, medical aesthetics (where applicable), and future digital wellness offerings.\n\nThis position ensures that luxury wellness standards, service rituals, therapeutic excellence, and holistic wellbeing philosophies are fully embedded—particularly for Explora Journeys—while maintaining scalable, brand-differentiated wellness frameworks across the fleet.\n\nThe VP defines the long-term global SPA and wellness vision, drives commercial performance, elevates guest satisfaction, and evolves wellness concepts that differentiate MSC Group’s Cruise Division across contemporary, premium, and luxury segments. \n\nYour Impact\n\nStrategic & Commercial Leadership\n\n- Define and lead the global SPA and wellness strategy across contemporary, premium, and luxury brands, aligned with differentiated guest profiles and brand positioning.\n\n- Act as business owner for Global SPA and Wellness, with explicit accountability for luxury wellness concepts and standards.\n\n- Own the end-to-end commercial roadmap, including treatment architecture, pricing strategy, promotions, capacity optimisation, and end-to-end guest journey design.\n\n- Lead strategic negotiations with SPA operators, wellness partners, medical aesthetics providers (where permitted), product brands, and equipment suppliers.\n\n- Drive growth in high-margin and premium wellness categories, including signature treatments, medical aesthetics, fitness and longevity programs, wellness retail, and personalised wellbeing journeys.\n\n- Develop scalable yet brand-distinct SPA and wellness frameworks, enabling selective deployment of premium and luxury concepts across MSC Cruises and Explora Journeys.\n\nOperational and Brand Excellence\n\n- Oversee SPA operations fleet-wide, ensuring consistent service delivery, treatment quality, hygiene standards, and guest satisfaction.\n\n- Define service standards, therapist certification requirements, training programs, and performance benchmarks across all SPA formats.\n\n- Ensure luxury wellness excellence for Explora Journeys, including service rituals, therapist conduct, holistic programming, privacy standards, and immersive wellness environments.\n\n- Introduce tier-specific wellness concepts, signature and luxury rituals, experiential programming, and destination-inspired treatments.\n\n- Ensure fleet readiness for newbuilds and dry docks, including SPA layout design, equipment selection, CAPEX planning, and concept activation.\n\nFinancial Management\n\n- Own the full P&L for SPA and Wellness across all Cruise Division brands, including annual budgets, revenue targets, margin improvement, and cost control.\n\n- Optimise therapist productivity, treatment mix, pricing discipline, retail attachment rates, staffing models, and concession economics.\n\n- Leverage advanced analytics to drive demand forecasting, yield management, guest segmentation, booking optimisation, and treatment performance.\n\nCross-Functional Collaboration\n\n- Partner closely with Hotel Operations, Medical, Fitness, Retail, F&B, Shorex, Digital, Finance, and Newbuild teams to integrate wellness into the overall guest experience.\n\n- Collaborate with CRM and Digital teams on pre-cruise wellness engagement, onboard booking optimisation, and personalised wellness journeys.\n\n- Align SPA offerings with itinerary, destination, and onboard programming to maximise relevance differentiation, and revenue.\n\nLeadership & Organisational Development\n\n- Lead a global HQ and fleet SPA and wellness organisation, including strategy, operations, training, and partner management teams.\n\n- Build a culture of guest-centric service excellence, luxury wellness stewardship, commercial discipline, and continuous innovation.\n\n- Mentor senior leaders and strengthen capabilities across SPA operations, luxury wellness concept development, and data-driven performance management.\n\nYour Journey so far\n\n- 15+ years senior leadership experience in SPA, wellness, hospitality, cruise, or multi-site service businesses.\n\n- Proven success owning complex P&Ls and driving profitability in service-led environments.\n\n- Deep expertise in SPA operations, wellness programming, service quality management, and luxury guest experience standards.\n\n- Strong experience managing third-party operators, concession models, or global vendor partnerships.\n\nYour Essentials\n\n- Excellent leadership, negotiation, and cross-functional stakeholder management skills.\n\n- Willingness to travel extensively and operate in a fast-paced international environment.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!",
+      "fr": "Are you experienced in leading global SPA and wellness strategies? Join us as the Vice President Global SPA and Wellness, where you will drive luxury wellness standards and elevate guest satisfaction across our cruise division. Your expertise will shape the future of wellness at MSC Cruises!"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15903EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.778Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Marketing",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "mid",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-03-11",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB15903EXTERNALENGB",
+    "jobReqId": "15903",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.298Z",
+    "salaryMin": 75500,
+    "salaryMax": 133000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 75500,
+        "maxValue": 133000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-027165218aff",
+    "slug": "crm-direttore-msc-group-geneva",
+    "slugByLocale": {
+      "it": "crm-direttore-msc-group-geneva",
+      "en": "crm-director-msc-geneva",
+      "de": "crm-direktor-msc-group-geneva",
+      "fr": "crm-director-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "CRM Director",
+    "titleByLocale": {
+      "it": "CRM Direttore",
+      "en": "CRM Director",
+      "de": "CRM Direktor",
+      "fr": "CRM Director"
+    },
+    "description": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nExplora Journeys is a vibrant, cosmopolitan, European luxury brand, imagined in the heart of Swiss hospitality in Geneva. Leveraging our parent company MSC Group’s hundreds of years of maritime expertise, our fleet of six luxury ships (four currently in the pipeline) are being built and designed in a totally different and unique way that will transform and redefine the cruise experience, creating a category of its own, appealing to the next generation of luxury travellers. \nThe CRM Director – Insights, Customer Lifecycle & Marketing Automation leads the strategy and activation of data-driven customer engagement programs to inform the business and support commercial growth, loyalty and lifetime value.\nThe role acts as business lead for lifecycle marketing and marketing automation, working in close partnership with Commercial, Digital, IT, Data and Legal teams to ensure scalable, compliant and high-performing customer communications. He/ She leads the customer’s insights area recommending how to approach the brand evolution assessment. The role is based in Geneva, Switzerland.\n\nYour Impact\n\n1. Lifecycle Strategy & Co-Ownership\n• Lead the definition of the global customer lifecycle strategy organizing the customer journey vision with Commercial, Digital and Guest Experience teams.\n• Translate lifecycle ambition into structured activation roadmaps across owned marketing automation channels.\n• Define lifecycle design principles, segmentation logic and engagement frameworks aligned with brand and commercial objectives.\n• Ensure cross-functional alignment between customer experience, commercial priorities and lifecycle communications.\n\n2. Journey Activation & Channel Governance\n• Lead automated journey orchestration primarily across owned CRM channels \n• Establish governance for segmentation, personalization and campaign standards.\n• Coordinate with other channel owners (e.g., Media, Social, Digital) to ensure journey consistency.\n• Drive structured adoption of personalization and audience activation tools.\n\n3. Platform Business Ownership \n• Act as business product owner of marketing automation platforms (e.g., Salesforce Marketing Cloud).\n• Define functional requirements, prioritization and business roadmap.\n• Partner with IT, as technical owner, for architecture, integrations, security and scalability.\n• Ensure operational excellence of automations, data flows and activation processes.\n\n4. Data Governance & Compliance\n• Define lifecycle communication standards in alignment with Legal and IT.\n• Ensure consent management and subscription governance frameworks are operationalized within marketing automation tools.\n• Support privacy-by-design principles across activation use cases.\n\n5. Commercial Impact & Performance\n• Define CRM contribution metrics and dashboards.\n• Monitor engagement, retention and revenue influence.\n• Provide optimization roadmaps to senior leadership.\n\n6. Lead the development of a customer insights framework, leveraging CRM data, external ad hoc research to inform brand health evolution. Translate customer understanding into actionable growth opportunities. Partner with Guest Experience teams, Marketing and Commercial teams to design and prioritize customer research initiatives, including satisfaction tracking, journey analysis, loyalty drivers, brand tracking,etc.\n\n7. Team & Capability Building\n• Build a high-performing marketing CRM team.\n• Elevate internal understanding of marketing automation capabilities and limitations.\n• Drive adoption and maturity of audience strategy and segmentation practices.\n\nYour Journey so far\n\n•    15+ years of experience in CRM, customer lifecycle management, marketing automation or customer data roles, ideally in global and local environments.\n•    Proven experience driving customer acquisition, engagement, loyalty and retention through CRM at scale.\n•    Proven experience designing and managing complex customer journeys across multiple channels, markets and touchpoints, including long consideration and purchase cycles\n•    Deep understanding of CRM platforms, marketing automation tools and data-driven marketing, \n•    Solid knowledge on global standards for data capture, consent management, governance, and enrichment\n•    Strong analytical mindset with experience translating CRM data into actionable insights. Experience leading customer insights initiatives such as segmentation studies, loyalty drivers, NPS/satisfaction research or journey diagnostics.\n•     Proven people manager, able to build, structure and develop teams to deliver measurable business outcomes.\n•     Strong track record of working hands-on while leading strategically, especially in complex or fast-growth environments.\n•     Experience managing agencies and external partners.\n•     Prior experience in luxury, premium or high-end consumer brands strongly preferred as well as Travel & hospitality\n\nYour Essentials\n\n• Strategic, customer-centric and commercially minded leader.\n• Highly analytical, data-driven and comfortable translating insights into action.\n• Technically savvy, with the ability to bridge business, data and technology teams.\n• Structured, detail-oriented and able to manage multiple priorities in a fast-paced, evolving environment.\n• Outstanding collaboration and influencing skills, with proven ability to operate in a matrix organization.\n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+    "descriptionByLocale": {
+      "it": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!",
+      "en": "Where passion meets opportunity\n\nDiscover your journey into the extraordinary.\n\nYour Purpose\n\nExplora Journeys is a vibrant, cosmopolitan, European luxury brand, imagined in the heart of Swiss hospitality in Geneva. Leveraging our parent company MSC Group’s hundreds of years of maritime expertise, our fleet of six luxury ships (four currently in the pipeline) are being built and designed in a totally different and unique way that will transform and redefine the cruise experience, creating a category of its own, appealing to the next generation of luxury travellers. \nThe CRM Director – Insights, Customer Lifecycle & Marketing Automation leads the strategy and activation of data-driven customer engagement programs to inform the business and support commercial growth, loyalty and lifetime value.\nThe role acts as business lead for lifecycle marketing and marketing automation, working in close partnership with Commercial, Digital, IT, Data and Legal teams to ensure scalable, compliant and high-performing customer communications. He/ She leads the customer’s insights area recommending how to approach the brand evolution assessment. The role is based in Geneva, Switzerland.\n\nYour Impact\n\n1. Lifecycle Strategy & Co-Ownership\n• Lead the definition of the global customer lifecycle strategy organizing the customer journey vision with Commercial, Digital and Guest Experience teams.\n• Translate lifecycle ambition into structured activation roadmaps across owned marketing automation channels.\n• Define lifecycle design principles, segmentation logic and engagement frameworks aligned with brand and commercial objectives.\n• Ensure cross-functional alignment between customer experience, commercial priorities and lifecycle communications.\n\n2. Journey Activation & Channel Governance\n• Lead automated journey orchestration primarily across owned CRM channels \n• Establish governance for segmentation, personalization and campaign standards.\n• Coordinate with other channel owners (e.g., Media, Social, Digital) to ensure journey consistency.\n• Drive structured adoption of personalization and audience activation tools.\n\n3. Platform Business Ownership \n• Act as business product owner of marketing automation platforms (e.g., Salesforce Marketing Cloud).\n• Define functional requirements, prioritization and business roadmap.\n• Partner with IT, as technical owner, for architecture, integrations, security and scalability.\n• Ensure operational excellence of automations, data flows and activation processes.\n\n4. Data Governance & Compliance\n• Define lifecycle communication standards in alignment with Legal and IT.\n• Ensure consent management and subscription governance frameworks are operationalized within marketing automation tools.\n• Support privacy-by-design principles across activation use cases.\n\n5. Commercial Impact & Performance\n• Define CRM contribution metrics and dashboards.\n• Monitor engagement, retention and revenue influence.\n• Provide optimization roadmaps to senior leadership.\n\n6. Lead the development of a customer insights framework, leveraging CRM data, external ad hoc research to inform brand health evolution. Translate customer understanding into actionable growth opportunities. Partner with Guest Experience teams, Marketing and Commercial teams to design and prioritize customer research initiatives, including satisfaction tracking, journey analysis, loyalty drivers, brand tracking,etc.\n\n7. Team & Capability Building\n• Build a high-performing marketing CRM team.\n• Elevate internal understanding of marketing automation capabilities and limitations.\n• Drive adoption and maturity of audience strategy and segmentation practices.\n\nYour Journey so far\n\n•    15+ years of experience in CRM, customer lifecycle management, marketing automation or customer data roles, ideally in global and local environments.\n•    Proven experience driving customer acquisition, engagement, loyalty and retention through CRM at scale.\n•    Proven experience designing and managing complex customer journeys across multiple channels, markets and touchpoints, including long consideration and purchase cycles\n•    Deep understanding of CRM platforms, marketing automation tools and data-driven marketing, \n•    Solid knowledge on global standards for data capture, consent management, governance, and enrichment\n•    Strong analytical mindset with experience translating CRM data into actionable insights. Experience leading customer insights initiatives such as segmentation studies, loyalty drivers, NPS/satisfaction research or journey diagnostics.\n•     Proven people manager, able to build, structure and develop teams to deliver measurable business outcomes.\n•     Strong track record of working hands-on while leading strategically, especially in complex or fast-growth environments.\n•     Experience managing agencies and external partners.\n•     Prior experience in luxury, premium or high-end consumer brands strongly preferred as well as Travel & hospitality\n\nYour Essentials\n\n• Strategic, customer-centric and commercially minded leader.\n• Highly analytical, data-driven and comfortable translating insights into action.\n• Technically savvy, with the ability to bridge business, data and technology teams.\n• Structured, detail-oriented and able to manage multiple priorities in a fast-paced, evolving environment.\n• Outstanding collaboration and influencing skills, with proven ability to operate in a matrix organization.\n\nAt Explora Journeys, we are redefining luxury ocean travel — where discovery, well-being, and a deep respect for the seas come together in harmony. \nWe seek passionate professionals who share our vision of a more immersive, transformative way to discover the world’s most inspiring destinations by sea.\nAre you ready to turn your passion into something extraordinary? Join us at Explora Journeys, where an ocean of opportunities awaits. Your journey to the Ocean State of Mind starts here.",
+      "de": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!",
+      "fr": "Join our team as a CRM Director, where you will lead data-driven customer engagement programs and lifecycle marketing strategies. Leverage your expertise in CRM and marketing automation to drive commercial growth and enhance customer loyalty. Be part of a vibrant luxury brand redefining the cruise experience!"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16545EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.778Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Marketing",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-03-05",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16545EXTERNALENGB",
+    "jobReqId": "16545",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.299Z",
+    "previousSlugsByLocale": {
+      "it": [
+        "crm-director-msc-geneva"
+      ],
+      "de": [
+        "crm-director-msc-geneva"
+      ]
+    },
+    "previousSlugs": [
+      "crm-director-msc-geneva"
+    ],
+    "salaryMin": 75500,
+    "salaryMax": 133000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 75500,
+        "maxValue": 133000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-32cf9574722c",
+    "slug": "culinary-operations-manager-msc-geneva",
+    "slugByLocale": {
+      "it": "culinary-operations-manager-msc-geneva",
+      "en": "culinary-operations-manager-msc-geneva",
+      "de": "culinary-operations-manager-msc-geneva",
+      "fr": "culinary-operations-manager-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Culinary Operations Manager",
+    "titleByLocale": {
+      "it": "Culinary Operations Manager",
+      "en": "Culinary Operations Manager",
+      "de": "Culinary Operations Manager",
+      "fr": "Culinary Operations Manager"
+    },
+    "description": "Your Purpose\n\nThe Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financial cost of the culinary department, monitoring and guiding the team, and actively participating in recruitment for leadership positions within the culinary function. Acting as the strategic link between the corporate office in Geneva and the traveling and shipboard teams, this role ensures consistent quality, compliance with corporate standards, and continuous culinary innovation. This role directly reports to the Vice President of F&B.\n\nYour Impact\n\n \n\nStrategic Culinary Leadership\n\n- Provide visionary leadership and guidance for the culinary team across the fleet, ensuring alignment with brand philosophy.\n\n- Define, implement, and uphold fleet-wide culinary operational standards and best practices.\n\n- Play an active role in strategic planning for all F&B service and beverage needs.\n\n- Lead menu development, recipe creation, and implementation of culinary projects.\n\n \n\nOperational Oversight & Quality Assurance\n\n- Conduct structured operational reviews, remote audits, and ship visits as required.\n\n- Ensure food quality, presentation, and consistency across all vessels.\n\n- Monitor guest satisfaction metrics and implement strategic improvements.\n\n- Ensure compliance with global health, safety, and hygiene protocols.\n\n- Oversee beverage order and loading coordination.\n\n \n\nTraining & Leadership Development\n\n- Mentor and develop future culinary leaders and onboard chefs.\n\n- Design and implement fleet-wide training programs in line with brand standards.\n\n- Foster long-term succession planning for culinary leadership positions.\n\n \n\nHuman Resources & Team Management\n\n- Drive a high-performance culture emphasizing recognition, development, and fairness.\n\n- Oversee leadership performance reviews, promotions, and career pathing.\n\n- Support HR in recruitment for senior culinary positions and host rotations.\n\n \n\nFleet Support & Headquarters Coordination\n\n- Act as the principal liaison for all culinary matters between corporate headquarters and the fleet.\n\n- Coordinate galley equipment planning, material sourcing, and integration of brand standards.\n\n- Compile operational and financial reports for corporate leadership.\n\n \n\nFinancial Oversight\n\n- Overseeing food orders and maintaining the food master list to ensure accuracy, proper order planning, and sequence management.\n\n- Responsible for overall financial cost of the culinary department.\n\n- Implement continuous improvement plans to meet or exceed economic targets.\n\n- Oversee cost control, inventory optimization, and resource planning.\n\n- Play a key role for the overall financial cost of the culinary department.\n\n- Implement continuous improvement plans to meet or exceed economic targets.\n\n- Oversee cost control, inventory optimization, and resource planning.\n\nYour Journey so far\n\n- Minimum 15 years in high-end culinary operations with advanced skills.\n\n- At least 5 years in senior leadership roles within luxury hospitality or cruise operations.\n\n- Proven experience in fleet-wide or multi-site culinary management.\n\nYour Essentials\n\n \n\nLeadership & Communication\n\n- Dynamic, strategic leader with experience managing multicultural teams.\n\n- Excellent communication skills, fluent in English; additional languages an asset.\n\n \n\nTechnical & Operational Knowledge\n\n- Proficient in Microsoft Office Suite and industry-specific systems.\n\n- Knowledge of HR protocols, time and attendance compliance, and labor regulations.\n\n- Expertise in culinary operations, menu development, and luxury hospitality standards.\n\n \n\nProfessional Competencies\n\n- Strategic thinker with operational agility and strong business acumen.\n\n- Highly detail-oriented, results-driven, and guest experience-focused.\n\n- Strong collaborator capable of working cross-functionally across corporate and shipboard teams.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia...",
+      "en": "Your Purpose\n\nThe Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financial cost of the culinary department, monitoring and guiding the team, and actively participating in recruitment for leadership positions within the culinary function. Acting as the strategic link between the corporate office in Geneva and the traveling and shipboard teams, this role ensures consistent quality, compliance with corporate standards, and continuous culinary innovation. This role directly reports to the Vice President of F&B.\n\nYour Impact\n\n \n\nStrategic Culinary Leadership\n\n- Provide visionary leadership and guidance for the culinary team across the fleet, ensuring alignment with brand philosophy.\n\n- Define, implement, and uphold fleet-wide culinary operational standards and best practices.\n\n- Play an active role in strategic planning for all F&B service and beverage needs.\n\n- Lead menu development, recipe creation, and implementation of culinary projects.\n\n \n\nOperational Oversight & Quality Assurance\n\n- Conduct structured operational reviews, remote audits, and ship visits as required.\n\n- Ensure food quality, presentation, and consistency across all vessels.\n\n- Monitor guest satisfaction metrics and implement strategic improvements.\n\n- Ensure compliance with global health, safety, and hygiene protocols.\n\n- Oversee beverage order and loading coordination.\n\n \n\nTraining & Leadership Development\n\n- Mentor and develop future culinary leaders and onboard chefs.\n\n- Design and implement fleet-wide training programs in line with brand standards.\n\n- Foster long-term succession planning for culinary leadership positions.\n\n \n\nHuman Resources & Team Management\n\n- Drive a high-performance culture emphasizing recognition, development, and fairness.\n\n- Oversee leadership performance reviews, promotions, and career pathing.\n\n- Support HR in recruitment for senior culinary positions and host rotations.\n\n \n\nFleet Support & Headquarters Coordination\n\n- Act as the principal liaison for all culinary matters between corporate headquarters and the fleet.\n\n- Coordinate galley equipment planning, material sourcing, and integration of brand standards.\n\n- Compile operational and financial reports for corporate leadership.\n\n \n\nFinancial Oversight\n\n- Overseeing food orders and maintaining the food master list to ensure accuracy, proper order planning, and sequence management.\n\n- Responsible for overall financial cost of the culinary department.\n\n- Implement continuous improvement plans to meet or exceed economic targets.\n\n- Oversee cost control, inventory optimization, and resource planning.\n\n- Play a key role for the overall financial cost of the culinary department.\n\n- Implement continuous improvement plans to meet or exceed economic targets.\n\n- Oversee cost control, inventory optimization, and resource planning.\n\nYour Journey so far\n\n- Minimum 15 years in high-end culinary operations with advanced skills.\n\n- At least 5 years in senior leadership roles within luxury hospitality or cruise operations.\n\n- Proven experience in fleet-wide or multi-site culinary management.\n\nYour Essentials\n\n \n\nLeadership & Communication\n\n- Dynamic, strategic leader with experience managing multicultural teams.\n\n- Excellent communication skills, fluent in English; additional languages an asset.\n\n \n\nTechnical & Operational Knowledge\n\n- Proficient in Microsoft Office Suite and industry-specific systems.\n\n- Knowledge of HR protocols, time and attendance compliance, and labor regulations.\n\n- Expertise in culinary operations, menu development, and luxury hospitality standards.\n\n \n\nProfessional Competencies\n\n- Strategic thinker with operational agility and strong business acumen.\n\n- Highly detail-oriented, results-driven, and guest experience-focused.\n\n- Strong collaborator capable of working cross-functionally across corporate and shipboard teams.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia...",
+      "fr": "The Culinary Operations Manager provides strategic leadership and oversight for all culinary operations across the fleet. The Manager of Culinary Operations is a strategic role on the overall financia..."
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16385EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.777Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Produzione",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-01-30",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16385EXTERNALENGB",
+    "jobReqId": "16385",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.299Z",
+    "salaryMin": 68000,
+    "salaryMax": 103000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 68000,
+        "maxValue": 103000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-72e4b16fc7fa",
+    "slug": "mobile-app-product-specialista-msc-group-geneva",
+    "slugByLocale": {
+      "it": "mobile-app-product-specialista-msc-group-geneva",
+      "en": "mobile-app-product-specialist-msc-geneva",
+      "de": "mobile-app-product-spezialist-msc-group-geneva",
+      "fr": "mobile-app-product-specialiste-msc-group-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Mobile App Product Specialist",
+    "titleByLocale": {
+      "it": "Mobile App Product Specialista",
+      "en": "Mobile App Product Specialist",
+      "de": "Mobile App Product Spezialist",
+      "fr": "Mobile App Product Spécialiste"
+    },
+    "description": "Your Purpose\n\nWe are seeking a dynamic and highly motivated Mobile App Product Specialist to join our Business Innovation team at MSC Cruises Headquarters in Geneva. This role is designed for a data-driven professional with a strong commercial acumen, an analytical mindset, and a passion for optimizing mobile user journeys. The successful candidate will explore in-app behaviors, remove friction in the sales funnel, and drive product-led initiatives to maximize conversion rates and shape the future of digital guest experiences across the MSC for Me digital ecosystem.\n\nYour Impact\n\n- Analyze the MSC for Me in-app user journey and behavior to identify bottlenecks, proposing and validating product initiatives that optimize the sales funnel and boost in-app conversion rates.\n\n- Collaborate with Product, Tech, and UX/UI cross-functional teams to design and implement features that drive organic user acquisition and increase cross-selling/up-selling opportunities for the MSC for Me digital ecosystem.\n\n- Implement and optimize the in-app position of commercial offerings (working closing with Onboard Revenues Commercial Department) to maximize visibility and sales conversions specifically for mobile users.\n\n- Use advanced product analytics tools and data visualization (Power BI) to track sales performance, user activation rates, and drop-offs into the MSC for Me digital ecosystem.\n\n- Act as a bridge between the Onboard Revenues Commercial department and the Tech/Development teams, translating revenue goals into clear digital product requirements to enhance the MSC for Me digital ecosystem.\n\n- Drive MSC for Me  channel-led acquisition by refining native in-app features—such as frictionless guest-to-registered user flows, invite-a-friend mechanisms, and seamless app sharing—to grow the user base.\n\n- Conduct A/B testing on MSC for Me  in-app sales flows, checkout processes, and subscription models to continuously improve operational efficiency and revenue generation.\n\nYour Journey so far\n\n- Bachelor’s or master’s degree in Business Administration, Economics, Marketing Management, Digital or a related field.\n\n- Strong commercial and analytical skills with 3 to 5 years of proven experience in digital sales, product growth, or digital business development, with a strict focus on mobile applications.\n\n- Hands-on experience with app analytics, Conversion Rate Optimization (CRO), and data manipulation/visualization tools (Power BI, SQL; Python is a plus).\n\n- Familiarity with agile methodologies and ability to work side-by-side with developers and product managers in dynamic, fast-paced environments.\n\n- Excellent communication and collaboration skills, with the ability to translate data-driven insights into actionable business and product recommendations.\n\n- Creative thinker with a proactive approach to problem-solving, capable of driving \"Product-Led Growth\" rather than relying on traditional marketing spend.\n\n- Fluent in English; additional European languages are a plus.\n\nYour Essentials\n\n- Deep understanding of mobile user behavior, digital sales funnels, and product-centric acquisition ecosystems.\n\n- Strong business acumen with a focus on maximizing Customer Lifetime Value (CLV) and removing friction from the mobile buying experience.\n\n- Ability to manage multiple priorities and deliver high-quality outputs under tight deadlines.\n\n \n\nVISA REQUIREMENTS (if any) : \n\n- Right to work in Switzerland.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications.",
+      "en": "Your Purpose\n\nWe are seeking a dynamic and highly motivated Mobile App Product Specialist to join our Business Innovation team at MSC Cruises Headquarters in Geneva. This role is designed for a data-driven professional with a strong commercial acumen, an analytical mindset, and a passion for optimizing mobile user journeys. The successful candidate will explore in-app behaviors, remove friction in the sales funnel, and drive product-led initiatives to maximize conversion rates and shape the future of digital guest experiences across the MSC for Me digital ecosystem.\n\nYour Impact\n\n- Analyze the MSC for Me in-app user journey and behavior to identify bottlenecks, proposing and validating product initiatives that optimize the sales funnel and boost in-app conversion rates.\n\n- Collaborate with Product, Tech, and UX/UI cross-functional teams to design and implement features that drive organic user acquisition and increase cross-selling/up-selling opportunities for the MSC for Me digital ecosystem.\n\n- Implement and optimize the in-app position of commercial offerings (working closing with Onboard Revenues Commercial Department) to maximize visibility and sales conversions specifically for mobile users.\n\n- Use advanced product analytics tools and data visualization (Power BI) to track sales performance, user activation rates, and drop-offs into the MSC for Me digital ecosystem.\n\n- Act as a bridge between the Onboard Revenues Commercial department and the Tech/Development teams, translating revenue goals into clear digital product requirements to enhance the MSC for Me digital ecosystem.\n\n- Drive MSC for Me  channel-led acquisition by refining native in-app features—such as frictionless guest-to-registered user flows, invite-a-friend mechanisms, and seamless app sharing—to grow the user base.\n\n- Conduct A/B testing on MSC for Me  in-app sales flows, checkout processes, and subscription models to continuously improve operational efficiency and revenue generation.\n\nYour Journey so far\n\n- Bachelor’s or master’s degree in Business Administration, Economics, Marketing Management, Digital or a related field.\n\n- Strong commercial and analytical skills with 3 to 5 years of proven experience in digital sales, product growth, or digital business development, with a strict focus on mobile applications.\n\n- Hands-on experience with app analytics, Conversion Rate Optimization (CRO), and data manipulation/visualization tools (Power BI, SQL; Python is a plus).\n\n- Familiarity with agile methodologies and ability to work side-by-side with developers and product managers in dynamic, fast-paced environments.\n\n- Excellent communication and collaboration skills, with the ability to translate data-driven insights into actionable business and product recommendations.\n\n- Creative thinker with a proactive approach to problem-solving, capable of driving \"Product-Led Growth\" rather than relying on traditional marketing spend.\n\n- Fluent in English; additional European languages are a plus.\n\nYour Essentials\n\n- Deep understanding of mobile user behavior, digital sales funnels, and product-centric acquisition ecosystems.\n\n- Strong business acumen with a focus on maximizing Customer Lifetime Value (CLV) and removing friction from the mobile buying experience.\n\n- Ability to manage multiple priorities and deliver high-quality outputs under tight deadlines.\n\n \n\nVISA REQUIREMENTS (if any) : \n\n- Right to work in Switzerland.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications.",
+      "fr": "Are you experienced in optimizing mobile user journeys? Join our team as a Mobile App Product Specialist and drive product-led initiatives to enhance digital guest experiences. Your analytical mindset and commercial acumen will be key in maximizing conversion rates and shaping the future of our mobile applications."
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16552EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.775Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Marketing",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "mid",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-03-10",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16552EXTERNALENGB",
+    "jobReqId": "16552",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.297Z",
+    "previousSlugsByLocale": {
+      "it": [
+        "mobile-app-product-specialist-msc-geneva"
+      ],
+      "de": [
+        "mobile-app-product-specialist-msc-geneva"
+      ],
+      "fr": [
+        "mobile-app-product-specialist-msc-geneva"
+      ]
+    },
+    "previousSlugs": [
+      "mobile-app-product-specialist-msc-geneva"
+    ],
+    "salaryMin": 50500,
+    "salaryMax": 89000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 50500,
+        "maxValue": 89000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-620a4e378a97",
+    "slug": "finanza-and-accounting-manager-new-investments-msc-group-geneva",
+    "slugByLocale": {
+      "it": "finanza-and-accounting-manager-new-investments-msc-group-geneva",
+      "en": "finance-and-accounting-manager-new-investments-msc-geneva",
+      "de": "finanzen-and-accounting-manager-new-investments-msc-group-geneva",
+      "fr": "finance-and-accounting-manager-new-investments-msc-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Finance and Accounting Manager - New Investments",
+    "titleByLocale": {
+      "it": "Finanza and Accounting Manager - New Investments",
+      "en": "Finance and Accounting Manager - New Investments",
+      "de": "Finanzen and Accounting Manager - New Investments",
+      "fr": "Finance and Accounting Manager - New Investments"
+    },
+    "description": "Your Purpose\n\nThe Finance and Accounting Manager – New Investments will lead financial oversight, accounting, and performance management for the company’s new Strategic Value Chain Investments (“SVCI”). This role plays a critical part in ensuring strong financial controls, and partnering with cross-functional teams to optimize profitability across non-core cruise operations.\nThe ideal candidate brings a blend of technical accounting expertise, commercial finance acumen, and experience supporting investment-driven or multi-business environments.\n\nYour Impact\n\nFinancial Management & Reporting\n\n- Oversee accounting, month-end close, and financial reporting for SVCI\n\n- Ensure accurate revenue recognition, cost allocation, and margin analysis for SVCI\n\n- Prepare and review management reports, KPIs, and variance analyses to support business decisions\n\n- Maintain compliance with internal controls, accounting standards, and company policies\n\n \n\nNew Investments & Business Evaluation\n\n- Track post-investment performance versus plan and identify risks and improvement opportunities\n\n \n\nBudgeting & Forecasting\n\n- Assist the investments and the group during budgeting and rolling forecast processes \n\n- Partner with operational leaders to develop realistic assumptions and financial targets\n\n- Monitor performance against budgets and provide actionable insights\n\n \n\nCross-Functional Support\n\n- Act as a finance business partner to support potential synergies within the investments. \n\n- Collaborate with Legal, Treasury, Operations, and Commercial teams on contract structures, pricing models, and financial implications\n\n- Support strategic initiatives related to expansion, innovation, and optimization of new investments\n\n \n\nProcess Improvement & Systems\n\n- Improve financial processes, reporting automation, and data quality across investment activities\n\n- Support implementation or enhancement of ERP, reporting tools, or financial systems as needed\n\n- Identify opportunities to scale finance processes as new businesses grow\n\nYour Journey so far\n\n- Master’s degree in Finance, Accounting, or related field (CPA, ACA, ACCA, or equivalent strongly preferred) with a Big 4 background\n\n- 6–10 years of progressive experience in finance and accounting, including exposure to investments, or multi-entity environments\n\n- Experience in hospitality, travel, cruise, retail, consumer services, or asset-heavy industries is a strong plus\n\n- Solid understanding of financial modeling, budgeting, forecasting, and management reporting\n\n- Strong knowledge of IFRS accounting principles and financial controls\n\n- Fluent in English, French and/or Italian are a plus\n\nYour Essentials\n\n- Strong analytical and problem-solving skills with a commercial mindset\n\n- Ability to translate financial data into clear insights for non-finance stakeholders\n\n- Comfortable working in a fast-paced, evolving environment with multiple stakeholders\n\n- High attention to detail with the ability to see the big picture\n\n- Excellent communication and relationship-building skills\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!",
+      "en": "Your Purpose\n\nThe Finance and Accounting Manager – New Investments will lead financial oversight, accounting, and performance management for the company’s new Strategic Value Chain Investments (“SVCI”). This role plays a critical part in ensuring strong financial controls, and partnering with cross-functional teams to optimize profitability across non-core cruise operations.\nThe ideal candidate brings a blend of technical accounting expertise, commercial finance acumen, and experience supporting investment-driven or multi-business environments.\n\nYour Impact\n\nFinancial Management & Reporting\n\n- Oversee accounting, month-end close, and financial reporting for SVCI\n\n- Ensure accurate revenue recognition, cost allocation, and margin analysis for SVCI\n\n- Prepare and review management reports, KPIs, and variance analyses to support business decisions\n\n- Maintain compliance with internal controls, accounting standards, and company policies\n\n \n\nNew Investments & Business Evaluation\n\n- Track post-investment performance versus plan and identify risks and improvement opportunities\n\n \n\nBudgeting & Forecasting\n\n- Assist the investments and the group during budgeting and rolling forecast processes \n\n- Partner with operational leaders to develop realistic assumptions and financial targets\n\n- Monitor performance against budgets and provide actionable insights\n\n \n\nCross-Functional Support\n\n- Act as a finance business partner to support potential synergies within the investments. \n\n- Collaborate with Legal, Treasury, Operations, and Commercial teams on contract structures, pricing models, and financial implications\n\n- Support strategic initiatives related to expansion, innovation, and optimization of new investments\n\n \n\nProcess Improvement & Systems\n\n- Improve financial processes, reporting automation, and data quality across investment activities\n\n- Support implementation or enhancement of ERP, reporting tools, or financial systems as needed\n\n- Identify opportunities to scale finance processes as new businesses grow\n\nYour Journey so far\n\n- Master’s degree in Finance, Accounting, or related field (CPA, ACA, ACCA, or equivalent strongly preferred) with a Big 4 background\n\n- 6–10 years of progressive experience in finance and accounting, including exposure to investments, or multi-entity environments\n\n- Experience in hospitality, travel, cruise, retail, consumer services, or asset-heavy industries is a strong plus\n\n- Solid understanding of financial modeling, budgeting, forecasting, and management reporting\n\n- Strong knowledge of IFRS accounting principles and financial controls\n\n- Fluent in English, French and/or Italian are a plus\n\nYour Essentials\n\n- Strong analytical and problem-solving skills with a commercial mindset\n\n- Ability to translate financial data into clear insights for non-finance stakeholders\n\n- Comfortable working in a fast-paced, evolving environment with multiple stakeholders\n\n- High attention to detail with the ability to see the big picture\n\n- Excellent communication and relationship-building skills\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!",
+      "fr": "Are you experienced in financial management and accounting? Join our team as a Finance and Accounting Manager for New Investments, where you will lead financial oversight and performance management for strategic investments. Bring your expertise to optimize profitability and drive business success!"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16550EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.774Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "Finanza",
+    "contract": "full-time",
+    "employmentType": "OTHER",
+    "experienceLevel": "senior",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-03-09",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16550EXTERNALENGB",
+    "jobReqId": "16550",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "needsRetranslation": true,
+    "firstSeenAt": "2026-05-17T10:50:48.295Z",
+    "previousSlugsByLocale": {
+      "it": [
+        "finance-and-accounting-manager-new-investments-msc-geneva"
+      ],
+      "de": [
+        "finance-and-accounting-manager-new-investments-msc-geneva"
+      ]
+    },
+    "previousSlugs": [
+      "finance-and-accounting-manager-new-investments-msc-geneva"
+    ],
+    "salaryMin": 68000,
+    "salaryMax": 103000,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 68000,
+        "maxValue": 103000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "id": "msc-cargo-1850ab808b78",
+    "slug": "junior-architetto-port-development-intern-msc-group-geneva",
+    "slugByLocale": {
+      "it": "junior-architetto-port-development-intern-msc-group-geneva",
+      "en": "junior-architect-port-development-intern-msc-geneva",
+      "de": "junior-architect-port-development-praktikant-msc-group-geneva",
+      "fr": "junior-architecte-port-development-stagiaire-msc-group-geneva"
+    },
+    "company": "MSC Group",
+    "companyKey": "msc-cargo",
+    "companyDomain": "msc.com",
+    "title": "Junior Architect Port Development Intern",
+    "titleByLocale": {
+      "it": "Junior Architetto Port Development Tirocinante",
+      "en": "Junior Architect Port Development Intern",
+      "de": "Junior Architect Port Development Praktikant",
+      "fr": "Junior Architecte Port Development Stagiaire"
+    },
+    "description": "Your Purpose\n\nThe Junior Architect supports the Port Development team through fast and accurate production of conceptual and technical drawings.\nThe role is focused on internal execution: transforming design inputs into conceptual documentation and effective visualizations to support decision-making across private destinations, cruise terminals, port infrastructure and related facilities.\n\nYour Impact\n\n- Support the translation of business and design inputs into zoning studies, basic spatial diagrams, and architectural layouts.\n\n- Assist in the development of preliminary layouts following internal design guidance and operational requirements.\n\n- Prepare early stage conceptual design packages for internal review and coordination.\n\n- Produce presentation decks, diagrams, visual narratives, and material boards to support internal communication.\n\n- Develop mandatory 3D models and real time visualizations to support internal reviews and executive level presentations.\n\n- Rapidly update, correct, and revise architectural drawings, including plans, sections, elevations, layouts, façade studies, and circulation diagrams.\n\n- Adapt and coordinate port and civil drawings, including site layouts, infrastructure interfaces, circulation roads, and hardscape coordination.\n\nYour Journey so far\n\n- Strong passion for architecture and the world of interiors, materials and spatial composition.\n\n- Curious and design-oriented, with attention to proportion, atmosphere and detail.\n\n- Execution-driven and highly operational.\n\n- Fast in drawing production and revisions.\n\n- Detail-oriented and structured.\n\n- Comfortable working under tight timelines in a dynamic development environment.\n\nYour Essentials\n\n- Advanced proficiency in AutoCAD with strong drafting speed and precision.\n\n- Strong 3D modeling capabilities in SketchUp or Revit (SketchUp preferred).\n\n- Mandatory experience with real-time rendering tools (Enscape, Twinmotion or equivalent).\n\n- Good knowledge of Photoshop for post-production and corrections.\n\n- Basic knowledge of (or interest in) AI tools such as Stable Diffusion or Magnific AI.\n\n- The ability to independently produce clear, standard-quality visualizations for internal decision-making.\n\n- Portfolio including technical drawings and rendered visualizations to be shared with the CV.\n\nThe Junior Architect Port Development Intern must be enrolled in a study program requiring a valid internship agreement. Candidates must hold an EU passport or have the legal right to work in Switzerland. Full professional proficiency in English is required; additional languages are an advantage.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+    "descriptionByLocale": {
+      "it": "Descrizione - Inizia la tua carriera di architetto junior Port Development Intern! - Sostenere progetti innovativi di porto e infrastrutture - Creare disegni tecnici - Sviluppare modelli 3D utilizzando strumenti di rendering AutoCAD, SketchUp e in tempo reale - Collaborare su studi e presentazioni spaziali - Ottieni esperienza pratica in un ambiente dinamico e internazionale - Unisciti a noi e modella il futuro dello sviluppo portuale!",
+      "en": "Your Purpose\n\nThe Junior Architect supports the Port Development team through fast and accurate production of conceptual and technical drawings.\nThe role is focused on internal execution: transforming design inputs into conceptual documentation and effective visualizations to support decision-making across private destinations, cruise terminals, port infrastructure and related facilities.\n\nYour Impact\n\n- Support the translation of business and design inputs into zoning studies, basic spatial diagrams, and architectural layouts.\n\n- Assist in the development of preliminary layouts following internal design guidance and operational requirements.\n\n- Prepare early stage conceptual design packages for internal review and coordination.\n\n- Produce presentation decks, diagrams, visual narratives, and material boards to support internal communication.\n\n- Develop mandatory 3D models and real time visualizations to support internal reviews and executive level presentations.\n\n- Rapidly update, correct, and revise architectural drawings, including plans, sections, elevations, layouts, façade studies, and circulation diagrams.\n\n- Adapt and coordinate port and civil drawings, including site layouts, infrastructure interfaces, circulation roads, and hardscape coordination.\n\nYour Journey so far\n\n- Strong passion for architecture and the world of interiors, materials and spatial composition.\n\n- Curious and design-oriented, with attention to proportion, atmosphere and detail.\n\n- Execution-driven and highly operational.\n\n- Fast in drawing production and revisions.\n\n- Detail-oriented and structured.\n\n- Comfortable working under tight timelines in a dynamic development environment.\n\nYour Essentials\n\n- Advanced proficiency in AutoCAD with strong drafting speed and precision.\n\n- Strong 3D modeling capabilities in SketchUp or Revit (SketchUp preferred).\n\n- Mandatory experience with real-time rendering tools (Enscape, Twinmotion or equivalent).\n\n- Good knowledge of Photoshop for post-production and corrections.\n\n- Basic knowledge of (or interest in) AI tools such as Stable Diffusion or Magnific AI.\n\n- The ability to independently produce clear, standard-quality visualizations for internal decision-making.\n\n- Portfolio including technical drawings and rendered visualizations to be shared with the CV.\n\nThe Junior Architect Port Development Intern must be enrolled in a study program requiring a valid internship agreement. Candidates must hold an EU passport or have the legal right to work in Switzerland. Full professional proficiency in English is required; additional languages are an advantage.\n\nOur commitment\n\nWe are committed to building a future that values diverse perspectives, embraces the world beyond borders, and fosters an inclusive environment where every individual feels valued, respected and empowered to be their authentic selves. Our commitment extends to taking meaningful, measurable actions that have a long-term positive impact on our guests, our employees and our planet.\n\nReady to turn your passion into something extraordinary? Join us at MSC Cruises, where new opportunities await. Apply today to be part of a global team that is pushing boundaries and achieving something remarkable. Your journey starts here!",
+      "de": "Beschreibung - Starten Sie Ihre Architekturkarriere als Junior Architect Port Development Intern! - Unterstützung innovativer Hafen- und Infrastrukturprojekte - technische Zeichnungen erstellen - Entwickeln Sie 3D-Modelle mit AutoCAD, SketchUp und Echtzeit-Rendering-Tools - Zusammenarbeit bei Raumstudien und Präsentationen - Erfahrung in einem dynamischen, internationalen Umfeld sammeln - Mitmachen und die Zukunft der Hafenentwicklung gestalten!",
+      "fr": "Descrizione - Commencez votre carrière d'architecte junior en tant que stagiaire en développement portuaire ! - Soutenir des projets portuaires et d'infrastructure innovants - Créer des dessins techniques - Développer des modèles 3D en utilisant AutoCAD, SketchUp et des outils de rendu en temps réel - Collaborer à des études et des présentations spatiales - Acquérir une expérience pratique dans un environnement international dynamique - Rejoignez-nous et façonnez l'avenir du développement portuaire !"
+    },
+    "location": "Geneva",
+    "canton": "GE",
+    "url": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16951EXTERNALENGB",
+    "source": "MSC Group Dedicated Parser (Phenom careers portal)",
+    "sourceLang": "en",
+    "crawledAt": "2026-05-17T22:15:34.764Z",
+    "addressLocality": "Geneva",
+    "addressRegion": "GE",
+    "addressCountry": "CH",
+    "country": "CH",
+    "category": "IT",
+    "contract": "full-time",
+    "employmentType": "INTERN",
+    "experienceLevel": "intern",
+    "sector": "Logistica e crocieristica",
+    "currency": "CHF",
+    "featured": false,
+    "postedDate": "2026-05-05",
+    "applyUrl": "https://careers.msccruises.com/gb/en/job/MCTMCUGB16951EXTERNALENGB",
+    "jobReqId": "16951",
+    "requirements": [],
+    "requirementsByLocale": {},
+    "previousSlugs": [
+      "junior-architect-port-development-intern-msc-geneva"
+    ],
+    "previousSlugsByLocale": {
+      "it": [
+        "junior-architect-port-development-intern-msc-geneva"
+      ],
+      "de": [
+        "junior-architect-port-development-intern-msc-geneva"
+      ],
+      "fr": [
+        "junior-architect-port-development-intern-msc-geneva"
+      ]
+    },
+    "firstSeenAt": "2026-05-13T22:48:16.135Z",
+    "salaryMin": 46000,
+    "salaryMax": 78500,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 46000,
+        "maxValue": 78500,
+        "unitText": "YEAR"
+      }
+    }
+  }
+]

--- a/data/jobs/by-crawler/posta-svizzera-centro-regionale.json
+++ b/data/jobs/by-crawler/posta-svizzera-centro-regionale.json
@@ -1,790 +1,786 @@
-{
-  "crawlerKey": "posta-svizzera-centro-regionale",
-  "assembledAt": "2026-05-17T22:18:30.964Z",
-  "jobs": [
-    {
-      "url": "https://job.post.ch/default/job/Quereinsteigerin-als-PostAuto-Fahrerin/73637-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/Quereinsteigerin-als-PostAuto-Fahrerin/73637-de_DE",
-      "title": "Quereinsteiger:in als PostAuto-Fahrer:in",
-      "company": "PostAuto",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Ilanz",
-      "canton": "GR",
-      "country": "CH",
-      "description": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
-      "descriptionByLocale": {
-        "it": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
-        "en": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
-        "de": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
-        "fr": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten."
-      },
-      "titleByLocale": {
-        "it": "Candidato/a in riqualificazione come PostAuto-Fahrer:in",
-        "en": "Quereinsteiger:in als PostAuto-Fahrer:in",
-        "de": "Quereinsteiger:in als PostAuto-Fahrer:in",
-        "fr": "Quereinsteiger:in als PostAuto-Fahrer:in"
-      },
-      "slug": "candidato-a-in-riqualificazione-come-postauto-fahrer-in-postauto-ilanz",
-      "slugByLocale": {
-        "it": "candidato-a-in-riqualificazione-come-postauto-fahrer-in-postauto-ilanz",
-        "en": "quereinsteiger-in-als-postauto-fahrer-in-post",
-        "de": "quereinsteiger-in-als-postauto-fahrer-in-postauto-ilanz",
-        "fr": "quereinsteiger-in-als-postauto-fahrer-in-post"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-05-13",
-      "validThrough": "2026-06-10",
-      "source": "postch-careers-crawler",
-      "employmentType": "FULL_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "80-100%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Ilanz"
-      },
-      "crawledAt": "",
-      "needsRetranslation": true,
-      "id": "posta-svizzera-centro-regionale-528fb1160ca5",
-      "previousSlugsByLocale": {
-        "it": [
-          "quereinsteiger-in-als-postauto-fahrer-in-post"
-        ]
-      },
-      "previousSlugs": [
-        "quereinsteiger-in-als-postauto-fahrer-in-post"
-      ],
-      "salaryMin": 49500,
-      "salaryMax": 75000,
-      "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Ilanz",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-17T10:53:34.351Z",
-      "retranslationAttempts": 1
+[
+  {
+    "url": "https://job.post.ch/default/job/Quereinsteigerin-als-PostAuto-Fahrerin/73637-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/Quereinsteigerin-als-PostAuto-Fahrerin/73637-de_DE",
+    "title": "Quereinsteiger:in als PostAuto-Fahrer:in",
+    "company": "PostAuto",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Ilanz",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse.\n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein.\n\r\n\n- Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an.\n\r\n\n- Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel.\n\r\n\n- Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.\n\r\n\n- Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung!\n\r\n\n- Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit.\n\r\n\n- Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.\n\r\n\n- Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
+    "descriptionByLocale": {
+      "it": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse.\n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein.\n\r\n\n- Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an.\n\r\n\n- Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel.\n\r\n\n- Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.\n\r\n\n- Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung!\n\r\n\n- Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit.\n\r\n\n- Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.\n\r\n\n- Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
+      "en": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
+      "de": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
+      "fr": "Möchtest du ganz vorne links Platz nehmen und unsere Postautos lenken? Dann lasse dich bei uns als PostAuto-Fahrer:in ausbilden und begleite uns auf unserer Erfolgsgeschichte. Denn mit dir dir bringen wir nicht nur Menschen ans Ziel, sondern sorgen für erstklassigen Service auf der Strasse. Das kannst du bewirken In den ersten vier Monaten erhältst du theoretischen und praktischen Fahrunterricht, um dich optimal auf die Prüfungen der Kategorie D vorzubereiten. Nach erfolgreich absolvierter Prüfung führen wir dich als Fahrer:in auf unseren Linien ein. Danach bist du startklar und wir bieten dir eine unbefristete Festanstellung an. Im Alltag bringst du dann unsere Fahrgäste sicher und pünktlich von Montag bis Sonntag auf unseren abwechslungsreichen regionalen Linien an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug - auf der Strasse und im direkten Kundenkontakt schaffst du jeden Tag positive Erlebnisse für unsere Kundschaft. Das bringst du mit Du verfügst über eine Grundausbildung und bist bereit, den Führerausweis der Kategorie D zu erlangen - wir übernehmen die Kosten der Ausbildung! Um den Führerausweis der Kategorie D zu erlangen, bringst du den Führerausweis der Kategorie B (mind. 2 Jahre) oder C (mind. 3 Monate) mit. Zuverlässigkeit ist eine deiner Stärken, und du schätzt die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten."
     },
-    {
-      "url": "https://job.post.ch/default/job/PostAuto-Fahrerin/73636-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/PostAuto-Fahrerin/73636-de_DE",
-      "title": "PostAuto-Fahrer:in",
-      "company": "PostAuto",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Ilanz",
+    "titleByLocale": {
+      "it": "Candidato/a in riqualificazione come PostAuto-Fahrer:in",
+      "en": "Quereinsteiger:in als PostAuto-Fahrer:in",
+      "de": "Quereinsteiger:in als PostAuto-Fahrer:in",
+      "fr": "Quereinsteiger:in als PostAuto-Fahrer:in"
+    },
+    "slug": "candidato-a-in-riqualificazione-come-postauto-fahrer-in-postauto-ilanz",
+    "slugByLocale": {
+      "it": "candidato-a-in-riqualificazione-come-postauto-fahrer-in-postauto-ilanz",
+      "en": "quereinsteiger-in-als-postauto-fahrer-in-post",
+      "de": "quereinsteiger-in-als-postauto-fahrer-in-postauto-ilanz",
+      "fr": "quereinsteiger-in-als-postauto-fahrer-in-post"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-05-13",
+    "validThrough": "2026-06-10",
+    "source": "postch-careers-crawler",
+    "employmentType": "FULL_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "80-100%",
+    "_targetScope": {
       "canton": "GR",
-      "country": "CH",
-      "description": "Möchtest du ganz vorne links Platz nehmen und als PostAuto-Fahrer:in bei uns einsteigen? Willst du Teil der gelben Klasse werden und dich mit deinem aktiven Beitrag täglich am Erfolg von PostAuto beteiligen? Dann bewirb dich bei uns, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich, sicher und komfortabel ans Ziel. Das kannst du bewirken Auf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Der tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug auf der Strasse. Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen. Das bringst du mit Du verfügst über Fahrpraxis im Personentransport und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Für diese Stelle benötigst du einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis. Zuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten",
-      "descriptionByLocale": {
-        "it": "Descrizione\nTi piace incontrare nuove persone ogni giorno e vuoi lavorare in modo indipendente? Allora ti stiamo cercando, perche' con te sulla ruota, i nostri passeggeri arrivano in tempo e in sicurezza.\n\nMansioni\n- Nelle nostre varie linee regionali porti i nostri passeggeri a destinazione da lunedì a domenica.\n- Lei è ospite: nelle nostre auto postali e consiglia ai nostri clienti in domande tariffarie e orari.\n- Il contatto quotidiano con i passeggeri arricchisce la vostra vita quotidiana con incontri emozionanti e crei esperienze positive per i nostri clienti.\n\nRequisiti\n- Ha la pratica di guida nel trasporto passeggeri.\n- Vi piace il cambiamento che porta ore di lavoro irregolari (comprese le domeniche e le vacanze).\n- Hai bisogno di un ID driver di categoria D e di un certificato di qualifica del conducente valido.\n- Affidabilità e gioia nel contatto quotidiano del cliente sono tra i vostri punti di forza.\n- Hai buone competenze tedesche.\n- Sei esperto nella gestione di dispositivi digitali.\n\nCosa?\n- Muovi molto di più del tuo veicolo sulla strada.\n- In contatto diretto con i clienti si verificano situazioni nuove e variegate ogni giorno.\n\nContatto\n- (Contatto non specificato)",
-        "en": "Descrizione\nDo you love meeting new people every day and want to work independently? Then we're looking for you, because with you on the wheel, our passengers arrive on time and safely.\n\nMansioni\n- On our varied regional lines you bring our passengers to their destination from Monday to Sunday.\n- You are host:in our post cars and advises our customers in tariff and timetable questions.\n- Daily contact with your passengers enriches your everyday life with exciting encounters and you create positive experiences for our customers.\n\nRequisiti\n- You have driving practice in passenger transport.\n- You enjoy the change that brings irregular working hours (including Sundays and holidays).\n- You need a category D driver ID and a valid driver qualification certificate.\n- Reliability and joy in daily customer contact are among your strengths.\n- You have good German skills.\n- You are experienced in handling digital devices.\n\nCosa offriamo\n- You move far more than your vehicle on the road.\n- In direct customer contact you will experience new and varied situations every day.\n\nContatto\n- (Contatto non specificato)",
-        "de": "## Descrizione\nLiebst du es, jeden Tag neue Menschen zu treffen und möchtest eigenverantwortlich arbeiten? Dann suchen wir genau dich, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich und sicher ans Ziel.\n\n## Mansioni\n- Auf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel.\n- Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.\n- Der tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.\n\n## Requisiti\n- Du verfügst über Fahrpraxis im Personentransport.\n- Du geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.\n- Du benötigst einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis.\n- Zuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken.\n- Du verfügst über gute Deutschkenntnisse.\n- Du bist versiert im Umgang mit digitalen Geräten.\n\n## Cosa offriamo\n- Du bewegst weit mehr als nur dein Fahrzeug auf der Strasse.\n- Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen.\n\n## Contatto\n- (Contatto non specificato)",
-        "fr": "Descrizione\nAimez-vous rencontrer de nouvelles personnes chaque jour et souhaitez-vous travailler de façon indépendante? Ensuite, nous vous cherchons, car avec vous au volant, nos passagers arrivent à temps et en toute sécurité.\n\nMansioni\n- Sur nos lignes régionales variées, vous amènez nos passagers à destination du lundi au dimanche.\n- Vous êtes l'hôte: dans nos voitures postales et conseille nos clients dans les questions de tarif et d'horaire.\n- Le contact quotidien avec vos passagers enrichit votre vie quotidienne de rencontres passionnantes et vous créez des expériences positives pour nos clients.\n\nRequisiti\n- Vous avez un entraînement en transport de passagers.\n- Vous appréciez le changement qui apporte des horaires de travail irréguliers (y compris le dimanche et les jours fériés).\n- Vous avez besoin d'un identifiant de conducteur de catégorie D et d'un certificat de qualification valide.\n- Fiabilité et joie dans le contact quotidien avec le client sont parmi vos forces.\n- Vous avez de bonnes compétences en allemand.\n- Vous êtes expérimenté dans la manipulation des appareils numériques.\n\nCosa offriamo\n- Tu bouges bien plus que ton véhicule sur la route.\n- En contact direct avec le client, vous vivrez des situations nouvelles et variées chaque jour.\n\nContatto\n- (Contatto non spécifique)"
-      },
-      "titleByLocale": {
-        "it": "Driver per il carrello",
-        "en": "Postcar driver:in",
-        "de": "PostAuto-Fahrer:in",
-        "fr": "Conducteur d ' une voiture"
-      },
-      "slug": "driver-per-il-carrello-postauto-ilanz",
-      "slugByLocale": {
-        "it": "driver-per-il-carrello-postauto-ilanz",
-        "en": "postcar-driver-in-postauto-davos-platz",
-        "de": "postauto-fahrer-in-postauto-davos-platz",
-        "fr": "conducteur-d-une-voiture-postauto-davos-platz"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-05-13",
-      "validThrough": "2026-06-03",
-      "source": "postch-careers-crawler",
-      "employmentType": "FULL_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "20-100%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Ilanz"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-17ff4c3a48fc",
-      "salaryMin": 49500,
-      "salaryMax": 75000,
+      "location": "Ilanz"
+    },
+    "crawledAt": "",
+    "needsRetranslation": true,
+    "id": "posta-svizzera-centro-regionale-528fb1160ca5",
+    "previousSlugsByLocale": {
+      "it": [
+        "quereinsteiger-in-als-postauto-fahrer-in-post"
+      ]
+    },
+    "previousSlugs": [
+      "quereinsteiger-in-als-postauto-fahrer-in-post"
+    ],
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
       "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Ilanz",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-17T10:53:34.351Z",
-      "previousSlugsByLocale": {
-        "de": [
-          "postauto-fahrer-in-postauto-ilanz"
-        ],
-        "it": [
-          "postauto-fahrer-in-post-2",
-          "postauto-fahrer-in-post"
-        ]
-      },
-      "previousSlugs": [
-        "postauto-fahrer-in-postauto-ilanz",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Ilanz",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-17T10:53:34.351Z",
+    "retranslationAttempts": 1
+  },
+  {
+    "url": "https://job.post.ch/default/job/PostAuto-Fahrerin/73636-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/PostAuto-Fahrerin/73636-de_DE",
+    "title": "PostAuto-Fahrer:in",
+    "company": "PostAuto",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Ilanz",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Möchtest du ganz vorne links Platz nehmen und als PostAuto-Fahrer:in bei uns einsteigen? Willst du Teil der gelben Klasse werden und dich mit deinem aktiven Beitrag täglich am Erfolg von PostAuto beteiligen? Dann bewirb dich bei uns, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich, sicher und komfortabel ans Ziel. \n\r\n\n  \n\r\n\nDas kannst du bewirken \n\r\n\n\r\n\n- \r\n\nAuf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDer tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nAls Fahrer:in bewegst du weit mehr als nur dein Fahrzeug auf der Strasse. Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen. \n\r\n\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit \n\r\n\n\r\n\n- \r\n\nDu verfügst über Fahrpraxis im Personentransport und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nFür diese Stelle benötigst du einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nZuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten",
+    "descriptionByLocale": {
+      "it": "Möchtest du ganz vorne links Platz nehmen und als PostAuto-Fahrer:in bei uns einsteigen? Willst du Teil der gelben Klasse werden und dich mit deinem aktiven Beitrag täglich am Erfolg von PostAuto beteiligen? Dann bewirb dich bei uns, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich, sicher und komfortabel ans Ziel. \n\r\n\n  \n\r\n\nDas kannst du bewirken \n\r\n\n\r\n\n- \r\n\nAuf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDer tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nAls Fahrer:in bewegst du weit mehr als nur dein Fahrzeug auf der Strasse. Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen. \n\r\n\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit \n\r\n\n\r\n\n- \r\n\nDu verfügst über Fahrpraxis im Personentransport und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nFür diese Stelle benötigst du einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nZuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken. \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten",
+      "en": "Descrizione\nDo you love meeting new people every day and want to work independently? Then we're looking for you, because with you on the wheel, our passengers arrive on time and safely.\n\nMansioni\n- On our varied regional lines you bring our passengers to their destination from Monday to Sunday.\n- You are host:in our post cars and advises our customers in tariff and timetable questions.\n- Daily contact with your passengers enriches your everyday life with exciting encounters and you create positive experiences for our customers.\n\nRequisiti\n- You have driving practice in passenger transport.\n- You enjoy the change that brings irregular working hours (including Sundays and holidays).\n- You need a category D driver ID and a valid driver qualification certificate.\n- Reliability and joy in daily customer contact are among your strengths.\n- You have good German skills.\n- You are experienced in handling digital devices.\n\nCosa offriamo\n- You move far more than your vehicle on the road.\n- In direct customer contact you will experience new and varied situations every day.\n\nContatto\n- (Contatto non specificato)",
+      "de": "## Descrizione\nLiebst du es, jeden Tag neue Menschen zu treffen und möchtest eigenverantwortlich arbeiten? Dann suchen wir genau dich, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich und sicher ans Ziel.\n\n## Mansioni\n- Auf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel.\n- Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.\n- Der tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.\n\n## Requisiti\n- Du verfügst über Fahrpraxis im Personentransport.\n- Du geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.\n- Du benötigst einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis.\n- Zuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken.\n- Du verfügst über gute Deutschkenntnisse.\n- Du bist versiert im Umgang mit digitalen Geräten.\n\n## Cosa offriamo\n- Du bewegst weit mehr als nur dein Fahrzeug auf der Strasse.\n- Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen.\n\n## Contatto\n- (Contatto non specificato)",
+      "fr": "Descrizione\nAimez-vous rencontrer de nouvelles personnes chaque jour et souhaitez-vous travailler de façon indépendante? Ensuite, nous vous cherchons, car avec vous au volant, nos passagers arrivent à temps et en toute sécurité.\n\nMansioni\n- Sur nos lignes régionales variées, vous amènez nos passagers à destination du lundi au dimanche.\n- Vous êtes l'hôte: dans nos voitures postales et conseille nos clients dans les questions de tarif et d'horaire.\n- Le contact quotidien avec vos passagers enrichit votre vie quotidienne de rencontres passionnantes et vous créez des expériences positives pour nos clients.\n\nRequisiti\n- Vous avez un entraînement en transport de passagers.\n- Vous appréciez le changement qui apporte des horaires de travail irréguliers (y compris le dimanche et les jours fériés).\n- Vous avez besoin d'un identifiant de conducteur de catégorie D et d'un certificat de qualification valide.\n- Fiabilité et joie dans le contact quotidien avec le client sont parmi vos forces.\n- Vous avez de bonnes compétences en allemand.\n- Vous êtes expérimenté dans la manipulation des appareils numériques.\n\nCosa offriamo\n- Tu bouges bien plus que ton véhicule sur la route.\n- En contact direct avec le client, vous vivrez des situations nouvelles et variées chaque jour.\n\nContatto\n- (Contatto non spécifique)"
+    },
+    "titleByLocale": {
+      "it": "Driver per il carrello",
+      "en": "Postcar driver:in",
+      "de": "PostAuto-Fahrer:in",
+      "fr": "Conducteur d ' une voiture"
+    },
+    "slug": "driver-per-il-carrello-postauto-ilanz",
+    "slugByLocale": {
+      "it": "driver-per-il-carrello-postauto-ilanz",
+      "en": "postcar-driver-in-postauto-davos-platz",
+      "de": "postauto-fahrer-in-postauto-davos-platz",
+      "fr": "conducteur-d-une-voiture-postauto-davos-platz"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-05-13",
+    "validThrough": "2026-06-03",
+    "source": "postch-careers-crawler",
+    "employmentType": "FULL_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "20-100%",
+    "_targetScope": {
+      "canton": "GR",
+      "location": "Ilanz"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-17ff4c3a48fc",
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Ilanz",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-17T10:53:34.351Z",
+    "previousSlugsByLocale": {
+      "de": [
+        "postauto-fahrer-in-postauto-ilanz"
+      ],
+      "it": [
         "postauto-fahrer-in-post-2",
         "postauto-fahrer-in-post"
       ]
     },
-    {
-      "url": "https://job.post.ch/default/job/Zustellerin-Pakete/73486-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/Zustellerin-Pakete/73486-de_DE",
-      "title": "Zusteller:in Pakete",
-      "company": "Die Schweizerische Post",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Untervaz",
+    "previousSlugs": [
+      "postauto-fahrer-in-postauto-ilanz",
+      "postauto-fahrer-in-post-2",
+      "postauto-fahrer-in-post"
+    ]
+  },
+  {
+    "url": "https://job.post.ch/default/job/Zustellerin-Pakete/73486-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/Zustellerin-Pakete/73486-de_DE",
+    "title": "Zusteller:in Pakete",
+    "company": "Die Schweizerische Post",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Untervaz",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Zielgerichtet lenkst du den Lieferwagen durch die Häuser - ob Baustelle oder Rushhour - du findest den schnellsten Weg. Mit dir kommen Pakete unversehrt und pünktlich an die richtige Adresse in Buchs SG .\n\r\n\n \n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Gemeinsam mit deinem Team bereitest du am frühen Morgen (06.00 Uhr) die Zustelltour für den Tag vor.\n\r\n\n- Dank dir kommen Pakete in deinem zugeteilten Gebiet pünktlich zu den richtigen Adressen.\n\r\n\n- Sympathisch und kompetent beantwortest du Anfragen zu unseren Dienstleistungen.\n\r\n\n- Mit deiner Freundlichkeit und Zuverlässigkeit trägst du zur Kundenzufriedenheit bei.\n\r\n\n- Du setzt moderne Arbeitsgeräte – wie ein Smartphone – zum Scannen der Sendungen ein.\n\r\n\n- Nach der Zustellung nimmst du das Fahrzeug mit Nachhause und fährst am Morgen direkt nach Untervaz.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\n\r\n\n\r\n\n- \r\n\nMit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.  \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und bist gerne bei Wind und Wetter draussen unterwegs \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.   \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist zuverlässig und arbeitest speditiv.   \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nGute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab",
+    "descriptionByLocale": {
+      "it": "Zielgerichtet lenkst du den Lieferwagen durch die Häuser - ob Baustelle oder Rushhour - du findest den schnellsten Weg. Mit dir kommen Pakete unversehrt und pünktlich an die richtige Adresse in Buchs SG .\n\r\n\n \n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Gemeinsam mit deinem Team bereitest du am frühen Morgen (06.00 Uhr) die Zustelltour für den Tag vor.\n\r\n\n- Dank dir kommen Pakete in deinem zugeteilten Gebiet pünktlich zu den richtigen Adressen.\n\r\n\n- Sympathisch und kompetent beantwortest du Anfragen zu unseren Dienstleistungen.\n\r\n\n- Mit deiner Freundlichkeit und Zuverlässigkeit trägst du zur Kundenzufriedenheit bei.\n\r\n\n- Du setzt moderne Arbeitsgeräte – wie ein Smartphone – zum Scannen der Sendungen ein.\n\r\n\n- Nach der Zustellung nimmst du das Fahrzeug mit Nachhause und fährst am Morgen direkt nach Untervaz.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\n\r\n\n\r\n\n- \r\n\nMit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.  \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und bist gerne bei Wind und Wetter draussen unterwegs \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.   \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist zuverlässig und arbeitest speditiv.   \n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nGute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab",
+      "en": "Descrizione\n\n- Targeted, you'll drive the van through the houses - whether construction site or rushhour - you'll find the fastest way.\n- With you, packages come unharmed and on time to the right address in Buchs SG.\n- You can do this together with your team in the early morning (06.00) to prepare the delivery time for the day.\n- Thanks to you, parcels in your assigned area come on time to the right addresses.\n- Sympathetic and competent, you answer questions about our services.\n- With your kindness and reliability, you contribute to customer satisfaction.\n- You use modern work equipment – like a smartphone – to scan the broadcasts.\n- After delivery, take the vehicle with the house and drive directly to Untervaz in the morning.\n\nRequisiti\n\n- You are happy to travel, have the category B guide card and are happy to travel in wind and weather\n- You appreciate the work in the team, but you also like to travel independently and feel comfortable with large vehicles in road traffic\n- You are reliable and work speditive\n- Good oral German knowledge\n- An experienced handling of digital devices\n\nCosa offriamo\n\n- With your physical fitness, you will be able to regularly charge packages up to 30 kg\n- You like to travel and have the opportunity to use your skills in a team\n\nContatto",
+      "de": "## Descrizione\n\n- Zielgerichtet lenkst du den Lieferwagen durch die Häuser - ob Baustelle oder Rushhour - du findest den schnellsten Weg.\n- Mit dir kommen Pakete unversehrt und pünktlich an die richtige Adresse in Buchs SG.\n- Das kannst du bewirken Gemeinsam mit deinem Team bereitest du am frühen Morgen (06.00 Uhr) die Zustelltour für den Tag vor.\n- Dank dir kommen Pakete in deinem zugeteilten Gebiet pünktlich zu den richtigen Adressen.\n- Sympathisch und kompetent beantwortest du Anfragen zu unseren Dienstleistungen.\n- Mit deiner Freundlichkeit und Zuverlässigkeit trägst du zur Kundenzufriedenheit bei.\n- Du setzt moderne Arbeitsgeräte – wie ein Smartphone – zum Scannen der Sendungen ein.\n- Nach der Zustellung nimmst du das Fahrzeug mit Nachhause und fährst am Morgen direkt nach Untervaz.\n\n## Requisiti\n\n- Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und bist gerne bei Wind und Wetter draussen unterwegs\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl\n- Du bist zuverlässig und arbeitest speditiv\n- Gute mündliche Deutschkenntnisse\n- Ein versierter Umgang mit digitalen Geräten\n\n## Cosa offriamo\n\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg\n- Du bist gerne unterwegs und hast die Möglichkeit, deine Fähigkeiten in einem Team zu nutzen\n\n## Contatto",
+      "fr": "Descrizione\n\n- Cibled, vous allez conduire le van à travers les maisons - que ce soit le chantier ou l'heure de pointe - vous trouverez le moyen le plus rapide.\n- Avec vous, les paquets viennent indemnes et à temps à la bonne adresse dans Buchs SG.\n- Vous pouvez le faire avec votre équipe au petit matin (06,00) pour préparer le délai de livraison de la journée.\n- Grâce à vous, les colis dans la zone assignée arrivent à temps aux bonnes adresses.\n- Sympathique et compétent, vous répondez à des questions sur nos services.\n- Avec votre gentillesse et votre fiabilité, vous contribuez à la satisfaction des clients.\n- Vous utilisez des équipements de travail modernes – comme un smartphone – pour scanner les émissions.\n- Après la livraison, prendre le véhicule avec la maison et conduire directement à Untervaz le matin.\n\nRequisiti\n\n- Vous êtes heureux de voyager, avoir la carte-guide catégorie B et être heureux de voyager par le vent et la météo\n- Vous appréciez le travail de l'équipe, mais vous aimez aussi voyager indépendamment et vous sentir à l'aise avec les grands véhicules dans la circulation routière\n- Vous êtes fiable et vous travaillez\n- Bonne connaissance orale allemande\n- Une manipulation expérimentée des appareils numériques\n\nCosa offriamo\n\n- Avec votre forme physique, vous pourrez recharger régulièrement des paquets jusqu'à 30 kg\n- Vous aimez voyager et avez la possibilité d'utiliser vos compétences dans une équipe\n\nContatto"
+    },
+    "titleByLocale": {
+      "it": "Fornitore/in pacchetti",
+      "en": "Supplier:in packages",
+      "de": "Zusteller:in Pakete",
+      "fr": "Fournisseur/en paquets"
+    },
+    "slug": "fornitore-in-pacchetti-die-schweizerische-post-untervaz",
+    "slugByLocale": {
+      "it": "fornitore-in-pacchetti-die-schweizerische-post-untervaz",
+      "en": "supplier-in-packages-die-schweizerische-post-untervaz",
+      "de": "zusteller-in-pakete-die-schweizerische-post-untervaz",
+      "fr": "fournisseur-en-paquets-die-schweizerische-post-untervaz"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-05-13",
+    "validThrough": "2026-06-03",
+    "source": "postch-careers-crawler",
+    "employmentType": "FULL_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "80-100%",
+    "_targetScope": {
       "canton": "GR",
-      "country": "CH",
-      "description": "Zielgerichtet lenkst du den Lieferwagen durch die Häuser - ob Baustelle oder Rushhour - du findest den schnellsten Weg. Mit dir kommen Pakete unversehrt und pünktlich an die richtige Adresse in Buchs SG . Das kannst du bewirken Gemeinsam mit deinem Team bereitest du am frühen Morgen (06.00 Uhr) die Zustelltour für den Tag vor. Dank dir kommen Pakete in deinem zugeteilten Gebiet pünktlich zu den richtigen Adressen. Sympathisch und kompetent beantwortest du Anfragen zu unseren Dienstleistungen. Mit deiner Freundlichkeit und Zuverlässigkeit trägst du zur Kundenzufriedenheit bei. Du setzt moderne Arbeitsgeräte – wie ein Smartphone – zum Scannen der Sendungen ein. Nach der Zustellung nimmst du das Fahrzeug mit Nachhause und fährst am Morgen direkt nach Untervaz. Das bringst du mit Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg. Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und bist gerne bei Wind und Wetter draussen unterwegs Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl. Du bist zuverlässig und arbeitest speditiv. Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab",
-      "descriptionByLocale": {
-        "it": "Descrizione\n\n- Destinato, guiderai il furgone attraverso le case - se cantiere o fretta - troverai il modo più veloce.\n- Con te, i pacchetti vengono non danneggiati e in tempo all'indirizzo giusto in Buchs SG.\n- Si può fare questo insieme con la vostra squadra al mattino presto (06.00) per preparare il tempo di consegna per il giorno.\n- Grazie a voi, i pacchi nella vostra area assegnata vengono in tempo agli indirizzi giusti.\n- Simpatici e competenti, risponde alle domande sui nostri servizi.\n- Con la vostra gentilezza e affidabilità, contribuite alla soddisfazione del cliente.\n- Si utilizza attrezzature di lavoro moderne – come uno smartphone – per la scansione delle trasmissioni.\n- Dopo la consegna, prendere il veicolo con la casa e guidare direttamente a Untervaz al mattino.\n\nRequisiti\n\n- Sei felice di viaggiare, avere la carta guida di categoria B e sono felici di viaggiare in vento e tempo\n- Apprezzi il lavoro nel team, ma ti piace anche viaggiare in modo indipendente e sentirsi a proprio agio con grandi veicoli nel traffico stradale\n- Sei affidabile e speditivo di lavoro\n- Buona conoscenza orale tedesca\n- Una gestione esperta dei dispositivi digitali\n\nCosa?\n\n- Con la vostra forma fisica, sarete in grado di caricare regolarmente pacchetti fino a 30 kg\n- Ti piace viaggiare e avere l'opportunità di utilizzare le tue abilità in un team\n\nContatto",
-        "en": "Descrizione\n\n- Targeted, you'll drive the van through the houses - whether construction site or rushhour - you'll find the fastest way.\n- With you, packages come unharmed and on time to the right address in Buchs SG.\n- You can do this together with your team in the early morning (06.00) to prepare the delivery time for the day.\n- Thanks to you, parcels in your assigned area come on time to the right addresses.\n- Sympathetic and competent, you answer questions about our services.\n- With your kindness and reliability, you contribute to customer satisfaction.\n- You use modern work equipment – like a smartphone – to scan the broadcasts.\n- After delivery, take the vehicle with the house and drive directly to Untervaz in the morning.\n\nRequisiti\n\n- You are happy to travel, have the category B guide card and are happy to travel in wind and weather\n- You appreciate the work in the team, but you also like to travel independently and feel comfortable with large vehicles in road traffic\n- You are reliable and work speditive\n- Good oral German knowledge\n- An experienced handling of digital devices\n\nCosa offriamo\n\n- With your physical fitness, you will be able to regularly charge packages up to 30 kg\n- You like to travel and have the opportunity to use your skills in a team\n\nContatto",
-        "de": "## Descrizione\n\n- Zielgerichtet lenkst du den Lieferwagen durch die Häuser - ob Baustelle oder Rushhour - du findest den schnellsten Weg.\n- Mit dir kommen Pakete unversehrt und pünktlich an die richtige Adresse in Buchs SG.\n- Das kannst du bewirken Gemeinsam mit deinem Team bereitest du am frühen Morgen (06.00 Uhr) die Zustelltour für den Tag vor.\n- Dank dir kommen Pakete in deinem zugeteilten Gebiet pünktlich zu den richtigen Adressen.\n- Sympathisch und kompetent beantwortest du Anfragen zu unseren Dienstleistungen.\n- Mit deiner Freundlichkeit und Zuverlässigkeit trägst du zur Kundenzufriedenheit bei.\n- Du setzt moderne Arbeitsgeräte – wie ein Smartphone – zum Scannen der Sendungen ein.\n- Nach der Zustellung nimmst du das Fahrzeug mit Nachhause und fährst am Morgen direkt nach Untervaz.\n\n## Requisiti\n\n- Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und bist gerne bei Wind und Wetter draussen unterwegs\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl\n- Du bist zuverlässig und arbeitest speditiv\n- Gute mündliche Deutschkenntnisse\n- Ein versierter Umgang mit digitalen Geräten\n\n## Cosa offriamo\n\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg\n- Du bist gerne unterwegs und hast die Möglichkeit, deine Fähigkeiten in einem Team zu nutzen\n\n## Contatto",
-        "fr": "Descrizione\n\n- Cibled, vous allez conduire le van à travers les maisons - que ce soit le chantier ou l'heure de pointe - vous trouverez le moyen le plus rapide.\n- Avec vous, les paquets viennent indemnes et à temps à la bonne adresse dans Buchs SG.\n- Vous pouvez le faire avec votre équipe au petit matin (06,00) pour préparer le délai de livraison de la journée.\n- Grâce à vous, les colis dans la zone assignée arrivent à temps aux bonnes adresses.\n- Sympathique et compétent, vous répondez à des questions sur nos services.\n- Avec votre gentillesse et votre fiabilité, vous contribuez à la satisfaction des clients.\n- Vous utilisez des équipements de travail modernes – comme un smartphone – pour scanner les émissions.\n- Après la livraison, prendre le véhicule avec la maison et conduire directement à Untervaz le matin.\n\nRequisiti\n\n- Vous êtes heureux de voyager, avoir la carte-guide catégorie B et être heureux de voyager par le vent et la météo\n- Vous appréciez le travail de l'équipe, mais vous aimez aussi voyager indépendamment et vous sentir à l'aise avec les grands véhicules dans la circulation routière\n- Vous êtes fiable et vous travaillez\n- Bonne connaissance orale allemande\n- Une manipulation expérimentée des appareils numériques\n\nCosa offriamo\n\n- Avec votre forme physique, vous pourrez recharger régulièrement des paquets jusqu'à 30 kg\n- Vous aimez voyager et avez la possibilité d'utiliser vos compétences dans une équipe\n\nContatto"
-      },
-      "titleByLocale": {
-        "it": "Fornitore/in pacchetti",
-        "en": "Supplier:in packages",
-        "de": "Zusteller:in Pakete",
-        "fr": "Fournisseur/en paquets"
-      },
-      "slug": "fornitore-in-pacchetti-die-schweizerische-post-untervaz",
-      "slugByLocale": {
-        "it": "fornitore-in-pacchetti-die-schweizerische-post-untervaz",
-        "en": "supplier-in-packages-die-schweizerische-post-untervaz",
-        "de": "zusteller-in-pakete-die-schweizerische-post-untervaz",
-        "fr": "fournisseur-en-paquets-die-schweizerische-post-untervaz"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-05-13",
-      "validThrough": "2026-06-03",
-      "source": "postch-careers-crawler",
-      "employmentType": "FULL_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "80-100%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Untervaz"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-946e766a9940",
-      "salaryMin": 49500,
-      "salaryMax": 75000,
+      "location": "Untervaz"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-946e766a9940",
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
       "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Untervaz",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-13T11:42:33.116Z",
-      "previousSlugsByLocale": {
-        "it": [
-          "zusteller-in-pakete-post"
-        ]
-      },
-      "previousSlugs": [
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Untervaz",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-13T11:42:33.116Z",
+    "previousSlugsByLocale": {
+      "it": [
         "zusteller-in-pakete-post"
       ]
     },
-    {
-      "url": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73273-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73273-de_DE",
-      "title": "Zusteller:in Briefe und Pakete",
-      "company": "Die Schweizerische Post",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Trun",
+    "previousSlugs": [
+      "zusteller-in-pakete-post"
+    ]
+  },
+  {
+    "url": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73273-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73273-de_DE",
+    "title": "Zusteller:in Briefe und Pakete",
+    "company": "Die Schweizerische Post",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Trun",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Stehst du gerne früh auf und suchst eine körperlich herausfordernde Tätigkeit? Dann passt du perfekt zu uns! Mit dir bleibt die Post von morgen in Bewegung. Auch Quereinsteiger:innen sind bei uns herzlich willkommen! Das kannst du bewirken Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor. Durch deine Arbeit prägst du das Strassenbild von Trun und verkörperst die Werte Zuverlässigkeit und Qualität. Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich. Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei. Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden. Das bringst du mit Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg. Du bist gerne unterwegs und besitzt den Führerausweis der Kategorie B. Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl. Du bist zuverlässig und arbeitest speditiv. Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+    "descriptionByLocale": {
+      "it": "Descrizione\n\n- Ti piace alzarti presto e cercare un lavoro fisicamente impegnativo? Allora sei perfetto per noi!\n- Con te, la posta di domani si sta muovendo.\n- Anche i cross-comers: dentro sono i benvenuti!\n\nMansioni\n\n- Al mattino presto (circa 18:00) si caricano i veicoli di consegna insieme al vostro team e preparano la vostra consegna.\n- Sei responsabile della consegna puntuale e perfetta dei pacchi e delle lettere nella tua zona.\n- Nel tour, risponderai alle domande dei nostri clienti e contribuirai alla soddisfazione del cliente.\n- Lavori regolarmente il sabato, con i servizi che si dividono nella squadra.\n\nRequisiti\n\n- Con il tuo fitness, puoi caricare pacchetti regolari fino a 30 kg.\n- Ti piace viaggiare e possedere la carta guida di categoria B.\n- Apprezzi il lavoro nel team, ma ti piace anche viaggiare in modo indipendente e sentirsi a proprio agio con grandi veicoli nel traffico stradale.\n- Sei affidabile e speditivo.\n- Buona conoscenza orale tedesca e una gestione esperta di dispositivi digitali completano il tuo profilo.",
+      "en": "Descrizione\n\n- Do you like getting up early and looking for a physically challenging job? Then you're perfect for us!\n- With you, the mail of tomorrow is moving.\n- Cross-comers too: inside are welcome!\n\nMansioni\n\n- Early in the morning (about 6:00 p.m.) you'll charge the delivery vehicles together with your team and prepare your delivery.\n- You are responsible for the punctual and perfect delivery of the parcels and letters in your area.\n- On your tour, you will answer questions from our customers and contribute to customer satisfaction.\n- You regularly work on Saturdays, with the services being split up in the team.\n\nRequisiti\n\n- With your physical fitness, you can charge regular packages up to 30 kg.\n- You like to travel and own the category B guide card.\n- You appreciate the work in the team, but you also like to travel independently and feel comfortable with large vehicles in road traffic.\n- You're reliable and work speditive.\n- Good oral German knowledge as well as an experienced handling of digital devices complete your profile.",
+      "de": "## Descrizione\n\n- Stehst du gerne früh auf und suchst eine körperlich herausfordernde Tätigkeit? Dann passt du perfekt zu uns!\n- Mit dir bleibt die Post von morgen in Bewegung.\n- Auch Quereinsteiger:innen sind bei uns herzlich willkommen!\n\n## Mansioni\n\n- Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor.\n- Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich.\n- Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei.\n- Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden.\n\n## Requisiti\n\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.\n- Du bist gerne unterwegs und besitzt den Führerausweis der Kategorie B.\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.\n- Du bist zuverlässig und arbeitest speditiv.\n- Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+      "fr": "Descrizione\n\n- Tu aimes te lever tôt et chercher un boulot difficile ? Alors tu es parfait pour nous !\n- Avec toi, le courrier de demain bouge.\n- Les croisés aussi: à l'intérieur sont les bienvenus!\n\nMansioni\n\n- Tôt le matin (vers 18h00), vous facturerez les véhicules de livraison avec votre équipe et préparerez votre livraison.\n- Vous êtes responsable de la livraison ponctuelle et parfaite des colis et des lettres dans votre région.\n- Lors de votre visite, vous répondrez aux questions de nos clients et contribuerez à la satisfaction des clients.\n- Vous travaillez régulièrement le samedi, les services étant séparés dans l'équipe.\n\nRequisiti\n\n- Avec votre forme physique, vous pouvez charger des paquets réguliers jusqu'à 30 kg.\n- Vous aimez voyager et posséder la carte-guide de catégorie B.\n- Vous appréciez le travail de l'équipe, mais vous aimez aussi voyager indépendamment et vous sentir à l'aise avec les grands véhicules dans la circulation routière.\n- Vous êtes fiable et spéditive.\n- Bonne connaissance orale allemande ainsi qu'une manipulation expérimentée des appareils numériques complètent votre profil."
+    },
+    "titleByLocale": {
+      "it": "Zusteller:in lettere e pacchi",
+      "en": "Supplier:in letters and packages",
+      "de": "Zusteller:in Briefe und Pakete",
+      "fr": "Lettres et colis"
+    },
+    "slug": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-trun",
+    "slugByLocale": {
+      "it": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-trun",
+      "en": "supplier-in-letters-and-packages-die-schweizerische-post-trun",
+      "de": "zusteller-in-briefe-und-pakete-post",
+      "fr": "lettres-et-colis-die-schweizerische-post-trun"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-04-30",
+    "validThrough": "2026-05-21",
+    "source": "postch-careers-crawler",
+    "employmentType": "PART_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "60-90%",
+    "_targetScope": {
       "canton": "GR",
-      "country": "CH",
-      "description": "Stehst du gerne früh auf und suchst eine körperlich herausfordernde Tätigkeit? Dann passt du perfekt zu uns! Mit dir bleibt die Post von morgen in Bewegung. Auch Quereinsteiger:innen sind bei uns herzlich willkommen! Das kannst du bewirken Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor. Durch deine Arbeit prägst du das Strassenbild von Trun und verkörperst die Werte Zuverlässigkeit und Qualität. Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich. Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei. Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden. Das bringst du mit Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg. Du bist gerne unterwegs und besitzt den Führerausweis der Kategorie B. Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl. Du bist zuverlässig und arbeitest speditiv. Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
-      "descriptionByLocale": {
-        "it": "Descrizione\n\n- Ti piace alzarti presto e cercare un lavoro fisicamente impegnativo? Allora sei perfetto per noi!\n- Con te, la posta di domani si sta muovendo.\n- Anche i cross-comers: dentro sono i benvenuti!\n\nMansioni\n\n- Al mattino presto (circa 18:00) si caricano i veicoli di consegna insieme al vostro team e preparano la vostra consegna.\n- Sei responsabile della consegna puntuale e perfetta dei pacchi e delle lettere nella tua zona.\n- Nel tour, risponderai alle domande dei nostri clienti e contribuirai alla soddisfazione del cliente.\n- Lavori regolarmente il sabato, con i servizi che si dividono nella squadra.\n\nRequisiti\n\n- Con il tuo fitness, puoi caricare pacchetti regolari fino a 30 kg.\n- Ti piace viaggiare e possedere la carta guida di categoria B.\n- Apprezzi il lavoro nel team, ma ti piace anche viaggiare in modo indipendente e sentirsi a proprio agio con grandi veicoli nel traffico stradale.\n- Sei affidabile e speditivo.\n- Buona conoscenza orale tedesca e una gestione esperta di dispositivi digitali completano il tuo profilo.",
-        "en": "Descrizione\n\n- Do you like getting up early and looking for a physically challenging job? Then you're perfect for us!\n- With you, the mail of tomorrow is moving.\n- Cross-comers too: inside are welcome!\n\nMansioni\n\n- Early in the morning (about 6:00 p.m.) you'll charge the delivery vehicles together with your team and prepare your delivery.\n- You are responsible for the punctual and perfect delivery of the parcels and letters in your area.\n- On your tour, you will answer questions from our customers and contribute to customer satisfaction.\n- You regularly work on Saturdays, with the services being split up in the team.\n\nRequisiti\n\n- With your physical fitness, you can charge regular packages up to 30 kg.\n- You like to travel and own the category B guide card.\n- You appreciate the work in the team, but you also like to travel independently and feel comfortable with large vehicles in road traffic.\n- You're reliable and work speditive.\n- Good oral German knowledge as well as an experienced handling of digital devices complete your profile.",
-        "de": "## Descrizione\n\n- Stehst du gerne früh auf und suchst eine körperlich herausfordernde Tätigkeit? Dann passt du perfekt zu uns!\n- Mit dir bleibt die Post von morgen in Bewegung.\n- Auch Quereinsteiger:innen sind bei uns herzlich willkommen!\n\n## Mansioni\n\n- Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor.\n- Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich.\n- Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei.\n- Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden.\n\n## Requisiti\n\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.\n- Du bist gerne unterwegs und besitzt den Führerausweis der Kategorie B.\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.\n- Du bist zuverlässig und arbeitest speditiv.\n- Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
-        "fr": "Descrizione\n\n- Tu aimes te lever tôt et chercher un boulot difficile ? Alors tu es parfait pour nous !\n- Avec toi, le courrier de demain bouge.\n- Les croisés aussi: à l'intérieur sont les bienvenus!\n\nMansioni\n\n- Tôt le matin (vers 18h00), vous facturerez les véhicules de livraison avec votre équipe et préparerez votre livraison.\n- Vous êtes responsable de la livraison ponctuelle et parfaite des colis et des lettres dans votre région.\n- Lors de votre visite, vous répondrez aux questions de nos clients et contribuerez à la satisfaction des clients.\n- Vous travaillez régulièrement le samedi, les services étant séparés dans l'équipe.\n\nRequisiti\n\n- Avec votre forme physique, vous pouvez charger des paquets réguliers jusqu'à 30 kg.\n- Vous aimez voyager et posséder la carte-guide de catégorie B.\n- Vous appréciez le travail de l'équipe, mais vous aimez aussi voyager indépendamment et vous sentir à l'aise avec les grands véhicules dans la circulation routière.\n- Vous êtes fiable et spéditive.\n- Bonne connaissance orale allemande ainsi qu'une manipulation expérimentée des appareils numériques complètent votre profil."
-      },
-      "titleByLocale": {
-        "it": "Zusteller:in lettere e pacchi",
-        "en": "Supplier:in letters and packages",
-        "de": "Zusteller:in Briefe und Pakete",
-        "fr": "Lettres et colis"
-      },
-      "slug": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-trun",
-      "slugByLocale": {
-        "it": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-trun",
-        "en": "supplier-in-letters-and-packages-die-schweizerische-post-trun",
-        "de": "zusteller-in-briefe-und-pakete-post",
-        "fr": "lettres-et-colis-die-schweizerische-post-trun"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-04-30",
-      "validThrough": "2026-05-21",
-      "source": "postch-careers-crawler",
-      "employmentType": "PART_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "60-90%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Trun"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-c4c3d5a77223",
-      "previousSlugsByLocale": {
-        "it": [
-          "zusteller-in-briefe-und-pakete-post"
-        ],
-        "en": [
-          "zusteller-in-briefe-und-pakete-post"
-        ],
-        "fr": [
-          "zusteller-in-briefe-und-pakete-post"
-        ]
-      },
-      "previousSlugs": [
+      "location": "Trun"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-c4c3d5a77223",
+    "previousSlugsByLocale": {
+      "it": [
         "zusteller-in-briefe-und-pakete-post"
       ],
-      "salaryMin": 49500,
-      "salaryMax": 75000,
-      "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Trun",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-13T11:42:33.116Z"
+      "en": [
+        "zusteller-in-briefe-und-pakete-post"
+      ],
+      "fr": [
+        "zusteller-in-briefe-und-pakete-post"
+      ]
     },
-    {
-      "url": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73542-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73542-de_DE",
-      "title": "Zusteller:in Briefe und Pakete",
-      "company": "Die Schweizerische Post",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Samedan",
+    "previousSlugs": [
+      "zusteller-in-briefe-und-pakete-post"
+    ],
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Trun",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-13T11:42:33.116Z"
+  },
+  {
+    "url": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73542-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/Zustellerin-Briefe-und-Pakete/73542-de_DE",
+    "title": "Zusteller:in Briefe und Pakete",
+    "company": "Die Schweizerische Post",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Samedan",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Bist du ein Morgenmensch und arbeitest gerne draussen? Dann bist du bei uns genau richtig, denn mit dir startet Samedan mit einem Lachen in den Tag!\n\r\n\nAuch Quereinsteiger:innen sind bei uns herzlich willkommen!\n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor.\n\r\n\n- Durch deine Arbeit prägst du das Strassenbild von Samedan und verkörperst die Werte Zuverlässigkeit und Qualität.\n\r\n\n- Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich.\n\r\n\n- Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei.\n\r\n\n- Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.\n\r\n\n- Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und idealerweise A1 - oder bist bereit diesen vor Stellenantritt nachzuholen.\n\r\n\n\r\n\n\r\n\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.\n\r\n\n- Du bist zuverlässig und arbeitest speditiv.\n\r\n\n\r\n\n\r\n\n- Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+    "descriptionByLocale": {
+      "it": "Bist du ein Morgenmensch und arbeitest gerne draussen? Dann bist du bei uns genau richtig, denn mit dir startet Samedan mit einem Lachen in den Tag!\n\r\n\nAuch Quereinsteiger:innen sind bei uns herzlich willkommen!\n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor.\n\r\n\n- Durch deine Arbeit prägst du das Strassenbild von Samedan und verkörperst die Werte Zuverlässigkeit und Qualität.\n\r\n\n- Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich.\n\r\n\n- Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei.\n\r\n\n- Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.\n\r\n\n- Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und idealerweise A1 - oder bist bereit diesen vor Stellenantritt nachzuholen.\n\r\n\n\r\n\n\r\n\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.\n\r\n\n- Du bist zuverlässig und arbeitest speditiv.\n\r\n\n\r\n\n\r\n\n- Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+      "en": "Descrizione\n- Are you a morning man and you like to work out? Then you are right with us, because with you Samedan starts with a laugh in the day!\n- Cross-comers too: inside are welcome!\n\nMansioni\n- Early in the morning (about 6:00 p.m.) you'll charge the delivery vehicles together with your team and prepare your delivery.\n- You are responsible for the punctual and perfect delivery of the parcels and letters in your area.\n- On your tour, you will answer questions from our customers and contribute to customer satisfaction.\n- You regularly work on Saturdays, with the services being split up in the team.\n\nRequisiti\n- With your physical fitness, you can charge regular packages up to 30 kg.\n- You are happy to travel, have the category B guide card and ideally A1 - or are ready to catch it before job start.\n- You appreciate the work in the team, but you also like to travel independently and feel comfortable with large vehicles in road traffic.\n- You're reliable and work speditive.\n- Good oral German knowledge as well as an experienced handling of digital devices complete your profile.",
+      "de": "## Descrizione\n- Bist du ein Morgenmensch und arbeitest gerne draussen? Dann bist du bei uns genau richtig, denn mit dir startet Samedan mit einem Lachen in den Tag!\n- Auch Quereinsteiger:innen sind bei uns herzlich willkommen!\n\n## Mansioni\n- Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor.\n- Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich.\n- Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei.\n- Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden.\n\n## Requisiti\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.\n- Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und idealerweise A1 - oder bist bereit diesen vor Stellenantritt nachzuholen.\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.\n- Du bist zuverlässig und arbeitest speditiv.\n- Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+      "fr": "Descrizione\n- Tu es un homme du matin et tu aimes t'entraîner ? Alors tu as raison avec nous, car avec toi Samedan commence par un rire dans la journée !\n- Les croisés aussi: à l'intérieur sont les bienvenus!\n\nMansioni\n- Tôt le matin (vers 18h00), vous facturerez les véhicules de livraison avec votre équipe et préparerez votre livraison.\n- Vous êtes responsable de la livraison ponctuelle et parfaite des colis et des lettres dans votre région.\n- Lors de votre visite, vous répondrez aux questions de nos clients et contribuerez à la satisfaction des clients.\n- Vous travaillez régulièrement le samedi, les services étant séparés dans l'équipe.\n\nRequisiti\n- Avec votre forme physique, vous pouvez charger des paquets réguliers jusqu'à 30 kg.\n- Vous êtes heureux de voyager, avoir la carte-guide catégorie B et idéalement A1 - ou sont prêts à l'attraper avant le début du travail.\n- Vous appréciez le travail de l'équipe, mais vous aimez aussi voyager indépendamment et vous sentir à l'aise avec les grands véhicules dans la circulation routière.\n- Vous êtes fiable et spéditive.\n- Bonne connaissance orale allemande ainsi qu'une manipulation expérimentée des appareils numériques complètent votre profil."
+    },
+    "titleByLocale": {
+      "it": "Zusteller:in lettere e pacchi",
+      "en": "Supplier:in letters and packages",
+      "de": "Zusteller:in Briefe und Pakete",
+      "fr": "Lettres et colis"
+    },
+    "slug": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-samedan",
+    "slugByLocale": {
+      "it": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-samedan",
+      "en": "supplier-in-letters-and-packages-die-schweizerische-post-samedan",
+      "de": "zusteller-in-briefe-und-pakete-post-2",
+      "fr": "lettres-et-colis-die-schweizerische-post-samedan"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-04-29",
+    "validThrough": "2026-05-20",
+    "source": "postch-careers-crawler",
+    "employmentType": "PART_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "60-80%",
+    "_targetScope": {
       "canton": "GR",
-      "country": "CH",
-      "description": "Bist du ein Morgenmensch und arbeitest gerne draussen? Dann bist du bei uns genau richtig, denn mit dir startet Samedan mit einem Lachen in den Tag! Auch Quereinsteiger:innen sind bei uns herzlich willkommen! Das kannst du bewirken Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor. Durch deine Arbeit prägst du das Strassenbild von Samedan und verkörperst die Werte Zuverlässigkeit und Qualität. Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich. Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei. Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden. Das bringst du mit Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg. Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und idealerweise A1 - oder bist bereit diesen vor Stellenantritt nachzuholen. Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl. Du bist zuverlässig und arbeitest speditiv. Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
-      "descriptionByLocale": {
-        "it": "Descrizione\n- Sei un uomo del mattino e ti piace lavorare? Allora hai ragione con noi, perché con te Samedan inizia con una risata al giorno!\n- Anche i cross-comers: dentro sono i benvenuti!\n\nMansioni\n- Al mattino presto (circa 18:00) si caricano i veicoli di consegna insieme al vostro team e preparano la vostra consegna.\n- Sei responsabile della consegna puntuale e perfetta dei pacchi e delle lettere nella tua zona.\n- Nel tour, risponderai alle domande dei nostri clienti e contribuirai alla soddisfazione del cliente.\n- Lavori regolarmente il sabato, con i servizi che si dividono nella squadra.\n\nRequisiti\n- Con il tuo fitness, puoi caricare pacchetti regolari fino a 30 kg.\n- Sei felice di viaggiare, avere la carta guida di categoria B e idealmente A1 - o sono pronti a prenderlo prima dell'inizio del lavoro.\n- Apprezzi il lavoro nel team, ma ti piace anche viaggiare in modo indipendente e sentirsi a proprio agio con grandi veicoli nel traffico stradale.\n- Sei affidabile e speditivo.\n- Buona conoscenza orale tedesca e una gestione esperta di dispositivi digitali completano il tuo profilo.",
-        "en": "Descrizione\n- Are you a morning man and you like to work out? Then you are right with us, because with you Samedan starts with a laugh in the day!\n- Cross-comers too: inside are welcome!\n\nMansioni\n- Early in the morning (about 6:00 p.m.) you'll charge the delivery vehicles together with your team and prepare your delivery.\n- You are responsible for the punctual and perfect delivery of the parcels and letters in your area.\n- On your tour, you will answer questions from our customers and contribute to customer satisfaction.\n- You regularly work on Saturdays, with the services being split up in the team.\n\nRequisiti\n- With your physical fitness, you can charge regular packages up to 30 kg.\n- You are happy to travel, have the category B guide card and ideally A1 - or are ready to catch it before job start.\n- You appreciate the work in the team, but you also like to travel independently and feel comfortable with large vehicles in road traffic.\n- You're reliable and work speditive.\n- Good oral German knowledge as well as an experienced handling of digital devices complete your profile.",
-        "de": "## Descrizione\n- Bist du ein Morgenmensch und arbeitest gerne draussen? Dann bist du bei uns genau richtig, denn mit dir startet Samedan mit einem Lachen in den Tag!\n- Auch Quereinsteiger:innen sind bei uns herzlich willkommen!\n\n## Mansioni\n- Frühmorgens (ca. 06.00 Uhr) belädst du gemeinsam mit deinem Team die Zustellfahrzeuge und bereitest deine Zustelltour vor.\n- Du bist für die pünktliche und einwandfreie Zustellung der Pakete- und Briefe in deinem Gebiet verantwortlich.\n- Auf deiner Tour beantwortest du Fragen unserer Kund:innen und trägst zur Kundenzufriedenheit bei.\n- Du arbeitest regelmässig an Samstagen, wobei die Dienste im Team aufgeteilt werden.\n\n## Requisiti\n- Mit deiner körperlichen Fitness verlädst und hebst du problemlos regelmässig Pakete bis 30 kg.\n- Du bist gerne unterwegs, besitzt den Führerausweis der Kategorie B und idealerweise A1 - oder bist bereit diesen vor Stellenantritt nachzuholen.\n- Du schätzt die Arbeit im Team bist aber auch gerne selbstständig unterwegs und fühlst dich mit grossen Fahrzeugen im Strassenverkehr wohl.\n- Du bist zuverlässig und arbeitest speditiv.\n- Gute mündliche Deutschkenntnisse sowie ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
-        "fr": "Descrizione\n- Tu es un homme du matin et tu aimes t'entraîner ? Alors tu as raison avec nous, car avec toi Samedan commence par un rire dans la journée !\n- Les croisés aussi: à l'intérieur sont les bienvenus!\n\nMansioni\n- Tôt le matin (vers 18h00), vous facturerez les véhicules de livraison avec votre équipe et préparerez votre livraison.\n- Vous êtes responsable de la livraison ponctuelle et parfaite des colis et des lettres dans votre région.\n- Lors de votre visite, vous répondrez aux questions de nos clients et contribuerez à la satisfaction des clients.\n- Vous travaillez régulièrement le samedi, les services étant séparés dans l'équipe.\n\nRequisiti\n- Avec votre forme physique, vous pouvez charger des paquets réguliers jusqu'à 30 kg.\n- Vous êtes heureux de voyager, avoir la carte-guide catégorie B et idéalement A1 - ou sont prêts à l'attraper avant le début du travail.\n- Vous appréciez le travail de l'équipe, mais vous aimez aussi voyager indépendamment et vous sentir à l'aise avec les grands véhicules dans la circulation routière.\n- Vous êtes fiable et spéditive.\n- Bonne connaissance orale allemande ainsi qu'une manipulation expérimentée des appareils numériques complètent votre profil."
-      },
-      "titleByLocale": {
-        "it": "Zusteller:in lettere e pacchi",
-        "en": "Supplier:in letters and packages",
-        "de": "Zusteller:in Briefe und Pakete",
-        "fr": "Lettres et colis"
-      },
-      "slug": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-samedan",
-      "slugByLocale": {
-        "it": "zusteller-in-lettere-e-pacchi-die-schweizerische-post-samedan",
-        "en": "supplier-in-letters-and-packages-die-schweizerische-post-samedan",
-        "de": "zusteller-in-briefe-und-pakete-post-2",
-        "fr": "lettres-et-colis-die-schweizerische-post-samedan"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-04-29",
-      "validThrough": "2026-05-20",
-      "source": "postch-careers-crawler",
-      "employmentType": "PART_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "60-80%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Samedan"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-26e166c0a5d1",
-      "previousSlugsByLocale": {
-        "it": [
-          "zusteller-in-briefe-und-pakete-post-2"
-        ],
-        "en": [
-          "zusteller-in-briefe-und-pakete-post-2"
-        ],
-        "fr": [
-          "zusteller-in-briefe-und-pakete-post-2"
-        ]
-      },
-      "previousSlugs": [
+      "location": "Samedan"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-26e166c0a5d1",
+    "previousSlugsByLocale": {
+      "it": [
         "zusteller-in-briefe-und-pakete-post-2"
       ],
-      "salaryMin": 49500,
-      "salaryMax": 75000,
-      "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Samedan",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-13T11:42:33.116Z"
+      "en": [
+        "zusteller-in-briefe-und-pakete-post-2"
+      ],
+      "fr": [
+        "zusteller-in-briefe-und-pakete-post-2"
+      ]
     },
-    {
-      "url": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73537-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73537-de_DE",
-      "title": "Ticketkontrolleur:in und Kundenberatung",
-      "company": "PostAuto",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Chur",
+    "previousSlugs": [
+      "zusteller-in-briefe-und-pakete-post-2"
+    ],
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Samedan",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-13T11:42:33.116Z"
+  },
+  {
+    "url": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73537-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73537-de_DE",
+    "title": "Ticketkontrolleur:in und Kundenberatung",
+    "company": "PostAuto",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Chur",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n\r\n\n \n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.  \n\r\n\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.  \n\r\n\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.  \n\r\n\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\r\n\n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Du hast eine Grundausbildung abgeschlossen und verfügst über den Führerausweis der Kategorie B oder D.   \n\r\n\n- Dank deiner lösungsorientierten Art kannst du geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben.   \n\r\n\n- Du hast Freude am täglichen Kundenkontakt und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.   \n\r\n\n- Deine sehr guten Deutschkenntnisse sowie gute Italienisch- und Englischkenntniesse in Wort und Schrift und ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+    "descriptionByLocale": {
+      "it": "Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n\r\n\n \n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.  \n\r\n\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.  \n\r\n\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.  \n\r\n\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\r\n\n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Du hast eine Grundausbildung abgeschlossen und verfügst über den Führerausweis der Kategorie B oder D.   \n\r\n\n- Dank deiner lösungsorientierten Art kannst du geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben.   \n\r\n\n- Du hast Freude am täglichen Kundenkontakt und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.   \n\r\n\n- Deine sehr guten Deutschkenntnisse sowie gute Italienisch- und Englischkenntniesse in Wort und Schrift und ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+      "en": "Descrizione\nAre you happy to be on the go and appreciate direct contact with passengers? Then you are right with us, because with you our passengers experience first-class service and professional advice on every kilometre!\n- You can do this together with your team for professional ticket controls and make an important contribution to securing revenue.\n- From Monday to Sunday you will be on our varied regional lines.\n- You advise our passengers competently and accommodatingly in tariff and timetable questions and create positive experiences for our customers.\n- You also take special tasks such as structural surveys or fraud prevention.\n\nRequisiti\n- You have completed basic training\n- You have the category B or D guide card\n- You have very good German skills\n- You have good knowledge of Italian and English in word and writing\n- You have an experienced handling of digital devices\n\nCosa offriamo\n- You have the opportunity to work irregular working hours (including Sundays and holidays)\n- You have the opportunity to work in a varied environment\n- You have the opportunity to develop your skills and knowledge\n\nContatto\n- (Contatto non specificato)",
+      "de": "## Descrizione\n- Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n- Das kannst du bewirken Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\n## Requisiti\n- Du hast eine Grundausbildung abgeschlossen\n- Du verfügst über den Führerausweis der Kategorie B oder D\n- Du hast sehr gute Deutschkenntnisse\n- Du hast gute Italienisch- und Englischkenntnisse in Wort und Schrift\n- Du hast ein versierter Umgang mit digitalen Geräten\n\n## Cosa offriamo\n- Du hast die Möglichkeit, unregelmäßige Arbeitszeiten (inkl. Sonn- und Feiertage) zu arbeiten\n- Du hast die Möglichkeit, in einer abwechslungsreichen Umgebung zu arbeiten\n- Du hast die Möglichkeit, deine Fähigkeiten und Kenntnisse zu entwickeln\n\n## Contatto\n- (Contatto non specificato)",
+      "fr": "Descrizione\nÊtes-vous heureux d'être en route et d'apprécier le contact direct avec les passagers? Alors vous avez raison avec nous, car avec vous nos passagers font l'expérience de services de première classe et de conseils professionnels sur tous les kilomètres!\n- Vous pouvez le faire avec votre équipe pour le contrôle professionnel des billets et contribuer de façon importante à obtenir des revenus.\n- Du lundi au dimanche, vous serez sur nos lignes régionales variées.\n- Vous conseillez nos passagers avec compétence et accommodement dans les questions de tarif et d'horaire et créez des expériences positives pour nos clients.\n- Vous assumez également des tâches spéciales telles que les enquêtes structurelles ou la prévention de la fraude.\n\nRequisiti\n- Vous avez suivi une formation de base\n- Vous avez la carte de guide de catégorie B ou D\n- Vous avez de très bonnes compétences en allemand\n- Vous avez une bonne connaissance de l'italien et de l'anglais en paroles et en écriture\n- Vous avez une gestion expérimentée des appareils numériques\n\nCosa offriamo\n- Vous avez la possibilité de travailler en horaires irréguliers (y compris le dimanche et les jours fériés)\n- Vous avez la possibilité de travailler dans un environnement varié\n- Vous avez la possibilité de développer vos compétences et connaissances\n\nContatto\n- (Contatto non spécifique)"
+    },
+    "titleByLocale": {
+      "it": "Ticketkontrolleur:in e Kundenberatung",
+      "en": "Ticket controller:in and customer consulting",
+      "de": "Ticketkontrolleur:in und Kundenberatung",
+      "fr": "Contrôleur de billets et conseil à la clientèle"
+    },
+    "slug": "ticketkontrolleur-in-e-kundenberatung-postauto-chur",
+    "slugByLocale": {
+      "it": "ticketkontrolleur-in-e-kundenberatung-postauto-chur",
+      "en": "ticket-controller-in-and-customer-consulting-postauto-chur",
+      "de": "ticketkontrolleur-in-und-kundenberatung-postauto-chur",
+      "fr": "controleur-de-billets-et-conseil-a-la-clientele-postauto-chur"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-04-29",
+    "validThrough": "2026-05-20",
+    "source": "postch-careers-crawler",
+    "employmentType": "FULL_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "40-100%",
+    "_targetScope": {
       "canton": "GR",
-      "country": "CH",
-      "description": "Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer! Das kannst du bewirken Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung. Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz. Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft. Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention. Das bringst du mit Du hast eine Grundausbildung abgeschlossen und verfügst über den Führerausweis der Kategorie B oder D. Dank deiner lösungsorientierten Art kannst du geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben. Du hast Freude am täglichen Kundenkontakt und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Deine sehr guten Deutschkenntnisse sowie gute Italienisch- und Englischkenntniesse in Wort und Schrift und ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
-      "descriptionByLocale": {
-        "it": "Descrizione\nSei felice di essere in viaggio e apprezzare il contatto diretto con i passeggeri? Allora avete ragione con noi, perché con voi i nostri passeggeri sperimentano servizio di prima classe e consulenza professionale su ogni chilometro!\n- Puoi farlo insieme al tuo team per i controlli dei biglietti professionali e dare un contributo importante per garantire i ricavi.\n- Da lunedì a domenica sarete sulle nostre varie linee regionali.\n- Si consiglia ai nostri passeggeri in modo competente e accomodante in domande tariffarie e orari e creare esperienze positive per i nostri clienti.\n- Si occupano anche di compiti speciali come le indagini strutturali o la prevenzione delle frodi.\n\nRequisiti\n- Hai completato l'allenamento di base\n- Hai la scheda guida categoria B o D\n- Hai ottime competenze tedesche\n- Hai una buona conoscenza di italiano e inglese in parola e scrittura\n- Hai una gestione esperta dei dispositivi digitali\n\nCosa?\n- Hai la possibilità di lavorare ore di lavoro irregolari (comprese le domeniche e le vacanze)\n- Hai la possibilità di lavorare in un ambiente vario\n- Hai l'opportunità di sviluppare le tue competenze e conoscenze\n\nContatto\n- (Contatto non specificato)",
-        "en": "Descrizione\nAre you happy to be on the go and appreciate direct contact with passengers? Then you are right with us, because with you our passengers experience first-class service and professional advice on every kilometre!\n- You can do this together with your team for professional ticket controls and make an important contribution to securing revenue.\n- From Monday to Sunday you will be on our varied regional lines.\n- You advise our passengers competently and accommodatingly in tariff and timetable questions and create positive experiences for our customers.\n- You also take special tasks such as structural surveys or fraud prevention.\n\nRequisiti\n- You have completed basic training\n- You have the category B or D guide card\n- You have very good German skills\n- You have good knowledge of Italian and English in word and writing\n- You have an experienced handling of digital devices\n\nCosa offriamo\n- You have the opportunity to work irregular working hours (including Sundays and holidays)\n- You have the opportunity to work in a varied environment\n- You have the opportunity to develop your skills and knowledge\n\nContatto\n- (Contatto non specificato)",
-        "de": "## Descrizione\n- Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n- Das kannst du bewirken Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\n## Requisiti\n- Du hast eine Grundausbildung abgeschlossen\n- Du verfügst über den Führerausweis der Kategorie B oder D\n- Du hast sehr gute Deutschkenntnisse\n- Du hast gute Italienisch- und Englischkenntnisse in Wort und Schrift\n- Du hast ein versierter Umgang mit digitalen Geräten\n\n## Cosa offriamo\n- Du hast die Möglichkeit, unregelmäßige Arbeitszeiten (inkl. Sonn- und Feiertage) zu arbeiten\n- Du hast die Möglichkeit, in einer abwechslungsreichen Umgebung zu arbeiten\n- Du hast die Möglichkeit, deine Fähigkeiten und Kenntnisse zu entwickeln\n\n## Contatto\n- (Contatto non specificato)",
-        "fr": "Descrizione\nÊtes-vous heureux d'être en route et d'apprécier le contact direct avec les passagers? Alors vous avez raison avec nous, car avec vous nos passagers font l'expérience de services de première classe et de conseils professionnels sur tous les kilomètres!\n- Vous pouvez le faire avec votre équipe pour le contrôle professionnel des billets et contribuer de façon importante à obtenir des revenus.\n- Du lundi au dimanche, vous serez sur nos lignes régionales variées.\n- Vous conseillez nos passagers avec compétence et accommodement dans les questions de tarif et d'horaire et créez des expériences positives pour nos clients.\n- Vous assumez également des tâches spéciales telles que les enquêtes structurelles ou la prévention de la fraude.\n\nRequisiti\n- Vous avez suivi une formation de base\n- Vous avez la carte de guide de catégorie B ou D\n- Vous avez de très bonnes compétences en allemand\n- Vous avez une bonne connaissance de l'italien et de l'anglais en paroles et en écriture\n- Vous avez une gestion expérimentée des appareils numériques\n\nCosa offriamo\n- Vous avez la possibilité de travailler en horaires irréguliers (y compris le dimanche et les jours fériés)\n- Vous avez la possibilité de travailler dans un environnement varié\n- Vous avez la possibilité de développer vos compétences et connaissances\n\nContatto\n- (Contatto non spécifique)"
-      },
-      "titleByLocale": {
-        "it": "Ticketkontrolleur:in e Kundenberatung",
-        "en": "Ticket controller:in and customer consulting",
-        "de": "Ticketkontrolleur:in und Kundenberatung",
-        "fr": "Contrôleur de billets et conseil à la clientèle"
-      },
-      "slug": "ticketkontrolleur-in-e-kundenberatung-postauto-chur",
-      "slugByLocale": {
-        "it": "ticketkontrolleur-in-e-kundenberatung-postauto-chur",
-        "en": "ticket-controller-in-and-customer-consulting-postauto-chur",
-        "de": "ticketkontrolleur-in-und-kundenberatung-postauto-chur",
-        "fr": "controleur-de-billets-et-conseil-a-la-clientele-postauto-chur"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-04-29",
-      "validThrough": "2026-05-20",
-      "source": "postch-careers-crawler",
-      "employmentType": "FULL_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "40-100%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Chur"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-4a516de3ee04",
-      "previousSlugsByLocale": {
-        "it": [
-          "ticketkontrolleur-in-und-kundenberatung-post"
-        ],
-        "en": [
-          "ticketkontrolleur-in-und-kundenberatung-postauto-chur"
-        ],
-        "fr": [
-          "ticketkontrolleur-in-und-kundenberatung-postauto-chur"
-        ]
-      },
-      "previousSlugs": [
-        "ticketkontrolleur-in-und-kundenberatung-post",
+      "location": "Chur"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-4a516de3ee04",
+    "previousSlugsByLocale": {
+      "it": [
+        "ticketkontrolleur-in-und-kundenberatung-post"
+      ],
+      "en": [
         "ticketkontrolleur-in-und-kundenberatung-postauto-chur"
       ],
-      "salaryMin": 49500,
-      "salaryMax": 75000,
-      "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Chur",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-13T11:42:33.116Z"
+      "fr": [
+        "ticketkontrolleur-in-und-kundenberatung-postauto-chur"
+      ]
     },
-    {
-      "url": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73538-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73538-de_DE",
-      "title": "Ticketkontrolleur:in und Kundenberatung",
-      "company": "PostAuto",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Scuol",
+    "previousSlugs": [
+      "ticketkontrolleur-in-und-kundenberatung-post",
+      "ticketkontrolleur-in-und-kundenberatung-postauto-chur"
+    ],
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Chur",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-13T11:42:33.116Z"
+  },
+  {
+    "url": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73538-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/Ticketkontrolleurin-und-Kundenberatung/73538-de_DE",
+    "title": "Ticketkontrolleur:in und Kundenberatung",
+    "company": "PostAuto",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Scuol",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n\r\n\n \n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.  \n\r\n\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.  \n\r\n\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.  \n\r\n\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\r\n\n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Du hast eine Grundausbildung abgeschlossen und verfügst über den Führerausweis der Kategorie B oder D.   \n\r\n\n- Dank deiner lösungsorientierten Art kannst du geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben.   \n\r\n\n- Du hast Freude am täglichen Kundenkontakt und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.   \n\r\n\n- Deine sehr guten Deutschkentnisse sowie gute Italienisch- und Englischkenntnisse in Wort und Schrift und ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+    "descriptionByLocale": {
+      "it": "Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n\r\n\n \n\r\n\nDas kannst du bewirken\n\r\n\n\r\n\n- Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.  \n\r\n\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.  \n\r\n\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.  \n\r\n\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\r\n\n\r\n\nDas bringst du mit\n\r\n\n\r\n\n- Du hast eine Grundausbildung abgeschlossen und verfügst über den Führerausweis der Kategorie B oder D.   \n\r\n\n- Dank deiner lösungsorientierten Art kannst du geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben.   \n\r\n\n- Du hast Freude am täglichen Kundenkontakt und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.   \n\r\n\n- Deine sehr guten Deutschkentnisse sowie gute Italienisch- und Englischkenntnisse in Wort und Schrift und ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
+      "en": "Descrizione\n\nAre you happy to be on the go and appreciate direct contact with passengers? Then you are right with us, because with you our passengers experience first-class service and professional advice on every kilometre!\n- You can do this together with your team for professional ticket controls and make an important contribution to securing revenue.\n- From Monday to Sunday you will be on our varied regional lines.\n- You advise our passengers competently and accommodatingly in tariff and timetable questions and create positive experiences for our customers.\n- You also take special tasks such as structural surveys or fraud prevention.\n\nRequisiti\n\n- You have completed basic training\n- You have the category B or D guide card\n- You have very good German skills\n- You have good knowledge of Italian and English in word and writing\n- You have an experienced handling of digital devices\n\nCosa offriamo\n\n- You're enjoying your daily customer contact\n- You enjoy the change, the irregular working hours (including Sundays and holidays)\n- You can skillfully argue and stay confident and calm in hectic situations",
+      "de": "## Descrizione\n\n- Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n- Das kannst du bewirken Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\n## Requisiti\n\n- Du hast eine Grundausbildung abgeschlossen\n- Du verfügst über den Führerausweis der Kategorie B oder D\n- Du hast sehr gute Deutschkentnisse\n- Du hast gute Italienisch- und Englischkenntnisse in Wort und Schrift\n- Du hast ein versierter Umgang mit digitalen Geräten\n\n## Cosa offriamo\n\n- Du hast Freude am täglichen Kundenkontakt\n- Du geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen\n- Du kannst geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben",
+      "fr": "Descrizione\n\nÊtes-vous heureux d'être en route et d'apprécier le contact direct avec les passagers? Alors vous avez raison avec nous, car avec vous nos passagers font l'expérience de services de première classe et de conseils professionnels sur tous les kilomètres!\n- Vous pouvez le faire avec votre équipe pour le contrôle professionnel des billets et contribuer de façon importante à obtenir des revenus.\n- Du lundi au dimanche, vous serez sur nos lignes régionales variées.\n- Vous conseillez nos passagers avec compétence et accommodement dans les questions de tarif et d'horaire et créez des expériences positives pour nos clients.\n- Vous assumez également des tâches spéciales telles que les enquêtes structurelles ou la prévention de la fraude.\n\nRequisiti\n\n- Vous avez suivi une formation de base\n- Vous avez la carte de guide de catégorie B ou D\n- Vous avez de très bonnes compétences en allemand\n- Vous avez une bonne connaissance de l'italien et de l'anglais en paroles et en écriture\n- Vous avez une gestion expérimentée des appareils numériques\n\nCosa offriamo\n\n- Vous appréciez votre contact client quotidien\n- Vous appréciez le changement, les horaires de travail irréguliers (y compris les dimanches et jours fériés)\n- Vous pouvez argumenter habilement et rester confiant et calme dans des situations agitées"
+    },
+    "titleByLocale": {
+      "it": "Ticketkontrolleur:in e Kundenberatung",
+      "en": "Ticket controller:in and customer consulting",
+      "de": "Ticketkontrolleur:in und Kundenberatung",
+      "fr": "Contrôleur de billets et conseil à la clientèle"
+    },
+    "slug": "ticketkontrolleur-in-e-kundenberatung-postauto-scuol",
+    "slugByLocale": {
+      "it": "ticketkontrolleur-in-e-kundenberatung-postauto-scuol",
+      "en": "ticket-controller-in-and-customer-consulting-postauto-scuol",
+      "de": "ticketkontrolleur-in-und-kundenberatung-postauto-scuol",
+      "fr": "controleur-de-billets-et-conseil-a-la-clientele-postauto-scuol"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-04-29",
+    "validThrough": "2026-05-20",
+    "source": "postch-careers-crawler",
+    "employmentType": "PART_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "50%",
+    "_targetScope": {
       "canton": "GR",
-      "country": "CH",
-      "description": "Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer! Das kannst du bewirken Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung. Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz. Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft. Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention. Das bringst du mit Du hast eine Grundausbildung abgeschlossen und verfügst über den Führerausweis der Kategorie B oder D. Dank deiner lösungsorientierten Art kannst du geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben. Du hast Freude am täglichen Kundenkontakt und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Deine sehr guten Deutschkentnisse sowie gute Italienisch- und Englischkenntnisse in Wort und Schrift und ein versierter Umgang mit digitalen Geräten runden dein Profil ab.",
-      "descriptionByLocale": {
-        "it": "Descrizione\n\nSei felice di essere in viaggio e apprezzare il contatto diretto con i passeggeri? Allora avete ragione con noi, perché con voi i nostri passeggeri sperimentano servizio di prima classe e consulenza professionale su ogni chilometro!\n- Puoi farlo insieme al tuo team per i controlli dei biglietti professionali e dare un contributo importante per garantire i ricavi.\n- Da lunedì a domenica sarete sulle nostre varie linee regionali.\n- Si consiglia ai nostri passeggeri in modo competente e accomodante in domande tariffarie e orari e creare esperienze positive per i nostri clienti.\n- Si occupano anche di compiti speciali come le indagini strutturali o la prevenzione delle frodi.\n\nRequisiti\n\n- Hai completato l'allenamento di base\n- Hai la scheda guida categoria B o D\n- Hai ottime competenze tedesche\n- Hai una buona conoscenza di italiano e inglese in parola e scrittura\n- Hai una gestione esperta dei dispositivi digitali\n\nCosa?\n\n- Ti stai godendo il tuo contatto giornaliero con i clienti\n- Vi piace il cambiamento, le ore di lavoro irregolari (comprese le domeniche e le vacanze)\n- Si può abilmente discutere e rimanere sicuri e calmi in situazioni frenetiche",
-        "en": "Descrizione\n\nAre you happy to be on the go and appreciate direct contact with passengers? Then you are right with us, because with you our passengers experience first-class service and professional advice on every kilometre!\n- You can do this together with your team for professional ticket controls and make an important contribution to securing revenue.\n- From Monday to Sunday you will be on our varied regional lines.\n- You advise our passengers competently and accommodatingly in tariff and timetable questions and create positive experiences for our customers.\n- You also take special tasks such as structural surveys or fraud prevention.\n\nRequisiti\n\n- You have completed basic training\n- You have the category B or D guide card\n- You have very good German skills\n- You have good knowledge of Italian and English in word and writing\n- You have an experienced handling of digital devices\n\nCosa offriamo\n\n- You're enjoying your daily customer contact\n- You enjoy the change, the irregular working hours (including Sundays and holidays)\n- You can skillfully argue and stay confident and calm in hectic situations",
-        "de": "## Descrizione\n\n- Bist du gerne unterwegs und schätzt den direkten Kontakt mit Fahrgästen? Dann bist du bei uns genau richtig, denn mit dir erleben unsere Fahrgäste erstklassigen Service und professionelle Beratung auf jedem Kilometer!\n- Das kannst du bewirken Zusammen mit deinem Team sorgst du für professionelle Ticketkontrollen und leistest damit einen wichtigen Beitrag zur Einnahmensicherung.\n- Von Montag bis Sonntag bist du auf unseren abwechslungsreichen regionalen Linien im Einsatz.\n- Du berätst unsere Fahrgäste kompetent und zuvorkommend in Tarif- und Fahrplanfragen und schaffst positive Erlebnisse für unsere Kundschaft.\n- Ausserdem übernimmst du Sonderaufgaben wie Strukturerhebungen oder Betrugsprävention.\n\n## Requisiti\n\n- Du hast eine Grundausbildung abgeschlossen\n- Du verfügst über den Führerausweis der Kategorie B oder D\n- Du hast sehr gute Deutschkentnisse\n- Du hast gute Italienisch- und Englischkenntnisse in Wort und Schrift\n- Du hast ein versierter Umgang mit digitalen Geräten\n\n## Cosa offriamo\n\n- Du hast Freude am täglichen Kundenkontakt\n- Du geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen\n- Du kannst geschickt argumentieren und auch in hektischen Situationen souverän und ruhig bleiben",
-        "fr": "Descrizione\n\nÊtes-vous heureux d'être en route et d'apprécier le contact direct avec les passagers? Alors vous avez raison avec nous, car avec vous nos passagers font l'expérience de services de première classe et de conseils professionnels sur tous les kilomètres!\n- Vous pouvez le faire avec votre équipe pour le contrôle professionnel des billets et contribuer de façon importante à obtenir des revenus.\n- Du lundi au dimanche, vous serez sur nos lignes régionales variées.\n- Vous conseillez nos passagers avec compétence et accommodement dans les questions de tarif et d'horaire et créez des expériences positives pour nos clients.\n- Vous assumez également des tâches spéciales telles que les enquêtes structurelles ou la prévention de la fraude.\n\nRequisiti\n\n- Vous avez suivi une formation de base\n- Vous avez la carte de guide de catégorie B ou D\n- Vous avez de très bonnes compétences en allemand\n- Vous avez une bonne connaissance de l'italien et de l'anglais en paroles et en écriture\n- Vous avez une gestion expérimentée des appareils numériques\n\nCosa offriamo\n\n- Vous appréciez votre contact client quotidien\n- Vous appréciez le changement, les horaires de travail irréguliers (y compris les dimanches et jours fériés)\n- Vous pouvez argumenter habilement et rester confiant et calme dans des situations agitées"
-      },
-      "titleByLocale": {
-        "it": "Ticketkontrolleur:in e Kundenberatung",
-        "en": "Ticket controller:in and customer consulting",
-        "de": "Ticketkontrolleur:in und Kundenberatung",
-        "fr": "Contrôleur de billets et conseil à la clientèle"
-      },
-      "slug": "ticketkontrolleur-in-e-kundenberatung-postauto-scuol",
-      "slugByLocale": {
-        "it": "ticketkontrolleur-in-e-kundenberatung-postauto-scuol",
-        "en": "ticket-controller-in-and-customer-consulting-postauto-scuol",
-        "de": "ticketkontrolleur-in-und-kundenberatung-postauto-scuol",
-        "fr": "controleur-de-billets-et-conseil-a-la-clientele-postauto-scuol"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-04-29",
-      "validThrough": "2026-05-20",
-      "source": "postch-careers-crawler",
-      "employmentType": "PART_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "50%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Scuol"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-890e79c1b976",
-      "previousSlugsByLocale": {
-        "it": [
-          "ticketkontrolleur-in-und-kundenberatung-post-2"
-        ],
-        "en": [
-          "ticketkontrolleur-in-und-kundenberatung-postauto-scuol"
-        ],
-        "fr": [
-          "ticketkontrolleur-in-und-kundenberatung-postauto-scuol"
-        ]
-      },
-      "previousSlugs": [
-        "ticketkontrolleur-in-und-kundenberatung-post-2",
+      "location": "Scuol"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-890e79c1b976",
+    "previousSlugsByLocale": {
+      "it": [
+        "ticketkontrolleur-in-und-kundenberatung-post-2"
+      ],
+      "en": [
         "ticketkontrolleur-in-und-kundenberatung-postauto-scuol"
       ],
-      "salaryMin": 49500,
-      "salaryMax": 75000,
-      "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Scuol",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-13T11:42:33.116Z"
+      "fr": [
+        "ticketkontrolleur-in-und-kundenberatung-postauto-scuol"
+      ]
     },
-    {
-      "url": "https://job.post.ch/default/job/PostAuto-Fahrerin/73523-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/PostAuto-Fahrerin/73523-de_DE",
-      "title": "PostAuto-Fahrer:in",
-      "company": "PostAuto",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Davos Platz",
-      "canton": "GR",
-      "country": "CH",
-      "description": "Liebst du es, jeden Tag neue Menschen zu treffen und möchtest eigenverantwortlich arbeiten? Dann suchen wir genau dich, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich und sicher ans Ziel. Das kannst du bewirken Auf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel. Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen. Der tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft. Als Fahrer:in bewegst du weit mehr als nur dein Fahrzeug auf der Strasse. Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen. Das bringst du mit Du verfügst über Fahrpraxis im Personentransport und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen. Für diese Stelle benötigst du einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis. Zuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken. Du verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
-      "descriptionByLocale": {
-        "it": "Descrizione\nTi piace incontrare nuove persone ogni giorno e vuoi lavorare in modo indipendente? Allora ti stiamo cercando, perche' con te sulla ruota, i nostri passeggeri arrivano in tempo e in sicurezza.\n\nMansioni\n- Nelle nostre varie linee regionali porti i nostri passeggeri a destinazione da lunedì a domenica.\n- Lei è ospite: nelle nostre auto postali e consiglia ai nostri clienti in domande tariffarie e orari.\n- Il contatto quotidiano con i passeggeri arricchisce la vostra vita quotidiana con incontri emozionanti e crei esperienze positive per i nostri clienti.\n\nRequisiti\n- Ha la pratica di guida nel trasporto passeggeri.\n- Vi piace il cambiamento che porta ore di lavoro irregolari (comprese le domeniche e le vacanze).\n- Hai bisogno di un ID driver di categoria D e di un certificato di qualifica del conducente valido.\n- Affidabilità e gioia nel contatto quotidiano del cliente sono tra i vostri punti di forza.\n- Hai buone competenze tedesche.\n- Sei esperto nella gestione di dispositivi digitali.\n\nCosa?\n- Muovi molto di più del tuo veicolo sulla strada.\n- In contatto diretto con i clienti si verificano situazioni nuove e variegate ogni giorno.\n\nContatto\n- (Contatto non specificato)",
-        "en": "Descrizione\nDo you love meeting new people every day and want to work independently? Then we're looking for you, because with you on the wheel, our passengers arrive on time and safely.\n\nMansioni\n- On our varied regional lines you bring our passengers to their destination from Monday to Sunday.\n- You are host:in our post cars and advises our customers in tariff and timetable questions.\n- Daily contact with your passengers enriches your everyday life with exciting encounters and you create positive experiences for our customers.\n\nRequisiti\n- You have driving practice in passenger transport.\n- You enjoy the change that brings irregular working hours (including Sundays and holidays).\n- You need a category D driver ID and a valid driver qualification certificate.\n- Reliability and joy in daily customer contact are among your strengths.\n- You have good German skills.\n- You are experienced in handling digital devices.\n\nCosa offriamo\n- You move far more than your vehicle on the road.\n- In direct customer contact you will experience new and varied situations every day.\n\nContatto\n- (Contatto non specificato)",
-        "de": "## Descrizione\nLiebst du es, jeden Tag neue Menschen zu treffen und möchtest eigenverantwortlich arbeiten? Dann suchen wir genau dich, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich und sicher ans Ziel.\n\n## Mansioni\n- Auf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel.\n- Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.\n- Der tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.\n\n## Requisiti\n- Du verfügst über Fahrpraxis im Personentransport.\n- Du geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.\n- Du benötigst einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis.\n- Zuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken.\n- Du verfügst über gute Deutschkenntnisse.\n- Du bist versiert im Umgang mit digitalen Geräten.\n\n## Cosa offriamo\n- Du bewegst weit mehr als nur dein Fahrzeug auf der Strasse.\n- Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen.\n\n## Contatto\n- (Contatto non specificato)",
-        "fr": "Descrizione\nAimez-vous rencontrer de nouvelles personnes chaque jour et souhaitez-vous travailler de façon indépendante? Ensuite, nous vous cherchons, car avec vous au volant, nos passagers arrivent à temps et en toute sécurité.\n\nMansioni\n- Sur nos lignes régionales variées, vous amènez nos passagers à destination du lundi au dimanche.\n- Vous êtes l'hôte: dans nos voitures postales et conseille nos clients dans les questions de tarif et d'horaire.\n- Le contact quotidien avec vos passagers enrichit votre vie quotidienne de rencontres passionnantes et vous créez des expériences positives pour nos clients.\n\nRequisiti\n- Vous avez un entraînement en transport de passagers.\n- Vous appréciez le changement qui apporte des horaires de travail irréguliers (y compris le dimanche et les jours fériés).\n- Vous avez besoin d'un identifiant de conducteur de catégorie D et d'un certificat de qualification valide.\n- Fiabilité et joie dans le contact quotidien avec le client sont parmi vos forces.\n- Vous avez de bonnes compétences en allemand.\n- Vous êtes expérimenté dans la manipulation des appareils numériques.\n\nCosa offriamo\n- Tu bouges bien plus que ton véhicule sur la route.\n- En contact direct avec le client, vous vivrez des situations nouvelles et variées chaque jour.\n\nContatto\n- (Contatto non spécifique)"
-      },
-      "titleByLocale": {
-        "it": "Driver per il carrello",
-        "en": "Postcar driver:in",
-        "de": "PostAuto-Fahrer:in",
-        "fr": "Conducteur d ' une voiture"
-      },
-      "slug": "driver-per-il-carrello-postauto-davos-platz",
-      "slugByLocale": {
-        "it": "driver-per-il-carrello-postauto-davos-platz",
-        "en": "postcar-driver-in-postauto-davos-platz",
-        "de": "postauto-fahrer-in-postauto-davos-platz",
-        "fr": "conducteur-d-une-voiture-postauto-davos-platz"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-04-28",
-      "validThrough": "2026-05-19",
-      "source": "postch-careers-crawler",
-      "employmentType": "FULL_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "80-100%",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Davos Platz"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-c26b019ebd4e",
-      "salaryMin": 49500,
-      "salaryMax": 75000,
+    "previousSlugs": [
+      "ticketkontrolleur-in-und-kundenberatung-post-2",
+      "ticketkontrolleur-in-und-kundenberatung-postauto-scuol"
+    ],
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
       "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Davos Platz",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-13T11:42:33.116Z",
-      "previousSlugsByLocale": {
-        "en": [
-          "postauto-fahrer-in-post"
-        ],
-        "fr": [
-          "postauto-fahrer-in-post"
-        ],
-        "it": [
-          "postauto-fahrer-in-post-2"
-        ]
-      },
-      "previousSlugs": [
-        "postauto-fahrer-in-post",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Scuol",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-13T11:42:33.116Z"
+  },
+  {
+    "url": "https://job.post.ch/default/job/PostAuto-Fahrerin/73523-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/PostAuto-Fahrerin/73523-de_DE",
+    "title": "PostAuto-Fahrer:in",
+    "company": "PostAuto",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Davos Platz",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Liebst du es, jeden Tag neue Menschen zu treffen und möchtest eigenverantwortlich arbeiten? Dann suchen wir genau dich, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich und sicher ans Ziel.  \n\r\n\n \n\r\n\nDas kannst du bewirken  \n\r\n\n\r\n\n- \r\n\nAuf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDer tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.   \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nAls Fahrer:in bewegst du weit mehr als nur dein Fahrzeug auf der Strasse. Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen.  \n\r\n\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit  \n\r\n\n\r\n\n- \r\n\nDu verfügst über Fahrpraxis im Personentransport und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nFür diese Stelle benötigst du einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nZuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
+    "descriptionByLocale": {
+      "it": "Liebst du es, jeden Tag neue Menschen zu treffen und möchtest eigenverantwortlich arbeiten? Dann suchen wir genau dich, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich und sicher ans Ziel.  \n\r\n\n \n\r\n\nDas kannst du bewirken  \n\r\n\n\r\n\n- \r\n\nAuf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDer tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.   \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nAls Fahrer:in bewegst du weit mehr als nur dein Fahrzeug auf der Strasse. Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen.  \n\r\n\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit  \n\r\n\n\r\n\n- \r\n\nDu verfügst über Fahrpraxis im Personentransport und geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nFür diese Stelle benötigst du einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nZuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken.  \n\r\n\n\r\n\n\r\n\n\r\n\n- \r\n\nDu verfügst über gute Deutschkenntnisse und bist versiert im Umgang mit digitalen Geräten.",
+      "en": "Descrizione\nDo you love meeting new people every day and want to work independently? Then we're looking for you, because with you on the wheel, our passengers arrive on time and safely.\n\nMansioni\n- On our varied regional lines you bring our passengers to their destination from Monday to Sunday.\n- You are host:in our post cars and advises our customers in tariff and timetable questions.\n- Daily contact with your passengers enriches your everyday life with exciting encounters and you create positive experiences for our customers.\n\nRequisiti\n- You have driving practice in passenger transport.\n- You enjoy the change that brings irregular working hours (including Sundays and holidays).\n- You need a category D driver ID and a valid driver qualification certificate.\n- Reliability and joy in daily customer contact are among your strengths.\n- You have good German skills.\n- You are experienced in handling digital devices.\n\nCosa offriamo\n- You move far more than your vehicle on the road.\n- In direct customer contact you will experience new and varied situations every day.\n\nContatto\n- (Contatto non specificato)",
+      "de": "## Descrizione\nLiebst du es, jeden Tag neue Menschen zu treffen und möchtest eigenverantwortlich arbeiten? Dann suchen wir genau dich, denn mit dir am Steuer kommen unsere Fahrgäste pünktlich und sicher ans Ziel.\n\n## Mansioni\n- Auf unseren abwechslungsreichen regionalen Linien bringst du unsere Fahrgäste von Montag bis Sonntag an ihr Ziel.\n- Du bist Gastgeber:in in unseren Postautos und berätst unsere Kundschaft in Tarif- und Fahrplanfragen.\n- Der tägliche Kontakt mit deinen Fahrgästen bereichert deinen Alltag mit spannenden Begegnungen und du schaffst positive Erlebnisse für unsere Kundschaft.\n\n## Requisiti\n- Du verfügst über Fahrpraxis im Personentransport.\n- Du geniesst die Abwechslung, die unregelmässige Arbeitszeiten (inkl. Sonn- und Feiertage) mit sich bringen.\n- Du benötigst einen Führerausweis der Kategorie D und einen gültigen Fahrerqualifizierungsnachweis.\n- Zuverlässigkeit und Freude am täglichen Kundenkontakt gehören zu deinen Stärken.\n- Du verfügst über gute Deutschkenntnisse.\n- Du bist versiert im Umgang mit digitalen Geräten.\n\n## Cosa offriamo\n- Du bewegst weit mehr als nur dein Fahrzeug auf der Strasse.\n- Im direkten Kundenkontakt erlebst du jeden Tag neue und abwechslungsreiche Situationen.\n\n## Contatto\n- (Contatto non specificato)",
+      "fr": "Descrizione\nAimez-vous rencontrer de nouvelles personnes chaque jour et souhaitez-vous travailler de façon indépendante? Ensuite, nous vous cherchons, car avec vous au volant, nos passagers arrivent à temps et en toute sécurité.\n\nMansioni\n- Sur nos lignes régionales variées, vous amènez nos passagers à destination du lundi au dimanche.\n- Vous êtes l'hôte: dans nos voitures postales et conseille nos clients dans les questions de tarif et d'horaire.\n- Le contact quotidien avec vos passagers enrichit votre vie quotidienne de rencontres passionnantes et vous créez des expériences positives pour nos clients.\n\nRequisiti\n- Vous avez un entraînement en transport de passagers.\n- Vous appréciez le changement qui apporte des horaires de travail irréguliers (y compris le dimanche et les jours fériés).\n- Vous avez besoin d'un identifiant de conducteur de catégorie D et d'un certificat de qualification valide.\n- Fiabilité et joie dans le contact quotidien avec le client sont parmi vos forces.\n- Vous avez de bonnes compétences en allemand.\n- Vous êtes expérimenté dans la manipulation des appareils numériques.\n\nCosa offriamo\n- Tu bouges bien plus que ton véhicule sur la route.\n- En contact direct avec le client, vous vivrez des situations nouvelles et variées chaque jour.\n\nContatto\n- (Contatto non spécifique)"
+    },
+    "titleByLocale": {
+      "it": "Driver per il carrello",
+      "en": "Postcar driver:in",
+      "de": "PostAuto-Fahrer:in",
+      "fr": "Conducteur d ' une voiture"
+    },
+    "slug": "driver-per-il-carrello-postauto-davos-platz",
+    "slugByLocale": {
+      "it": "driver-per-il-carrello-postauto-davos-platz",
+      "en": "postcar-driver-in-postauto-davos-platz",
+      "de": "postauto-fahrer-in-postauto-davos-platz",
+      "fr": "conducteur-d-une-voiture-postauto-davos-platz"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-04-28",
+    "validThrough": "2026-05-19",
+    "source": "postch-careers-crawler",
+    "employmentType": "FULL_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "80-100%",
+    "_targetScope": {
+      "canton": "GR",
+      "location": "Davos Platz"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-c26b019ebd4e",
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Davos Platz",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-13T11:42:33.116Z",
+    "previousSlugsByLocale": {
+      "en": [
+        "postauto-fahrer-in-post"
+      ],
+      "fr": [
+        "postauto-fahrer-in-post"
+      ],
+      "it": [
         "postauto-fahrer-in-post-2"
       ]
     },
-    {
-      "url": "https://job.post.ch/default/job/Lehre-als-Logistikerin-EFZ-Distribution-gemischte-Zustellung-%28Briefe-und-Pakete%29/73223-de_DE",
-      "applyUrl": "https://job.post.ch/default/job/Lehre-als-Logistikerin-EFZ-Distribution-gemischte-Zustellung-%28Briefe-und-Pakete%29/73223-de_DE",
-      "title": "Lehre als Logistiker:in EFZ Distribution gemischte Zustellung (Briefe und Pakete)",
-      "company": "Die Schweizerische Post",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Davos Platz",
-      "canton": "GR",
-      "country": "CH",
-      "description": "Startest du gerne früh in den Tag, liebst du es, an der frischen Luft zu sein, und hast du Freude daran, den Menschen ein Lächeln ins Gesicht zu zaubern? Dann ist eine Ausbildung in der Zustellung (Fachrichtung Distribution) genau das Richtige für dich! Während der dreijährigen Grundausbildung erwirbst du dir das Rüstzeug für einen erfolgreichen Einstieg in die vielfältige Welt der Logistik. Deine Ausbildungsstelle befindet sich in Lausen oder Reinach BL. Deine Ausbildung Am frühen Morgen sortierst du deine Briefe und Pakete und belädst dein Zustellfahrzeug für die anschliessende Zustelltour. Danach bist du selbstständig unterwegs, bringst und holst Sendungen jeder Art und kümmerst dich um die Anliegen unserer Kundinnen und Kunden. Bevor du in deinen wohlverdienten Feierabend startest, erledigst du diverse Nacharbeiten an deiner Ausbildungsstelle. Während deiner Ausbildung wirst du von Profis betreut, in die Praxis eingeführt und laufend weiterentwickelt. Zusätzlich erwirbst du mit finanzieller Unterstützung der Post entweder den Führerschein für Motorräder der Kategorie A1 oder den Führerschein für Motorfahrzeuge der Kategorie B und erlernst das Führen eines Staplers. Mit verschiedenen internen Stationen, einem Einsatz in einem Lagerbetrieb, sowie mit individuellen Wahlmodulen nach deinen Wünschen, vervollständigen wir deine breite Logistikausbildung. Das bringst du mit Wir suchen junge Menschen mit Begeisterung, Freude und Motivation, die etwas bewegen wollen. Folgende Punkte solltest du erfüllen: Körperliche Betätigung und die Arbeit an der frischen Luft begeistern dich. Darüber hinaus hast du Freude am Umgang mit Menschen, bist zuverlässig, ehrlich und verschwiegen. Du bist bereit, bis spätestens zum Lehrstart den Lernfahrausweis Führerschein A1 oder B zu erlangen. Die obligatorische Schulpflicht muss mit einem genügenden Notendurchschnitt auf dem tiefsten Niveau abgeschlossen sein. Bei Lehrbeginn verfügst du über das Sprachniveau B2 in Deutsch",
-      "descriptionByLocale": {
-        "it": "Descrizione\n\nTi piace iniziare presto la giornata, ti piace essere nell'aria fresca, e ti piace coniugare le persone un sorriso in faccia? Poi un allenamento nella consegna (distribuzione di direzione) è giusto per voi! Durante la formazione di base di tre anni si acquisirà lo strumento per un ingresso di successo nel diverso mondo della logistica. Il vostro centro di formazione si trova a Lausen o Reinach BL.\n\nMansioni\n\n- Al mattino presto ordina le lettere e i pacchetti\n- Carica il tuo veicolo di consegna per la consegna successiva la nostra\n- Sei da solo, porti e ricevi spedizioni di qualsiasi tipo.\n- Prenditi cura delle preoccupazioni dei nostri clienti\n- Fai vari lavori nel tuo centro di allenamento\n\nRequisiti\n\n- L'attività fisica e il lavoro all'aria fresca ti ispirano\n- Divertiti a trattare con le persone\n- Sono affidabili, onesti e silenziosi\n- Pronto ad ottenere la patente di guida di apprendimento A1 o B all'inizio dell'apprendistato\n- La scuola obbligatoria obbligatoria obbligatoria obbligatoria deve essere completata con una media di grado sufficiente al livello più basso\n- Caratteristiche del livello di lingua B2 in tedesco\n\nCosa?\n\n- Siamo supervisionati da professionisti, introdotti in pratica e continuamente sviluppati\n- Con l'assistenza finanziaria del servizio postale, o acquisisce la licenza del conducente per i motocicli della categoria A1 o la licenza del conducente per i veicoli a motore della categoria B\n- Scopri come eseguire un carrello elevatore\n- Con varie stazioni interne, un'operazione in un magazzino, così come singoli moduli di selezione secondo i vostri desideri, completiamo la vostra ampia formazione logistica\n\nContatto",
-        "en": "Descrizione\n\nDo you like to start early in the day, do you love being in the fresh air, and do you enjoy conjuring people a smile in the face? Then a training in the delivery (direction distribution) is just right for you! During the three-year basic training you will acquire the tool for a successful entry into the diverse world of logistics. Your training centre is located in Lausen or Reinach BL.\n\nMansioni\n\n- In the early morning you sort your letters and packages\n- Charge your delivery vehicle for the subsequent delivery our\n- Are you on your own, bring and get shipments of any kind\n- Take care of the concerns of our customers\n- Do various rework at your training centre\n\nRequisiti\n\n- Physical activity and fresh air work inspire you\n- Have fun dealing with people\n- Are reliable, honest and silent\n- Ready to obtain the learning driving licence A1 or B by the start of the apprenticeship\n- Compulsory compulsory schooling must be completed with sufficient grade average at the lowest level\n- Features of the language level B2 in German\n\nCosa offriamo\n\n- We are supervised by professionals, introduced into practice and continuously developed\n- With financial assistance from the postal service, it either acquires the driver's license for motorcycles of category A1 or the driver's license for motor vehicles of category B\n- Learn how to run a forklift\n- With various internal stations, an operation in a warehouse, as well as individual selection modules according to your wishes, we complete your broad logistics training\n\nContatto",
-        "de": "## Descrizione\n\nStartest du gerne früh in den Tag, liebst du es, an der frischen Luft zu sein, und hast du Freude daran, den Menschen ein Lächeln ins Gesicht zu zaubern? Dann ist eine Ausbildung in der Zustellung (Fachrichtung Distribution) genau das Richtige für dich! Während der dreijährigen Grundausbildung erwirbst du dir das Rüstzeug für einen erfolgreichen Einstieg in die vielfältige Welt der Logistik. Deine Ausbildungsstelle befindet sich in Lausen oder Reinach BL.\n\n## Mansioni\n\n- Am frühen Morgen sortierst du deine Briefe und Pakete\n- Belädst dein Zustellfahrzeug für die anschliessende Zustelltour\n- Bist selbstständig unterwegs, bringst und holst Sendungen jeder Art\n- Kümmert dich um die Anliegen unserer Kundinnen und Kunden\n- Erledigst diverse Nacharbeiten an deiner Ausbildungsstelle\n\n## Requisiti\n\n- Körperliche Betätigung und die Arbeit an der frischen Luft begeistern dich\n- Hast Freude am Umgang mit Menschen\n- Bist zuverlässig, ehrlich und verschwiegen\n- Bereit, bis spätestens zum Lehrstart den Lernfahrausweis Führerschein A1 oder B zu erlangen\n- Obligatorische Schulpflicht muss mit einem genügenden Notendurchschnitt auf dem tiefsten Niveau abgeschlossen sein\n- Verfügst über das Sprachniveau B2 in Deutsch\n\n## Cosa offriamo\n\n- Wirst von Profis betreut, in die Praxis eingeführt und laufend weiterentwickelt\n- Erwirbst mit finanzieller Unterstützung der Post entweder den Führerschein für Motorräder der Kategorie A1 oder den Führerschein für Motorfahrzeuge der Kategorie B\n- Erlernst das Führen eines Staplers\n- Mit verschiedenen internen Stationen, einem Einsatz in einem Lagerbetrieb, sowie mit individuellen Wahlmodulen nach deinen Wünschen, vervollständigen wir deine breite Logistikausbildung\n\n## Contatto",
-        "fr": "Descrizione\n\nVous aimez commencer tôt dans la journée, aimez-vous être dans l'air frais, et aimez-vous conjurer les gens un sourire dans le visage? Alors une formation à la livraison (distribution de direction) est juste pour vous! Au cours de la formation de base de trois ans, vous allez acquérir l'outil pour une entrée réussie dans le monde diversifié de la logistique. Votre centre de formation est situé à Lausen ou Reinach BL.\n\nMansioni\n\n- Au petit matin, vous triez vos lettres et vos colis\n- Chargez votre véhicule de livraison pour la livraison suivante\n- Êtes-vous seul, apportez et obtenez des envois de toute sorte\n- Prendre soin des préoccupations de nos clients\n- Retravaillez dans votre centre de formation\n\nRequisiti\n\n- L'activité physique et le travail d'air frais vous inspirent\n- Amusez-vous bien avec les gens\n- Sont fiables, honnêtes et silencieux\n- Prêt à obtenir le permis de conduire A1 ou B dès le début de l'apprentissage\n- La scolarité obligatoire doit être complétée avec une moyenne de classe suffisante au niveau le plus bas\n- Caractéristiques du niveau de langue B2 en allemand\n\nCosa offriamo\n\n- Nous sommes supervisés par des professionnels, introduits dans la pratique et continuellement développés\n- Avec l'aide financière du service postal, elle acquiert soit le permis de conduire pour les motocyclettes de la catégorie A1 soit le permis de conduire pour les véhicules automobiles de la catégorie B\n- Apprenez à faire un chariot élévateur\n- Avec différentes stations internes, une opération dans un entrepôt, ainsi que des modules de sélection individuels selon vos souhaits, nous complétons votre vaste formation logistique\n\nContatto"
-      },
-      "titleByLocale": {
-        "it": "Apprendistato come impiegata/impiegato in logistica CFC Distribuzione recapito misto (lettere e pacchi)",
-        "en": "Teaching as a logistics provider: mixed delivery in EFZ Distribution (letters and packages)",
-        "de": "Lehre als Logistiker:in EFZ Distribution gemischte Zustellung (Briefe und Pakete)",
-        "fr": "Enseignement en tant que fournisseur de logistique EFZ Distribution livraison mixte (lettres et paquets)"
-      },
-      "slug": "apprendistato-come-impiegata-impiegato-in-logistica-cfc-distribuzione-recapito-misto-lettere-e-pacchi-die-schweizerische-post-davos-platz",
-      "slugByLocale": {
-        "it": "apprendistato-come-impiegata-impiegato-in-logistica-cfc-distribuzione-recapito-misto-lettere-e-pacchi-die-schweizerische-post-davos-platz",
-        "en": "teaching-as-a-logistics-provider-mixed-delivery-in-efz-distribution-letters-and-packages-die-schweizerische-post-davos",
-        "de": "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post",
-        "fr": "enseignement-en-tant-que-fournisseur-de-logistique-efz-distribution-livraison-mixte-lettres-et-paquets-die"
-      },
-      "sourceLang": "de",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-05-13",
-      "validThrough": "",
-      "source": "postch-careers-crawler",
-      "employmentType": "INTERN",
-      "experienceLevel": "",
-      "sector": "Logistica",
-      "workload": "",
-      "_targetScope": {
-        "canton": "GR",
-        "location": "Davos Platz"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-374c1ef0e3a2",
-      "previousSlugsByLocale": {
-        "it": [
-          "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post"
-        ],
-        "en": [
-          "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post"
-        ],
-        "fr": [
-          "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post"
-        ]
-      },
-      "previousSlugs": [
-        "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post",
-        "apprendistato-come-impiegata-impiegato-in-logistica-cfc-distribuzione-recapito-misto-lette"
-      ],
-      "salaryMin": 41600,
-      "salaryMax": 63000,
-      "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 41600,
-          "maxValue": 63000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Davos Platz",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-13T11:42:33.116Z"
+    "previousSlugs": [
+      "postauto-fahrer-in-post",
+      "postauto-fahrer-in-post-2"
+    ]
+  },
+  {
+    "url": "https://job.post.ch/default/job/Lehre-als-Logistikerin-EFZ-Distribution-gemischte-Zustellung-%28Briefe-und-Pakete%29/73223-de_DE",
+    "applyUrl": "https://job.post.ch/default/job/Lehre-als-Logistikerin-EFZ-Distribution-gemischte-Zustellung-%28Briefe-und-Pakete%29/73223-de_DE",
+    "title": "Lehre als Logistiker:in EFZ Distribution gemischte Zustellung (Briefe und Pakete)",
+    "company": "Die Schweizerische Post",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Davos Platz",
+    "canton": "GR",
+    "country": "CH",
+    "description": "Startest du gerne früh in den Tag, liebst du es, an der frischen Luft zu sein, und hast du Freude daran, den Menschen ein Lächeln ins Gesicht zu zaubern? Dann ist eine Ausbildung in der Zustellung (Fachrichtung Distribution) genau das Richtige für dich!\n\r\n\nWährend der dreijährigen Grundausbildung erwirbst du dir das Rüstzeug für einen erfolgreichen Einstieg in die vielfältige Welt der Logistik. Deine Ausbildungsstelle befindet sich in Lausen oder Reinach BL.\n\r\n\n \n\r\n\nDeine Ausbildung\n\r\n\n\r\n\n- Am frühen Morgen sortierst du deine Briefe und Pakete und belädst dein Zustellfahrzeug für die anschliessende Zustelltour.\n\r\n\n- Danach bist du selbstständig unterwegs, bringst und holst Sendungen jeder Art und kümmerst dich um die Anliegen unserer Kundinnen und Kunden.\n\r\n\n- Bevor du in deinen wohlverdienten Feierabend startest, erledigst du diverse Nacharbeiten an deiner Ausbildungsstelle.\n\r\n\n- Während deiner Ausbildung wirst du von Profis betreut, in die Praxis eingeführt und laufend weiterentwickelt.\n\r\n\n- Zusätzlich erwirbst du mit finanzieller Unterstützung der Post entweder den Führerschein für Motorräder der Kategorie A1 oder den Führerschein für Motorfahrzeuge der Kategorie B und erlernst das Führen eines Staplers.\n\r\n\n- Mit verschiedenen internen Stationen, einem Einsatz in einem Lagerbetrieb, sowie mit individuellen Wahlmodulen nach deinen Wünschen, vervollständigen wir deine breite Logistikausbildung.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\nWir suchen junge Menschen mit Begeisterung, Freude und Motivation, die etwas bewegen wollen. Folgende Punkte solltest du erfüllen:\n\r\n\n\r\n\n- Körperliche Betätigung und die Arbeit an der frischen Luft begeistern dich.\n\r\n\n- Darüber hinaus hast du Freude am Umgang mit Menschen, bist zuverlässig, ehrlich und verschwiegen.\n\r\n\n- Du bist bereit, bis spätestens zum Lehrstart den Lernfahrausweis Führerschein A1 oder B zu erlangen.\n\r\n\n- Die obligatorische Schulpflicht muss mit einem genügenden Notendurchschnitt auf dem tiefsten Niveau abgeschlossen sein.\n\r\n\n- Bei Lehrbeginn verfügst du über das Sprachniveau B2 in Deutsch",
+    "descriptionByLocale": {
+      "it": "Startest du gerne früh in den Tag, liebst du es, an der frischen Luft zu sein, und hast du Freude daran, den Menschen ein Lächeln ins Gesicht zu zaubern? Dann ist eine Ausbildung in der Zustellung (Fachrichtung Distribution) genau das Richtige für dich!\n\r\n\nWährend der dreijährigen Grundausbildung erwirbst du dir das Rüstzeug für einen erfolgreichen Einstieg in die vielfältige Welt der Logistik. Deine Ausbildungsstelle befindet sich in Lausen oder Reinach BL.\n\r\n\n \n\r\n\nDeine Ausbildung\n\r\n\n\r\n\n- Am frühen Morgen sortierst du deine Briefe und Pakete und belädst dein Zustellfahrzeug für die anschliessende Zustelltour.\n\r\n\n- Danach bist du selbstständig unterwegs, bringst und holst Sendungen jeder Art und kümmerst dich um die Anliegen unserer Kundinnen und Kunden.\n\r\n\n- Bevor du in deinen wohlverdienten Feierabend startest, erledigst du diverse Nacharbeiten an deiner Ausbildungsstelle.\n\r\n\n- Während deiner Ausbildung wirst du von Profis betreut, in die Praxis eingeführt und laufend weiterentwickelt.\n\r\n\n- Zusätzlich erwirbst du mit finanzieller Unterstützung der Post entweder den Führerschein für Motorräder der Kategorie A1 oder den Führerschein für Motorfahrzeuge der Kategorie B und erlernst das Führen eines Staplers.\n\r\n\n- Mit verschiedenen internen Stationen, einem Einsatz in einem Lagerbetrieb, sowie mit individuellen Wahlmodulen nach deinen Wünschen, vervollständigen wir deine breite Logistikausbildung.\n\r\n\n\r\n\n \n\r\n\nDas bringst du mit\n\r\n\nWir suchen junge Menschen mit Begeisterung, Freude und Motivation, die etwas bewegen wollen. Folgende Punkte solltest du erfüllen:\n\r\n\n\r\n\n- Körperliche Betätigung und die Arbeit an der frischen Luft begeistern dich.\n\r\n\n- Darüber hinaus hast du Freude am Umgang mit Menschen, bist zuverlässig, ehrlich und verschwiegen.\n\r\n\n- Du bist bereit, bis spätestens zum Lehrstart den Lernfahrausweis Führerschein A1 oder B zu erlangen.\n\r\n\n- Die obligatorische Schulpflicht muss mit einem genügenden Notendurchschnitt auf dem tiefsten Niveau abgeschlossen sein.\n\r\n\n- Bei Lehrbeginn verfügst du über das Sprachniveau B2 in Deutsch",
+      "en": "Descrizione\n\nDo you like to start early in the day, do you love being in the fresh air, and do you enjoy conjuring people a smile in the face? Then a training in the delivery (direction distribution) is just right for you! During the three-year basic training you will acquire the tool for a successful entry into the diverse world of logistics. Your training centre is located in Lausen or Reinach BL.\n\nMansioni\n\n- In the early morning you sort your letters and packages\n- Charge your delivery vehicle for the subsequent delivery our\n- Are you on your own, bring and get shipments of any kind\n- Take care of the concerns of our customers\n- Do various rework at your training centre\n\nRequisiti\n\n- Physical activity and fresh air work inspire you\n- Have fun dealing with people\n- Are reliable, honest and silent\n- Ready to obtain the learning driving licence A1 or B by the start of the apprenticeship\n- Compulsory compulsory schooling must be completed with sufficient grade average at the lowest level\n- Features of the language level B2 in German\n\nCosa offriamo\n\n- We are supervised by professionals, introduced into practice and continuously developed\n- With financial assistance from the postal service, it either acquires the driver's license for motorcycles of category A1 or the driver's license for motor vehicles of category B\n- Learn how to run a forklift\n- With various internal stations, an operation in a warehouse, as well as individual selection modules according to your wishes, we complete your broad logistics training\n\nContatto",
+      "de": "## Descrizione\n\nStartest du gerne früh in den Tag, liebst du es, an der frischen Luft zu sein, und hast du Freude daran, den Menschen ein Lächeln ins Gesicht zu zaubern? Dann ist eine Ausbildung in der Zustellung (Fachrichtung Distribution) genau das Richtige für dich! Während der dreijährigen Grundausbildung erwirbst du dir das Rüstzeug für einen erfolgreichen Einstieg in die vielfältige Welt der Logistik. Deine Ausbildungsstelle befindet sich in Lausen oder Reinach BL.\n\n## Mansioni\n\n- Am frühen Morgen sortierst du deine Briefe und Pakete\n- Belädst dein Zustellfahrzeug für die anschliessende Zustelltour\n- Bist selbstständig unterwegs, bringst und holst Sendungen jeder Art\n- Kümmert dich um die Anliegen unserer Kundinnen und Kunden\n- Erledigst diverse Nacharbeiten an deiner Ausbildungsstelle\n\n## Requisiti\n\n- Körperliche Betätigung und die Arbeit an der frischen Luft begeistern dich\n- Hast Freude am Umgang mit Menschen\n- Bist zuverlässig, ehrlich und verschwiegen\n- Bereit, bis spätestens zum Lehrstart den Lernfahrausweis Führerschein A1 oder B zu erlangen\n- Obligatorische Schulpflicht muss mit einem genügenden Notendurchschnitt auf dem tiefsten Niveau abgeschlossen sein\n- Verfügst über das Sprachniveau B2 in Deutsch\n\n## Cosa offriamo\n\n- Wirst von Profis betreut, in die Praxis eingeführt und laufend weiterentwickelt\n- Erwirbst mit finanzieller Unterstützung der Post entweder den Führerschein für Motorräder der Kategorie A1 oder den Führerschein für Motorfahrzeuge der Kategorie B\n- Erlernst das Führen eines Staplers\n- Mit verschiedenen internen Stationen, einem Einsatz in einem Lagerbetrieb, sowie mit individuellen Wahlmodulen nach deinen Wünschen, vervollständigen wir deine breite Logistikausbildung\n\n## Contatto",
+      "fr": "Descrizione\n\nVous aimez commencer tôt dans la journée, aimez-vous être dans l'air frais, et aimez-vous conjurer les gens un sourire dans le visage? Alors une formation à la livraison (distribution de direction) est juste pour vous! Au cours de la formation de base de trois ans, vous allez acquérir l'outil pour une entrée réussie dans le monde diversifié de la logistique. Votre centre de formation est situé à Lausen ou Reinach BL.\n\nMansioni\n\n- Au petit matin, vous triez vos lettres et vos colis\n- Chargez votre véhicule de livraison pour la livraison suivante\n- Êtes-vous seul, apportez et obtenez des envois de toute sorte\n- Prendre soin des préoccupations de nos clients\n- Retravaillez dans votre centre de formation\n\nRequisiti\n\n- L'activité physique et le travail d'air frais vous inspirent\n- Amusez-vous bien avec les gens\n- Sont fiables, honnêtes et silencieux\n- Prêt à obtenir le permis de conduire A1 ou B dès le début de l'apprentissage\n- La scolarité obligatoire doit être complétée avec une moyenne de classe suffisante au niveau le plus bas\n- Caractéristiques du niveau de langue B2 en allemand\n\nCosa offriamo\n\n- Nous sommes supervisés par des professionnels, introduits dans la pratique et continuellement développés\n- Avec l'aide financière du service postal, elle acquiert soit le permis de conduire pour les motocyclettes de la catégorie A1 soit le permis de conduire pour les véhicules automobiles de la catégorie B\n- Apprenez à faire un chariot élévateur\n- Avec différentes stations internes, une opération dans un entrepôt, ainsi que des modules de sélection individuels selon vos souhaits, nous complétons votre vaste formation logistique\n\nContatto"
     },
-    {
-      "url": "https://job.post.ch/default/job/Pianificatore-Pianificatrice-d'offerta-Sud/73503-it_IT",
-      "applyUrl": "https://job.post.ch/default/job/Pianificatore-Pianificatrice-d'offerta-Sud/73503-it_IT",
-      "title": "Pianificatore / Pianificatrice d'offerta Sud",
-      "company": "AutoPostale",
-      "companyKey": "posta-svizzera-centro-regionale",
-      "location": "Bellinzona",
-      "canton": "TI",
-      "country": "CH",
-      "description": "Vuoi contribuire in modo concreto alla pianificazione e allo sviluppo dell’offerta di trasporto pubblico di AutoPostale? In questo ruolo lavori su ottimizzazioni dei quadri d’orario, concetti e varianti d'orario, collaborando con partner interni ed esterni e creando basi decisionali affidabili. Con te garantiamo una pianificazione dell’offerta coerente, orientata alla domanda e allineata ai principi nazionali del trasporto pubblico. Ti occuperai delle seguenti attività Pianifichi i servizi di trasporto pubblico per le linee in concessione di AutoPostale, assicurando un’offerta efficiente e orientata alle esigenze della clientela e dei committenti. Il coordinamento e l’elaborazione delle direttive annuali sugli orari per la pianificazione d’esercizio rientrano nelle tue responsabilità principali. Svolgi il calcolo delle prestazioni (principalmente ore e chilometri) in modo strutturato, includendo lo sviluppo e la valutazione di varianti d'orario e d’offerta. Analizzi la puntualità e l’evoluzione della domanda di passeggeri, traendone indicazioni concrete per l’ottimizzazione dell’orario e dell’offerta. La pianificazione delle capacità necessarie fa parte del tuo contributo quotidiano alla qualità del servizio. Apporti proattivamente proposte di miglioramento e svolgi valutazioni di fattibilità nell’ambito dei progetti di elettromobilità. Garantisci una collaborazione efficace e un coordinamento continuo con il Key Account Manager, i committenti esterni e la pianificazione d’esercizio, operando nel rispetto delle linee guida nazionali della pianificazione d’offerta. Le tue competenze Possiedi una formazione base presso una scuola specializzata superiore, università o politecnico, ad esempio nei sistemi di trasporto, nella pianificazione del territorio, nella geografia o nel management del trasporto pubblico. Un’esperienza professionale nella pianificazione dei trasporti costituisce un vantaggio e completa idealmente il tuo profilo. Dimostri un’elevata affinità con gli strumenti informatici e li utilizzi con sicurezza nel lavoro quotidiano. Un pensiero analitico, concettuale e interdisciplinare ti permette di valutare varianti e individuare soluzioni sostenibili. La capacità di trovare compromessi e la comprensione delle interdipendenze del sistema del trasporto pubblico caratterizzano il tuo approccio. Ottime competenze comunicative e una spiccata attitudine al lavoro di squadra favoriscono una collaborazione efficace con i diversi interlocutori. Hai un’ottima conoscenza della lingua italiana a livello scritto e orale e una buona conoscenza di una seconda lingua nazionale.",
-      "descriptionByLocale": {
-        "it": "Vuoi contribuire in modo concreto alla pianificazione e allo sviluppo dell’offerta di trasporto pubblico di AutoPostale? In questo ruolo lavori su ottimizzazioni dei quadri d’orario, concetti e varianti d'orario, collaborando con partner interni ed esterni e creando basi decisionali affidabili. Con te garantiamo una pianificazione dell’offerta coerente, orientata alla domanda e allineata ai principi nazionali del trasporto pubblico. Ti occuperai delle seguenti attività Pianifichi i servizi di trasporto pubblico per le linee in concessione di AutoPostale, assicurando un’offerta efficiente e orientata alle esigenze della clientela e dei committenti. Il coordinamento e l’elaborazione delle direttive annuali sugli orari per la pianificazione d’esercizio rientrano nelle tue responsabilità principali. Svolgi il calcolo delle prestazioni (principalmente ore e chilometri) in modo strutturato, includendo lo sviluppo e la valutazione di varianti d'orario e d’offerta. Analizzi la puntualità e l’evoluzione della domanda di passeggeri, traendone indicazioni concrete per l’ottimizzazione dell’orario e dell’offerta. La pianificazione delle capacità necessarie fa parte del tuo contributo quotidiano alla qualità del servizio. Apporti proattivamente proposte di miglioramento e svolgi valutazioni di fattibilità nell’ambito dei progetti di elettromobilità. Garantisci una collaborazione efficace e un coordinamento continuo con il Key Account Manager, i committenti esterni e la pianificazione d’esercizio, operando nel rispetto delle linee guida nazionali della pianificazione d’offerta. Le tue competenze Possiedi una formazione base presso una scuola specializzata superiore, università o politecnico, ad esempio nei sistemi di trasporto, nella pianificazione del territorio, nella geografia o nel management del trasporto pubblico. Un’esperienza professionale nella pianificazione dei trasporti costituisce un vantaggio e completa idealmente il tuo profilo. Dimostri un’elevata affinità con gli strumenti informatici e li utilizzi con sicurezza nel lavoro quotidiano. Un pensiero analitico, concettuale e interdisciplinare ti permette di valutare varianti e individuare soluzioni sostenibili. La capacità di trovare compromessi e la comprensione delle interdipendenze del sistema del trasporto pubblico caratterizzano il tuo approccio. Ottime competenze comunicative e una spiccata attitudine al lavoro di squadra favoriscono una collaborazione efficace con i diversi interlocutori. Hai un’ottima conoscenza della lingua italiana a livello scritto e orale e una buona conoscenza di una seconda lingua nazionale.",
-        "en": "Description Do you want to contribute concretely to the planning and development of the public transport offer of AutoPostale? In this role he works on optimizations of timeframes, concepts and variations of time, collaborating with internal and external partners and creating reliable decision bases. With you we guarantee a coherent supply planning, oriented to demand and aligned with the national principles of public transport. Shipments - Plan public transport services for AutoPostale lines, ensuring an efficient and customer-oriented offer. - The coordination and elaboration of the annual operating schedule directives are your main responsibilities. - Apply performance calculation (mainly hours and kilometers) in a structured manner, including the development and evaluation of time and offer variants. - Analyze the punctuality and evolution of passenger demand, drawing concrete indications for the optimization of time and supply. - Planning your skills is part of your daily contribution to the quality of the service. - Proactively put forward proposals for improvement and carry out feasibility assessments within electromobility projects. - Ensure effective collaboration and continuous coordination with the Key Account Manager, external clients and exercise planning, operating in compliance with the national supply planning guidelines.\n• Requirements - You have basic training at a specialized high school, university or polytechnic, for example in transport systems, land planning, geography or public transport management. - A professional experience in transport planning is an advantage and ideally complements your profile. - Demonstrate a high affinity with computer tools and use them safely in everyday work. - An analytical, conceptual and interdisciplinary thinking allows you to evaluate variants and identify sustainable solutions. - The ability to find compromises and understanding of the interdependence of the public transport system characterize your approach. - Excellent communication skills and a strong attitude to teamwork promote effective collaboration with different interlocutors. - You have an excellent knowledge of the Italian language at written and oral level and a good knowledge of a second national language.\n• What we offer With you we guarantee a coherent supply planning, oriented to demand and aligned with the national principles of public transport. Contact",
-        "de": "Warenbezeichnung Möchten Sie konkret zur Planung und Entwicklung des öffentlichen Verkehrsangebots von AutoPostale beitragen? In dieser Rolle arbeitet er an Optimierungen von Zeitrahmen, Konzepten und Variationen der Zeit, Zusammenarbeit mit internen und externen Partnern und Schaffung zuverlässiger Entscheidungsgrundlagen. Mit Ihnen garantieren wir eine kohärente Angebotsplanung, die auf Nachfrage ausgerichtet und mit den nationalen Grundsätzen des öffentlichen Verkehrs abgestimmt ist. Sendungen - Planen Sie öffentliche Verkehrsdienste für AutoPostale Linien, um ein effizientes und kundenorientiertes Angebot zu gewährleisten. - Die Koordinierung und Ausarbeitung der jährlichen Betriebsplanrichtlinien sind\n• Ihre Hauptaufgaben. - Leistungsberechnung (hauptsächlich Stunden und Kilometer) auf strukturierte Weise anwenden, einschließlich der Entwicklung und Auswertung von Zeit und Angebotsvarianten. - Analysieren Sie die Pünktlichkeit und Entwicklung des Passagierbedarfs und zeichnen konkrete Hinweise für die Optimierung von Zeit und Angebot. - Planung Ihrer Fähigkeiten ist Teil Ihres täglichen Beitrags zur Qualität des Dienstes. - Proaktiv Vorschläge zur Verbesserung vorgelegt und Machbarkeitsbeurteilungen in Elektromobilitätsprojekten durchgeführt. - Gewährleistung einer effektiven Zusammenarbeit und kontinuierlichen Abstimmung mit dem Key Account Manager, externen Kunden und Übungsplanung, die in Übereinstimmung mit den nationalen Richtlinien zur Versorgungsplanung eingesetzt werden.\n• Anforderungen - Sie haben Grundausbildung an einer spezialisierten High School, Universität oder Polytechnik, zum Beispiel in Transportsystemen, Landplanung, Geographie oder öffentlichen Verkehrsmanagement. - Eine professionelle Erfahrung in der Transportplanung ist ein Vorteil und ergänzt\n• Ihr Profil ideal. - Demonstrieren Sie eine hohe Affinität mit Computerwerkzeugen und verwenden Sie sie sicher im Alltag. - Ein analytisches, konzeptionelles und interdisziplinäres Denken ermöglicht es Ihnen, Varianten zu bewerten und nachhaltige Lösungen zu identifizieren. - Die Fähigkeit, Kompromisse zu finden und die Interdependenz des öffentlichen Verkehrssystems zu verstehen, charakterisieren Ihren Ansatz. - Ausgezeichnete Kommunikationsfähigkeiten und eine starke Einstellung zu Teamwork fördern eine effektive Zusammenarbeit mit verschiedenen Gesprächspartnern. - Sie haben eine ausgezeichnete Kenntnis der italienischen Sprache auf schriftlicher und mündlicher Ebene und eine gute Kenntnis einer zweiten nationalen Sprache.\n• Was wir bieten Mit Ihnen garantieren wir eine kohärente Angebotsplanung, die auf Nachfrage ausgerichtet und mit den nationalen Grundsätzen des öffentlichen Verkehrs abgestimmt ist. Kontakt",
-        "fr": "Désignation des marchandises Voulez-vous contribuer concrètement à la planification et au développement de l'offre de transport public d'AutoPostale ? Dans ce rôle, il travaille sur l'optimisation des délais, des concepts et des variations de temps, en collaborant avec des partenaires internes et externes et en créant des bases de décision fiables. Avec vous, nous garantissons une planification cohérente de l'offre, orientée vers la demande et alignée sur les principes nationaux des transports publics. Expéditions - Planifier les services de transport public pour les lignes AutoPostale, en assurant une offre efficace et orientée vers le client. - La coordination et l'élaboration des directives relatives au calendrier de fonctionnement annuel sont vos principales responsabilités. - Appliquer le calcul des performances (essentiellement les heures et les kilomètres) de manière structurée, y compris le développement et l'évaluation du temps et proposer des variantes. - Analyser la ponctualité et l'évolution de la demande de passagers, en tirant des indications concrètes pour l'optimisation du temps et de l'offre. - La planification de vos compétences fait partie de votre contribution quotidienne à la qualité du service. - Présenter des propositions d'amélioration et réaliser des évaluations de faisabilité dans le cadre de projets d'électromobilité. - Assurer une collaboration efficace et une coordination continue avec le gestionnaire de comptes clés, les clients externes et la planification des exercices, conformément aux lignes directrices nationales en matière de planification des approvisionnements.\n• Exigences - Vous avez une formation de base dans un lycée spécialisé, une université ou une polytechnique, par exemple dans les systèmes de transport, l'aménagement du territoire, la géographie ou la gestion des transports publics. - Une expérience professionnelle dans la planification des transports est un avantage et complète idéalement votre profil. - Démontrer une grande affinité avec les outils informatiques et les utiliser en toute sécurité dans le travail quotidien. - Une réflexion analytique, conceptuelle et interdisciplinaire vous permet d'évaluer les variantes et d'identifier des solutions durables. - La capacité de trouver des compromis et la compréhension de l'interdépendance du système de transport public caractérisent votre approche. - Excellentes compétences en communication et une forte attitude envers le travail d'équipe favorisent une collaboration efficace avec différents interlocuteurs. - Vous avez une excellente connaissance de la langue italienne au niveau écrit et oral et une bonne connaissance d'une deuxième langue nationale. Ce que nous offrons Avec vous, nous garantissons une planification cohérente de l'offre, orientée vers la demande et alignée sur les principes nationaux des transports publics. Personne à contacter"
-      },
-      "titleByLocale": {
-        "it": "Pianificatore / Pianificatrice d'offerta Sud",
-        "en": "Planner / South supply planner",
-        "de": "Planner / Süd-Lieferplaner",
-        "fr": "Planificateur / Planificateur d'approvisionnement Sud"
-      },
-      "slug": "pianificatore-pianificatrice-d-offerta-sud-autopostale-bellinzona",
-      "slugByLocale": {
-        "it": "pianificatore-pianificatrice-d-offerta-sud-autopostale-bellinzona",
-        "en": "planner-south-supply-planner-autopostale-bellinzona",
-        "de": "planner-sud-lieferplaner-autopostale-bellinzona",
-        "fr": "planificateur-planificateur-d-approvisionnement-sud-autopostale-bellinzona"
-      },
-      "sourceLang": "it",
-      "department": "",
-      "category": "servizi-postali",
-      "datePosted": "2026-04-28",
-      "validThrough": "2026-05-19",
-      "source": "postch-careers-crawler",
-      "employmentType": "FULL_TIME",
-      "experienceLevel": "",
-      "sector": "Servizi Postali",
-      "workload": "80-100%",
-      "_targetScope": {
-        "canton": "TI",
-        "location": "Bellinzona"
-      },
-      "crawledAt": "",
-      "id": "posta-svizzera-centro-regionale-83cfb3b84e0a",
-      "salaryMin": 49500,
-      "salaryMax": 75000,
+    "titleByLocale": {
+      "it": "Apprendistato come impiegata/impiegato in logistica CFC Distribuzione recapito misto (lettere e pacchi)",
+      "en": "Teaching as a logistics provider: mixed delivery in EFZ Distribution (letters and packages)",
+      "de": "Lehre als Logistiker:in EFZ Distribution gemischte Zustellung (Briefe und Pakete)",
+      "fr": "Enseignement en tant que fournisseur de logistique EFZ Distribution livraison mixte (lettres et paquets)"
+    },
+    "slug": "apprendistato-come-impiegata-impiegato-in-logistica-cfc-distribuzione-recapito-misto-lettere-e-pacchi-die-schweizerische-post-davos-platz",
+    "slugByLocale": {
+      "it": "apprendistato-come-impiegata-impiegato-in-logistica-cfc-distribuzione-recapito-misto-lettere-e-pacchi-die-schweizerische-post-davos-platz",
+      "en": "teaching-as-a-logistics-provider-mixed-delivery-in-efz-distribution-letters-and-packages-die-schweizerische-post-davos",
+      "de": "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post",
+      "fr": "enseignement-en-tant-que-fournisseur-de-logistique-efz-distribution-livraison-mixte-lettres-et-paquets-die"
+    },
+    "sourceLang": "de",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-05-13",
+    "validThrough": "",
+    "source": "postch-careers-crawler",
+    "employmentType": "INTERN",
+    "experienceLevel": "",
+    "sector": "Logistica",
+    "workload": "",
+    "_targetScope": {
+      "canton": "GR",
+      "location": "Davos Platz"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-374c1ef0e3a2",
+    "previousSlugsByLocale": {
+      "it": [
+        "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post"
+      ],
+      "en": [
+        "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post"
+      ],
+      "fr": [
+        "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post"
+      ]
+    },
+    "previousSlugs": [
+      "lehre-als-logistiker-in-efz-distribution-gemischte-zustellung-briefe-und-pakete-post",
+      "apprendistato-come-impiegata-impiegato-in-logistica-cfc-distribuzione-recapito-misto-lette"
+    ],
+    "salaryMin": 41600,
+    "salaryMax": 63000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
       "currency": "CHF",
-      "baseSalary": {
-        "@type": "MonetaryAmount",
-        "currency": "CHF",
-        "value": {
-          "@type": "QuantitativeValue",
-          "minValue": 49500,
-          "maxValue": 75000,
-          "unitText": "YEAR"
-        }
-      },
-      "streetAddress": "Via la Santa 1",
-      "postalCode": "6500",
-      "addressLocality": "Bellinzona",
-      "addressRegion": "TI",
-      "addressCountry": "CH",
-      "firstSeenAt": "2026-05-16T10:49:06.746Z",
-      "previousSlugsByLocale": {
-        "en": [
-          "pianificatore-pianificatrice-d-offerta-sud-post"
-        ],
-        "de": [
-          "pianificatore-pianificatrice-d-offerta-sud-post"
-        ],
-        "fr": [
-          "pianificatore-pianificatrice-d-offerta-sud-post"
-        ]
-      },
-      "previousSlugs": [
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 41600,
+        "maxValue": 63000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Davos Platz",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-13T11:42:33.116Z"
+  },
+  {
+    "url": "https://job.post.ch/default/job/Pianificatore-Pianificatrice-d'offerta-Sud/73503-it_IT",
+    "applyUrl": "https://job.post.ch/default/job/Pianificatore-Pianificatrice-d'offerta-Sud/73503-it_IT",
+    "title": "Pianificatore / Pianificatrice d'offerta Sud",
+    "company": "AutoPostale",
+    "companyKey": "posta-svizzera-centro-regionale",
+    "location": "Bellinzona",
+    "canton": "TI",
+    "country": "CH",
+    "description": "Vuoi contribuire in modo concreto alla pianificazione e allo sviluppo dell’offerta di trasporto pubblico di AutoPostale? In questo ruolo lavori su ottimizzazioni dei quadri d’orario, concetti e varianti d'orario, collaborando con partner interni ed esterni e creando basi decisionali affidabili. Con te garantiamo una pianificazione dell’offerta coerente, orientata alla domanda e allineata ai principi nazionali del trasporto pubblico.  \n\r\n\nTi occuperai delle seguenti attività \n\r\n\n\r\n\n- Pianifichi i servizi di trasporto pubblico per le linee in concessione di AutoPostale, assicurando un’offerta efficiente e orientata alle esigenze della clientela e dei committenti.   \n\r\n\n- Il coordinamento e l’elaborazione delle direttive annuali sugli orari per la pianificazione d’esercizio rientrano nelle tue responsabilità principali.   \n\r\n\n- Svolgi il calcolo delle prestazioni (principalmente ore e chilometri) in modo strutturato, includendo lo sviluppo e la valutazione di varianti d'orario e d’offerta.   \n\r\n\n- Analizzi la puntualità e l’evoluzione della domanda di passeggeri, traendone indicazioni concrete per l’ottimizzazione dell’orario e dell’offerta.   \n\r\n\n- La pianificazione delle capacità necessarie fa parte del tuo contributo quotidiano alla qualità del servizio.   \n\r\n\n- Apporti proattivamente proposte di miglioramento e svolgi valutazioni di fattibilità nell’ambito dei progetti di elettromobilità.   \n\r\n\n- Garantisci una collaborazione efficace e un coordinamento continuo con il Key Account Manager, i committenti esterni e la pianificazione d’esercizio, operando nel rispetto delle linee guida nazionali della pianificazione d’offerta.  \n\r\n\n\r\n\nLe tue competenze\n\r\n\n\r\n\n- Possiedi una formazione base presso una scuola specializzata superiore, università o politecnico, ad esempio nei sistemi di trasporto, nella pianificazione del territorio, nella geografia o nel management del trasporto pubblico.  \n\r\n\n- Un’esperienza professionale nella pianificazione dei trasporti costituisce un vantaggio e completa idealmente il tuo profilo.  \n\r\n\n- Dimostri un’elevata affinità con gli strumenti informatici e li utilizzi con sicurezza nel lavoro quotidiano.  \n\r\n\n- Un pensiero analitico, concettuale e interdisciplinare ti permette di valutare varianti e individuare soluzioni sostenibili.  \n\r\n\n- La capacità di trovare compromessi e la comprensione delle interdipendenze del sistema del trasporto pubblico caratterizzano il tuo approccio.  \n\r\n\n- Ottime competenze comunicative e una spiccata attitudine al lavoro di squadra favoriscono una collaborazione efficace con i diversi interlocutori.  \n\r\n\n- Hai un’ottima conoscenza della lingua italiana a livello scritto e orale e una buona conoscenza di una seconda lingua nazionale.",
+    "descriptionByLocale": {
+      "it": "Vuoi contribuire in modo concreto alla pianificazione e allo sviluppo dell’offerta di trasporto pubblico di AutoPostale? In questo ruolo lavori su ottimizzazioni dei quadri d’orario, concetti e varianti d'orario, collaborando con partner interni ed esterni e creando basi decisionali affidabili. Con te garantiamo una pianificazione dell’offerta coerente, orientata alla domanda e allineata ai principi nazionali del trasporto pubblico.  \n\r\n\nTi occuperai delle seguenti attività \n\r\n\n\r\n\n- Pianifichi i servizi di trasporto pubblico per le linee in concessione di AutoPostale, assicurando un’offerta efficiente e orientata alle esigenze della clientela e dei committenti.   \n\r\n\n- Il coordinamento e l’elaborazione delle direttive annuali sugli orari per la pianificazione d’esercizio rientrano nelle tue responsabilità principali.   \n\r\n\n- Svolgi il calcolo delle prestazioni (principalmente ore e chilometri) in modo strutturato, includendo lo sviluppo e la valutazione di varianti d'orario e d’offerta.   \n\r\n\n- Analizzi la puntualità e l’evoluzione della domanda di passeggeri, traendone indicazioni concrete per l’ottimizzazione dell’orario e dell’offerta.   \n\r\n\n- La pianificazione delle capacità necessarie fa parte del tuo contributo quotidiano alla qualità del servizio.   \n\r\n\n- Apporti proattivamente proposte di miglioramento e svolgi valutazioni di fattibilità nell’ambito dei progetti di elettromobilità.   \n\r\n\n- Garantisci una collaborazione efficace e un coordinamento continuo con il Key Account Manager, i committenti esterni e la pianificazione d’esercizio, operando nel rispetto delle linee guida nazionali della pianificazione d’offerta.  \n\r\n\n\r\n\nLe tue competenze\n\r\n\n\r\n\n- Possiedi una formazione base presso una scuola specializzata superiore, università o politecnico, ad esempio nei sistemi di trasporto, nella pianificazione del territorio, nella geografia o nel management del trasporto pubblico.  \n\r\n\n- Un’esperienza professionale nella pianificazione dei trasporti costituisce un vantaggio e completa idealmente il tuo profilo.  \n\r\n\n- Dimostri un’elevata affinità con gli strumenti informatici e li utilizzi con sicurezza nel lavoro quotidiano.  \n\r\n\n- Un pensiero analitico, concettuale e interdisciplinare ti permette di valutare varianti e individuare soluzioni sostenibili.  \n\r\n\n- La capacità di trovare compromessi e la comprensione delle interdipendenze del sistema del trasporto pubblico caratterizzano il tuo approccio.  \n\r\n\n- Ottime competenze comunicative e una spiccata attitudine al lavoro di squadra favoriscono una collaborazione efficace con i diversi interlocutori.  \n\r\n\n- Hai un’ottima conoscenza della lingua italiana a livello scritto e orale e una buona conoscenza di una seconda lingua nazionale.",
+      "en": "Description Do you want to contribute concretely to the planning and development of the public transport offer of AutoPostale? In this role he works on optimizations of timeframes, concepts and variations of time, collaborating with internal and external partners and creating reliable decision bases. With you we guarantee a coherent supply planning, oriented to demand and aligned with the national principles of public transport. Shipments - Plan public transport services for AutoPostale lines, ensuring an efficient and customer-oriented offer. - The coordination and elaboration of the annual operating schedule directives are your main responsibilities. - Apply performance calculation (mainly hours and kilometers) in a structured manner, including the development and evaluation of time and offer variants. - Analyze the punctuality and evolution of passenger demand, drawing concrete indications for the optimization of time and supply. - Planning your skills is part of your daily contribution to the quality of the service. - Proactively put forward proposals for improvement and carry out feasibility assessments within electromobility projects. - Ensure effective collaboration and continuous coordination with the Key Account Manager, external clients and exercise planning, operating in compliance with the national supply planning guidelines.\n• Requirements - You have basic training at a specialized high school, university or polytechnic, for example in transport systems, land planning, geography or public transport management. - A professional experience in transport planning is an advantage and ideally complements your profile. - Demonstrate a high affinity with computer tools and use them safely in everyday work. - An analytical, conceptual and interdisciplinary thinking allows you to evaluate variants and identify sustainable solutions. - The ability to find compromises and understanding of the interdependence of the public transport system characterize your approach. - Excellent communication skills and a strong attitude to teamwork promote effective collaboration with different interlocutors. - You have an excellent knowledge of the Italian language at written and oral level and a good knowledge of a second national language.\n• What we offer With you we guarantee a coherent supply planning, oriented to demand and aligned with the national principles of public transport. Contact",
+      "de": "Warenbezeichnung Möchten Sie konkret zur Planung und Entwicklung des öffentlichen Verkehrsangebots von AutoPostale beitragen? In dieser Rolle arbeitet er an Optimierungen von Zeitrahmen, Konzepten und Variationen der Zeit, Zusammenarbeit mit internen und externen Partnern und Schaffung zuverlässiger Entscheidungsgrundlagen. Mit Ihnen garantieren wir eine kohärente Angebotsplanung, die auf Nachfrage ausgerichtet und mit den nationalen Grundsätzen des öffentlichen Verkehrs abgestimmt ist. Sendungen - Planen Sie öffentliche Verkehrsdienste für AutoPostale Linien, um ein effizientes und kundenorientiertes Angebot zu gewährleisten. - Die Koordinierung und Ausarbeitung der jährlichen Betriebsplanrichtlinien sind\n• Ihre Hauptaufgaben. - Leistungsberechnung (hauptsächlich Stunden und Kilometer) auf strukturierte Weise anwenden, einschließlich der Entwicklung und Auswertung von Zeit und Angebotsvarianten. - Analysieren Sie die Pünktlichkeit und Entwicklung des Passagierbedarfs und zeichnen konkrete Hinweise für die Optimierung von Zeit und Angebot. - Planung Ihrer Fähigkeiten ist Teil Ihres täglichen Beitrags zur Qualität des Dienstes. - Proaktiv Vorschläge zur Verbesserung vorgelegt und Machbarkeitsbeurteilungen in Elektromobilitätsprojekten durchgeführt. - Gewährleistung einer effektiven Zusammenarbeit und kontinuierlichen Abstimmung mit dem Key Account Manager, externen Kunden und Übungsplanung, die in Übereinstimmung mit den nationalen Richtlinien zur Versorgungsplanung eingesetzt werden.\n• Anforderungen - Sie haben Grundausbildung an einer spezialisierten High School, Universität oder Polytechnik, zum Beispiel in Transportsystemen, Landplanung, Geographie oder öffentlichen Verkehrsmanagement. - Eine professionelle Erfahrung in der Transportplanung ist ein Vorteil und ergänzt\n• Ihr Profil ideal. - Demonstrieren Sie eine hohe Affinität mit Computerwerkzeugen und verwenden Sie sie sicher im Alltag. - Ein analytisches, konzeptionelles und interdisziplinäres Denken ermöglicht es Ihnen, Varianten zu bewerten und nachhaltige Lösungen zu identifizieren. - Die Fähigkeit, Kompromisse zu finden und die Interdependenz des öffentlichen Verkehrssystems zu verstehen, charakterisieren Ihren Ansatz. - Ausgezeichnete Kommunikationsfähigkeiten und eine starke Einstellung zu Teamwork fördern eine effektive Zusammenarbeit mit verschiedenen Gesprächspartnern. - Sie haben eine ausgezeichnete Kenntnis der italienischen Sprache auf schriftlicher und mündlicher Ebene und eine gute Kenntnis einer zweiten nationalen Sprache.\n• Was wir bieten Mit Ihnen garantieren wir eine kohärente Angebotsplanung, die auf Nachfrage ausgerichtet und mit den nationalen Grundsätzen des öffentlichen Verkehrs abgestimmt ist. Kontakt",
+      "fr": "Désignation des marchandises Voulez-vous contribuer concrètement à la planification et au développement de l'offre de transport public d'AutoPostale ? Dans ce rôle, il travaille sur l'optimisation des délais, des concepts et des variations de temps, en collaborant avec des partenaires internes et externes et en créant des bases de décision fiables. Avec vous, nous garantissons une planification cohérente de l'offre, orientée vers la demande et alignée sur les principes nationaux des transports publics. Expéditions - Planifier les services de transport public pour les lignes AutoPostale, en assurant une offre efficace et orientée vers le client. - La coordination et l'élaboration des directives relatives au calendrier de fonctionnement annuel sont vos principales responsabilités. - Appliquer le calcul des performances (essentiellement les heures et les kilomètres) de manière structurée, y compris le développement et l'évaluation du temps et proposer des variantes. - Analyser la ponctualité et l'évolution de la demande de passagers, en tirant des indications concrètes pour l'optimisation du temps et de l'offre. - La planification de vos compétences fait partie de votre contribution quotidienne à la qualité du service. - Présenter des propositions d'amélioration et réaliser des évaluations de faisabilité dans le cadre de projets d'électromobilité. - Assurer une collaboration efficace et une coordination continue avec le gestionnaire de comptes clés, les clients externes et la planification des exercices, conformément aux lignes directrices nationales en matière de planification des approvisionnements.\n• Exigences - Vous avez une formation de base dans un lycée spécialisé, une université ou une polytechnique, par exemple dans les systèmes de transport, l'aménagement du territoire, la géographie ou la gestion des transports publics. - Une expérience professionnelle dans la planification des transports est un avantage et complète idéalement votre profil. - Démontrer une grande affinité avec les outils informatiques et les utiliser en toute sécurité dans le travail quotidien. - Une réflexion analytique, conceptuelle et interdisciplinaire vous permet d'évaluer les variantes et d'identifier des solutions durables. - La capacité de trouver des compromis et la compréhension de l'interdépendance du système de transport public caractérisent votre approche. - Excellentes compétences en communication et une forte attitude envers le travail d'équipe favorisent une collaboration efficace avec différents interlocuteurs. - Vous avez une excellente connaissance de la langue italienne au niveau écrit et oral et une bonne connaissance d'une deuxième langue nationale. Ce que nous offrons Avec vous, nous garantissons une planification cohérente de l'offre, orientée vers la demande et alignée sur les principes nationaux des transports publics. Personne à contacter"
+    },
+    "titleByLocale": {
+      "it": "Pianificatore / Pianificatrice d'offerta Sud",
+      "en": "Planner / South supply planner",
+      "de": "Planner / Süd-Lieferplaner",
+      "fr": "Planificateur / Planificateur d'approvisionnement Sud"
+    },
+    "slug": "pianificatore-pianificatrice-d-offerta-sud-autopostale-bellinzona",
+    "slugByLocale": {
+      "it": "pianificatore-pianificatrice-d-offerta-sud-autopostale-bellinzona",
+      "en": "planner-south-supply-planner-autopostale-bellinzona",
+      "de": "planner-sud-lieferplaner-autopostale-bellinzona",
+      "fr": "planificateur-planificateur-d-approvisionnement-sud-autopostale-bellinzona"
+    },
+    "sourceLang": "it",
+    "department": "",
+    "category": "servizi-postali",
+    "datePosted": "2026-04-28",
+    "validThrough": "2026-05-19",
+    "source": "postch-careers-crawler",
+    "employmentType": "FULL_TIME",
+    "experienceLevel": "",
+    "sector": "Servizi Postali",
+    "workload": "80-100%",
+    "_targetScope": {
+      "canton": "TI",
+      "location": "Bellinzona"
+    },
+    "crawledAt": "",
+    "id": "posta-svizzera-centro-regionale-83cfb3b84e0a",
+    "salaryMin": 49500,
+    "salaryMax": 75000,
+    "currency": "CHF",
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "CHF",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 49500,
+        "maxValue": 75000,
+        "unitText": "YEAR"
+      }
+    },
+    "streetAddress": "Via la Santa 1",
+    "postalCode": "6500",
+    "addressLocality": "Bellinzona",
+    "addressRegion": "TI",
+    "addressCountry": "CH",
+    "firstSeenAt": "2026-05-16T10:49:06.746Z",
+    "previousSlugsByLocale": {
+      "en": [
+        "pianificatore-pianificatrice-d-offerta-sud-post"
+      ],
+      "de": [
+        "pianificatore-pianificatrice-d-offerta-sud-post"
+      ],
+      "fr": [
         "pianificatore-pianificatrice-d-offerta-sud-post"
       ]
-    }
-  ]
-}
+    },
+    "previousSlugs": [
+      "pianificatore-pianificatrice-d-offerta-sud-post"
+    ]
+  }
+]

--- a/data/parser-quality-report.json
+++ b/data/parser-quality-report.json
@@ -1,15 +1,15 @@
 {
-  "timestamp": "2026-05-11T17:27:13.882Z",
+  "timestamp": "2026-05-18T06:41:20.513Z",
   "crawlersChecked": 193,
   "urlChecksEnabled": false,
   "crawlers": {
     "a-group": {
-      "total": 2,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
     "abb-svizzera-sede-ticino": {
-      "total": 15,
+      "total": 9,
       "issues": [],
       "severity": "OK"
     },
@@ -19,20 +19,20 @@
       "severity": "OK"
     },
     "agie-charmilles": {
-      "total": 40,
+      "total": 45,
       "issues": [
         {
           "type": "missing-locales",
           "count": 1,
-          "total": 40,
+          "total": 45,
           "avgMissing": 0,
-          "message": "1/40 missing 0+ locales"
+          "message": "1/45 missing 0+ locales"
         }
       ],
       "severity": "WARNING"
     },
     "agroscope": {
-      "total": 13,
+      "total": 22,
       "issues": [],
       "severity": "OK"
     },
@@ -52,7 +52,7 @@
       "severity": "OK"
     },
     "allianz-suisse": {
-      "total": 7,
+      "total": 6,
       "issues": [],
       "severity": "OK"
     },
@@ -62,7 +62,7 @@
       "severity": "OK"
     },
     "alten-switzerland": {
-      "total": 2,
+      "total": 4,
       "issues": [],
       "severity": "OK"
     },
@@ -72,12 +72,20 @@
       "severity": "OK"
     },
     "amministrazione-cantonale-ti": {
-      "total": 19,
-      "issues": [],
-      "severity": "OK"
+      "total": 17,
+      "issues": [
+        {
+          "type": "missing-locales",
+          "count": 1,
+          "total": 17,
+          "avgMissing": 0,
+          "message": "1/17 missing 0+ locales"
+        }
+      ],
+      "severity": "WARNING"
     },
     "ariston-group": {
-      "total": 30,
+      "total": 28,
       "issues": [],
       "severity": "OK"
     },
@@ -87,18 +95,18 @@
       "severity": "OK"
     },
     "arxada": {
-      "total": 18,
+      "total": 19,
       "issues": [
         {
           "type": "duplicate-descriptions",
           "count": 2,
-          "total": 18,
-          "message": "2/18 duplicate descriptions"
+          "total": 19,
+          "message": "2/19 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
           "count": 2,
-          "total": 18,
+          "total": 19,
           "message": "",
           "hidden": true
         }
@@ -124,19 +132,19 @@
       "severity": "WARNING"
     },
     "axpo-group": {
-      "total": 51,
+      "total": 49,
       "issues": [
         {
           "type": "missing-locales",
           "count": 1,
-          "total": 51,
+          "total": 49,
           "avgMissing": 0,
-          "message": "1/51 missing 0+ locales"
+          "message": "1/49 missing 0+ locales"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 13,
-          "total": 51,
+          "count": 8,
+          "total": 49,
           "message": "",
           "hidden": true
         }
@@ -144,12 +152,12 @@
       "severity": "WARNING"
     },
     "badrutts-palace": {
-      "total": 8,
+      "total": 7,
       "issues": [],
       "severity": "OK"
     },
     "banca-cler": {
-      "total": 5,
+      "total": 4,
       "issues": [],
       "severity": "OK"
     },
@@ -159,7 +167,7 @@
       "severity": "OK"
     },
     "banca-sempione": {
-      "total": 1,
+      "total": 3,
       "issues": [],
       "severity": "OK"
     },
@@ -230,7 +238,7 @@
       "severity": "OK"
     },
     "bps-suisse": {
-      "total": 2,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
@@ -240,13 +248,20 @@
       "severity": "OK"
     },
     "burkhalter-group": {
-      "total": 92,
+      "total": 246,
       "issues": [
         {
           "type": "duplicate-descriptions",
-          "count": 10,
-          "total": 92,
-          "message": "10/92 duplicate descriptions"
+          "count": 34,
+          "total": 246,
+          "message": "34/246 duplicate descriptions"
+        },
+        {
+          "type": "duplicate-descriptions-desc-only",
+          "count": 12,
+          "total": 246,
+          "message": "",
+          "hidden": true
         }
       ],
       "severity": "WARNING"
@@ -305,7 +320,7 @@
       "severity": "OK"
     },
     "citta-di-mendrisio": {
-      "total": 4,
+      "total": 3,
       "issues": [],
       "severity": "OK"
     },
@@ -323,7 +338,7 @@
       "severity": "WARNING"
     },
     "confederazione-ticino": {
-      "total": 8,
+      "total": 7,
       "issues": [],
       "severity": "OK"
     },
@@ -333,25 +348,25 @@
       "severity": "OK"
     },
     "coop-ticino-locale-cache": {
-      "total": 156,
+      "total": 154,
       "issues": [
         {
           "type": "missing-locales",
-          "count": 70,
-          "total": 156,
+          "count": 67,
+          "total": 154,
           "avgMissing": 2,
-          "message": "70/156 missing 2+ locales"
+          "message": "67/154 missing 2+ locales"
         },
         {
           "type": "duplicate-descriptions",
-          "count": 88,
-          "total": 156,
-          "message": "88/156 duplicate descriptions"
+          "count": 107,
+          "total": 154,
+          "message": "107/154 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 71,
-          "total": 156,
+          "count": 11,
+          "total": 154,
           "message": "",
           "hidden": true
         }
@@ -359,18 +374,25 @@
       "severity": "WARNING"
     },
     "coop-ticino": {
-      "total": 156,
+      "total": 154,
       "issues": [
         {
+          "type": "missing-locales",
+          "count": 67,
+          "total": 154,
+          "avgMissing": 2,
+          "message": "67/154 missing 2+ locales"
+        },
+        {
           "type": "duplicate-descriptions",
-          "count": 88,
-          "total": 156,
-          "message": "88/156 duplicate descriptions"
+          "count": 107,
+          "total": 154,
+          "message": "107/154 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 71,
-          "total": 156,
+          "count": 11,
+          "total": 154,
           "message": "",
           "hidden": true
         }
@@ -378,7 +400,7 @@
       "severity": "WARNING"
     },
     "coopers": {
-      "total": 5,
+      "total": 2,
       "issues": [],
       "severity": "OK"
     },
@@ -401,7 +423,7 @@
       "severity": "OK"
     },
     "cseb": {
-      "total": 18,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
@@ -416,19 +438,12 @@
       "severity": "OK"
     },
     "denner": {
-      "total": 12,
+      "total": 13,
       "issues": [
         {
-          "type": "missing-locales",
-          "count": 1,
-          "total": 12,
-          "avgMissing": 0,
-          "message": "1/12 missing 0+ locales"
-        },
-        {
           "type": "duplicate-descriptions-desc-only",
-          "count": 2,
-          "total": 12,
+          "count": 4,
+          "total": 13,
           "message": "",
           "hidden": true
         }
@@ -446,19 +461,18 @@
       "severity": "OK"
     },
     "efg-international": {
-      "total": 30,
+      "total": 32,
       "issues": [],
       "severity": "OK"
     },
     "ems-chemie": {
-      "total": 1,
+      "total": 10,
       "issues": [
         {
-          "type": "missing-locales",
-          "count": 1,
-          "total": 1,
-          "avgMissing": 0,
-          "message": "1/1 missing 0+ locales"
+          "type": "no-structured-content",
+          "count": 10,
+          "total": 10,
+          "message": "10/10 no structured content (no bullets/lists)"
         }
       ],
       "severity": "WARNING"
@@ -488,25 +502,25 @@
       "severity": "WARNING"
     },
     "eoc-ente-ospedaliero-cantonale": {
-      "total": 192,
+      "total": 196,
       "issues": [
         {
           "type": "missing-locales",
           "count": 3,
-          "total": 192,
+          "total": 196,
           "avgMissing": 0,
-          "message": "3/192 missing 0+ locales"
+          "message": "3/196 missing 0+ locales"
         },
         {
           "type": "duplicate-descriptions",
           "count": 6,
-          "total": 192,
-          "message": "6/192 duplicate descriptions"
+          "total": 196,
+          "message": "6/196 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
           "count": 6,
-          "total": 192,
+          "total": 196,
           "message": "",
           "hidden": true
         }
@@ -514,7 +528,7 @@
       "severity": "WARNING"
     },
     "epfl": {
-      "total": 61,
+      "total": 64,
       "issues": [],
       "severity": "OK"
     },
@@ -524,7 +538,7 @@
       "severity": "OK"
     },
     "eth-zurich": {
-      "total": 108,
+      "total": 114,
       "issues": [],
       "severity": "OK"
     },
@@ -544,7 +558,7 @@
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 2,
+          "count": 4,
           "total": 10,
           "message": "",
           "hidden": true
@@ -558,22 +572,45 @@
       "severity": "OK"
     },
     "fhgr": {
-      "total": 5,
+      "total": 4,
       "issues": [],
       "severity": "OK"
     },
     "fielmann": {
-      "total": 0,
-      "issues": [],
-      "severity": "OK"
+      "total": 39,
+      "issues": [
+        {
+          "type": "thin-description",
+          "count": 1,
+          "total": 39,
+          "reasons": {
+            "too-short": 1
+          },
+          "message": "1/39 thin descriptions (1 too-short)"
+        },
+        {
+          "type": "duplicate-descriptions",
+          "count": 27,
+          "total": 39,
+          "message": "27/39 duplicate descriptions"
+        },
+        {
+          "type": "duplicate-descriptions-desc-only",
+          "count": 27,
+          "total": 39,
+          "message": "",
+          "hidden": true
+        }
+      ],
+      "severity": "WARNING"
     },
     "fincons-group": {
-      "total": 7,
+      "total": 8,
       "issues": [],
       "severity": "OK"
     },
     "flury-stiftung": {
-      "total": 26,
+      "total": 21,
       "issues": [],
       "severity": "OK"
     },
@@ -583,7 +620,7 @@
       "severity": "OK"
     },
     "fondation-domus": {
-      "total": 4,
+      "total": 3,
       "issues": [],
       "severity": "OK"
     },
@@ -615,7 +652,7 @@
       "severity": "OK"
     },
     "giardino": {
-      "total": 2,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
@@ -624,7 +661,7 @@
       "issues": [
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 4,
+          "count": 2,
           "total": 10,
           "message": "",
           "hidden": true
@@ -638,24 +675,17 @@
       "severity": "OK"
     },
     "grace-la-margna": {
-      "total": 13,
-      "issues": [
-        {
-          "type": "no-structured-content",
-          "count": 13,
-          "total": 13,
-          "message": "13/13 no structured content (no bullets/lists)"
-        }
-      ],
-      "severity": "WARNING"
+      "total": 1,
+      "issues": [],
+      "severity": "OK"
     },
     "grand-hotel-des-bains-kempinski": {
-      "total": 6,
+      "total": 7,
       "issues": [],
       "severity": "OK"
     },
     "grand-hotel-kronenhof": {
-      "total": 15,
+      "total": 12,
       "issues": [],
       "severity": "OK"
     },
@@ -673,23 +703,23 @@
       "severity": "WARNING"
     },
     "guess-europe": {
-      "total": 4,
+      "total": 6,
       "issues": [],
       "severity": "OK"
     },
     "hamilton-bonaduz-ag": {
-      "total": 26,
+      "total": 24,
       "issues": [
         {
           "type": "duplicate-descriptions",
           "count": 2,
-          "total": 26,
-          "message": "2/26 duplicate descriptions"
+          "total": 24,
+          "message": "2/24 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
           "count": 4,
-          "total": 26,
+          "total": 24,
           "message": "",
           "hidden": true
         }
@@ -697,17 +727,17 @@
       "severity": "WARNING"
     },
     "has-healthcare": {
-      "total": 1,
+      "total": 4,
       "issues": [],
       "severity": "OK"
     },
     "heineken-ch": {
-      "total": 0,
+      "total": 10,
       "issues": [],
       "severity": "OK"
     },
     "hes-so-valais": {
-      "total": 2,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
@@ -725,17 +755,9 @@
       "severity": "WARNING"
     },
     "hitachi-energy": {
-      "total": 78,
-      "issues": [
-        {
-          "type": "duplicate-descriptions-desc-only",
-          "count": 2,
-          "total": 78,
-          "message": "",
-          "hidden": true
-        }
-      ],
-      "severity": "WARNING"
+      "total": 76,
+      "issues": [],
+      "severity": "OK"
     },
     "hochgebirgsklinik-davos": {
       "total": 16,
@@ -743,12 +765,12 @@
       "severity": "OK"
     },
     "hopital-du-valais": {
-      "total": 53,
+      "total": 50,
       "issues": [],
       "severity": "OK"
     },
     "hoval": {
-      "total": 6,
+      "total": 7,
       "issues": [],
       "severity": "OK"
     },
@@ -758,7 +780,7 @@
       "severity": "OK"
     },
     "ibsa-institut-biochimique": {
-      "total": 11,
+      "total": 10,
       "issues": [],
       "severity": "OK"
     },
@@ -768,18 +790,18 @@
       "severity": "OK"
     },
     "interdiscount": {
-      "total": 6,
+      "total": 5,
       "issues": [
         {
           "type": "duplicate-descriptions",
           "count": 2,
-          "total": 6,
-          "message": "2/6 duplicate descriptions"
+          "total": 5,
+          "message": "2/5 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
           "count": 2,
-          "total": 6,
+          "total": 5,
           "message": "",
           "hidden": true
         }
@@ -824,12 +846,12 @@
       "severity": "WARNING"
     },
     "jysk": {
-      "total": 10,
+      "total": 14,
       "issues": [
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 7,
-          "total": 10,
+          "count": 11,
+          "total": 14,
           "message": "",
           "hidden": true
         }
@@ -837,23 +859,23 @@
       "severity": "WARNING"
     },
     "kanton-gr": {
-      "total": 40,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
     "kantonsspital-graubuenden-ksgr": {
-      "total": 116,
+      "total": 118,
       "issues": [
         {
           "type": "duplicate-descriptions",
-          "count": 5,
-          "total": 116,
-          "message": "5/116 duplicate descriptions"
+          "count": 7,
+          "total": 118,
+          "message": "7/118 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 7,
-          "total": 116,
+          "count": 9,
+          "total": 118,
           "message": "",
           "hidden": true
         }
@@ -866,45 +888,27 @@
       "severity": "OK"
     },
     "kssg": {
-      "total": 20,
-      "issues": [
-        {
-          "type": "thin-description",
-          "count": 1,
-          "total": 20,
-          "reasons": {
-            "too-short": 1
-          },
-          "message": "1/20 thin descriptions (1 too-short)"
-        }
-      ],
-      "severity": "WARNING"
+      "total": 23,
+      "issues": [],
+      "severity": "OK"
     },
     "ksw": {
-      "total": 60,
+      "total": 47,
       "issues": [],
       "severity": "OK"
     },
     "kulm-hotel": {
-      "total": 15,
+      "total": 12,
       "issues": [],
       "severity": "OK"
     },
     "la-fonte": {
       "total": 4,
-      "issues": [
-        {
-          "type": "missing-locales",
-          "count": 1,
-          "total": 4,
-          "avgMissing": 0,
-          "message": "1/4 missing 0+ locales"
-        }
-      ],
-      "severity": "WARNING"
+      "issues": [],
+      "severity": "OK"
     },
     "laderach": {
-      "total": 27,
+      "total": 25,
       "issues": [],
       "severity": "OK"
     },
@@ -927,23 +931,9 @@
       "severity": "WARNING"
     },
     "lindenhofgruppe": {
-      "total": 36,
-      "issues": [
-        {
-          "type": "duplicate-descriptions",
-          "count": 2,
-          "total": 36,
-          "message": "2/36 duplicate descriptions"
-        },
-        {
-          "type": "duplicate-descriptions-desc-only",
-          "count": 2,
-          "total": 36,
-          "message": "",
-          "hidden": true
-        }
-      ],
-      "severity": "WARNING"
+      "total": 32,
+      "issues": [],
+      "severity": "OK"
     },
     "linnea": {
       "total": 1,
@@ -955,10 +945,10 @@
       "issues": [
         {
           "type": "missing-locales",
-          "count": 2,
+          "count": 1,
           "total": 13,
           "avgMissing": 0,
-          "message": "2/13 missing 0+ locales"
+          "message": "1/13 missing 0+ locales"
         }
       ],
       "severity": "WARNING"
@@ -968,13 +958,13 @@
       "issues": [
         {
           "type": "duplicate-descriptions",
-          "count": 7,
+          "count": 9,
           "total": 35,
-          "message": "7/35 duplicate descriptions"
+          "message": "9/35 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 9,
+          "count": 5,
           "total": 35,
           "message": "",
           "hidden": true
@@ -1006,27 +996,27 @@
       "severity": "WARNING"
     },
     "lwphr": {
-      "total": 12,
+      "total": 10,
       "issues": [],
       "severity": "OK"
     },
     "mabetex": {
-      "total": 0,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
     "manor": {
-      "total": 3,
+      "total": 2,
       "issues": [],
       "severity": "OK"
     },
     "marriott": {
-      "total": 53,
+      "total": 49,
       "issues": [
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 7,
-          "total": 53,
+          "count": 6,
+          "total": 49,
           "message": "",
           "hidden": true
         }
@@ -1044,12 +1034,12 @@
       "severity": "OK"
     },
     "medacta-international": {
-      "total": 3,
+      "total": 0,
       "issues": [],
       "severity": "OK"
     },
     "migros-ticino": {
-      "total": 26,
+      "total": 24,
       "issues": [],
       "severity": "OK"
     },
@@ -1071,17 +1061,17 @@
       "severity": "WARNING"
     },
     "mobiliar": {
-      "total": 85,
+      "total": 83,
       "issues": [],
       "severity": "OK"
     },
     "moncucco": {
-      "total": 4,
+      "total": 3,
       "issues": [],
       "severity": "OK"
     },
     "msc-cargo": {
-      "total": 19,
+      "total": 16,
       "issues": [],
       "severity": "OK"
     },
@@ -1096,35 +1086,35 @@
       "severity": "OK"
     },
     "otis": {
-      "total": 28,
+      "total": 27,
       "issues": [],
       "severity": "OK"
     },
     "pdgr": {
-      "total": 38,
+      "total": 37,
       "issues": [],
       "severity": "OK"
     },
     "pemsa": {
-      "total": 48,
+      "total": 65,
       "issues": [
         {
           "type": "missing-locales",
-          "count": 11,
-          "total": 48,
+          "count": 17,
+          "total": 65,
           "avgMissing": 0,
-          "message": "11/48 missing 0+ locales"
+          "message": "17/65 missing 0+ locales"
         },
         {
           "type": "duplicate-descriptions",
           "count": 2,
-          "total": 48,
-          "message": "2/48 duplicate descriptions"
+          "total": 65,
+          "message": "2/65 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
           "count": 2,
-          "total": 48,
+          "total": 65,
           "message": "",
           "hidden": true
         }
@@ -1142,7 +1132,7 @@
       "severity": "OK"
     },
     "posta-svizzera-centro-regionale": {
-      "total": 0,
+      "total": 10,
       "issues": [],
       "severity": "OK"
     },
@@ -1164,18 +1154,18 @@
       "severity": "OK"
     },
     "pwc": {
-      "total": 148,
+      "total": 119,
       "issues": [
         {
           "type": "duplicate-descriptions",
-          "count": 53,
-          "total": 148,
-          "message": "53/148 duplicate descriptions"
+          "count": 13,
+          "total": 119,
+          "message": "13/119 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 48,
-          "total": 148,
+          "count": 14,
+          "total": 119,
           "message": "",
           "hidden": true
         }
@@ -1193,18 +1183,18 @@
       "severity": "OK"
     },
     "reboot-monkey": {
-      "total": 142,
+      "total": 128,
       "issues": [
         {
           "type": "duplicate-descriptions",
-          "count": 58,
-          "total": 142,
-          "message": "58/142 duplicate descriptions"
+          "count": 42,
+          "total": 128,
+          "message": "42/128 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 128,
-          "total": 142,
+          "count": 114,
+          "total": 128,
           "message": "",
           "hidden": true
         }
@@ -1217,20 +1207,14 @@
       "severity": "OK"
     },
     "richemont": {
-      "total": 164,
+      "total": 180,
       "issues": [
         {
-          "type": "no-structured-content",
-          "count": 136,
-          "total": 164,
-          "message": "136/164 no structured content (no bullets/lists)"
-        },
-        {
           "type": "missing-locales",
-          "count": 6,
-          "total": 164,
+          "count": 5,
+          "total": 180,
           "avgMissing": 0,
-          "message": "6/164 missing 0+ locales"
+          "message": "5/180 missing 0+ locales"
         }
       ],
       "severity": "WARNING"
@@ -1258,12 +1242,12 @@
       "severity": "WARNING"
     },
     "ruag-ag": {
-      "total": 6,
+      "total": 5,
       "issues": [],
       "severity": "OK"
     },
     "schindler": {
-      "total": 3,
+      "total": 0,
       "issues": [],
       "severity": "OK"
     },
@@ -1290,14 +1274,14 @@
       "severity": "OK"
     },
     "solothurner-spitaeler": {
-      "total": 124,
+      "total": 116,
       "issues": [
         {
           "type": "missing-locales",
           "count": 1,
-          "total": 124,
+          "total": 116,
           "avgMissing": 0,
-          "message": "1/124 missing 0+ locales"
+          "message": "1/116 missing 0+ locales"
         }
       ],
       "severity": "WARNING"
@@ -1321,30 +1305,23 @@
       "severity": "WARNING"
     },
     "spital-limmattal": {
-      "total": 49,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
     "spital-thurgau": {
-      "total": 154,
+      "total": 157,
       "issues": [
-        {
-          "type": "missing-locales",
-          "count": 1,
-          "total": 154,
-          "avgMissing": 0,
-          "message": "1/154 missing 0+ locales"
-        },
         {
           "type": "duplicate-descriptions",
           "count": 2,
-          "total": 154,
-          "message": "2/154 duplicate descriptions"
+          "total": 157,
+          "message": "2/157 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
           "count": 6,
-          "total": 154,
+          "total": 157,
           "message": "",
           "hidden": true
         }
@@ -1352,25 +1329,17 @@
       "severity": "WARNING"
     },
     "sunrise-sede-ticino": {
-      "total": 2,
-      "issues": [
-        {
-          "type": "duplicate-descriptions-desc-only",
-          "count": 2,
-          "total": 2,
-          "message": "",
-          "hidden": true
-        }
-      ],
-      "severity": "WARNING"
+      "total": 1,
+      "issues": [],
+      "severity": "OK"
     },
     "supsi-dti": {
-      "total": 13,
+      "total": 12,
       "issues": [],
       "severity": "OK"
     },
     "swatch-group-assembly": {
-      "total": 18,
+      "total": 12,
       "issues": [],
       "severity": "OK"
     },
@@ -1385,23 +1354,23 @@
       "severity": "OK"
     },
     "swisscom-sede-ticino": {
-      "total": 50,
+      "total": 52,
       "issues": [],
       "severity": "OK"
     },
     "tally-weijl": {
-      "total": 26,
+      "total": 31,
       "issues": [
         {
           "type": "duplicate-descriptions",
-          "count": 11,
-          "total": 26,
-          "message": "11/26 duplicate descriptions"
+          "count": 13,
+          "total": 31,
+          "message": "13/31 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 14,
-          "total": 26,
+          "count": 19,
+          "total": 31,
           "message": "",
           "hidden": true
         }
@@ -1414,12 +1383,12 @@
       "severity": "OK"
     },
     "tether": {
-      "total": 67,
+      "total": 62,
       "issues": [
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 23,
-          "total": 67,
+          "count": 21,
+          "total": 62,
           "message": "",
           "hidden": true
         }
@@ -1427,7 +1396,7 @@
       "severity": "WARNING"
     },
     "tinext": {
-      "total": 2,
+      "total": 1,
       "issues": [],
       "severity": "OK"
     },
@@ -1437,23 +1406,9 @@
       "severity": "OK"
     },
     "trumpf-schweiz": {
-      "total": 21,
-      "issues": [
-        {
-          "type": "duplicate-descriptions",
-          "count": 4,
-          "total": 21,
-          "message": "4/21 duplicate descriptions"
-        },
-        {
-          "type": "duplicate-descriptions-desc-only",
-          "count": 4,
-          "total": 21,
-          "message": "",
-          "hidden": true
-        }
-      ],
-      "severity": "WARNING"
+      "total": 19,
+      "issues": [],
+      "severity": "OK"
     },
     "tschuggen": {
       "total": 10,
@@ -1487,38 +1442,38 @@
       "severity": "WARNING"
     },
     "ubp": {
-      "total": 51,
+      "total": 52,
       "issues": [],
       "severity": "OK"
     },
     "ubs": {
-      "total": 50,
+      "total": 49,
       "issues": [],
       "severity": "OK"
     },
     "unispital-basel": {
-      "total": 98,
+      "total": 96,
       "issues": [],
       "severity": "OK"
     },
     "usi-universita-della-svizzera-italiana": {
-      "total": 20,
+      "total": 22,
       "issues": [],
       "severity": "OK"
     },
     "usz": {
-      "total": 187,
+      "total": 191,
       "issues": [
         {
           "type": "duplicate-descriptions",
           "count": 4,
-          "total": 187,
-          "message": "4/187 duplicate descriptions"
+          "total": 191,
+          "message": "4/191 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
           "count": 4,
-          "total": 187,
+          "total": 191,
           "message": "",
           "hidden": true
         }
@@ -1526,28 +1481,28 @@
       "severity": "WARNING"
     },
     "vaxcyte": {
-      "total": 3,
+      "total": 2,
       "issues": [],
       "severity": "OK"
     },
     "vf-international-the-north-face-timberland": {
-      "total": 40,
+      "total": 19,
       "issues": [],
       "severity": "OK"
     },
     "volg-fenaco": {
-      "total": 41,
+      "total": 49,
       "issues": [
         {
           "type": "duplicate-descriptions",
-          "count": 17,
-          "total": 41,
-          "message": "17/41 duplicate descriptions"
+          "count": 24,
+          "total": 49,
+          "message": "24/49 duplicate descriptions"
         },
         {
           "type": "duplicate-descriptions-desc-only",
-          "count": 20,
-          "total": 41,
+          "count": 29,
+          "total": 49,
           "message": "",
           "hidden": true
         }
@@ -1555,7 +1510,7 @@
       "severity": "WARNING"
     },
     "vtg": {
-      "total": 33,
+      "total": 29,
       "issues": [],
       "severity": "OK"
     },
@@ -1587,7 +1542,7 @@
   },
   "summary": {
     "critical": 0,
-    "warning": 56,
-    "ok": 137
+    "warning": 51,
+    "ok": 142
   }
 }

--- a/scripts/lib/msc-cargo-job-parser.mjs
+++ b/scripts/lib/msc-cargo-job-parser.mjs
@@ -135,6 +135,83 @@ function detectEmploymentType(text = '') {
   return 'OTHER';
 }
 
+/* ── HTML → text with bullet preservation ─────────────────── */
+
+/**
+ * Decode common HTML entities. The Phenom JobPosting JSON-LD ships the
+ * description HTML-entity-encoded (`&lt;ul&gt;&lt;li&gt;…`) so the static
+ * HTML stays well-formed JSON. We must decode before extracting `<li>`.
+ */
+function decodeHtmlEntities(value = '') {
+  return String(value || '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#13;/g, '\n')
+    .replace(/&#10;/g, '\n')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)));
+}
+
+/**
+ * Convert HTML body → plain text while preserving `<li>` items as
+ * line-start "- " bullet markers. Mirrors the strategy used in
+ * `lidl-job-parser.mjs` and `postch-job-parser.mjs`: the parser-quality
+ * audit's `hasStructuredContent` gate requires either real `<li>` tags or
+ * line-start markdown bullets (`/^\s*[-•*]\s/m`). Collapsing list markup
+ * into flat prose is the root cause of the "no structured content"
+ * regression on this crawler.
+ */
+function htmlBodyToBulletedText(rawHtml = '') {
+  if (!rawHtml) return '';
+  const decoded = decodeHtmlEntities(String(rawHtml || ''));
+  const withBullets = decoded
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '\n- ')
+    .replace(/<\/li>/gi, '\n')
+    .replace(/<\/?(p|div|ul|ol|h[1-6])[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+  return withBullets
+    .replace(/[ \t]+/g, ' ')
+    .replace(/[ \t]*\n[ \t]*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Extract the JobPosting JSON-LD block from a Phenom detail page and
+ * return the bullet-preserved description text. Returns '' when the page
+ * lacks JSON-LD or the description field is empty.
+ */
+function extractDetailDescription(html = '') {
+  if (!html) return '';
+  const re = /<script[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    let data;
+    try {
+      data = JSON.parse(m[1]);
+    } catch {
+      continue;
+    }
+    const blocks = Array.isArray(data) ? data : [data];
+    for (const block of blocks) {
+      const type = block?.['@type'];
+      const isJobPosting = type === 'JobPosting' || (Array.isArray(type) && type.includes('JobPosting'));
+      if (!isJobPosting) continue;
+      const desc = block?.description || '';
+      if (!desc) continue;
+      return htmlBodyToBulletedText(desc);
+    }
+  }
+  return '';
+}
+
 /* ── Phenom embedded-JSON extraction ───────────────────────── */
 
 /**
@@ -305,8 +382,27 @@ export async function fetchAllMscCargoJobs() {
     const city = normalizeSpace(String(locationText).split(',')[0] || 'Geneva');
     const canton = inferSwissTargetCanton(locationText) || inferAnyCanton(locationText) || 'GE';
 
-    const description = normalizeSpace(raw?.descriptionTeaser || '');
+    const teaser = normalizeSpace(raw?.descriptionTeaser || '');
     const applyUrl = buildApplyUrl(raw);
+
+    // Fetch the detail page and pull the full JobPosting description with
+    // <li> bullets preserved. The listing JSON only ships a one-paragraph
+    // `descriptionTeaser` (flat prose, no structure) which fails the
+    // parser-quality audit's hasStructuredContent gate. Fall back to the
+    // teaser when the detail fetch fails or yields nothing.
+    let description = teaser;
+    try {
+      const detailHtml = await fetchHtml(applyUrl, { timeoutMs: 20000 });
+      const detailDesc = extractDetailDescription(detailHtml);
+      if (detailDesc && detailDesc.length >= 100) {
+        description = detailDesc;
+      }
+    } catch (err) {
+      console.warn(`  Detail fetch failed for ${applyUrl}: ${err?.message || err}`);
+    }
+    // Be polite to the Phenom origin — the listing pass already paginates
+    // at FETCH_DELAY_MS; per-detail pacing protects against burst-throttle.
+    await sleep(500);
     const sourceLang = detectLang(description || title, 'en');
     const jobSlug = slugify(`${title} msc ${city || 'geneva'}`);
     const urlHash = createHash('sha1').update(applyUrl).digest('hex').slice(0, 12);

--- a/scripts/lib/postch-job-parser.mjs
+++ b/scripts/lib/postch-job-parser.mjs
@@ -167,8 +167,12 @@ function deriveStreetAddress(jobPosting = {}) {
 function deriveDescription(jobPosting = {}, html = '') {
   const desc = jobPosting.description || '';
   if (desc) {
-    // Strip HTML tags if present
-    return normalizeSpace(desc.replace(/<[^>]+>/g, ' '));
+    // Preserve <li> markup as "- " line-start bullets so the audit's
+    // hasStructuredContent gate (`/^\s*[-•*]\s/m`) still passes after
+    // HTML-to-text conversion. Upstream JobPosting JSON-LD on post.ch
+    // pages contains real <ul><li> blocks — collapsing them into plain
+    // prose was the root cause of the "no structured content" regression.
+    return htmlBlockToTextWithBullets(desc);
   }
   return extractMeta(html, 'description') || extractMeta(html, 'og:description') || '';
 }
@@ -194,6 +198,38 @@ function htmlBlockToText(value = '') {
       .replace(/<\/?(p|div|li|ul|ol|h[1-6])[^>]*>/gi, ' ')
       .replace(/<[^>]+>/g, ' ')
   );
+}
+
+/**
+ * Convert HTML to plain text WHILE preserving `<li>` items as line-start
+ * "- " bullet markers. The audit-parser-quality.mjs ratchet requires
+ * descriptions to contain structured content (`<li>` tag OR `^\s*[-•*]\s`
+ * line-start markers). Post.ch detail pages serve real `<ul><li>` blocks
+ * upstream — collapsing them into a single line of prose with the generic
+ * `htmlBlockToText` above produces "flat" descriptions that fail the gate.
+ *
+ * Strategy mirrors `innerTextWithBullets` in `lidl-job-parser.mjs`: replace
+ * `<li>` with "- " and `</li>` with newline, then strip every other tag.
+ * Resulting text contains line-start "- item" markers that satisfy both
+ * `hasStructuredContent` (audit gate) and the existing text-to-HTML ratio
+ * gate.
+ *
+ * Idempotent on bullet-free text.
+ */
+function htmlBlockToTextWithBullets(value = '') {
+  if (!value) return '';
+  const withBullets = String(value || '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '\n- ')
+    .replace(/<\/li>/gi, '\n')
+    .replace(/<\/?(p|div|ul|ol|h[1-6])[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+  // Collapse extra spaces but keep newlines so "- " stays line-start.
+  return withBullets
+    .replace(/[ \t]+/g, ' ')
+    .replace(/[ \t]*\n[ \t]*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
 }
 
 /**
@@ -339,9 +375,9 @@ function buildJobPostingFromTokens(html = '', url = '') {
   if (jobLocation.length === 0) return null;
 
   const regularDescInner = tokens[18]?.inner || '';
-  const regularDesc = htmlBlockToText(regularDescInner);
+  const regularDesc = htmlBlockToTextWithBullets(regularDescInner);
   const apprenticeshipDescInner = tokens[11]?.inner || '';
-  const apprenticeshipDesc = htmlBlockToText(apprenticeshipDescInner);
+  const apprenticeshipDesc = htmlBlockToTextWithBullets(apprenticeshipDescInner);
 
   const isRegular = regularDesc.length > 40;
   const descriptionInner = isRegular ? regularDescInner : apprenticeshipDescInner;


### PR DESCRIPTION
Both parsers were producing flat-prose descriptions that failed the
audit-parser-quality.mjs hasStructuredContent gate (NEW OFFENDER, 100%
of jobs flat).

msc-cargo: the Phenom careers listing JSON ships only descriptionTeaser
(a one-paragraph blurb, no markup). Now also fetch each job's detail
page, parse the JobPosting JSON-LD, decode HTML entities, and convert
the upstream <ul><li> markup into line-start '- ' bullets.

posta-svizzera (postch): the htmlBlockToText helper stripped every
<ul>/<li> tag before normalizing whitespace, collapsing real list
markup into prose. New htmlBlockToTextWithBullets preserves <li> as
line-start '- ' markers (same pattern as lidl-job-parser.mjs).

Existing slice descriptions for both crawlers patched in-place by
re-fetching detail pages so the audit ratchet clears immediately —
next orchestrator run produces the same shape natively.
