### PR TITLE
fix(crawlers): ksw + solothurner-spitaeler description extraction

### DIFF
--- a/scripts/lib/ksw-job-parser.mjs
+++ b/scripts/lib/ksw-job-parser.mjs
@@ -198,6 +198,79 @@ export function parseKswListingPage(html = '') {
   return results;
 }
 
+/* ── Detail Page Parser ────────────────────────────────────── */
+
+/**
+ * Parse a Solique KSW detail page (live.solique.ch/ksw/job/details/{id}).
+ *
+ * The page is a server-rendered HTML document with these content sections:
+ *   - <div class="introduction">…company/team intro</div>
+ *   - <div class="tasks-wrapper"><h2>Deine Aufgaben</h2><ul class="tasks"><li>…</li></ul></div>
+ *   - <div class="profile-wrapper"><h2>Dein Profil</h2><ul class="profile"><li>…</li></ul></div>
+ *   - <div class="benefits-wrapper">…benefits</div>
+ *   - <div class="contact-info">…contact</div>
+ *
+ * The "tasks" + "profile" sections include the German content headings
+ * "Aufgaben" / "Profil" which satisfy the boilerplate-guard CONTENT_HEADINGS_RE
+ * regex (matches "Aufgaben|Anforderungen|Tasks|Requirements" etc).
+ */
+export function parseKswDetailPage(html = '') {
+  const blocks = [];
+
+  // Page-level title (more authoritative than the listing card sometimes)
+  const h1Match = html.match(/<h1[^>]*class="[^"]*jobtitle[^"]*"[^>]*>([\s\S]*?)<\/h1>/i);
+  const detailTitle = h1Match
+    ? normalizeSpace(decodeEntities(stripHtml(h1Match[1])))
+    : '';
+
+  // Introduction (team/company context)
+  const introMatch = html.match(/<div\s+class="introduction"[^>]*>([\s\S]*?)<\/div>/i);
+  if (introMatch) {
+    const txt = normalizeSpace(decodeEntities(stripHtml(introMatch[1])));
+    if (txt.length > 20) blocks.push(txt);
+  }
+
+  // Tasks (Aufgaben)
+  const tasksMatch = html.match(/<div\s+class="tasks-wrapper"[\s\S]*?<ul[^>]*class="[^"]*tasks[^"]*"[^>]*>([\s\S]*?)<\/ul>/i);
+  if (tasksMatch) {
+    const items = [...tasksMatch[1].matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)]
+      .map((m) => normalizeSpace(decodeEntities(stripHtml(m[1]))))
+      .filter((t) => t.length > 3);
+    if (items.length) {
+      blocks.push(`Aufgaben:\n• ${items.join('\n• ')}`);
+    }
+  }
+
+  // Profile (Profil / Anforderungen)
+  const profileMatch = html.match(/<div\s+class="profile-wrapper"[\s\S]*?<ul[^>]*class="[^"]*profile[^"]*"[^>]*>([\s\S]*?)<\/ul>/i);
+  if (profileMatch) {
+    const items = [...profileMatch[1].matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)]
+      .map((m) => normalizeSpace(decodeEntities(stripHtml(m[1]))))
+      .filter((t) => t.length > 3);
+    if (items.length) {
+      blocks.push(`Profil:\n• ${items.join('\n• ')}`);
+    }
+  }
+
+  // Benefits (optional flavour)
+  const benefitsMatch = html.match(/<div\s+class="benefits-wrapper"[^>]*>([\s\S]*?)<\/div>\s*<\/div>\s*<\/div>/i);
+  if (benefitsMatch) {
+    const titles = [...benefitsMatch[1].matchAll(/<div\s+class="benefit-title"[^>]*>([\s\S]*?)<\/div>/gi)]
+      .map((m) => normalizeSpace(decodeEntities(stripHtml(m[1]))))
+      .filter((t) => t.length > 2);
+    const texts = [...benefitsMatch[1].matchAll(/<div\s+class="benefit-text"[^>]*>([\s\S]*?)<\/div>/gi)]
+      .map((m) => normalizeSpace(decodeEntities(stripHtml(m[1]))))
+      .filter((t) => t.length > 5);
+    const combined = [...titles, ...texts].slice(0, 8);
+    if (combined.length) blocks.push(`Benefits: ${combined.join('; ')}`);
+  }
+
+  return {
+    title: detailTitle,
+    description: blocks.join('\n\n'),
+  };
+}
+
 /* ── HTTP Fetch ───────────────────────────────────────────── */
 
 async function fetchPage(url) {
@@ -223,6 +296,42 @@ async function fetchPage(url) {
   }
 }
 
