### PR TITLE
perf(audit): unified audit runner — single Node process, one dist walk, dispatch to N audits

### DIFF
--- a/docs/superpowers/specs/2026-05-19-build-and-audit-optimization-baseline.md
+++ b/docs/superpowers/specs/2026-05-19-build-and-audit-optimization-baseline.md
@@ -1,0 +1,109 @@
+# Build + audit optimization — baseline measurements (2026-05-19)
+
+Baseline numbers locked in **before** L1+L2+L3 optimization rollout. Each
+phase commits a delta against these.
+
+## Environment
+
+- Local dev machine (Darwin 25.2.0, Apple Silicon)
+- Cores: `sysctl hw.ncpu` (Mac default 8-10 perf+efficiency)
+- Storage: APFS local SSD
+- `dist/`: 81.684 HTML files / 2.1 GB (local FAST_BUILD output, partial coverage)
+- Production `dist/`: 650.257 HTML files / 8.2 GB (downloaded artifact reference)
+- Linear scaling factor local→prod: ~8× on file count, ~4× on bytes
+
+CI runner (estimated, from `post-deploy-validate-dist.yml` comments):
+- ubuntu-latest free, 7 GB RAM, 2-4 vCPU
+- Memory-constrained: forced `MAX_PARALLEL=1` to avoid OOM when running
+  multiple dist-walking audits concurrently (1-3 GB RSS per process)
+
+## L3 — Audit pipeline baseline
+
+Six audits running sequentially as independent Node processes (current
+behavior of `post-deploy-validate-dist.yml`):
+
+| Audit | Local wall time (s) |
+|---|---|
+| `audit-text-html-ratio` | 58.34 |
+| `audit-title-length` | 36.05 |
+| `audit-h1-title-duplicates` | 29.20 |
+| `audit-footer-root-presence` | 28.96 |
+| `audit-title-no-disambig-hash` | 28.60 |
+| `audit-jsonld-no-nested-scripts` | 28.17 |
+| **Sequential total (6 audits)** | **209.32** |
+
+Extrapolated to CI dist (650k files):
+- Local: ~30s per audit average on 82k files
+- CI scaling: ~8× file count → ~240s per audit → ~24 min total sequential
+
+Matches the empirical "10-12 min chain" reported in `post-deploy-validate-dist.yml`
+since the chain only runs 4-7 audits with OS page-cache warm-up amortizing
+the walk cost across consecutive audits in the same shell.
+
+## L3 — Phase 1 measurement (3 audits migrated)
+
+Migrated to unified runner (`scripts/audit-all.mjs`):
+- `audit-footer-root-presence`
+- `audit-jsonld-no-nested-scripts`
+- `audit-title-length`
+
+Run via `node scripts/audit-all.mjs`:
+
+| Mode | Wall time (s) | Notes |
+|---|---|---|
+| Sequential (baseline sum, warm cache) | **93.18** | sum of standalone runs |
+| Unified runner (warm cache) | **39.73** | single Node process, single walk |
+| **Speedup** | **2.35×** | with 3 audits |
+
+Walk breakdown:
+- File walk (`readdir` traversal): 13.36s
+- File read + collect (`readFile` + 3 audit regex per file): 26.25s
+
+The walk is roughly equivalent to ONE original audit's wall time. Adding
+more audits to the unified runner barely increases total time (each audit's
+regex is microseconds per file in memory, dominated by file I/O which is
+already done once).
+
+## Extrapolated win (full 6-audit migration)
+
+Linear projection: with 6 audits in the unified runner, wall time stays ≈
+walk time + N×regex (where N×regex is tiny). Expected:
+
+| Audits in runner | Sequential baseline | Unified runner | Speedup |
+|---|---|---|---|
+| 2 | 57.13s | ~31s | ~1.8× |
+| 3 | 93.18s | **39.73s (measured)** | **2.35×** |
+| 6 (projected) | 209.32s | ~45-50s | **~4-5×** |
+
+CI estimate post-full-migration (650k files):
+- Today: ~25-45 min for the dist-walking chain
+- After L3 full: ~5-8 min
+- **Wall-time reduction: -70/80%**
+
+## L1 + L2 baselines (TODO — measured in subsequent phases)
+
+- `closeBundle` per-plugin timing (top-5 plugins): not yet instrumented
+- `dist/` artifact total size: 8.2 GB (production reference)
+- Average HTML page size: ~25 KB
+
+These get committed when L1 and L2 ship.
+
+## How baseline was measured
+
+```bash
+mkdir -p /tmp/audit-baseline-2026-05-19
+for audit in audit-title-length audit-title-no-disambig-hash \
+             audit-footer-root-presence audit-jsonld-no-nested-scripts \
+             audit-h1-title-duplicates audit-text-html-ratio; do
+  /usr/bin/time -p node "scripts/${audit}.mjs" \
+    > "/tmp/audit-baseline-2026-05-19/${audit}.stdout" \
+    2> "/tmp/audit-baseline-2026-05-19/${audit}.timing"
+done
+awk '/^real/ {s+=$2} END {printf "%.2f sec\n", s}' /tmp/audit-baseline-2026-05-19/*.timing
+```
+
+Unified runner measurement after cache warm-up:
+```bash
+node -e "import('./scripts/lib/audit-runner.mjs').then(m => m.walkHtmlFiles('dist'))" > /dev/null
+/usr/bin/time -p node scripts/audit-all.mjs
+```

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "validate:thin-pages": "node scripts/find-thin-pages.mjs --min-words=100 --fail-on-any",
     "audit:content-duplicates": "node scripts/audit-content-duplicates.mjs dist",
     "audit:dist-multi": "node scripts/audit-dist-multi.mjs",
+    "audit:all": "node scripts/audit-all.mjs",
     "audit:page-weight": "node scripts/audit-page-weight.mjs",
     "audit:text-html-ratio": "node scripts/audit-text-html-ratio.mjs --baseline=data/text-html-ratio-baseline.json",
     "audit:text-html-ratio:rebaseline": "node scripts/audit-text-html-ratio.mjs --write-baseline=data/text-html-ratio-baseline.json",

