### PR TITLE
fix(centiel): fetch PDF descriptions + bound parser to accordion items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "leaflet": "^1.9.4",
         "lucide-react": "^0.563.0",
         "mailcheck": "^1.1.1",
+        "pdf-parse": "^2.4.5",
         "playwright": "^1.58.2",
         "posthog-js": "^1.367.0",
         "react": "^19.2.4",
@@ -2477,6 +2478,205 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -7786,6 +7986,38 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
     },
     "node_modules/pdfkit": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -277,6 +277,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.563.0",
     "mailcheck": "^1.1.1",
+    "pdf-parse": "^2.4.5",
     "playwright": "^1.58.2",
     "posthog-js": "^1.367.0",
     "react": "^19.2.4",

--- a/scripts/audit-parser-quality.mjs
+++ b/scripts/audit-parser-quality.mjs
@@ -157,12 +157,54 @@ function plainText(html) {
 
 const BOILERPLATE_RE = /^(datore di lavoro|als arbeitgeber|come employer|en tant qu.?employeur|as employer)/i;
 
+/**
+ * Phrases that only appear when a parser has leaked the surrounding
+ * application form, footer, or contact chrome into the per-job description.
+ * A real role description never mentions wpcf7 form-element classes,
+ * "I agree to the treatment of my personal information", "Attachment: CV
+ * in PDF format", "Send your application" headers, or the standard
+ * cookie/privacy policy footers.
+ *
+ * Added 2026-05-18 after the Centiel After-Sales Technician regression:
+ * the regex-split parser ran from the last <h3> to end-of-document and
+ * swept in the WordPress Contact Form 7 application widget plus the
+ * footer's Centiel Global HQ block. None of the existing checks caught
+ * it — ~1000 chars of plain-text labels passed both the 100-char minimum
+ * and the 15% tag-soup ratio, and 1/5 contaminated rows was below the
+ * duplicate-description threshold.
+ */
+// Each pattern must be a phrase that ONLY appears in a rendered web
+// form / footer widget and never inside a legitimate role description or
+// PDF instruction text. "Send your application" was rejected — every
+// Centiel role PDF ends with "please send your application to hr@..."
+// which is legitimate apply-instruction content. The phrases below are
+// widget tells (form labels, WordPress Contact Form 7 classes, exact
+// placeholder strings) with no legitimate counterpart in role copy.
+const FORM_CHROME_PATTERNS = [
+  /Attachment\s*:?\s*CV in PDF format,\s*maximum weight/i,
+  /I agree to the treatment of my personal information/i,
+  /\bwpcf7[-_]/i,
+  /\bDesired Position\b.*\bAfter[- ]?Sales\b/i,
+  /A brief presentation\s*\*/i,
+  /CORPORATE ENQUIRIES/i,
+  /Media\s*&\s*Investor Enquiries/i,
+];
+
+export function hasFormChrome(desc) {
+  const text = plainText(desc);
+  return FORM_CHROME_PATTERNS.some((re) => re.test(text));
+}
+
 function isThinDescription(desc) {
   const text = plainText(desc);
   if (text.length < 100) return 'too-short';
   if (BOILERPLATE_RE.test(text)) return 'boilerplate';
   // Mostly whitespace / tags — if raw is 5x longer than plain, it's tag soup
   if ((desc || '').length > 200 && text.length < (desc || '').length * 0.15) return 'tag-soup';
+  // Form/footer/contact chrome leaked from the page surrounding the job.
+  // Treated as thin because the actual role content is buried under noise
+  // and the page's text-to-content ratio is destroyed.
+  if (hasFormChrome(desc)) return 'form-chrome';
   return false;
 }
 
@@ -462,13 +504,20 @@ async function main() {
     const types = new Set(entry.issues.map((i) => i.type));
     const thin = entry.issues.find((i) => i.type === 'thin-description');
     const thinRatio = thin ? thin.count / thin.total : 0;
+    const formChromeCount = thin?.reasons?.['form-chrome'] || 0;
     const urlFail = types.has('stale-urls');
     if (types.has('parse-error')) entry.severity = 'CRITICAL';
+    // Form-chrome is a hard signal: even one row means the parser is
+    // leaking the surrounding page (form, footer, contact info) into the
+    // job description. There is no benign source of these phrases — never
+    // a false positive — so skip the ratio gate.
+    else if (formChromeCount > 0) entry.severity = 'CRITICAL';
     else if (thinRatio >= 0.5 || (thinRatio > 0 && urlFail)) entry.severity = 'CRITICAL';
     else if (entry.issues.length > 0) entry.severity = 'WARNING';
     else entry.severity = 'OK';
     if (entry.severity === 'CRITICAL') {
       const h = [];
+      if (formChromeCount > 0) h.push(`${formChromeCount} description(s) contain form/footer/contact chrome — parser is sweeping page boundaries (most likely an unbounded HTML split). Bound extraction to the per-job DOM subtree`);
       if (thinRatio >= 0.5) h.push('Most descriptions are thin — parser likely scraping nav/boilerplate instead of job content');
       if (urlFail) h.push('Detail URLs returning errors — likely site migration or URL structure change');
       if (types.has('parse-error')) h.push('Crawler JSON file could not be parsed');

--- a/scripts/update-centiel-jobs.mjs
+++ b/scripts/update-centiel-jobs.mjs
@@ -6,19 +6,28 @@
  * Cadro (Lugano), CH-6965, Via alla Stampa 15.
  *
  * The careers page at https://www.centiel.com/careers/ lists jobs inline
- * inside accordion items — there are no individual detail-page URLs.
- * Each listing links to a PDF job description.
+ * inside div.accordion-item blocks — there are no individual detail-page URLs.
+ * Each accordion shows a short summary and links to a PDF job description
+ * containing the full role details (responsibilities, requirements,
+ * qualifications). The PDF is the source of truth for description content.
  *
  * This crawler:
  *   1. Fetches the /careers/ page HTML.
- *   2. Parses accordion blocks to extract title, description, location, PDF URL.
- *   3. Builds job objects and merges them into jobs.json.
- *   4. Translates and validates locale coverage.
+ *   2. Parses div.accordion-item blocks via jsdom to extract title, summary,
+ *      PDF URL. Bounded extraction prevents form-chrome leak into the last
+ *      accordion's content.
+ *   3. Fetches each linked PDF and extracts the full text. PDF text is
+ *      preferred when richer than the inline summary; falls back to inline
+ *      on PDF fetch/parse failure.
+ *   4. Builds job objects and merges into jobs.json.
+ *   5. Translates and validates locale coverage.
  */
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { PDFParse } from 'pdf-parse';
 import { extractStableJobId } from './lib/job-match-key.mjs';
 import {
   snapshotJobSlugs,
@@ -149,66 +158,68 @@ async function fetchCareersHtml() {
 /**
  * Parse job listings from the Centiel careers page HTML.
  *
- * The page lists jobs under an "Current vacancies" h2.
- * Each job is an <h3> title followed by paragraphs containing the
- * description, metadata (<strong> labels), and a "Learn more" PDF link.
- * There are no wrapper divs or accordion classes — just sequential
- * h3 + p elements.
+ * Current layout: div.accordion-item wrappers, each containing
+ *   button > h3.block-title   (job title)
+ *   div.accordion-content > div.career-block > div.block-content
+ *     > <p> paragraphs with the summary, <strong>Workplace</strong>,
+ *       <strong>Reporting to</strong>, and a "Learn more" link to the PDF.
+ *
+ * Bounded extraction via DOM walk prevents the last accordion from
+ * sweeping the application form, footer, and contact chrome (the
+ * pre-2026 regex parser leaked all of that into the After-Sales
+ * Technician description).
  */
 function parseCareersPage(html) {
   const jobs = [];
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
 
-  // Isolate the vacancies section: everything after "Current vacancies" h2
-  const vacancyStart = html.search(/<h2[^>]*>[^<]*Current\s+vacancies[^<]*<\/h2>/i);
-  if (vacancyStart === -1) {
-    // Fallback: try to find the first h3 that looks like a job title
-    // (page may restructure again)
-  }
-  const sectionHtml = vacancyStart !== -1 ? html.slice(vacancyStart) : html;
-
-  // Split by <h3> tags to get one block per job.
-  // Each block starts right after the <h3> open tag.
-  const h3Parts = sectionHtml.split(/<h3[^>]*>/i).slice(1);
-
-  for (const part of h3Parts) {
-    // Extract title (text before closing </h3>)
-    const closingH3 = part.indexOf('</h3>');
-    if (closingH3 === -1) continue;
-    const rawTitle = part.slice(0, closingH3);
-    const title = decodeHtmlEntities(stripHtml(rawTitle)).trim();
+  const items = doc.querySelectorAll('div.accordion-item');
+  for (const item of items) {
+    const titleEl = item.querySelector('h3.block-title, .block-title');
+    const title = (titleEl?.textContent || '').trim();
     if (!title) continue;
 
-    // The content after </h3> until the end of this block
-    const contentHtml = part.slice(closingH3 + 5);
+    const block = item.querySelector('.block-content');
+    if (!block) continue;
 
-    // Extract PDF URL and resolve to absolute
-    const pdfMatch = contentHtml.match(/href="([^"]*\.pdf[^"]*)"/i);
-    const pdfUrl = pdfMatch
-      ? new URL(pdfMatch[1], CAREERS_URL).href
+    // PDF link (Learn more) — bounded to this accordion only.
+    const pdfAnchor = [...block.querySelectorAll('a[href]')]
+      .find((a) => /\.pdf(\?|$)/i.test(a.getAttribute('href') || ''));
+    const pdfUrl = pdfAnchor
+      ? new URL(pdfAnchor.getAttribute('href'), CAREERS_URL).href
       : '';
 
-    // Extract workplace/location
-    const workplaceMatch = contentHtml.match(/<strong>\s*Workplace\s*:?\s*<\/strong>\s*(.*?)(?:<br|<\/p|<strong)/i);
+    // Pull labelled metadata from the block content. The page mixes
+    // <strong>Workplace:</strong> and <strong>Reporting to:</strong>
+    // inside <p> elements without consistent closing tags.
+    const blockHtml = block.innerHTML || '';
+    const workplaceMatch = blockHtml.match(
+      /<strong[^>]*>\s*Workplace\s*:?\s*<\/?strong[^>]*>\s*([^<]+)/i,
+    );
     const workplace = workplaceMatch
       ? stripHtml(workplaceMatch[1]).trim()
       : 'Cadro (Lugano)';
-
-    // Extract reporting-to
-    const reportingMatch = contentHtml.match(/<strong>\s*Reporting\s+to\s*:?\s*<\/strong>\s*(.*?)(?:<br|<\/p|<strong)/i);
+    const reportingMatch = blockHtml.match(
+      /<strong[^>]*>\s*Reporting\s+to\s*:?\s*<\/?strong[^>]*>\s*([^<]+)/i,
+    );
     const reportingTo = reportingMatch ? stripHtml(reportingMatch[1]).trim() : '';
-
-    // Extract working rate
-    const rateMatch = contentHtml.match(/<strong>\s*Working\s+rate\s*:?\s*<\/strong>\s*(.*?)(?:<br|<\/p|<strong)/i);
+    const rateMatch = blockHtml.match(
+      /<strong[^>]*>\s*Working\s+rate\s*:?\s*<\/?strong[^>]*>\s*([^<]+)/i,
+    );
     const workingRate = rateMatch ? stripHtml(rateMatch[1]).trim() : '';
 
-    // Build clean description from the content paragraphs (exclude the "Learn more" link text)
-    const description = stripHtml(contentHtml)
-      .replace(/Learn more\s*$/, '')
-      .trim();
+    // Inline summary = block-content text minus the "Learn more" link text.
+    const inlineSummary = decodeHtmlEntities(
+      (block.textContent || '')
+        .replace(/\s+/g, ' ')
+        .replace(/\bLearn more\b/i, '')
+        .trim(),
+    );
 
     jobs.push({
       title,
-      description,
+      inlineSummary,
       workplace,
       reportingTo,
       workingRate,
@@ -217,6 +228,74 @@ function parseCareersPage(html) {
   }
 
   return jobs;
+}
+
+/**
+ * Fetch a PDF URL and extract its text. Returns the cleaned text or
+ * an empty string on any failure (network error, non-200, parse error).
+ * The crawler falls back to the inline summary when this returns empty.
+ */
+async function fetchPdfText(pdfUrl) {
+  if (!pdfUrl) return '';
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_PDF_TIMEOUT_MS) || 30000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(pdfUrl, {
+      signal: controller.signal,
+      headers: { Accept: 'application/pdf', 'User-Agent': UA },
+      redirect: 'follow',
+    });
+    if (!res.ok) {
+      console.warn(`  ⚠️ PDF ${pdfUrl} → HTTP ${res.status}`);
+      return '';
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    const parser = new PDFParse({ data: buf });
+    const out = await parser.getText();
+    const raw = (out?.text || '').trim();
+    if (!raw) return '';
+    // Light cleanup: normalise line breaks, collapse whitespace, then
+    // drop the contact-instruction tail that every Centiel PDF ends with
+    // (e.g. "If you identify with this role ... please send your
+    // application ... to: hr@hq.centiel.com"). The role-relevant content
+    // ends before this paragraph; keeping it bloats the description and
+    // exposes a contact email on the public job page.
+    const normalised = raw
+      .replace(/\r\n?/g, '\n')
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .replace(/[ \t]{2,}/g, ' ')
+      .trim();
+    const contactCutMarkers = [
+      /\n[^\n]*If you (?:identify|are interested|recognise)[^\n]*\n[\s\S]*$/i,
+      /\nplease send your application[\s\S]*$/i,
+      /\n[^\n]*\b(?:hr|write|jobs)@(?:hq\.)?centiel\.com[\s\S]*$/i,
+    ];
+    let text = normalised;
+    for (const re of contactCutMarkers) text = text.replace(re, '').trim();
+    return text;
+  } catch (err) {
+    console.warn(`  ⚠️ PDF ${pdfUrl} failed: ${err?.message || err}`);
+    return '';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Decide which description body to use: PDF text when it's substantially
+ * richer than the inline summary, otherwise the inline summary. Both can
+ * be empty; downstream `buildJob` pads with company boilerplate to meet
+ * the 50-word non-negotiable.
+ */
+function selectDescriptionBody(pdfText, inlineSummary) {
+  const pdfWords = (pdfText || '').split(/\s+/).filter(Boolean).length;
+  const inlineWords = (inlineSummary || '').split(/\s+/).filter(Boolean).length;
+  // Prefer PDF when it's at least 1.5× longer than the inline summary
+  // (the inline tail typically only has summary + labels).
+  if (pdfWords >= 80 && pdfWords >= inlineWords * 1.5) return pdfText;
+  return inlineSummary || pdfText || '';
 }
 
 /* ── Category inference ────────────────────────────────────── */
@@ -236,8 +315,10 @@ function buildJob(row) {
   // Use the PDF URL as the canonical URL if available, otherwise careers page
   const url = row.pdfUrl || CAREERS_URL;
 
+  // Pick PDF text over inline summary when meaningfully richer.
+  let description = selectDescriptionBody(row.pdfText, row.inlineSummary);
+
   // Ensure description meets the 50-word minimum threshold
-  let description = row.description || '';
   const wordCount = description.split(/\s+/).filter(Boolean).length;
   if (wordCount < 50) {
     // Build a richer description with job-specific details
@@ -381,21 +462,30 @@ async function main() {
     return;
   }
 
-  // 2. Build job objects
+  // 2. Fetch each PDF for the full role description (sequential to be
+  //    polite to centiel.com — 5 PDFs typical).
+  console.log('\n📄 Fetching role PDFs for full descriptions...');
+  for (const l of listings) {
+    l.pdfText = await fetchPdfText(l.pdfUrl);
+    const pdfWords = (l.pdfText || '').split(/\s+/).filter(Boolean).length;
+    console.log(`  ${pdfWords > 0 ? '✓' : '∅'} ${l.title} → PDF ${pdfWords} words`);
+  }
+
+  // 3. Build job objects
   const jobs = listings.map(buildJob);
 
-  // 3. Merge into jobs.json
+  // 4. Merge into jobs.json
   const { total, added, updated, diff} = mergeJobs(jobs);
   updateAdapterConfig(jobs);
 
-  // 4. Translate missing locales
+  // 5. Translate missing locales
   console.log('\n🌐 Running locale fill for Centiel jobs...');
   await translateMissingJobLocales({
     dataJobsPath: DATA_JOBS,
     isTargetJob,
   });
 
-  // 5. Validate
+  // 6. Validate
   validateLocales();
 
   console.log('\n📊 === Centiel Job Stats ===');

--- a/tests/scripts/audit-parser-quality.test.ts
+++ b/tests/scripts/audit-parser-quality.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect } from 'vitest';
 import {
   applyNoStructureRatchet,
   applyDuplicateDescriptionRatchet,
+  hasFormChrome,
 } from '../../scripts/audit-parser-quality.mjs';
 
 type Issue = {
@@ -296,5 +297,43 @@ describe('applyDuplicateDescriptionRatchet', () => {
 
     expect(report['templated-source'].severity).toBe('WARNING');
     expect(regressions).toHaveLength(0);
+  });
+});
+
+describe('hasFormChrome', () => {
+  // Each pattern came from the 2026-05-18 Centiel After-Sales Technician
+  // regression: the regex-split parser ran past the last accordion and
+  // swept in WordPress Contact Form 7 widget HTML + footer chrome.
+  it('flags the wpcf7 form-control class', () => {
+    expect(hasFormChrome('Some text wpcf7-form-control here')).toBe(true);
+  });
+
+  it('flags the privacy-checkbox label verbatim', () => {
+    expect(hasFormChrome('I agree to the treatment of my personal information.')).toBe(true);
+  });
+
+  it('flags the exact CV-upload field label', () => {
+    expect(hasFormChrome('Attachment: CV in PDF format, maximum weight 3 Mb')).toBe(true);
+  });
+
+  it('flags the "A brief presentation *" placeholder', () => {
+    expect(hasFormChrome('A brief presentation *')).toBe(true);
+  });
+
+  it('flags the CORPORATE ENQUIRIES footer block', () => {
+    expect(hasFormChrome('CORPORATE ENQUIRIES Media & Investor Enquiries')).toBe(true);
+  });
+
+  it('does NOT flag legitimate apply-instruction copy from a role PDF', () => {
+    // The Centiel role PDFs all end with this sentence. It is legitimate
+    // role content (the apply-to address) and must not trigger the chrome
+    // signal — that would force a parser fix where none is needed.
+    const pdfTail = 'If you identify with this role, please send your application, indicating "After-Sales Technician" in the subject line, to: hr@hq.centiel.com';
+    expect(hasFormChrome(pdfTail)).toBe(false);
+  });
+
+  it('does NOT flag a generic role description', () => {
+    const desc = 'We are looking for a Senior Engineer to join our team in Lugano. Responsibilities include designing systems, reviewing code, and mentoring junior engineers.';
+    expect(hasFormChrome(desc)).toBe(false);
   });
 });


### PR DESCRIPTION
The careers page lists 5 roles inside <div class="accordion-item"> blocks.
The previous parser split on <h3> and ran each block from one <h3> to the
next — but the last block extended to end-of-document, sweeping the
WordPress Contact Form 7 application widget plus the footer's Centiel
Global HQ contact block into the After-Sales Technician description.

Also: each accordion only carries a 3-sentence summary; the real role
description (responsibilities, requirements, contract terms) lives in
the linked PDF and was never fetched.

Changes:
- Rewrite parseCareersPage with jsdom, bounded to .accordion-item subtrees
- Fetch each Learn-more PDF via pdf-parse (new dep), strip the
  contact-instruction tail (hr@hq.centiel.com), prefer PDF text when
  meaningfully richer than the inline summary, fall back to inline on
  PDF fetch/parse failure
- Add form-chrome contamination check to audit-parser-quality.mjs with
  high-specificity widget-only patterns (wpcf7-, exact placeholders,
  privacy-checkbox label) that never false-positive on legitimate role
  copy. Even one match escalates the crawler to CRITICAL.
- Regression test coverage for the form-chrome detector
