### PR TITLE
fix(seo): salary-landing template renders on every locale, not only IT

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -390,6 +390,8 @@ jobs:
             npm run audit:max-bfs-depth
           spawn_capped audit:footer-root-presence    /tmp/g20.log \
             npm run audit:footer-root-presence
+          spawn_capped audit:salary-landing-template /tmp/g22.log \
+            npm run audit:salary-landing-template
           spawn_capped audit:jsonld-no-nested-scripts /tmp/g21.log \
             npm run audit:jsonld-no-nested-scripts
           # NOTE: live:post-deploy-smoke moved to validate-live workflow.

--- a/build-plugins/shared/salaryLandingShell.ts
+++ b/build-plugins/shared/salaryLandingShell.ts
@@ -1755,18 +1755,34 @@ const NET_COMPARISON_SCENARIOS: Record<NetComparisonKey, Record<SalaryLocale, Sa
 
 function parseNetComparisonPath(canonicalPath: string): { key: NetComparisonKey; locale: SalaryLocale } | null {
   const stripped = canonicalPath.replace(/\/+$/, '');
-  // IT canonical paths
-  const itSlugs: Array<{ slug: string; key: NetComparisonKey }> = [
-    { slug: '/calcola-stipendio/confronto-netto-2025-2026-entro-20km', key: 'confronto-netto-2025-2026-entro-20km' },
-    { slug: '/calcola-stipendio/confronto-netto-2025-2026-oltre-20km', key: 'confronto-netto-2025-2026-oltre-20km' },
-    { slug: '/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km', key: 'confronto-permesso-g-vs-b-entro-20km' },
-    { slug: '/calcola-stipendio/confronto-permesso-g-vs-b-oltre-20km', key: 'confronto-permesso-g-vs-b-oltre-20km' },
+  // All 4 net-comparison scenarios × 4 locales. Slugs match
+  // services/router.ts REVERSE_SALARY_SUBTAB_BY_LOCALE tables and the
+  // hreflang alternates emitted in dist/sitemap-pages.xml.
+  const slugMap: Array<{ slug: string; key: NetComparisonKey; locale: SalaryLocale }> = [
+    // confronto-netto-2025-2026-entro-20km
+    { slug: '/calcola-stipendio/confronto-netto-2025-2026-entro-20km', key: 'confronto-netto-2025-2026-entro-20km', locale: 'it' },
+    { slug: '/en/calculate-salary/net-comparison-2025-2026-within-20km', key: 'confronto-netto-2025-2026-entro-20km', locale: 'en' },
+    { slug: '/de/gehalt-berechnen/nettovergleich-2025-2026-bis-20km', key: 'confronto-netto-2025-2026-entro-20km', locale: 'de' },
+    { slug: '/fr/calculer-salaire/comparaison-net-2025-2026-moins-20km', key: 'confronto-netto-2025-2026-entro-20km', locale: 'fr' },
+    // confronto-netto-2025-2026-oltre-20km
+    { slug: '/calcola-stipendio/confronto-netto-2025-2026-oltre-20km', key: 'confronto-netto-2025-2026-oltre-20km', locale: 'it' },
+    { slug: '/en/calculate-salary/net-comparison-2025-2026-over-20km', key: 'confronto-netto-2025-2026-oltre-20km', locale: 'en' },
+    { slug: '/de/gehalt-berechnen/nettovergleich-2025-2026-ueber-20km', key: 'confronto-netto-2025-2026-oltre-20km', locale: 'de' },
+    { slug: '/fr/calculer-salaire/comparaison-net-2025-2026-plus-20km', key: 'confronto-netto-2025-2026-oltre-20km', locale: 'fr' },
+    // confronto-permesso-g-vs-b-entro-20km
+    { slug: '/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km', key: 'confronto-permesso-g-vs-b-entro-20km', locale: 'it' },
+    { slug: '/en/calculate-salary/permit-g-vs-b-comparison-within-20km', key: 'confronto-permesso-g-vs-b-entro-20km', locale: 'en' },
+    { slug: '/de/gehalt-berechnen/vergleich-bewilligung-g-vs-b-bis-20km', key: 'confronto-permesso-g-vs-b-entro-20km', locale: 'de' },
+    { slug: '/fr/calculer-salaire/comparaison-permis-g-vs-b-moins-20km', key: 'confronto-permesso-g-vs-b-entro-20km', locale: 'fr' },
+    // confronto-permesso-g-vs-b-oltre-20km
+    { slug: '/calcola-stipendio/confronto-permesso-g-vs-b-oltre-20km', key: 'confronto-permesso-g-vs-b-oltre-20km', locale: 'it' },
+    { slug: '/en/calculate-salary/permit-g-vs-b-comparison-over-20km', key: 'confronto-permesso-g-vs-b-oltre-20km', locale: 'en' },
+    { slug: '/de/gehalt-berechnen/vergleich-bewilligung-g-vs-b-ueber-20km', key: 'confronto-permesso-g-vs-b-oltre-20km', locale: 'de' },
+    { slug: '/fr/calculer-salaire/comparaison-permis-g-vs-b-plus-20km', key: 'confronto-permesso-g-vs-b-oltre-20km', locale: 'fr' },
   ];
-  for (const { slug, key } of itSlugs) {
-    if (stripped === slug) return { key, locale: 'it' };
+  for (const { slug, key, locale } of slugMap) {
+    if (stripped === slug) return { key, locale };
   }
-  // Per live sitemap-pages.xml the net-comparison URLs are IT-only.
-  // EN/DE/FR were never emitted as static landings — no mapping needed.
   return null;
 }
 

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -110,7 +110,12 @@ function lookupStaticOverlayHubChrome(canonicalPath: string): StaticOverlayHubCh
  // Every /calcola-stipendio/* scenario page (and locale equivalents) renders
  // through `buildSalaryLandingBody` as a staticOverlay route — emit the body
  // OUTSIDE `#root` so React hydration keeps the SEO-landing template visible.
- if (/^\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath)) {
+ // Both the IT canonical paths and the locale-prefixed EN/DE/FR variants
+ // ship the same template — keep the gate symmetric across all 4 locales.
+ if (
+   /^\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath) ||
+   /^\/(en|de|fr)\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath)
+ ) {
    return { hubKey: 'calculator', activeSubTab: 'calculator' };
  }
  return null;
