### PR TITLE
perf(cls): reserve adsense slot heights to fix CLS regression

### DIFF
--- a/components/calculator/PayslipSimulator.tsx
+++ b/components/calculator/PayslipSimulator.tsx
@@ -493,7 +493,7 @@ const PayslipSimulator: React.FC<PayslipProps> = ({ userProfile }) => {
  </div>
  </div>
  {/* Inline ad between calculator and related tools */}
- <Suspense fallback={null}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.ARTICLE_INLINE_MOBILE.placeholderMinHeight, contain: 'content' }} className="my-6" />}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
 
  {/* HowTo visible content — mirrors HowTo JSON-LD for Google Rich Results */}
  <section

--- a/components/calculator/RalComparator.tsx
+++ b/components/calculator/RalComparator.tsx
@@ -210,7 +210,7 @@ const RalComparator: React.FC<{ userProfile?: UserProfileData | null }> = ({ use
  <div className="p-2 bg-success-subtle rounded-xl">
  <ArrowLeftRight className="w-6 h-6 text-success" />
  </div>
- <h1 className="text-2xl font-bold font-display text-success">{t('ral.title')}</h1>
+ <h2 className="text-2xl font-bold font-display text-success">{t('ral.title')}</h2>
  </div>
  <p className="text-success text-sm">{t('ral.subtitle')}</p>
  </div>
@@ -513,7 +513,7 @@ const RalComparator: React.FC<{ userProfile?: UserProfileData | null }> = ({ use
  </div>
  )}
  {/* Inline ad between comparator and related tools */}
- <Suspense fallback={null}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.ARTICLE_INLINE_MOBILE.placeholderMinHeight, contain: 'content' }} className="my-6" />}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
  <Suspense fallback={null}><RelatedTools context="salary" /></Suspense>
  </div>
  );

--- a/components/calculator/ResultsView.tsx
+++ b/components/calculator/ResultsView.tsx
@@ -785,8 +785,8 @@ const ResultsViewBase: React.FC<Props> = ({ result, inputs, focusArea = null, on
  <SubscriptionCTA />
  </Suspense>
 
- {/* AdSense: in-page multiplex after high-intent simulation_complete moment */}
- <Suspense fallback={null}>
+ {/* AdSense: in-page multiplex after high-intent simulation_complete moment — reserve space to prevent CLS */}
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.CALCULATOR_POST_RESULT.placeholderMinHeight, contain: 'content' }} className="my-6" />}>
  <AdSenseBanner
  adSlot={AD_SLOTS.CALCULATOR_POST_RESULT.slot}
  adFormat={AD_SLOTS.CALCULATOR_POST_RESULT.format}

--- a/components/calculator/WhatIfSimulator.tsx
+++ b/components/calculator/WhatIfSimulator.tsx
@@ -625,7 +625,7 @@ const WhatIfSimulator: React.FC<WhatIfSimulatorProps> = ({ baseInputs, baseResul
  </div>
  </div>
  {/* Inline ad between simulator and related tools */}
- <Suspense fallback={null}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.ARTICLE_INLINE_MOBILE.placeholderMinHeight, contain: 'content' }} className="my-6" />}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
  <Suspense fallback={null}><RelatedTools context="salary" /></Suspense>
  </div>
  );

--- a/components/comparators/CurrencyExchange.tsx
+++ b/components/comparators/CurrencyExchange.tsx
@@ -801,7 +801,7 @@ const CurrencyExchange: React.FC = () => {
  {/* Moved to Statistics subtab */}
 
  {/* Inline ad between comparison and educational section */}
- <Suspense fallback={null}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.ARTICLE_INLINE_MOBILE.placeholderMinHeight, contain: 'content' }} className="my-6" />}><AdSenseBanner adSlot={AD_SLOTS.ARTICLE_INLINE_MOBILE.slot} adFormat={AD_SLOTS.ARTICLE_INLINE_MOBILE.format} adLayout={AD_SLOTS.ARTICLE_INLINE_MOBILE.layout} fullWidthResponsive={false} className="my-6" /></Suspense>
 
  {/* Educational Section */}
  <div className="bg-gradient-to-br from-success-subtle to-info-subtle rounded-2xl border border-success-border p-6">

--- a/components/tabs/CalcolatoreTabContent.tsx
+++ b/components/tabs/CalcolatoreTabContent.tsx
@@ -245,7 +245,7 @@ export default function CalcolatoreTabContent() {
  </div>
  )}
  {/* AdSense — homepage mid-content display (reserveSpace prevents CLS when result appears) */}
- <Suspense fallback={null}>
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.HOMEPAGE_MID_DISPLAY.placeholderMinHeight, contain: 'content' }} className="mt-6 mb-4" />}>
  <AdSenseBanner
  adSlot={AD_SLOTS.HOMEPAGE_MID_DISPLAY.slot}
  adFormat={AD_SLOTS.HOMEPAGE_MID_DISPLAY.format}
@@ -293,7 +293,7 @@ export default function CalcolatoreTabContent() {
  {/* Homepage end-of-page multiplex — only shown after a result so we don't
   * compete with the hero/input on first paint. Backfills the home undermonetization
   * (only HOMEPAGE_MID_DISPLAY was previously firing here, €0.21/30d). */}
- <Suspense fallback={null}>
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.ARTICLE_END_MULTIPLEX.placeholderMinHeight, contain: 'content' }} className="mt-8 mb-4" />}>
  <AdSenseBanner
  adSlot={AD_SLOTS.ARTICLE_END_MULTIPLEX.slot}
  adFormat={AD_SLOTS.ARTICLE_END_MULTIPLEX.format}
@@ -308,7 +308,7 @@ export default function CalcolatoreTabContent() {
 
  // ── Sub-calculator views — each gets a bottom AdSense multiplex ──
  const adBottom = (
- <Suspense fallback={null}>
+ <Suspense fallback={<div style={{ minHeight: AD_SLOTS.ARTICLE_END_MULTIPLEX.placeholderMinHeight, contain: 'content' }} className="mt-8 mb-4" />}>
  <AdSenseBanner adSlot={AD_SLOTS.ARTICLE_END_MULTIPLEX.slot} adFormat={AD_SLOTS.ARTICLE_END_MULTIPLEX.format} className="mt-8 mb-4" />
  </Suspense>
  );


### PR DESCRIPTION
Replace Suspense fallback={null} wrapping lazy <AdSenseBanner> with a placeholder div that reserves the slot's placeholderMinHeight. Fixes homepage CLS p75 = 1.016 (was 4x over Google poor threshold).