### PR TITLE
feat(authgate): A/B test gate H2 via PostHog feature flag

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -93,6 +93,7 @@ import JobOrphanView from '@/components/community/JobOrphanView';
 import { AD_SLOTS } from '@/services/adsenseSlots';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { eagerAuth, getAuthEmail, promptOneTap, renderGoogleButton, isLinkedInSignInAvailable, signInWithLinkedIn, saveAuthJobContext } from '@/services/authService';
+import { useAuthGateHeadlineVariant } from '@/services/authGateExperiment';
 import {
  isMultiLocation,
  normalizeJobCategory,
@@ -2459,6 +2460,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
 }) => {
  const { t } = useTranslation();
  const [locale] = useLocale();
+ const { headline: gateHeadline } = useAuthGateHeadlineVariant(locale, t('jobBoard.gate.title'));
  const nav = useNavigation();
  const pageSize = 10;
  // Runtime kill-switches for the "Strumenti correlati" sidebar cross-links.
@@ -6005,7 +6007,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  <div id="job-auth-gate" role="region" aria-label={t('jobBoard.gate.title')} className="relative z-10 mt-3 scroll-mt-20 rounded-stripe border border-accent-border bg-accent-subtle p-4 sm:p-6">
  <h2 className="flex items-start gap-2 text-lg sm:text-xl font-bold font-display text-heading leading-tight">
  <Eye className="w-5 h-5 mt-0.5 text-accent flex-shrink-0" aria-hidden="true" />
- <span>{t('jobBoard.gate.title')}</span>
+ <span>{gateHeadline}</span>
  </h2>
 
  {/* Trust signals — 2 lines at text-sm. text-xs is reserved for metadata

--- a/components/community/JobExpiredView.tsx
+++ b/components/community/JobExpiredView.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, ArrowRight, ArrowUpRight, Briefcase, Building2, Calendar, Ch
 import { useLocale, t } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
 import { renderGoogleButton, isLinkedInSignInAvailable, signInWithLinkedIn, saveAuthJobContext } from '@/services/authService';
+import { useAuthGateHeadlineVariant } from '@/services/authGateExperiment';
 import { reportCaughtError } from '@/services/errorReporter';
 import { upsertNewsletterSubscriber } from '@/services/newsletterSubscribers';
 import { resolveCompanyLogoUrl } from '@/services/jobDataNormalization';
@@ -154,6 +155,7 @@ const JOB_EMAIL_ACCESS_KEY = 'ft_job_email';
 
 export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAccess: hasAccessProp, totalActiveJobs, onNavigateToCompany, onNavigateToLocation, onNavigateToJob, onPostJob, onNavigateToSearch }: JobExpiredViewProps) {
  const [locale] = useLocale();
+ const { headline: gateHeadline } = useAuthGateHeadlineVariant(locale, t('jobBoard.gate.title'));
  const isDesktopXl = useMediaQuery('(min-width: 1280px)');
  const isDesktopLg = useMediaQuery('(min-width: 1024px)');
  const googleButtonRef = useRef<HTMLDivElement>(null);
@@ -694,7 +696,7 @@ export default function JobExpiredView({ job, relatedJobs = [], onBack, hasAcces
  <div id="job-auth-gate" role="region" aria-label={t('jobBoard.gate.title')} className="relative z-10 mt-3 scroll-mt-20 rounded-stripe border border-accent-border bg-accent-subtle p-4 sm:p-6">
  <h2 className="flex items-start gap-2 text-lg sm:text-xl font-bold font-display text-heading leading-tight">
  <Eye className="w-5 h-5 mt-0.5 text-accent flex-shrink-0" aria-hidden="true" />
- <span>{t('jobBoard.gate.title')}</span>
+ <span>{gateHeadline}</span>
  </h2>
 
  {/* Trust signals — 2 lines at text-sm (matches active job gate) */}

--- a/components/community/JobOrphanView.tsx
+++ b/components/community/JobOrphanView.tsx
@@ -15,6 +15,7 @@ import { ArrowLeft, ArrowRight, Briefcase, Building2, CheckCircle2, ChevronDown,
 import { useLocale, t } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
 import { renderGoogleButton, isLinkedInSignInAvailable, signInWithLinkedIn, saveAuthJobContext } from '@/services/authService';
+import { useAuthGateHeadlineVariant } from '@/services/authGateExperiment';
 import { reportCaughtError } from '@/services/errorReporter';
 import { upsertNewsletterSubscriber } from '@/services/newsletterSubscribers';
 import { CRAWLED_COMPANY_LOGOS, resolveCompanyLogoUrl } from '@/services/jobDataNormalization';
@@ -162,6 +163,7 @@ function extractActiveJobLinks(html: string): Array<{ href: string; title: strin
 
 export default function JobOrphanView({ slug, onBack, hasAccess: hasAccessProp, totalActiveJobs, onNavigateToCompany, onNavigateToLocation, onNavigateToJob }: JobOrphanViewProps) {
  const [locale] = useLocale();
+ const { headline: gateHeadline } = useAuthGateHeadlineVariant(locale, t('jobBoard.gate.title'));
  const isDesktopXl = useMediaQuery('(min-width: 1280px)');
  const isDesktopLg = useMediaQuery('(min-width: 1024px)');
  const googleButtonRef = useRef<HTMLDivElement>(null);
@@ -512,7 +514,7 @@ export default function JobOrphanView({ slug, onBack, hasAccess: hasAccessProp, 
  <div id="job-auth-gate" role="region" aria-label={t('jobBoard.gate.title')} className="relative z-10 mt-3 scroll-mt-20 rounded-stripe border border-accent-border bg-accent-subtle p-4 sm:p-6">
  <h2 className="flex items-start gap-2 text-lg sm:text-xl font-bold font-display text-heading leading-tight">
  <Eye className="w-5 h-5 mt-0.5 text-accent flex-shrink-0" aria-hidden="true" />
- <span>{t('jobBoard.gate.title')}</span>
+ <span>{gateHeadline}</span>
  </h2>
 
  {/* Trust signals — 2 lines at text-sm (matches active job gate) */}

--- a/services/authGateExperiment.ts
+++ b/services/authGateExperiment.ts
@@ -1,0 +1,68 @@
+/**
+ * Auth-gate H2 A/B test wiring.
+ *
+ * Backed by the PostHog feature flag `authgate-headline-v1`. Variant assignment
+ * is per-distinctId and sticky; PostHog handles bucketing + the experiment
+ * statistics. This module just resolves the variant, returns the matching
+ * headline string for the active locale, and tags every subsequent PostHog
+ * event with `headline_variant` so the funnel queries can split by arm.
+ *
+ * Variants:
+ *   control      — t('jobBoard.gate.title') passed in from the caller.
+ *   frictionless — neutral outcome-framed CTA, tested across all 4 locales.
+ *
+ * Initial render is always control until PostHog loads (~200-400 ms cold).
+ * The experiment's exposure metric should be `gate_view WHERE headline_variant
+ * IS NOT NULL` so the brief unattributed window does not bias the outcome.
+ */
+
+import { useEffect, useState } from 'react';
+import { getFeatureFlag, onFeatureFlags, registerSuperProperty } from './posthog';
+
+const FLAG_KEY = 'authgate-headline-v1';
+
+export type AuthGateVariant = 'control' | 'frictionless';
+
+const CHALLENGER_HEADLINES: Record<string, string> = {
+ it: "Continua per vedere l'annuncio completo",
+ en: 'Continue to see the full listing',
+ de: 'Weiter zum vollständigen Stellenangebot',
+ fr: "Continuer pour voir l'annonce complète",
+};
+
+function resolveChallenger(locale: string): string {
+ return CHALLENGER_HEADLINES[locale] ?? CHALLENGER_HEADLINES.it;
+}
+
+function normalizeVariant(raw: unknown): AuthGateVariant {
+ return raw === 'frictionless' ? 'frictionless' : 'control';
+}
+
+interface UseAuthGateHeadlineVariantResult {
+ variant: AuthGateVariant;
+ headline: string;
+}
+
+/**
+ * Returns the headline + variant for the current PostHog assignment. Pass the
+ * control headline (typically `t('jobBoard.gate.title')`) so this hook can
+ * fall back without duplicating the i18n key.
+ */
+export function useAuthGateHeadlineVariant(
+ locale: string,
+ controlHeadline: string,
+): UseAuthGateHeadlineVariantResult {
+ const [variant, setVariant] = useState<AuthGateVariant>('control');
+
+ useEffect(() => {
+ const unsubscribe = onFeatureFlags(() => {
+ const resolved = normalizeVariant(getFeatureFlag(FLAG_KEY));
+ setVariant(resolved);
+ registerSuperProperty('headline_variant', resolved);
+ });
+ return unsubscribe;
+ }, []);
+
+ const headline = variant === 'frictionless' ? resolveChallenger(locale) : controlHeadline;
+ return { variant, headline };
+}

--- a/services/posthog.ts
+++ b/services/posthog.ts
@@ -98,3 +98,46 @@ export function identifyUser(distinctId: string, properties?: Record<string, any
  if (ph) ph.identify(distinctId, properties);
  });
 }
+
+/**
+ * Synchronously read a feature flag's variant string. Returns null when PostHog
+ * has not loaded yet or the flag is undefined — callers must handle the null
+ * branch (typically by falling back to the control experience).
+ */
+export function getFeatureFlag(key: string): string | boolean | null {
+ if (!_posthog) return null;
+ const v = _posthog.getFeatureFlag(key);
+ return v === undefined ? null : v;
+}
+
+/**
+ * Register a callback that fires once feature flags are loaded (and on every
+ * subsequent reload). Returns an unsubscribe function. The callback fires
+ * immediately if flags are already loaded.
+ */
+export function onFeatureFlags(callback: () => void): () => void {
+ let unsubscribe: (() => void) | null = null;
+ let cancelled = false;
+ ensurePostHog().then(ph => {
+ if (cancelled || !ph) return;
+ unsubscribe = ph.onFeatureFlags(() => callback());
+ callback();
+ });
+ return () => {
+ cancelled = true;
+ if (unsubscribe) unsubscribe();
+ };
+}
+
+/**
+ * Attach a property to every subsequent PostHog event (super-property).
+ * Used to tag every event with the active A/B variant once it resolves.
+ */
+export function registerSuperProperty(key: string, value: string | number | boolean): void {
+ const apply = (ph: any) => ph.register({ [key]: value });
+ if (_posthog) {
+ apply(_posthog);
+ return;
+ }
+ ensurePostHog().then(ph => { if (ph) apply(ph); });
+}


### PR DESCRIPTION
Wires the auth-gate H2 to the PostHog feature flag 'authgate-headline-v1'
with two variants:

  control      — t('jobBoard.gate.title') = 'Leggi requisiti e come candidarti'
  frictionless — 'Continua per vedere l'annuncio completo' (4 locales)

The variant resolves once PostHog loads, sets 'headline_variant' as a
super-property so every subsequent job_auth_funnel event carries the
arm tag, and falls back to control on cold start so the gate never
renders empty. PostHog handles per-distinctId sticky bucketing.

Changes:
- services/posthog.ts: expose getFeatureFlag, onFeatureFlags, registerSuperProperty
- services/authGateExperiment.ts (new): useAuthGateHeadlineVariant hook + locale table
- components/community/JobBoard.tsx + JobExpiredView.tsx + JobOrphanView.tsx:
  call the hook, render variant headline in the gate H2

Experiment power calc: baseline 8% success/views, 1200 daily gate_views
(mobile + desktop), 50/50 split → detect +20% relative lift in ~12 days
at 95% confidence, 80% power. Stop early if PostHog's Bayesian engine
shows >95% probability of one arm winning.
