### PR TITLE
worktree canton aware followups

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,71 @@
+name: unit-tests
+
+# Vitest unit + integration suite. Runs on every PR + every push to main.
+#
+# Why: PR #318 / #319 added regression tests for canton-aware city hubs +
+# SEO meta/title builders. Without a CI runner those tests are a "gate finto"
+# (memory: feedback_regression_gates_need_ci_runner.md) — they pass locally
+# but a future change can silently break them in main. This workflow keeps
+# every committed `vitest run` test honest.
+#
+# Scope:
+#   - `npm test` runs the full Vitest suite (`vitest run`).
+#   - Mocked Firebase + leaflet (see tests/setup.tsx) — no live secrets needed.
+#   - Tests that read `data/jobs.json` (gitignored) are expected to skip
+#     gracefully in CI; the assemble step rebuilds the dataset from per-crawler
+#     slices so the corpus matches deploy.yml.
+#
+# Time budget: ~2-4 min on ubuntu-latest. Fails fast on the first broken test
+# so feedback lands before the orchestrator squash-merges the PR.
+#
+# CLAUDE.md non-negotiable #14 — live test after merge:
+#   gh workflow run unit-tests.yml --ref main
+#   gh run view <id>  # verify conclusion: success
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  vitest:
+    name: Vitest (run --bail 1)
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Assemble jobs dataset (per-crawler slices → data/jobs.json)
+        # Mirrors deploy.yml's assemble step so tests reading data/jobs.json
+        # see the same corpus shape CI builds against. SKIP_* env gates avoid
+        # the heavy SEO plugin work — tests don't need emitted dist/.
+        env:
+          SKIP_FUEL_DAILY: '1'
+          SKIP_WEEKLY_EMPLOYERS: '1'
+          SKIP_JOB_MARKET_SNAPSHOT: '1'
+          SKIP_HEALTH_PREMIUMS: '1'
+          SKIP_ORPHAN_LANDINGS: '1'
+          SKIP_BORDER_WAIT: '1'
+        run: node scripts/assemble-jobs-dataset.mjs --stats || echo "::warning::assemble-jobs-dataset failed — tests that need jobs.json will skip"
+
+      - name: Run vitest suite
+        run: npm run test:fast

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -3066,10 +3066,15 @@ ${hreflangHtml}
  };
  organizationLd = JSON.stringify(curatedOrgLd);
 
