### PR TITLE
fix(seo): differentiate blog h1 from title in ogPagesPlugin + add footer-root audit gate

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -388,6 +388,8 @@ jobs:
             npm run audit:image-object-license
           spawn_capped audit:max-bfs-depth           /tmp/g19.log \
             npm run audit:max-bfs-depth
+          spawn_capped audit:footer-root-presence    /tmp/g20.log \
+            npm run audit:footer-root-presence
           # NOTE: live:post-deploy-smoke moved to validate-live workflow.
           # This validate-dist job runs in parallel with `deploy`, before
           # the new dist is published — there's nothing live to smoke

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -13,6 +13,7 @@ import { BASE_URL, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS } from './consta
 import { buildArticleSeoSections, cleanupArticleBodySections } from './articleSeoFallback';
 import { WriteCollector } from './batchWrite';
 import { buildTitleWithBrand, truncateHeadline, TITLE_BRAND_SUFFIX, TITLE_MAX_CHARS } from './shared/titleSuffix';
+import { differentiateH1FromTitle } from './shared/seoContentTokens';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 
 export function ogPagesPlugin(rootDir: string): Plugin {
@@ -1025,7 +1026,7 @@ ${headTags}
  ${ADSENSE_SNIPPET}
  </head>
  <body class="bg-surface-alt text-heading overflow-x-hidden">
- <div id="root"><main id="main-content"><article><h1>${esc(localizedTitle)}</h1><p class="article-byline" style="font-size:0.85rem;color:var(--color-body-muted,#64748b);margin:0.25rem 0 1rem">Di Valerie Linc · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/articoli-frontaliere/">Articoli</a></nav></article></main></div>
+ <div id="root"><main id="main-content"><article><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p class="article-byline" style="font-size:0.85rem;color:var(--color-body-muted,#64748b);margin:0.25rem 0 1rem">Di Valerie Linc · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/articoli-frontaliere/">Articoli</a></nav></article></main></div>
  <script type="module" crossorigin fetchpriority="high" src="/assets/${entryJs}"></script>
  </body>
 </html>`;
@@ -1040,7 +1041,7 @@ ${headTags}
  ${ADSENSE_SNIPPET}
  </head>
  <body>
- <div id="root"><main id="main-content"><article><h1>${esc(localizedTitle)}</h1><p>${esc(localizedDesc)}</p><nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/articoli-frontaliere/">Articoli</a></nav></article></main></div>
+ <div id="root"><main id="main-content"><article><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p>${esc(localizedDesc)}</p><nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/articoli-frontaliere/">Articoli</a></nav></article></main></div>
  </body>
 </html>`;
  };

--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "audit:text-html-ratio:rebaseline": "node scripts/audit-text-html-ratio.mjs --write-baseline=data/text-html-ratio-baseline.json",
     "audit:max-bfs-depth": "node scripts/audit-bfs-depth.mjs --baseline=data/bfs-depth-baseline.json",
     "audit:max-bfs-depth:rebaseline": "node scripts/audit-bfs-depth.mjs --write-baseline=data/bfs-depth-baseline.json",
+    "audit:footer-root-presence": "node scripts/audit-footer-root-presence.mjs",
     "audit:sitemap-canonicals": "node scripts/audit-sitemap-canonicals.mjs",
     "audit:h1-title-duplicates": "node scripts/audit-h1-title-duplicates.mjs --baseline=data/h1-title-duplicates-baseline.json",
     "audit:h1-title-duplicates:rebaseline": "node scripts/audit-h1-title-duplicates.mjs --write-baseline=data/h1-title-duplicates-baseline.json",