--- a/scripts/audit-all.mjs
+++ b/scripts/audit-all.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * audit-all.mjs
+ *
+ * Unified entry point for the audit pipeline. Imports every migrated audit
+ * (each exposes a `factory()` creating a fresh Auditor closure), runs them
+ * through `runAudits()` in ONE Node process, walking dist/ exactly once.
+ *
+ * Replaces the per-audit `npm run audit:<name>` calls that today fan out 12+
+ * Node processes (each loading V8 + dependencies, each walking dist/ from
+ * scratch). On the 7 GB ubuntu-latest free runner, that fan-out forced
+ * everything serial to avoid OOM (post-deploy-validate-dist.yml comments
+ * spell out the history).
+ *
+ * Usage:
+ *   node scripts/audit-all.mjs                       # run all registered audits
+ *   node scripts/audit-all.mjs --audits=text-html-ratio,footer-root-presence
+ *   node scripts/audit-all.mjs --dist=path/to/dist   # default: ./dist
+ *   AUDIT_STRICT=1 node scripts/audit-all.mjs        # detect AST mutation
+ *
+ * Exit codes:
+ *   0 — every audit passed
+ *   1 — one or more audits failed (gate or threshold)
+ *   2 — dist/ missing or fatal error
+ */
+import { stat } from 'node:fs/promises';
+import { runAudits, filterAuditors, DEFAULT_DIST } from './lib/audit-runner.mjs';
+
+// ─── Register migrated audits ────────────────────────────────────────────────
+// Each migration imports the audit's `factory()` and the runner instantiates
+// a fresh Auditor per pass. Add new audits here as they migrate.
+
+import { factory as footerRootPresence } from './audit-footer-root-presence.mjs';
+import { factory as jsonldNoNestedScripts } from './audit-jsonld-no-nested-scripts.mjs';
+import { factory as titleLength } from './audit-title-length.mjs';
+
+const REGISTRY = [
+  { factory: footerRootPresence, name: 'footer-root-presence' },
+  { factory: jsonldNoNestedScripts, name: 'jsonld-no-nested-scripts' },
+  { factory: titleLength, name: 'title-length' },
+];
+
+// ─── CLI parsing ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+function getArg(name, fallback) {
+  const a = args.find((s) => s.startsWith(`--${name}=`));
+  return a ? a.split('=').slice(1).join('=') : fallback;
+}
+
+const distArg = getArg('dist', DEFAULT_DIST);
+const auditFilter = getArg('audits', undefined); // CSV of audit names
+const verbose = !args.includes('--quiet');
+
+async function main() {
+  const s = await stat(distArg).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`audit-all: dist not found or not a directory: ${distArg}`);
+    process.exit(2);
+  }
+
+  // Instantiate fresh auditors from factories
+  const auditors = REGISTRY.map((r) => r.factory());
+
+  // Optional filter
+  const selected = filterAuditors(auditors, auditFilter);
+  if (selected.length === 0) {
+    console.error(`audit-all: no auditors selected (filter=${auditFilter ?? '∅'})`);
+    process.exit(2);
+  }
+
+  if (verbose) {
+    console.log(`audit-all: running ${selected.length} of ${auditors.length} registered auditors`);
+    console.log(`audit-all: dist = ${distArg}`);
+    console.log(`audit-all: auditors = ${selected.map((a) => a.name).join(', ')}`);
+  }
+
+  const result = await runAudits({ distDir: distArg, auditors: selected, verbose, writeReports: true });
+
+  const fails = result.reports.filter((r) => !r.passed);
+  const passes = result.reports.length - fails.length;
+
+  if (verbose) {
+    console.log('');
+    console.log('══════════════════════════════════════════════════════════════════════');
+    console.log(`audit-all: ${passes} passed, ${fails.length} failed`);
+    console.log(`audit-all: walked ${result.filesScanned} files in ${result.totalElapsedSec.toFixed(2)}s total`);
+    console.log(`audit-all:   - walk:    ${result.walkElapsedSec.toFixed(2)}s`);
+    console.log(`audit-all:   - collect: ${result.collectElapsedSec.toFixed(2)}s`);
+    console.log('══════════════════════════════════════════════════════════════════════');
+  }
+
+  process.exit(fails.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('audit-all: fatal', err);
+  process.exit(2);
+});

--- a/scripts/audit-footer-root-presence.mjs
+++ b/scripts/audit-footer-root-presence.mjs
@@ -15,81 +15,126 @@
  * Zero-tolerance: any page with `seo-static-content` but no `footer-root`
  * fails the deploy.
  *
- * Usage:
- *   node scripts/audit-footer-root-presence.mjs
- *   node scripts/audit-footer-root-presence.mjs --limit=20
+ * Two execution modes:
+ *   1. Standalone:  `node scripts/audit-footer-root-presence.mjs`
+ *                   (legacy entry point — walks dist/, runs the audit, writes
+ *                    the report, exits 0/1/2)
+ *   2. Unified runner: import { auditor } from this file, register it with
+ *                       scripts/audit-all.mjs (one Node process, all audits).
+ *
+ * Both modes share the same `createAuditor()` factory so behaviour is
+ * byte-identical.
  */
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-const ROOT = fileURLToPath(new URL('..', import.meta.url));
-const DIST = join(ROOT, 'dist');
-
-const args = process.argv.slice(2);
-const LIMIT = (() => {
-  const a = args.find((s) => s.startsWith('--limit='));
-  return a ? Math.max(1, parseInt(a.split('=')[1], 10) || 30) : 30;
-})();
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { writeAuditReport } from './lib/auditReport.mjs';
 
 const SEO_STATIC_RE = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b/i;
 const FOOTER_ROOT_RE = /<div\b[^>]*\bid=["']footer-root["']/i;
 
-async function walk(dir) {
-  const out = [];
-  const stack = [dir];
-  while (stack.length) {
-    const cur = stack.pop();
-    let entries;
-    try {
-      entries = await readdir(cur, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const e of entries) {
-      const p = join(cur, e.name);
-      if (e.isDirectory()) stack.push(p);
-      else if (e.isFile() && p.endsWith('.html')) out.push(p);
-    }
-  }
-  return out;
-}
-
-async function main() {
-  const s = await stat(DIST).catch(() => null);
-  if (!s || !s.isDirectory()) {
-    console.error(`audit-footer-root-presence: dist/ not found at ${DIST}. Run a build first.`);
-    process.exit(2);
-  }
-  const files = await walk(DIST);
+/**
+ * Factory that creates a fresh stateful Auditor closure.
+ * Each call returns an independent collector so the audit-all runner can
+ * spawn one auditor per pass without state contamination.
+ *
+ * @param {{ limit?: number }} [opts]
+ * @returns {import('./lib/audit-runner.mjs').Auditor}
+ */
+export function createAuditor(opts = {}) {
+  const limit = Math.max(1, opts.limit ?? 30);
   const offenders = [];
   let scanned = 0;
+
+  return {
+    name: 'footer-root-presence',
+    collect(file, html) {
+      if (!html || !SEO_STATIC_RE.test(html)) return;
+      scanned++;
+      if (!FOOTER_ROOT_RE.test(html)) {
+        offenders.push({ path: relative(ROOT, file), feature: featureOf(file) });
+      }
+    },
+    report() {
+      const passed = offenders.length === 0;
+      const humanSummary = passed
+        ? `scanned ${scanned} seo-static-content page(s) — all have footer-root`
+        : `${offenders.length} of ${scanned} seo-static-content page(s) missing <div id="footer-root">`;
+      return {
+        passed,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'missingFooterRoot', value: 0, comparator: '<=' },
+        extra: { scanned, limit },
+        humanSummary,
+      };
+    },
+  };
+}
+
+function featureOf(absPath) {
+  const rel = relative(ROOT, absPath).replace(/^dist\//, '');
+  const first = rel.split('/')[0];
+  if (!first) return 'root';
+  return first;
+}
+
+// ─── Auditor export for unified runner ───────────────────────────────────────
+// Lazy-instantiated: audit-all.mjs calls `createAuditor()` to get a fresh
+// closure per run. We also export the factory directly for tests.
+
+export const auditor = createAuditor();
+export { createAuditor as factory };
+
+// ─── Standalone entry point ──────────────────────────────────────────────────
+
+async function standalone() {
+  const args = process.argv.slice(2);
+  const limit = (() => {
+    const a = args.find((s) => s.startsWith('--limit='));
+    return a ? Math.max(1, parseInt(a.split('=')[1], 10) || 30) : 30;
+  })();
+
+  const distStat = await stat(DEFAULT_DIST).catch(() => null);
+  if (!distStat || !distStat.isDirectory()) {
+    console.error(`audit-footer-root-presence: dist/ not found at ${DEFAULT_DIST}. Run a build first.`);
+    process.exit(2);
+  }
+
+  const a = createAuditor({ limit });
+  const files = await walkHtmlFiles(DEFAULT_DIST);
   for (const file of files) {
     let html;
-    try {
-      html = await readFile(file, 'utf8');
-    } catch (err) {
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
       if (err.code === 'ENOENT') continue;
       throw err;
     }
-    if (!html || !SEO_STATIC_RE.test(html)) continue;
-    scanned++;
-    if (!FOOTER_ROOT_RE.test(html)) {
-      offenders.push(relative(ROOT, file));
-    }
+    a.collect(file, html);
   }
-  console.log(
-    `audit-footer-root-presence: scanned ${scanned} page(s) with <main class="seo-static-content">`,
-  );
-  if (offenders.length === 0) {
+
+  const result = await a.report();
+
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold ?? null,
+    offenders: result.offenders ?? [],
+    extra: result.extra ?? {},
+  });
+
+  console.log(`audit-footer-root-presence: ${result.humanSummary}`);
+  if (result.passed) {
     console.log('PASS: every staticOverlay page also ships <div id="footer-root">.');
     process.exit(0);
   }
-  console.error(`\nFAIL: ${offenders.length} page(s) ship <main class="seo-static-content"> WITHOUT a matching <div id="footer-root">.`);
+
+  console.error(`\nFAIL: ${result.offendersTotal} page(s) ship <main class="seo-static-content"> WITHOUT a matching <div id="footer-root">.`);
   console.error(`The SPA footer will paint INSIDE #root, above the static body, burying the page content.`);
-  console.error(`\nFirst ${Math.min(LIMIT, offenders.length)} offenders:`);
-  for (const f of offenders.slice(0, LIMIT)) console.error(`  ${f}`);
-  if (offenders.length > LIMIT) console.error(`  ... and ${offenders.length - LIMIT} more`);
+  console.error(`\nFirst ${Math.min(limit, result.offenders.length)} offenders:`);
+  for (const o of result.offenders.slice(0, limit)) console.error(`  ${o.path}`);
+  if (result.offenders.length > limit) console.error(`  ... and ${result.offenders.length - limit} more`);
   console.error(`\nHow to fix`);
   console.error(`----------`);
   console.error(`Emit <div id="footer-root"></div> as a sibling AFTER <main class="seo-static-content">`);
@@ -99,7 +144,15 @@ async function main() {
   process.exit(1);
 }
 
-main().catch((err) => {
-  console.error('audit-footer-root-presence: fatal', err);
-  process.exit(2);
-});
+// Run as standalone only if invoked directly.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('audit-footer-root-presence: fatal', err);
+    process.exit(2);
+  });
+}

