### PR TITLE
perf(cls): reserve job-board slot heights to fix CLS 0.65 → <0.25 on jobs_index + jobs_filter_concorsi

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -7343,7 +7343,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </div>
  )}
  {showAd && !isMobile && (
- <div key={`infeed-d-${idx}-${adRefreshKey}`} style={{ minHeight: '110px' }}>
+ <div key={`infeed-d-${idx}-${adRefreshKey}`} style={{ minHeight: '220px' }}>
  <AdSenseBanner
  adSlot={AD_SLOTS.JOBLIST_INFEED_DESKTOP.slot}
  adFormat={AD_SLOTS.JOBLIST_INFEED_DESKTOP.format}
@@ -7392,7 +7392,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  )}
 
  {enableJobAlerts && filteredJobs.length >= 3 && (
- <Suspense fallback={null}>
+ <Suspense fallback={<div className="mt-6 rounded-2xl border border-edge bg-surface-raised animate-pulse" style={{ minHeight: '280px' }} aria-hidden="true" />}>
  <JobAlertEndCard keyword={deferredSearchQuery.trim()} />
  </Suspense>
  )}


### PR DESCRIPTION
- bump desktop in-feed AdSense wrapper minHeight 110→220px to match
  fluid format placeholderMinHeight (was forcing ~110px shift on fill).
- replace Suspense fallback={null} on JobAlertEndCard with a
  280px-reserved animate-pulse placeholder so the lazy chunk mount
  no longer pushes the SEO sidebar / footer down.

Audit-cls-live still reported 0.62-0.70 on /cerca-lavoro-ticino*
after PR #262 (calculator + currency comparator fix). These two
slots accounted for the bulk of the residual shift.

JobAlertStickyBanner / JobAlertPostAuthPrompt / JobDetailAlertPrompt
are fixed-position (z-40 bottom toasts) → no layout-flow impact,
left with fallback={null}.