- // ItemList with top open roles
+ // ItemList with top open roles. URLs must be canton-aware so that
+ // structured data points at the actually-emitted job-detail page
+ // (not the soft-canonical TI redirect). Otherwise Google ingests
+ // canonical chains in rich-result candidates.
  const itemListItems = companyJobs.slice(0, 10).map((job, idx) => {
  const jSlug = localizedSlug(job, locale);
- const jPath = `${localePrefix[locale]}/${sectionByLocale[locale]}/${jSlug}`.replace(/\/+/g, '/');
+ const jobCantonForList = sharedResolveJobCanton(job as { canton?: string; location?: string });
+ const sectionForJob = jobCantonForList ? sharedResolveCantonSection(locale, jobCantonForList) : sectionByLocale[locale];
+ const jPath = `${localePrefix[locale]}/${sectionForJob}/${jSlug}`.replace(/\/+/g, '/');
  const jHref = `${BASE_URL}${withSlash(jPath)}`;
  const jTitle = String(job?.titleByLocale?.[locale] || job.title || '');
  return { '@type': 'ListItem', position: idx + 1, url: jHref, name: jTitle };
@@ -5490,7 +5495,14 @@ ${alternates}
  const pgNextLink = pgNextHref ? `\n <link rel="next" href="${pgNextHref}">` : '';
  const pgListHtml = pgJobs.map((job: any) => renderJobCardLi(job, locale)).join('');
  const pgCollLd = JSON.stringify({ '@context': 'https://schema.org', '@type': 'CollectionPage', name: pgTitle, url: pgCanonicalUrl, description: pgDesc, inLanguage: locale, isPartOf: { '@type': 'WebSite', name: 'Frontaliere Ticino', url: BASE_URL } });
- const pgItemLd = JSON.stringify({ '@context': 'https://schema.org', '@type': 'ItemList', name: pgTitle, numberOfItems: pgJobs.length, itemListElement: pgJobs.slice(0, 10).map((job: any, i: number) => ({ '@type': 'ListItem', position: i + 1, name: String(job?.titleByLocale?.[locale] || job.title || ''), url: `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${localizedSlug(job, locale)}`.replace(/\/+/g, '/'))}` })) });
+ const pgItemLd = JSON.stringify({ '@context': 'https://schema.org', '@type': 'ItemList', name: pgTitle, numberOfItems: pgJobs.length, itemListElement: pgJobs.slice(0, 10).map((job: any, i: number) => {
+ // Canton-aware item URL: pagination is TI-section by design but the jobs
+ // listed may live in any canton. Point ItemList at the actually-emitted
+ // canonical URL, not the soft-canonical TI detour.
+ const jc = sharedResolveJobCanton(job as { canton?: string; location?: string });
+ const secForJob = jc ? sharedResolveCantonSection(locale, jc) : sectionByLocale[locale];
+ return { '@type': 'ListItem', position: i + 1, name: String(job?.titleByLocale?.[locale] || job.title || ''), url: `${BASE_URL}${withSlash(`${localePrefix[locale]}/${secForJob}/${localizedSlug(job, locale)}`.replace(/\/+/g, '/'))}` };
+ }) });
  const pgMainUrl = `${BASE_URL}${withSlash(pgSectionPath)}`;
  const pgHomeUrl = `${BASE_URL}${locale === 'it' ? '/' : `/${locale}/`}`;
  const pgListName = locale === 'it' ? 'Lavoro in Ticino' : locale === 'en' ? 'Jobs in Ticino' : locale === 'de' ? 'Jobs im Tessin' : 'Emploi au Tessin';

--- a/tests/city-jobs-hub.test.ts
+++ b/tests/city-jobs-hub.test.ts
@@ -255,3 +255,51 @@ describe('router — city hub URLs', () => {
     }
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────
+// PR #318 regression — buildCityHubSeo forwards cantonDisplay through to
+// both buildCityHubTitle and buildCityHubMeta. Cross-canton city hubs like
+// /cerca-lavoro-basilea/pratteln/ must not say "in Ticino" / "Tessin".
+// ──────────────────────────────────────────────────────────────────────
+describe('buildCityHubSeo — non-TI cantonDisplay forwarded to title and meta', () => {
+  it('IT non-TI: title omits "in Ticino" pad when cantonDisplay is set', () => {
+    const tiPratteln = buildCityHubSeo('it', 'pratteln' as never, 3, YEAR);
+    const bsPratteln = buildCityHubSeo('it', 'pratteln' as never, 3, YEAR, 'Basilea Città');
+    // With no cantonDisplay, short titles fall back to "in Ticino" pad
+    // (preserves legacy TI behaviour). With cantonDisplay, the pad swaps to
+    // the actual canton — so the BS variant must not say "Ticino" anywhere.
+    expect(bsPratteln.title).not.toContain('Ticino');
+    expect(bsPratteln.title).not.toContain('Tessin');
+    // If the IT title was short enough to trigger pad-to-min, verify the
+    // substitution actually happened.
+    if (tiPratteln.title.includes('in Ticino')) {
+      expect(bsPratteln.title).toContain('Basilea Città');
+    }
+  });
+
+  it('EN/DE/FR non-TI: title + meta substitute the actual canton', () => {
+    const cantonByLocale = {
+      en: 'Basel-City',
+      de: 'Basel-Stadt',
+      fr: 'Bâle-Ville',
+    } as const;
+    for (const locale of ['en', 'de', 'fr'] as const) {
+      const seo = buildCityHubSeo(locale, 'pratteln' as never, 3, YEAR, cantonByLocale[locale]);
+      expect(seo.title, `${locale} title`).not.toContain('Ticino');
+      expect(seo.title, `${locale} title`).not.toContain('Tessin');
+      expect(seo.title, `${locale} title`).toContain(cantonByLocale[locale]);
+      expect(seo.desc, `${locale} desc`).not.toContain('Ticino');
+      expect(seo.desc, `${locale} desc`).not.toContain('Tessin');
+      expect(seo.desc, `${locale} desc`).toContain(cantonByLocale[locale]);
+    }
+  });
+
+  it('TI callers (no 5th arg) keep legacy Ticino/Tessin copy — byte-identical guarantee', () => {
+    const legacyLugano = buildCityHubSeo('en', 'lugano', 50, YEAR);
+    const explicitNoCanton = buildCityHubSeo('en', 'lugano', 50, YEAR, undefined);
+    expect(legacyLugano.title).toBe(explicitNoCanton.title);
+    expect(legacyLugano.desc).toBe(explicitNoCanton.desc);
+    expect(legacyLugano.h1).toBe(explicitNoCanton.h1);
+    expect(legacyLugano.title).toContain('Ticino');
+  });
+});

--- a/tests/job-board-titles.test.ts
+++ b/tests/job-board-titles.test.ts
@@ -316,3 +316,61 @@ describe('all 4 locales covered for every page type', () => {
     }
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────
+// Regression: non-TI city hubs must NOT leak "Ticino"/"Tessin" into title
+// (PR #318 — buildCityHubTitle gained optional cantonDisplay)
+// ──────────────────────────────────────────────────────────────────────
+describe('buildCityHubTitle — non-TI cantonDisplay (no Ticino/Tessin leak)', () => {
+  it('IT non-TI city omits "in Ticino" pad and substitutes the actual canton', () => {
+    // Pratteln (BS) is a short city name that historically triggered pad-to-min
+    // with "in Ticino", producing a misleading title on the per-canton city hub.
+    const t = buildCityHubTitle({
+      locale: 'it',
+      cityDisplay: 'Pratteln',
+      count: 3,
+      year: YEAR,
+      cantonDisplay: 'Basilea Città',
+    });
+    expect(t).not.toContain('Ticino');
+    expect(t).not.toContain('Tessin');
+    expect(t).toContain('Pratteln');
+    // When the title is short enough to trigger pad-to-min, the canton fills in.
+    if (t.length < 60) expect(t).toContain('Basilea Città');
+  });
+
+  it('EN/DE/FR non-TI: base title uses the canton, not Ticino/Tessin', () => {
+    const cantonByLocale = {
+      en: 'Basel-City',
+      de: 'Basel-Stadt',
+      fr: 'Bâle-Ville',
+    } as const;
+    for (const locale of ['en', 'de', 'fr'] as const) {
+      const t = buildCityHubTitle({
+        locale,
+        cityDisplay: 'Pratteln',
+        count: 3,
+        year: YEAR,
+        cantonDisplay: cantonByLocale[locale],
+      });
+      expect(t, `${locale}`).not.toContain('Ticino');
+      expect(t, `${locale}`).not.toContain('Tessin');
+      expect(t, `${locale}`).toContain(cantonByLocale[locale]);
+      expect(t, `${locale}`).toContain('Pratteln');
+    }
+  });
+
+  it('TI callers (cantonDisplay undefined) keep legacy Ticino/Tessin copy', () => {
+    // Backward-compat: existing TI city hubs must be byte-identical pre/post-fix.
+    const it = buildCityHubTitle({ locale: 'it', cityDisplay: 'Lugano', count: 123, year: YEAR });
+    const en = buildCityHubTitle({ locale: 'en', cityDisplay: 'Lugano', count: 123, year: YEAR });
+    const de = buildCityHubTitle({ locale: 'de', cityDisplay: 'Bellinzona', count: 123, year: YEAR });
+    const fr = buildCityHubTitle({ locale: 'fr', cityDisplay: 'Mendrisio', count: 123, year: YEAR });
+    // Italian title doesn't contain "Ticino" in its base form, so just verify the
+    // shape stays the same (no canton word injected).
+    expect(it).toContain('Lugano');
+    expect(en).toContain('Ticino');
+    expect(de).toContain('Tessin');
+    expect(fr).toContain('Tessin');
+  });
+});

--- a/tests/meta-descriptions.test.ts
+++ b/tests/meta-descriptions.test.ts
@@ -221,3 +221,39 @@ describe('all 4 locales covered for every page type', () => {
     }
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────
+// Regression: non-TI city hubs must NOT hardcode "Ticino Switzerland" /
+// "Tessin" / "Tessin Suisse" in the meta description (PR #318 — buildCityHubMeta
+// gained optional cantonDisplay).
+// ──────────────────────────────────────────────────────────────────────
+describe('buildCityHubMeta — non-TI cantonDisplay (no Ticino/Tessin leak)', () => {
+  it('EN/DE/FR non-TI: meta substitutes the actual canton', () => {
+    const cantonByLocale = {
+      en: 'Basel-City',
+      de: 'Basel-Stadt',
+      fr: 'Bâle-Ville',
+    } as const;
+    for (const locale of ['en', 'de', 'fr'] as const) {
+      const m = buildCityHubMeta({
+        locale,
+        cityDisplay: 'Pratteln',
+        count: 3,
+        cantonDisplay: cantonByLocale[locale],
+      });
+      expect(m, `${locale}`).not.toContain('Ticino');
+      expect(m, `${locale}`).not.toContain('Tessin');
+      expect(m, `${locale}`).toContain(cantonByLocale[locale]);
+      expect(m, `${locale}`).toContain('Pratteln');
+    }
+  });
+
+  it('TI callers (cantonDisplay undefined) keep legacy Ticino/Tessin copy', () => {
+    const en = buildCityHubMeta({ locale: 'en', cityDisplay: 'Lugano', count: 50 });
+    const de = buildCityHubMeta({ locale: 'de', cityDisplay: 'Lugano', count: 50 });
+    const fr = buildCityHubMeta({ locale: 'fr', cityDisplay: 'Lugano', count: 50 });
+    expect(en).toContain('Ticino');
+    expect(de).toContain('Tessin');
+    expect(fr).toContain('Tessin');
+  });
+});


### PR DESCRIPTION
- **fix(seo): canton-aware ItemList structured data + regression tests**
- **ci: wire vitest unit-test suite into PR + main push events**
