### PR TITLE
fix(crawlers): fetch real descriptions from Workday detail + repair SR detail URL

### DIFF
--- a/scripts/lib/ats-clients/smartrecruiters-client.mjs
+++ b/scripts/lib/ats-clients/smartrecruiters-client.mjs
@@ -89,7 +89,6 @@
 /* ── Constants ───────────────────────────────────────────────── */
 
 const SR_API_BASE = 'https://api.smartrecruiters.com/v1/companies';
-const SR_DETAIL_BASE = 'https://api.smartrecruiters.com/v1/postings';
 const SR_PUBLIC_JOBS_BASE = 'https://jobs.smartrecruiters.com';
 const POLITE_UA = 'FrontaliereTicino-Bot/1.0 (+https://frontaliereticino.ch/bot)';
 const DEFAULT_TIMEOUT_MS = 20_000;
@@ -272,7 +271,12 @@ async function fetchListPage(url, { timeoutMs, userAgent }) {
 async function fetchPostingDetail(tenant, listingPosting, { timeoutMs, userAgent }) {
   const id = String(listingPosting?.id || '').trim();
   if (!id) return listingPosting;
-  const url = `${SR_DETAIL_BASE}/${encodeURIComponent(id)}`;
+  // SmartRecruiters detail endpoint REQUIRES the company prefix —
+  // `/v1/postings/{id}` returns 404. The full payload (jobAd.sections) lives
+  // at `/v1/companies/{tenant}/postings/{id}`. Using the tenant-less path was
+  // a regression that left every detail fetch returning the listing summary,
+  // which trips the thin-source guard for crawlers like Avaloq + HUG.
+  const url = `${SR_API_BASE}/${encodeURIComponent(tenant)}/postings/${encodeURIComponent(id)}`;
   try {
     const res = await timedFetch(url, {
       timeoutMs,

--- a/scripts/lib/ats-clients/workday-client.mjs
+++ b/scripts/lib/ats-clients/workday-client.mjs
@@ -309,6 +309,116 @@ export async function* fetchWorkdayJobs(apiBase, options = {}) {
   }
 }
 
+/* ── Detail fetch ──────────────────────────────────────────────────────── */
+
+/**
+ * Fetch a single Workday job's detail payload (`jobPostingInfo`) from the CXS
+ * API.
+ *
+ * The listing endpoint (`POST /jobs`) returns only summary fields
+ * (`title`, `externalPath`, `locationsText`, `postedOn`, `bulletFields`) —
+ * it never carries the job body. The body lives at
+ * `GET {apiBase}{externalPath}` under `jobPostingInfo.jobDescription` (HTML).
+ *
+ * Returns the parsed JSON on success. Returns `null` on any failure (4xx, 5xx,
+ * timeout, abort, network error) so the caller can fall back to a structured
+ * stub built from listing metadata without aborting the whole crawler run.
+ *
+ * NOTE: this helper deliberately swallows errors. Workday occasionally serves
+ * 403 on individual listings (anti-bot heuristics) or 404 when a posting was
+ * pulled between the listing and detail fetch. Either case should not poison
+ * the rest of the run — the caller's thin-source guard catches widespread
+ * failures.
+ *
+ * @param {string} apiBase Output of `buildWorkdayApiBase`.
+ * @param {string} externalPath The `externalPath` field returned for each
+ *   posting by the listing endpoint (already starts with `/job/...`).
+ * @param {Object} [options]
+ * @param {number} [options.timeoutMs] Per-request timeout. Default 15000ms.
+ * @param {string} [options.userAgent] Override User-Agent header.
+ * @returns {Promise<any|null>} The detail JSON, or `null` on failure.
+ *
+ * @example
+ *   const apiBase = buildWorkdayApiBase('roche.wd3.myworkdayjobs.com', 'roche-ext');
+ *   const detail = await fetchWorkdayJobDetail(apiBase, posting.externalPath);
+ *   const html = detail?.jobPostingInfo?.jobDescription || '';
+ */
+export async function fetchWorkdayJobDetail(apiBase, externalPath, options = {}) {
+  if (!apiBase || !externalPath) return null;
+  const {
+    timeoutMs = 15_000,
+    userAgent = DEFAULT_USER_AGENT,
+  } = options;
+
+  const url = `${String(apiBase).replace(/\/+$/, '')}${externalPath}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: {
+        Accept: 'application/json',
+        'Accept-Language': 'en,de-CH;q=0.9,it-CH;q=0.8,fr-CH;q=0.7',
+        'User-Agent': userAgent,
+      },
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Convenience: fetch the job detail and return the description body as
+ * bullet-preserving plain text. Returns '' on any failure.
+ *
+ * Pipeline:
+ *   GET {apiBase}{externalPath} → jobPostingInfo.jobDescription (HTML)
+ *   → stripHtml (caller-supplied) → newline-preserving compaction → 4000-char cap
+ *
+ * The caller passes `stripHtml` (typically from `crawler-template.mjs`) so this
+ * client module has no dependency on the project's stripper. The 4000-char cap
+ * keeps downstream AI translation costs predictable.
+ *
+ * @param {string} apiBase
+ * @param {string} externalPath
+ * @param {(html: string) => string} stripHtml HTML→text stripper.
+ * @param {Object} [options]
+ * @param {number} [options.timeoutMs]
+ * @param {string} [options.userAgent]
+ * @param {number} [options.maxChars] Hard cap on returned text. Default 4000.
+ * @returns {Promise<string>} Plain-text description, or '' on failure.
+ */
+export async function fetchWorkdayJobDescriptionText(
+  apiBase,
+  externalPath,
+  stripHtml,
+  options = {},
+) {
+  if (typeof stripHtml !== 'function') {
+    throw new TypeError('fetchWorkdayJobDescriptionText: stripHtml function is required');
+  }
+  const { maxChars = 4000, ...fetchOptions } = options;
+
+  const detail = await fetchWorkdayJobDetail(apiBase, externalPath, fetchOptions);
+  const html = String(detail?.jobPostingInfo?.jobDescription || '').trim();
+  if (!html) return '';
+
+  const text = stripHtml(html);
+  return String(text || '')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/[ \t]*\n[ \t]*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+    .slice(0, maxChars);
+}
+
 /* ── Date parsing ──────────────────────────────────────────────────────── */
 
 function dateOnlyIso(ms) {

--- a/scripts/lib/ksb-job-parser.mjs
+++ b/scripts/lib/ksb-job-parser.mjs
@@ -31,6 +31,7 @@ import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
   buildWorkdayApiBase,
   fetchWorkdayJobs,
+  fetchWorkdayJobDescriptionText,
   parseWorkdayPostedDate,
   extractWorkdayJobIdentity,
   WorkdayAuthError,
@@ -181,9 +182,25 @@ export async function fetchAllKsbJobs() {
 
     const location = listing.location || 'Baden';
     const canton = inferSwissTargetCanton(location) || 'AG';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || CAREER_URL;
+
+    // Workday listing endpoint NEVER returns the job body — see workday-client.mjs.
+    const detailDescription = await fetchWorkdayJobDescriptionText(
+      WORKDAY_API_BASE,
+      listing.externalPath,
+      stripHtml,
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    const fallbackDescription = [
+      `${title} — ${KSB_COMPANY_NAME}, ${location}.`,
+      '',
+      'Key details:',
+      `• Location: ${location}${canton ? `, Kanton ${canton}` : ''}, Schweiz`,
+      '• Arbeitgeber: Kantonsspital Baden — Akutspital im Kanton Aargau',
+      '• Bewerbung über: KSB-Karriereportal',
+    ].join('\n');
+    const descriptionText = detailDescription.length >= 100 ? detailDescription : fallbackDescription;
 
     const sourceLang = detectLang(descriptionText || title, 'de');
     const jobSlug = slugify(`${title} ${KSB_KEY} ch`);
@@ -198,8 +215,8 @@ export async function fetchAllKsbJobs() {
       companyDomain: KSB_COMPANY_DOMAIN,
       title,
       titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — ${KSB_COMPANY_NAME}`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — ${KSB_COMPANY_NAME}` },
+      description: descriptionText,
+      descriptionByLocale: { [sourceLang]: descriptionText },
       location,
       canton,
       url: publicUrl,

--- a/scripts/lib/lombard-odier-job-parser.mjs
+++ b/scripts/lib/lombard-odier-job-parser.mjs
@@ -17,6 +17,7 @@ import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
   buildWorkdayApiBase,
   fetchWorkdayJobs,
+  fetchWorkdayJobDescriptionText,
   parseWorkdayPostedDate,
   extractWorkdayJobIdentity,
   WorkdayAuthError,
@@ -124,9 +125,10 @@ const _WORKDAY_URL = new URL(CAREER_URL);
 const WORKDAY_TENANT_HOST = _WORKDAY_URL.hostname;
 const WORKDAY_SITE_PATH = (_WORKDAY_URL.pathname.replace(/^\/+|\/+$/g, '').split('/').pop()) || 'External';
 const WORKDAY_LOCATION_FILTERS = []; // TODO: e.g. ['187134fccb084a0ea9b4b95f23890dbe'] for CH on most tenants
+const WORKDAY_API_BASE = buildWorkdayApiBase(WORKDAY_TENANT_HOST, WORKDAY_SITE_PATH);
 
 async function fetchJobListings() {
-  const apiBase = buildWorkdayApiBase(WORKDAY_TENANT_HOST, WORKDAY_SITE_PATH);
+  const apiBase = WORKDAY_API_BASE;
   const out = [];
   try {
     for await (const posting of fetchWorkdayJobs(apiBase, {
@@ -181,9 +183,25 @@ export async function fetchAllLombardOdierJobs() {
 
     const location = listing.location || 'Geneva'; // HQ: Geneva
     const canton = inferSwissTargetCanton(location) || 'GE';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || CAREER_URL;
+
+    // Workday listing endpoint NEVER returns the job body — see workday-client.mjs.
+    const detailDescription = await fetchWorkdayJobDescriptionText(
+      WORKDAY_API_BASE,
+      listing.externalPath,
+      stripHtml,
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    const fallbackDescription = [
+      `${title} — ${LOMBARD_ODIER_COMPANY_NAME}, ${location}.`,
+      '',
+      'Key details:',
+      `• Location: ${location}${canton ? `, ${canton} canton` : ''}, Switzerland`,
+      '• Employer: Lombard Odier — Swiss private bank and wealth manager',
+      '• Apply on: Lombard Odier careers portal',
+    ].join('\n');
+    const descriptionText = detailDescription.length >= 100 ? detailDescription : fallbackDescription;
 
     const sourceLang = detectLang(descriptionText || title, 'en');
     const jobSlug = slugify(`${title} lombard-odier ch`);
@@ -199,8 +217,8 @@ export async function fetchAllLombardOdierJobs() {
       companyDomain: LOMBARD_ODIER_COMPANY_DOMAIN,
       title,
       titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — Lombard Odier`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — Lombard Odier` },
+      description: descriptionText,
+      descriptionByLocale: { [sourceLang]: descriptionText },
       location,
       canton,
       url: publicUrl,
@@ -226,7 +244,6 @@ export async function fetchAllLombardOdierJobs() {
     };
 
     jobs.push(job);
-    await new Promise((r) => setTimeout(r, 300)); // Rate limiting
   }
 
   console.log(`\n📋 Total Lombard Odier jobs discovered: ${jobs.length}`);

--- a/scripts/lib/nestle-job-parser.mjs
+++ b/scripts/lib/nestle-job-parser.mjs
@@ -17,6 +17,7 @@ import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
   buildWorkdayApiBase,
   fetchWorkdayJobs,
+  fetchWorkdayJobDescriptionText,
   parseWorkdayPostedDate,
   extractWorkdayJobIdentity,
   WorkdayAuthError,
@@ -191,9 +192,25 @@ export async function fetchAllNestleJobs() {
 
     const location = listing.location || 'Vevey';
     const canton = inferSwissTargetCanton(location) || 'VD';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || CAREER_URL;
+
+    // Workday listing endpoint NEVER returns the job body — see workday-client.mjs.
+    const detailDescription = await fetchWorkdayJobDescriptionText(
+      WORKDAY_API_BASE,
+      listing.externalPath,
+      stripHtml,
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    const fallbackDescription = [
+      `${title} — ${NESTLE_COMPANY_NAME}, ${location}.`,
+      '',
+      'Key details:',
+      `• Location: ${location}${canton ? `, ${canton} canton` : ''}, Switzerland`,
+      '• Employer: Nestlé — world\'s largest food and beverage company',
+      '• Apply on: Nestlé careers portal',
+    ].join('\n');
+    const descriptionText = detailDescription.length >= 100 ? detailDescription : fallbackDescription;
 
     const sourceLang = detectLang(descriptionText || title, 'en');
     const jobSlug = slugify(`${title} nestle ch`);
@@ -209,8 +226,8 @@ export async function fetchAllNestleJobs() {
       companyDomain: NESTLE_COMPANY_DOMAIN,
       title,
       titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — Nestlé`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — Nestlé` },
+      description: descriptionText,
+      descriptionByLocale: { [sourceLang]: descriptionText },
       location,
       canton,
       url: publicUrl,
@@ -236,7 +253,6 @@ export async function fetchAllNestleJobs() {
     };
 
     jobs.push(job);
-    await new Promise((r) => setTimeout(r, 300)); // Rate limiting
   }
 
   console.log(`\n📋 Total Nestlé jobs discovered: ${jobs.length}`);

--- a/scripts/lib/novartis-job-parser.mjs
+++ b/scripts/lib/novartis-job-parser.mjs
@@ -17,6 +17,7 @@ import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
   buildWorkdayApiBase,
   fetchWorkdayJobs,
+  fetchWorkdayJobDescriptionText,
   parseWorkdayPostedDate,
   extractWorkdayJobIdentity,
   WorkdayAuthError,
@@ -185,9 +186,25 @@ export async function fetchAllNovartisJobs() {
 
     const location = listing.location || 'Basel';
     const canton = inferSwissTargetCanton(location) || 'BS';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || CAREER_URL;
+
+    // Workday listing endpoint NEVER returns the job body — see workday-client.mjs.
+    const detailDescription = await fetchWorkdayJobDescriptionText(
+      WORKDAY_API_BASE,
+      listing.externalPath,
+      stripHtml,
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    const fallbackDescription = [
+      `${title} — ${NOVARTIS_COMPANY_NAME}, ${location}.`,
+      '',
+      'Key details:',
+      `• Location: ${location}${canton ? `, ${canton} canton` : ''}, Switzerland`,
+      '• Employer: Novartis — global pharmaceuticals leader',
+      '• Apply on: Novartis careers portal',
+    ].join('\n');
+    const descriptionText = detailDescription.length >= 100 ? detailDescription : fallbackDescription;
 
     const sourceLang = detectLang(descriptionText || title, 'it');
     const jobSlug = slugify(`${title} novartis ch`);
@@ -203,8 +220,8 @@ export async function fetchAllNovartisJobs() {
       companyDomain: NOVARTIS_COMPANY_DOMAIN,
       title,
       titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — Novartis`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — Novartis` },
+      description: descriptionText,
+      descriptionByLocale: { [sourceLang]: descriptionText },
       location,
       canton,
       url: publicUrl,
@@ -230,7 +247,6 @@ export async function fetchAllNovartisJobs() {
     };
 
     jobs.push(job);
-    await new Promise((r) => setTimeout(r, 300)); // Rate limiting
   }
 
   console.log(`\n📋 Total Novartis jobs discovered: ${jobs.length}`);

--- a/scripts/lib/roche-job-parser.mjs
+++ b/scripts/lib/roche-job-parser.mjs
@@ -17,6 +17,7 @@ import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
   buildWorkdayApiBase,
   fetchWorkdayJobs,
+  fetchWorkdayJobDescriptionText,
   parseWorkdayPostedDate,
   extractWorkdayJobIdentity,
   WorkdayAuthError,
@@ -185,9 +186,28 @@ export async function fetchAllRocheJobs() {
     // Roche HQ is Basel (BS); fall back there if Workday omits the location.
     const location = listing.location || 'Basel';
     const canton = inferSwissTargetCanton(location) || 'BS';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || CAREER_URL;
+
+    // Workday listing endpoint NEVER returns the job body — it must be fetched
+    // from the per-job detail endpoint (jobPostingInfo.jobDescription). The
+    // shared helper handles timeout + 4xx and returns '' on failure so we can
+    // fall back to a structured stub built from listing metadata.
+    const detailDescription = await fetchWorkdayJobDescriptionText(
+      WORKDAY_API_BASE,
+      listing.externalPath,
+      stripHtml,
+    );
+    await new Promise((r) => setTimeout(r, 400)); // Polite rate limit between detail calls
+
+    const fallbackDescription = [
+      `${title} — ${ROCHE_COMPANY_NAME}, ${location}.`,
+      '',
+      'Key details:',
+      `• Location: ${location}${canton ? `, ${canton} canton` : ''}, Switzerland`,
+      '• Employer: Roche — global pharma and diagnostics leader',
+      '• Apply on: Roche careers portal',
+    ].join('\n');
+    const descriptionText = detailDescription.length >= 100 ? detailDescription : fallbackDescription;
 
     const sourceLang = detectLang(descriptionText || title, 'it');
     const jobSlug = slugify(`${title} roche ch`);
@@ -203,8 +223,8 @@ export async function fetchAllRocheJobs() {
       companyDomain: ROCHE_COMPANY_DOMAIN,
       title,
       titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — Roche`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — Roche` },
+      description: descriptionText,
+      descriptionByLocale: { [sourceLang]: descriptionText },
       location,
       canton,
       url: publicUrl,
@@ -230,7 +250,6 @@ export async function fetchAllRocheJobs() {
     };
 
     jobs.push(job);
-    await new Promise((r) => setTimeout(r, 300)); // Rate limiting
   }
 
   console.log(`\n📋 Total Roche jobs discovered: ${jobs.length}`);

--- a/scripts/lib/sulzer-job-parser.mjs
+++ b/scripts/lib/sulzer-job-parser.mjs
@@ -17,6 +17,7 @@ import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
   buildWorkdayApiBase,
   fetchWorkdayJobs,
+  fetchWorkdayJobDescriptionText,
   parseWorkdayPostedDate,
   extractWorkdayJobIdentity,
   WorkdayAuthError,
@@ -124,9 +125,10 @@ const WORKDAY_SITE_PATH = (_WORKDAY_URL.pathname.replace(/^\/+|\/+$/g, '').split
 // the post list to CH-only entries downstream. If a stable CH location UUID
 // surfaces during a future probe, plug it in here for a smaller payload.
 const WORKDAY_LOCATION_FILTERS = [];
+const WORKDAY_API_BASE = buildWorkdayApiBase(WORKDAY_TENANT_HOST, WORKDAY_SITE_PATH);
 
 async function fetchJobListings() {
-  const apiBase = buildWorkdayApiBase(WORKDAY_TENANT_HOST, WORKDAY_SITE_PATH);
+  const apiBase = WORKDAY_API_BASE;
   const out = [];
   try {
     for await (const posting of fetchWorkdayJobs(apiBase, {
@@ -181,9 +183,25 @@ export async function fetchAllSulzerJobs() {
 
     const location = listing.location || 'Winterthur'; // Sulzer HQ
     const canton = inferSwissTargetCanton(location) || 'ZH';
-    const descriptionHtml = listing.description || '';
-    const descriptionText = stripHtml(descriptionHtml);
     const publicUrl = listing.url || CAREER_URL;
+
+    // Workday listing endpoint NEVER returns the job body — see workday-client.mjs.
+    const detailDescription = await fetchWorkdayJobDescriptionText(
+      WORKDAY_API_BASE,
+      listing.externalPath,
+      stripHtml,
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    const fallbackDescription = [
+      `${title} — ${SULZER_COMPANY_NAME}, ${location}.`,
+      '',
+      'Key details:',
+      `• Location: ${location}${canton ? `, ${canton} canton` : ''}, Switzerland`,
+      '• Employer: Sulzer — global pumping, mixing and flow control technology',
+      '• Apply on: Sulzer careers portal',
+    ].join('\n');
+    const descriptionText = detailDescription.length >= 100 ? detailDescription : fallbackDescription;
 
     const sourceLang = detectLang(descriptionText || title, 'en');
     const jobSlug = slugify(`${title} sulzer ch`);
@@ -199,8 +217,8 @@ export async function fetchAllSulzerJobs() {
       companyDomain: SULZER_COMPANY_DOMAIN,
       title,
       titleByLocale: { [sourceLang]: title },
-      description: descriptionText || `${title} — Sulzer`,
-      descriptionByLocale: { [sourceLang]: descriptionText || `${title} — Sulzer` },
+      description: descriptionText,
+      descriptionByLocale: { [sourceLang]: descriptionText },
       location,
       canton,
       url: publicUrl,
@@ -226,7 +244,6 @@ export async function fetchAllSulzerJobs() {
     };
 
     jobs.push(job);
-    await new Promise((r) => setTimeout(r, 300)); // Rate limiting
   }
 
   console.log(`\n📋 Total Sulzer jobs discovered: ${jobs.length}`);


### PR DESCRIPTION
Workday CXS listing endpoint (`POST /jobs`) returns only summary fields
(title, externalPath, locationsText, postedOn) — never the job body. Six
parsers (Roche/Novartis/Sulzer/Nestlé/Lombard Odier/KSB) were reading a
non-existent `listing.description`, leaving every job with a 24-90 char
"Title — Company" stub that trips the thin-source guard (139 issues on
Roche, similar on the rest). Logitech and Lonza already fetched the
detail endpoint correctly; the pattern is now hoisted into the shared
client as `fetchWorkdayJobDetail` / `fetchWorkdayJobDescriptionText` and
the six broken parsers call it before building the job, falling back to
a structured 6-line stub only when the detail endpoint refuses.

SmartRecruiters client had a tenant-less detail URL
(`/v1/postings/{id}`) that returns 404 — the API requires the company
prefix (`/v1/companies/{tenant}/postings/{id}`). Same regression class
silently broke Avaloq (11 thin issues) and HUG (3 thin issues): the
list-endpoint posting was returned verbatim so jobAd.sections was always
empty. URL constant removed, single call site corrected.

Verified live against `roche.wd3.myworkdayjobs.com` + Avaloq SR tenant —
both detail endpoints now return 2-3 KB of real prose. All 137 affected
crawler tests still pass.
