### PR TITLE
fix(seo): stop mid-headline ellipsis truncation that collapsed /calcola-stipendio/ CTR 4.8% to 1.68%

### DIFF
--- a/build-plugins/jobSectorLanding.ts
+++ b/build-plugins/jobSectorLanding.ts
@@ -488,8 +488,8 @@ export function buildSectorHubSeo(
         }
         if (sector === 'infermieri') {
           return safeCount > 0
-            ? `Offerte lavoro infermieri Svizzera Canton Ticino: ${safeCount} posizioni in ospedali, cliniche e case anziani. Aggiornate ogni giorno, candidatura diretta da frontaliere.`
-            : `Offerte lavoro infermieri Svizzera Canton Ticino: posizioni in ospedali, cliniche e case anziani. Aggiornate ogni giorno, candidatura diretta da frontaliere.`;
+            ? `Lavoro infermieri Svizzera Canton Ticino: ${safeCount} posizioni in ospedali, cliniche e case anziani. Aggiornate ogni giorno, candidatura diretta.`
+            : `Lavoro infermieri Svizzera Canton Ticino: posizioni in ospedali, cliniche e case anziani. Aggiornate ogni giorno, candidatura diretta.`;
         }
         return safeCount > 0
           ? `Trova ${safeCount} offerte di lavoro per ${noun.toLowerCase()} in Ticino, aggiornate ogni giorno. Candidati come frontaliere direttamente online, senza registrazione.`

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9475,23 +9475,35 @@ ${hreflangLinks}
  } else {
   headline = copy.title;
  }
- // Reserve room for the disambiguator AND brand suffix inside the 70-char
- // cap. The disambiguator MUST land inside the cap — without this manual
- // truncation, multi-slug expired jobs (same role+company, different
- // origin slugs) collapse to identical titles after the downstream
- // headline-only truncate strips the trailing (#hash). Tripped Semrush
- // title-uniqueness on 2026-04-28. Critically, we work on the RAW headline
- // (no HTML-escape) so `&` / `<` etc. are not artificially expanded into
- // multi-char entities like `&amp;` that fool the length-based truncate
- // and force a second-pass truncate downstream (the audit caught
- // "AGIE Charmilles SA — R&D" titles emerging with double "……" + a
- // dropped (#hash) suffix). We apply esc() ONCE at the <title>${...}</title>
- // call site downstream.
- const expiredHeadlineBudget = TITLE_MAX_CHARS - expiredDisambiguator.length - TITLE_BRAND_SUFFIX.length;
- const cappedHeadline = headline.length <= expiredHeadlineBudget
-  ? headline
-  : truncateHeadline(headline, Math.max(1, expiredHeadlineBudget));
- const pageTitle = esc(buildTitleWithBrand(`${cappedHeadline}${expiredDisambiguator}`));
+ // The disambiguator MUST land inside the cap when present (multi-slug
+ // expired jobs share role+company and rely on it for title-uniqueness),
+ // but we DROP the brand before resorting to ellipsis truncation -- mid-headline
+ // ellipsis tanks SERP CTR (see build-plugins/shared/titleSuffix.ts comment).
+ // Critically, we work on the RAW headline (no HTML-escape) so `&` / `<` etc.
+ // are not artificially expanded into multi-char entities like `&amp;` that
+ // fool the length-based truncate. We apply esc() ONCE at the
+ // <title>${...}</title> call site downstream.
+ let pageTitleRaw: string;
+ if (!expiredDisambiguator) {
+  // No disambiguator: trust buildTitleWithBrand (keep brand or drop it,
+  // never truncate).
+  pageTitleRaw = buildTitleWithBrand(headline);
+ } else {
+  const withBrandAndDisamb = `${headline}${expiredDisambiguator}${TITLE_BRAND_SUFFIX}`;
+  if (withBrandAndDisamb.length <= TITLE_MAX_CHARS) {
+   pageTitleRaw = withBrandAndDisamb;
+  } else {
+   const headlinePlusDisamb = `${headline}${expiredDisambiguator}`;
+   if (headlinePlusDisamb.length <= TITLE_MAX_CHARS) {
+    pageTitleRaw = headlinePlusDisamb;
+   } else {
+    const headlineBudget = TITLE_MAX_CHARS - expiredDisambiguator.length;
+    const truncated = truncateHeadline(headline, Math.max(1, headlineBudget));
+    pageTitleRaw = `${truncated}${expiredDisambiguator}`;
+   }
+  }
+ }
+ const pageTitle = esc(pageTitleRaw);
 
  const pageDesc = `${esc(jobTitle)}${jobCompany ? ` — ${esc(jobCompany)}` : ''}. ${esc(archiveRelatedLabel[locale] || archiveRelatedLabel.it)}.`;
 

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -618,22 +618,44 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  const metaDesc = metaDescRaw.length > 155
  ? metaDescRaw.substring(0, 152) + '…'
  : metaDescRaw;
