### PR TITLE
feat(seo): roll out canonical "prose-at-bottom" template to 5 more landing families

### DIFF
--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -1687,13 +1687,11 @@ function renderLeafPage(inp: LeafInputs): string {
   ${adviceBannerHtml}
   ${currentCardHtml}
   ${webcamHtml}
-  <section style="margin:0 0 24px">
-    <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(paragraph)}</p>
-  </section>
   ${hourlyHtml}
   ${weeklyHtml}
   ${infoHtml}
   ${alternativeRoutesHtml}
+  ${faqHtml}
   ${renderCommuterContextProse(locale, crossingDisplay, region, bestHour, worstHour)}
   ${renderLeafLivePlanningProse(
     locale,
@@ -1704,7 +1702,9 @@ function renderLeafPage(inp: LeafInputs): string {
       .map((s) => BORDER_CROSSING_DISPLAY[s])
       .filter(Boolean),
   )}
-  ${faqHtml}
+  <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.faqTitle ?? 'Contesto')}">
+    <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(paragraph)}</p>
+  </section>
   ${renderDiscoverMore(locale, BORDER_WAIT_DISCOVER_MORE_CTAS[locale])}
   ${generateRelatedLinksBlock(locale, 'border_wait', relatedCtx)}
   <section style="margin-top:32px" aria-label="advertisement">

--- a/build-plugins/jobMarketSnapshotPlugin.ts
+++ b/build-plugins/jobMarketSnapshotPlugin.ts
@@ -1741,13 +1741,13 @@ function renderSnapshotPage(inp: SnapshotPageInputs): string {
     ${topEmployersList}
     ${cityBreakdown}
     ${trendSection}
-    <section style="margin:24px 0 0">
-      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(intro)}</p>
-      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:860px">${esc(paragraph)}</p>
-    </section>
     ${frontalierContextHtml}
     ${methodology}
     ${faqHtml}
+    <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.seriesKicker)}">
+      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(intro)}</p>
+      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(paragraph)}</p>
+    </section>
     ${relatedHtml}
     ${renderDiscoverMore(locale, JOB_MARKET_DISCOVER_MORE_CTAS[locale])}
     ${generateRelatedLinksBlock(locale, 'job_market_snapshot')}
@@ -2017,15 +2017,15 @@ function renderHubPage(inp: HubPageInputs): string {
     ${degradedNote}
     ${heroStatsHtml}
     ${ctaHtml}
-    <section style="margin:0 0 22px">
-      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(copy.hubIntro)}</p>
-      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:860px">${esc(copy.hubParagraph)}</p>
-    </section>
     ${latestWeeksHtml}
     ${archiveHtml}
     ${sectorsHtml}
     ${methodology}
     ${faqHtml}
+    <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.seriesKicker)}">
+      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(copy.hubIntro)}</p>
+      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(copy.hubParagraph)}</p>
+    </section>
     ${relatedHtml}
     ${renderDiscoverMore(locale, JOB_MARKET_DISCOVER_MORE_CTAS[locale])}
     ${generateRelatedLinksBlock(locale, 'job_market_snapshot')}
@@ -2986,16 +2986,16 @@ function renderSectorPage(inp: SectorPageInputs): string {
     </header>
     ${statTiles}
     ${ctaHtml}
-    <section style="margin:0 0 22px">
-      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(copy.intro(sectorLabel, stats.activeJobs))}</p>
-      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(copy.paragraph1(sectorLabel, stats))}</p>
-      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:860px">${esc(copy.paragraph2(sectorLabel))}</p>
-    </section>
     ${topEmployersList}
     ${trendSection}
     ${frontalierContextHtml}
     ${methodology}
     ${faqHtml}
+    <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.kicker)}">
+      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(copy.intro(sectorLabel, stats.activeJobs))}</p>
+      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(copy.paragraph1(sectorLabel, stats))}</p>
+      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(copy.paragraph2(sectorLabel))}</p>
+    </section>
     ${renderDiscoverMore(locale, JOB_MARKET_DISCOVER_MORE_CTAS[locale])}
     ${generateRelatedLinksBlock(locale, 'job_market_snapshot')}
     <section style="margin-top:32px" aria-label="advertisement">

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -2939,13 +2939,13 @@ export function renderWeeklyEmployersPage(inp: WeeklyEmployersPageInputs): strin
     <h2 id="roles" style="${H2_STYLE}">${esc(copy.rolesTitle)}</h2>
     ${rolesHtml}
   </section>
-  <section style="margin:0 0 28px" aria-labelledby="editorial">
-    <h2 id="editorial" style="${H2_STYLE}">${esc(cityDisplay)}</h2>
-    <p style="margin:0 0 10px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(heroSummary)}</p>
-    <p style="margin:0 0 10px;color:var(--color-body);line-height:1.7;max-width:860px">${esc(editorial)}</p>
-    <p style="margin:0;color:var(--color-subtle);line-height:1.7;max-width:860px;font-size:14px">${esc(methodology)}</p>
-  </section>
   ${renderWeeklyEmployersFrontalierContext({ locale, cityDisplay, isRegional, jobsCount, companiesCount })}
+  <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-labelledby="editorial">
+    <h2 id="editorial" style="${H2_STYLE};margin:0 0 12px;font-size:18px">${esc(cityDisplay)}</h2>
+    <p style="margin:0 0 12px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(heroSummary)}</p>
+    <p style="margin:0 0 12px;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px">${esc(editorial)}</p>
+    <p style="margin:0;color:var(--color-subtle);line-height:1.7;max-width:72ch;font-size:14px">${esc(methodology)}</p>
+  </section>
   ${renderCompanyLeavesForCityBlock(locale, city, cityLeaves ?? [])}
   ${renderCityHubsListBlock(locale, city)}
   ${renderWeeklyArchiveListBlock(


### PR DESCRIPTION
Extends the same CLAUDE.md rule #17 layout discipline (data above the
mobile fold, SEO prose at the bottom in its own card) from the fuel
pages to the remaining high-traffic SEO landing families:

- **border-wait** (`renderLeafPage`): single middle prose paragraph
  moved to a bottom card after the live-planning + commuter-context
  prose blocks. Hub + archive renderers were already canonical.

- **weekly-employers** (`renderCityHubPage`): editorial-summary card
  (heroSummary + editorial + methodology) moved from between data
  sections (after roles) to AFTER the frontalier-context block.
  Top-hub + company×city + canton-hub renderers already canonical.

- **job-market-snapshot** (3 renderers): `renderPage`, `renderHubPage`,
  and the per-sector renderer each had a 2-paragraph prose block
  sandwiched between data sections — moved to bottom cards after FAQ.

- **health-premiums** + **orphan-landings**: audit-only — already
  canonical (prose grouped at bottom after data + FAQ).

Pure layout reorder, no copy change, no behaviour change.
Tests: 486/486 SEO suite pass.
