### PR TITLE
chore: flush local WIP — gitnexus index, squirrel seeds, comment Unicode polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ Key routing rules:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **frontaliere-si-o-no** (28666 symbols, 61425 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **frontaliere-si-o-no** (28982 symbols, 61573 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9477,7 +9477,7 @@ ${hreflangLinks}
  }
  // The disambiguator MUST land inside the cap when present (multi-slug
  // expired jobs share role+company and rely on it for title-uniqueness),
- // but we DROP the brand before resorting to ellipsis truncation -- mid-headline
+ // but we DROP the brand before resorting to `…` truncation — mid-headline
  // ellipsis tanks SERP CTR (see build-plugins/shared/titleSuffix.ts comment).
  // Critically, we work on the RAW headline (no HTML-escape) so `&` / `<` etc.
  // are not artificially expanded into multi-char entities like `&amp;` that

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -618,13 +618,12 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  const metaDesc = metaDescRaw.length > 155
  ? metaDescRaw.substring(0, 152) + '…'
  : metaDescRaw;
- // <title>: headline VERBATIM, brand suffix only when total <= TITLE_MAX_CHARS.
- // Per build-plugins/shared/titleSuffix.ts, mid-headline ellipsis truncation
- // tanks CTR (see /calcola-stipendio/ regression doc). We only force a
- // truncation when there's a real disambiguator collision that MUST be
- // preserved to satisfy audit:title-uniqueness -- and even then, we drop the
- // brand first (it's "nice-to-have", not a ranking signal) before resorting
- // to mid-headline truncation.
+ // <title>: headline VERBATIM, brand suffix only when total ≤ TITLE_MAX_CHARS.
+ // Per build-plugins/shared/titleSuffix.ts, mid-headline `…` truncation tanks
+ // CTR (see /calcola-stipendio/ regression doc). We only force a truncation
+ // when there's a real disambiguator collision that MUST be preserved to
+ // satisfy audit:title-uniqueness — and even then, we drop the brand first
+ // (it's "nice-to-have", not a ranking signal) before resorting to `…`.
  const articleLocale: 'it' | 'en' | 'de' | 'fr' = (locale === 'en' || locale === 'de' || locale === 'fr') ? locale : 'it';
  const baseTitleProbe = buildTitleWithBrand(localizedTitle);
  const collidesInLocale = (articleTitleCollisions[articleLocale].get(baseTitleProbe) || 0) > 1;
@@ -633,15 +632,15 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  let htmlPageTitle: string;
  if (!disamb) {
   // No collision: trust buildTitleWithBrand to either keep brand or drop it.
-  // It never truncates -- long headlines emit verbatim and the audit baseline
+  // It never truncates — long headlines emit verbatim and the audit baseline
   // ratchets them down at source.
   htmlPageTitle = buildTitleWithBrand(localizedTitle);
  } else {
   // Disambiguator MUST survive (collision-resolution for title-uniqueness).
   // Try brand+disamb first; if it doesn't fit, drop brand and keep disamb;
-  // if even headline+disamb overflows, truncate headline (last resort -- the
-  // only path where ellipsis truncation is acceptable because the alternative
-  // is dropping the (#hash) and breaking the title-uniqueness audit).
+  // if even headline+disamb overflows, truncate headline (last resort, the
+  // only path where `…` is acceptable because the alternative is dropping
+  // the (#hash) and breaking the title-uniqueness audit).
   const withBrandAndDisamb = `${localizedTitle}${disamb}${TITLE_BRAND_SUFFIX}`;
   if (withBrandAndDisamb.length <= TITLE_MAX_CHARS) {
    htmlPageTitle = withBrandAndDisamb;

--- a/data/title-length-baseline.json
+++ b/data/title-length-baseline.json
@@ -16,5 +16,5 @@
     "fr": 13957,
     "de": 13466
   },
-  "note": "blog bucket added 2026-05-18: ogPagesPlugin stopped truncating long article headlines with mid-word ellipsis (CTR collapsed 4.8 to 1.68 percent on /calcola-stipendio/ era). Articles now emit verbatim per universal titleSuffix policy. Source count of article headlines over 66 chars: ~2336 across 4 locales; baseline set to 2700 to absorb collision-disambiguator variance. Drive DOWN by shortening titleBase in scripts/create-article.mjs prompts and back-editing seo-blog*.ts headlines, then rebaseline."
+  "note": "blog bucket added 2026-05-18: ogPagesPlugin stopped truncating long article headlines with mid-word '…' (CTR collapsed 4.8 % → 1.68 % on /calcola-stipendio/ era). Articles now emit verbatim per universal titleSuffix policy. Source count of article headlines >66 chars: ~2336 across 4 locales; baseline set to 2700 to absorb collision-disambiguator variance. Drive DOWN by shortening titleBase in scripts/create-article.mjs prompts and back-editing seo-blog*.ts headlines, then rebaseline."
 }

--- a/squirrel.toml
+++ b/squirrel.toml
@@ -3,7 +3,7 @@ domains = []
 name = "frontaliere-ticino"
 
 [crawler]
-max_pages = 100
+max_pages = 120
 coverage = "surface"
 delay_ms = 100
 timeout_ms = 30000
@@ -12,7 +12,7 @@ follow_redirects = true
 concurrency = 5
 per_host_concurrency = 2
 per_host_delay_ms = 200
-include = ["/about", "/contact", "/privacy-policy"]
+include = []
 exclude = []
 allow_query_params = []
 drop_query_prefixes = [ "utm_", "gclid", "fbclid" ]
@@ -20,17 +20,29 @@ respect_robots = true
 breadth_first = true
 max_prefix_budget = 1.0
 seed_urls = [
-  "https://frontaliereticino.ch/chi-siamo",
-  "https://frontaliereticino.ch/contattaci",
-  "https://frontaliereticino.ch/privacy",
+  "https://frontaliereticino.ch/",
+  "https://frontaliereticino.ch/calcola-stipendio/",
+  "https://frontaliereticino.ch/calcola-stipendio/stipendio-netto-60000-chf/",
+  "https://frontaliereticino.ch/calcola-stipendio/confronta-retribuzione-ral",
+  "https://frontaliereticino.ch/cerca-lavoro-ticino/",
+  "https://frontaliereticino.ch/cerca-lavoro-ticino/lavora-con-noi-casale-sa-lugano",
+  "https://frontaliereticino.ch/cerca-lavoro-ticino/concorsi-per-l-assunzione-di-personale-educativo",
+  "https://frontaliereticino.ch/comparatori/",
+  "https://frontaliereticino.ch/comparatori/cambio-valuta",
+  "https://frontaliereticino.ch/fisco/",
+  "https://frontaliereticino.ch/guida-frontaliere/",
+  "https://frontaliereticino.ch/articoli-frontaliere/",
+  "https://frontaliereticino.ch/articoli-frontaliere/stipendio-medio-ticino-2026",
+  "https://frontaliereticino.ch/articoli-frontaliere/a13-cantieri-frontalieri-ticino",
+  "https://frontaliereticino.ch/vita-quotidiana/",
+  "https://frontaliereticino.ch/statistiche/",
   "https://frontaliereticino.ch/about",
   "https://frontaliereticino.ch/contact",
   "https://frontaliereticino.ch/privacy-policy",
-  "https://frontaliereticino.ch/articoli-frontaliere/a13-cantieri-frontalieri-ticino",
-  "https://frontaliereticino.ch/articoli-frontaliere/stipendio-medio-ticino-2026",
-  "https://frontaliereticino.ch/en/about-us",
-  "https://frontaliereticino.ch/en/contact-us",
-  "https://frontaliereticino.ch/en/privacy"
+  "https://frontaliereticino.ch/fuel-daily/coop-mendrisio",
+  "https://frontaliereticino.ch/aziende-che-assumono-questa-settimana/lugano",
+  "https://frontaliereticino.ch/health-premiums/ticino",
+  "https://frontaliereticino.ch/border-wait/chiasso-brogeda"
 ]
 
 [rules]


### PR DESCRIPTION
Bundling 5 ambient WIP files that had piled up locally as UU / M after autostash.

- **CLAUDE.md**: refresh GitNexus index counter (28666→28982 symbols, 61425→61573 relationships) — output of `npx gitnexus analyze` hook.
- **squirrel.toml**: bump `max_pages` 100→120, drop legacy `/chi-siamo` / `/privacy` seeds in favour of real SEO landings (calcola-stipendio scenarios, cerca-lavoro-ticino, fuel-daily, weekly-employers, health-premiums, border-wait).
- **build-plugins/jobsSeoPagesPlugin.ts + ogPagesPlugin.ts + data/title-length-baseline.json**: ASCII → Unicode polish in code comments + JSON note field (`--` → `—`, `ellipsis` → `…`, `<=` → `≤`, `percent` → `%`, `to` → `→`). Zero behavioral impact.