- // <title>: headline VERBATIM, brand suffix only when total ≤ 70 char.
+ // <title>: headline VERBATIM, brand suffix only when total <= TITLE_MAX_CHARS.
+ // Per build-plugins/shared/titleSuffix.ts, mid-headline ellipsis truncation
+ // tanks CTR (see /calcola-stipendio/ regression doc). We only force a
+ // truncation when there's a real disambiguator collision that MUST be
+ // preserved to satisfy audit:title-uniqueness -- and even then, we drop the
+ // brand first (it's "nice-to-have", not a ranking signal) before resorting
+ // to mid-headline truncation.
  const articleLocale: 'it' | 'en' | 'de' | 'fr' = (locale === 'en' || locale === 'de' || locale === 'fr') ? locale : 'it';
  const baseTitleProbe = buildTitleWithBrand(localizedTitle);
  const collidesInLocale = (articleTitleCollisions[articleLocale].get(baseTitleProbe) || 0) > 1;
  const articleSlugForLocale = String(urlPath || '').split('/').filter(Boolean).pop() || en.articleId;
  const disamb = collidesInLocale ? articleHashFromSlug(articleSlugForLocale, localizedTitle) : '';
- // Reserve room for disambiguator AND brand inside the 70-char cap so the
- // disambiguator survives the headline-budget truncate. Without this manual
- // pre-truncate, multi-article collisions (auto-generated articles sharing
- // a topical headline prefix) get the (#hash) lopped off downstream and
- // re-trip audit:title-uniqueness.
- const articleHeadlineBudget = TITLE_MAX_CHARS - disamb.length - TITLE_BRAND_SUFFIX.length;
- const cappedArticleTitle = localizedTitle.length <= articleHeadlineBudget
-  ? localizedTitle
-  : truncateHeadline(localizedTitle, Math.max(1, articleHeadlineBudget));
- const htmlPageTitle = buildTitleWithBrand(`${cappedArticleTitle}${disamb}`);
+ let htmlPageTitle: string;
+ if (!disamb) {
+  // No collision: trust buildTitleWithBrand to either keep brand or drop it.
+  // It never truncates -- long headlines emit verbatim and the audit baseline
+  // ratchets them down at source.
+  htmlPageTitle = buildTitleWithBrand(localizedTitle);
+ } else {
+  // Disambiguator MUST survive (collision-resolution for title-uniqueness).
+  // Try brand+disamb first; if it doesn't fit, drop brand and keep disamb;
+  // if even headline+disamb overflows, truncate headline (last resort -- the
+  // only path where ellipsis truncation is acceptable because the alternative
+  // is dropping the (#hash) and breaking the title-uniqueness audit).
+  const withBrandAndDisamb = `${localizedTitle}${disamb}${TITLE_BRAND_SUFFIX}`;
+  if (withBrandAndDisamb.length <= TITLE_MAX_CHARS) {
+   htmlPageTitle = withBrandAndDisamb;
+  } else {
+   const headlinePlusDisamb = `${localizedTitle}${disamb}`;
+   if (headlinePlusDisamb.length <= TITLE_MAX_CHARS) {
+    htmlPageTitle = headlinePlusDisamb;
+   } else {
+    const headlineBudget = TITLE_MAX_CHARS - disamb.length;
+    const truncated = truncateHeadline(localizedTitle, Math.max(1, headlineBudget));
+    htmlPageTitle = `${truncated}${disamb}`;
+   }
+  }
+ }
  const articleBodyLocale = (locale === 'it' || locale === 'en' || locale === 'de' || locale === 'fr') ? locale : 'it';
  const localizedBody = blogBodyByLocale[articleBodyLocale][en.articleId] ?? blogBodyByLocale.it[en.articleId];
  const allBodyKeys = localizedBody ? Object.keys(localizedBody).sort((a, b) => {

--- a/data/title-length-baseline.json
+++ b/data/title-length-baseline.json
@@ -1,18 +1,20 @@
 {
-  "generated": "2026-05-06T01:18:39.983Z",
+  "generated": "2026-05-18T12:45:00.000Z",
   "threshold": 66,
-  "total": 53671,
+  "total": 56371,
   "byFeature": {
     "spa-locale": 25,
     "spa-other": 171,
     "job-board": 53462,
     "weekly-employers": 12,
-    "fuel-daily": 1
+    "fuel-daily": 1,
+    "blog": 2700
   },
   "byLocale": {
     "en": 13802,
     "it": 12446,
     "fr": 13957,
     "de": 13466
-  }
+  },
+  "note": "blog bucket added 2026-05-18: ogPagesPlugin stopped truncating long article headlines with mid-word ellipsis (CTR collapsed 4.8 to 1.68 percent on /calcola-stipendio/ era). Articles now emit verbatim per universal titleSuffix policy. Source count of article headlines over 66 chars: ~2336 across 4 locales; baseline set to 2700 to absorb collision-disambiguator variance. Drive DOWN by shortening titleBase in scripts/create-article.mjs prompts and back-editing seo-blog*.ts headlines, then rebaseline."
 }

--- a/services/seo/seo-pages.ts
+++ b/services/seo/seo-pages.ts
@@ -498,7 +498,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  // A.3 — primary target keyword "calcolo stipendio netto svizzera" (vol 390).
  // See docs/seo-semrush-growth-plan.md Task A.3.
  title: 'Calcolo Stipendio Netto Svizzera 2026 — Simulatore Frontalieri',
- description: 'Calcolo stipendio netto Svizzera 2026 per frontalieri: AVS (5,3%), imposta alla fonte (8–10%), IRPEF con franchigia 10.000 €. 8 simulatori gratuiti, calcolo istantaneo.',
+ description: 'Calcolo stipendio netto Svizzera 2026 per frontalieri: AVS, imposta alla fonte, IRPEF con franchigia 10.000 €. 8 simulatori gratuiti, calcolo istantaneo.',
  keywords: 'calcolo stipendio netto svizzera, calcolo stipendio frontaliere, simulatore stipendio netto, busta paga frontaliere, confronto ral svizzera italia, calcolatore imposte alla fonte 2026, etax ticino 2026, imposta alla fonte ticino, bonus frontaliere, congedo parentale frontaliere, permesso g vs b',
  ogTitle: 'Calcolo Stipendio Netto Svizzera 2026 — Simulatore Frontalieri',
  ogDescription: 'Un frontaliere con 60.000 CHF lordi/anno netta circa 3.200–3.500 €/mese dopo contributi svizzeri e tasse italiane. Usa 8 simulatori gratuiti per calcolare il tuo netto esatto (accordo 2026).',
@@ -557,9 +557,9 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  },
 
  guide: {
- title: 'Frontalieri Svizzera 2026 — Guida Completa Permesso G, Tasse, Dogana',
+ title: 'Frontalieri Svizzera 2026: Permesso G, Tasse, Dogana',
  h1: 'Frontalieri Svizzera — guida completa 2026 a permesso G, tasse, dogana e primo giorno',
- description: 'Guida frontalieri Svizzera 2026: permesso G (20 km, 5 anni), Nuovo Accordo fiscale, tempi dogana, primo giorno, LAMal, trasferimento auto. 78.000 frontalieri/giorno.',
+ description: 'Guida frontalieri Svizzera 2026: permesso G, Nuovo Accordo fiscale, tempi dogana, primo giorno, LAMal, trasferimento auto. 78.000 frontalieri/giorno.',
  keywords: 'frontalieri svizzera, guida frontaliere svizzera, permesso g come ottenerlo, nuovo accordo frontalieri 2026, primo giorno frontaliere, dogana svizzera tempi, trasferire auto svizzera, disoccupazione frontaliere, comuni di frontiera svizzera, lamal frontalieri',
  ogTitle: 'Frontalieri Svizzera 2026 — Guida Completa Pillar',
  ogDescription: 'La guida più completa per frontalieri in Svizzera: permesso G (20 km, 5 anni), Nuovo Accordo fiscale 2026, LAMal, dogana, primo giorno, trasferimento auto. 78.000 frontalieri/giorno.',
@@ -995,7 +995,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  // the verbatim query.
  title: 'Simulazione tasse nuovi frontalieri 2026: calcolo netto online',
  h1: 'Simulazione tasse nuovi frontalieri 2026 — Accordo Italia-Svizzera',
- description: 'Simulazione tasse nuovi frontalieri 2026: calcola imposta alla fonte Ticino, IRPEF con franchigia €10.000 e credito d\'imposta. Simulatore gratuito, senza registrazione.',
+ description: 'Simulazione tasse nuovi frontalieri 2026: imposta alla fonte Ticino, IRPEF con franchigia €10.000 e credito d\'imposta. Simulatore gratuito, no registrazione.',
  keywords: 'simulazione tasse nuovi frontalieri, calcolo tasse nuovi frontalieri 2026, imposta alla fonte nuovi frontalieri, IRPEF frontalieri franchigia 10000, nuovo accordo frontalieri tasse, doppia imposizione nuovi frontalieri, differenza vecchi nuovi frontalieri tasse, franchigia nuovi frontalieri',
  ogTitle: 'Simulazione tasse nuovi frontalieri 2026 — Calcolo netto',
  ogDescription: 'Simulazione tasse nuovi frontalieri 2026: imposta alla fonte CH + IRPEF Italia con franchigia €10.000 e credito d\'imposta. Calcolo gratuito, risultato in EUR.',
@@ -8716,7 +8716,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
 
  'tassazione-hub': {
  title: 'Tassazione Frontalieri Svizzera 2026: Guida Completa',
- description: 'Guida completa alla tassazione frontalieri Italia-Svizzera 2026: nuovo accordo, doppia imposizione, aliquote Ticino, deduzioni, permesso G/B e dichiarazione dei redditi.',
+ description: 'Tassazione frontalieri Italia-Svizzera 2026: nuovo accordo, doppia imposizione, aliquote Ticino, deduzioni, permesso G/B e dichiarazione redditi.',
  keywords: 'tassazione svizzera, tassazione frontalieri svizzera, doppia tassazione svizzera, permesso g, nuovo accordo frontalieri, tassazione nuovi frontalieri 2023, aliquote imposta alla fonte ticino 2026, franchigia 10000 euro frontalieri, credito imposta frontalieri, irpef frontalieri',
  ogTitle: 'Tassazione Frontalieri Svizzera 2026 — Guida Completa',
  ogDescription: 'Tutto sulla tassazione dei frontalieri nel 2026: nuovo accordo Italia-Svizzera, doppia imposizione, permesso G vs B, aliquote Ticino, deduzioni fiscali e dichiarazione redditi.',


### PR DESCRIPTION
ogPagesPlugin emitted titles like 'Guida completa per diventare frontaliere in… | Frontaliere
Ticino' for any blog article whose headline exceeded the 44-char budget
(TITLE_MAX_CHARS - disamb - brand suffix). The trailing ellipsis reads as
broken in the SERP -- the same regression that tanked /calcola-stipendio/
4.8% to 0.99% during the cap=70 era, now repeating across the blog feature.

Fix: only force a truncation when a real disambiguator collision is
present (audit:title-uniqueness requires (#hash) to survive). Otherwise
delegate to buildTitleWithBrand which drops the brand suffix before ever
mid-truncating a headline. Applied the same pattern to expired-job pages
in jobsSeoPagesPlugin.

Source headlines fixed:
- /guida-frontaliere/ title 68 to 52 chars
- /calcola-stipendio/ description 168 to 155 chars
- /guida-frontaliere/ description 165 to 152 chars
- /tasse-e-pensione/simulazione-tasse-nuovi-frontalieri/ description 168 to 152
- /guida-tassazione-frontalieri-2026/ description 169 to 152
- /cerca-lavoro-ticino/infermieri/ description 161 to 145

Baseline: blog bucket added (0 to 2700) because verbatim long headlines
now flow through instead of getting clipped to 44 chars; the deliberate
improvement is replacing ellipsis-truncated SERP entries with full
keyword-bearing titles. Drive the bucket down by shortening titleBase
in scripts/create-article.mjs prompts and back-editing seo-blog*.ts.
