### PR TITLE
perf(seo): externalise dark-mode init script to /assets/dark-mode-init.js

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -43,6 +43,18 @@ export const BUILD_ID = String(Date.now());
 export const SPA_ACTION_REDIRECT_SCRIPT_CONTENT = `(function(){var p=new URLSearchParams(location.search);if(p.get('action')||p.get('at')||p.get('authToken')||p.get('newsletter_autologin')){sessionStorage.redirect=location.href;location.replace('/');}})();`;
 export const SPA_ACTION_REDIRECT_SCRIPT = `<script src="/assets/spa-action-redirect.js?v=${BUILD_ID}"></script>`;
 
+/**
+ * Plain JS body for the dark-mode init — written to dist/assets/dark-mode-init.js
+ * by staticScriptsPlugin. Adds 'dark' class to <html> before first paint to avoid
+ * FOUC on dark-mode pages. Used by soft-landing + staticPagesPlugin templates.
+ * Externalising drops ~140 B/page across the ~100k pages that emit it (~14 MB dist).
+ *
+ * Loaded synchronously (no defer/async) — must run before paint so dark-mode
+ * styles in seo-static.css apply on first render.
+ */
+export const DARK_MODE_INIT_CONTENT = `(function(){if(localStorage.theme==='dark'||((!('theme' in localStorage))&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}})();`;
+export const DARK_MODE_SCRIPT = `<script src="/assets/dark-mode-init.js?v=${BUILD_ID}"></script>`;
+
 export function buildCanonicalBridgePage(options: {
  canonicalUrl: string;
  pathLabel: string;

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9,7 +9,7 @@
 
 import path from 'path';
 import type { Plugin } from 'vite';
-import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, BUILD_ID } from './constants';
+import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, BUILD_ID, DARK_MODE_SCRIPT } from './constants';
 import { buildSimplePage } from './htmlTemplate';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { WriteCollector } from './batchWrite';
@@ -9065,7 +9065,10 @@ ${alternates}
  // Pre-compute invariant HTML fragments for soft-landing pages (~69K pages).
  // Avoids re-building the same ~2KB of boilerplate for each page.
  const currentYear = new Date().getFullYear();
- const darkModeScript = `<script>(function(){if(localStorage.theme==='dark'||((!('theme' in localStorage))&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}})()</script>`;
+ // Was inline (~200 B per soft-landing page). Now references
+ // /assets/dark-mode-init.js via DARK_MODE_SCRIPT — emitted by
+ // staticScriptsPlugin at build, browser-cached globally.
+ const darkModeScript = DARK_MODE_SCRIPT;
  // darkModeStyles + nav/footer/article inline styles now live in
  // /assets/seo-static.css (loaded via <link> in the template head).
  // Deduplicates ~1 KB of identical CSS across ~98k soft-landing pages

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Plugin } from 'vite';
-import { BASE_URL, ANALYTICS_SNIPPET } from './constants';
+import { BASE_URL, ANALYTICS_SNIPPET, DARK_MODE_SCRIPT } from './constants';
 import { WriteCollector } from './batchWrite';
 import { resolveSpaBundle } from './spaBundleResolver';
 import { resolveStaticPagesFlushed } from './shared/buildSignals';
@@ -4305,7 +4305,7 @@ ${hubChromeSplit.bodyHtml}
  <meta name="twitter:site" content="@frontaliereticino">
 ${hrefTags}
  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
- <script>if(localStorage.theme==='dark')document.documentElement.classList.add('dark')</script>
+ ${DARK_MODE_SCRIPT}
  <style>${criticalCSS}</style>
  <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
  ${stylesheetMarkup}${preloadTag}${getPagePreloads(urlPath, locale)}

--- a/build-plugins/staticScriptsPlugin.ts
+++ b/build-plugins/staticScriptsPlugin.ts
@@ -22,6 +22,7 @@ import {
   ADSENSE_LOADER_CONTENT,
   SPA_ACTION_REDIRECT_SCRIPT_CONTENT,
   POSTHOG_INIT_CONTENT,
+  DARK_MODE_INIT_CONTENT,
 } from './constants';
 
 export function staticScriptsPlugin(rootDir: string): Plugin {
@@ -38,6 +39,7 @@ export function staticScriptsPlugin(rootDir: string): Plugin {
         ['adsense-loader.js', ADSENSE_LOADER_CONTENT],
         ['spa-action-redirect.js', SPA_ACTION_REDIRECT_SCRIPT_CONTENT],
         ['posthog-init.js', POSTHOG_INIT_CONTENT],
+        ['dark-mode-init.js', DARK_MODE_INIT_CONTENT],
       ];
 
       let totalBytes = 0;


### PR DESCRIPTION
darkModeScript was inlined in two places:
- jobsSeoPagesPlugin.ts soft-landing (~98k pages)
- staticPagesPlugin.ts hub template (~600 pages)

Two slightly different versions: soft-landing was the fuller one (also
checks prefers-color-scheme), staticPages was simpler (localStorage only).
Consolidated to the fuller version, externalised via staticScriptsPlugin
following the same pattern as gtag-init / adsense-loader / posthog-init.

Per-page cost drops from ~200 B inline → ~85 B (script src tag).

Estimated dist savings: ~12-15 MB across ~100k pages.

Loaded synchronously (no defer/async) so it runs before first paint and
avoids FOUC on dark-mode pages — same blocking behaviour as before.
