### PR TITLE
perf(seo): externalise inline analytics + SPA bootstrap scripts to /assets/*.js

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -35,13 +35,13 @@ export const BUILD_ID = String(Date.now());
  * has those globals — soft-landing pages then fall back to the generic
  * "annuncio non trovato" view instead of the rich expired-job content.
  */
-export const SPA_ACTION_REDIRECT_SCRIPT = `<script>(function(){
- var p=new URLSearchParams(location.search);
- if(p.get('action')||p.get('at')||p.get('authToken')||p.get('newsletter_autologin')){
- sessionStorage.redirect=location.href;
- location.replace('/');
- }
-})()</script>`;
+/**
+ * Plain JS body (no <script> wrapper) — written to dist/assets/spa-action-redirect.js
+ * by staticScriptsPlugin and referenced via <script src="..."> from SPA_ACTION_REDIRECT_SCRIPT.
+ * Externalising this snippet saves ~150 B/page across ~200k SEO pages (~30 MB dist).
+ */
+export const SPA_ACTION_REDIRECT_SCRIPT_CONTENT = `(function(){var p=new URLSearchParams(location.search);if(p.get('action')||p.get('at')||p.get('authToken')||p.get('newsletter_autologin')){sessionStorage.redirect=location.href;location.replace('/');}})();`;
+export const SPA_ACTION_REDIRECT_SCRIPT = `<script src="/assets/spa-action-redirect.js?v=${BUILD_ID}"></script>`;
 
 export function buildCanonicalBridgePage(options: {
  canonicalUrl: string;
@@ -195,8 +195,14 @@ export const GA4_MEASUREMENT_ID = 'G-LGJ9LE360F';
  * Firebase now always fires page_view, accepting a minor duplicate for
  * non-blocked users in exchange for correct landing page in all sessions.
  */
+/**
+ * Plain JS body for the gtag init — written to dist/assets/gtag-init.js by
+ * staticScriptsPlugin. The googletagmanager loader stays inline (it's already
+ * external + async). Saves ~260 B/page across ~200k SEO pages (~52 MB dist).
+ */
+export const GTAG_INIT_CONTENT = `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${GA4_MEASUREMENT_ID}',{transport_type:'beacon'});`;
 export const GTAG_SNIPPET = `<script async crossorigin="anonymous" src="https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}"></script>
- <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${GA4_MEASUREMENT_ID}',{transport_type:'beacon'})</script>`;
+ <script src="/assets/gtag-init.js?v=${BUILD_ID}"></script>`;
 
 /**
  * PostHog EU Cloud init snippet for standalone static pages that don't load the
@@ -257,59 +263,14 @@ export const ADSENSE_SCRIPT_SRC = `https://pagead2.googlesyndication.com/pagead/
  *  3. On script load, pushes {} for every slot currently in the DOM.
  */
 const BOT_PATTERNS_LITERAL = JSON.stringify(BOT_UA_PATTERNS);
-export const ADSENSE_LAZY_LOADER = `<script>
-(function(){
-  var ua=(navigator.userAgent||'').toLowerCase();
-  if(!ua||navigator.webdriver===true)return;
-  var P=${BOT_PATTERNS_LITERAL};
-  for(var k=0;k<P.length;k++)if(ua.indexOf(P[k])>=0)return;
-  if(ua.indexOf('chrome')>=0&&!('chrome' in window))return;
-  // Modern stealth signals — only fire on a UA claiming desktop Chrome.
-  // Mirror the layered logic in services/adAnalytics.ts isLikelyBot().
-  if(ua.indexOf('chrome')>=0&&ua.indexOf('mobile')<0){
-    var L=navigator.languages;
-    if(L&&L.length===0)return;
-    if(navigator.plugins&&navigator.plugins.length===0)return;
-    if(typeof navigator.permissions==='undefined')return;
-  }
-  var loaded=false;
-  function loadScript(){
-    if(loaded)return;loaded=true;
-    var s=document.createElement('script');
-    s.async=true;s.crossOrigin='anonymous';
-    s.src='${ADSENSE_SCRIPT_SRC}';
-    s.setAttribute('data-overlays','bottom');
-    s.setAttribute('data-ad-frequency-hint','120s');
-    s.onload=function(){
-      var slots=document.querySelectorAll('ins.adsbygoogle:not([data-adsbygoogle-status])');
-      for(var i=0;i<slots.length;i++){
-        try{(window.adsbygoogle=window.adsbygoogle||[]).push({});}catch(e){}
-      }
-    };
-    document.head.appendChild(s);
-  }
-  function observe(){
-    var slots=document.querySelectorAll('ins.adsbygoogle');
-    if(!('IntersectionObserver' in window)||slots.length===0){
-      // No manual slots or old browser — still load for Auto Ads, but deferred.
-      (window.requestIdleCallback||function(cb){return setTimeout(cb,2000);})(loadScript,{timeout:4000});
-      return;
-    }
-    var io=new IntersectionObserver(function(entries){
-      for(var i=0;i<entries.length;i++){
-        if(entries[i].isIntersecting){io.disconnect();loadScript();return;}
-      }
-    },{rootMargin:'200px 0px'});
-    for(var j=0;j<slots.length;j++)io.observe(slots[j]);
-    // Always also schedule an idle fallback so Auto Ads can run even if no
-    // manual slot ever enters the viewport (e.g. short pages above the fold).
-    (window.requestIdleCallback||function(cb){return setTimeout(cb,3000);})(loadScript,{timeout:6000});
-  }
-  if(document.readyState==='loading'){
-    document.addEventListener('DOMContentLoaded',observe,{once:true});
-  }else{observe();}
-})();
-</script>`;
+/**
+ * Plain JS body for the AdSense lazy loader — written to dist/assets/adsense-loader.js
+ * by staticScriptsPlugin. This was the LARGEST inline script in every static page:
+ * ~2 KB minified × ~200k SEO pages = ~400 MB dist. Externalising drops per-page cost
+ * from ~2200 B to ~90 B (the <script src=...> tag).
+ */
+export const ADSENSE_LOADER_CONTENT = `(function(){var ua=(navigator.userAgent||'').toLowerCase();if(!ua||navigator.webdriver===true)return;var P=${BOT_PATTERNS_LITERAL};for(var k=0;k<P.length;k++)if(ua.indexOf(P[k])>=0)return;if(ua.indexOf('chrome')>=0&&!('chrome' in window))return;if(ua.indexOf('chrome')>=0&&ua.indexOf('mobile')<0){var L=navigator.languages;if(L&&L.length===0)return;if(navigator.plugins&&navigator.plugins.length===0)return;if(typeof navigator.permissions==='undefined')return;}var loaded=false;function loadScript(){if(loaded)return;loaded=true;var s=document.createElement('script');s.async=true;s.crossOrigin='anonymous';s.src='${ADSENSE_SCRIPT_SRC}';s.setAttribute('data-overlays','bottom');s.setAttribute('data-ad-frequency-hint','120s');s.onload=function(){var slots=document.querySelectorAll('ins.adsbygoogle:not([data-adsbygoogle-status])');for(var i=0;i<slots.length;i++){try{(window.adsbygoogle=window.adsbygoogle||[]).push({});}catch(e){}}};document.head.appendChild(s);}function observe(){var slots=document.querySelectorAll('ins.adsbygoogle');if(!('IntersectionObserver' in window)||slots.length===0){(window.requestIdleCallback||function(cb){return setTimeout(cb,2000);})(loadScript,{timeout:4000});return;}var io=new IntersectionObserver(function(entries){for(var i=0;i<entries.length;i++){if(entries[i].isIntersecting){io.disconnect();loadScript();return;}}},{rootMargin:'200px 0px'});for(var j=0;j<slots.length;j++)io.observe(slots[j]);(window.requestIdleCallback||function(cb){return setTimeout(cb,3000);})(loadScript,{timeout:6000});}if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',observe,{once:true});}else{observe();}})();`;
+export const ADSENSE_LAZY_LOADER = `<script defer src="/assets/adsense-loader.js?v=${BUILD_ID}"></script>`;
 
 export const ADSENSE_SNIPPET = `<meta name="google-adsense-account" content="${ADSENSE_CLIENT_ID}">
  <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>

--- a/build-plugins/staticScriptsPlugin.ts
+++ b/build-plugins/staticScriptsPlugin.ts
@@ -1,0 +1,54 @@
+/**
+ * Emits the previously-inline analytics / SPA bootstrap scripts as standalone
+ * .js files under dist/assets/ at the end of the build. Used by:
+ *
+ *   GTAG_SNIPPET                  → /assets/gtag-init.js
+ *   ADSENSE_SNIPPET               → /assets/adsense-loader.js
+ *   SPA_ACTION_REDIRECT_SCRIPT    → /assets/spa-action-redirect.js
+ *
+ * Each SEO-static HTML page (per-job, soft-landing, bridge, hub, etc.) used to
+ * inline all three constants directly. That duplicated ~2.5 KB per page × ~200k
+ * pages → ~500 MB across dist. After this plugin runs, each page only references
+ * the small <script src="/assets/..."> tag and the browser caches the JS file
+ * once globally.
+ *
+ * Cache-busting via ?v=${BUILD_ID} query string appended in constants.ts.
+ */
+
+import path from 'path';
+import type { Plugin } from 'vite';
+import {
+  GTAG_INIT_CONTENT,
+  ADSENSE_LOADER_CONTENT,
+  SPA_ACTION_REDIRECT_SCRIPT_CONTENT,
+} from './constants';
+
+export function staticScriptsPlugin(rootDir: string): Plugin {
+  return {
+    name: 'static-scripts',
+    apply: 'build',
+    async closeBundle() {
+      const fs = await import('fs');
+      const outDir = path.resolve(rootDir, 'dist', 'assets');
+      fs.mkdirSync(outDir, { recursive: true });
+
+      const files: Array<readonly [string, string]> = [
+        ['gtag-init.js', GTAG_INIT_CONTENT],
+        ['adsense-loader.js', ADSENSE_LOADER_CONTENT],
+        ['spa-action-redirect.js', SPA_ACTION_REDIRECT_SCRIPT_CONTENT],
+      ];
+
+      let totalBytes = 0;
+      for (const [name, content] of files) {
+        fs.writeFileSync(path.join(outDir, name), content, 'utf-8');
+        totalBytes += content.length;
+      }
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `\x1b[36m[static-scripts]\x1b[0m Emitted ${files.length} script(s) ` +
+          `→ dist/assets/ (${totalBytes} bytes total)`,
+      );
+    },
+  };
+}

--- a/tests/adsense-lazy-load.test.ts
+++ b/tests/adsense-lazy-load.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ADSENSE_CLIENT_ID,
   ADSENSE_LAZY_LOADER,
+  ADSENSE_LOADER_CONTENT,
   ADSENSE_SCRIPT_SRC,
   ADSENSE_SNIPPET,
 } from '@/build-plugins/constants';
@@ -55,10 +56,16 @@ describe('AdSense lazy loading — ADSENSE_SNIPPET (static pages)', () => {
     );
   });
 
-  it('embeds the IntersectionObserver-based lazy loader', () => {
+  it('embeds the IntersectionObserver-based lazy loader (via external /assets/adsense-loader.js)', () => {
     expect(ADSENSE_SNIPPET).toContain(ADSENSE_LAZY_LOADER);
-    expect(ADSENSE_LAZY_LOADER).toContain('IntersectionObserver');
-    expect(ADSENSE_LAZY_LOADER).toContain('rootMargin');
+    // ADSENSE_LAZY_LOADER is now a tiny <script src="..."> tag pointing to the
+    // externalised loader file written by staticScriptsPlugin. The actual loader
+    // body lives in ADSENSE_LOADER_CONTENT (also written to dist/assets/adsense-loader.js).
+    expect(ADSENSE_LAZY_LOADER).toMatch(
+      /<script\s+defer\s+src=["']\/assets\/adsense-loader\.js\?v=\d+["']><\/script>/,
+    );
+    expect(ADSENSE_LOADER_CONTENT).toContain('IntersectionObserver');
+    expect(ADSENSE_LOADER_CONTENT).toContain('rootMargin');
   });
 
   it('exposes the correct client id + script URL', () => {
@@ -79,9 +86,11 @@ describe('AdSense lazy loading — ADSENSE_SNIPPET (static pages)', () => {
 
   it('pushes queued slots after script onload (not synchronously on DOMContentLoaded)', () => {
     // Regression: ensure we call push({}) only after the dynamically-injected
-    // script fires its onload event, not before it exists.
-    expect(ADSENSE_LAZY_LOADER).toContain('s.onload');
-    expect(ADSENSE_LAZY_LOADER).toContain('adsbygoogle');
+    // script fires its onload event, not before it exists. Assertions moved to
+    // ADSENSE_LOADER_CONTENT (the actual JS body) after the external-script
+    // refactor.
+    expect(ADSENSE_LOADER_CONTENT).toContain('s.onload');
+    expect(ADSENSE_LOADER_CONTENT).toContain('adsbygoogle');
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ import { BUILD_ID, COMMIT_HASH, SHORT_COMMIT_HASH } from './build-plugins/consta
 
 /* ── Custom build plugins (extracted for clarity) ─────────────── */
 import { buildIdPlugin } from './build-plugins/buildIdPlugin';
+import { staticScriptsPlugin } from './build-plugins/staticScriptsPlugin';
 import { asyncCssPlugin } from './build-plugins/asyncCssPlugin';
 import { prepareOutDirPlugin } from './build-plugins/prepareOutDirPlugin';
 import { preloadLocalePlugin } from './build-plugins/preloadLocalePlugin';
@@ -117,6 +118,7 @@ export default defineConfig(({ mode }) => {
  // To re-enable: restore the bootstrap+finalize plugins below and the
  // `Cache content-hash manifest` step in .github/workflows/deploy.yml.
  buildIdPlugin(__dirname),
+ staticScriptsPlugin(__dirname),
  asyncCssPlugin(),
  preloadLocalePlugin(__dirname),
  sitemapAliasPlugin(__dirname),


### PR DESCRIPTION
Three constants used to inline a combined ~2.5 KB of identical JS into
every SEO-static HTML page (per-job, soft-landing, bridge, hub, etc.):

  GTAG_SNIPPET inline init      → ~270 B/page
  ADSENSE_LAZY_LOADER           → ~2.0 KB/page (the elephant)
  SPA_ACTION_REDIRECT_SCRIPT    → ~230 B/page

Across ~200k pages that's ~500 MB of duplicated JS embedded in HTML.

New staticScriptsPlugin emits each as a standalone file under dist/assets/
at closeBundle (same pattern as buildIdPlugin). The SNIPPET constants now
reference the external paths via small <script src> tags. Cache-busting
via ?v=${BUILD_ID} query string (BUILD_ID = build-time timestamp).

Per-page cost drops from ~2.5 KB inline → ~250 B (3 small <script> tags).

Estimated dist savings: ~450 MB.

Tests:
- tests/adsense-lazy-load.test.ts updated to assert against the new
  ADSENSE_LOADER_CONTENT (the externalised loader body) instead of
  ADSENSE_LAZY_LOADER (now just the <script src> tag).
- 28/28 affected tests pass.

Side effects:
- Browser caches the 3 files once globally instead of re-parsing inline
  blobs per page navigation.
- adsense-loader.js now defers (was sync before — but it always ran in
  IIFE on DOMContentLoaded, so deferred load has identical timing).
- gtag-init.js loads synchronously (same as before — it was the second
  <script> after the async googletagmanager loader).
