### PR TITLE
feat(seo): ItemList JSON-LD on indexes + prose-at-bottom on daily/station/city

### DIFF
--- a/build-plugins/fuelDailyPagesPlugin.ts
+++ b/build-plugins/fuelDailyPagesPlugin.ts
@@ -1833,12 +1833,12 @@ function renderPage(inp: PageInputs): string {
     ${trendTableHtml}
     ${periodAvgNoteHtml}
   </section>
-  <section style="margin:0 0 24px">
-    <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(intro)}</p>
-    <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:860px">${esc(paragraph)}</p>
-  </section>
   ${faqHtml}
   ${renderFuelTodayFrontalierContext({ locale, fuelLabel, zoneLabel, priceFmt, deltaYestFmt, delta7Fmt, isZone: !!zone })}
+  <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.faqTitle)}">
+    <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(intro)}</p>
+    <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(paragraph)}</p>
+  </section>
   ${avg !== null
     ? renderFuelTodayMethodologyAndScenarios({
         locale,
@@ -3183,10 +3183,6 @@ function renderStationPage(opts: {
     <h2 id="stationReview" style="${H2_STYLE};margin:0 0 12px;font-size:20px">${esc(editorialAssessment.heading)}</h2>
     <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:860px">${esc(editorialAssessment.body)}</p>
   </section>
-  <section style="margin:0 0 24px">
-    <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(intro)}</p>
-    <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:860px">${esc(paragraph)}</p>
-  </section>
   <section style="margin:0 0 24px;${CARD_STYLE}" aria-labelledby="stationInfo">
     <h2 id="stationInfo" style="${H2_STYLE};margin:0 0 12px;font-size:20px">${esc(copy.infoHeading)}</h2>
     <dl style="margin:0;display:grid;grid-template-columns:max-content 1fr;column-gap:16px;row-gap:8px;font-size:14px;color:var(--color-body)">
@@ -3218,7 +3214,11 @@ function renderStationPage(opts: {
     )}</p>
   </section>
   ${renderFuelStationFrontalierContext({ locale, brand: ctx.brandDisplay, city: ctx.city, zone: zoneLabel, fuel, fuelLabel, priceFmt, zoneAvgFmt })}
-  <p style="margin:0 0 22px"><a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, ctx.zone)}" style="${LINK_ACCENT_STYLE};font-weight:600">← ${esc(copy.backToZone(zoneLabel))}</a></p>
+  <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.contextHeading)}">
+    <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(intro)}</p>
+    <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(paragraph)}</p>
+  </section>
+  <p style="margin:24px 0 22px"><a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, ctx.zone)}" style="${LINK_ACCENT_STYLE};font-weight:600">← ${esc(copy.backToZone(zoneLabel))}</a></p>
   ${generateRelatedLinksBlock(locale, 'fuel_station', {
     fuelType: fuel,
     fuelZone: ctx.zone,
@@ -3706,10 +3706,6 @@ function renderItalianCityPage(opts: {
     <h2 id="itCityTable" style="${H2_STYLE}">${esc(copy.tableTitle(entry.display))}</h2>
     ${stationListHtml}
   </section>
-  <section style="margin:0 0 24px">
-    <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(intro)}</p>
-    <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:860px">${esc(paragraph)}</p>
-  </section>
   ${historyCard
     ? `<section style="margin:0 0 24px" aria-labelledby="itCityTrend">
         <h2 id="itCityTrend" style="${H2_STYLE}">${esc(IT_TREND_LABEL[locale])}</h2>
@@ -3733,7 +3729,11 @@ function renderItalianCityPage(opts: {
     </ul>
   </section>
   ${renderItalianCityFrontalierExtra({ locale, fuelLabel, cityDisplay: entry.display, nearestZoneLabel, minPriceFmt })}
-  <p style="margin:0 0 22px"><a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, entry.nearestZone)}" style="${LINK_ACCENT_STYLE};font-weight:600">→ ${esc(copy.backLink)} (${esc(nearestZoneLabel)})</a></p>
+  <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.contextHeading)}">
+    <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(intro)}</p>
+    <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(paragraph)}</p>
+  </section>
+  <p style="margin:24px 0 22px"><a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, entry.nearestZone)}" style="${LINK_ACCENT_STYLE};font-weight:600">→ ${esc(copy.backLink)} (${esc(nearestZoneLabel)})</a></p>
   ${generateRelatedLinksBlock(locale, 'fuel_italian_city', {
     fuelType: fuel,
     italianCitySlug: entry.slug,

--- a/build-plugins/fuelStationIndexPages.ts
+++ b/build-plugins/fuelStationIndexPages.ts
@@ -879,6 +879,20 @@ function renderIndexPage(opts: RenderIndexOpts): string {
     ],
   });
 
+  // CollectionPage + mainEntity ItemList — gives Google a structured view
+  // of every station/city the page links to. Position is global (1..N)
+  // across all groups so the list reads top-to-bottom on the rendered page.
+  const flatListItems: Array<{ name: string; href: string }> = [];
+  for (const g of groups) {
+    for (const a of g.anchors) flatListItems.push({ name: a.label, href: a.href });
+  }
+  const itemListElements = flatListItems.map((item, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: item.name,
+    url: `${BASE_URL}${item.href}`,
+  }));
+
   const webPageLd = JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
@@ -892,6 +906,13 @@ function renderIndexPage(opts: RenderIndexOpts): string {
       '@type': 'WebSite',
       url: BASE_URL,
       name: 'Frontaliere Ticino',
+    },
+    mainEntity: {
+      '@type': 'ItemList',
+      name: titles.h1,
+      numberOfItems: itemListElements.length,
+      itemListOrder: 'https://schema.org/ItemListOrderAscending',
+      itemListElement: itemListElements,
     },
   });
 


### PR DESCRIPTION
Two follow-ups to the fuel-page redesign series:

1. **ItemList JSON-LD on fuel-index pages** — augments the existing
   `CollectionPage` JSON-LD with `mainEntity: ItemList` listing every
   station/city the page links to as a `ListItem` (position, name, url).
   Gives Google a structured machine-readable view of the index, which
   can power list-style rich snippets and improves topical clarity.

2. **Prose-at-bottom on the high-traffic daily-fuel pages** — extends
   the CLAUDE.md rule #17 canonical template ("data before prose")
   beyond the indexes to the daily pages users actually land on from
   search:

   - `renderPage` (daily hub `/prezzi-benzina/oggi/…`): the long
     `intro + paragraph` block moved from between trend-chart and FAQ
     to AFTER the frontalier-context section, rendered in its own
     bottom card.
   - `renderStationPage` (per Swiss station): same move — prose now
     sits below the frontalier-context, just before the back-link.
   - `renderItalianCityPage` (per IT border city): same move — prose
     in a bottom card after the frontalier-extra section.
   - `renderItalianStationPage`: already had prose at the bottom; no
     change.

All five renderers already had the other canonical pieces (short
tagline, stat tiles, advice/editorial card, entity-card grid, brand
logos). Pure layout reorder — no copy or behaviour change.

Tests: 63/63 fuel-station tests pass; 483/486 SEO tests pass (3
pre-existing failures in cathedral-no-ti-hardcodes, unrelated).
