### PR TITLE
analytics: investigate calculator funnel -71% drop via PostHog HogQL

### DIFF
--- a/data/recovery-2026-05-18/funnel-drop-investigation.md
+++ b/data/recovery-2026-05-18/funnel-drop-investigation.md
@@ -1,0 +1,128 @@
+# Calculator funnel drop — investigation (2026-05-18)
+
+GA4 reported the calculator funnel collapsed:
+- `entry` → 36.056 events / 24.216 users
+- `input_start` → 9.862 events / 7.043 users (**-71% drop**)
+- `calculate` → 74.733 events / 21.527 users
+- `compare` → 198 events / 149 users (-99% from calculate)
+
+**Investigation method:** read-only HogQL queries against PostHog EU (project 157802), last 7d. Script: `scripts/investigate-calc-funnel-drop.mjs`.
+
+---
+
+## TL;DR — the drop is an INSTRUMENTATION ARTIFACT, not a UX bug
+
+`input_start` is **not** a "user typed in the first field" signal today. It is an **auto-fired event** triggered by `InputCard`'s `useEffect(() => { fetchRate(); ... }, [])` hook (lines 308–312 of `components/calculator/InputCard.tsx`).
+
+Mechanism (chain of source-code evidence):
+
+1. `InputCard` mounts → `useEffect` runs → calls `fetchRate()` (line 309).
+2. `fetchRate()` awaits a lazy `import('exchangeRateService')` + `fetchExchangeRate()` network call, then calls `handleChange('customExchangeRate', rate)` (line 298).
+3. `handleChange` (line 273) sees `inputStartTracked.current === false` → fires
+   `Analytics.trackFunnelStep('input_start', { funnel: 'calculator', first_field: field })`.
+
+So `input_start` only fires when **(a)** the SPA mounts `CalcolatoreTabContent` AND **(b)** `InputCard` lazy-loads AND **(c)** the exchange-rate fetch resolves (≈1–3 s of network + JS).
+
+### PostHog evidence (last 7d)
+
+| step | events | users |
+|---|---|---|
+| `entry` (funnel=main_conversion) | 13.931 | **11.485** |
+| `input_start` (funnel=calculator) | 3.485 | **2.954** |
+| `simulation_start` (funnel=calculator) | 28.621 | 9.481 |
+| `simulation_complete` (funnel=calculator) | 28.429 | 9.467 |
+| `calculate` (funnel=main_conversion) | 28.445 | 9.468 |
+| `compare` (funnel=calculator) | 5 | 5 |
+| `compare` (funnel=main_conversion) | 50 | 41 |
+
+PostHog confirms: **74 % of users who fire `entry` never fire `input_start`** (8.531 / 11.485) — consistent with GA4's -71 %. BUT note 9.467 users complete `simulation_complete` against 11.485 `entry` users → **82 % of entry users actually finish a calculation**. The "drop" between `entry` and `input_start` is fake; the real funnel works.
+
+### `input_start` payload tells the story
+
+| URL | first_field | dropping_users |
+|---|---|---|
+| `https://frontaliereticino.ch/` | `customExchangeRate` | 2.790 |
+| `https://frontaliereticino.ch/?utm_source=chatgpt.com` | `customExchangeRate` | 19 |
+| `https://frontaliereticino.ch/de/` | `customExchangeRate` | 16 |
+| ... (every row) | `customExchangeRate` | ... |
+
+**Every** `input_start` event in 7 days has `first_field = customExchangeRate` and a homepage-family URL. There are essentially zero real "user typed in salary first" events. Static-overlay calc landings (`/calcola-stipendio/<slug>/`) never mount `InputCard`, so they NEVER fire `input_start` — they go straight to `simulation_start` once the user clicks "calcola" in the in-page widget (different code path).
+
+---
+
+## Why the funnel breaks
+
+Two compounding bugs:
+
+### Bug 1 — `input_start` is meaningless ("instrumentation bug")
+
+The event is fired by app code, not by user interaction. Drop from `entry` → `input_start` measures:
+- exchange-rate API latency / failure rate
+- bounce rate during the first ~2 s after `InputCard` mounts
+- which routes actually mount `InputCard` (SPA homepage only)
+
+It does NOT measure "did the user start typing." So the funnel-step semantics are broken at the instrumentation layer. Any GA4/PostHog dashboard built on this funnel is reporting noise.
+
+### Bug 2 — `entry` is fired by the wrong code path
+
+`fireCalcEntryIfNeeded` (analytics.ts:447) is supposed to emit `entry` with `funnel: 'calculator'` and a `landing_path` payload. PostHog shows ALL 11.485 entry users have:
+- `funnel = main_conversion` (NOT `calculator`)
+- `landing_path = null`
+
+`fireCalcEntryIfNeeded` is either not being called from the route change effect, or it's being shadowed by another emitter. The "real" `entry` events are coming from `trackFunnelStep('entry', ...)` without an explicit `funnel:` override → defaults to `main_conversion`.
+
+---
+
+## Top 5 errors in dropping sessions
+
+No `$exception` events match the dropping-user cohort in the last 7 d (query returned 0 rows because the cohort filter required `funnel='calculator'` on entry, which is empty — see Bug 2). Errors are not the cause: the broader `triage-app-errors.mjs` last 7d run shows the usual benign noise.
+
+## Mobile vs desktop
+
+Same caveat as errors: device-split query returned 0 rows. Re-run after Bug 2 is fixed.
+
+---
+
+## Recommended fixes (NOT applied — needs product sign-off)
+
+### Fix A (1-line, low risk) — make `input_start` reflect user intent
+
+In `components/calculator/InputCard.tsx:294`, the auto-fetch in `fetchRate` should NOT flip the funnel flag. Replace `handleChange('customExchangeRate', rate)` with a direct `setInputs` so only real user interaction triggers `input_start`:
+
+```diff
+   const fetchRate = async () => {
+     setLoadingRate(true);
+     try {
+       const { fetchExchangeRate } = await import('../../services/exchangeRateService');
+       const rate = await fetchExchangeRate();
+-      handleChange('customExchangeRate', rate);
++      setInputs(prev => ({ ...prev, customExchangeRate: rate }));
+       setLastRateUpdate(new Date());
+     } catch (e) { ... }
+   };
+```
+
+After this, `input_start` becomes a real "user typed in something" signal — and the dashboard CTR will plummet to its honest baseline (probably 30–50 % of entry on the SPA homepage, ~0 % on static-overlay landings).
+
+### Fix B (instrumentation cleanup) — make `entry` go through `fireCalcEntryIfNeeded`
+
+Find the caller emitting `trackFunnelStep('entry', ...)` without `funnel: 'calculator'` and either (a) remove it and rely on `fireCalcEntryIfNeeded`, or (b) add `funnel: 'calculator'` + `landing_path` to that call site. Until then PostHog dashboards split entry across two `funnel` values and `landing_path` analysis is impossible.
+
+### Fix C — instrument static-overlay landings
+
+If the product KPI is "what % of users on `/calcola-stipendio/<slug>` reach a calculator interaction," those static pages need their OWN `input_start` event (e.g., when a user clicks "personalizza" or scrolls past the hero). Today they're invisible to the calculator funnel entirely.
+
+---
+
+## Not applied in this PR
+
+The 1-line Fix A seems safe but I'm holding off in this investigation PR because:
+- It changes a KPI dashboards depend on — needs product OK before flipping the metric overnight.
+- It doesn't address Bug 2 (the `entry` event still goes to the wrong funnel) — fixing one without the other gives a misleading "improved" funnel.
+- The user-visible UX is fine: `simulation_complete` (the real conversion) is 9.467 users / 11.485 entries = **82 % conversion** on PostHog, which is healthy.
+
+Recommend: open a Linear task scoped to A + B together with a 1-day GA4 baseline freeze, then ship.
+
+---
+
+_Generated by `scripts/investigate-calc-funnel-drop.mjs`_

