### PR TITLE
feat(seo): final prose-at-bottom pass — career/nursing/profession landings

### DIFF
--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -492,9 +492,6 @@ function renderPage(opts: {
     ${featuredHtml}
     ${employerHtml}
     ${dividerHtml}
-    <section style="margin:0 0 28px">
-      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:62ch;font-size:17px;font-style:italic">${esc(copy.lede)}</p>
-    </section>
     ${sectionsHtml}
     <section style="margin:0 0 28px">
       <h2 style="${H2_STYLE}">${esc(copy.faqTitle)}</h2>
@@ -505,6 +502,9 @@ function renderPage(opts: {
     <section style="display:flex;gap:12px;flex-wrap:wrap;margin:0 0 16px">
       <a href="${esc(jobBoardUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.ctaJobs)}</a>
       <a href="${esc(calculatorUrl)}" style="padding:10px 16px;border-radius:10px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-body);text-decoration:none;font-weight:600">${esc(copy.ctaSimulator)}</a>
+    </section>
+    <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.h1)}">
+      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px;font-style:italic">${esc(copy.lede)}</p>
     </section>`;
 
   const bodyHtml = `<main class="seo-static-content" style="max-width:1100px;margin:0 auto;padding:32px 20px 56px">${body}</main>`;

--- a/build-plugins/nursingLandingsPlugin.ts
+++ b/build-plugins/nursingLandingsPlugin.ts
@@ -421,9 +421,6 @@ function renderPage(opts: {
     ${featuredHtml}
     ${employerGridHtml}
     ${dividerHtml}
-    <section style="margin:0 0 28px">
-      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:62ch;font-size:17px;font-style:italic">${esc(copy.lede)}</p>
-    </section>
     ${sectionsHtml}
     <section style="margin:0 0 28px">
       <h2 style="margin:0 0 12px;font-size:24px;color:var(--color-heading);font-weight:600">${esc(copy.faqTitle)}</h2>
@@ -433,6 +430,9 @@ function renderPage(opts: {
     <section style="display:flex;gap:12px;flex-wrap:wrap;margin:0 0 16px">
       <a href="${esc(ctaJobsUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.ctaJobs)}</a>
       <a href="${esc(calculatorUrl)}" style="padding:12px 18px;border-radius:12px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-body);text-decoration:none;font-weight:700">${esc(copy.ctaSimulator)}</a>
+    </section>
+    <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.h1)}">
+      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px;font-style:italic">${esc(copy.lede)}</p>
     </section>`;
 
   const bodyHtml = `<main style="max-width:1100px;margin:0 auto;padding:32px 20px 56px;color:var(--color-body)">${body}</main>`;

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -504,9 +504,6 @@ function renderPage(opts: {
     ${featuredHtml}
     ${employerGridHtml}
     ${dividerHtml}
-    <section style="margin:0 0 28px">
-      <p style="margin:0 0 14px;color:var(--color-body);line-height:1.7;max-width:62ch;font-size:17px;font-style:italic">${inlineFormat(copy.lede)}</p>
-    </section>
     ${sectionsHtml}
     ${salaryTable}
     ${employersTable}
@@ -519,6 +516,9 @@ function renderPage(opts: {
     <section style="display:flex;gap:12px;flex-wrap:wrap;margin:0 0 16px">
       <a href="${esc(jobBoardUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.ctaJobs)}</a>
       <a href="${esc(calculatorUrl)}" style="padding:10px 16px;border-radius:10px;background:var(--color-surface);border:1px solid var(--color-edge);color:var(--color-body);text-decoration:none;font-weight:600">${esc(copy.ctaSimulator)}</a>
+    </section>
+    <section style="margin:32px 0 0;padding:24px 22px;border-radius:16px;background:var(--color-surface);border:1px solid var(--color-edge)" aria-label="${esc(copy.h1)}">
+      <p style="margin:0;color:var(--color-body);line-height:1.7;max-width:72ch;font-size:15px;font-style:italic">${inlineFormat(copy.lede)}</p>
     </section>`;
 
   const bodyHtml = `<main style="max-width:1100px;margin:0 auto;padding:32px 20px 56px;color:var(--color-body)">${body}</main>`;


### PR DESCRIPTION
Closes the canonical SEO template rollout (CLAUDE.md rule #17) across
the last 3 landing families that had a stray middle prose block:

- **careerLandings**: italic `copy.lede` paragraph moved from between
  `dividerHtml` and `sectionsHtml` to a dedicated bottom card.
- **nursingLandings**: same fix — italic lede now at the bottom.
- **professionLandings**: same fix — italic lede (with inline format
  markers) now at the bottom.

Audit results for the other 6 plugins requested:

- costOfLivingLandings, comparisonsHubPlugin, faqHubPlugin,
  frSalaireNetLandingPlugin, annualReportPlugin — already canonical
  (prose either at bottom, or interleaved with tables as legitimate
  section captions, or TLDR-style quick-answer above the fold).
- cityJobsHub — not a page renderer (constants + helpers only).

Pure layout reorder, no copy or behaviour change.
Tests: 496/496 SEO suite pass (+ 1 new test file vs prior run).
