### PR TITLE
fix(seo): shard sitemap-search-clusters at 45k URLs to comply with sitemaps.org limit

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -218,7 +218,50 @@ const CACHE_KEY_INPUTS = [
 // clusters (GSC orphans with expired source jobs; audit-derived slugs
 // whose tokens don't AND-match any current job) now emit. Bumping the
 // version invalidates v3 caches so the new pages render on next build.
-const CACHE_VERSION = 'v4';
+//
+// v5 (2026-05-18) shards sitemap-search-clusters.xml into <45k-URL files
+// (sitemap-search-clusters-001.xml, …) so we stay under the sitemaps.org
+// 50k hard cap. Old single-file caches would restore one 81k file and
+// reintroduce the violation — bump invalidates them.
+const CACHE_VERSION = 'v5';
+
+/**
+ * sitemaps.org caps each sitemap at 50,000 URLs. We shard at 45,000 to
+ * leave a safety margin for incidental growth between builds. The
+ * `sitemap-search-clusters.xml` cohort topped 81,537 URLs as of
+ * 2026-05-18, silently failing GSC ingestion above the cap.
+ */
+const SITEMAP_SHARD_CAP = 45_000;
+const SITEMAP_SHARD_PREFIX = 'sitemap-search-clusters';
+
+function padShardIndex(index: number): string {
+  return index >= 1000 ? String(index) : String(index).padStart(3, '0');
+}
+
+function shardFilename(index: number): string {
+  return `${SITEMAP_SHARD_PREFIX}-${padShardIndex(index)}.xml`;
+}
+
+/**
+ * Remove any pre-existing cluster sitemap files (single-file legacy +
+ * stale shard residue from a previous, longer run). Returns the list of
+ * filenames removed so callers can log if desired.
+ */
+function clearStaleClusterSitemaps(distDir: string): string[] {
+  const removed: string[] = [];
+  if (!fs.existsSync(distDir)) return removed;
+  const re = new RegExp(`^${SITEMAP_SHARD_PREFIX}(?:-\\d+)?\\.xml$`);
+  for (const file of fs.readdirSync(distDir)) {
+    if (!re.test(file)) continue;
+    try {
+      fs.unlinkSync(path.join(distDir, file));
+      removed.push(file);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  return removed;
+}
 
 interface CacheManifest {
   version: string;
@@ -306,14 +349,25 @@ async function tryRestoreFromCache(
     }));
   }
 
-  // The sitemap fragment carries a `<lastmod>` per URL; refresh today's date
-  // so the master sitemap signals freshness even when the body is unchanged.
-  const sitemapPath = path.join(distDir, 'sitemap-search-clusters.xml');
-  if (fs.existsSync(sitemapPath)) {
-    const today = new Date().toISOString().slice(0, 10);
-    const xml = fs.readFileSync(sitemapPath, 'utf-8')
-      .replace(/<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/g, `<lastmod>${today}</lastmod>`);
-    fs.writeFileSync(sitemapPath, xml, 'utf-8');
+  // Each shard carries a `<lastmod>` per URL; refresh today's date on every
+  // restored sitemap-search-clusters*.xml so the master sitemap signals
+  // freshness even when the body is unchanged. Walks the actual restored
+  // shard set (legacy single-file caches will surface as a single match;
+  // post-sharding caches have N matches — both handled uniformly).
+  const today = new Date().toISOString().slice(0, 10);
+  if (fs.existsSync(distDir)) {
+    const shardRe = new RegExp(`^${SITEMAP_SHARD_PREFIX}(?:-\\d+)?\\.xml$`);
+    for (const file of fs.readdirSync(distDir)) {
+      if (!shardRe.test(file)) continue;
+      const p = path.join(distDir, file);
+      try {
+        const xml = fs.readFileSync(p, 'utf-8')
+          .replace(/<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/g, `<lastmod>${today}</lastmod>`);
+        fs.writeFileSync(p, xml, 'utf-8');
+      } catch {
+        // best-effort refresh
+      }
+    }
   }
   return { ...manifest, emittedCount: restored };
 }
@@ -1331,7 +1385,11 @@ function dropOverwrittenLocs(distDir: string, locs: ReadonlyArray<string>): stri
   return out;
 }
 