@@ -3925,7 +3930,9 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  // as `<details>` from `landingData.faqs`. Suppress this editorial `<dl>`
  // mirror for those paths to avoid a duplicate FAQ section on every
  // /calcola-stipendio/* scenario page. JSON-LD FAQPage stays unchanged.
- const salaryLandingPath = /^\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath);
+ const salaryLandingPath =
+   /^\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath) ||
+   /^\/(en|de|fr)\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath);
  try {
  const sdSeparator = '</script>\n <script type="application/ld+json">';
  const sdParts = seoData.sd.split(sdSeparator);
@@ -4148,7 +4155,11 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  // helper renders breadcrumb + eyebrow + H1 + lede + stat tiles +
  // consiglio + CTA + comparative table + FAQ, with long prose pushed
  // BELOW the data area so the meaty content stays above the mobile fold.
- /^\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath)
+ // Accept both the IT canonical paths (no locale prefix) and the
+ // /{en|de|fr}/{calculate-salary|gehalt-berechnen|calculer-salaire}/* variants
+ // — every locale ships these landings (see sitemap-pages.xml hreflangs).
+ (/^\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath) ||
+  /^\/(en|de|fr)\/(calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)\/[^/]/.test(canonicalPath))
  ) {
  // H1 must be a headline, not a SERP title. Strip the `| Simulazione 2026`
  // and `| Frontaliere Ticino` suffixes that come from seoData.title

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "audit:max-bfs-depth": "node scripts/audit-bfs-depth.mjs --baseline=data/bfs-depth-baseline.json",
     "audit:max-bfs-depth:rebaseline": "node scripts/audit-bfs-depth.mjs --write-baseline=data/bfs-depth-baseline.json",
     "audit:footer-root-presence": "node scripts/audit-footer-root-presence.mjs",
+    "audit:salary-landing-template": "node scripts/audit-salary-landing-template.mjs",
     "audit:jsonld-no-nested-scripts": "node scripts/audit-jsonld-no-nested-scripts.mjs",
     "audit:sitemap-canonicals": "node scripts/audit-sitemap-canonicals.mjs",
     "audit:h1-title-duplicates": "node scripts/audit-h1-title-duplicates.mjs --baseline=data/h1-title-duplicates-baseline.json",

--- a/scripts/audit-all.mjs
+++ b/scripts/audit-all.mjs
@@ -33,11 +33,13 @@ import { runAudits, filterAuditors, DEFAULT_DIST } from './lib/audit-runner.mjs'
 import { factory as footerRootPresence } from './audit-footer-root-presence.mjs';
 import { factory as jsonldNoNestedScripts } from './audit-jsonld-no-nested-scripts.mjs';
 import { factory as titleLength } from './audit-title-length.mjs';
+import { factory as salaryLandingTemplate } from './audit-salary-landing-template.mjs';
 
 const REGISTRY = [
   { factory: footerRootPresence, name: 'footer-root-presence' },
   { factory: jsonldNoNestedScripts, name: 'jsonld-no-nested-scripts' },
   { factory: titleLength, name: 'title-length' },
+  { factory: salaryLandingTemplate, name: 'salary-landing-template' },
 ];
 
 // ─── CLI parsing ─────────────────────────────────────────────────────────────

--- a/scripts/audit-salary-landing-template.mjs
+++ b/scripts/audit-salary-landing-template.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * audit-salary-landing-template
+ *
+ * Enforces CLAUDE.md non-negotiable rule #17 ("SEO-landing UI/UX template")
+ * on every static HTML page emitted under the salary-calculator hubs:
+ *
+ *   /calcola-stipendio/{slug}/      (IT)
+ *   /en/calculate-salary/{slug}/    (EN)
+ *   /de/gehalt-berechnen/{slug}/    (DE)
+ *   /fr/calculer-salaire/{slug}/    (FR)
+ *
+ * Every URL emitted by build-plugins/staticPagesPlugin.ts under those hubs
+ * MUST be rendered through build-plugins/shared/salaryLandingShell.ts's
+ * `buildSalaryLandingBody()`, which produces:
+ *
+ *   <main class="seo-static-content"> ... </main>
+ *     ├─ eyebrow line
+ *     ├─ <h1 style="...clamp(...)">  ← large clamp-sized H1
+ *     ├─ lede ≤120 chars
+ *     ├─ stat-tile grid (≥3 tiles, OKLCH semantic tokens)
+ *     ├─ "Consiglio" advisory banner (when applicable)
+ *     ├─ primary CTA above the fold
+ *     ├─ data area (comparative table / list / cards)
+ *     └─ long prose BELOW the action area
+ *
+ * Symptom this catches: a salary-landing URL falls through the default
+ * "thin" placeholder branch in staticPagesPlugin (empty calculator slot
+ * `<div height:38rem>`, tiny `<h1 style="font-size:1.25rem">`, no stat tiles).
+ * Root cause for the 2026-05-19 regression: the regex gate at
+ * staticPagesPlugin.ts:4151 was IT-only — non-IT locale variants leaked
+ * through to the default branch.
+ *
+ * Zero tolerance: any matching URL without `<main class="seo-static-content">`
+ * fails the deploy.
+ */
+import { readFile, stat } from 'node:fs/promises';
+import { relative } from 'node:path';
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { writeAuditReport } from './lib/auditReport.mjs';
+
+// Match every salary-landing scenario URL across the 4 locales. The trailing
+// segment must be a real slug (`[^/]+`) — the hub root pages `/calcola-stipendio/`
+// and locale variants are intentionally out of scope (they ship through a
+// different code path: see `isCalcStipendioIndex` in staticPagesPlugin.ts).
+const SALARY_LANDING_PATH_RE = new RegExp(
+  '/dist/(?:' +
+  '(?:calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)/[^/]+/index\\.html$' +
+  '|' +
+  '(?:en|de|fr)/(?:calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire)/[^/]+/index\\.html$' +
+  ')',
+);
+
+const SEO_STATIC_RE = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b/i;
+// Thin/default placeholder H1 emitted by the `} else {` fallback branch.
+// salary-landing shell uses `font-size:clamp(...)` so this exact string
+// can only come from the default thin layout.
+const THIN_H1_RE = /<h1\s+style="font-size:1\.25rem;font-weight:700;margin-bottom:\.5rem">/i;
+// Empty calculator placeholder div from the default branch.
+const PLACEHOLDER_DIV_RE = /<div\s+style="[^"]*;height:38rem;margin-top:1\.5rem"><\/div>/i;
+
+/**
+ * @param {{ limit?: number }} [opts]
+ * @returns {import('./lib/audit-runner.mjs').Auditor}
+ */
+export function createAuditor(opts = {}) {
+  const limit = Math.max(1, opts.limit ?? 30);
+  const offenders = [];
+  let scanned = 0;
+
+  return {
+    name: 'salary-landing-template',
+    collect(file, html) {
+      // Normalize to a posix-style path so the regex matches on Windows too.
+      const posixPath = file.replace(/\\/g, '/');
+      if (!SALARY_LANDING_PATH_RE.test(posixPath)) return;
+      scanned++;
+
+      const reasons = [];
+      if (!SEO_STATIC_RE.test(html)) reasons.push('missing <main class="seo-static-content">');
+      if (THIN_H1_RE.test(html)) reasons.push('thin default H1 (font-size:1.25rem)');
+      if (PLACEHOLDER_DIV_RE.test(html)) reasons.push('empty calculator placeholder (height:38rem)');
+
+      if (reasons.length > 0) {
+        offenders.push({ path: relative(ROOT, file), reasons });
+      }
+    },
+    report() {
+      const passed = offenders.length === 0;
+      const humanSummary = passed
+        ? `scanned ${scanned} salary-landing page(s) — all use buildSalaryLandingBody template`
+        : `${offenders.length} of ${scanned} salary-landing page(s) ship the thin fallback layout`;
+      return {
+        passed,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'thinSalaryLandings', value: 0, comparator: '<=' },
+        extra: { scanned, limit },
+        humanSummary,
+      };
+    },
+  };
+}
+
+export const auditor = createAuditor();
+export { createAuditor as factory };
+
+async function standalone() {
+  const args = process.argv.slice(2);
+  const limit = (() => {
+    const a = args.find((s) => s.startsWith('--limit='));
+    return a ? Math.max(1, parseInt(a.split('=')[1], 10) || 30) : 30;
+  })();
+
+  const distStat = await stat(DEFAULT_DIST).catch(() => null);
+  if (!distStat || !distStat.isDirectory()) {
+    console.error(`audit-salary-landing-template: dist/ not found at ${DEFAULT_DIST}. Run a build first.`);
+    process.exit(2);
+  }
+
+  const a = createAuditor({ limit });
+  const files = await walkHtmlFiles(DEFAULT_DIST);
+  for (const file of files) {
+    let html;
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    a.collect(file, html);
+  }
+
+  const result = await a.report();
+
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold ?? null,
+    offenders: result.offenders ?? [],
+    extra: result.extra ?? {},
+  });
+
+  console.log(`audit-salary-landing-template: ${result.humanSummary}`);
+  if (result.passed) {
+    console.log('PASS: every salary-landing page uses the mobile-first SEO template.');
+    process.exit(0);
+  }
+
+  console.error(`\nFAIL: ${result.offendersTotal} salary-landing page(s) ship the thin fallback layout.`);
+  console.error(`CLAUDE.md rule #17 requires every /{calcola-stipendio|calculate-salary|gehalt-berechnen|calculer-salaire}/*`);
+  console.error(`scenario page to render through buildSalaryLandingBody() (eyebrow + H1 + lede + stat tiles + CTA + data area + long prose).`);
+  console.error(`\nFirst ${Math.min(limit, result.offenders.length)} offenders:`);
+  for (const o of result.offenders.slice(0, limit)) {
+    console.error(`  ${o.path}`);
+    for (const r of o.reasons) console.error(`    - ${r}`);
+  }
+  if (result.offenders.length > limit) console.error(`  ... and ${result.offenders.length - limit} more`);
+  console.error(`\nHow to fix`);
+  console.error(`----------`);
+  console.error(`In build-plugins/staticPagesPlugin.ts, confirm both gates accept the locale prefix:`);
+  console.error(`  - lookupStaticOverlayHubChrome() at line ~106`);
+  console.error(`  - the salary-landing branch around line ~4145`);
+  console.error(`In build-plugins/shared/salaryLandingShell.ts, confirm parseNetComparisonPath()`);
+  console.error(`maps every locale variant (4 slugs × 4 locales = 16 entries).`);
+  process.exit(1);
+}
+
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('audit-salary-landing-template: fatal', err);
+    process.exit(2);
+  });
+}

