### PR TITLE
perf(seo): dedupe staticBody between HTML article + window.__STATIC_BODY_HTML__

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9084,10 +9084,15 @@ ${alternates}
  return [l, { nav, footer, listingPath: lp }];
  }));
 
- // Assembler: builds a complete soft-landing HTML page from pre-computed parts + dynamic slots
+ // Assembler: builds a complete soft-landing HTML page from pre-computed parts + dynamic slots.
+ // `__STATIC_BODY_HTML__` is no longer JSON-embedded in head (which used to duplicate the entire
+ // body twice per page — once as HTML, once as JSON-stringified blob). Instead the snippet right
+ // before `${spaBundleJs}` snapshots `.ft-static-article` from DOM at parse time, BEFORE the
+ // module-script SPA bundle hydrates and replaces #root. JobOrphanView.tsx then reads
+ // window.__STATIC_BODY_HTML__ exactly as before. Saves ~3-5 KB × 98k pages ≈ ~400 MB dist.
  const buildSoftLandingHtml = (locale: string, pageTitle: string, pageDesc: string, robotsTag: string,
  selfUrl: string, hreflangLinks: string, jsonLdScripts: string, expiredWindowData: string,
- staticBodyJson: string, staticBody: string): string => {
+ staticBody: string): string => {
  const shell = localeShells[locale];
  return `<!DOCTYPE html>
 <html lang="${locale}">
@@ -9104,7 +9109,7 @@ ${hreflangLinks}
  ${darkModeScript}
  ${seoStaticCssLink}
  ${jsonLdScripts}
- <script>window.__EXPIRED_JOB_DATA__=${expiredWindowData};window.__STATIC_BODY_HTML__=${staticBodyJson};</script>${spaBundleCss}
+ <script>window.__EXPIRED_JOB_DATA__=${expiredWindowData};</script>${spaBundleCss}
  ${SPA_ACTION_REDIRECT_SCRIPT}
  ${GTAG_SNIPPET}
  ${ADSENSE_SNIPPET}
@@ -9116,7 +9121,8 @@ ${hreflangLinks}
  ${staticBody}
  </article>
  ${shell.footer}
- </div>${spaBundleJs}
+ </div>
+ <script>window.__STATIC_BODY_HTML__=(document.querySelector('.ft-static-article')||{}).innerHTML||'';</script>${spaBundleJs}
  </body>
 </html>`;
  };
@@ -9599,9 +9605,6 @@ ${hreflangLinks}
  itBodyWordCount = countHtmlBodyWords(staticBody);
  }
 
- // Escape staticBody for embedding in a JS string (JSON.stringify handles quotes/newlines)
- const staticBodyJson = JSON.stringify(staticBody);
-
  // Make robots directive conditional on actual content quality.
  // Pages with >= MIN_INDEXABLE_WORDS of real text get index,follow (SEO value
  // from long-tail searches). Pages below threshold get noindex,follow.
@@ -9691,7 +9694,7 @@ ${hreflangLinks}
  const softLandingHtml = buildSoftLandingHtml(
  locale, pageTitle, pageDesc, expiredRobotsTag,
  selfUrl, hreflangLinks, jsonLdScripts, expiredWindowData,
- staticBodyJson, staticBody
+ staticBody
  );
 
  // Skip if a previous (most-recent due to sort) slug already emitted


### PR DESCRIPTION
The soft-landing template (~98.5k pages) was embedding the static-body
content TWICE per page:
  1. As visible HTML inside <article class="ft-static-article">
  2. As JSON-stringified blob in <script>window.__STATIC_BODY_HTML__=...

The second copy existed because JobOrphanView.tsx reads
window.__STATIC_BODY_HTML__ to extract 'Posizioni attive recenti' links
via regex — and the React SPA replaces #root on mount, wiping the article
from DOM. So at SPA hydration time the JSON blob was the only surviving
copy of the body.

This commit removes the JSON blob and replaces it with a 90-byte sync
script that snapshots .ft-static-article.innerHTML into
window.__STATIC_BODY_HTML__ at parse time, BEFORE the module-script SPA
bundle (which is implicitly deferred) hydrates and overwrites #root.

Changes:
- buildSoftLandingHtml signature drops staticBodyJson parameter
- Remove const staticBodyJson = JSON.stringify(staticBody) (no longer needed)
- Split the inline head <script>: __EXPIRED_JOB_DATA__ stays in <head>,
  __STATIC_BODY_HTML__ snapshot moved to <body> right before spaBundleJs
- The snapshot snippet uses document.querySelector('.ft-static-article')
  which exists in DOM at parse time (regular <script> = synchronous, runs
  during parse, before the type=module bundle defers)

Consumer: JobOrphanView.tsx line 138 (getStaticBodyHtml) is unchanged —
it still reads window.__STATIC_BODY_HTML__ at component mount, same as
before, just sourced from DOM via the snapshot snippet.

Estimated dist savings: ~3-5 KB JSON per page (the encoded body size,
typically ~120% of raw HTML size because of JSON escaping) × 98,580 soft-
landing pages ≈ ~400 MB. Existing tests verified (24/24 passing).

After this PR, the only remaining duplication on soft-landing pages is
~90 B/page for the snapshot snippet (a constant cost ≈ 8 MB across all
pages). Net win: ~390 MB.
