### PR TITLE
revert(authgate): restore generic gate H2 across all 3 views

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -5919,21 +5919,6 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const gateCompanyHref = buildPath({ activeTab: 'job-board' as any, jobSlug: gateCompanySlug }, locale);
  const gateLocationSlug = jobLocation ? buildLocationSearchSlug(selectedJob.addressLocality || jobLocation, locale) : '';
  const gateLocationHref = gateLocationSlug ? buildPath({ activeTab: 'job-board' as any, jobSlug: gateLocationSlug }, locale) : '';
- // Personalized gate H2: surface the job-specific value (salary + company) so the
- // CTA promise is concrete, not generic. Falls back to "Unlock contacts" when no salary.
- const gateHeadline = (() => {
- const company = companyName;
- if (gateSalary) {
- if (locale === 'it') return `Sblocca ${gateSalary} — ${company}`;
- if (locale === 'de') return `${gateSalary} freischalten — ${company}`;
- if (locale === 'fr') return `Débloquer ${gateSalary} — ${company}`;
- return `Unlock ${gateSalary} — ${company}`;
- }
- if (locale === 'it') return `Sblocca contatti — ${company}`;
- if (locale === 'de') return `Kontakte freischalten — ${company}`;
- if (locale === 'fr') return `Débloquer les contacts — ${company}`;
- return `Unlock contacts — ${company}`;
- })();
 
  return (
  <div className="space-y-5">
@@ -6018,12 +6003,9 @@ const JobBoard: React.FC<JobBoardProps> = ({
 
  {/* Auth gate — embedded inline for all viewports (no extra click needed) */}
  <div id="job-auth-gate" role="region" aria-label={t('jobBoard.gate.title')} className="relative z-10 mt-3 scroll-mt-20 rounded-stripe border border-accent-border bg-accent-subtle p-4 sm:p-6">
- {/* Compact header: H2 with inline Eye icon. Personalized with the job's salary
- + company so the click promise is concrete, not generic. Subtitle removed:
- the trust bullets below already carry that information. */}
  <h2 className="flex items-start gap-2 text-lg sm:text-xl font-bold font-display text-heading leading-tight">
  <Eye className="w-5 h-5 mt-0.5 text-accent flex-shrink-0" aria-hidden="true" />
- <span>{gateHeadline}</span>
+ <span>{t('jobBoard.gate.title')}</span>
  </h2>
 
  {/* Trust signals — 2 lines at text-sm. text-xs is reserved for metadata

--- a/components/community/JobExpiredView.tsx
+++ b/components/community/JobExpiredView.tsx
@@ -690,11 +690,11 @@ export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAcces
  </div>
  )}
 
- {/* Auth gate — expired-context headline (job not applicable → promise is "similar listings") */}
+ {/* Auth gate */}
  <div id="job-auth-gate" role="region" aria-label={t('jobBoard.gate.title')} className="relative z-10 mt-3 scroll-mt-20 rounded-stripe border border-accent-border bg-accent-subtle p-4 sm:p-6">
  <h2 className="flex items-start gap-2 text-lg sm:text-xl font-bold font-display text-heading leading-tight">
  <Eye className="w-5 h-5 mt-0.5 text-accent flex-shrink-0" aria-hidden="true" />
- <span>{locale === 'it' ? 'Sblocca annunci simili' : locale === 'de' ? 'Ähnliche Stellen freischalten' : locale === 'fr' ? 'Débloquer les offres similaires' : 'Unlock similar listings'}</span>
+ <span>{t('jobBoard.gate.title')}</span>
  </h2>
 
  {/* Trust signals — 2 lines at text-sm (matches active job gate) */}

--- a/components/community/JobOrphanView.tsx
+++ b/components/community/JobOrphanView.tsx
@@ -508,15 +508,11 @@ export default function JobOrphanView({ slug, onBack, hasAccess: hasAccessProp, 
  {/* Active jobs */}
  {activeJobsSection}
 
- {/* Sign-in / alert block — orphan-context headline (slug has no job data → promise is "all active listings") */}
+ {/* Sign-in / alert block */}
  <div id="job-auth-gate" role="region" aria-label={t('jobBoard.gate.title')} className="relative z-10 mt-3 scroll-mt-20 rounded-stripe border border-accent-border bg-accent-subtle p-4 sm:p-6">
  <h2 className="flex items-start gap-2 text-lg sm:text-xl font-bold font-display text-heading leading-tight">
  <Eye className="w-5 h-5 mt-0.5 text-accent flex-shrink-0" aria-hidden="true" />
- <span>{
- totalActiveJobs != null && totalActiveJobs > 0
- ? (locale === 'it' ? `Sblocca ${totalActiveJobs.toLocaleString()}+ annunci attivi` : locale === 'de' ? `${totalActiveJobs.toLocaleString()}+ aktive Stellen freischalten` : locale === 'fr' ? `Débloquer ${totalActiveJobs.toLocaleString()}+ offres actives` : `Unlock ${totalActiveJobs.toLocaleString()}+ active listings`)
- : (locale === 'it' ? 'Sblocca tutti gli annunci attivi' : locale === 'de' ? 'Alle aktiven Stellen freischalten' : locale === 'fr' ? 'Débloquer toutes les offres actives' : 'Unlock all active listings')
- }</span>
+ <span>{t('jobBoard.gate.title')}</span>
  </h2>
 
  {/* Trust signals — 2 lines at text-sm (matches active job gate) */}


### PR DESCRIPTION
The personalized 'Sblocca {salary} — {company}' headline (commit 4a2a68e)
regressed mobile conversion. PostHog over a 6-day symmetric window:

  Mobile  CTR        3.34% → 2.44%  (-27%)
  Mobile  success/v  8.27% → 5.93%  (-28%)
  Desktop CTR        2.78% → 1.31%  (-53%)
  Desktop success/v  8.31% → 5.72%  (-31%)

Revert only the H2 text back to t('jobBoard.gate.title'); keep the
compact header layout, trust signals, and collapsible email form.
