### PR TITLE
fix(seo): city hub staticOverlay + canton-scoped legacy fallback

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -19,6 +19,7 @@ import {
  fetchAllJobs,
  fetchJobsForCanton,
  getDefaultCantonForVisit,
+ scopeJobsToCanton,
  AGGREGATE_CANTON_CODE,
  type Job as RawJob,
 } from '@/services/jobsService';
@@ -2768,21 +2769,28 @@ const JobBoard: React.FC<JobBoardProps> = ({
  };
 
  const run = async (): Promise<void> => {
- try {
  // P7.2 — URL-driven canton pre-filter takes precedence over
  // referrer-based default. /cerca-lavoro-zurigo/ → ZH shard;
  // /cerca-lavoro-svizzera/ → AGGREGATE; legacy /cerca-lavoro-ticino/
  // → TI (router sets jobBoardCanton:'TI' explicitly per P7.1).
+ // Hoisted above try/catch so the catch block can scope its legacy
+ // fallback to the same canton.
  const targetCanton = initialFilterCanton || getDefaultCantonForVisit();
+ try {
  const shardJobs: RawJob[] =
  targetCanton === AGGREGATE_CANTON_CODE
  ? await fetchAggregatedJobs(TOP_AGGREGATE_CANTONS, { deduplicate: true })
  : await fetchJobsForCanton(targetCanton);
 
  // Shards not yet deployed (every shard 404'd / empty) → legacy loader.
+ // The legacy payload is the locale-wide monolith (~13 MB, all 26 cantons
+ // mixed, TI-dominant). Without a post-filter the canton SERP degenerates
+ // to a TI-biased listing — visible on every non-TI /cerca-lavoro-{canton}/
+ // page until shards land. Aggregator keeps the full list.
  if (shardJobs.length === 0) {
  const legacy = await loadLegacyLocaleJobs();
- finalize(Array.isArray(legacy) ? legacy : []);
+ const legacyArr = Array.isArray(legacy) ? legacy : [];
+ finalize(scopeJobsToCanton(legacyArr, targetCanton));
  return;
  }
 
@@ -2793,7 +2801,8 @@ const JobBoard: React.FC<JobBoardProps> = ({
  reportCaughtError(err, 'jobBoard.loadJobs.shards');
  try {
  const legacy = await loadLegacyLocaleJobs();
- finalize(Array.isArray(legacy) ? legacy : []);
+ const legacyArr = Array.isArray(legacy) ? legacy : [];
+ finalize(scopeJobsToCanton(legacyArr, targetCanton));
  } catch (legacyErr: unknown) {
  console.warn('Legacy locale-jobs fallback also failed:', legacyErr);
  reportCaughtError(legacyErr, 'jobBoard.loadJobs.legacy');

--- a/services/jobsService.ts
+++ b/services/jobsService.ts
@@ -407,6 +407,23 @@ export async function fetchAllJobs(): Promise<Job[]> {
  return data as Job[];
 }
 
+/**
+ * Scope a job array to a canton, preserving the input when the canton is
+ * {@link AGGREGATE_CANTON_CODE}. Used by JobBoard's legacy-fallback path:
+ * when the per-canton shard 404s and we load the locale-wide monolith
+ * (`/data/jobs-{locale}.json`, ~13 MB, all 26 cantons mixed), this filter
+ * prevents the TI-dominant payload from leaking into non-TI canton SERPs.
+ *
+ * Pure / side-effect free → unit-testable without DOM or network.
+ */
+export function scopeJobsToCanton<T extends { canton?: string | null }>(
+ jobs: ReadonlyArray<T>,
+ targetCanton: string,
+): T[] {
+ if (targetCanton === AGGREGATE_CANTON_CODE) return jobs.slice();
+ return jobs.filter((j) => j.canton === targetCanton);
+}
+
 // --------------------------------------------------------------------------
 // Internals
 // --------------------------------------------------------------------------

--- a/services/router.ts
+++ b/services/router.ts
@@ -2443,11 +2443,17 @@ export function parsePath(pathname: string): ParseResult {
        // across cantons (handled inside `isKnownCityHub`).
        const cantonForCityLookup = cantonCode !== '_AGGREGATE_' ? cantonCode : undefined;
        if (isKnownCityHub(rawSecond, cantonForCityLookup)) {
+         // Build emits a real per-city static HTML at this path (city-jobs-hub
+         // plugin) with the jobs already filtered and ranked for the city.
+         // staticOverlay:true keeps that SSR content visible — without it the
+         // SPA hydration replaces the 3 city-filtered cards with a generic
+         // canton-wide SERP (jobBoardCity is currently a dead field downstream).
          return {
            route: {
              activeTab: 'job-board',
              jobBoardCanton: cantonCode,
              jobBoardCity: rawSecond,
+             staticOverlay: true,
            },
            locale,
          };

--- a/tests/router/canton-city-routing.test.ts
+++ b/tests/router/canton-city-routing.test.ts
@@ -23,6 +23,22 @@ describe('Phase 2 — per-canton city routing', () => {
     expect(parsed.notFoundPath).toBeUndefined();
   });
 
+  // Regression 2026-05-19: city hub routes must set staticOverlay:true so
+  // the build-time SSR (city-jobs-hub plugin) survives hydration. Without
+  // it the SPA replaces 3 city-filtered cards with a generic canton SERP —
+  // user-visible bug on /cerca-lavoro-basilea/pratteln/ before this fix.
+  it('city hub sets staticOverlay:true (parity with company hubs)', () => {
+    const parsed = parsePath('/cerca-lavoro-basilea/pratteln/');
+    expect(parsed.route.activeTab).toBe('job-board');
+    expect(parsed.route.jobBoardCity).toBe('pratteln');
+    expect(parsed.route.staticOverlay).toBe(true);
+  });
+
+  it('non-TI city hub fix applies broadly (Zurigo)', () => {
+    const parsed = parsePath('/cerca-lavoro-zurigo/zurich/');
+    expect(parsed.route.staticOverlay).toBe(true);
+  });
+
   it('/cerca-lavoro-ginevra/geneve/ → jobBoardCanton=GE, jobBoardCity=geneve', () => {
     const parsed = parsePath('/cerca-lavoro-ginevra/geneve/');
     expect(parsed.route.activeTab).toBe('job-board');

--- a/tests/router/canton-static-overlay-slugs.test.ts
+++ b/tests/router/canton-static-overlay-slugs.test.ts
@@ -101,9 +101,15 @@ describe('per-canton static-overlay slugs', () => {
     expect(parsed.route.jobSlug).toBe('software-engineer-acme-basel');
   });
 
-  it('ZH city slug still routes to jobBoardCity (no false positive)', () => {
+  // 2026-05-19: city hubs now ALSO carry staticOverlay:true (parity with
+  // company hubs / categories). The build emits a real per-city HTML
+  // (city-jobs-hub plugin) with jobs already filtered to the city and the
+  // SEO copy block underneath. Without staticOverlay the SPA replaced the
+  // 3 city-filtered cards with a generic canton-wide SERP — visible bug
+  // on /cerca-lavoro-basilea/pratteln/.
+  it('ZH city slug routes to jobBoardCity with staticOverlay:true', () => {
     const parsed = parsePath('/cerca-lavoro-zurigo/zurich/');
     expect(parsed.route.jobBoardCity).toBe('zurich');
-    expect(parsed.route.staticOverlay).toBeFalsy();
+    expect(parsed.route.staticOverlay).toBe(true);
   });
 });

--- a/tests/services/jobsService.scopeJobsToCanton.test.ts
+++ b/tests/services/jobsService.scopeJobsToCanton.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression 2026-05-19 — JobBoard legacy-fallback canton filter.
+ *
+ * Context: the per-canton shards at /data/jobs-by-canton/{CODE}.json are not
+ * yet emitted in production (every shard 404s). JobBoard's fallback path
+ * loads the locale-wide monolith (`/data/jobs-it.json`, ~13 MB, TI-dominant).
+ * Without a post-filter, every non-TI /cerca-lavoro-{canton}/ SERP renders a
+ * TI-biased listing — user-visible bug reported on /cerca-lavoro-basilea/.
+ *
+ * `scopeJobsToCanton` is the pure helper that filters the legacy payload to
+ * the URL-driven canton before it reaches React state. Aggregator routes
+ * (`_AGGREGATE_`) keep the full list.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  scopeJobsToCanton,
+  AGGREGATE_CANTON_CODE,
+} from '@/services/jobsService';
+
+type Fixture = { id: string; canton?: string | null };
+
+const FIXTURE: Fixture[] = [
+  { id: 'a', canton: 'TI' },
+  { id: 'b', canton: 'TI' },
+  { id: 'c', canton: 'BL' },
+  { id: 'd', canton: 'BS' },
+  { id: 'e', canton: 'ZH' },
+  { id: 'f', canton: null },
+  { id: 'g' }, // canton field absent
+];
+
+describe('scopeJobsToCanton', () => {
+  it('filters legacy payload to the target canton', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, 'BL');
+    expect(scoped.map((j) => j.id)).toEqual(['c']);
+  });
+
+  it('TI bias regression: BL request must NOT leak TI jobs', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, 'BL');
+    expect(scoped.every((j) => j.canton === 'BL')).toBe(true);
+    expect(scoped.some((j) => j.canton === 'TI')).toBe(false);
+  });
+
+  it('aggregator sentinel preserves the full payload', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, AGGREGATE_CANTON_CODE);
+    expect(scoped).toHaveLength(FIXTURE.length);
+    expect(scoped.map((j) => j.id)).toEqual(FIXTURE.map((j) => j.id));
+  });
+
+  it('aggregator returns a defensive copy (caller can mutate without side effects)', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, AGGREGATE_CANTON_CODE);
+    scoped.pop();
+    expect(FIXTURE).toHaveLength(7);
+  });
+
+  it('unknown canton yields empty array (no silent fallthrough)', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, 'XX');
+    expect(scoped).toEqual([]);
+  });
+
+  it('jobs with null/missing canton are dropped (strict equality)', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, 'TI');
+    expect(scoped.map((j) => j.id).sort()).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary

Due bug user-visible su SERP canton non-TI, riportati su `/cerca-lavoro-basilea/pratteln/` e `/cerca-lavoro-basilea/`.

### Fix #1 — `/cerca-lavoro-{canton}/{city}/`: SSR cancellata dalla hydration

Il router parsava il city hub a `{ jobBoardCanton, jobBoardCity }` **senza** `staticOverlay`. La SPA hydratava JobBoard sopra la SSR del `city-jobs-hub` plugin e cancellava le card filtrate per città lasciando un SERP canton-wide. `jobBoardCity` è un campo morto: né `App.tsx` né `JobBoard.tsx` lo leggono.

**Fix**: aggiunto `staticOverlay:true` al ramo `isKnownCityHub` in `services/router.ts` — stesso pattern di company hub (PR #318) e weekly-employers.

### Fix #2 — `/cerca-lavoro-{canton}/`: TI-bias dopo shard 404

`/data/jobs-by-canton/*.json` non viene emesso in produzione (404 verificato su TI, ZH, BL, BS, VD, GE, ...). `fetchJobsForCanton` ritorna `[]` → JobBoard cade su `loadLegacyLocaleJobs()` che scarica `/data/jobs-it.json` (~13 MB, tutti i 26 cantoni, TI-dominante). Il fallback **non filtrava** per canton.

**Fix**: nuovo helper puro `scopeJobsToCanton(jobs, targetCanton)` in `services/jobsService.ts`; JobBoard lo applica in entrambi i path di fallback (shard vuoto + service error). `AGGREGATE` preserva il payload intero (copia difensiva).

## Test plan

- [x] `tests/services/jobsService.scopeJobsToCanton.test.ts` — 6 test (BL, TI, aggregator, unknown canton, defensive copy, missing canton field)
- [x] `tests/router/canton-city-routing.test.ts` — +2 test per staticOverlay su city hub (BL, ZH)
- [x] `tests/router/canton-static-overlay-slugs.test.ts` — aggiornato il test ZH che codificava il vecchio bug
- [x] `npx vitest run tests/router/ tests/services/jobsService.scopeJobsToCanton.test.ts tests/city-jobs-hub.test.ts tests/router-locale-slugs.test.ts tests/job-sector-landing.test.ts` → **240/240 passed**
- [x] `npx tsc --noEmit` → pulito (gli errori `post_auth_prompt_${any}` sono pre-esistenti, unrelated)
- [ ] CI gate `tests.yml` verde su PR
- [ ] Dopo deploy: `curl -I https://frontaliereticino.ch/cerca-lavoro-basilea/pratteln/` → 200, body shows 3 Pratteln cards (non più sostituite dalla SPA)
- [ ] Dopo deploy: `/cerca-lavoro-basilea/` SERP mostra solo job BL/BS (no TI leak)

## Riferimenti

- Estende PR #318 (canton-aware company hubs) con lo stesso pattern di fix
- Memory: `feedback_static_overlay_truth_is_router` — `parsePath().route.staticOverlay` resta single source of truth
- Memory: `feedback_regression_gates_need_ci_runner` — `tests.yml` gate verificato attivo