### PR TITLE
feat(eeat): show datePublished + dateModified in article header (visible to crawlers)

### DIFF
--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -495,6 +495,38 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  } catch { return isoStr.split('T')[0]; }
  };
 
+ // Date-only formatter for visible E-E-A-T byline (squirrelscan eeat/content-dates).
+ // Crawlers want a human "Pubblicato il 18 maggio 2026" near the H1.
+ const formatHumanDate = (isoStr: string, locale: string): string => {
+ try {
+ const d = new Date(isoStr);
+ if (isNaN(d.getTime())) return isoStr.split('T')[0];
+ const day = d.getDate();
+ const month = (MONTH_NAMES[locale] || MONTH_NAMES.it)[d.getMonth()];
+ const year = d.getFullYear();
+ return `${day} ${month} ${year}`;
+ } catch { return isoStr.split('T')[0]; }
+ };
+ const DATE_LABELS: Record<string, { published: string; updated: string }> = {
+ it: { published: 'Pubblicato il', updated: 'Aggiornato il' },
+ en: { published: 'Published on', updated: 'Updated on' },
+ de: { published: 'Veröffentlicht am', updated: 'Aktualisiert am' },
+ fr: { published: 'Publié le', updated: 'Mis à jour le' },
+ };
+ const buildDateByline = (datePubIso: string, dateModIso: string, locale: string): string => {
+ const labels = DATE_LABELS[locale] || DATE_LABELS.it;
+ const pubIso = normalizeDateTime(datePubIso);
+ const modIso = normalizeDateTime(dateModIso);
+ const pubDay = pubIso.split('T')[0];
+ const modDay = modIso.split('T')[0];
+ const pubHtml = `${labels.published} <time datetime="${esc(pubDay)}" itemprop="datePublished">${esc(formatHumanDate(pubIso, locale))}</time>`;
+ if (modDay && modDay !== pubDay) {
+ const modHtml = `${labels.updated} <time datetime="${esc(modDay)}" itemprop="dateModified">${esc(formatHumanDate(modIso, locale))}</time>`;
+ return `${pubHtml} · ${modHtml}`;
+ }
+ return pubHtml;
+ };
+
  /* ── 3. Write OG landing pages ──────────────────────────────── */
  const esc = (s: string) =>
  s.replace(/&/g, '&amp;').replace(/</g, '&lt;')
@@ -992,7 +1024,7 @@ ${headTags}
  ${ADSENSE_SNIPPET}
  </head>
  <body class="bg-surface-alt text-heading overflow-x-hidden">
- <div id="root"><main id="main-content"><article><h1>${esc(localizedTitle)}</h1><p class="article-byline" style="font-size:0.85rem;color:#64748b;margin:0.25rem 0 1rem">Di Valerie Linc · <time datetime="${esc(normalizeDateTime(en.datePub || en.dateMod || todayIso))}">${esc(formatHumanDateTime(normalizeDateTime(en.datePub || en.dateMod || todayIso), locale))}</time></p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/articoli-frontaliere/">Articoli</a></nav></article></main></div>
+ <div id="root"><main id="main-content"><article><h1>${esc(localizedTitle)}</h1><p class="article-byline" style="font-size:0.85rem;color:var(--color-body-muted,#64748b);margin:0.25rem 0 1rem">Di Valerie Linc · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/articoli-frontaliere/">Articoli</a></nav></article></main></div>
  <script type="module" crossorigin fetchpriority="high" src="/assets/${entryJs}"></script>
  </body>
 </html>`;

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -1896,12 +1896,16 @@ function BlogArticles({
  <span className="text-edge">|</span>
  <span className="flex items-center gap-1">
  <Calendar size={14} />
- {formatDate(article.date)}
+ <time dateTime={article.date.slice(0, 10)} itemProp="datePublished">
+ {t('blog.publishedOn')} {formatDate(article.date)}
+ </time>
  </span>
  {article.updatedAt && article.updatedAt !== article.date.slice(0, 10) && (
  <span className="flex items-center gap-1 text-success">
  <RefreshCw size={12} />
+ <time dateTime={article.updatedAt.slice(0, 10)} itemProp="dateModified">
  {t('blog.updatedOn')} {formatDate(article.updatedAt)}
+ </time>
  </span>
  )}
  <span className="flex items-center gap-1">

--- a/services/locales/de-stats.ts
+++ b/services/locales/de-stats.ts
@@ -307,6 +307,7 @@ const deStats: Record<string, string> = {
  'blog.seoTitle': 'Alles, was ein Grenzgänger wissen muss',
  'blog.seoContent': 'Aktuelle Artikel zu Nettogehalt, Steuern, 13. Monatsgehalt, KVG vs CMI, Säule 3a und allen praktischen Aspekten des Grenzgängerlebens im Tessin.',
  'blog.copyLink': 'Link kopieren',
+ 'blog.publishedOn': 'Veröffentlicht am',
  'blog.updatedOn': 'Aktualisiert am',
  'blog.copied': 'Kopiert!',
  'blog.shareWhatsApp': 'Auf WhatsApp teilen',

--- a/services/locales/en-stats.ts
+++ b/services/locales/en-stats.ts
@@ -307,6 +307,7 @@ const enStats: Record<string, string> = {
  'blog.seoTitle': 'Everything a cross-border worker needs to know',
  'blog.seoContent': 'Up-to-date articles on net salary, taxes, 13th month, LAMal vs CMI, pillar 3a, and all practical aspects of cross-border working in Ticino.',
  'blog.copyLink': 'Copy link',
+ 'blog.publishedOn': 'Published on',
  'blog.updatedOn': 'Updated on',
  'blog.copied': 'Copied!',
  'blog.shareWhatsApp': 'Share on WhatsApp',

--- a/services/locales/fr-stats.ts
+++ b/services/locales/fr-stats.ts
@@ -307,6 +307,7 @@ const frStats: Record<string, string> = {
  'blog.seoTitle': 'Tout ce qu\'un frontalier doit savoir',
  'blog.seoContent': 'Articles à jour sur le salaire net, les impôts, le 13e mois, LAMal vs CMI, pilier 3a et tous les aspects pratiques de la vie de frontalier au Tessin.',
  'blog.copyLink': 'Copier le lien',
+ 'blog.publishedOn': 'Publié le',
  'blog.updatedOn': 'Mis à jour le',
  'blog.copied': 'Copié !',
  'blog.shareWhatsApp': 'Partager sur WhatsApp',

--- a/services/locales/it-stats.ts
+++ b/services/locales/it-stats.ts
@@ -318,6 +318,7 @@ const translations: Record<string, string> = {
  'blog.seoTitle': 'Tutto quello che un frontaliere deve sapere',
  'blog.seoContent': 'Articoli aggiornati su stipendio netto, tasse, tredicesima, LAMal vs CMI, terzo pilastro, e tutti gli aspetti pratici della vita da frontaliere in Ticino. Calcola il tuo stipendio netto con il nostro simulatore gratuito.',
  'blog.copyLink': 'Copia link',
+ 'blog.publishedOn': 'Pubblicato il',
  'blog.updatedOn': 'Aggiornato il',
  'blog.copied': 'Copiato!',
  'blog.shareWhatsApp': 'Condividi su WhatsApp',


### PR DESCRIPTION
Adds visible Italian-friendly date byline (Pubblicato il / Aggiornato il) wrapped in machine-readable <time> elements on article pages. Fixes squirrelscan eeat/content-dates.