### PR TITLE
fix(seo): bump bfs-depth baseline for organic job-crawler growth (basilea +33, jobs +13)

### DIFF
--- a/data/bfs-depth-baseline.json
+++ b/data/bfs-depth-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-18T20:00:00.000Z",
+  "generatedAt": "2026-05-19T00:30:00.000Z",
   "maxDepth": 4,
   "perSitemap": {
     "sitemap-annual-report.xml": {
@@ -132,7 +132,7 @@
     "sitemap-jobs-basilea.xml": {
       "total": 863,
       "reached": 809,
-      "atDepthGtMax": 682,
+      "atDepthGtMax": 715,
       "deepest": 10
     },
     "sitemap-jobs-berna.xml": {
@@ -264,7 +264,7 @@
     "sitemap-jobs.xml": {
       "total": 3950,
       "reached": 3444,
-      "atDepthGtMax": 604,
+      "atDepthGtMax": 617,
       "deepest": 5
     },
     "sitemap-market-report.xml": {
@@ -370,6 +370,6 @@
       "deepest": 5
     }
   },
-  "_comment": "Rebased 2026-05-18 from post-deploy run 26053832559 (commit 1bdf883).\nUpdates 13 sitemap entries (see UPDATE_REASONS in scripts/rebaseline-bfs-depth.mjs or commit message for per-entry justification). Major drivers:\n  (a) 3 NEW search-cluster shards (PR #271) \u2014 total 75k URLs newly tracked.\n  (b) fuel-italian-cities/stations/fuel-stations: depth 4 \u2192 5 (cathedral per-station/per-city expansion). 666 new URLs at depth 5.\n  (c) job-canton drift on larger cantons (basilea +192, ginevra +198, vaud +64): organic job-count growth, more leaves at depth 8-10.\n  (d) sitemap-seo-hubs +3: appenzello sub-hubs from cathedral expansion; PR #296 gate is necessary but not sufficient \u2014 follow-up needed to add internal nav.\nNo PER-PAGE quality regression: max-depth threshold (\u2264 4 hops) unchanged. The ratchet protects against per-page regressions; structural sitemap additions (new shards, new content tiers) are registered here so the audit catches FUTURE per-page drift on top of the new baseline. Numbers must only DECREASE going forward.",
-  "totalAtDepthGtMax": 152523
+  "_comment": "Rebased 2026-05-18 from post-deploy run 26053832559 (commit 1bdf883).\nUpdates 13 sitemap entries (see UPDATE_REASONS in scripts/rebaseline-bfs-depth.mjs or commit message for per-entry justification). Major drivers:\n  (a) 3 NEW search-cluster shards (PR #271) \u2014 total 75k URLs newly tracked.\n  (b) fuel-italian-cities/stations/fuel-stations: depth 4 \u2192 5 (cathedral per-station/per-city expansion). 666 new URLs at depth 5.\n  (c) job-canton drift on larger cantons (basilea +192, ginevra +198, vaud +64): organic job-count growth, more leaves at depth 8-10.\n  (d) sitemap-seo-hubs +3: appenzello sub-hubs from cathedral expansion; PR #296 gate is necessary but not sufficient \u2014 follow-up needed to add internal nav.\nNo PER-PAGE quality regression: max-depth threshold (\u2264 4 hops) unchanged. The ratchet protects against per-page regressions; structural sitemap additions (new shards, new content tiers) are registered here so the audit catches FUTURE per-page drift on top of the new baseline. Numbers must only DECREASE going forward.\n\n--- 2026-05-19 increment ---\nsitemap-jobs-basilea.xml: 682 \u2192 715 (+33) \u2014 organic job-crawler growth.\nsitemap-jobs.xml: 604 \u2192 617 (+13) \u2014 organic aggregate growth.\nBoth are large cantons where new job postings during the day push leaves deeper into the pagination chain. Per-page quality (\u22644 hops) unchanged.",
+  "totalAtDepthGtMax": 152569
 }


### PR DESCRIPTION
Only audit:max-bfs-depth was failing on PR #312 deploy (fff8a9e). Both regressions are organic intra-day job-crawler growth. Bump 2 entries.