### PR TITLE
fix(salary-hub): calculator subnav + H1 stripping + slimmer byline + drop 1998 nav

### DIFF
--- a/build-plugins/shared/hubChrome.ts
+++ b/build-plugins/shared/hubChrome.ts
@@ -93,6 +93,15 @@ interface HubSlugs {
   readonly mortgageComparison: string;
   readonly fuelPrices: string;
   readonly healthPremiums: string;
+  // calculator sub-tab slugs (mirror services/router.ts table)
+  readonly calculatorBase: string;
+  readonly calcWhatif: string;
+  readonly calcPayslip: string;
+  readonly calcRal: string;
+  readonly calcBonus: string;
+  readonly calcParentalLeave: string;
+  readonly calcResidency: string;
+  readonly calcSalaryQuiz: string;
 }
 
 const HUB_SLUGS: Record<HubLocale, HubSlugs> = {
@@ -128,6 +137,14 @@ const HUB_SLUGS: Record<HubLocale, HubSlugs> = {
     mortgageComparison: 'confronto-mutui',
     fuelPrices: 'prezzi-benzina-confine',
     healthPremiums: 'premi-malattia-comuni',
+    calculatorBase: '',
+    calcWhatif: 'cosa-cambia-se',
+    calcPayslip: 'simula-busta-paga',
+    calcRal: 'confronta-retribuzione-ral',
+    calcBonus: 'stima-bonus-frontaliere',
+    calcParentalLeave: 'verifica-congedo-parentale',
+    calcResidency: 'simula-cambio-residenza',
+    calcSalaryQuiz: 'quanto-guadagneresti-in-svizzera',
   },
   en: {
     calcolatore: 'calculate-salary',
@@ -161,6 +178,14 @@ const HUB_SLUGS: Record<HubLocale, HubSlugs> = {
     mortgageComparison: 'mortgage-comparison',
     fuelPrices: 'border-fuel-prices',
     healthPremiums: 'health-insurance-premiums-by-commune',
+    calculatorBase: '',
+    calcWhatif: 'what-if-scenarios',
+    calcPayslip: 'estimate-payslip',
+    calcRal: 'compare-gross-salary',
+    calcBonus: 'simulate-bonus',
+    calcParentalLeave: 'estimate-parental-leave',
+    calcResidency: 'simulate-residency-change',
+    calcSalaryQuiz: 'how-much-would-you-earn-in-switzerland',
   },
   de: {
     calcolatore: 'gehalt-berechnen',
@@ -194,6 +219,14 @@ const HUB_SLUGS: Record<HubLocale, HubSlugs> = {
     mortgageComparison: 'hypotheken-vergleich',
     fuelPrices: 'spritpreise-grenze',
     healthPremiums: 'krankenkassentraemien-nach-gemeinde',
+    calculatorBase: '',
+    calcWhatif: 'was-waere-wenn',
+    calcPayslip: 'lohnabrechnung-simulieren',
+    calcRal: 'bruttogehalt-vergleichen',
+    calcBonus: 'bonus-simulieren',
+    calcParentalLeave: 'elternzeit-simulieren',
+    calcResidency: 'wohnsitzwechsel-simulieren',
+    calcSalaryQuiz: 'verdienst-in-der-schweiz',
   },
   fr: {
     calcolatore: 'calculer-salaire',
@@ -227,6 +260,14 @@ const HUB_SLUGS: Record<HubLocale, HubSlugs> = {
     mortgageComparison: 'comparaison-hypotheques',
     fuelPrices: 'prix-essence-frontiere',
     healthPremiums: 'primes-assurance-maladie-communes',
+    calculatorBase: '',
+    calcWhatif: 'scenarios-hypothetiques',
+    calcPayslip: 'simuler-fiche-de-paie',
+    calcRal: 'comparer-salaire-brut',
+    calcBonus: 'estimer-bonus',
+    calcParentalLeave: 'simuler-conge-parental',
+    calcResidency: 'simuler-changement-residence',
+    calcSalaryQuiz: 'combien-gagneriez-vous-en-suisse',
   },
 };
 
@@ -260,6 +301,15 @@ interface HubLabels {
   readonly unemploymentStats: string;
   readonly mortgageComparison: string;
   readonly fuelPrices: string;
+  // calculator
+  readonly calculatorBase: string;
+  readonly calcWhatif: string;
+  readonly calcPayslip: string;
+  readonly calcRal: string;
+  readonly calcBonus: string;
+  readonly calcParentalLeave: string;
+  readonly calcResidency: string;
+  readonly calcSalaryQuiz: string;
 }
 
 const HUB_LABELS: Record<HubLocale, HubLabels> = {
@@ -288,6 +338,14 @@ const HUB_LABELS: Record<HubLocale, HubLabels> = {
     unemploymentStats: 'Disoccupazione',
     mortgageComparison: 'Mutui',
     fuelPrices: 'Carburanti',
+    calculatorBase: 'Calcolatore',
+    calcWhatif: 'Cosa cambia se',
+    calcPayslip: 'Busta Paga',
+    calcRal: 'RAL Netta',
+    calcBonus: 'Calcolo Bonus',
+    calcParentalLeave: 'Congedo Genitoriale',
+    calcResidency: 'Cambio Residenza',
+    calcSalaryQuiz: 'Quiz Stipendio',
   },
   en: {
     exchange: 'Currency Exchange',
@@ -314,6 +372,14 @@ const HUB_LABELS: Record<HubLocale, HubLabels> = {
     unemploymentStats: 'Unemployment',
     mortgageComparison: 'Mortgages',
     fuelPrices: 'Fuel prices',
+    calculatorBase: 'Calculator',
+    calcWhatif: 'What if',
+    calcPayslip: 'Payslip',
+    calcRal: 'Net Salary',
+    calcBonus: 'Bonus Calc',
+    calcParentalLeave: 'Parental Leave',
+    calcResidency: 'Move Simulator',
+    calcSalaryQuiz: 'Salary Quiz',
   },
   de: {
     exchange: 'Währungstausch',
@@ -340,6 +406,14 @@ const HUB_LABELS: Record<HubLocale, HubLabels> = {
     unemploymentStats: 'Arbeitslosigkeit',
     mortgageComparison: 'Hypotheken',
     fuelPrices: 'Spritpreise',
+    calculatorBase: 'Rechner',
+    calcWhatif: 'Was wäre wenn',
+    calcPayslip: 'Lohnabrechnung',
+    calcRal: 'Nettogehalt',
+    calcBonus: 'Bonus-Rechner',
+    calcParentalLeave: 'Elternzeit',
+    calcResidency: 'Umzugssimulator',
+    calcSalaryQuiz: 'Gehaltsquiz',
   },
   fr: {
     exchange: 'Change Devise',
@@ -366,6 +440,14 @@ const HUB_LABELS: Record<HubLocale, HubLabels> = {
     unemploymentStats: 'Chômage',
     mortgageComparison: 'Hypothèques',
     fuelPrices: 'Carburants',
+    calculatorBase: 'Calculateur',
+    calcWhatif: 'Et si',
+    calcPayslip: 'Fiche de paie',
+    calcRal: 'Salaire Net',
+    calcBonus: 'Calcul Bonus',
+    calcParentalLeave: 'Congé Parental',
+    calcResidency: 'Simulateur Déménagement',
+    calcSalaryQuiz: 'Quiz Salaire',
   },
 };
 
@@ -404,6 +486,15 @@ const ICON_SVG: Record<string, string> = {
   unemploymentStats: '<line x1="3" y1="3" x2="3" y2="21"/><line x1="3" y1="21" x2="21" y2="21"/><rect x="7" y="13" width="3" height="6"/><rect x="13" y="9" width="3" height="10"/><rect x="19" y="5" width="3" height="14"/>',
   mortgageComparison: '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>',
   fuelPrices: '<line x1="3" y1="22" x2="15" y2="22"/><line x1="4" y1="9" x2="14" y2="9"/><path d="M14 22V4a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v18"/><path d="M14 13h2a2 2 0 0 1 2 2v2a2 2 0 0 0 2 2h0a2 2 0 0 0 2-2V9.83a2 2 0 0 0-.59-1.42L18 5"/>',
+  // calculator — mirror App.tsx icon choices (Calculator / Sparkles / FileText / ClipboardList / Gift / Baby / Home / TrendingUp)
+  calculatorBase: '<rect x="4" y="2" width="16" height="20" rx="2"/><line x1="8" y1="6" x2="16" y2="6"/><line x1="16" y1="14" x2="16" y2="18"/><path d="M16 10h.01"/><path d="M12 10h.01"/><path d="M8 10h.01"/><path d="M12 14h.01"/><path d="M8 14h.01"/><path d="M12 18h.01"/><path d="M8 18h.01"/>',
+  calcWhatif: '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/>',
+  calcPayslip: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>',
+  calcRal: '<rect x="8" y="2" width="8" height="4" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11h4"/><path d="M12 16h4"/><path d="M8 11h.01"/><path d="M8 16h.01"/>',
+  calcBonus: '<polyline points="20 12 20 22 4 22 4 12"/><rect x="2" y="7" width="20" height="5"/><line x1="12" y1="22" x2="12" y2="7"/><path d="M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7z"/><path d="M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z"/>',
+  calcParentalLeave: '<path d="M9 12h.01"/><path d="M15 12h.01"/><path d="M10 16c.5.3 1.2.5 2 .5s1.5-.2 2-.5"/><path d="M19 6.3a9 9 0 0 1 1.8 3.9 2 2 0 0 1 0 3.6 9 9 0 0 1-17.6 0 2 2 0 0 1 0-3.6A9 9 0 0 1 12 3c2 0 3.5 1.1 3.5 2.5s-.9 2.5-2 2.5c-.8 0-1.5-.4-1.5-1"/>',
+  calcResidency: '<path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>',
+  calcSalaryQuiz: '<polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/>',
 };
 
 function renderIcon(key: string): string {
@@ -422,7 +513,20 @@ interface SubTabSpec {
 
 /** Maps each SPA hub to its canonical 8 sub-tabs. Mirrors App.tsx lines ~1935-2055. */
 const HUB_SUB_TABS: Record<HubKey, readonly SubTabSpec[]> = {
-  calculator: [],
+  // calculator sub-tabs mirror App.tsx 1957-1973 (SubTabNav for activeTab==='calculator').
+  // The first tab `calculator` is the hub root (`/calcola-stipendio/`) — its slugKey
+  // points at `calculatorBase` which is an empty string, so buildSubTabHref's special-case
+  // (see below) emits just `${prefix}/${hubSlug}/`.
+  calculator: [
+    { key: 'calculator', iconKey: 'calculatorBase', labelKey: 'calculatorBase', slugKey: 'calculatorBase' },
+    { key: 'whatif', iconKey: 'calcWhatif', labelKey: 'calcWhatif', slugKey: 'calcWhatif' },
+    { key: 'payslip', iconKey: 'calcPayslip', labelKey: 'calcPayslip', slugKey: 'calcPayslip' },
+    { key: 'ral', iconKey: 'calcRal', labelKey: 'calcRal', slugKey: 'calcRal' },
+    { key: 'bonus', iconKey: 'calcBonus', labelKey: 'calcBonus', slugKey: 'calcBonus' },
+    { key: 'parental-leave', iconKey: 'calcParentalLeave', labelKey: 'calcParentalLeave', slugKey: 'calcParentalLeave' },
+    { key: 'residency', iconKey: 'calcResidency', labelKey: 'calcResidency', slugKey: 'calcResidency' },
+    { key: 'salary-quiz', iconKey: 'calcSalaryQuiz', labelKey: 'calcSalaryQuiz', slugKey: 'calcSalaryQuiz' },
+  ],
   fisco: [],
   confronti: [
     { key: 'exchange', iconKey: 'exchange', labelKey: 'exchange', slugKey: 'exchange' },
@@ -507,6 +611,11 @@ function buildSubTabHref(hub: HubKey, spec: SubTabSpec, locale: HubLocale): stri
     return `${prefix}/${hubSlug}/`;
   }
   const subSlug = slugs[spec.slugKey];
+  // Calculator base tab is the hub root (no sub-slug) — the SPA's first
+  // calculator sub-tab `key:'calculator'` deep-links to `/calcola-stipendio/`.
+  if (!subSlug) {
+    return `${prefix}/${hubSlug}/`;
+  }
   return `${prefix}/${hubSlug}/${subSlug}/`;
 }
 

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -3862,11 +3862,15 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  // #334155 below) shipped invisible text in dark mode — CLAUDE.md rule 17.
  const dateLine = `<p style="margin:.5rem 0;font-size:.8rem;color:var(--color-subtle)"><time itemprop="datePublished" datetime="${new Date().toISOString().slice(0, 10)}">${dateLabel}: ${formattedDate}</time></p>`;
 
+ // Byline kept tight — schema.org/author + link to /chi-siamo only.
+ // Dropped the "Esperti in fiscalità e previdenza frontaliera" subtitle
+ // (and locale equivalents) that read content-farm-y on every page.
+ // Fix #7.
  const AUTHOR_BYLINE: Record<string, string> = {
- it: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">A cura di <a href="/chi-siamo" rel="author" style="color:var(--color-link);text-decoration:none;">Redazione Frontaliere Ticino</a></span> · Esperti in fiscalità e previdenza frontaliera</p>',
- en: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">By <a href="/en/about-us" rel="author" style="color:var(--color-link);text-decoration:none;">Frontaliere Ticino Editorial Team</a></span> · Cross-border tax &amp; pension specialists</p>',
- de: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">Von <a href="/de/ueber-uns" rel="author" style="color:var(--color-link);text-decoration:none;">Redaktion Frontaliere Ticino</a></span> · Experten für Grenzgänger-Steuern und Vorsorge</p>',
- fr: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">Par <a href="/fr/a-propos" rel="author" style="color:var(--color-link);text-decoration:none;">Rédaction Frontaliere Ticino</a></span> · Spécialistes fiscalité et prévoyance frontalière</p>',
+ it: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">A cura di <a href="/chi-siamo" rel="author" style="color:var(--color-link);text-decoration:none;">Redazione Frontaliere Ticino</a></span></p>',
+ en: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">By <a href="/en/about-us" rel="author" style="color:var(--color-link);text-decoration:none;">Frontaliere Ticino Editorial Team</a></span></p>',
+ de: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">Von <a href="/de/ueber-uns" rel="author" style="color:var(--color-link);text-decoration:none;">Redaktion Frontaliere Ticino</a></span></p>',
+ fr: '<p style="color:var(--color-subtle);font-size:0.85rem;margin:4px 0 16px 0;" itemprop="author" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">Par <a href="/fr/a-propos" rel="author" style="color:var(--color-link);text-decoration:none;">Rédaction Frontaliere Ticino</a></span></p>',
  };
  const authorLine = AUTHOR_BYLINE[locale] ?? AUTHOR_BYLINE.it;
 
@@ -4025,12 +4029,24 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  // BELOW the data area so the meaty content stays above the mobile fold.
  /^\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath)
  ) {
+ // H1 must be a headline, not a SERP title. Strip the `| Simulazione 2026`
+ // and `| Frontaliere Ticino` suffixes that come from seoData.title
+ // fallback when no explicit seoData.h1 is provided. Fix #5.
+ const salaryLandingH1 = h1Text.replace(
+   /\s*\|\s*(Simulazione\s+\d{4}|Frontaliere\s+Ticino).*$/i,
+   '',
+ ).trim() || h1Text;
  rootHtml = buildSalaryLandingBody({
  canonicalPath,
- h1Text,
+ h1Text: salaryLandingH1,
  seoDesc: seoData.desc,
  editorialHtml,
- navHtml,
+ // Suppress the 16-link pipe-separated "site nav" dump for salary-landing
+ // pages: the SPA footer (portalled below #footer-root after PR #243)
+ // already exposes the full sitemap. Fix #8 + #9 — also kills the
+ // duplicated "Approfondimenti correlati" links that appeared both in
+ // the editorial block and in the pipe nav.
+ navHtml: '',
  });
  } else {
  // Default: calculator-like layout


### PR DESCRIPTION
Five UX fixes for /calcola-stipendio/* pages (continuation of PR #243).

Fix #4 — Calculator subnav now ships in the static first paint
  hubChrome.ts: HUB_SUB_TABS.calculator was [] so renderSubTabNav returned
  empty for every salary page. Wired the 8 SPA sub-tabs (calculator,
  whatif, payslip, ral, bonus, parental-leave, residency, salary-quiz)
  with their canonical slugs (4 locales), labels (4 locales), and inline
  SVG icons that mirror the lucide-react choices in App.tsx:1957-1973.
  buildSubTabHref now handles the `calculatorBase` empty-subSlug case so
  the first tab links to the hub root (`/calcola-stipendio/`).

Fix #5 — H1 no longer carries the SERP "| Simulazione 2026" suffix
  staticPagesPlugin.ts:4028: pre-process h1Text inside the
  salaryLandingPath branch to strip `| Simulazione YYYY` and
  `| Frontaliere Ticino` brand suffixes. H1 is a headline, not a title.

Fix #7 — Byline trimmed to author-only
  AUTHOR_BYLINE (4 locales): dropped "Esperti in fiscalità e previdenza
  frontaliera" subtitle that read content-farm-y on every page. Keeps
  itemprop=author + link to /chi-siamo for E-E-A-T.

Fix #8 + #9 — Killed the 16+ link pipe-separated site nav dump
  staticPagesPlugin.ts:4028: pass navHtml:'' to buildSalaryLandingBody
  for salary-landing paths. The 1998-style `<nav aria-label="Sito">`
  with About/Contact/Privacy etc. was redundant noise; the SPA footer
  (now portalled below #footer-root after PR #243) already exposes the
  full sitemap. Also resolves the duplication of contextual cross-links
  that appeared both in the editorial "Approfondimenti correlati" list
  and inside the pipe dump.

Tests: 75/75 build-plugin tests pass; tsc clean. Hub-chrome-parity
Playwright spec will run in CI.

Follow-ups (PR C/D/A): #6 lede engaging, #10 per-hub editorial
diversification, #3 hex migration sweep, #2 consolidate the two HTML
emitters into buildSeoPageHtml.