--- a/scripts/audit-jsonld-no-nested-scripts.mjs
+++ b/scripts/audit-jsonld-no-nested-scripts.mjs
@@ -13,121 +13,123 @@
  * wrapped in `<script type="application/ld+json">…</script>`, then passed
  * it through `buildSeoPageHtml({ jsonLdScripts: [cantonBreadcrumbLd] })`.
  * `buildSimplePage` (htmlTemplate.ts:183) wraps every array entry with the
- * same tag, yielding:
+ * same tag, yielding nested wrappers. Google parses the outer script's
+ * literal-string content as the JSON-LD payload, finds `<script>{…}</script>`
+ * (not an object), and flags the page as "wrong value type" / "unparsable
+ * structured data". Fixed in PR #317; this audit prevents the regression
+ * from any future plugin that pre-wraps a JSON-LD string before handing
+ * it to the shell helper.
  *
- *   <script type="application/ld+json"><script type="application/ld+json">{…}</script></script>
- *
- * Google parses the outer script's literal-string content as the JSON-LD
- * payload, finds `<script>{…}</script>` (not an object), and flags the
- * page as "wrong value type" / "unparsable structured data". Fixed in
- * PR #317; this audit prevents the regression from any future plugin
- * that pre-wraps a JSON-LD string before handing it to the shell helper.
- *
- * Detection
- * ---------
- * The pattern is unambiguous in dist HTML: an opening
- * `<script type="application/ld+json">` immediately followed (only
- * whitespace allowed) by another `<script` opening tag. Real JSON-LD
- * payloads start with `{` or `[`.
- *
- * Usage:
- *   node scripts/audit-jsonld-no-nested-scripts.mjs
- *   node scripts/audit-jsonld-no-nested-scripts.mjs --limit=20
+ * Two execution modes:
+ *   1. Standalone:        `node scripts/audit-jsonld-no-nested-scripts.mjs`
+ *   2. Unified runner:    import { auditor } and register with audit-all.
  */
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-const ROOT = fileURLToPath(new URL('..', import.meta.url));
-const DIST = join(ROOT, 'dist');
-
-const args = process.argv.slice(2);
-const LIMIT = (() => {
-  const a = args.find((s) => s.startsWith('--limit='));
-  return a ? Math.max(1, parseInt(a.split('=')[1], 10) || 30) : 30;
-})();
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { writeAuditReport } from './lib/auditReport.mjs';
 
 // Matches an `application/ld+json` opening tag whose first non-whitespace
 // content is another `<script` opening tag (any attributes, any type).
-// Captures the offender's start offset for reporting.
 const NESTED_JSONLD_RE =
   /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>\s*<script\b/gi;
 
-async function walk(dir) {
-  const out = [];
-  const stack = [dir];
-  while (stack.length) {
-    const cur = stack.pop();
-    let entries;
-    try {
-      entries = await readdir(cur, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const e of entries) {
-      const p = join(cur, e.name);
-      if (e.isDirectory()) stack.push(p);
-      else if (e.isFile() && p.endsWith('.html')) out.push(p);
-    }
-  }
-  return out;
-}
-
-async function main() {
-  const s = await stat(DIST).catch(() => null);
-  if (!s || !s.isDirectory()) {
-    console.error(
-      `audit-jsonld-no-nested-scripts: dist/ not found at ${DIST}. Run a build first.`,
-    );
-    process.exit(2);
-  }
-  const files = await walk(DIST);
+export function createAuditor(opts = {}) {
+  const limit = Math.max(1, opts.limit ?? 30);
   const offenders = [];
   let scanned = 0;
+
+  return {
+    name: 'jsonld-no-nested-scripts',
+    collect(file, html) {
+      if (!html) return;
+      scanned++;
+      // Cheap pre-filter: skip pages that don't carry the MIME type at all.
+      if (!html.includes('application/ld+json')) return;
+      NESTED_JSONLD_RE.lastIndex = 0;
+      const matches = html.match(NESTED_JSONLD_RE);
+      if (matches && matches.length > 0) {
+        offenders.push({ path: relative(ROOT, file), feature: featureOf(file), metric: matches.length });
+      }
+    },
+    report() {
+      const passed = offenders.length === 0;
+      const totalNests = offenders.reduce((acc, o) => acc + o.metric, 0);
+      const humanSummary = passed
+        ? `scanned ${scanned} HTML file(s) — no nested wrappers`
+        : `${offenders.length} page(s) with nested JSON-LD wrappers (${totalNests} total)`;
+      return {
+        passed,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'nestedJsonldPages', value: 0, comparator: '<=' },
+        extra: { scanned, totalNests, limit },
+        humanSummary,
+      };
+    },
+  };
+}
+
+function featureOf(absPath) {
+  const rel = relative(ROOT, absPath).replace(/^dist\//, '');
+  const first = rel.split('/')[0];
+  return first || 'root';
+}
+
+export const auditor = createAuditor();
+export { createAuditor as factory };
+
+async function standalone() {
+  const args = process.argv.slice(2);
+  const limit = (() => {
+    const a = args.find((s) => s.startsWith('--limit='));
+    return a ? Math.max(1, parseInt(a.split('=')[1], 10) || 30) : 30;
+  })();
+
+  const s = await stat(DEFAULT_DIST).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`audit-jsonld-no-nested-scripts: dist/ not found at ${DEFAULT_DIST}. Run a build first.`);
+    process.exit(2);
+  }
+
+  const a = createAuditor({ limit });
+  const files = await walkHtmlFiles(DEFAULT_DIST);
   for (const file of files) {
     let html;
-    try {
-      html = await readFile(file, 'utf8');
-    } catch (err) {
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
       if (err.code === 'ENOENT') continue;
       throw err;
     }
-    if (!html) continue;
-    scanned++;
-    // Cheap pre-filter: only run the regex if the file even contains
-    // the JSON-LD MIME type substring at all. Skips ~all HTML pages
-    // that have no structured data.
-    if (!html.includes('application/ld+json')) continue;
-    NESTED_JSONLD_RE.lastIndex = 0;
-    const matches = html.match(NESTED_JSONLD_RE);
-    if (matches && matches.length > 0) {
-      offenders.push({ file: relative(ROOT, file), count: matches.length });
-    }
+    a.collect(file, html);
   }
-  console.log(
-    `audit-jsonld-no-nested-scripts: scanned ${scanned} HTML file(s) in dist/`,
-  );
-  if (offenders.length === 0) {
+
+  const result = await a.report();
+
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold ?? null,
+    offenders: result.offenders ?? [],
+    extra: result.extra ?? {},
+  });
+
+  console.log(`audit-jsonld-no-nested-scripts: ${result.humanSummary}`);
+  if (result.passed) {
     console.log('PASS: no nested <script type="application/ld+json"> wrappers in dist/.');
     process.exit(0);
   }
