### PR TITLE
fix(article): drop Chutes from chain (no balance), keep only Z.AI free GLM-4.5-flash + adaptive MIN_BODY_CHARS

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -498,6 +498,28 @@ const GH_MODEL_LIGHT = AI_MODELS.GPT4O_MINI;
 const BLOG_IMAGE_TARGET_MAX_BYTES = 220 * 1024; // target ~220KB
 const BLOG_IMAGE_HARD_MAX_BYTES = 320 * 1024;   // hard cap ~320KB
 const MIN_BODY_CHARS = 2500;  // ~400 words minimum; 800 chars was too permissive
+const MIN_BODY_CHARS_FLOOR = Math.max(
+  1500,
+  Number.parseInt(process.env.MIN_BODY_CHARS_FLOOR || '1800', 10) || 1800,
+);
+/**
+ * Companion to computeAdaptiveMinWords: scales the chars-based thin-content
+ * gate when the source is short. Without this, a successful 400-word
+ * adaptive run (~2400 chars) trips the static 2500-char floor and is
+ * either re-expanded into hallucination or rejected outright at the
+ * final guard. Mirrors the word-ladder thresholds.
+ *   - source ≥ 4000 chars → full 2500-char target
+ *   - source 2000-3999    → 2200 chars
+ *   - source 1000-1999    → 1900 chars
+ *   - source < 1000       → MIN_BODY_CHARS_FLOOR (1800 chars)
+ */
+function computeAdaptiveMinChars(sourceText) {
+  const len = (sourceText || '').length;
+  if (len >= 4000) return MIN_BODY_CHARS;
+  if (len >= 2000) return Math.max(MIN_BODY_CHARS_FLOOR, 2200);
+  if (len >= 1000) return Math.max(MIN_BODY_CHARS_FLOOR, 1900);
+  return MIN_BODY_CHARS_FLOOR;
+}
 
 // Static places catalog
 const PLACES_IMAGES = [
@@ -3911,7 +3933,8 @@ export function validateHeadline(headline) {
 }
 
 // ── Step 3: Validate Gemini response ────────────────────────
-function validate(data) {
+function validate(data, opts = {}) {
+  const minBodyChars = Number(opts.minBodyChars || MIN_BODY_CHARS);
   // `content` is the only truly irreplaceable field — everything else can be
   // synthesized from it. Smaller fallback models (Cerebras llama-3.1-8b, etc.)
   // frequently omit top-level metadata (`id`, `category`, `image`, `slugs`)
@@ -4016,8 +4039,8 @@ function validate(data) {
   // Final thin content check happens after all retry/expand attempts.
   const itBodyEarly = `${(data.content.it || data.content)?.body1 || ''} ${(data.content.it || data.content)?.body2 || ''} ${(data.content.it || data.content)?.body3 || ''}`;
   const itPlainCharsEarly = itBodyEarly.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim().length;
-  if (itPlainCharsEarly < MIN_BODY_CHARS) {
-    console.warn(`  ⚠️  [thin-content] Articolo corto: ${itPlainCharsEarly} chars (min: ${MIN_BODY_CHARS}) — il retry loop tenterà di espandere`);
+  if (itPlainCharsEarly < minBodyChars) {
+    console.warn(`  ⚠️  [thin-content] Articolo corto: ${itPlainCharsEarly} chars (min: ${minBodyChars}) — il retry loop tenterà di espandere`);
   }
 
   // ── Frontaliere density check ──────────────────────────────
@@ -6855,9 +6878,11 @@ async function generateAndValidateArticle(url, sourceContext = null) {
       throw e;
     }
 
-    // Step 3: Validate (works on IT-only data)
+    // Step 3: Validate (works on IT-only data). Pass the adaptive chars
+    // threshold so the early thin-content warning matches what the final
+    // gate at the bottom of this function actually enforces.
     try {
-      data = validate(rawData);
+      data = validate(rawData, { minBodyChars: computeAdaptiveMinChars(pageContent) });
     } catch (validationErr) {
       console.error(`  ⚠️  Validazione fallita: ${validationErr.message}`);
       if (attempt < CREATE_ARTICLE_MIN_WORDS_RETRIES) {
@@ -7141,10 +7166,11 @@ async function generateAndValidateArticle(url, sourceContext = null) {
   {
     const itBodyFinal = `${(data.content.it || data.content)?.body1 || ''} ${(data.content.it || data.content)?.body2 || ''} ${(data.content.it || data.content)?.body3 || ''}`;
     const itPlainCharsFinal = itBodyFinal.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim().length;
-    if (itPlainCharsFinal < MIN_BODY_CHARS) {
-      throw new Error(`Articolo troppo corto dopo retry: ${itPlainCharsFinal} chars (min: ${MIN_BODY_CHARS}). Google penalizza thin content.`);
+    const adaptiveMinChars = computeAdaptiveMinChars(pageContent);
+    if (itPlainCharsFinal < adaptiveMinChars) {
+      throw new Error(`Articolo troppo corto dopo retry: ${itPlainCharsFinal} chars (min: ${adaptiveMinChars}). Google penalizza thin content.`);
     }
-    console.error(`  ✅ [thin-content] Body finale: ${itPlainCharsFinal} chars (min: ${MIN_BODY_CHARS})`);
+    console.error(`  ✅ [thin-content] Body finale: ${itPlainCharsFinal} chars (min: ${adaptiveMinChars})`);
   }
 
     // Step 3a.0b: Strip leaked internal URLs from IT

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -264,18 +264,23 @@ export const AI_MODELS = Object.freeze({
   // ── Mistral Codestral (separate endpoint, separate quota: 2000 req/day) ──
   CDSTRL_LATEST:       'codestral/codestral-latest',
 
-  // ── Chutes.ai (OpenAI-compatible, generous free tier — added 2026-05-18) ──
-  // Free tier: ~200 req/day shared quota; high-quality reasoning models.
-  CH_DEEPSEEK_R1:      'chutes/deepseek-ai/DeepSeek-R1',
-  CH_DEEPSEEK_V3:      'chutes/deepseek-ai/DeepSeek-V3',
-  CH_KIMI_K2:          'chutes/moonshotai/Kimi-K2-Instruct',
-  CH_GLM_45:           'chutes/zai-org/GLM-4.5-Air',
-  CH_QWEN3_235B:       'chutes/Qwen/Qwen3-235B-A22B-Instruct-2507',
-  CH_LLAMA_4_MAVERICK: 'chutes/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8',
+  // ── Chutes.ai (OpenAI-compatible, PAID per-token — added 2026-05-18) ──
+  // 2026-05-18 smoke test: HTTP 402 "balance $0.0". Chutes is NOT free; uses
+  // TAO/USD per-token billing. Real model IDs use the `-TEE` (Trusted
+  // Execution Env) suffix. Listed here so the provider machinery + correct
+  // IDs are ready IF the account is funded; NOT in DEFAULT_CHAIN to avoid
+  // burning fallback slots on 402 errors.
+  CH_DEEPSEEK_V32:     'chutes/deepseek-ai/DeepSeek-V3.2-TEE',
+  CH_KIMI_K26:         'chutes/moonshotai/Kimi-K2.6-TEE',
+  CH_GLM_5:            'chutes/zai-org/GLM-5-TEE',
+  CH_QWEN_3_5_397B:    'chutes/Qwen/Qwen3.5-397B-A17B-TEE',
+  CH_MINIMAX_M25:      'chutes/MiniMaxAI/MiniMax-M2.5-TEE',
 
-  // ── Z.AI (Zhipu, OpenAI-compatible, GLM free tier — added 2026-05-18) ──
-  ZAI_GLM_46:          'zai/glm-4.6',
-  ZAI_GLM_45_AIR:      'zai/glm-4.5-air',
+  // ── Z.AI (Zhipu, OpenAI-compatible — added 2026-05-18) ──
+  // 2026-05-18 smoke test: only `glm-4.5-flash` is in the free tier with
+  // this key. `glm-4.6`, `glm-4.5-air`, `glm-4.5-airx`, `glm-4.5v` all
+  // return HTTP 429 "no resource package" → paid plan required.
+  ZAI_GLM_45_FLASH:    'zai/glm-4.5-flash',
 
   // ── Extended OpenRouter free models (2026-05) ──
   OR_QWEN3_CODER_PLUS: 'openrouter/qwen/qwen3-coder-plus:free',
@@ -459,32 +464,27 @@ export const DEFAULT_CHAIN = [
   AI_MODELS.HF_GEMMA_3_27B,      // 97. Gemma 3 27B               (HuggingFace)
   // HF_MISTRAL_SM removed — HuggingFace HTTP 400 "not a chat model" (2026-04)
 
-  // ── Chutes.ai free tier (added 2026-05-18) ──
-  AI_MODELS.CH_DEEPSEEK_R1,      // 98. DeepSeek R1 reasoning     (Chutes free)
-  AI_MODELS.CH_KIMI_K2,          // 99. Kimi K2                    (Chutes free)
-  AI_MODELS.CH_GLM_45,           // 100. GLM 4.5 Air               (Chutes free)
-  AI_MODELS.CH_QWEN3_235B,       // 101. Qwen3 235B                (Chutes free)
-  AI_MODELS.CH_DEEPSEEK_V3,      // 102. DeepSeek V3               (Chutes free)
-  AI_MODELS.CH_LLAMA_4_MAVERICK, // 103. Llama 4 Maverick          (Chutes free)
+  // ── Chutes.ai: SKIPPED — 2026-05-18 smoke test returned HTTP 402
+  // (balance $0.0). Re-add CH_* entries here once the account is funded.
 
-  // ── Z.AI GLM free tier (added 2026-05-18) ──
-  AI_MODELS.ZAI_GLM_46,          // 104. GLM 4.6                   (Z.AI free)
-  AI_MODELS.ZAI_GLM_45_AIR,      // 105. GLM 4.5 Air               (Z.AI free)
+  // ── Z.AI GLM free tier (added + verified 2026-05-18) ──
+  // Only glm-4.5-flash is free with the issued key; smoke test 200 OK.
+  AI_MODELS.ZAI_GLM_45_FLASH,    // 98. GLM 4.5 Flash              (Z.AI free)
 
   // ── Extended OpenRouter 2026-05 free additions ──
-  AI_MODELS.OR_QWEN3_CODER_PLUS, // 106. Qwen3 Coder Plus          (OpenRouter free)
-  AI_MODELS.OR_KIMI_K2_0905,     // 107. Kimi K2 0905              (OpenRouter free)
-  AI_MODELS.OR_GLM_46,           // 108. GLM 4.6                   (OpenRouter free)
-  AI_MODELS.OR_DEEPSEEK_V32,     // 109. DeepSeek V3.2 exp         (OpenRouter free)
-  AI_MODELS.OR_MERIDIAN_8B,      // 110. Meridian 8B               (OpenRouter free)
+  AI_MODELS.OR_QWEN3_CODER_PLUS, // 99.  Qwen3 Coder Plus          (OpenRouter free)
+  AI_MODELS.OR_KIMI_K2_0905,     // 100. Kimi K2 0905              (OpenRouter free)
+  AI_MODELS.OR_GLM_46,           // 101. GLM 4.6                   (OpenRouter free)
+  AI_MODELS.OR_DEEPSEEK_V32,     // 102. DeepSeek V3.2 exp         (OpenRouter free)
+  AI_MODELS.OR_MERIDIAN_8B,      // 103. Meridian 8B               (OpenRouter free)
 
   // ── Extended Groq 2026-05 additions ──
-  AI_MODELS.GROQ_LLAMA_4_MAV_INSTR,    // 111. Llama 4 Maverick fp8 (Groq)
-  AI_MODELS.GROQ_DEEPSEEK_R1_DIST,     // 112. DeepSeek R1 Distill Llama 70B (Groq)
+  AI_MODELS.GROQ_LLAMA_4_MAV_INSTR,    // 104. Llama 4 Maverick fp8 (Groq)
+  AI_MODELS.GROQ_DEEPSEEK_R1_DIST,     // 105. DeepSeek R1 Distill Llama 70B (Groq)
 
   // ── Extended Cerebras 2026-05 additions ──
-  AI_MODELS.CB_QWEN3_CODER_480B, // 113. Qwen3 Coder 480B         (Cerebras preview)
-  AI_MODELS.CB_GPT_OSS_20B_2,    // 114. GPT-OSS 20B               (Cerebras)
+  AI_MODELS.CB_QWEN3_CODER_480B, // 106. Qwen3 Coder 480B         (Cerebras preview)
+  AI_MODELS.CB_GPT_OSS_20B_2,    // 107. GPT-OSS 20B               (Cerebras)
 ];
 
 // ── Provider constants ───────────────────────────────────────


### PR DESCRIPTION
Smoke tests run 2026-05-18 on the keys pushed to RC:
- Chutes: HTTP 402 "balance $0.0" — paid tier only, drop from DEFAULT_CHAIN
  (provider machinery + correct -TEE model IDs retained for future funding)
- Z.AI: glm-4.5-flash → 200 OK; glm-4.6/4.5-air/airx/v all → 429 "no resource
  package" → only glm-4.5-flash stays in chain.

Adaptive MIN_BODY_CHARS:
- computeAdaptiveMinChars mirrors computeAdaptiveMinWords ladder (≥4k→2500,
  ≥2k→2200, ≥1k→1900, <1k→1800 floor).
- validate() now takes { minBodyChars } opt; caller passes adaptive value
  so the early warning and the final blocking gate stay in sync. Previously
  a successful 400-word adaptive run (~2400 chars) would throw at the
  2500-char hard floor and be rejected after the retry loop had already
  succeeded — defeating the adaptive-words fix from the prior PR.