-async function writeSitemap(distDir: string, allLocs: ReadonlyArray<string>, dateStamp: string): Promise<void> {
+async function writeSitemap(
+  distDir: string,
+  allLocs: ReadonlyArray<string>,
+  dateStamp: string,
+): Promise<string[]> {
   // Wait for jobsSeoPagesPlugin to flush its buffered writes (notably the
   // previousSlugs bridge HTML) before scanning dist/ HTML for canonical
   // mismatches. Vite/Rollup runs closeBundle hooks in parallel by default
@@ -1341,20 +1399,37 @@ async function writeSitemap(distDir: string, allLocs: ReadonlyArray<string>, dat
   // leak into sitemap-search-clusters.xml — audit:sitemap-canonicals fails.
   await jobsSeoPagesFlushed;
   const locs = dropOverwrittenLocs(distDir, allLocs);
-  if (locs.length === 0) return;
-  const entries = locs.map((loc) =>
-    `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.6</priority>\n  </url>`,
-  ).join('\n');
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
-  const sitemapPath = path.join(distDir, 'sitemap-search-clusters.xml');
+  if (locs.length === 0) return [];
+
+  // Clear any stale single-file legacy sitemap or shard residue from a
+  // previous run that produced more shards than this one. Without this,
+  // a shrinking corpus would leave dangling sitemap-search-clusters-NNN.xml
+  // files referenced by the auto-discovered sitemap.xml index.
+  clearStaleClusterSitemaps(distDir);
+
+  const totalShards = Math.max(1, Math.ceil(locs.length / SITEMAP_SHARD_CAP));
+  const written: string[] = [];
   try {
     fs.mkdirSync(distDir, { recursive: true });
-    fs.writeFileSync(sitemapPath, xml, 'utf-8');
+    for (let i = 0; i < totalShards; i++) {
+      const slice = locs.slice(i * SITEMAP_SHARD_CAP, (i + 1) * SITEMAP_SHARD_CAP);
+      const entries = slice.map((loc) =>
+        `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.6</priority>\n  </url>`,
+      ).join('\n');
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+      const file = shardFilename(i + 1);
+      fs.writeFileSync(path.join(distDir, file), xml, 'utf-8');
+      written.push(file);
+    }
   } catch (err) {
     console.warn('\x1b[33m[related-search-clusters]\x1b[0m sitemap write failed:', err);
-    return;
+    return written;
   }
-  patchMasterSitemap(distDir, dateStamp);
+  console.log(
+    `\x1b[36m[related-search-clusters]\x1b[0m sharded ${locs.length} URLs into ${written.length} file(s) at ${SITEMAP_SHARD_CAP}/shard`,
+  );
+  patchMasterSitemap(distDir, dateStamp, written);
+  return written;
 }
 
 /**
@@ -1364,26 +1439,33 @@ async function writeSitemap(distDir: string, allLocs: ReadonlyArray<string>, dat
  * `dist/sitemap.xml` is owned by another plugin and is regenerated each
  * build.
  */
-function patchMasterSitemap(distDir: string, dateStamp: string): void {
+function patchMasterSitemap(distDir: string, dateStamp: string, shardFiles: ReadonlyArray<string>): void {
   const masterPath = path.join(distDir, 'sitemap.xml');
   if (!fs.existsSync(masterPath)) return;
+  if (shardFiles.length === 0) return;
   try {
     let idx = fs.readFileSync(masterPath, 'utf-8');
-    if (idx.includes('sitemap-search-clusters.xml')) {
-      idx = idx.replace(
-        /(<loc>https:\/\/frontaliereticino\.ch\/sitemap-search-clusters\.xml<\/loc>\s*<lastmod>)\d{4}-\d{2}-\d{2}(<\/lastmod>)/,
-        `$1${dateStamp}$2`,
-      );
-    } else {
-      idx = idx.replace(
-        '</sitemapindex>',
-        `  <sitemap>\n    <loc>${BASE_URL}/sitemap-search-clusters.xml</loc>\n    <lastmod>${dateStamp}</lastmod>\n  </sitemap>\n</sitemapindex>`,
-      );
-    }
+    // Strip any legacy single-file entry plus prior shard entries — they're
+    // re-emitted below from the authoritative shardFiles list.
+    idx = idx.replace(
+      /\s*<sitemap>\s*<loc>https:\/\/frontaliereticino\.ch\/sitemap-search-clusters(?:-\d+)?\.xml<\/loc>\s*<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>\s*<\/sitemap>/g,
+      '',
+    );
+    const newEntries = shardFiles
+      .map(
+        (file) =>
+          `  <sitemap>\n    <loc>${BASE_URL}/${file}</loc>\n    <lastmod>${dateStamp}</lastmod>\n  </sitemap>`,
+      )
+      .join('\n');
+    idx = idx.replace('</sitemapindex>', `${newEntries}\n</sitemapindex>`);
     fs.writeFileSync(masterPath, idx, 'utf-8');
   } catch (err) {
     console.warn('\x1b[33m[related-search-clusters]\x1b[0m failed to patch master sitemap:', err);
   }
+  // Note: sitemapAliasPlugin runs `enforce: 'post'` AFTER us and regenerates
+  // sitemap.xml entirely from a directory scan of dist/sitemap-*.xml. This
+  // patch is therefore defensive — it keeps the file valid for any consumer
+  // that inspects it between our write and the alias plugin's overwrite.
 }
 
 // ── Plugin entry ────────────────────────────────────────────────────────
@@ -1432,7 +1514,14 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           for (const { locale, url } of restored.hubs) {
             injectHubLinkIntoSectionLanding(distDir, locale, url, COPY[locale]);
           }
-          patchMasterSitemap(distDir, dateStamp);
+          // Discover whatever shards the cache restored (legacy single-file
+          // or sharded) and re-advertise them in the master sitemap.
+          const restoredShards = fs.existsSync(distDir)
+            ? fs.readdirSync(distDir).filter((f) =>
+                new RegExp(`^${SITEMAP_SHARD_PREFIX}(?:-\\d+)?\\.xml$`).test(f),
+              ).sort()
+            : [];
+          patchMasterSitemap(distDir, dateStamp, restoredShards);
           console.log(
             `\x1b[36m[related-search-clusters]\x1b[0m cache HIT (key=${cacheKey}): ${restored.emittedCount} files restored in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
           );
@@ -1587,8 +1676,8 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       }
 
       const written = await collector.flush();
-      await writeSitemap(distDir, sitemapLocs, dateStamp);
-      emittedFiles.push('sitemap-search-clusters.xml');
+      const sitemapShards = await writeSitemap(distDir, sitemapLocs, dateStamp);
+      for (const shard of sitemapShards) emittedFiles.push(shard);
 
       // Capture stats before releasing the maps that hold them.
       const ctxCount = contexts.length;

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "validate:sitemap": "node scripts/validate-sitemap.mjs",
     "validate:sitemap-links": "node scripts/validate-sitemap-links.mjs",
     "validate:sitemap-pages": "node scripts/validate-sitemap-pages.mjs",
+    "validate:sitemap-shard-size": "node scripts/check-dist-sitemap-shard-size.mjs",
     "validate:page-seo": "node scripts/validate-page-seo-quality.mjs",
     "validate:spa-render": "node scripts/validate-spa-render.mjs",
     "validate:blog-meta-placeholders": "node scripts/validate-blog-meta-placeholders.mjs",

--- a/scripts/check-dist-sitemap-shard-size.mjs
+++ b/scripts/check-dist-sitemap-shard-size.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Local/CI gate: assert every dist/sitemap-*.xml urlset has < SHARD_HARD_CAP URLs.
+ *
+ * Background: sitemaps.org caps each sitemap file at 50,000 URLs. We enforce
+ * a 45,000 ceiling locally to leave a safety margin for incidental growth
+ * between builds. The `sitemap-search-clusters.xml` cohort breached 81k
+ * URLs in May 2026, silently failing GSC ingestion — this script prevents
+ * that class of regression before it ships.
+ *
+ * Behavior:
+ *   - Reads every dist/sitemap-*.xml that is NOT a sitemapindex.
+ *   - Counts <url> opening tags per file.
+ *   - Exits 1 with a detailed error if any shard ≥ SHARD_HARD_CAP.
+ *   - Exits 0 with a summary when every shard fits.
+ *
+ * Companion to `check-sitemap-shard-size.mjs` (which polls the LIVE deployed
+ * sitemap index post-deploy). This script runs against the local dist/ so
+ * we catch regressions before they're pushed.
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const DIST = path.resolve('dist');
+const SHARD_HARD_CAP = 45_000;
+const SHARD_WARN_CAP = 40_000;
+
+function countUrlEntries(xml) {
+  const matches = xml.match(/<url[\s>]/g);
+  return matches ? matches.length : 0;
+}
+
+if (!existsSync(DIST)) {
+  console.error(`[check-dist-sitemap-shard-size] dist/ does not exist at ${DIST}`);
+  console.error('[check-dist-sitemap-shard-size] run a build first (e.g. `npm run build`)');
+  process.exit(2);
+}
+
+const shardFiles = readdirSync(DIST)
+  .filter((name) => name.startsWith('sitemap') && name.endsWith('.xml'))
+  .sort();
+
+if (shardFiles.length === 0) {
+  console.error('[check-dist-sitemap-shard-size] no dist/sitemap-*.xml files found');
+  process.exit(2);
+}
+
+const oversized = [];
+const warnings = [];
+let totalUrls = 0;
+let inspected = 0;
+
+for (const file of shardFiles) {
+  const full = path.join(DIST, file);
+  const xml = readFileSync(full, 'utf-8');
+  // Sitemap indexes (sitemap.xml, sitemap-index.xml) contain <sitemap> entries,
+  // not <url> entries. Skip the URL count for those.
+  if (xml.includes('<sitemapindex')) continue;
+  const urlCount = countUrlEntries(xml);
+  totalUrls += urlCount;
+  inspected += 1;
+  if (urlCount >= SHARD_HARD_CAP) {
+    oversized.push({ file, urlCount });
+  } else if (urlCount >= SHARD_WARN_CAP) {
+    warnings.push({ file, urlCount });
+  }
+}
+
+for (const w of warnings) {
+  console.warn(
+    `[check-dist-sitemap-shard-size] WARNING ${w.file}: ${w.urlCount} URLs (≥${SHARD_WARN_CAP}, approaching ${SHARD_HARD_CAP} cap)`,
+  );
+}
+
+if (oversized.length > 0) {
+  console.error('');
+  console.error(`[check-dist-sitemap-shard-size] FAIL — ${oversized.length} shard(s) over the ${SHARD_HARD_CAP}-URL cap:`);
+  for (const o of oversized) {
+    console.error(`  - ${o.file}: ${o.urlCount} URLs`);
+  }
+  console.error('');
+  console.error('  Sharding is mandatory: sitemaps.org caps sitemap files at 50,000 URLs');
+  console.error('  and Google Search Console silently drops oversized files. Fix the');
+  console.error('  emitter (build-plugin or script) to split URLs across multiple files,');
+  console.error('  e.g. sitemap-FEATURE-001.xml, sitemap-FEATURE-002.xml, …');
+  process.exit(1);
+}
+
+console.log(
+  `[check-dist-sitemap-shard-size] OK — ${inspected} shard(s), ${totalUrls} total URLs (cap ${SHARD_HARD_CAP}/shard, warn ${SHARD_WARN_CAP})`,
+);
+process.exit(0);

--- a/scripts/lib/post-build-tasks.sh
+++ b/scripts/lib/post-build-tasks.sh
@@ -30,6 +30,7 @@ run_post_build_task() {
     validate:jobposting-schema)   npm run validate:jobposting-schema ;;
     validate:jobs-quality)        npm run validate:jobs-quality ;;
     validate:sitemap-links)       npm run validate:sitemap-links ;;
+    validate:sitemap-shard-size)  npm run validate:sitemap-shard-size ;;
     validate:spa-render)          timeout 300 node scripts/validate-spa-render.mjs ;;
     validate:structured-data)     node scripts/validate-structured-data-completeness.mjs ;;
     validate:soft-404)            node scripts/validate-soft404.mjs ;;
@@ -62,6 +63,7 @@ ALL_POST_BUILD_TASKS=(
   validate:sitemap-links
   audit:sitemap-canonicals
   validate:canonical
+  validate:sitemap-shard-size
   gate:seo-source
   audit:faqpage-validity
 )
@@ -83,6 +85,7 @@ POST_BUILD_SHARD_2=(
   audit:h1-title-duplicates
   validate:structured-data
   validate:sitemap-links
+  validate:sitemap-shard-size
 )
 POST_BUILD_SHARD_3=(
   test:e2e:smoke


### PR DESCRIPTION
sitemap-search-clusters.xml grew to 81,537 URLs as of 2026-05-18, exceeding
the sitemaps.org 50k-URL hard cap. GSC silently drops oversized files,
losing ~99k cluster URLs from crawl coverage.

- relatedSearchClustersPlugin: shard writeSitemap output into
  sitemap-search-clusters-001.xml, -002.xml at 45k URLs each (safety
  margin under 50k). Bumped CACHE_VERSION v4 -> v5 to invalidate
  single-file caches. Stale shard residue cleared on each emit so a
  shrinking corpus never leaves dangling files referenced by the
  auto-discovered sitemap.xml index. patchMasterSitemap rewritten to
  drop legacy + add per-shard entries; sitemapAliasPlugin's directory
  scan still owns the final index.
- new scripts/check-dist-sitemap-shard-size.mjs: hard-fails CI when any
  dist/sitemap-*.xml urlset exceeds 45k URLs; warns at 40k. Wired into
  post-build SHARD_2.