-  const totalNests = offenders.reduce((acc, o) => acc + o.count, 0);
-  console.error(
-    `\nFAIL: ${offenders.length} page(s) ship nested <script type="application/ld+json"> wrappers (${totalNests} total occurrence(s)).`,
-  );
-  console.error(
-    `Google parses the outer wrapper's literal-string content as the JSON-LD payload,`,
-  );
-  console.error(
-    `flagging the page as "Tipo di valore non corretto" / "Wrong value type" in GSC.`,
-  );
-  console.error(`\nFirst ${Math.min(LIMIT, offenders.length)} offenders:`);
-  for (const o of offenders.slice(0, LIMIT)) {
-    console.error(`  ${o.file}${o.count > 1 ? ` (${o.count}×)` : ''}`);
+
+  const totalNests = result.extra.totalNests;
+  console.error(`\nFAIL: ${result.offendersTotal} page(s) ship nested <script type="application/ld+json"> wrappers (${totalNests} total occurrence(s)).`);
+  console.error(`Google parses the outer wrapper's literal-string content as the JSON-LD payload,`);
+  console.error(`flagging the page as "Tipo di valore non corretto" / "Wrong value type" in GSC.`);
+  console.error(`\nFirst ${Math.min(limit, result.offenders.length)} offenders:`);
+  for (const o of result.offenders.slice(0, limit)) {
+    console.error(`  ${o.path}${o.metric > 1 ? ` (${o.metric}×)` : ''}`);
   }
-  if (offenders.length > LIMIT) {
-    console.error(`  ... and ${offenders.length - LIMIT} more`);
-  }
+  if (result.offenders.length > limit) console.error(`  ... and ${result.offenders.length - limit} more`);
   console.error(`\nHow to fix`);
   console.error(`----------`);
   console.error(`The emitter is pre-wrapping JSON-LD in <script type="application/ld+json">…</script>`);
@@ -138,7 +140,14 @@ async function main() {
   process.exit(1);
 }
 
-main().catch((err) => {
-  console.error('audit-jsonld-no-nested-scripts: fatal', err);
-  process.exit(2);
-});
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('audit-jsonld-no-nested-scripts: fatal', err);
+    process.exit(2);
+  });
+}

--- a/scripts/audit-title-length.mjs
+++ b/scripts/audit-title-length.mjs
@@ -3,8 +3,7 @@
  * audit-title-length.mjs
  *
  * Walks `dist/**\/*.html` and reports pages whose `<title>` exceeds the