--- a/tests/build-plugins/salaryLandingShell.test.ts
+++ b/tests/build-plugins/salaryLandingShell.test.ts
@@ -45,7 +45,7 @@ describe('salaryLandingShell · resolver', () => {
     }
   });
 
-  it('resolves all 4 IT net-comparison scenarios (URLs only emitted in IT)', () => {
+  it('resolves all 4 net-comparison scenarios in IT (canonical paths)', () => {
     const cases: Array<{ path: string; eyebrowSubstr: string }> = [
       { path: '/calcola-stipendio/confronto-netto-2025-2026-entro-20km', eyebrowSubstr: 'Entro 20 km' },
       { path: '/calcola-stipendio/confronto-netto-2025-2026-oltre-20km', eyebrowSubstr: 'Oltre 20 km' },
@@ -59,6 +59,43 @@ describe('salaryLandingShell · resolver', () => {
       expect(r.data.table?.headers.length).toBe(4);
       expect(r.data.tiles.length).toBe(4);
       expect(r.data.faqs?.length).toBe(3);
+    }
+  });
+
+  // Regression guard for the 2026-05-19 bug: parseNetComparisonPath
+  // previously returned null for every non-IT variant, dropping all 12
+  // EN/DE/FR scenario URLs into the generic default branch. The sitemap
+  // declares hreflang alternates in all 4 locales and dist/ emits HTML
+  // for each — the resolver must keep all 16 mappings in sync with
+  // services/router.ts REVERSE_SALARY_SUBTAB_BY_LOCALE.
+  it('resolves all 4 net-comparison scenarios across EN, DE, FR', () => {
+    const cases: Array<{ path: string; locale: SalaryLocale }> = [
+      // confronto-netto-2025-2026-entro-20km
+      { path: '/en/calculate-salary/net-comparison-2025-2026-within-20km', locale: 'en' },
+      { path: '/de/gehalt-berechnen/nettovergleich-2025-2026-bis-20km', locale: 'de' },
+      { path: '/fr/calculer-salaire/comparaison-net-2025-2026-moins-20km', locale: 'fr' },
+      // confronto-netto-2025-2026-oltre-20km
+      { path: '/en/calculate-salary/net-comparison-2025-2026-over-20km', locale: 'en' },
+      { path: '/de/gehalt-berechnen/nettovergleich-2025-2026-ueber-20km', locale: 'de' },
+      { path: '/fr/calculer-salaire/comparaison-net-2025-2026-plus-20km', locale: 'fr' },
+      // confronto-permesso-g-vs-b-entro-20km
+      { path: '/en/calculate-salary/permit-g-vs-b-comparison-within-20km', locale: 'en' },
+      { path: '/de/gehalt-berechnen/vergleich-bewilligung-g-vs-b-bis-20km', locale: 'de' },
+      { path: '/fr/calculer-salaire/comparaison-permis-g-vs-b-moins-20km', locale: 'fr' },
+      // confronto-permesso-g-vs-b-oltre-20km
+      { path: '/en/calculate-salary/permit-g-vs-b-comparison-over-20km', locale: 'en' },
+      { path: '/de/gehalt-berechnen/vergleich-bewilligung-g-vs-b-ueber-20km', locale: 'de' },
+      { path: '/fr/calculer-salaire/comparaison-permis-g-vs-b-plus-20km', locale: 'fr' },
+    ];
+    for (const c of cases) {
+      const r = _internal.resolveScenarioData(c.path);
+      expect(r.locale, `wrong locale for ${c.path}`).toBe(c.locale);
+      // The shell must serve the net-comparison template (4-column table
+      // + 4 tiles + 3 FAQs), not the generic default that would otherwise
+      // catch unknown paths under /{locale}/{salary-hub}/anything.
+      expect(r.data.table?.headers.length, `missing comparison table for ${c.path}`).toBe(4);
+      expect(r.data.tiles.length, `wrong tile count for ${c.path}`).toBe(4);
+      expect(r.data.faqs?.length, `wrong FAQ count for ${c.path}`).toBe(3);
     }
   });
 


### PR DESCRIPTION
Three locale-prefixed regex gates in staticPagesPlugin.ts and the
parseNetComparisonPath resolver in salaryLandingShell.ts only matched IT
canonical paths (/calcola-stipendio/*). Every /{en|de|fr}/{calculate-salary
|gehalt-berechnen|calculer-salaire}/* URL therefore fell through to the
default thin-layout branch with an empty calculator placeholder
(<div height:38rem>) and a small <h1 style="font-size:1.25rem"> instead
of the mobile-first SEO-landing template (CLAUDE.md rule #17).

Symptom: pages like /en/calculate-salary/net-comparison-2025-2026-over-20km/
shipped without <main class="seo-static-content">, without the stat-tile
grid, without the advisory banner, and without the comparative table. The
IT canonical sibling worked correctly.

Fixes:
- staticPagesPlugin.ts: lookupStaticOverlayHubChrome, salary-landing gate,
  and FAQ-dedup gate now all accept /{en|de|fr}/ prefixes.
- salaryLandingShell.ts: parseNetComparisonPath maps all 16 slug variants
  (4 scenarios × 4 locales) matching services/router.ts. Removed the
  comment that incorrectly claimed non-IT URLs were never emitted.

Tests + audit:
- tests/build-plugins/salaryLandingShell.test.ts: new regression case
  feeds all 12 EN/DE/FR net-comparison paths through resolveScenarioData
  and asserts the comparison-template shape (4-column table, 4 tiles,
  3 FAQs). Existing IT case renamed (the "URLs only emitted in IT"
  assumption was wrong).
- scripts/audit-salary-landing-template.mjs: new zero-tolerance dist-walking
  audit that fails the deploy if any /{calcola-stipendio|calculate-salary
  |gehalt-berechnen|calculer-salaire}/* scenario page lacks
  <main class="seo-static-content">, ships the thin default <h1>, or the
  empty calculator placeholder. Wired into post-deploy-validate-dist.yml
  and registered in scripts/audit-all.mjs.
