### PR TITLE
fix(seo): expand canton group codes (BASILEA/APPENZELLO) in legacy-fallback filter

### DIFF
--- a/services/cantonList.ts
+++ b/services/cantonList.ts
@@ -67,6 +67,27 @@ const HALF_CANTON_LABELS: Record<string, Record<CantonLocale, string>> = {
 };
 
 /**
+ * Expand a URL canton code to its member BFS codes. For real cantons the
+ * input is returned as a single-element array unchanged. For group codes
+ * (`BASILEA` → `['BL','BS']`, `APPENZELLO` → `['AI','AR']`) the members
+ * are returned.
+ *
+ * Used wherever a downstream filter compares against `job.canton` (the
+ * BFS code on the data side) but the URL-driven canton may be a group
+ * code. Without this expansion, `scopeJobsToCanton(jobs, 'BASILEA')`
+ * silently yields zero rows because no job has `canton === 'BASILEA'`.
+ */
+export function expandCantonGroup(code: string): string[] {
+  const upper = String(code || '').toUpperCase().trim();
+  if (!upper) return [];
+  const groupDef = RAW.cantonGroups?.[upper];
+  if (groupDef?.members && groupDef.members.length > 0) {
+    return groupDef.members.map((m) => String(m).toUpperCase());
+  }
+  return [upper];
+}
+
+/**
  * 2-letter ISO canton codes (uppercase) — sorted alphabetically for stable
  * UI ordering. Frozen at module load. Always 26 entries (expands AI/AR/BL/BS
  * even though the URL slugs collapse them onto APPENZELLO/BASILEA).

--- a/services/jobsService.ts
+++ b/services/jobsService.ts
@@ -46,6 +46,8 @@
  * correctness over speed.
  */
 
+import { expandCantonGroup } from './cantonList';
+
 /**
  * Permissive Job shape. The full Job interface lives in component-level types,
  * but this fetch/cache layer is structure-agnostic — it only needs to round-trip
@@ -414,6 +416,12 @@ export async function fetchAllJobs(): Promise<Job[]> {
  * (`/data/jobs-{locale}.json`, ~13 MB, all 26 cantons mixed), this filter
  * prevents the TI-dominant payload from leaking into non-TI canton SERPs.
  *
+ * URL group codes (`BASILEA` → BL+BS, `APPENZELLO` → AI+AR) are expanded
+ * to their BFS members before matching, since `job.canton` always carries
+ * the real BFS code (BL/BS/AI/AR), never the URL group key. Without the
+ * expansion, `/cerca-lavoro-basilea/` would render an empty SERP because
+ * no row has `canton === 'BASILEA'`.
+ *
  * Pure / side-effect free → unit-testable without DOM or network.
  */
 export function scopeJobsToCanton<T extends { canton?: string | null }>(
@@ -421,7 +429,14 @@ export function scopeJobsToCanton<T extends { canton?: string | null }>(
  targetCanton: string,
 ): T[] {
  if (targetCanton === AGGREGATE_CANTON_CODE) return jobs.slice();
- return jobs.filter((j) => j.canton === targetCanton);
+ const members = expandCantonGroup(targetCanton);
+ if (members.length === 0) return [];
+ if (members.length === 1) {
+  const only = members[0];
+  return jobs.filter((j) => j.canton === only);
+ }
+ const memberSet = new Set(members);
+ return jobs.filter((j) => typeof j.canton === 'string' && memberSet.has(j.canton));
 }
 
 // --------------------------------------------------------------------------

--- a/tests/services/jobsService.scopeJobsToCanton.test.ts
+++ b/tests/services/jobsService.scopeJobsToCanton.test.ts
@@ -63,4 +63,28 @@ describe('scopeJobsToCanton', () => {
     const scoped = scopeJobsToCanton(FIXTURE, 'TI');
     expect(scoped.map((j) => j.id).sort()).toEqual(['a', 'b']);
   });
+
+  // Regression 2026-05-19: BASILEA and APPENZELLO are URL group codes that
+  // expand to multiple BFS members. Jobs always carry the BFS code
+  // (BL/BS/AI/AR) — never the group key. Without expansion the filter
+  // returned 0 rows on /cerca-lavoro-basilea/ and /cerca-lavoro-appenzello/.
+  it('BASILEA group code expands to BL+BS members', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, 'BASILEA');
+    expect(scoped.map((j) => j.id).sort()).toEqual(['c', 'd']);
+  });
+
+  it('APPENZELLO group expansion: jobs in AI/AR surface when none in fixture exists', () => {
+    const fixture: Fixture[] = [
+      { id: '1', canton: 'AI' },
+      { id: '2', canton: 'AR' },
+      { id: '3', canton: 'TI' },
+    ];
+    const scoped = scopeJobsToCanton(fixture, 'APPENZELLO');
+    expect(scoped.map((j) => j.id).sort()).toEqual(['1', '2']);
+  });
+
+  it('case-insensitive group code resolution', () => {
+    const scoped = scopeJobsToCanton(FIXTURE, 'basilea');
+    expect(scoped.map((j) => j.id).sort()).toEqual(['c', 'd']);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up a #330. La fix `scopeJobsToCanton` filtrava per uguaglianza stretta su `j.canton === targetCanton`, ma BASILEA (BL+BS) e APPENZELLO (AI+AR) sono **URL group code** — nessun job ha mai `canton === 'BASILEA'`. Risultato: SERP vuoto su `/cerca-lavoro-basilea/` e `/cerca-lavoro-appenzello/` quando lo shard 404.

## Cosa cambia

- **Nuovo helper** `expandCantonGroup(code)` in `services/cantonList.ts`. Restituisce i BFS member per i group key, o `[code]` per cantoni reali.
- **`scopeJobsToCanton`** ora espande il target prima di filtrare. Set-based membership per i gruppi, equality per cantoni single-member.
- Lookup case-insensitive (`'basilea'` → BASILEA → BL+BS).

## Estensione del fix a tutti i cantoni

Conferma su domanda di Valerie: il filtro canton-specifico (anti-TI-leak) ora si applica correttamente a **tutti i 26 cantoni**, inclusi i due gruppi virtuali BASILEA e APPENZELLO. Per i cantoni reali (TI, ZH, GE, VD, ...) il comportamento era già corretto pre-fix.

## Test plan

- [x] 3 test nuovi su `scopeJobsToCanton`: BASILEA expansion, APPENZELLO expansion, lookup case-insensitive
- [x] `npx vitest run tests/services/ tests/router/` → **57/57 passed**
- [x] `npx tsc --noEmit` → pulito
- [ ] CI tests.yml verde
- [ ] Post-deploy: `/cerca-lavoro-basilea/` SERP non vuota, mostra job BL+BS, niente TI leak
- [ ] Post-deploy: `/cerca-lavoro-appenzello/` SERP non vuota, mostra job AI+AR

## Riferimenti

- Fix d'origine: PR #330 (city hub staticOverlay + legacy canton filter)
- Group definitions: `data/canton-url-slugs.json` § `cantonGroups`