### PR TITLE
fix(seo): canton-aware company hubs + city section + non-TI city title/meta

### DIFF
--- a/build-plugins/cityJobsHub.ts
+++ b/build-plugins/cityJobsHub.ts
@@ -195,6 +195,7 @@ export function buildCityHubSeo(
   city: CityHubKey,
   count: number,
   year: number,
+  cantonDisplay?: string,
 ): CityHubSeoEntry {
   const safeCount = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
   const useFire = safeCount >= CITY_HUB_FIRE_THRESHOLD;
@@ -202,14 +203,17 @@ export function buildCityHubSeo(
   const name = CITY_HUB_DISPLAY_NAME[city] ?? cityHubDisplayName(city);
   // F3a — short <title> comes from the shared module (50-60 visible chars).
   // OG title + H1 keep the verbose legacy copy (unconstrained length).
+  // cantonDisplay is forwarded only when the caller is in a non-TI canton city
+  // hub — TI callers pass undefined and keep the legacy Ticino/Tessin copy.
   const title = buildCityHubTitle({
     locale,
     cityDisplay: name,
     count: safeCount,
     year,
     fireThreshold: CITY_HUB_FIRE_THRESHOLD,
+    cantonDisplay,
   });
-  const desc = buildCityHubMeta({ locale, cityDisplay: name, count: safeCount });
+  const desc = buildCityHubMeta({ locale, cityDisplay: name, count: safeCount, cantonDisplay });
 
   switch (locale) {
     case 'it': {

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2854,7 +2854,14 @@ ${hreflangHtml}
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
  const renderJobCardLi = (job: any, locale: 'it' | 'en' | 'de' | 'fr'): string => {
  const jSlug = localizedSlug(job, locale);
- const jPath = `${localePrefix[locale]}/${sectionByLocale[locale]}/${jSlug}`.replace(/\/+/g, '/');
+ // Section is canton-aware: a non-TI job's detail page is emitted under its
+ // own canton section (e.g. /cerca-lavoro-basilea/<slug>/). Hardcoding
+ // sectionByLocale[locale] worked only for TI jobs; non-TI jobs reached a
+ // soft-canonical /cerca-lavoro-ticino/ detour that <link rel=canonical>
+ // redirected back to the canton URL — needless hop and breadcrumb mismatch.
+ const jobCanton = sharedResolveJobCanton(job as { canton?: string; location?: string });
+ const sectionForJob = jobCanton ? sharedResolveCantonSection(locale, jobCanton) : sectionByLocale[locale];
+ const jPath = `${localePrefix[locale]}/${sectionForJob}/${jSlug}`.replace(/\/+/g, '/');
  const jHref = `${BASE_URL}${withSlash(jPath)}`;
  const cardHtml = renderJobCardHtml(job as JobCardJob, {
  href: jHref,
@@ -5331,7 +5338,7 @@ ${alternates}
  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
  const cDisplay = cantonDisplayLocalCity(canton, locale);
  const year = new Date().getFullYear();
- const cityHubSeo = buildCityHubSeo(locale as never, citySlug, cityJobs.length, year);
+ const cityHubSeo = buildCityHubSeo(locale as never, citySlug, cityJobs.length, year, cDisplay);
  const pageTitle = cityHubSeo.title;
  const pageDesc = cityHubSeo.desc;
  // Build hreflang including x-default

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -1288,17 +1288,26 @@ export function staticPagesPlugin(rootDir: string): Plugin {
          );
        }
        // ── company hubs: mirror MIN_JOBS_PER_CANTON_COMPANY=3 + top 6 (line 8156-8175).
-       //    Slug match is the canonical company id; for the local compute we
-       //    use the same lower-kebab fallback as the TI nav data-prep above.
+       //    Slug match MUST mirror the emitter's `canonicalCompanySlugBuild`
+       //    (jobsSeoPagesPlugin.ts:1893) and the runtime `canonicalCompanyRouteSlug`
+       //    (components/community/JobBoard.tsx:2147), both of which slugify the
+       //    DISPLAY NAME and ignore companyKey. Using companyKey here caused
+       //    the nav to roll up subsidiaries under a group key (e.g. all
+       //    Burkhalter Group subsidiaries → "burkhalter-group") that the
+       //    emitter never produced because it splits per display name. The
+       //    "burkhalter-group" link then 404'd → blank page under staticOverlay routing.
        const companyCounts = new Map<string, { name: string; count: number }>();
        for (const j of jobs) {
          const co = String((j as { company?: string }).company || '').trim();
+         if (!co) continue;
          const coKey = String((j as { companyKey?: string }).companyKey || '').trim();
-         const slug = coKey || co.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+         const slug = (co.toLowerCase().includes('lidl') || coKey.toLowerCase().includes('lidl'))
+           ? 'lidl'
+           : co.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
          if (!slug || slug.length < 2) continue;
          const cur = companyCounts.get(slug);
          if (cur) cur.count++;
-         else companyCounts.set(slug, { name: co || slug, count: 1 });
+         else companyCounts.set(slug, { name: co, count: 1 });
        }
        const topCompanies = [...companyCounts.entries()]
          .filter(([, v]) => v.count >= 3)

--- a/services/seo/job-board-titles.ts
+++ b/services/seo/job-board-titles.ts
@@ -168,6 +168,13 @@ interface CityHubArgs {
   year: number;
   /** Override the fire-emoji threshold. Defaults to FIRE_EMOJI_THRESHOLD. */
   fireThreshold?: number;
+  /**
+   * Optional canton display label (e.g. 'Basilea Città', 'Zurigo'). When set,
+   * the base title and pad-to-min use the actual canton instead of the legacy
+   * Ticino/Tessin fallback. Omit to preserve the legacy TI behavior — keeps
+   * existing TI city-hub titles byte-identical.
+   */
+  cantonDisplay?: string;
 }
 
 /** Default fire-emoji threshold for per-city hubs: single-city counts rarely
@@ -181,9 +188,18 @@ export function buildCityHubTitle({
   count,
   year,
   fireThreshold = DEFAULT_CITY_HUB_FIRE_THRESHOLD,
+  cantonDisplay,
 }: CityHubArgs): string {
   const n = safeCount(count);
   const city = cityDisplay;
+  // When the caller passes a non-TI cantonDisplay, weave it into the base
+  // title (en/de/fr) and into the pad-to-min fallback. For TI callers the
+  // arg is undefined and the legacy "Ticino/Tessin" copy stays byte-identical.
+  const regionLabels = {
+    en: cantonDisplay ?? 'Ticino',
+    de: cantonDisplay ?? 'Tessin',
+    fr: cantonDisplay ?? 'Tessin',
+  };
   let base: string;
   switch (locale) {
     case 'it':
@@ -193,18 +209,18 @@ export function buildCityHubTitle({
       break;
     case 'en':
       base = n > 0
-        ? `Jobs in ${city} Ticino ${year} — ${n} open positions today`
-        : `Jobs in ${city} Ticino Switzerland ${year} — Updated Daily`;
+        ? `Jobs in ${city} ${regionLabels.en} ${year} — ${n} open positions today`
+        : `Jobs in ${city} ${regionLabels.en} Switzerland ${year} — Updated Daily`;
       break;
     case 'de':
       base = n > 0
-        ? `Jobs in ${city} Tessin ${year} — ${n} offene Stellen heute`
-        : `Jobs in ${city} Tessin Schweiz ${year} — Täglich aktuell`;
+        ? `Jobs in ${city} ${regionLabels.de} ${year} — ${n} offene Stellen heute`
+        : `Jobs in ${city} ${regionLabels.de} Schweiz ${year} — Täglich aktuell`;
       break;
     case 'fr':
       base = n > 0
-        ? `Emploi à ${city} Tessin ${year} — ${n} postes aujourd'hui`
-        : `Emploi à ${city} Tessin Suisse ${year} — Mises à jour`;
+        ? `Emploi à ${city} ${regionLabels.fr} ${year} — ${n} postes aujourd'hui`
+        : `Emploi à ${city} ${regionLabels.fr} Suisse ${year} — Mises à jour`;
       break;
   }
   // Use per-caller fire threshold; city hubs pass 30, site-wide hub inherits 500.
@@ -216,7 +232,7 @@ export function buildCityHubTitle({
   base = trimToMax(base);
   if (visibleLength(base) < TITLE_MIN_CHARS) {
     const padWord = locale === 'it'
-      ? 'in Ticino'
+      ? (cantonDisplay ? `in ${cantonDisplay}` : 'in Ticino')
       : locale === 'en'
         ? 'Switzerland'
         : locale === 'de'

--- a/services/seo/meta-descriptions.ts
+++ b/services/seo/meta-descriptions.ts
@@ -125,11 +125,22 @@ interface CityHubArgs {
   locale: JobPageLocale;
   cityDisplay: string;
   count: number;
+  /**
+   * Optional canton display label. When provided, non-IT meta descriptions
+   * weave the actual canton in place of the legacy Ticino/Tessin fallback.
+   * Omit for TI city hubs — keeps existing meta byte-identical.
+   */
+  cantonDisplay?: string;
 }
 
-export function buildCityHubMeta({ locale, cityDisplay, count }: CityHubArgs): string {
+export function buildCityHubMeta({ locale, cityDisplay, count, cantonDisplay }: CityHubArgs): string {
   const n = safeCount(count);
   const city = cityDisplay;
+  const region = {
+    en: cantonDisplay ?? 'Ticino',
+    de: cantonDisplay ?? 'Tessin',
+    fr: cantonDisplay ?? 'Tessin',
+  };
   let base: string;
   let qualifier: string;
   switch (locale) {
@@ -141,20 +152,20 @@ export function buildCityHubMeta({ locale, cityDisplay, count }: CityHubArgs): s
       break;
     case 'en':
       base = n > 0
-        ? `Browse ${n} jobs in ${city}, Ticino Switzerland — updated today: healthcare, banking, offices, retail, hospitality. Apply online for free in 2 minutes.`
-        : `Browse jobs in ${city}, Ticino Switzerland — updated daily: healthcare, banking, offices, retail, hospitality. Apply online for free in 2 minutes.`;
+        ? `Browse ${n} jobs in ${city}, ${region.en} Switzerland — updated today: healthcare, banking, offices, retail, hospitality. Apply online for free in 2 minutes.`
+        : `Browse jobs in ${city}, ${region.en} Switzerland — updated daily: healthcare, banking, offices, retail, hospitality. Apply online for free in 2 minutes.`;
       qualifier = 'No signup needed.';
       break;
     case 'de':
       base = n > 0
-        ? `Durchsuche ${n} Stellenangebote in ${city}, Tessin — täglich aktualisiert: Pflege, Banken, Büros, Handel. Kostenlos online bewerben in Minuten.`
-        : `Durchsuche Stellenangebote in ${city}, Tessin — täglich aktualisiert: Pflege, Banken, Büros, Handel. Kostenlos online bewerben.`;
+        ? `Durchsuche ${n} Stellenangebote in ${city}, ${region.de} — täglich aktualisiert: Pflege, Banken, Büros, Handel. Kostenlos online bewerben in Minuten.`
+        : `Durchsuche Stellenangebote in ${city}, ${region.de} — täglich aktualisiert: Pflege, Banken, Büros, Handel. Kostenlos online bewerben.`;
       qualifier = 'Ohne Anmeldung.';
       break;
     case 'fr':
       base = n > 0
-        ? `Parcourez ${n} offres d'emploi à ${city}, Tessin mises à jour aujourd'hui : santé, banques, bureaux, commerce. Postulez gratuitement en ligne.`
-        : `Parcourez les offres d'emploi à ${city}, Tessin mises à jour chaque jour : santé, banques, bureaux, commerce. Postulez gratuitement.`;
+        ? `Parcourez ${n} offres d'emploi à ${city}, ${region.fr} mises à jour aujourd'hui : santé, banques, bureaux, commerce. Postulez gratuitement en ligne.`
+        : `Parcourez les offres d'emploi à ${city}, ${region.fr} mises à jour chaque jour : santé, banques, bureaux, commerce. Postulez gratuitement.`;
       qualifier = 'Sans inscription.';
       break;
   }


### PR DESCRIPTION
Three bugs fixed in non-TI canton job-board pages.

1. /cerca-lavoro-{canton}/azienda-{slug}/ → blank page
   staticPagesPlugin canton navigator built company-hub slugs via
   `companyKey || slugify(company)`, rolling up subsidiaries under a group
   key (e.g. all Burkhalter Group subsidiaries → "burkhalter-group").
   The emitter (jobsSeoPagesPlugin#canonicalCompanySlugBuild) and the
   runtime router (JobBoard#canonicalCompanyRouteSlug) both slugify the
   display name and ignore companyKey, so the nav linked to slugs no
   emitter produced. Result: 404 → 404.html → staticOverlay path → blank.
   Fix: mirror the emitter's slug rule (display-name NFD-slug + Lidl
   special case) in the navigator. Nav links now match emitted URLs.

2. /cerca-lavoro-basilea/pratteln/ → job cards pointing at /cerca-lavoro-ticino/
   renderJobCardLi used `sectionByLocale[locale]` (hardcoded to
   cerca-lavoro-ticino) for every job card href. Worked for TI jobs;
   non-TI jobs reached a soft-canonical TI detour with rel=canonical
   pointing back to the canton URL.
   Fix: resolve the section per-job via sharedResolveJobCanton +
   sharedResolveCantonSection. TI jobs remain byte-identical.

3. Page title "Lavoro Pratteln 2026 — 3 offerte aggiornate oggi in Ticino"
   buildCityHubTitle padded to TITLE_MIN_CHARS with "in Ticino" / "Tessin"
   regardless of the actual canton. buildCityHubMeta hardcoded
   "Ticino Switzerland" / "Tessin" in en/de/fr descriptions.
   Fix: accept optional cantonDisplay; weave it into the base title +
   meta (en/de/fr) and into the IT pad-to-min word. TI callers pass
   undefined → byte-identical legacy copy.

Test coverage: 201 tests in city-jobs-hub, job-board-titles,
meta-descriptions, multi-canton-seo, job-board-seo-titles,
jobs-seo-pages-plugin, canton-static-overlay-slugs, jobCardHtml,
job-editorial-enrichment — all pass.
