### PR TITLE
fix(authgate): emit job_auth_funnel auth_success for LinkedIn

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -495,6 +495,22 @@ const App: React.FC = () => {
  // Also pass job context saved before the OAuth redirect for personalized job recs.
  const email = getAuthEmail(user);
  const savedJobCtx = consumeAuthJobContext();
+
+ // Google/Email emit job_auth_funnel:auth_success inline; LinkedIn lands here
+ // after a full-page OAuth redirect so the success event must be emitted from
+ // the callback. Gated on savedJobCtx so LinkedIn auths from non-job CTAs
+ // (newsletter, calculator) don't pollute the job_auth funnel.
+ if (savedJobCtx) {
+ const emailDomain = email && email.includes('@') ? email.split('@')[1] : undefined;
+ Analytics.trackJobAuthFunnel('auth_success', {
+ method: 'linkedin',
+ emailDomain,
+ company: savedJobCtx.company || undefined,
+ location: savedJobCtx.location || undefined,
+ category: savedJobCtx.category || undefined,
+ });
+ }
+
  if (email) {
  try {
  await upsertNewsletterSubscriber(email, 'signup_linkedin', user.displayName || null, savedJobCtx);


### PR DESCRIPTION
The Google and Email flows emit auth_success inline from JobBoard.tsx,
but LinkedIn uses a full-page OAuth redirect and the callback handler
in App.tsx only logged trackUIInteraction — not trackJobAuthFunnel.

Result: PostHog reported 0 LinkedIn auth_success in the job_auth funnel
for the last 12 days (147 method_clicks/wk → 0 attributed successes,
mobile + desktop combined). Successful logins were happening, just not
counted in the funnel.

Fix: in the LinkedIn callback, after signInWithCustomAuthToken succeeds,
emit auth_success with method='linkedin' and the job context that was
saved before the redirect (saveAuthJobContext). Gated on savedJobCtx
being non-null so LinkedIn auths from non-job CTAs (newsletter,
calculator) don't pollute the job_auth funnel.
