### PR TITLE
fix(seo): translated EN slugs no longer 404 + orphan canton inferred from path/slug

### DIFF
--- a/scripts/lib/orphan-canton-paths.mjs
+++ b/scripts/lib/orphan-canton-paths.mjs
@@ -1,0 +1,215 @@
+/**
+ * Canton-aware locale path builder for GSC orphan slugs.
+ *
+ * Pre-fix: `scripts/sync-gsc-orphans.mjs` defaulted every orphan's localised
+ * fallback paths to Ticino — `/cerca-lavoro-ticino/${slug}/`, etc. That broke
+ * jobs whose canonical canton is non-TI: e.g. RhB Chur (canton GR) slugs got
+ * registered as `/en/find-jobs-ticino/...`, so the only soft-landing emitted
+ * was at the wrong canton. Google's actual indexed URL
+ * (`/en/find-jobs-graubunden/.../`) had no static page to land on and 404'd.
+ *
+ * This module infers the real canton from the orphan's GSC-reported path,
+ * falling back to a slug-suffix-vs-municipality lookup, then builds the four
+ * locale paths from `canton-url-slugs.mjs`. If nothing resolves confidently
+ * (city not found / ambiguous across cantons), callers get the legacy
+ * all-Ticino fallback so behaviour stays backward-compatible for slugs the
+ * heuristic can't classify.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getCantonUrlSlug,
+  parseCantonUrlSlug,
+} from './canton-url-slugs.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MUNICIPALITIES_PATH = path.resolve(__dirname, '..', '..', 'data', 'canton-municipalities.json');
+
+export const LOCALES = ['it', 'en', 'de', 'fr'];
+
+// `/{prefix}-{cantonSlug}/{slug}` — locale-aware "job board" segment prefix.
+// Mirrors build-plugins/weeklyEmployersChCantonPages.ts:JOB_BOARD_PREFIX.
+const JOB_BOARD_PREFIX = Object.freeze({
+  it: 'cerca-lavoro',
+  en: 'find-jobs',
+  de: 'jobs-im',
+  fr: 'trouver-emploi',
+});
+
+const LOCALE_URL_PREFIX = Object.freeze({
+  it: '',
+  en: '/en',
+  de: '/de',
+  fr: '/fr',
+});
+
+// Alternate prefix tokens we may see on inbound GSC paths — keep in sync with
+// the regexes in scripts/ingest-gsc-job-orphans.mjs:JOB_PATH_PATTERNS.
+const INBOUND_PREFIX_ALTERNATES = '(?:cerca-lavoro|find-jobs|find-job|job-search|jobs-im|jobsuche|stellenangebote|recherche-emploi|trouver-emploi|emplois)';
+
+const INBOUND_PATH_RE = new RegExp(
+  `^(?:/(?:en|de|fr))?/${INBOUND_PREFIX_ALTERNATES}-([a-z-]+)/[^/]+/?$`,
+);
+
+// 6-char hex disambiguator tail appended by the slug regen step (see
+// `appendDisambiguatorTail` in regenerate-slugs-helpers.mjs). Strip it before
+// looking up the city — the city name is what comes immediately before it.
+const DISAMBIGUATOR_TAIL_RE = /-[a-f0-9]{6}$/;
+
+let _cityCantonIndex = null;
+
+function normalizeCityToken(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Build (and cache) a `Map<normalizedCity, Set<cantonCode>>` from the BFS
+ * canton-municipalities snapshot. Multi-canton hits (e.g. "Buchs" lives in
+ * several cantons) keep all members in the Set so callers can decide whether
+ * an ambiguous match should be treated as "no confident match".
+ */
+export function buildCityCantonIndex() {
+  if (_cityCantonIndex) return _cityCantonIndex;
+  let data = { cantons: {} };
+  try {
+    data = JSON.parse(fs.readFileSync(MUNICIPALITIES_PATH, 'utf8')) || { cantons: {} };
+  } catch {
+    // Fall through — empty index means inference falls back to TI later.
+  }
+  const index = new Map();
+  for (const [code, entry] of Object.entries(data.cantons || {})) {
+    const cities = [
+      ...(Array.isArray(entry?.municipalities) ? entry.municipalities : []),
+      ...(Array.isArray(entry?.aliases) ? entry.aliases : []),
+    ];
+    for (const city of cities) {
+      const norm = normalizeCityToken(city);
+      if (!norm) continue;
+      if (!index.has(norm)) index.set(norm, new Set());
+      index.get(norm).add(code);
+    }
+  }
+  _cityCantonIndex = index;
+  return index;
+}
+
+/** Reset the cached index. Used by tests; not part of the public CLI flow. */
+export function _resetCityCantonIndex() {
+  _cityCantonIndex = null;
+}
+
+/**
+ * Walk the GSC-reported path and reverse-resolve its canton segment to a code.
+ * Returns null when the path doesn't match the locale-job-board shape or the
+ * canton segment isn't a known slug in any of the 4 locales.
+ */
+export function inferCantonFromPath(orphanPath) {
+  if (!orphanPath) return null;
+  const m = String(orphanPath).match(INBOUND_PATH_RE);
+  if (!m) return null;
+  const cantonSlug = m[1];
+  for (const loc of LOCALES) {
+    let code;
+    try {
+      code = parseCantonUrlSlug(cantonSlug, loc);
+    } catch {
+      continue;
+    }
+    if (code && code !== '_AGGREGATE_') return code;
+  }
+  return null;
+}
+
+/**
+ * Find the canton implied by the slug's city suffix. Tries the trailing 1-3
+ * tokens (cities can be hyphenated: "san-gallo", "la-chaux-de-fonds") and
+ * returns a single canton code only when the match is unambiguous. Multi-
+ * canton hits return null so the caller falls back gracefully — picking one
+ * arbitrarily would re-create the original "wrong canton" bug.
+ */
+export function inferCantonFromSlug(slug, cityIndex = buildCityCantonIndex()) {
+  if (!slug) return null;
+  const base = String(slug).replace(DISAMBIGUATOR_TAIL_RE, '');
+  const tokens = base.split('-').filter(Boolean);
+  if (tokens.length === 0) return null;
+  for (let n = Math.min(3, tokens.length); n >= 1; n--) {
+    const candidate = tokens.slice(-n).join('-');
+    const cantons = cityIndex.get(candidate);
+    if (cantons && cantons.size === 1) {
+      return [...cantons][0];
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the four locale paths for a slug under a specific canton. Returns
+ * null if the canton has no URL slug for any of the 4 locales — callers
+ * should fall back to `buildDefaultTiPaths` in that case.
+ */
+export function buildLocaleJobPaths(slug, cantonCode) {
+  if (!slug || !cantonCode) return null;
+  const paths = {};
+  for (const loc of LOCALES) {
+    const cantonSlug = getCantonUrlSlug(cantonCode, loc);
+    if (!cantonSlug) return null;
+    const prefix = LOCALE_URL_PREFIX[loc];
+    paths[loc] = `${prefix}/${JOB_BOARD_PREFIX[loc]}-${cantonSlug}/${slug}`;
+  }
+  return paths;
+}
+
+/** Legacy all-Ticino fallback. Preserves the pre-fix shape for slugs whose
+ *  canton can't be inferred — backward-compatible safety net. */
+export function buildDefaultTiPaths(slug) {
+  return {
+    it: `/cerca-lavoro-ticino/${slug}`,
+    en: `/en/find-jobs-ticino/${slug}`,
+    de: `/de/jobs-im-tessin/${slug}`,
+    fr: `/fr/trouver-emploi-tessin/${slug}`,
+  };
+}
+
+/**
+ * One-stop builder for an orphan: prefer the GSC-reported path's canton,
+ * then the slug-suffix-derived canton, then fall back to the legacy Ticino
+ * paths. Always returns a 4-locale path map.
+ *
+ * Optional `pathHints` lets callers pass already-known canton-prefixed paths
+ * (e.g. a tracking entry from `all-known-job-slugs.json`) so the resolver
+ * can read the canton off any of them too.
+ */
+export function buildOrphanLocalePaths(orphan, options = {}) {
+  const cityIndex = options.cityIndex || buildCityCantonIndex();
+  const slug = orphan?.slug;
+  if (!slug) return null;
+
+  const canton =
+    inferCantonFromPath(orphan?.path) ||
+    inferCantonFromHints(options.pathHints) ||
+    inferCantonFromSlug(slug, cityIndex);
+
+  if (canton) {
+    const paths = buildLocaleJobPaths(slug, canton);
+    if (paths) return paths;
+  }
+  return buildDefaultTiPaths(slug);
+}
+
+function inferCantonFromHints(hints) {
+  if (!hints) return null;
+  const candidates = Array.isArray(hints) ? hints : Object.values(hints);
+  for (const candidate of candidates) {
+    const c = inferCantonFromPath(candidate);
+    if (c) return c;
+  }
+  return null;
+}

--- a/scripts/lib/regenerate-slugs-helpers.mjs
+++ b/scripts/lib/regenerate-slugs-helpers.mjs
@@ -1,0 +1,120 @@
+/**
+ * Pure helpers for slugByLocale regeneration. Extracted from
+ * scripts/regenerate-slugs-by-locale.mjs so the slug heuristics can be
+ * unit-tested in isolation.
+ *
+ * The CLI lives in the parent file; this module owns only the slug math.
+ */
+
+import crypto from 'node:crypto';
+import { truncateSlugAtWordBoundary } from './slug-truncate.mjs';
+
+export const MAX_SLUG_LENGTH = 120;
+
+// IT/EN/DE/FR connectives stripped from slug token sets so they don't pollute
+// Jaccard comparisons. `und` (DE) lives here even though it's 3 chars.
+export const SLUG_STOP_WORDS = new Set(
+  'del,dei,della,delle,degli,nel,nella,per,con,una,uno,che,tra,fra,sur,les,des,une,pour,avec,dans,par,the,and,for,with,from,die,der,das,den,dem,des,und,fur,mit,von,bei,ein,eine,einer,einem,einen'.split(','),
+);
+
+export function slugify(text) {
+  const base = String(text || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return truncateSlugAtWordBoundary(base, MAX_SLUG_LENGTH);
+}
+
+export function shortJobHash(jobId) {
+  return crypto.createHash('sha1').update(String(jobId || '')).digest('hex').slice(0, 6);
+}
+
+export function appendDisambiguatorTail(slug, tail) {
+  const t = String(tail || '').trim();
+  if (!t) return slug;
+  const maxBase = Math.max(0, MAX_SLUG_LENGTH - t.length - 1);
+  const trimmed = truncateSlugAtWordBoundary(String(slug || ''), maxBase).replace(/-+$/, '');
+  return trimmed ? `${trimmed}-${t}` : t;
+}
+
+export function buildSlug(title, company, location, disambiguator = '') {
+  const parts = [title, company, location].filter(Boolean);
+  const base = slugify(parts.join(' '));
+  const d = String(disambiguator || '').trim();
+  if (!d || !base) return base;
+  const maxBase = Math.max(0, MAX_SLUG_LENGTH - d.length - 1);
+  const trimmed = truncateSlugAtWordBoundary(base, maxBase).replace(/-+$/, '');
+  return trimmed ? `${trimmed}-${d}` : d;
+}
+
+export function slugTokenSet(slug) {
+  return new Set(
+    String(slug || '').split('-').filter((w) => w.length >= 3 && !SLUG_STOP_WORDS.has(w)),
+  );
+}
+
+export function slugJaccard(a, b) {
+  const setA = slugTokenSet(a);
+  const setB = slugTokenSet(b);
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let intersection = 0;
+  for (const t of setA) if (setB.has(t)) intersection++;
+  return intersection / (setA.size + setB.size - intersection);
+}
+
+export function isLikelyUntranslated(localeTitle, sourceTitle) {
+  if (!localeTitle || !sourceTitle) return false;
+  const a = slugify(localeTitle);
+  const b = slugify(sourceTitle);
+  if (a === b) return true;
+  return slugJaccard(a, b) > 0.5;
+}
+
+// Tokens contributed by company / location / disambiguator. Used to subtract
+// "structural noise" from slug comparisons so the Jaccard score reflects only
+// the title portion of the slug.
+function noiseTokens(company, location, disambiguator) {
+  const out = new Set();
+  for (const text of [company, location, disambiguator]) {
+    for (const t of slugTokenSet(slugify(text))) out.add(t);
+  }
+  return out;
+}
+
+/**
+ * Decide whether `slug` already encodes the supplied locale `title` + the
+ * shared company/location context.
+ *
+ * Compares **only the title-derived tokens** of both slugs by subtracting
+ * company + location + disambiguator tokens first. Pre-fix this used a
+ * whole-slug Jaccard against `buildSlug(title, company, location)`, which
+ * false-positived on multi-locale jobs whose company+location share a long
+ * fingerprint (e.g. `ferrovia-retica-rhb-chur` contributes 4 shared tokens
+ * before the title is even considered). That false positive blocked
+ * regeneration of translated EN slugs, leaving `slugByLocale.en` stuck on
+ * the source-language form and the translated URL 404-ing.
+ *
+ * Returns true when the title-only token overlap is ≥ 0.5 (same Jaccard
+ * threshold as before — the change is *what* gets compared, not the bar).
+ */
+export function slugMatchesTitle(slug, title, company, location, disambiguator = '') {
+  if (!slug || !title) return false;
+  const noise = noiseTokens(company, location, disambiguator);
+
+  const slugTokens = new Set();
+  for (const t of slugTokenSet(slug)) if (!noise.has(t)) slugTokens.add(t);
+
+  const titleTokens = new Set();
+  for (const t of slugTokenSet(slugify(title))) if (!noise.has(t)) titleTokens.add(t);
+
+  if (slugTokens.size === 0 && titleTokens.size === 0) return true;
+  if (slugTokens.size === 0 || titleTokens.size === 0) return false;
+
+  let intersection = 0;
+  for (const t of slugTokens) if (titleTokens.has(t)) intersection++;
+  const union = slugTokens.size + titleTokens.size - intersection;
+  return intersection / union >= 0.5;
+}

--- a/scripts/regenerate-slugs-by-locale.mjs
+++ b/scripts/regenerate-slugs-by-locale.mjs
@@ -20,17 +20,20 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BY_CRAWLER_DIR = path.resolve(__dirname, '..', 'data', 'jobs', 'by-crawler');
 const LOCALES = ['it', 'en', 'de', 'fr'];
-const MAX_SLUG_LENGTH = 120;
 
-// Import locale-aware previousSlugs helpers
 import { addPreviousSlugForLocale, cleanPreviousSlugsPerLocale } from './lib/dedicated-crawler-common.mjs';
-import { truncateSlugAtWordBoundary } from './lib/slug-truncate.mjs';
+import {
+  appendDisambiguatorTail,
+  buildSlug,
+  isLikelyUntranslated,
+  shortJobHash,
+  slugMatchesTitle,
+} from './lib/regenerate-slugs-helpers.mjs';
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
@@ -38,111 +41,6 @@ function readJson(filePath) {
 
 function writeJson(filePath, value) {
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n', 'utf-8');
-}
-
-/**
- * Slugify a string: lowercase, replace non-alphanumeric with dashes, trim.
- * Trims at word boundary when the cap would split a token.
- */
-function slugify(text) {
-  const base = String(text || '')
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '') // strip diacritics
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return truncateSlugAtWordBoundary(base, MAX_SLUG_LENGTH);
-}
-
-/**
- * Derive a 6-char hex tail from a job identifier \u2014 used as a deterministic
- * disambiguating suffix when a generated slug already belongs to another job.
- *
- * Why 6 chars: 16^6 \u2248 16 M slots \u2192 birthday-paradox collision probability
- * with the ~3000 active jobs in the feed is well below 0.001 %, while
- * keeping URLs short. The hash is stable for a given `job.id` (which is
- * itself content-addressed by the crawler), so the suffix doesn't churn
- * across builds \u2014 Google's link equity stays glued to one URL per job.
- */
-function shortJobHash(jobId) {
-  return crypto.createHash('sha1').update(String(jobId || '')).digest('hex').slice(0, 6);
-}
-
-/**
- * Append a hex disambiguator tail to a slug, respecting MAX_SLUG_LENGTH.
- * Returns the original slug if it's empty (no point disambiguating nothing).
- */
-function appendDisambiguatorTail(slug, tail) {
-  const t = String(tail || '').trim();
-  if (!t) return slug;
-  const maxBase = Math.max(0, MAX_SLUG_LENGTH - t.length - 1);
-  const trimmed = truncateSlugAtWordBoundary(String(slug || ''), maxBase).replace(/-+$/, '');
-  return trimmed ? `${trimmed}-${t}` : t;
-}
-
-/**
- * Build a slug from title + company + location (same format as the crawler).
- * When disambiguator is provided, appends it as a stable suffix.
- */
-function buildSlug(title, company, location, disambiguator = '') {
-  const parts = [title, company, location].filter(Boolean);
-  const base = slugify(parts.join(' '));
-  const d = String(disambiguator || '').trim();
-  if (!d || !base) return base;
-  const maxBase = Math.max(0, MAX_SLUG_LENGTH - d.length - 1);
-  const trimmed = truncateSlugAtWordBoundary(base, maxBase).replace(/-+$/, '');
-  return trimmed ? `${trimmed}-${d}` : d;
-}
-
-// Stop words filtered from slug tokens (IT/EN/DE/FR connectives)
-const SLUG_STOP_WORDS = new Set(
-  'del,dei,della,delle,degli,nel,nella,per,con,una,uno,che,tra,fra,sur,les,des,une,pour,avec,dans,par,the,and,for,with,from,die,der,das,den,dem,des,und,fur,mit,von,bei,ein,eine,einer,einem,einen'.split(','),
-);
-
-function slugTokenSet(slug) {
-  return new Set(
-    String(slug || '').split('-').filter((w) => w.length >= 3 && !SLUG_STOP_WORDS.has(w)),
-  );
-}
-
-/**
- * Jaccard similarity between two slugified strings based on their meaningful tokens.
- * Returns a value in [0, 1]: 1 = identical token sets, 0 = disjoint.
- */
-function slugJaccard(a, b) {
-  const setA = slugTokenSet(a);
-  const setB = slugTokenSet(b);
-  if (setA.size === 0 && setB.size === 0) return 1;
-  if (setA.size === 0 || setB.size === 0) return 0;
-  let intersection = 0;
-  for (const t of setA) if (setB.has(t)) intersection++;
-  return intersection / (setA.size + setB.size - intersection);
-}
-
-/**
- * Check if a locale title is likely untranslated (still in the source language).
- * Uses Jaccard token similarity on slugified versions — threshold 0.5 catches
- * exact copies AND partial heuristic translations that changed only 1-2 words.
- */
-function isLikelyUntranslated(localeTitle, sourceTitle) {
-  if (!localeTitle || !sourceTitle) return false;
-  const a = slugify(localeTitle);
-  const b = slugify(sourceTitle);
-  if (a === b) return true;
-  return slugJaccard(a, b) > 0.5;
-}
-
-/**
- * Check if a slug roughly corresponds to a title+company+location (Jaccard-based).
- * Compares the full derived slug (with company+location) to avoid false negatives
- * when the existing slug contains company/location tokens that dilute Jaccard
- * against a title-only slugified string.
- */
-function slugMatchesTitle(slug, title, company, location, disambiguator = '') {
-  if (!slug || !title) return false;
-  const fullSlug = buildSlug(title, company, location, disambiguator);
-  if (!fullSlug) return false;
-  return slugJaccard(slug, fullSlug) >= 0.5;
 }
 
 async function main() {

--- a/scripts/sync-gsc-orphans.mjs
+++ b/scripts/sync-gsc-orphans.mjs
@@ -27,6 +27,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import {
+  buildCityCantonIndex,
+  buildOrphanLocalePaths,
+} from './lib/orphan-canton-paths.mjs';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 
@@ -1202,16 +1207,23 @@ async function main() {
       pathToTrackingEntry.set(key, entry);
     }
 
+    // City→canton index for canton-aware fallback path generation. Pre-fix
+    // every fallback hardcoded Ticino, so any orphan whose canonical canton
+    // is non-TI (e.g. RhB Chur → GR) ended up with a soft-landing only at
+    // `/en/find-jobs-ticino/...`, while Google's actual indexed URL at
+    // `/en/find-jobs-graubunden/...` had no page to land on and 404'd.
+    const cityIndex = buildCityCantonIndex();
+
     for (const o of orphans) {
       // Skip enrichment-only entries (already in tracking, no new compat paths needed)
       if (o.source === 'enrichment-only') continue;
-      // 1. Add basic slug × 4 locale paths
-      const basicPaths = [
-        `/cerca-lavoro-ticino/${o.slug}`,
-        `/en/find-jobs-ticino/${o.slug}`,
-        `/de/jobs-im-tessin/${o.slug}`,
-        `/fr/trouver-emploi-tessin/${o.slug}`,
-      ];
+      // 1. Add basic slug × 4 locale paths — canton-aware where possible,
+      //    falling back to legacy Ticino-only shape for unresolvable slugs.
+      const inferred = buildOrphanLocalePaths(
+        { slug: o.slug, path: o.path },
+        { cityIndex, pathHints: trackingData[o.slug] },
+      );
+      const basicPaths = [inferred.it, inferred.en, inferred.de, inferred.fr];
       for (const p of basicPaths) {
         if (!existingCompatPaths.has(p)) {
           existingCompatPaths.add(p);
@@ -1263,6 +1275,7 @@ async function main() {
   if (!DRY_RUN) {
     const trackingFile = dataPath('all-known-job-slugs.json');
     const tracking = readJsonSafe(trackingFile) || {};
+    const cityIndex = buildCityCantonIndex();
 
     // Build reverse index: slug-in-any-locale-path → tracking key
     const slugToKey = new Map();
@@ -1300,30 +1313,38 @@ async function main() {
       }
 
       if (existingKey) {
-        // Slug already tracked under a different key — ensure all 4 locales exist
+        // Slug already tracked under a different key — ensure all 4 locales exist.
+        // Re-derive the canton from the existing entry's own paths (the tracked
+        // entry usually already encodes the canonical canton) so backfills land
+        // under the right section instead of defaulting to Ticino.
         const entry = tracking[existingKey];
+        const inferred = buildOrphanLocalePaths(
+          { slug: existingKey, path: o.path },
+          { cityIndex, pathHints: entry },
+        );
         let patched = false;
-        if (!entry.it) { entry.it = `/cerca-lavoro-ticino/${existingKey}`; patched = true; }
-        if (!entry.en) { entry.en = `/en/find-jobs-ticino/${existingKey}`; patched = true; }
-        if (!entry.de) { entry.de = `/de/jobs-im-tessin/${existingKey}`; patched = true; }
-        if (!entry.fr) { entry.fr = `/fr/trouver-emploi-tessin/${existingKey}`; patched = true; }
+        for (const loc of ['it', 'en', 'de', 'fr']) {
+          if (!entry[loc]) { entry[loc] = inferred[loc]; patched = true; }
+        }
         if (patched) trackingPatched++;
       } else if (!tracking[o.slug]) {
-        // New slug — add to tracking
-        tracking[o.slug] = {
-          it: `/cerca-lavoro-ticino/${o.slug}`,
-          en: `/en/find-jobs-ticino/${o.slug}`,
-          de: `/de/jobs-im-tessin/${o.slug}`,
-          fr: `/fr/trouver-emploi-tessin/${o.slug}`,
-        };
+        // New slug — add to tracking with canton-aware paths.
+        tracking[o.slug] = buildOrphanLocalePaths(
+          { slug: o.slug, path: o.path },
+          { cityIndex },
+        );
         trackingAdded++;
       } else {
-        // Already tracked under this key — ensure all 4 locales exist
+        // Already tracked under this key — ensure all 4 locales exist, using
+        // existing locale paths as hints for canton inference.
         const entry = tracking[o.slug];
-        if (!entry.it) entry.it = `/cerca-lavoro-ticino/${o.slug}`;
-        if (!entry.en) entry.en = `/en/find-jobs-ticino/${o.slug}`;
-        if (!entry.de) entry.de = `/de/jobs-im-tessin/${o.slug}`;
-        if (!entry.fr) entry.fr = `/fr/trouver-emploi-tessin/${o.slug}`;
+        const inferred = buildOrphanLocalePaths(
+          { slug: o.slug, path: o.path },
+          { cityIndex, pathHints: entry },
+        );
+        for (const loc of ['it', 'en', 'de', 'fr']) {
+          if (!entry[loc]) entry[loc] = inferred[loc];
+        }
       }
     }
     if (trackingAdded > 0 || trackingPatched > 0) {

--- a/tests/orphan-canton-paths.test.ts
+++ b/tests/orphan-canton-paths.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOrphanLocalePaths,
+  buildDefaultTiPaths,
+  inferCantonFromPath,
+  inferCantonFromSlug,
+  buildCityCantonIndex,
+} from '../scripts/lib/orphan-canton-paths.mjs';
+
+describe('orphan-canton-paths — inferCantonFromPath', () => {
+  it('reverse-resolves the EN graubunden segment', () => {
+    expect(inferCantonFromPath('/en/find-jobs-graubunden/foo/')).toBe('GR');
+  });
+
+  it('reverse-resolves the DE tessin segment', () => {
+    expect(inferCantonFromPath('/de/jobs-im-tessin/foo/')).toBe('TI');
+  });
+
+  it('reverse-resolves the IT grigioni segment (no locale prefix)', () => {
+    expect(inferCantonFromPath('/cerca-lavoro-grigioni/foo/')).toBe('GR');
+  });
+
+  it('returns null when the path does not match the job-board shape', () => {
+    expect(inferCantonFromPath('/blog/some-article/')).toBeNull();
+    expect(inferCantonFromPath('')).toBeNull();
+    expect(inferCantonFromPath(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe('orphan-canton-paths — inferCantonFromSlug', () => {
+  const cityIndex = buildCityCantonIndex();
+
+  it('resolves Chur → GR via the trailing city token', () => {
+    expect(inferCantonFromSlug('product-manager-80-100-ferrovia-retica-rhb-chur', cityIndex)).toBe('GR');
+  });
+
+  it('resolves Lugano → TI', () => {
+    expect(inferCantonFromSlug('software-engineer-acme-lugano', cityIndex)).toBe('TI');
+  });
+
+  it('strips the 6-hex disambiguator tail before looking up the city', () => {
+    expect(
+      inferCantonFromSlug('product-manager-ferrovia-retica-rhb-chur-abc123', cityIndex),
+    ).toBe('GR');
+  });
+
+  it('returns null when the trailing token is not a known city', () => {
+    expect(inferCantonFromSlug('blah-blah-noplaceknown', cityIndex)).toBeNull();
+  });
+});
+
+describe('orphan-canton-paths — buildOrphanLocalePaths', () => {
+  // Regression: the RhB Chur 404 surfaced by the user lives here. The orphan
+  // slug is `product-manager-80-100-ferrovia-retica-rhb-chur`; pre-fix all 4
+  // localised fallbacks pointed at Ticino, while Google indexed the GR EN
+  // URL. The new builder MUST emit the GR EN URL so the soft-landing covers
+  // the path Google actually crawls.
+  it('builds canton-aware paths for a Chur orphan (the user-reported 404)', () => {
+    const paths = buildOrphanLocalePaths({
+      slug: 'product-manager-80-100-ferrovia-retica-rhb-chur',
+      path: '/en/find-jobs-graubunden/product-manager-80-100-ferrovia-retica-rhb-chur/',
+    });
+    expect(paths).toEqual({
+      it: '/cerca-lavoro-grigioni/product-manager-80-100-ferrovia-retica-rhb-chur',
+      en: '/en/find-jobs-graubunden/product-manager-80-100-ferrovia-retica-rhb-chur',
+      de: '/de/jobs-im-graubunden/product-manager-80-100-ferrovia-retica-rhb-chur',
+      fr: '/fr/trouver-emploi-grisons/product-manager-80-100-ferrovia-retica-rhb-chur',
+    });
+  });
+
+  it('prefers the GSC-reported path over the slug heuristic when both exist', () => {
+    // Slug suffix "chur" → GR; path says "/de/jobs-im-tessin/..." → TI.
+    // The GSC-reported path wins because it's what Google actually crawled.
+    const paths = buildOrphanLocalePaths({
+      slug: 'fake-chur',
+      path: '/de/jobs-im-tessin/fake-chur/',
+    });
+    expect(paths.en).toBe('/en/find-jobs-ticino/fake-chur');
+  });
+
+  it('falls back to Ticino when neither path nor slug resolves a canton', () => {
+    const paths = buildOrphanLocalePaths({ slug: 'random-noplace-xyz' });
+    expect(paths).toEqual(buildDefaultTiPaths('random-noplace-xyz'));
+  });
+
+  it('honours pathHints to recover canton from an already-tracked entry', () => {
+    const paths = buildOrphanLocalePaths(
+      { slug: 'unknown-city-job' },
+      {
+        pathHints: {
+          it: '/cerca-lavoro-grigioni/unknown-city-job',
+          en: '/en/find-jobs-graubunden/unknown-city-job',
+        },
+      },
+    );
+    expect(paths.en).toBe('/en/find-jobs-graubunden/unknown-city-job');
+  });
+
+  it('returns null when no slug is supplied', () => {
+    // Defensive: callers in sync-gsc-orphans.mjs guard on this.
+    expect(buildOrphanLocalePaths({ slug: '' })).toBeNull();
+  });
+});

--- a/tests/regenerate-slugs-helpers.test.ts
+++ b/tests/regenerate-slugs-helpers.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  slugMatchesTitle,
+  isLikelyUntranslated,
+  buildSlug,
+  slugify,
+} from '../scripts/lib/regenerate-slugs-helpers.mjs';
+
+describe('regenerate-slugs-helpers — slugMatchesTitle', () => {
+  // Regression: the original Jaccard threshold (0.5 on whole-slug overlap)
+  // false-positived when company+location+percentage shared enough tokens to
+  // dominate the score. RhB Chur surfaced this — the DE-derived slug was
+  // treated as "already matching" the EN title, blocking translated EN slug
+  // regeneration and 404-ing the EN URL.
+  it('returns false when the DE-derived slug shares only structural tokens with the EN title', () => {
+    const slug = 'produktmanager-in-sortiment-und-preis-80-100-ferrovia-retica-rhb-chur';
+    const title = 'Product Manager (80-100%)';
+    expect(slugMatchesTitle(slug, title, 'Ferrovia Retica (RhB)', 'Chur')).toBe(false);
+  });
+
+  it('returns true when the slug encodes the locale title + the same company/location', () => {
+    const slug = 'product-manager-80-100-ferrovia-retica-rhb-chur';
+    const title = 'Product Manager (80-100%)';
+    expect(slugMatchesTitle(slug, title, 'Ferrovia Retica (RhB)', 'Chur')).toBe(true);
+  });
+
+  it('returns true when the slug carries a stable disambiguator tail', () => {
+    const slug = 'product-manager-80-100-ferrovia-retica-rhb-chur-abc123';
+    const title = 'Product Manager (80-100%)';
+    expect(
+      slugMatchesTitle(slug, title, 'Ferrovia Retica (RhB)', 'Chur', 'abc123'),
+    ).toBe(true);
+  });
+
+  it('returns false on title-portion divergence even when 6 noise tokens overlap', () => {
+    // Engineer slug under same company/location/percentage — engineer ≠ manager
+    const slug = 'engineer-80-100-ferrovia-retica-rhb-chur';
+    const title = 'Product Manager (80-100%)';
+    expect(slugMatchesTitle(slug, title, 'Ferrovia Retica (RhB)', 'Chur')).toBe(false);
+  });
+
+  it('returns false for empty slug or title', () => {
+    expect(slugMatchesTitle('', 'Product Manager', 'Acme', 'Lugano')).toBe(false);
+    expect(slugMatchesTitle('product-manager', '', 'Acme', 'Lugano')).toBe(false);
+  });
+
+  it('returns true when both sides reduce to no title tokens after noise subtraction', () => {
+    // Pathological: title is only company+location words. Both reduce to empty
+    // → treat as a degenerate match (cannot meaningfully disagree).
+    expect(slugMatchesTitle('acme-lugano', 'Acme', 'Acme', 'Lugano')).toBe(true);
+  });
+});
+
+describe('regenerate-slugs-helpers — isLikelyUntranslated', () => {
+  it('flags an EN title that is byte-identical to the DE source', () => {
+    expect(isLikelyUntranslated('Software Engineer', 'Software Engineer')).toBe(true);
+  });
+
+  it('flags a partial translation that only swapped one word (Jaccard > 0.5)', () => {
+    // 4-token strings sharing 3 tokens → 3/5 = 0.6 > 0.5 → flagged.
+    expect(
+      isLikelyUntranslated(
+        'Software Ingenieur Permanent Zurich',
+        'Software Engineer Permanent Zurich',
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT flag a properly translated short title vs a longer source', () => {
+    expect(
+      isLikelyUntranslated('Product Manager (80-100%)', 'Produktmanager/in Sortiment und Preis (80-100%)'),
+    ).toBe(false);
+  });
+
+  it('returns false for empty inputs', () => {
+    expect(isLikelyUntranslated('', 'foo')).toBe(false);
+    expect(isLikelyUntranslated('foo', '')).toBe(false);
+  });
+});
+
+describe('regenerate-slugs-helpers — buildSlug + slugify', () => {
+  it('strips diacritics and lowercases', () => {
+    expect(slugify('Zürich')).toBe('zurich');
+    expect(slugify('Genève')).toBe('geneve');
+  });
+
+  it('joins title + company + location into a kebab slug', () => {
+    expect(buildSlug('Product Manager (80-100%)', 'Ferrovia Retica (RhB)', 'Chur')).toBe(
+      'product-manager-80-100-ferrovia-retica-rhb-chur',
+    );
+  });
+
+  it('appends a disambiguator tail without exceeding MAX_SLUG_LENGTH', () => {
+    const slug = buildSlug('Product Manager', 'Acme', 'Lugano', 'abc123');
+    expect(slug.endsWith('-abc123')).toBe(true);
+  });
+});


### PR DESCRIPTION
Two intertwined bugs combined to 404 indexed job URLs whose canonical canton
is non-Ticino. Surfaced by
/en/find-jobs-graubunden/product-manager-80-100-ferrovia-retica-rhb-chur/.

1) regenerate-slugs-by-locale.mjs:slugMatchesTitle
   Whole-slug Jaccard ≥0.5 false-positived when company+location+percentage
   shared enough tokens to dominate the score. Per-locale slug regen
   incorrectly concluded the DE-derived slug already matched the EN title
   and skipped translation. Result: slugByLocale.en stayed in DE form,
   previousSlugsByLocale stayed null, no bridge page emitted, the
   translated EN URL 404'd. Extracted helpers into
   scripts/lib/regenerate-slugs-helpers.mjs and rewrote the matcher to
   subtract company/location/disambiguator tokens before scoring — same
   Jaccard threshold, applied to title-only overlap.

2) sync-gsc-orphans.mjs orphan locale-path generation
   Hardcoded `/cerca-lavoro-ticino/...` (+ EN/DE/FR Ticino equivalents) for
   every orphan, regardless of where Google actually crawled the URL. A
   Chur/GR slug got registered under Ticino paths, so the soft-landing
   covered the wrong canton and Google's real graubunden URL had no page
   to land on. New scripts/lib/orphan-canton-paths.mjs reverse-resolves the
   canton from the GSC-reported path (canton-url-slugs.mjs), then from the
   slug's trailing city token (canton-municipalities.json), then from any
   already-tracked sibling path — and only falls back to Ticino when none
   of the three resolves confidently.

Regression tests cover the user-reported RhB Chur case end-to-end plus the
matcher's noise-token subtraction; full slug/canton/orphan suite (129 tests)
stays green.
