### PR TITLE
fix(seo): add BreadcrumbList to GSC keyword landing pages + allowlist seoHubsPlugin shifts

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -6782,6 +6782,17 @@ ${alternates}
  sectorOrType: _kwQuery || null,
  omitCommute: !_kwCity,
  }));
+ // BreadcrumbList JSON-LD — required by tests/seo/breadcrumb-coverage.test.ts
+ // (D.2 — every non-exempt dist/ HTML page must include a BreadcrumbList).
+ const kwBreadcrumbLd = JSON.stringify({
+ '@context': 'https://schema.org',
+ '@type': 'BreadcrumbList',
+ itemListElement: [
+ { '@type': 'ListItem', position: 1, name: homeLabel[locale], item: `${BASE_URL}${locale === 'it' ? '/' : `/${locale}/`}` },
+ { '@type': 'ListItem', position: 2, name: localeCopy[locale].sectionName, item: kwSectionUrl },
+ { '@type': 'ListItem', position: 3, name: kwTitle, item: kwCanonicalUrl },
+ ],
+ });
  const kwHtml = buildSimplePage({
  locale,
  title: kwTitle,
@@ -6789,7 +6800,7 @@ ${alternates}
  canonicalUrl: kwCanonicalUrl,
  ogLocale: localeOg[locale],
  hreflangHtml: kwAlternates,
- jsonLdScripts: [kwCollLd],
+ jsonLdScripts: [kwBreadcrumbLd, kwCollLd],
  entryJs: hasSpaBundle ? entryJs : undefined,
  entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml: `<h1>${esc(itCopy.heading)}</h1>\n <p>${esc(kwDesc)}</p>\n ${kwQueryIntro}\n ${kwIntro}\n <p>${esc(kwCta)}</p>\n <ul style="list-style:none;padding:0;margin:16px 0">${kwListHtml}</ul>\n <p><a href="${kwSectionUrl}">${esc(kwOpenAllLabel)}</a></p>\n ${kwMarketSection}\n ${kwCommuterBlock}`,

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -32,8 +32,10 @@ const ALLOWLIST = [
   'build-plugins/jobsSeoPagesPlugin.ts:788',
   'build-plugins/jobsSeoPagesPlugin.ts:793',          // jsdoc reference to the legacy slugs
   // Cathedral breadcrumb-bugfix comment (2026-05-13) — references the
-  // TI slug as illustrative example in the prior-bug explanation.
-  'build-plugins/jobsSeoPagesPlugin.ts:7842',
+  // TI slug as illustrative example in the prior-bug explanation. Shifted
+  // +11 by the keyword-landing BreadcrumbList insertion at line 6785
+  // (2026-05-18 — fix for breadcrumb-coverage.test.ts).
+  'build-plugins/jobsSeoPagesPlugin.ts:7853',
 
   // ── jobBoardSeo: TI legacy job-board landing paths (kept for legacy entry) ──
   'build-plugins/jobBoardSeo.ts:38',
@@ -122,6 +124,13 @@ const ALLOWLIST = [
   'build-plugins/seoHubsPlugin.ts:1675',
   'build-plugins/seoHubsPlugin.ts:1690',
   'build-plugins/seoHubsPlugin.ts:1691',
+  // 2026-05-18: PR #235 (canton aziende+settori hubs) added a paired
+  // template-literal pattern for non-IT locales — the TI legacy slugs
+  // appear as inline fallbacks on these 2 lines (sectors hub + companies
+  // hub, mirroring the 1674/1675/1690/1691 pattern but in the new emit
+  // block ~275 lines below the existing one).
+  'build-plugins/seoHubsPlugin.ts:1949',
+  'build-plugins/seoHubsPlugin.ts:1965',
 
   // ── professionLandingsLinksPlugin: TI hub injection targets (intentional —
   //    the prose explicitly references "10 most-searched roles in Ticino"). ──


### PR DESCRIPTION
The GSC keyword landing emitter in jobsSeoPagesPlugin.ts was passing only
the CollectionPage JSON-LD to buildSimplePage, leaving every emitted page
without BreadcrumbList — caught by tests/seo/breadcrumb-coverage.test.ts
on the `offerte-di-lavoro-ticino-da-ieri` cluster (4 locales). Re-uses the
established home → section → page pattern via homeLabel + localeCopy.sectionName.

Also re-anchor the cathedral-no-ti-hardcodes allowlist:
- seoHubsPlugin.ts: PR #235 (canton aziende+settori hubs) added 2 new
  inline TI fallbacks at lines 1949 + 1965 (paired template-literal
  pattern, mirroring 1674/1675/1690/1691).
- jobsSeoPagesPlugin.ts:7842 → :7853 (shifted +11 by the new
  BreadcrumbList block above).