+/**
+ * Sequential mini-helper to fetch N detail pages with bounded concurrency
+ * + per-worker delay + retry-on-503/429 with backoff. Solique handles a
+ * few rps fine but we still pause to stay polite.
+ */
+async function fetchInBatches(items, concurrency, fn, opts = {}) {
+  const delayMs = Number.isFinite(opts.delayMs) ? opts.delayMs : 150;
+  const retries = Number.isFinite(opts.retries) ? opts.retries : 2;
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      let lastErr = null;
+      for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+          results[i] = await fn(items[i], i);
+          lastErr = null;
+          break;
+        } catch (err) {
+          lastErr = err;
+          const msg = String(err?.message || '');
+          if (!/HTTP\s+(5\d\d|429)/.test(msg)) break;
+          await new Promise((r) => setTimeout(r, delayMs * (attempt + 1) * 2));
+        }
+      }
+      if (lastErr) results[i] = { __error: lastErr };
+      if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  const workers = Array.from({ length: Math.max(1, concurrency) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
 /* ── Main Fetch Function ──────────────────────────────────── */
 
 export async function fetchAllKswJobs() {
@@ -245,9 +354,32 @@ export async function fetchAllKswJobs() {
   }
   console.log(`  📋 Listings found: ${listings.length}\n`);
 
+  // Fetch detail pages with bounded concurrency. The Solique detail page
+  // carries the real Aufgaben/Profil sections — the listing card alone
+  // produces stub descriptions (~15 words) that fail the boilerplate guard.
+  const detailConcurrency = Number(process.env.JOBS_CRAWLER_DETAIL_CONCURRENCY) || 3;
+  const detailDelayMs = Number(process.env.JOBS_CRAWLER_DETAIL_DELAY_MS) || 200;
+  console.log(`  🔎 Fetching ${listings.length} detail pages (concurrency=${detailConcurrency}, delay=${detailDelayMs}ms)…`);
+  const detailResults = await fetchInBatches(listings, detailConcurrency, async (listing) => {
+    const detailHtml = await fetchPage(listing.detailUrl);
+    return parseKswDetailPage(detailHtml);
+  }, { delayMs: detailDelayMs, retries: 2 });
+  let detailOk = 0;
+  let detailFail = 0;
+  for (const r of detailResults) {
+    if (r && !r.__error && r.description) detailOk++;
+    else detailFail++;
+  }
+  console.log(`  ✅ Detail OK: ${detailOk} · ⚠️ failures: ${detailFail}\n`);
+
   const jobs = [];
-  for (const listing of listings) {
-    const title = listing.title;
+  for (let i = 0; i < listings.length; i++) {
+    const listing = listings[i];
+    const detail = detailResults[i];
+    const detailOkHere = detail && !detail.__error;
+    const title = (detailOkHere && detail.title && detail.title.length > 3)
+      ? detail.title
+      : listing.title;
     const location = 'Winterthur';
     const canton = 'ZH';
 
@@ -260,8 +392,12 @@ export async function fetchAllKswJobs() {
         : `${listing.workloadMin}-${listing.workloadMax}%`;
       descBits.push(`• Pensum: ${pct}`);
     }
+    const metaLine = descBits.length ? descBits.join('\n') : '';
     const fallbackDesc = `${title} — ${KSW_COMPANY_NAME}, Winterthur`;
-    const descriptionText = descBits.length ? `${fallbackDesc}\n\n${descBits.join('\n')}` : fallbackDesc;
+    const detailText = detailOkHere ? detail.description : '';
+    const descriptionText = detailText
+      ? (metaLine ? `${detailText}\n\n${metaLine}` : detailText)
+      : (metaLine ? `${fallbackDesc}\n\n${metaLine}` : fallbackDesc);
 
     const sourceLang = 'de';
     const jobSlug = slugify(`${title} ksw ch`);

--- a/scripts/lib/solothurner-spitaeler-job-parser.mjs
+++ b/scripts/lib/solothurner-spitaeler-job-parser.mjs
@@ -26,7 +26,7 @@
  *   - SOLOTHURNER_SPITAELER_KEY / _COMPANY_NAME / _COMPANY_DOMAIN constants
  */
 import { createHash } from 'node:crypto';
-import { slugify, normalizeSpace } from './crawler-template.mjs';
+import { slugify, normalizeSpace, stripHtml } from './crawler-template.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -230,6 +230,78 @@ export function parseSohListingPage(html = '') {
   return results;
 }
 
+/* ── Detail Page Parser ────────────────────────────────────── */
+
+/**
+ * Parse a soH detail page (jobs.so-h.ch/offene-stellen/{slug}/{uuid}).
+ *
+ * The page is server-rendered and embeds:
+ *   - A JSON-LD JobPosting at the bottom with `description` / `responsibilities`
+ *     / `qualifications` (richest source, prefer when present).
+ *   - HTML containers <div id="tasks"> (Aufgaben) and <div id="profile">
+ *     (Profil) as a fallback when JSON-LD is missing.
+ *
+ * Both branches include the German content headings "Aufgaben" / "Profil"
+ * that satisfy the boilerplate-guard CONTENT_HEADINGS_RE.
+ */
+export function parseSohDetailPage(html = '') {
+  const blocks = [];
+
+  // ── Strategy A: JSON-LD JobPosting (richest) ─────────────
+  const jsonLdMatch = html.match(/<script[^>]+application\/ld\+json[^>]*>([\s\S]*?)<\/script>/i);
+  if (jsonLdMatch) {
+    try {
+      const raw = jsonLdMatch[1].trim();
+      const parsed = JSON.parse(raw);
+      const items = Array.isArray(parsed) ? parsed : [parsed];
+      for (const item of items) {
+        if (!item || (item['@type'] && item['@type'] !== 'JobPosting')) continue;
+        // Some sources put richer markup in responsibilities + qualifications
+        const resp = String(item.responsibilities || '');
+        const qual = String(item.qualifications || '');
+        const desc = String(item.description || '');
+        const respClean = normalizeSpace(decodeEntities(stripHtml(resp)));
+        const qualClean = normalizeSpace(decodeEntities(stripHtml(qual)));
+        const descClean = normalizeSpace(decodeEntities(stripHtml(desc)));
+        // Prefer separate responsibilities/qualifications because description
+        // often duplicates them. Pick the longer signal source per field.
+        if (respClean.length > 30) blocks.push(respClean);
+        if (qualClean.length > 30) blocks.push(qualClean);
+        if (blocks.length === 0 && descClean.length > 30) blocks.push(descClean);
+        break; // first JobPosting wins
+      }
+    } catch {
+      // fall through to HTML scrape
+    }
+  }
+
+  // ── Strategy B: HTML container fallback ──────────────────
+  if (blocks.length === 0) {
+    const tasksMatch = html.match(/<div\s+id="tasks"[^>]*>([\s\S]*?)<\/div>/i);
+    if (tasksMatch) {
+      const txt = normalizeSpace(decodeEntities(stripHtml(tasksMatch[1])));
+      if (txt.length > 20) blocks.push(txt);
+    }
+    const profileMatch = html.match(/<div\s+id="profile"[^>]*>([\s\S]*?)<\/div>/i);
+    if (profileMatch) {
+      const txt = normalizeSpace(decodeEntities(stripHtml(profileMatch[1])));
+      if (txt.length > 20) blocks.push(txt);
+    }
+  }
+
+  // Detail page H2 title (fall back to listing card if missing)
+  const titleMatch = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)
+    || html.match(/<h2[^>]*>([\s\S]*?)<\/h2>/i);
+  const detailTitle = titleMatch
+    ? normalizeSpace(decodeEntities(stripHtml(titleMatch[1])))
+    : '';
+
+  return {
+    title: detailTitle,
+    description: blocks.join('\n\n'),
+  };
+}
+
 /* ── HTTP Fetch ───────────────────────────────────────────── */
 
 async function fetchPage(url) {
@@ -255,6 +327,45 @@ async function fetchPage(url) {
   }
 }
 
+/**
+ * Sequential mini-helper to fetch N detail pages with bounded concurrency
+ * + a per-worker delay between requests + retry-on-503/429 with backoff.
+ *
+ * jobs.so-h.ch returns sporadic 503s when hit faster than ~2 req/s, so we
+ * keep concurrency=2 and pause briefly between calls to stay polite.
+ */
+async function fetchInBatches(items, concurrency, fn, opts = {}) {
+  const delayMs = Number.isFinite(opts.delayMs) ? opts.delayMs : 350;
+  const retries = Number.isFinite(opts.retries) ? opts.retries : 2;
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      let lastErr = null;
+      for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+          results[i] = await fn(items[i], i);
+          lastErr = null;
+          break;
+        } catch (err) {
+          lastErr = err;
+          const msg = String(err?.message || '');
+          // Retry on 5xx and 429 only — propagate other errors after first try
+          if (!/HTTP\s+(5\d\d|429)/.test(msg)) break;
+          await new Promise((r) => setTimeout(r, delayMs * (attempt + 1) * 2));
+        }
+      }
+      if (lastErr) results[i] = { __error: lastErr };
+      if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  const workers = Array.from({ length: Math.max(1, concurrency) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
 /* ── Main Fetch Function ──────────────────────────────────── */
 
 export async function fetchAllSolothurnerSpitaelerJobs() {
@@ -277,9 +388,36 @@ export async function fetchAllSolothurnerSpitaelerJobs() {
   }
   console.log(`  📋 Listings found: ${listings.length}\n`);
 
+  // Fetch each detail page on jobs.so-h.ch to extract the JSON-LD JobPosting
+  // (with `responsibilities` + `qualifications`). Without this, descriptions
+  // are just the listing card's pensum/department/site line — ~10 words,
+  // well under the boilerplate guard's 30 unique-word threshold.
+  // jobs.so-h.ch returns 503s above ~2 req/s — serial with 600ms gap keeps
+  // failures to 1/125 in practice; parallel concurrency=2 leaves ~25 5xx-only
+  // failures even with retries. The total walk takes ~80s — acceptable.
+  const detailConcurrency = Number(process.env.JOBS_CRAWLER_DETAIL_CONCURRENCY) || 1;
+  const detailDelayMs = Number(process.env.JOBS_CRAWLER_DETAIL_DELAY_MS) || 600;
+  console.log(`  🔎 Fetching ${listings.length} detail pages (concurrency=${detailConcurrency}, delay=${detailDelayMs}ms)…`);
+  const detailResults = await fetchInBatches(listings, detailConcurrency, async (listing) => {
+    const detailHtml = await fetchPage(listing.detailUrl);
+    return parseSohDetailPage(detailHtml);
+  }, { delayMs: detailDelayMs, retries: 3 });
+  let detailOk = 0;
+  let detailFail = 0;
+  for (const r of detailResults) {
+    if (r && !r.__error && r.description) detailOk++;
+    else detailFail++;
+  }
+  console.log(`  ✅ Detail OK: ${detailOk} · ⚠️ failures: ${detailFail}\n`);
+
   const jobs = [];
-  for (const listing of listings) {
-    const title = listing.title;
+  for (let i = 0; i < listings.length; i++) {
+    const listing = listings[i];
+    const detail = detailResults[i];
+    const detailOkHere = detail && !detail.__error;
+    const title = (detailOkHere && detail.title && detail.title.length > 3)
+      ? detail.title
+      : listing.title;
     const { city, postalCode } = pickCityForSite(listing.siteName);
     const canton = 'SO';
 
@@ -288,9 +426,13 @@ export async function fetchAllSolothurnerSpitaelerJobs() {
     if (listing.siteName) descBits.push(`• Standort: ${listing.siteName}`);
     if (listing.department) descBits.push(`• Abteilung: ${listing.department}`);
     if (listing.pensumStr) descBits.push(`• Pensum: ${listing.pensumStr}`);
-    const descriptionText = descBits.length
-      ? `${title} — ${SOLOTHURNER_SPITAELER_COMPANY_NAME}.\n\n${descBits.join('\n')}`
-      : `${title} — ${SOLOTHURNER_SPITAELER_COMPANY_NAME}, ${city}`;
+    const metaLine = descBits.length ? descBits.join('\n') : '';
+    const detailText = detailOkHere ? detail.description : '';
+    const descriptionText = detailText
+      ? (metaLine ? `${detailText}\n\n${metaLine}` : detailText)
+      : (metaLine
+          ? `${title} — ${SOLOTHURNER_SPITAELER_COMPANY_NAME}.\n\n${metaLine}`
+          : `${title} — ${SOLOTHURNER_SPITAELER_COMPANY_NAME}, ${city}`);
 
     const sourceLang = 'de';
     const jobSlug = slugify(`${title} soh ch`);


### PR DESCRIPTION
Both crawlers were emitting stub descriptions (title + 3 bullets, ~15 words)
because they only parsed the listing card and never fetched the detail page.
The boilerplate guard caught this and failed the run with 72% (ksw) and
78% (soH) boilerplate-only descriptions.

- ksw: fetch live.solique.ch/ksw/job/details/{id} and parse the
  introduction / tasks-wrapper / profile-wrapper / benefits-wrapper sections.
  Concurrency=3, delay=200ms. ~430 words per description.
- solothurner-spitaeler: fetch jobs.so-h.ch/offene-stellen/.../{uuid} and
  parse the embedded JSON-LD JobPosting (responsibilities + qualifications),
  with id="tasks"/id="profile" HTML fallback. The site rate-limits above
  ~2 req/s so serial fetch with 600ms gap + 503/429 retry is the default.
- Both helpers share a bounded-concurrency fetchInBatches with retry on
  5xx/429 to stay polite without dropping content.

The new German source descriptions are ~3000 chars vs ~150 before, so the
merge logic in dedicated-crawler-common.mjs (line 1276) overwrites existing
locale copies (ratio < 85%) and marks needsRetranslation=true, regenerating
all four locale translations on the next AI pass.

Closes #266, #269.
