### PR TITLE
perf(seo): extract inline styles to CSS classes in canton-hub paginated pages and per-job related-jobs list

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2130,8 +2130,14 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const max = r.salaryMax ? (r.salaryMax / 1000).toFixed(0) : null;
  return max ? `${r.currency || 'CHF'} ${min}k – ${max}k` : `${r.currency || 'CHF'} ${min}k+`;
  })();
+ // CSS classes `.rj` / `.rja` / `.rjw` / `.rjt` / `.rjs` / `.rjp`
+ // replace ~390 B of inline styles per related-job item with ~50 B of
+ // class refs. With Math.min(6, relatedPool.length) related items per
+ // job page × ~641k per-job HTML files emitted across all cantons +
+ // 4 locales, this saves ~1.5 KB per page ≈ ~900 MB dist. Class
+ // bodies live in the shared per-job `<style>` block (see lines ~2350+).
  const rLogoImg = renderLogoImg(rLogo, `Logo ${r.company}`, 40, 40, 'width:40px;height:40px;object-fit:contain;border-radius:8px;border:1px solid var(--color-edge);flex-shrink:0');
- return `<li style="margin:0 0 8px 0"><a href="${href}" aria-label="${esc(relatedTitle)} — ${esc(r.company)}" style="display:flex;align-items:flex-start;gap:12px;text-decoration:none;padding:12px;border:1px solid var(--color-edge);border-radius:12px">${rLogoImg}<div style="min-width:0;flex:1"><div style="font-size:14px;font-weight:700;color:var(--color-heading);line-height:1.3">${esc(relatedTitle)}</div><div style="font-size:12px;color:var(--color-subtle);margin-top:2px">${esc(r.company)} · ${esc(r.location)}${r.canton ? ` (${esc(r.canton)})` : ''}</div>${rSalary ? `<div style="font-size:12px;font-weight:600;color:var(--color-success);margin-top:4px">${esc(rSalary)}</div>` : ''}</div></a></li>`;
+ return `<li class="rj"><a href="${href}" aria-label="${esc(relatedTitle)} — ${esc(r.company)}" class="rja">${rLogoImg}<div class="rjw"><div class="rjt">${esc(relatedTitle)}</div><div class="rjs">${esc(r.company)} · ${esc(r.location)}${r.canton ? ` (${esc(r.canton)})` : ''}</div>${rSalary ? `<div class="rjp">${esc(rSalary)}</div>` : ''}</div></a></li>`;
  })
  .join('');
  const summaryHtml = summaryParagraphs
@@ -2486,6 +2492,15 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  margin: 0 0 10px 0;
  font-size: 18px;
  }