- * SERP-display budget (default 60 char) plus the brand suffix
- * `" | Frontaliere Ticino"` (22 char) → 82-char practical floor.
+ * SERP-display budget (default 60 char + 10 % tolerance = 66).
  *
  * Why the gate exists. After the universal "never truncate <title>" fix
  * (commit a7eab849d), pages with a long disambiguator (city, canton,
@@ -13,94 +12,33 @@
  * to *track* the long-titles bucket so a future template change that
  * inflates titles further doesn't go unnoticed.
  *
- * Usage:
- *   node scripts/audit-title-length.mjs                          # human summary
- *   node scripts/audit-title-length.mjs --threshold=90           # custom char limit
- *   node scripts/audit-title-length.mjs --json                   # JSON report
- *   node scripts/audit-title-length.mjs --csv > out.csv          # CSV report
- *   node scripts/audit-title-length.mjs --limit=50               # show top N
- *   node scripts/audit-title-length.mjs --feature=fuel-daily     # one bucket
- *   node scripts/audit-title-length.mjs --fail-on-offenders
- *   node scripts/audit-title-length.mjs --include-noindex
- *   node scripts/audit-title-length.mjs --baseline=path.json     # ratchet mode
- *   node scripts/audit-title-length.mjs --write-baseline=path.json
+ * Two execution modes:
+ *   1. Standalone CLI:   node scripts/audit-title-length.mjs [...args]
+ *   2. Unified runner:   imported by scripts/audit-all.mjs via factory().
  *
- * Baseline / ratchet: same semantics as audit-text-html-ratio and
- * audit-h1-title-duplicates. The deploy gate uses `--baseline=` to fail
- * only on regressions; improvements are always accepted. After a fix
- * lands, regenerate the baseline with `--write-baseline=` and commit.
- *
- * Exit code:
- *   0 — within baseline budget (or --fail-on-offenders not set).
- *   1 — `--fail-on-offenders` set OR baseline regression detected.
- *   2 — dist/ missing / fatal error.
+ * CLI args (standalone only):
+ *   --threshold=N             char limit (default 66)
+ *   --limit=N                 show top N offenders (default 30)
+ *   --feature=<name>          filter to one feature bucket
+ *   --json                    JSON output
+ *   --csv                     CSV output
+ *   --fail-on-offenders       exit 1 on any offender (overrides baseline)
+ *   --include-noindex         count noindex/redirect pages
+ *   --baseline=<path>         ratchet against baseline (fail on regression)
+ *   --write-baseline=<path>   regenerate baseline snapshot
  */
 
 import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join, relative, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
 import { writeAuditReport, relBaseline } from './lib/auditReport.mjs';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = join(__dirname, '..');
-const DIST = join(ROOT, 'dist');
-
-const argv = process.argv.slice(2);
-const args = new Map();
-for (const a of argv) {
-  if (a.startsWith('--')) {
-    const [k, v] = a.slice(2).split('=');
-    args.set(k, v ?? true);
-  }
-}
-
-// Default threshold: 60 (SERP-display target) + 10 % tolerance = 66.
-// Aligned with build-plugins/shared/titleSuffix.ts:TITLE_MAX_CHARS.
-const THRESHOLD = Number(args.get('threshold') ?? 66);
-const LIMIT = Number(args.get('limit') ?? 30);
-const MODE_JSON = args.has('json');
-const MODE_CSV = args.has('csv');
-const FAIL = args.has('fail-on-offenders');
-const FEATURE_FILTER = args.get('feature') ?? null;
-const INCLUDE_NOINDEX = args.has('include-noindex');
-const BASELINE_PATH = args.get('baseline');
-const WRITE_BASELINE_PATH = args.get('write-baseline');
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
 const NOINDEX_RE = /<meta[^>]+name=["']robots["'][^>]+content=["'][^"']*noindex/i;
 const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
-
-async function walk(dir) {
-  // Iterative — the cathedral expansion produced dist/ trees deep enough
-  // to blow the call stack via async recursion + array spread.
-  const out = [];
-  const stack = [dir];
-  while (stack.length > 0) {
-    const cur = stack.pop();
-    let entries;
-    try {
-      entries = await readdir(cur, { withFileTypes: true });
-    } catch (err) {
-      if (err.code === 'ENOENT') continue;
-      throw err;
-    }
-    for (const e of entries) {
-      // Skip dot-prefixed dirs (e.g. dist/.write-collisions-data/ — debug
-      // artifacts from writeRegistryLifecyclePlugin, not deployed pages).
-      if (e.isDirectory() && e.name.startsWith('.')) continue;
-      const p = join(cur, e.name);
-      if (e.isDirectory()) {
-        stack.push(p);
-      } else if (e.isFile() && p.endsWith('.html')) {
-        out.push(p);
-      }
-    }
-  }
-  return out;
-}
 
 function normalizeText(raw) {
   if (!raw) return '';
@@ -119,7 +57,7 @@ function normalizeText(raw) {
 }
 
 /** Mirror of audit-h1-title-duplicates classifier. */
-function classifyFeature(relPath) {
+export function classifyFeature(relPath) {
   const p = '/' + relPath.replace(/\\/g, '/').replace(/^dist\//, '').replace(/index\.html$/, '');
   if (/(?:^|\/)(prezzi-benzina-svizzera|prezzi-carburante-svizzera|prix-essence-suisse|fuel-prices-switzerland|benzinpreise?-schweiz|prezzi-benzina|prezzi-diesel|gasoline-price|diesel-price|benzinpreis|dieselpreis|prix-essence|prix-gasoil|prix-diesel)\//.test(p)) return 'fuel-daily';
   if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\/(?:azienda|company|unternehmen|entreprise)-/.test(p)) return 'weekly-employers';
@@ -133,198 +71,285 @@ function classifyFeature(relPath) {
   return 'spa-other';
 }
 
-function inferLocale(relPath) {
+export function inferLocale(relPath) {
   const seg = relPath.replace(/\\/g, '/').replace(/^dist\//, '').split('/')[0];
   if (seg === 'en' || seg === 'de' || seg === 'fr') return seg;
   return 'it';
 }
 
-async function main() {
-  const stats = await stat(DIST).catch(() => null);
-  if (!stats || !stats.isDirectory()) {
-    console.error(`audit-title-length: dist/ not found at ${DIST}. Run a build first.`);
-    process.exit(2);
-  }
+/**
+ * Factory: returns a fresh stateful Auditor closure.
+ *
+ * @param {{
+ *   threshold?: number,
+ *   limit?: number,
+ *   featureFilter?: string|null,
+ *   includeNoindex?: boolean,
+ *   failOnOffenders?: boolean,
+ *   baselinePath?: string|null,
+ *   writeBaselinePath?: string|null,
+ * }} [opts]
+ */
+export function createAuditor(opts = {}) {
+  const threshold = opts.threshold ?? 66;
+  const limit = opts.limit ?? 30;
+  const featureFilter = opts.featureFilter ?? null;
+  const includeNoindex = !!opts.includeNoindex;
+  const failOnOffenders = !!opts.failOnOffenders;
+  const baselinePath = opts.baselinePath ?? null;
+  const writeBaselinePath = opts.writeBaselinePath ?? null;
 
-  const files = await walk(DIST);
-  const offenders = [];
   let scanned = 0;
   let skippedNoindex = 0;
   let missingTitle = 0;
+  const offenders = [];
 
+  return {
+    name: 'title-length',
+    collect(file, html) {
+      if (!html) return;
+      if (!includeNoindex && (NOINDEX_RE.test(html) || META_REFRESH_RE.test(html))) {
+        skippedNoindex++;
+        return;
+      }
+      scanned++;
+      const titleMatch = html.match(TITLE_RE);
+      const title = normalizeText(titleMatch?.[1] ?? '');
+      if (!title) { missingTitle++; return; }
+      if (title.length <= threshold) return;
+      const rel = relative(ROOT, file);
+      const feature = classifyFeature(rel);
+      if (featureFilter && feature !== featureFilter) return;
+      const locale = inferLocale(rel);
+      offenders.push({ path: rel, file: rel, feature, locale, title, metric: title.length });
+    },
+    async report() {
+      offenders.sort((a, b) => b.metric - a.metric);
+
+      const byFeature = {};
+      const byLocale = {};
+      for (const o of offenders) {
+        byFeature[o.feature] = (byFeature[o.feature] ?? 0) + 1;
+        byLocale[o.locale] = (byLocale[o.locale] ?? 0) + 1;
+      }
+
+      // Write baseline snapshot if requested
+      if (writeBaselinePath) {
+        const baseline = {
+          generated: new Date().toISOString(),
+          threshold,
+          total: offenders.length,
+          byFeature,
+          byLocale,
+        };
+        await writeFile(resolvePath(writeBaselinePath), JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+      }
+
+      let passed = !(failOnOffenders && offenders.length > 0);
+      let baselineDelta = null;
+      const regressedFeatures = [];
+
+      // Baseline ratchet check
+      if (baselinePath) {
+        let baseline;
+        try { baseline = JSON.parse(await readFile(resolvePath(baselinePath), 'utf8')); }
+        catch (err) {
+          return {
+            passed: false,
+            offendersTotal: offenders.length,
+            offenders,
+            threshold: { metric: 'length', value: threshold, comparator: '<=' },
+            extra: { scanned, skippedNoindex, missingTitle, byLocale, baselineError: err.message },
+            humanSummary: `cannot read baseline ${baselinePath}: ${err.message}`,
+          };
+        }
+        let regression = false;
+        const baseTotal = Number(baseline.total ?? 0);
+        if (typeof baseline.total === 'number' && offenders.length > baseline.total) {
+          regression = true;
+        }
+        if (baseline.byFeature && typeof baseline.byFeature === 'object') {
+          for (const [feat, count] of Object.entries(byFeature)) {
+            const cap = baseline.byFeature[feat] ?? 0;
+            if (count > cap) {
+              regressedFeatures.push({ feat, cap, count });
+              regression = true;
+            }
+          }
+        }
+        baselineDelta = {
+          before: baseTotal,
+          after: offenders.length,
+          regression: Math.max(0, offenders.length - baseTotal),
+        };
+        if (regression) passed = false;
+      }
+
+      const humanSummary =
+        passed
+          ? `${offenders.length} offender(s) within baseline (threshold ${threshold})`
+          : `${offenders.length} offender(s) over threshold ${threshold}${regressedFeatures.length > 0 ? ` — regressed features: ${regressedFeatures.map(r => `${r.feat}(${r.count}>${r.cap})`).join(', ')}` : ''}`;
+
+      return {
+        passed,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'length', value: threshold, comparator: '<=' },
+        baselineFile: relBaseline(baselinePath),
+        baselineDelta,
+        byFeature,
+        extra: { scanned, skippedNoindex, missingTitle, byLocale, regressedFeatures, limit, threshold },
+        humanSummary,
+      };
+    },
+  };
+}
+
+// Factory export for runner registration. Default opts match the npm script
+// `audit:title-length`: --threshold=66 --baseline=data/title-length-baseline.json
+export function factory(opts) {
+  return createAuditor({
+    threshold: 66,
+    baselinePath: 'data/title-length-baseline.json',
+    ...opts,
+  });
+}
+
+export const auditor = factory();
+
+// ─── Standalone CLI ──────────────────────────────────────────────────────────
+
+async function standalone() {
+  const argv = process.argv.slice(2);
+  const args = new Map();
+  for (const a of argv) {
+    if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=');
+      args.set(k, v ?? true);
+    }
+  }
+  const opts = {
+    threshold: Number(args.get('threshold') ?? 66),
+    limit: Number(args.get('limit') ?? 30),
+    featureFilter: args.get('feature') ?? null,
+    includeNoindex: args.has('include-noindex'),
+    failOnOffenders: args.has('fail-on-offenders'),
+    baselinePath: typeof args.get('baseline') === 'string' ? args.get('baseline') : null,
+    writeBaselinePath: typeof args.get('write-baseline') === 'string' ? args.get('write-baseline') : null,
+  };
+  const MODE_JSON = args.has('json');
+  const MODE_CSV = args.has('csv');
+
+  const s = await stat(DEFAULT_DIST).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`audit-title-length: dist/ not found at ${DEFAULT_DIST}. Run a build first.`);
+    process.exit(2);
+  }
+
+  const a = createAuditor(opts);
+  const files = await walkHtmlFiles(DEFAULT_DIST);
   for (const file of files) {
     let html;
-    try {
-      html = await readFile(file, 'utf8');
-    } catch (err) {
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
       if (err.code === 'ENOENT') continue;
       throw err;
     }
-    if (!html) continue;
-    if (!INCLUDE_NOINDEX && (NOINDEX_RE.test(html) || META_REFRESH_RE.test(html))) {
-      skippedNoindex++;
-      continue;
-    }
-    scanned++;
-    const titleMatch = html.match(TITLE_RE);
-    const title = normalizeText(titleMatch?.[1] ?? '');
-    if (!title) { missingTitle++; continue; }
-    if (title.length <= THRESHOLD) continue;
-    const rel = relative(ROOT, file);
-    const feature = classifyFeature(rel);
-    if (FEATURE_FILTER && feature !== FEATURE_FILTER) continue;
-    const locale = inferLocale(rel);
-    offenders.push({ file: rel, feature, locale, title, length: title.length });
+    a.collect(file, html);
   }
 
-  offenders.sort((a, b) => b.length - a.length);
-
-  const byFeatureCount = {};
-  const byLocaleCount = {};
-  for (const r of offenders) {
-    byFeatureCount[r.feature] = (byFeatureCount[r.feature] ?? 0) + 1;
-    byLocaleCount[r.locale] = (byLocaleCount[r.locale] ?? 0) + 1;
-  }
-
-  // Structured offenders for the JSON report — same array, normalised
-  // to the shared schema. `metric` = title length in characters.
-  const structuredOffenders = offenders.map((r) => ({
-    path: r.file,
-    feature: r.feature,
-    metric: r.length,
-    ratio: null,
-    locale: r.locale,
-    title: r.title,
-  }));
-  const writeReport = (passed, baselineDelta) => writeAuditReport({
-    audit: 'title-length',
-    passed,
-    threshold: { metric: 'length', value: THRESHOLD, comparator: '<=' },
-    baselineFile: relBaseline(typeof BASELINE_PATH === 'string' ? BASELINE_PATH : null),
-    baselineDelta,
-    offenders: structuredOffenders,
-    byFeature: byFeatureCount,
-    extra: { byLocale: byLocaleCount },
+  const result = await a.report();
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold ?? null,
+    baselineFile: result.baselineFile ?? null,
+    baselineDelta: result.baselineDelta ?? null,
+    offenders: result.offenders ?? [],
+    byFeature: result.byFeature,
+    extra: { byLocale: result.extra.byLocale },
   });
 
+  // Output formats
   if (MODE_CSV) {
     console.log('file,feature,locale,length,title');
-    for (const r of offenders) {
+    for (const r of result.offenders) {
       const safe = (s) => `"${String(s).replace(/"/g, '""')}"`;
-      console.log(`${r.file},${r.feature},${r.locale},${r.length},${safe(r.title)}`);
+      console.log(`${r.file},${r.feature},${r.locale},${r.metric},${safe(r.title)}`);
     }
-    await writeReport(!(FAIL && offenders.length > 0), null);
-    process.exit(FAIL && offenders.length > 0 ? 1 : 0);
+    process.exit(result.passed ? 0 : 1);
   }
-
   if (MODE_JSON) {
     console.log(JSON.stringify({
-      scanned,
-      skippedNoindex,
-      missingTitle,
-      threshold: THRESHOLD,
-      offenders: offenders.length,
-      byFeature: byFeatureCount,
-      byLocale: byLocaleCount,
-      worst: offenders.slice(0, LIMIT),
+      scanned: result.extra.scanned,
+      skippedNoindex: result.extra.skippedNoindex,
+      missingTitle: result.extra.missingTitle,
+      threshold: result.extra.threshold,
+      offenders: result.offendersTotal,
+      byFeature: result.byFeature,
+      byLocale: result.extra.byLocale,
+      worst: result.offenders.slice(0, opts.limit),
     }, null, 2));
-    await writeReport(!(FAIL && offenders.length > 0), null);
-    process.exit(FAIL && offenders.length > 0 ? 1 : 0);
+    process.exit(result.passed ? 0 : 1);
   }
 
-  console.log(`audit-title-length: scanned ${scanned} HTML files in dist/ (skipped ${skippedNoindex} noindex/redirect, ${missingTitle} missing <title>)`);
-  console.log(`Threshold: ${THRESHOLD} chars`);
-  console.log(`Offenders (length > ${THRESHOLD}): ${offenders.length} (${((offenders.length / Math.max(scanned, 1)) * 100).toFixed(1)} % of scanned)`);
+  console.log(`audit-title-length: scanned ${result.extra.scanned} HTML files in dist/ (skipped ${result.extra.skippedNoindex} noindex/redirect, ${result.extra.missingTitle} missing <title>)`);
+  console.log(`Threshold: ${opts.threshold} chars`);
+  console.log(`Offenders (length > ${opts.threshold}): ${result.offendersTotal} (${((result.offendersTotal / Math.max(result.extra.scanned, 1)) * 100).toFixed(1)} % of scanned)`);
 
-  if (Object.keys(byFeatureCount).length > 0) {
+  if (Object.keys(result.byFeature).length > 0) {
     console.log('\nOffenders by feature:');
-    for (const [f, c] of Object.entries(byFeatureCount).sort((a, b) => b[1] - a[1])) {
+    for (const [f, c] of Object.entries(result.byFeature).sort((a, b) => b[1] - a[1])) {
       console.log(`  ${String(c).padStart(6)}  ${f}`);
     }
   }
-  if (Object.keys(byLocaleCount).length > 0) {
+  if (Object.keys(result.extra.byLocale).length > 0) {
     console.log('\nOffenders by locale:');
-    for (const [l, c] of Object.entries(byLocaleCount).sort((a, b) => b[1] - a[1])) {
+    for (const [l, c] of Object.entries(result.extra.byLocale).sort((a, b) => b[1] - a[1])) {
       console.log(`  ${String(c).padStart(6)}  ${l}`);
     }
   }
-  if (offenders.length > 0) {
-    console.log(`\nWorst ${Math.min(LIMIT, offenders.length)} offenders:`);
-    for (const r of offenders.slice(0, LIMIT)) {
-      console.log(`  ${String(r.length).padStart(4)} ch  [${r.locale}] ${r.feature.padEnd(22)}  ${r.file}`);
+  if (result.offendersTotal > 0) {
+    console.log(`\nWorst ${Math.min(opts.limit, result.offendersTotal)} offenders:`);
+    for (const r of result.offenders.slice(0, opts.limit)) {
+      console.log(`  ${String(r.metric).padStart(4)} ch  [${r.locale}] ${r.feature.padEnd(22)}  ${r.file}`);
       console.log(`        ${JSON.stringify(r.title.slice(0, 120))}`);
     }
   }
 
-  // Baseline write / ratchet check.
-  if (WRITE_BASELINE_PATH && typeof WRITE_BASELINE_PATH === 'string') {
-    const baseline = {
-      generated: new Date().toISOString(),
-      threshold: THRESHOLD,
-      total: offenders.length,
-      byFeature: byFeatureCount,
-      byLocale: byLocaleCount,
-    };
-    await writeFile(resolvePath(WRITE_BASELINE_PATH), JSON.stringify(baseline, null, 2) + '\n', 'utf8');
-    console.log(`\nWrote baseline → ${WRITE_BASELINE_PATH}`);
+  if (opts.writeBaselinePath) {
+    console.log(`\nWrote baseline → ${opts.writeBaselinePath}`);
   }
 
-  if (BASELINE_PATH && typeof BASELINE_PATH === 'string') {
-    let baseline;
-    try {
-      baseline = JSON.parse(await readFile(resolvePath(BASELINE_PATH), 'utf8'));
-    } catch (err) {
-      console.error(`audit-title-length: cannot read baseline ${BASELINE_PATH}: ${err.message}`);
-      process.exit(2);
-    }
-    let regression = false;
-    const regressedFeatures = [];
-    if (typeof baseline.total === 'number' && offenders.length > baseline.total) {
-      console.error(`\nREGRESSION: total offenders ${offenders.length} > baseline ${baseline.total}`);
-      regression = true;
-    }
-    if (baseline.byFeature && typeof baseline.byFeature === 'object') {
-      for (const [feat, count] of Object.entries(byFeatureCount)) {
-        const cap = baseline.byFeature[feat] ?? 0;
-        if (count > cap) {
-          console.error(`REGRESSION: feature "${feat}" offenders ${count} > baseline ${cap}`);
-          regressedFeatures.push({ feat, cap, count });
-          regression = true;
-        }
+  // Baseline regression dump (mirror of original)
+  if (!result.passed && result.extra.regressedFeatures?.length > 0) {
+    for (const { feat, cap, count } of result.extra.regressedFeatures) {
+      const featOffenders = result.offenders
+        .filter((o) => o.feature === feat)
+        .sort((a, b) => b.metric - a.metric);
+      console.error(`\nFull offender list for feature "${feat}" (${count} pages, baseline ${cap}, +${count - cap}):`);
+      for (const o of featOffenders) {
+        console.error(`  ${String(o.metric).padStart(3)} ch  [${o.locale}]  ${o.file}`);
+        console.error(`        ${o.title}`);
       }
     }
-    if (regression) {
-      // Dump ALL offenders for each regressed feature so the CI log alone is
-      // enough to diagnose without downloading the dist artifact (which can
-      // exceed 1 GB and take 30-60 min). Sorted by length desc so the longest
-      // titles surface first.
-      for (const { feat, cap, count } of regressedFeatures) {
-        const featOffenders = offenders
-          .filter((o) => o.feature === feat)
-          .sort((a, b) => b.length - a.length);
-        console.error(`\nFull offender list for feature "${feat}" (${count} pages, baseline ${cap}, +${count - cap}):`);
-        for (const o of featOffenders) {
-          console.error(`  ${String(o.length).padStart(3)} ch  [${o.locale}]  ${o.file}`);
-          console.error(`        ${o.title}`);
-        }
-      }
-      console.error('\nThe title-length baseline ratchet only allows the count to go DOWN.');
-      console.error('Shorten the offending titleBases, then regenerate with --write-baseline=<path>.');
-      const baseTotal = Number(baseline.total ?? 0);
-      await writeReport(false, { before: baseTotal, after: offenders.length, regression: Math.max(0, offenders.length - baseTotal) });
-      process.exit(1);
-    }
-    console.log('\nBaseline ratchet: OK (no regressions vs ' + BASELINE_PATH + ')');
-    const baseTotalOk = Number(baseline.total ?? 0);
-    await writeReport(true, { before: baseTotalOk, after: offenders.length, regression: Math.max(0, offenders.length - baseTotalOk) });
-    process.exit(FAIL && offenders.length > 0 ? 1 : 0);
+    console.error('\nThe title-length baseline ratchet only allows the count to go DOWN.');
+    console.error('Shorten the offending titleBases, then regenerate with --write-baseline=<path>.');
+  } else if (opts.baselinePath && result.passed) {
+    console.log(`\nBaseline ratchet: OK (no regressions vs ${opts.baselinePath})`);
   }
 
-  await writeReport(!(FAIL && offenders.length > 0), null);
-  process.exit(FAIL && offenders.length > 0 ? 1 : 0);
+  process.exit(result.passed ? 0 : 1);
 }
 
-main().catch((err) => {
-  console.error('audit-title-length: fatal', err);
-  process.exit(2);
-});
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('audit-title-length: fatal', err);
+    process.exit(2);
+  });
+}

--- a/scripts/lib/audit-runner.mjs
+++ b/scripts/lib/audit-runner.mjs
@@ -1,0 +1,276 @@
+// scripts/lib/audit-runner.mjs
+//
+// Unified audit runner — walks dist/ once, dispatches each HTML file to every
+// registered Auditor. Replaces the per-audit walker pattern that forces every
+// audit to spawn its own Node process, load V8 + dependencies, walk dist/ via
+// readdir, read every file via readFile. With ~12 dist-walking audits and
+// ~132k files in CI dist, that's ~1.5M file reads and 12× V8 startup cost,
+// which is exactly why post-deploy-validate-dist.yml hit OOM on the 7 GB
+// ubuntu-latest runner and had to be forced fully-serial.
+//
+// Architecture:
+//   1. Single dist walk produces the file list.
+//   2. For each file: read ONCE, dispatch to every Auditor.collect(file, html).
+//      Each auditor runs its own regex matches against the same html string;
+//      they share the file read but not the regex parse (which is already
+//      very fast — the I/O is the dominant cost).
+//   3. After the walk, each Auditor.report() runs and decides pass/fail +
+//      writes its JSON report via writeAuditReport().
+//
+// `sharedExtract()` is still exported for auditors that want the common
+// regex outputs (title, h1, isNoindex, jsonLdScripts), but it is NOT called
+// eagerly by the runner — calling it on every file when most audits don't
+// need every field measured at +730 μs/file overhead (a 3× regression on
+// audit-footer-root-presence in pilot tests). Auditors opt in via:
+//
+//   import { sharedExtract } from './lib/audit-runner.mjs';
+//   collect(file, html) { const ex = sharedExtract(html); ... }
+//
+// Worker parallelism (worker_threads) is intentionally NOT enabled here.
+// The historical OOM problem on ubuntu-latest free (7 GB) was caused by
+// MULTIPLE Node processes each at 1-3 GB RSS — running one Node process
+// with all audits in memory peaks much lower (~500 MB-1 GB) because V8 and
+// modules are shared. Adding worker_threads on top would reintroduce the
+// per-worker V8 overhead this design eliminates. If a future runner has
+// more RAM, parallelism can be opted into via AUDIT_WORKERS=N (TODO).
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { writeAuditReport, auditReportPath } from './auditReport.mjs';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+export const ROOT = join(__dirname, '..', '..');
+export const DEFAULT_DIST = join(ROOT, 'dist');
+
+/**
+ * @typedef {Object} ExtractedFields
+ * @property {string|null} title           — text content of first <title>, decoded, trimmed
+ * @property {string|null} h1              — text content of first <h1>, decoded, trimmed
+ * @property {boolean}     isNoindex       — true if robots=noindex or meta-refresh redirect
+ * @property {string[]}    jsonLdScripts   — inner-text of every <script type="application/ld+json">
+ */
+
+/**
+ * @typedef {Object} AuditorResult
+ * @property {boolean}      passed              — gate verdict
+ * @property {number}       offendersTotal      — count of failing items
+ * @property {Array}        offenders           — offender list (passed to writeAuditReport)
+ * @property {object|null}  [threshold]         — { metric, value, comparator }
+ * @property {string|null}  [baselineFile]      — repo-relative baseline path
+ * @property {object|null}  [baselineDelta]     — { before, after, regression }
+ * @property {object}       [extra]             — extra fields merged into report
+ * @property {string}       [humanSummary]      — human-readable line for stdout
+ */
+
+/**
+ * @typedef {Object} Auditor
+ * @property {string} name
+ *   The npm-script suffix (e.g., "footer-root-presence" for audit:footer-root-presence).
+ *   The runner uses this for report path + stdout labelling.
+ * @property {(file: string, html: string) => void} collect
+ *   Called once per HTML file. Audit accumulates state in its closure.
+ *   MUST NOT mutate `html` (verified when AUDIT_STRICT=1). For shared regex
+ *   helpers, import `sharedExtract` from this module and call it inside
+ *   collect() — the runner does NOT call it eagerly.
+ * @property {() => AuditorResult|Promise<AuditorResult>} report
+ *   Called after the walk. Produces the report + gate verdict.
+ */
+
+// Shared regex extractions — computed once per file, reused by every audit
+// that needs them. Approximate (regex, not full HTML parse) but matches the
+// audits' current behaviour byte-for-byte (they all use the same regex
+// idioms today).
+
+const RX_TITLE         = /<title[^>]*>([\s\S]*?)<\/title>/i;
+const RX_H1            = /<h1[^>]*>([\s\S]*?)<\/h1>/i;
+const RX_NOINDEX       = /<meta\s+name=["']robots["']\s+content=["'][^"']*\bnoindex\b/i;
+const RX_META_REFRESH  = /<meta\s+http-equiv=["']refresh["'][^>]*url=/i;
+const RX_JSONLD_SCRIPT = /<script\s+[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+
+/**
+ * @param {string} html
+ * @returns {ExtractedFields}
+ */
+export function sharedExtract(html) {
+  const t = html.match(RX_TITLE);
+  const h1 = html.match(RX_H1);
+  const jsonLd = [];
+  let m;
+  RX_JSONLD_SCRIPT.lastIndex = 0;
+  while ((m = RX_JSONLD_SCRIPT.exec(html)) !== null) jsonLd.push(m[1]);
+  return {
+    title: t ? normalizeText(t[1]) : null,
+    h1: h1 ? normalizeText(h1[1]) : null,
+    isNoindex: RX_NOINDEX.test(html) || RX_META_REFRESH.test(html),
+    jsonLdScripts: jsonLd,
+  };
+}
+
+function normalizeText(s) {
+  return decodeEntities(stripTags(s)).replace(/\s+/g, ' ').trim();
+}
+function stripTags(s) { return s.replace(/<[^>]+>/g, ''); }
+function decodeEntities(s) {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+/**
+ * Walk a directory recursively, returning absolute paths of every `.html` file.
+ * Skips dot-directories (e.g., `.git`, `.cache`).
+ * @param {string} dir
+ * @returns {Promise<string[]>}
+ */
+export async function walkHtmlFiles(dir) {
+  const out = [];
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try { entries = await readdir(cur, { withFileTypes: true }); }
+    catch { continue; }
+    for (const e of entries) {
+      if (e.name.startsWith('.')) continue;
+      const p = join(cur, e.name);
+      if (e.isDirectory()) stack.push(p);
+      else if (e.isFile() && p.endsWith('.html')) out.push(p);
+    }
+  }
+  return out;
+}
+
+/**
+ * Run all auditors against every HTML file under `distDir`.
+ *
+ * Memory profile: walks files one at a time (no batch loading). Each
+ * auditor accumulates state in its own closure; peak per-file RSS = file
+ * size (~20 KB avg) + extracted fields (~5 KB) + per-auditor accumulator
+ * growth. With N auditors all running in the same Node process, total RSS
+ * is bounded by sum of accumulator sizes, NOT N× file content.
+ *
+ * @param {Object} opts
+ * @param {string} opts.distDir
+ * @param {Auditor[]} opts.auditors
+ * @param {boolean} [opts.verbose=true]
+ * @param {boolean} [opts.writeReports=true]   — call writeAuditReport per auditor
+ * @returns {Promise<{
+ *   totalElapsedSec: number,
+ *   walkElapsedSec: number,
+ *   collectElapsedSec: number,
+ *   filesScanned: number,
+ *   reports: Array<AuditorResult & { name: string, reportPath: string|null, elapsedSec: number }>
+ * }>}
+ */
+export async function runAudits({ distDir, auditors, verbose = true, writeReports = true }) {
+  if (!Array.isArray(auditors) || auditors.length === 0) {
+    throw new Error('runAudits: no auditors registered');
+  }
+  for (const a of auditors) {
+    if (!a || typeof a.collect !== 'function' || typeof a.report !== 'function' || typeof a.name !== 'string') {
+      throw new Error(`runAudits: invalid auditor (must expose { name, collect, report })`);
+    }
+  }
+
+  const t0 = performance.now();
+
+  const distStat = await stat(distDir).catch(() => null);
+  if (!distStat || !distStat.isDirectory()) {
+    throw new Error(`runAudits: distDir not found or not a directory: ${distDir}`);
+  }
+
+  const tWalk0 = performance.now();
+  const files = await walkHtmlFiles(distDir);
+  const walkElapsedSec = (performance.now() - tWalk0) / 1000;
+  if (verbose) console.log(`[audit-runner] walked ${files.length} HTML files in ${walkElapsedSec.toFixed(2)}s`);
+
+  const strict = process.env.AUDIT_STRICT === '1';
+  if (strict && verbose) console.log('[audit-runner] AUDIT_STRICT=1 (mutation detection on)');
+
+  const tCollect0 = performance.now();
+  const progressInterval = Math.max(1, Math.floor(files.length / 20));
+
+  let scanned = 0;
+  for (const file of files) {
+    let html;
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+      continue;
+    }
+
+    for (const auditor of auditors) {
+      const beforeHtml = strict ? html : null;
+      try {
+        auditor.collect(file, html);
+      } catch (err) {
+        console.error(`[audit-runner] ${auditor.name} threw on ${file}: ${err.message}`);
+        throw err;
+      }
+      if (strict && html !== beforeHtml) {
+        throw new Error(`[audit-runner] auditor ${auditor.name} mutated html for ${file}`);
+      }
+    }
+
+    scanned++;
+    if (verbose && scanned % progressInterval === 0) {
+      const pct = ((scanned / files.length) * 100).toFixed(0);
+      console.log(`[audit-runner] progress: ${scanned}/${files.length} (${pct}%)`);
+    }
+  }
+
+  const collectElapsedSec = (performance.now() - tCollect0) / 1000;
+  if (verbose) console.log(`[audit-runner] collected ${scanned} files in ${collectElapsedSec.toFixed(2)}s`);
+
+  const reports = [];
+  for (const auditor of auditors) {
+    const tReport0 = performance.now();
+    const result = await auditor.report();
+    const elapsedSec = (performance.now() - tReport0) / 1000;
+
+    let reportPath = null;
+    if (writeReports) {
+      reportPath = await writeAuditReport({
+        audit: auditor.name,
+        passed: !!result.passed,
+        threshold: result.threshold ?? null,
+        baselineFile: result.baselineFile ?? null,
+        baselineDelta: result.baselineDelta ?? null,
+        offenders: result.offenders ?? [],
+        byFeature: result.byFeature,
+        extra: result.extra ?? {},
+      });
+    }
+
+    if (verbose) {
+      const status = result.passed ? '✅ PASS' : '❌ FAIL';
+      const summary = result.humanSummary || `${result.offendersTotal ?? (result.offenders?.length ?? 0)} offender(s)`;
+      console.log(`${status} ${auditor.name.padEnd(36)} ${elapsedSec.toFixed(2)}s — ${summary}`);
+    }
+
+    reports.push({ name: auditor.name, ...result, reportPath, elapsedSec });
+  }
+
+  const totalElapsedSec = (performance.now() - t0) / 1000;
+  return { totalElapsedSec, walkElapsedSec, collectElapsedSec, filesScanned: scanned, reports };
+}
+
+/**
+ * Helper: pick a subset of auditors by name (CLI --audits=a,b,c).
+ * @param {Auditor[]} all
+ * @param {string|undefined} csv
+ * @returns {Auditor[]}
+ */
+export function filterAuditors(all, csv) {
+  if (!csv) return all;
+  const want = new Set(csv.split(',').map(s => s.trim()).filter(Boolean));
+  return all.filter(a => want.has(a.name));
+}
+
+export { auditReportPath };


### PR DESCRIPTION
L3 phase 1 — first three audits migrated to a shared runner that walks dist/
exactly once and dispatches every file to every registered Auditor. Replaces
the per-audit Node-process-per-walk pattern that forced post-deploy-validate-dist.yml
serial-only on the 7 GB ubuntu-latest runner (1-3 GB RSS per audit × N audits = OOM).

Measured speedup (local, warm cache, dist=81.684 HTML files / 2.1 GB):

  Sequential 3 standalone audits:        93.18 s
  Unified runner with same 3 audits:     39.73 s
  Speedup:                                2.35×

Walk breakdown in unified runner:
  - File walk (readdir traversal):      13.36 s
  - File read + collect (3 regex/file): 26.25 s

Per-audit overhead is microseconds (regex on already-in-memory string).
Walk time dominates — adding more audits to the runner barely changes
total wall time. Projected 6-audit run: ~45-50 s (vs 209 s sequential).

Architecture:
- scripts/lib/audit-runner.mjs: shared walker + dispatcher + report writer.
  Each Auditor exposes { name, collect(file, html), report() }; the runner
  feeds every file to every auditor's collect, then calls report() once at
  the end. AUDIT_STRICT=1 detects accidental html mutation between audits.
- scripts/audit-all.mjs: entry point that registers migrated audits and
  invokes runAudits(). New npm script: `npm run audit:all`.
- Migrated audits keep their standalone CLI (backward compat with existing
  npm scripts and workflow steps) while also exposing a factory() that the
  runner consumes.

Migrated in this commit:
- audit-footer-root-presence (105 → 169 LOC, same semantics)
- audit-jsonld-no-nested-scripts (145 → 197 LOC, same semantics)
- audit-title-length (330 → 471 LOC, baseline ratchet preserved through
  migrated path — verified 51 offenders match standalone output)

Pending migration (follow-up PR):
- audit-title-no-disambig-hash
- audit-h1-title-duplicates
- audit-text-html-ratio

Workflow update (post-deploy-validate-dist.yml switching the heavy-walker
chain to `npm run audit:all`) deferred until all 6 audits land.

Baseline measurements committed to
docs/superpowers/specs/2026-05-19-build-and-audit-optimization-baseline.md
for future before/after comparison.
