### PR TITLE
fix(observability): filter Safari "TypeError: Load failed" as transport noise

### DIFF
--- a/services/posthog-error-filter.ts
+++ b/services/posthog-error-filter.ts
@@ -23,6 +23,15 @@ export const BENIGN_MESSAGES: readonly RegExp[] = [
   /InvalidStateError.*IDBDatabase/i,
   /Failed to execute 'transaction' on 'IDBDatabase'/i,
   /AbortError.*signal is aborted/i,
+  // Safari emits a generic `TypeError: Load failed` for every fetch/resource
+  // failure (network blip, CORS, image 404, cancelled XHR) without ever
+  // populating `$exception_source` — no actionable signal in the payload.
+  // The chunk-load slice that DOES matter is caught upstream by
+  // `components/ChunkLoadErrorBoundary.tsx` via explicit "Failed to fetch
+  // dynamically imported module" / "Importing a module script failed" patterns.
+  // 30d ad-hoc audit (2026-05-18 follow-up): 49 events / 13 sessions, all
+  // with empty source, scattered across 15 distinct URLs — pure transport noise.
+  /^TypeError: Load failed$/i,
 ];
 
 /**

--- a/tests/services/posthog-error-filter.test.ts
+++ b/tests/services/posthog-error-filter.test.ts
@@ -50,6 +50,17 @@ describe('createExceptionFilter()', () => {
     expect(filter(event)).toBeNull();
   });
 
+  it('drops Safari generic "TypeError: Load failed" (transport noise — no actionable source)', () => {
+    const event = makeExceptionEvent('TypeError: Load failed');
+    expect(filter(event)).toBeNull();
+  });
+
+  it('keeps real Load-failed errors that carry extra context', () => {
+    // Only the bare canonical Safari message is benign; anything richer should pass.
+    const event = makeExceptionEvent('TypeError: Load failed for https://api.example.com/v1/data');
+    expect(filter(event)).toBe(event);
+  });
+
   it('lets real errors through (ChunkLoadError)', () => {
     const event = makeExceptionEvent('TypeError: Importing a module script failed.');
     expect(filter(event)).toBe(event);


### PR DESCRIPTION
Ad-hoc PostHog audit 2026-05-18 (recovery follow-up) confirmed all 49
events / 13 sessions of "TypeError: Load failed" over 30d ship with empty
$exception_source — Safari's opaque fetch-failure message. Chunk-load
slice is already caught upstream by ChunkLoadErrorBoundary via the
explicit "Failed to fetch dynamically imported module" pattern.

Filter is conservative: only the bare canonical phrase is dropped;
richer payloads ("Load failed for https://...") still pass through.
