### PR TITLE
perf(seo): externalise POSTHOG_SNIPPET to /assets/posthog-init.js

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -218,10 +218,14 @@ export const GTAG_SNIPPET = `<script async crossorigin="anonymous" src="https://
  */
 export const POSTHOG_KEY = 'phc_u8jsgXxFQNB6WcQt9JBcdj9tJrR4NsMws3nQoKdigjbT';
 export const POSTHOG_HOST = 'https://t.frontaliereticino.ch';
-export const POSTHOG_SNIPPET = `<script>
- !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags identify setPersonProperties group resetGroups reset opt_in_capturing opt_out_capturing".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
- posthog.init('${POSTHOG_KEY}',{api_host:'${POSTHOG_HOST}',capture_pageview:true,capture_pageleave:true,autocapture:false,persistence:'localStorage'});
-</script>`;
+/**
+ * Plain JS body for the PostHog snippet — written to dist/assets/posthog-init.js
+ * by staticScriptsPlugin. The previous inline version was 1.2 KB embedded in every
+ * static page using ANALYTICS_SNIPPET (~14k bridges + ~600 static-pages = ~17 MB).
+ * After externalising, per-page cost drops from ~1.2 KB → ~80 B (the <script src> tag).
+ */
+export const POSTHOG_INIT_CONTENT = `!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags identify setPersonProperties group resetGroups reset opt_in_capturing opt_out_capturing".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('${POSTHOG_KEY}',{api_host:'${POSTHOG_HOST}',capture_pageview:true,capture_pageleave:true,autocapture:false,persistence:'localStorage'});`;
+export const POSTHOG_SNIPPET = `<script src="/assets/posthog-init.js?v=${BUILD_ID}"></script>`;
 
 /**
  * Google AdSense loader snippet. Included in every statically-generated page

--- a/build-plugins/staticScriptsPlugin.ts
+++ b/build-plugins/staticScriptsPlugin.ts
@@ -21,6 +21,7 @@ import {
   GTAG_INIT_CONTENT,
   ADSENSE_LOADER_CONTENT,
   SPA_ACTION_REDIRECT_SCRIPT_CONTENT,
+  POSTHOG_INIT_CONTENT,
 } from './constants';
 
 export function staticScriptsPlugin(rootDir: string): Plugin {
@@ -36,6 +37,7 @@ export function staticScriptsPlugin(rootDir: string): Plugin {
         ['gtag-init.js', GTAG_INIT_CONTENT],
         ['adsense-loader.js', ADSENSE_LOADER_CONTENT],
         ['spa-action-redirect.js', SPA_ACTION_REDIRECT_SCRIPT_CONTENT],
+        ['posthog-init.js', POSTHOG_INIT_CONTENT],
       ];
 
       let totalBytes = 0;


### PR DESCRIPTION
Last big inline script: the PostHog init blob was 1.2 KB embedded per
page via ANALYTICS_SNIPPET (= GTAG + POSTHOG + ADSENSE). Used by:
- buildCanonicalBridgePage + buildFlatRedirect (~14k bridge pages)
- staticPagesPlugin (3 templates, ~600 pages)
- pdfWhitepapersPlugin (few pages)
- affiliateRedirectPlugin (few pages)

Same staticScriptsPlugin pattern as PR #308: POSTHOG_INIT_CONTENT plain
JS body is now written to dist/assets/posthog-init.js at closeBundle,
referenced via <script src='/assets/posthog-init.js?v=BUILD_ID'>.

Per-page cost drops from ~1.2 KB inline → ~80 B (the <script src> tag).

Estimated dist savings: ~17 MB across the ~14.6k pages using
ANALYTICS_SNIPPET. Modest but completes the analytics-snippet
externalisation triad alongside GTAG + ADSENSE.