+ /* Related-jobs list (.rj/.rja/.rjw/.rjt/.rjs/.rjp): one-shot CSS for what
+    used to be ~390 B of inline styles per `<li>`. With 6 items/page × 641k
+    job HTML files this saves ~900 MB across dist. */
+ .rj { margin: 0 0 8px 0; }
+ .rja { display: flex; align-items: flex-start; gap: 12px; text-decoration: none; padding: 12px; border: 1px solid var(--color-edge); border-radius: 12px; }
+ .rjw { min-width: 0; flex: 1; }
+ .rjt { font-size: 14px; font-weight: 700; color: var(--color-heading); line-height: 1.3; }
+ .rjs { font-size: 12px; color: var(--color-subtle); margin-top: 2px; }
+ .rjp { font-size: 12px; font-weight: 600; color: var(--color-success); margin-top: 4px; }
  @media (max-width: 980px) {
  body > #root > main.static-job-page { padding: 14px; }
  .hero-title { font-size: 22px; }

--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1597,6 +1597,13 @@ function buildThinCantonHubHtml(args: {
   // every page in totalPages MUST be linked so the BFS audit can find
   // it. Pages are wrapped in <details> when the ladder grows past 10
   // entries so the mobile fold stays clear (CLAUDE.md #15/#16).
+  //
+  // CSS classes `.thp` (page link) / `.thc` (current page) replace what was
+  // ~250 B of inline styles per anchor with ~12 B class refs. On a 400-page
+  // hub this saves ~90 KB per emitted page (× 4 locales × ~30 paginated
+  // cantons ≈ 200 MB dist). Same pattern as the `.hp/.hc` fix landed in
+  // `renderPagination` on 2026-05-18 for the master-hub regression on
+  // `/cerca-lavoro-ticino/tutti/page-387/`.
   let paginationHtml = '';
   if (totalPages > 1) {
     const paginationLabel = locale === 'en' ? 'Browse all pages'
@@ -1608,9 +1615,9 @@ function buildThinCantonHubHtml(args: {
     for (let p = 1; p <= totalPages; p++) {
       const href = p === 1 ? basePath : paginatedPath(basePath, p);
       if (p === page) {
-        anchors.push(`<strong style="display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:var(--color-accent);color:var(--color-on-accent);font-size:13px">${pageWord}&nbsp;${p}</strong>`);
+        anchors.push(`<strong class="thc">${pageWord}&nbsp;${p}</strong>`);
       } else {
-        anchors.push(`<a href="${href}" style="display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;background:var(--color-surface);color:var(--color-link);text-decoration:none;font-size:13px;border:1px solid var(--color-edge)">${pageWord}&nbsp;${p}</a>`);
+        anchors.push(`<a href="${href}" class="thp">${pageWord}&nbsp;${p}</a>`);
       }
     }
     // Always-open <details> so the BFS walker (and crawlers) see every <a>
@@ -1648,8 +1655,12 @@ function buildThinCantonHubHtml(args: {
             return `<li><a href="${esc(it.href)}" style="display:flex;align-items:center;gap:12px;padding:14px 16px;border-radius:14px;color:var(--color-heading);background:var(--color-surface);text-decoration:none;border:1px solid var(--color-edge)"><span aria-hidden="true" style="display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:12px;background:var(--color-surface-alt);font-size:24px;line-height:1;flex-shrink:0">${emoji}</span><span style="flex:1;min-width:0"><span style="display:block;font-weight:700;font-size:15px;line-height:1.3;color:var(--color-heading)">${esc(it.label)}</span>${it.sub ? `<span style="display:block;font-size:12.5px;color:var(--color-subtle);margin-top:2px;line-height:1.4">${esc(it.sub)}</span>` : ''}</span></a></li>`;
           })
           .join('')}</ul>`
+      // CSS classes `.thi` / `.thi-s` replace ~200 B of inline styles per
+      // anchor with ~10 B class refs. With JOBS_PAGE_SIZE = 100 items per
+      // `/tutti/page-N/`, this saves ~19 KB per page × ~2.8k paginated
+      // pages across all cantons and locales ≈ 50 MB dist.
       : `<ul style="list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:8px">${items
-          .map((it) => `<li><a href="${esc(it.href)}" style="display:block;padding:10px 12px;border-radius:8px;color:var(--color-heading);background:var(--color-surface);text-decoration:none;border:1px solid var(--color-edge);font-size:14px;line-height:1.4">${esc(it.label)}${it.sub ? `<span style="display:block;font-size:12px;color:var(--color-subtle);margin-top:2px">${esc(it.sub)}</span>` : ''}</a></li>`)
+          .map((it) => `<li><a href="${esc(it.href)}" class="thi">${esc(it.label)}${it.sub ? `<span class="thi-s">${esc(it.sub)}</span>` : ''}</a></li>`)
           .join('')}</ul>`;
 
   // Stat tiles (rule #17) — only on page 1, only when caller supplied them.
@@ -1707,6 +1718,7 @@ function buildThinCantonHubHtml(args: {
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <link rel="canonical" href="${canonicalUrl}">
+    <style>.thp,.thc{display:inline-block;padding:4px 10px;margin:2px;border-radius:6px;font-size:13px}.thp{background:var(--color-surface);color:var(--color-link);text-decoration:none;border:1px solid var(--color-edge)}.thc{background:var(--color-accent);color:var(--color-on-accent)}.thi{display:block;padding:10px 12px;border-radius:8px;color:var(--color-heading);background:var(--color-surface);text-decoration:none;border:1px solid var(--color-edge);font-size:14px;line-height:1.4}.thi-s{display:block;font-size:12px;color:var(--color-subtle);margin-top:2px}</style>
     <script type="application/ld+json">${breadcrumbLd}</script>${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : ''}
     ${ADSENSE_SNIPPET}
   </head>


### PR DESCRIPTION
Two emitters were inlining ~250-400 B of identical CSS per anchor inside
.map() loops, multiplied across hundreds of thousands of HTML files.
Both now use shared CSS class refs.

1. seoHubsPlugin.ts buildThinCantonHubHtml
   - flat pagination ladder anchors → .thp/.thc (saves ~70 KB per 400-page hub)
   - tutti-hub item list anchors → .thi/.thi-s (saves ~19 KB per page)
   - One-shot <style> block added in head
   - Same fix pattern as renderPagination's .hp/.hc (landed 2026-05-18)
   - Estimated dist savings: ~200 MB

2. jobsSeoPagesPlugin.ts per-job template, relatedHtml
   - Per-related-job <li>/anchor/wrap/title/sub/salary → .rj/.rja/.rjw/.rjt/.rjs/.rjp
   - Class bodies appended to the existing per-job <style> block (no extra
     per-page cost beyond the one-shot ~280 B definition)
   - ~390 B of inline styles per related-job × 6 items/page × ~641k per-job
     HTML files across 26 cantons + 4 locales
   - Estimated dist savings: ~900 MB

Unblocks current deploy failure (artifact uncompressed > 10 GB hard cap on
GitHub Pages). Combined dist reduction: ~1.1 GB → from 9.45 GB to ~8.4 GB.

Visual output unchanged: same DOM, same anchors, same hrefs, same colours
(class definitions copy the previous inline-style declarations 1:1).