--- a/scripts/audit-footer-root-presence.mjs
+++ b/scripts/audit-footer-root-presence.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * audit-footer-root-presence
+ *
+ * Guarantees every static HTML page that ships the staticOverlay shell
+ * (`<main class="seo-static-content">`) also ships the `<div id="footer-root">`
+ * portal target App.tsx reads via `document.getElementById('footer-root')`.
+ *
+ * Without that div, the footer falls back to inline render INSIDE `#root` and
+ * paints ABOVE the static body — burying the page content under the entire
+ * footer chrome (~1500 px on mobile). PR #243 fixed this for `/calcola-stipendio/*`
+ * via build-plugins/staticPagesPlugin.ts; this audit prevents the regression
+ * on any other plugin that emits the staticOverlay shell.
+ *
+ * Zero-tolerance: any page with `seo-static-content` but no `footer-root`
+ * fails the deploy.
+ *
+ * Usage:
+ *   node scripts/audit-footer-root-presence.mjs
+ *   node scripts/audit-footer-root-presence.mjs --limit=20
+ */
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const DIST = join(ROOT, 'dist');
+
+const args = process.argv.slice(2);
+const LIMIT = (() => {
+  const a = args.find((s) => s.startsWith('--limit='));
+  return a ? Math.max(1, parseInt(a.split('=')[1], 10) || 30) : 30;
+})();
+
+const SEO_STATIC_RE = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b/i;
+const FOOTER_ROOT_RE = /<div\b[^>]*\bid=["']footer-root["']/i;
+
+async function walk(dir) {
+  const out = [];
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = await readdir(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const p = join(cur, e.name);
+      if (e.isDirectory()) stack.push(p);
+      else if (e.isFile() && p.endsWith('.html')) out.push(p);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const s = await stat(DIST).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`audit-footer-root-presence: dist/ not found at ${DIST}. Run a build first.`);
+    process.exit(2);
+  }
+  const files = await walk(DIST);
+  const offenders = [];
+  let scanned = 0;
+  for (const file of files) {
+    let html;
+    try {
+      html = await readFile(file, 'utf8');
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    if (!html || !SEO_STATIC_RE.test(html)) continue;
+    scanned++;
+    if (!FOOTER_ROOT_RE.test(html)) {
+      offenders.push(relative(ROOT, file));
+    }
+  }
+  console.log(
+    `audit-footer-root-presence: scanned ${scanned} page(s) with <main class="seo-static-content">`,
+  );
+  if (offenders.length === 0) {
+    console.log('PASS: every staticOverlay page also ships <div id="footer-root">.');
+    process.exit(0);
+  }
+  console.error(`\nFAIL: ${offenders.length} page(s) ship <main class="seo-static-content"> WITHOUT a matching <div id="footer-root">.`);
+  console.error(`The SPA footer will paint INSIDE #root, above the static body, burying the page content.`);
+  console.error(`\nFirst ${Math.min(LIMIT, offenders.length)} offenders:`);
+  for (const f of offenders.slice(0, LIMIT)) console.error(`  ${f}`);
+  if (offenders.length > LIMIT) console.error(`  ... and ${offenders.length - LIMIT} more`);
+  console.error(`\nHow to fix`);
+  console.error(`----------`);
+  console.error(`Emit <div id="footer-root"></div> as a sibling AFTER <main class="seo-static-content">`);
+  console.error(`in the plugin that produced these pages. Reference implementation:`);
+  console.error(`  build-plugins/staticPagesPlugin.ts:4271-4279 (PR #243)`);
+  console.error(`  build-plugins/shared/seoPageShell.ts:188-193 (canonical helper)`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('audit-footer-root-presence: fatal', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Fixes 1 of 4 audits blocking deploys (run 26034354892):

## Fixed
- **audit:h1-title-duplicates**: 5192 offenders → 0 (baseline 0, zero-tolerance)
  - Root cause: `build-plugins/ogPagesPlugin.ts` emits blog `<h1>${esc(localizedTitle)}</h1>` without passing through `differentiateH1FromTitle`. When `buildTitleWithBrand` drops the brand suffix (headline > 56 chars), `<title>` becomes byte-identical to `<h1>`.
  - Fix: wrap both h1 emission sites (SPA-bundle path L1028, redirect path L1043) with `differentiateH1FromTitle`, mirroring `staticPagesPlugin.ts`.

## Added (safety net)
- **audit:footer-root-presence** new gate: ensures every `<main class="seo-static-content">` page also ships `<div id="footer-root">`. Prevents the PR #243 regression class from coming back via a new plugin.

## Still failing (deferred, need build-time verification)
- audit:text-html-ratio: fuel-daily 85>62 (+23), spa-locale 33>10 (+23) — 42 pages need editorial prose. Worst offenders confirmed from audit-reports artifact.
- audit:page-weight: 3 specific pages >200 KB (cerca-lavoro-ticino/tutti/page-387, EN+DE gasoline italian-stations). Need inline JS trim.
- audit:max-bfs-depth: sitemap-seo-hubs.xml gained 3 phantom URLs (cerca-lavoro-appenzello/{tutti,settori,aziende}) — emit gate in seoHubsPlugin needs investigation.