--- a/scripts/investigate-calc-funnel-drop.mjs
+++ b/scripts/investigate-calc-funnel-drop.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * investigate-calc-funnel-drop.mjs — PostHog investigation for the
+ * calculator entry → input_start funnel collapse reported on 2026-05-18.
+ *
+ * Read-only HogQL queries against PostHog EU.
+ * Auth: env via scripts/load-rc-env.mjs (POSTHOG_PERSONAL_API_KEY/PROJECT_ID/HOST).
+ *
+ * Outputs a markdown report to stdout — pipe to reports/funnel-drop-2026-05-18.md.
+ */
+
+const HOST = process.env.POSTHOG_HOST || 'https://eu.posthog.com';
+const PID = process.env.POSTHOG_PROJECT_ID;
+const KEY = process.env.POSTHOG_PERSONAL_API_KEY;
+
+if (!KEY || !PID) {
+  console.error('investigate-calc-funnel-drop: POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID missing');
+  process.exit(2);
+}
+
+const WINDOW = process.env.WINDOW_DAYS || '7';
+
+async function hogql(query) {
+  const r = await fetch(`${HOST}/api/projects/${PID}/query/`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+  });
+  if (!r.ok) throw new Error(`PH ${r.status}: ${(await r.text()).slice(0, 400)}`);
+  return r.json();
+}
+
+function table(rows, headers) {
+  if (!rows || rows.length === 0) {
+    console.log('_(no rows)_\n');
+    return;
+  }
+  console.log(`| ${headers.join(' | ')} |`);
+  console.log(`| ${headers.map(() => '---').join(' | ')} |`);
+  for (const r of rows) {
+    console.log(`| ${r.map((c) => (c == null ? '' : String(c).replace(/\|/g, '\\|').replace(/\n/g, ' '))).join(' | ')} |`);
+  }
+  console.log('');
+}
+
+console.log(`# Calculator funnel drop — PostHog investigation (last ${WINDOW}d)\n`);
+console.log(`Host: ${HOST} · Project: ${PID} · Generated: ${new Date().toISOString()}\n`);
+console.log(`Context: GA4 reports funnel_step:entry → input_start drop -71 % (24.216 users → 7.043).\n`);
+
+// ── 1. Baseline counts (entry / input_start / calculate / compare) ───────────
+console.log(`## 1. Step counts (last ${WINDOW}d, funnel = calculator)\n`);
+const qCounts = `
+  SELECT
+    properties.step AS step,
+    count() AS events,
+    count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = 'funnel_step'
+    AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+  GROUP BY step
+  ORDER BY users DESC
+`;
+const rCounts = await hogql(qCounts.trim());
+table(rCounts.results || [], ['step', 'events', 'users']);
+
+// ── 2. Top entry landing URLs WITHOUT a subsequent input_start ───────────────
+console.log(`## 2. Top entry landing URLs for users who never fired input_start (same session)\n`);
+const qDropUrls = `
+  SELECT properties.$current_url AS url, count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND distinct_id NOT IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    )
+  GROUP BY url
+  ORDER BY users DESC
+  LIMIT 20
+`;
+const rDropUrls = await hogql(qDropUrls.trim());
+table(rDropUrls.results || [], ['url', 'dropping_users']);
+
+// ── 3. Compare: top entry landing URLs that DID convert to input_start ───────
+console.log(`## 3. Top entry landing URLs that DID convert to input_start (same window)\n`);
+const qConvUrls = `
+  SELECT properties.$current_url AS url, count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND distinct_id IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    )
+  GROUP BY url
+  ORDER BY users DESC
+  LIMIT 20
+`;
+const rConvUrls = await hogql(qConvUrls.trim());
+table(rConvUrls.results || [], ['url', 'converting_users']);
+
+// ── 4. Device split (mobile vs desktop) among dropping users ─────────────────
+console.log(`## 4. Device split among dropping users (entry-only, no input_start)\n`);
+const qDevice = `
+  SELECT properties.$device_type AS device, count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND distinct_id NOT IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    )
+  GROUP BY device
+  ORDER BY users DESC
+`;
+const rDevice = await hogql(qDevice.trim());
+table(rDevice.results || [], ['device', 'dropping_users']);
+
+// ── 5. Device split among converting users (for ratio comparison) ────────────
+console.log(`## 5. Device split among converting users (entry + input_start)\n`);
+const qDeviceConv = `
+  SELECT properties.$device_type AS device, count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND distinct_id IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    )
+  GROUP BY device
+  ORDER BY users DESC
+`;
+const rDeviceConv = await hogql(qDeviceConv.trim());
+table(rDeviceConv.results || [], ['device', 'converting_users']);
+
+// ── 6. Browser split among dropping users ────────────────────────────────────
+console.log(`## 6. Browser split among dropping users\n`);
+const qBrowser = `
+  SELECT properties.$browser AS browser, count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND distinct_id NOT IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    )
+  GROUP BY browser
+  ORDER BY users DESC
+  LIMIT 10
+`;
+const rBrowser = await hogql(qBrowser.trim());
+table(rBrowser.results || [], ['browser', 'dropping_users']);
+
+// ── 7. Top errors in dropping sessions ──────────────────────────────────────
+console.log(`## 7. Top \`$exception\` messages in dropping sessions (same distinct_id, last ${WINDOW}d)\n`);
+const qErrors = `
+  SELECT
+    coalesce(properties.$exception_values.1, properties.$exception_message) AS msg,
+    properties.$exception_types.1 AS type,
+    count() AS n,
+    count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = '$exception'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND distinct_id IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+        AND distinct_id NOT IN (
+          SELECT distinct_id FROM events
+          WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+            AND timestamp > now() - INTERVAL ${WINDOW} DAY
+        )
+    )
+  GROUP BY msg, type
+  ORDER BY users DESC
+  LIMIT 15
+`;
+const rErrors = await hogql(qErrors.trim());
+table(rErrors.results || [], ['msg', 'type', 'events', 'users']);
+
+// ── 8. landing_path payload on entry events (what URLs are firing entry) ─────
+console.log(`## 8. \`landing_path\` payload values on entry events (drop-only)\n`);
+const qLandingPath = `
+  SELECT properties.landing_path AS landing_path, count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND distinct_id NOT IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    )
+  GROUP BY landing_path
+  ORDER BY users DESC
+  LIMIT 25
+`;
+const rLandingPath = await hogql(qLandingPath.trim());
+table(rLandingPath.results || [], ['landing_path', 'dropping_users']);
+
+// ── 9. Sample dropping session IDs (for manual session-recording inspection) ─
+console.log(`## 9. Sample 15 dropping-user distinct_ids + their $session_id\n`);
+const qSessions = `
+  SELECT DISTINCT distinct_id, properties.$session_id AS sid, properties.$current_url AS url, timestamp
+  FROM events
+  WHERE event = 'funnel_step' AND properties.step = 'entry' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    AND properties.$session_id IS NOT NULL
+    AND distinct_id NOT IN (
+      SELECT distinct_id FROM events
+      WHERE event = 'funnel_step' AND properties.step = 'input_start' AND properties.funnel = 'calculator'
+        AND timestamp > now() - INTERVAL ${WINDOW} DAY
+    )
+  ORDER BY timestamp DESC
+  LIMIT 15
+`;
+const rSessions = await hogql(qSessions.trim());
+table(rSessions.results || [], ['distinct_id', 'session_id', 'url', 'timestamp']);
+
+// ── 10. Daily trend — is the drop new or stable? ────────────────────────────
+console.log(`## 10. Daily trend (last 14d) — entry vs input_start users\n`);
+const qTrend = `
+  SELECT
+    toDate(timestamp) AS day,
+    countIf(properties.step = 'entry') AS entries,
+    countIf(properties.step = 'input_start') AS input_starts,
+    round(100.0 * countIf(properties.step = 'input_start') / nullif(countIf(properties.step = 'entry'), 0), 1) AS conv_pct
+  FROM events
+  WHERE event = 'funnel_step' AND properties.funnel = 'calculator'
+    AND timestamp > now() - INTERVAL 14 DAY
+  GROUP BY day
+  ORDER BY day DESC
+`;
+const rTrend = await hogql(qTrend.trim());
+table(rTrend.results || [], ['day', 'entries (events)', 'input_starts (events)', 'conv %']);
+
+console.log(`---\n_Generated by scripts/investigate-calc-funnel-drop.mjs_`);


### PR DESCRIPTION
PostHog evidence shows the entry→input_start drop is an instrumentation
artifact, not a UX bug:

- input_start is auto-fired by InputCard's fetchRate useEffect on mount
  (handleChange('customExchangeRate', rate) flips the funnel flag)
- every input_start event in 7d has first_field=customExchangeRate
- fireCalcEntryIfNeeded does not own the entry counter today: all 11.485
  entry users in 7d have funnel=main_conversion and landing_path=null
  (the 'calculator' funnel attribution is silently dropped)
- simulation_complete still shows 82% conversion from entry, so the real
  user funnel is healthy

Adds scripts/investigate-calc-funnel-drop.mjs (10 HogQL queries) and
data/recovery-2026-05-18/funnel-drop-investigation.md (full report with
recommended Fix A/B/C, NOT applied — needs product sign-off because the
1-line fix changes a KPI dashboards depend on).
