### PR TITLE
fix(cls): reserve heights on top desktop shifters + E2E budget guard (Phase 6)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2404,8 +2404,13 @@ const App: React.FC = () => {
    * so the footer flows naturally after the SEO content in visual order. */}
  {(() => {
    const footerPortalTarget = staticOverlay ? document.getElementById('footer-root') : null;
+   // CLS fix (Phase 6 — 2026-05-18): removed content-visibility:auto +
+   // containIntrinsicSize 'auto 1600px'. Lighthouse desktop attributed score
+   // 0.61+0.26=0.87 on /cerca-lavoro-ticino/ to this footer because the real
+   // rendered height (lazy weather/newsletter/donation/sponsor logos) diverged
+   // too much from the 1600px intrinsic-size. Widgets stay Suspense-lazy.
    const footerJsx = (
- <footer className="border-t border-edge bg-surface-alt py-8 pb-20 md:pb-8 mt-auto relative z-10" style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 1600px' }}>
+ <footer className="border-t border-edge bg-surface-alt py-8 pb-20 md:pb-8 mt-auto relative z-10">
  <div className="max-w-7xl mx-auto px-4 space-y-6">
  {/* Footer weather widget */}
  <Suspense fallback={<SkeletonFooterSlot height="min-h-[36px]" />}><FooterWeather /></Suspense>

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -2633,7 +2633,10 @@ function BlogArticles({
  // ── List View (Newspaper style) ──────────────────────
 
  return (
- <div className="max-w-5xl mx-auto space-y-6">
+ // CLS fix (Phase 6 — 2026-05-18): reserve min-height to absorb the
+ // async articles-load reflow that Lighthouse desktop attributed score 0.17
+ // to this container on /articoli-frontaliere/.
+ <div className="max-w-5xl mx-auto space-y-6 min-h-[640px]">
  {/* Header with stats hook */}
  <div className="text-center mb-2">
  <h1 className="text-2xl sm:text-3xl font-bold font-display text-strong mb-2 flex items-center justify-center gap-2">

--- a/data/recovery-2026-05-18/cls-top.json
+++ b/data/recovery-2026-05-18/cls-top.json
@@ -1,0 +1,337 @@
+{
+  "generated_at": "2026-05-18T10:15:04.377Z",
+  "approach": "CrUX API (real-user p75) + Lighthouse 13 desktop lab (shifter elements)",
+  "crux": {
+    "https://frontaliereticino.ch/": {
+      "DESKTOP": {
+        "cls_p75": "1.02",
+        "cls_dist": [
+          {
+            "start": "0.00",
+            "end": "0.10",
+            "density": 0.311
+          },
+          {
+            "start": "0.10",
+            "end": "0.25",
+            "density": 0.0626
+          },
+          {
+            "start": "0.25",
+            "density": 0.6264
+          }
+        ],
+        "lcp_p75": 787
+      },
+      "PHONE": {
+        "cls_p75": "1.09",
+        "cls_dist": [
+          {
+            "start": "0.00",
+            "end": "0.10",
+            "density": 0.2487
+          },
+          {
+            "start": "0.10",
+            "end": "0.25",
+            "density": 0.2009
+          },
+          {
+            "start": "0.25",
+            "density": 0.5504
+          }
+        ],
+        "lcp_p75": 1000,
+        "inp_p75": 345
+      }
+    },
+    "https://frontaliereticino.ch/cerca-lavoro-ticino/": {
+      "DESKTOP": {
+        "error": "chrome ux report data not found"
+      },
+      "PHONE": {
+        "cls_p75": "0.72",
+        "cls_dist": [
+          {
+            "start": "0.00",
+            "end": "0.10",
+            "density": 0.1345
+          },
+          {
+            "start": "0.10",
+            "end": "0.25",
+            "density": 0.0574
+          },
+          {
+            "start": "0.25",
+            "density": 0.8081
+          }
+        ],
+        "lcp_p75": 955
+      }
+    },
+    "https://frontaliereticino.ch/calcola-stipendio/": {
+      "DESKTOP": {
+        "error": "chrome ux report data not found"
+      },
+      "PHONE": {
+        "error": "chrome ux report data not found"
+      }
+    },
+    "https://frontaliereticino.ch/articoli-frontaliere/": {
+      "DESKTOP": {
+        "error": "chrome ux report data not found"
+      },
+      "PHONE": {
+        "error": "chrome ux report data not found"
+      }
+    }
+  },
+  "lighthouse_desktop": {
+    "https://frontaliereticino.ch/": {
+      "cls": 1.2949,
+      "lcp_ms": 1042.3717400000003,
+      "top_shifters": [
+        {
+          "score": 1,
+          "selector": "body.bg-slate-50",
+          "snippet": "<body class=\"bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 transitio…\">"
+        },
+        {
+          "score": 0.2833,
+          "selector": null,
+          "snippet": null
+        },
+        {
+          "score": 0.0092,
+          "selector": "div.hidden > div.grid > div.md:col-span-13 > div.flex",
+          "snippet": "<div class=\"flex items-center gap-2 h-[34px] bg-surface rounded-xl border border-edge …\" data-testid=\"news-ticker\">"
+        },
+        {
+          "score": 0.0024,
+          "selector": "nav.sticky > div.max-w-[2400px] > div.flex > div.flex",
+          "snippet": "<div class=\"flex items-center gap-0.5 sm:gap-1.5 pl-2 sm:pl-4 border-l border-edge shr…\">"
+        },
+        {
+          "score": 0,
+          "selector": "div.relative > div.flex > a.flex > span.leading-tight",
+          "snippet": "<span class=\"leading-tight text-center whitespace-nowrap md:whitespace-normal md:w-full…\">"
+        }
+      ],
+      "culprits": [
+        {
+          "score": 1.2949,
+          "selector": null
+        },
+        {
+          "score": 1,
+          "selector": "body.bg-slate-50"
+        },
+        {
+          "score": 0.2833,
+          "selector": null,
+          "cause": [
+            {
+              "cause": "Web font",
+              "url": "https://frontaliereticino.ch/fonts/inter-latin.woff2"
+            },
+            {
+              "cause": "Web font",
+              "url": "https://frontaliereticino.ch/fonts/space-grotesk-latin.woff2"
+            }
+          ]
+        },
+        {
+          "score": 0.0092,
+          "selector": "div.hidden > div.grid > div.md:col-span-13 > div.flex"
+        },
+        {
+          "score": 0.0024,
+          "selector": "nav.sticky > div.max-w-[2400px] > div.flex > div.flex"
+        },
+        {
+          "score": 0,
+          "selector": "div.relative > div.flex > a.flex > span.leading-tight"
+        }
+      ]
+    },
+    "https://frontaliereticino.ch/cerca-lavoro-ticino/": {
+      "cls": 0.8983,
+      "lcp_ms": 717.625,
+      "top_shifters": [
+        {
+          "score": 0.6076,
+          "selector": "body.bg-surface-alt > div#root > div.min-h-screen > footer.border-t",
+          "snippet": "<footer class=\"border-t border-edge bg-surface-alt py-8 pb-20 md:pb-8 mt-auto relative z-…\" style=\"content-visibility: auto; contain-intrins"
+        },
+        {
+          "score": 0.2597,
+          "selector": "body.bg-surface-alt > div#root > div.min-h-screen > footer.border-t",
+          "snippet": "<footer class=\"border-t border-edge bg-surface-alt py-8 pb-20 md:pb-8 mt-auto relative z-…\" style=\"content-visibility: auto; contain-intrins"
+        },
+        {
+          "score": 0.0179,
+          "selector": "body.bg-surface-alt",
+          "snippet": "<body class=\"bg-surface-alt text-heading overflow-x-hidden\" style=\"overflow: hidden;\">"
+        },
+        {
+          "score": 0.0042,
+          "selector": "div.min-h-screen > footer.border-t > div.max-w-7xl > div.text-center",
+          "snippet": "<div class=\"text-center text-muted text-sm space-y-3\">"
+        },
+        {
+          "score": 0.0037,
+          "selector": "body.bg-surface-alt > div.fc-consent-root > div.fc-dialog-container",
+          "snippet": "<div class=\"fc-dialog-container\">"
+        }
+      ],
+      "culprits": [
+        {
+          "score": 0.8983,
+          "selector": null
+        },
+        {
+          "score": 0.6076,
+          "selector": "body.bg-surface-alt > div#root > div.min-h-screen > footer.border-t"
+        },
+        {
+          "score": 0.2597,
+          "selector": "body.bg-surface-alt > div#root > div.min-h-screen > footer.border-t"
+        },
+        {
+          "score": 0.0179,
+          "selector": "body.bg-surface-alt"
+        },
+        {
+          "score": 0.0042,
+          "selector": "div.min-h-screen > footer.border-t > div.max-w-7xl > div.text-center"
+        },
+        {
+          "score": 0.0037,
+          "selector": "body.bg-surface-alt > div.fc-consent-root > div.fc-dialog-container",
+          "cause": [
+            {
+              "cause": "Unsized image element"
+            }
+          ]
+        }
+      ]
+    },
+    "https://frontaliereticino.ch/calcola-stipendio/": {
+      "cls": 0.0293,
+      "lcp_ms": 474.18600000000004,
+      "top_shifters": [
+        {
+          "score": 0.0179,
+          "selector": "body.bg-surface-alt",
+          "snippet": "<body class=\"bg-surface-alt text-heading overflow-x-hidden\" style=\"overflow: hidden;\">"
+        },
+        {
+          "score": 0.0092,
+          "selector": "div.hidden > div.grid > div.md:col-span-13 > div.flex",
+          "snippet": "<div class=\"flex items-center gap-2 h-[34px] bg-surface rounded-xl border border-edge …\" data-testid=\"news-ticker\">"
+        },
+        {
+          "score": 0.0015,
+          "selector": "body.bg-surface-alt > div.fc-consent-root > div.fc-dialog-container",
+          "snippet": "<div class=\"fc-dialog-container\">"
+        },
+        {
+          "score": 0.0007,
+          "selector": "nav.sticky > div.max-w-[2400px] > div.flex > div.flex",
+          "snippet": "<div class=\"flex items-center gap-0.5 sm:gap-1.5 pl-2 sm:pl-4 border-l border-edge shr…\">"
+        }
+      ],
+      "culprits": [
+        {
+          "score": 0.0293,
+          "selector": null
+        },
+        {
+          "score": 0.0179,
+          "selector": "body.bg-surface-alt"
+        },
+        {
+          "score": 0.0092,
+          "selector": "div.hidden > div.grid > div.md:col-span-13 > div.flex"
+        },
+        {
+          "score": 0.0015,
+          "selector": "body.bg-surface-alt > div.fc-consent-root > div.fc-dialog-container",
+          "cause": [
+            {
+              "cause": "Unsized image element"
+            },
+            {
+              "cause": "Web font",
+              "url": "https://fonts.gstatic.com/s/opensans/v40/memvYaGs126MiZpBA-UvWbX2vVnXBbObj2OVTS-mu0SC55I.woff2"
+            }
+          ]
+        },
+        {
+          "score": 0.0007,
+          "selector": "nav.sticky > div.max-w-[2400px] > div.flex > div.flex"
+        }
+      ]
+    },
+    "https://frontaliereticino.ch/articoli-frontaliere/": {
+      "cls": 0.1764,
+      "lcp_ms": 4008.6704999999984,
+      "top_shifters": [
+        {
+          "score": 0.1705,
+          "selector": "div.min-h-screen > main#main-content > div.max-w-7xl > div.max-w-5xl",
+          "snippet": "<div class=\"max-w-5xl mx-auto space-y-6\">"
+        },
+        {
+          "score": 0.0142,
+          "selector": null,
+          "snippet": null
+        },
+        {
+          "score": 0.0037,
+          "selector": "body.bg-surface-alt > div.fc-consent-root > div.fc-dialog-container",
+          "snippet": "<div class=\"fc-dialog-container\">"
+        },
+        {
+          "score": 0.0015,
+          "selector": "body.bg-surface-alt > div.fc-consent-root > div.fc-dialog-container",
+          "snippet": "<div class=\"fc-dialog-container\">"
+        },
+        {
+          "score": 0.0006,
+          "selector": "nav.sticky > div.max-w-[2400px] > div.flex > div.flex",
+          "snippet": "<div class=\"flex items-center gap-0.5 sm:gap-1.5 pl-2 sm:pl-4 border-l border-edge shr…\">"
+        }
+      ],
+      "culprits": [
+        {
+          "score": 0.0142,
+          "selector": null
+        },
+        {
+          "score": 0.0142,
+          "selector": null
+        }
+      ]
+    }
+  },
+  "fixes_applied": [
+    {
+      "shifter": "body (homepage, score 1.0)",
+      "fix": "Removed transition-colors duration-300 from body — eliminates transition cascade during SPA hydration"
+    },
+    {
+      "shifter": "web fonts Inter+SpaceGrotesk (homepage, score 0.28)",
+      "fix": "Added size-adjust + ascent/descent overrides to Space Grotesk @font-face to match Inter"
+    },
+    {
+      "shifter": "footer.border-t on /cerca-lavoro-ticino/ (score 0.61+0.26=0.87)",
+      "fix": "Removed content-visibility:auto on footer — actual height diverges too much from 1600px intrinsic-size"
+    },
+    {
+      "shifter": "div.max-w-5xl on /articoli-frontaliere/ (score 0.17)",
+      "fix": "Added min-h-[600px] on articles list container to absorb async article-load reflow"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -180,6 +180,13 @@
         font-weight: 300 700;
         font-display: swap;
         src: url('/fonts/space-grotesk-latin.woff2') format('woff2');
+        /* CLS fix (Phase 6 — 2026-05-18): align fallback metrics with the real
+           font so the heading swap doesn't reflow body. Values tuned to bring
+           Space Grotesk's x-height + cap-height close to the system-ui fallback. */
+        size-adjust: 95%;
+        ascent-override: 92%;
+        descent-override: 25%;
+        line-gap-override: 0%;
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
       }
       body { font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif; }
@@ -305,7 +312,7 @@
     </script>
 
 </head>
-  <body class="bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 transition-colors duration-300 overflow-x-hidden">
+  <body class="bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 overflow-x-hidden">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:px-4 focus:py-2 focus:text-blue-600 focus:rounded focus:shadow-lg focus:underline" style="position:absolute;top:0;left:0;width:1px;height:1px;margin:-1px;padding:0;border:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap">Vai al contenuto principale</a>
     <!-- Loading shell: fixed overlay so it never participates in layout flow.
          React renders behind it inside #root; shell is removed after first paint.

--- a/tests/e2e/cls-desktop-budget.spec.ts
+++ b/tests/e2e/cls-desktop-budget.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * CLS desktop budget guard — Phase 6 of the 2026-05-18 traffic-subs recovery.
+ *
+ * Goal: keep p75 cumulative-layout-shift under the Google "needs improvement"
+ * threshold (0.25) on the 4 highest-revenue paths. Real CrUX desktop p75 on
+ * the homepage was 1.02 (4x over) at plan time; baseline this test against the
+ * post-fix value to prevent regressions.
+ *
+ * Two run modes:
+ *   1. Local / CI: `npx playwright test tests/e2e/cls-desktop-budget.spec.ts`
+ *      → spins up `vite preview` on port 4173 (per playwright.config.ts).
+ *   2. Live: `LIVE_BASE_URL=https://frontaliereticino.ch SKIP_PROD_CLS=0 \
+ *               npx playwright test tests/e2e/cls-desktop-budget.spec.ts`
+ *      → measures CLS on the deployed site. Skipped by default in CI because
+ *      live network variability adds flake.
+ */
+
+import { test, expect } from 'playwright/test';
+
+const CRITICAL_PATHS = [
+  '/',
+  '/cerca-lavoro-ticino/',
+  '/calcola-stipendio/',
+  '/articoli-frontaliere/',
+] as const;
+
+// Allow opting out when only the dev server is running (e.g. local build cache).
+const SKIP_LIVE = process.env.SKIP_PROD_CLS === '1';
+
+test.describe('CLS desktop budget (Phase 6 guard)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  for (const path of CRITICAL_PATHS) {
+    test(`CLS budget < 0.25 desktop on ${path}`, async ({ page, baseURL }) => {
+      if (SKIP_LIVE && (baseURL ?? '').startsWith('https://')) {
+        test.skip(true, 'SKIP_PROD_CLS=1 set');
+      }
+
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.goto(path, { waitUntil: 'networkidle' });
+
+      // Sample CLS via the Web Performance API. Mirrors the spec used by
+      // CrUX / web-vitals.js (skip entries with hadRecentInput).
+      const cls = await page.evaluate(
+        () =>
+          new Promise<number>((resolve) => {
+            let total = 0;
+            const observer = new PerformanceObserver((list) => {
+              for (const entry of list.getEntries() as PerformanceEntry[]) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const e = entry as any;
+                if (!e.hadRecentInput) total += e.value;
+              }
+            });
+            observer.observe({ type: 'layout-shift', buffered: true });
+            setTimeout(() => {
+              observer.disconnect();
+              resolve(total);
+            }, 4000);
+          }),
+      );
+
+      // 0.25 is Google's "poor" threshold. We test under 0.25, not under the
+      // current value, so a future regression that doesn't cross "poor"
+      // still passes — the goal is to prevent re-entering the red zone.
+      expect(cls, `CLS on ${path} = ${cls.toFixed(3)} (budget < 0.25)`).toBeLessThan(0.25);
+    });
+  }
+});


### PR DESCRIPTION
CrUX p75 desktop CLS on homepage was 1.02 (4x Google "poor" threshold of 0.25);
Lighthouse 13 desktop lab identified 4 shifters across the top-revenue paths:

  1. body shift score=1.0 on / — transition-colors on body cascaded with SPA
     hydration. Removed `transition-colors duration-300` from body in index.html.
  2. web fonts score=0.28 on / — Inter had size-adjust + ascent/descent but
     Space Grotesk did not. Added matching @font-face metrics overrides.
  3. footer.border-t score=0.61+0.26=0.87 on /cerca-lavoro-ticino/ — the
     content-visibility:auto + containIntrinsicSize 'auto 1600px' over-estimated
     real footer height (weather/newsletter/donation/sponsors render shorter).
     Removed content-visibility; Suspense lazy-mount still defers widget cost.
  4. max-w-5xl articles list score=0.17 on /articoli-frontaliere/ — async
     article load reflowed the container. Added min-h-[640px] reservation.

Tests:
  - tests/e2e/cls-desktop-budget.spec.ts asserts CLS < 0.25 on the 4 critical
    paths; runs against local vite preview by default, supports LIVE_BASE_URL
    for post-deploy verification.

Artifacts:
  - data/recovery-2026-05-18/cls-top.json — CrUX + Lighthouse evidence used to
    pinpoint the shifters, with the applied-fix map.
