### PR TITLE
perf(audit): migrate last 3 audits into runner + lift MAX_PARALLEL + AUDIT_STRICT in CI (L3.x)

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -250,20 +250,29 @@ jobs:
           # capping it forces aggressive GC and prevents single-process
           # blow-ups when walking ~132k HTML files.
           NODE_OPTIONS: '--max-old-space-size=4096'
+          # AUDIT_STRICT=1 enables the unified runner's AST mutation
+          # detection: every audit's collect() runs against a frozen html
+          # string; any mutation triggers a fail loud with the auditor's
+          # name. Cheap (single equality check per file per audit) and
+          # catches accidental side-effects during future audit migrations.
+          AUDIT_STRICT: '1'
         run: |
-          # MAX_PARALLEL=1 — fully serialise the pool. After 5 iterations
+          # MAX_PARALLEL=2 — restored after the L3 unification.
+          # The previous MAX_PARALLEL=1 was forced by historical OOM kills
           # (runs 25400905401, 25402597503, 25404549152, 25406916097,
-          # 25408263066) post-deploy still OOM-killed audit:title-uniqueness
-          # at rc=134 with chain isolated, dist-multi removed, and
-          # NODE_OPTIONS=--max-old-space-size=4096. The 7 GB ubuntu-latest
-          # free runner can't reliably host TWO Node processes that each
-          # walk 132k HTML files, even with heap cap. With MAX_PARALLEL=1
-          # only the chain audit + at most one pool audit run at any
-          # moment; two 4 GB-cap Node processes plus OS overhead = ~5-6 GB
-          # peak, comfortably under the 7 GB ceiling. Wall-time penalty:
-          # pool tail = sum of pool durations ≈ 200 s vs. ~100 s parallel,
-          # but reliability wins.
-          MAX_PARALLEL=1
+          # 25408263066): the old chain spawned 7 separate Node processes
+          # each walking 132k HTML files at 1-3 GB RSS, so two concurrent
+          # walkers blew past the 7 GB ceiling.
+          #
+          # The new chain is 4 entries (audit:all + page-weight +
+          # content-duplicates + faqpage-validity), but with `audit:all`
+          # covering 10 audits in a SINGLE V8 process (~1 GB peak instead
+          # of 10× ~1-3 GB), the cumulative RSS profile is much lower.
+          # MAX_PARALLEL=2 lets the pool tail overlap with the chain's
+          # remaining serial steps; cumulative peak ≈ chain (~1 GB) +
+          # 2× pool (~1-1.5 GB each) ≈ 3-4 GB, comfortably under 7 GB.
+          # If a regression OOMs the runner, drop back to 1 in a hotfix.
+          MAX_PARALLEL=2
           : > /tmp/post-build-timings.txt
           : > /tmp/post-build-failures.txt
 
@@ -316,13 +325,17 @@ jobs:
           # walk dist/ from scratch — they stay serialized here until they
           # migrate too. audit:title-uniqueness lives in a weekly workflow
           # (memory-bound on the 7 GB runner; documented in run history).
+          # audit:all now covers ALL heavy dist-walking audits in a single
+          # Node process (text-html-ratio, h1-title-duplicates, title-length,
+          # title-no-disambig-hash, footer-root-presence, jsonld-no-nested-
+          # scripts, salary-landing-template, page-weight, content-duplicates,
+          # faqpage-validity). The "chain" is now one step. We keep the
+          # subshell wrapper + timing dump so the workflow summary still
+          # has a structured row per logical audit.
           (
             set +e
             for chain_step in \
               "audit:all|/tmp/g10.log|npm run audit:all" \
-              "audit:page-weight|/tmp/g12.log|npm run audit:page-weight" \
-              "audit:content-duplicates|/tmp/g8.log|npm run audit:content-duplicates" \
-              "audit:faqpage-validity|/tmp/g20.log|npm run audit:faqpage-validity" \
             ; do
               IFS='|' read -r step_name step_log step_cmd <<<"$chain_step"
               start=$(date +%s.%N)

--- a/scripts/audit-all.mjs
+++ b/scripts/audit-all.mjs
@@ -37,6 +37,9 @@ import { factory as titleNoDisambigHash } from './audit-title-no-disambig-hash.m
 import { factory as h1TitleDuplicates } from './audit-h1-title-duplicates.mjs';
 import { factory as textHtmlRatio } from './audit-text-html-ratio.mjs';
 import { factory as salaryLandingTemplate } from './audit-salary-landing-template.mjs';
+import { factory as pageWeight } from './audit-page-weight.mjs';
+import { factory as contentDuplicates } from './audit-content-duplicates.mjs';
+import { factory as faqpageValidity } from './audit-faqpage-validity.mjs';
 
 const REGISTRY = [
   { factory: footerRootPresence, name: 'footer-root-presence' },
@@ -46,6 +49,9 @@ const REGISTRY = [
   { factory: h1TitleDuplicates, name: 'h1-title-duplicates' },
   { factory: textHtmlRatio, name: 'text-html-ratio' },
   { factory: salaryLandingTemplate, name: 'salary-landing-template' },
+  { factory: pageWeight, name: 'page-weight' },
+  { factory: contentDuplicates, name: 'content-duplicates' },
+  { factory: faqpageValidity, name: 'faqpage-validity' },
 ];
 
 // ─── CLI parsing ─────────────────────────────────────────────────────────────

--- a/scripts/audit-content-duplicates.mjs
+++ b/scripts/audit-content-duplicates.mjs
@@ -2,83 +2,33 @@
 /**
  * Audit generated static HTML pages for duplicate body content within a locale.
  *
- * Walks `dist/**\/*.html`, groups pages by locale (inferred from the URL path
- * prefix: `/en/…`, `/de/…`, `/fr/…`, anything else = `it`). For each page it
- * extracts the visible body text — `<script>`, `<style>`, and the top-level
- * `<nav>` / `<header>` / `<footer>` / `<aside>` chrome are stripped before
- * hashing so that shared shell markup never triggers false positives.
+ * Walks `dist/**\/*.html`, groups pages by locale, hashes their visible body
+ * text (stripping head/scripts/styles/svg/chrome), and groups by SHA-256
+ * hash. Pages within the SAME locale that produce the same hash are
+ * "duplicate clusters". Cross-locale duplicates are ALLOWED.
  *
- * The remaining text is whitespace-normalised and hashed with SHA-256.
- * Pages within the SAME locale that produce the same hash are grouped into
- * "clusters" — each cluster ≥2 pages is a duplicate group.
- *
- * Exit code:
- *   0 — no locale has more than CLUSTER_THRESHOLD duplicate clusters
- *   1 — at least one locale breached the threshold; first 20 clusters are printed
- *
- * Cross-locale duplicates are ALLOWED (a page translated to the same editorial
- * copy in multiple languages is intentional, not a duplicate).
- *
- * Usage:
- *   node scripts/audit-content-duplicates.mjs            # audits ./dist
- *   node scripts/audit-content-duplicates.mjs path/to/dist
+ * Two execution modes:
+ *   1. Standalone CLI:  node scripts/audit-content-duplicates.mjs [dist]
+ *   2. Unified runner:  imported by scripts/audit-all.mjs via factory().
  */
 
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { writeAuditReport } from './lib/auditReport.mjs';
 
 const CLUSTER_THRESHOLD = 5;
 const MAX_REPORTED = 20;
-const LOCALE_PREFIXES = /** @type {const} */ (['en', 'de', 'fr']);
+const LOCALE_PREFIXES = ['en', 'de', 'fr'];
 
-/**
- * Recursively walk a directory and yield every `.html` file.
- * @param {string} dir
- * @returns {Generator<string>}
- */
-function* walkHtml(dir) {
-  for (const entry of readdirSync(dir)) {
-    // Skip dot-prefixed dirs (debug artifacts, not deployed pages).
-    if (entry.startsWith('.')) continue;
-    const full = join(dir, entry);
-    const stat = statSync(full);
-    if (stat.isDirectory()) {
-      yield* walkHtml(full);
-    } else if (stat.isFile() && full.endsWith('.html')) {
-      yield full;
-    }
-  }
-}
-
-/**
- * Infer locale from a `dist`-relative path. Italian is the implicit default.
- * @param {string} relPath
- * @returns {'it'|'en'|'de'|'fr'}
- */
 function inferLocale(relPath) {
   const first = relPath.split(sep)[0] || '';
-  if (LOCALE_PREFIXES.includes(/** @type {'en'|'de'|'fr'} */ (first))) {
-    return /** @type {'en'|'de'|'fr'} */ (first);
-  }
+  if (LOCALE_PREFIXES.includes(first)) return first;
   return 'it';
 }
 
-/**
- * Canonicalize a dist-relative HTML path so that `foo.html` and `foo/index.html`
- * — which GitHub Pages serves as the same URL — collapse to one logical page.
- * Without this every static page appears twice and pollutes the duplicate
- * clusters.
- *
- * `foo/index.html` → `foo/`
- * `foo.html`       → `foo/`
- * `index.html`     → `/`
- *
- * @param {string} relPath filesystem-relative (uses `path.sep`).
- * @returns {string} canonical URL-like key (forward slashes).
- */
 function canonicalizeDistPath(relPath) {
   const posix = relPath.split(sep).join('/');
   if (posix === 'index.html') return '/';
@@ -87,19 +37,6 @@ function canonicalizeDistPath(relPath) {
   return posix;
 }
 
-/**
- * Extract the absolute canonical URL from `<link rel="canonical">`.
- * Returns null if absent.
- *
- * Bridge pages (multi-locale slug variants, expired-job soft landings,
- * brand-alias `azienda-*` bridges, orphan-slug soft landings) all
- * legitimately share one body + one canonical URL. Google collapses them
- * into one indexed page via the canonical signal, so flagging them as
- * duplicate bodies is a false positive.
- *
- * @param {string} html
- * @returns {string|null}
- */
 function extractCanonical(html) {
   const headMatch = /<head\b[^>]*>([\s\S]*?)<\/head>/i.exec(html);
   const scope = headMatch ? headMatch[1] : html;
@@ -109,14 +46,6 @@ function extractCanonical(html) {
   return m2 ? m2[1].trim() : null;
 }
 
-/**
- * Return true when the page declares `noindex` via `<meta name="robots">`.
- * Noindex pages are intentionally hidden from SERP, so duplicate bodies
- * across these pages cannot trigger SERP cannibalization.
- *
- * @param {string} html
- * @returns {boolean}
- */
 function hasNoindex(html) {
   const headMatch = /<head\b[^>]*>([\s\S]*?)<\/head>/i.exec(html);
   const scope = headMatch ? headMatch[1] : html;
@@ -125,39 +54,16 @@ function hasNoindex(html) {
   return /\bnoindex\b/i.test(m[1]);
 }
 
-/**
- * Strip shared chrome (top-level nav/header/footer/aside) + scripts + styles
- * from raw HTML, returning the visible body text used for duplicate detection.
- *
- * The regexes intentionally use `.*?` (non-greedy) and the `s` flag so that
- * every match is as small as possible. We only strip ONE top-level block per
- * tag name — the goal is to remove the shell chrome emitted by
- * `buildSeoPageHtml`, not inline `<nav>` in article content (which belongs to
- * the per-entity body).
- *
- * @param {string} html
- * @returns {string}
- */
-function extractBodyText(html) {
+export function extractBodyText(html) {
   if (!html) return '';
   let body = html;
-
-  // Remove the <head>…</head> entirely.
   body = body.replace(/<head[^>]*>[\s\S]*?<\/head>/gi, ' ');
-
-  // Remove all script / style / svg / template blocks.
   body = body.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ');
   body = body.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ');
   body = body.replace(/<svg[^>]*>[\s\S]*?<\/svg>/gi, ' ');
   body = body.replace(/<noscript[^>]*>[\s\S]*?<\/noscript>/gi, ' ');
-
-  // Remove chrome shells — the first occurrence of each only, so we don't
-  // accidentally delete an article's inner <nav> (breadcrumb) that IS
-  // per-entity content.
   body = body.replace(/<footer[\s\S]*?<\/footer>/gi, ' ');
   body = body.replace(/<header\b[^>]*(role=["']banner["']|class=["'][^"']*site-[^"']*["'])[^>]*>[\s\S]*?<\/header>/gi, ' ');
-
-  // Strip any remaining tags + decode trivial entities.
   body = body.replace(/<[^>]+>/g, ' ');
   body = body
     .replace(/&nbsp;/g, ' ')
@@ -167,124 +73,128 @@ function extractBodyText(html) {
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&(?:[a-z]+|#\d+);/gi, ' ');
-
-  // Normalise whitespace.
   return body.replace(/\s+/g, ' ').trim();
 }
 
-/**
- * @param {string} content
- * @returns {string}
- */
-function sha256(content) {
+export function sha256(content) {
   return createHash('sha256').update(content, 'utf-8').digest('hex');
 }
 
-/**
- * Group duplicate hashes by locale.
- * @param {Array<{ relPath: string; locale: string; hash: string; wordCount: number }>} pages
- * @returns {Map<string, Map<string, string[]>>} locale → (hash → [relPath])
- */
-function groupDuplicates(pages) {
-  /** @type {Map<string, Map<string, string[]>>} */
-  const byLocale = new Map();
-  for (const p of pages) {
-    if (!byLocale.has(p.locale)) byLocale.set(p.locale, new Map());
-    const localeMap = /** @type {Map<string, string[]>} */ (byLocale.get(p.locale));
-    if (!localeMap.has(p.hash)) localeMap.set(p.hash, []);
-    /** @type {string[]} */ (localeMap.get(p.hash)).push(p.relPath);
-  }
-  return byLocale;
-}
+export { inferLocale };
 
-/**
- * @param {string} distDir
- * @returns {{ exitCode: number; totals: Record<string, number>; duplicates: Array<{ locale: string; hash: string; paths: string[] }> }}
- */
-function audit(distDir) {
-  /** @type {Array<{ relPath: string; locale: string; hash: string; wordCount: number }>} */
+export function createAuditor(opts = {}) {
+  const clusterThreshold = opts.clusterThreshold ?? CLUSTER_THRESHOLD;
   const pages = [];
-
-  try {
-    statSync(distDir);
-  } catch {
-    console.error(`[audit-content-duplicates] dist directory not found: ${distDir}`);
-    return { exitCode: 1, totals: {}, duplicates: [] };
-  }
-
-  /** @type {Set<string>} Already-seen canonical URL-keys (collapses `foo.html`
-   * + `foo/index.html` pairs which GH Pages serves as one URL). */
   const seenUrlKeys = new Set();
-  for (const file of walkHtml(distDir)) {
-    const relPath = relative(distDir, file);
-    const urlKey = canonicalizeDistPath(relPath);
-    // Deduplicate filesystem `.html` vs `/index.html` pairs that GH Pages
-    // serves under one URL. We keep the first occurrence (typically
-    // `foo/index.html`) and skip the flat-html sibling.
-    if (seenUrlKeys.has(urlKey)) continue;
-    seenUrlKeys.add(urlKey);
 
-    const html = readFileSync(file, 'utf-8');
+  return {
+    name: 'content-duplicates',
+    collect(file, html) {
+      const relPath = relative(DEFAULT_DIST, file);
+      const urlKey = canonicalizeDistPath(relPath);
+      if (seenUrlKeys.has(urlKey)) return;
+      seenUrlKeys.add(urlKey);
 
-    // Skip noindex pages outright — they are not indexable and cannot
-    // cause SERP cannibalization regardless of body similarity.
-    if (hasNoindex(html)) continue;
+      if (hasNoindex(html)) return;
+      const bodyText = extractBodyText(html);
+      if (!bodyText) return;
+      const wordCount = bodyText.split(/\s+/).length;
+      if (wordCount < 40) return;
 
-    const bodyText = extractBodyText(html);
-    if (!bodyText) continue;
-    // Skip very small stubs (error pages, 404, empty redirects) — they're not
-    // indexable content and dominate cross-locale noise.
-    const wordCount = bodyText.split(/\s+/).length;
-    if (wordCount < 40) continue;
-
-    // Skip pages whose <link rel="canonical"> points at a DIFFERENT page —
-    // these are intentional bridge/alias pages (orphan soft landings,
-    // brand-alias `azienda-<brand>` bridges, multi-slug-variant rescues).
-    // Google collapses them into their canonical target, so flagging the
-    // shared body as a duplicate is a false positive. We still include
-    // self-canonical pages so true editorial duplicates keep getting caught.
-    const canonical = extractCanonical(html);
-    if (canonical) {
-      const canonicalPath = canonical.replace(/^https?:\/\/[^/]+/, '').replace(/#.*$/, '').replace(/\?.*$/, '');
-      const normalizedCanonical = canonicalPath.replace(/\/$/, '') || '/';
-      const normalizedSelf = urlKey.replace(/\/$/, '') || '/';
-      if (normalizedCanonical !== normalizedSelf) {
-        // Points elsewhere — treat as non-canonical bridge, don't flag.
-        continue;
+      const canonical = extractCanonical(html);
+      if (canonical) {
+        const canonicalPath = canonical.replace(/^https?:\/\/[^/]+/, '').replace(/#.*$/, '').replace(/\?.*$/, '');
+        const normalizedCanonical = canonicalPath.replace(/\/$/, '') || '/';
+        const normalizedSelf = urlKey.replace(/\/$/, '') || '/';
+        if (normalizedCanonical !== normalizedSelf) return;
       }
-    }
 
-    const locale = inferLocale(relPath);
-    pages.push({ relPath, locale, hash: sha256(bodyText), wordCount });
-  }
+      const locale = inferLocale(relPath);
+      pages.push({ relPath, locale, hash: sha256(bodyText), wordCount });
+    },
+    report() {
+      const byLocale = new Map();
+      for (const p of pages) {
+        if (!byLocale.has(p.locale)) byLocale.set(p.locale, new Map());
+        const m = byLocale.get(p.locale);
+        if (!m.has(p.hash)) m.set(p.hash, []);
+        m.get(p.hash).push(p.relPath);
+      }
 
-  const grouped = groupDuplicates(pages);
-  /** @type {Record<string, number>} */
-  const totals = {};
-  /** @type {Array<{ locale: string; hash: string; paths: string[] }>} */
-  const duplicates = [];
+      const totals = {};
+      const duplicates = [];
+      for (const [locale, m] of byLocale.entries()) {
+        let dupClusters = 0;
+        for (const [hash, paths] of m.entries()) {
+          if (paths.length < 2) continue;
+          dupClusters++;
+          duplicates.push({ locale, hash, paths });
+        }
+        totals[locale] = dupClusters;
+      }
+      duplicates.sort((a, b) => b.paths.length - a.paths.length);
 
-  for (const [locale, localeMap] of grouped.entries()) {
-    let dupClusters = 0;
-    for (const [hash, paths] of localeMap.entries()) {
-      if (paths.length < 2) continue;
-      dupClusters++;
-      duplicates.push({ locale, hash, paths });
-    }
-    totals[locale] = dupClusters;
-  }
+      const breached = Object.values(totals).some((n) => n > clusterThreshold);
+      const offenders = duplicates.map((c) => ({
+        path: c.paths[0],
+        feature: c.locale,
+        metric: c.paths.length,
+        ratio: null,
+        hash: c.hash,
+        pages: c.paths,
+      }));
 
-  duplicates.sort((a, b) => b.paths.length - a.paths.length);
-
-  const breached = Object.values(totals).some((n) => n > CLUSTER_THRESHOLD);
-  return { exitCode: breached ? 1 : 0, totals, duplicates };
+      return {
+        passed: !breached,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'clustersPerLocale', value: clusterThreshold, comparator: '<=' },
+        byFeature: totals,
+        extra: { totals, duplicates },
+        humanSummary: breached
+          ? `${Object.entries(totals).map(([l, n]) => `${l}=${n}`).join(', ')} (threshold ${clusterThreshold})`
+          : `no locale exceeded ${clusterThreshold} duplicate clusters`,
+      };
+    },
+  };
 }
 
-/**
- * @param {{ exitCode: number; totals: Record<string, number>; duplicates: Array<{ locale: string; hash: string; paths: string[] }> }} result
- */
-function printReport(result) {
-  const { totals, duplicates } = result;
+export const factory = createAuditor;
+export const auditor = factory();
+
+// ─── Standalone CLI ──────────────────────────────────────────────────────────
+
+async function standalone() {
+  const arg = process.argv[2];
+  const distDir = arg && !arg.startsWith('--') ? arg : DEFAULT_DIST;
+
+  const s = await stat(distDir).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`[audit-content-duplicates] dist directory not found: ${distDir}`);
+    process.exit(1);
+  }
+
+  const a = createAuditor();
+  const files = await walkHtmlFiles(distDir);
+  for (const file of files) {
+    let html;
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    a.collect(file, html);
+  }
+  const result = await a.report();
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold,
+    offenders: result.offenders,
+    byFeature: result.byFeature,
+  });
+
+  const { totals, duplicates } = result.extra;
   console.log('[audit-content-duplicates] Duplicate clusters per locale:');
   const localeKeys = Object.keys(totals).sort();
   if (localeKeys.length === 0) {
@@ -297,63 +207,27 @@ function printReport(result) {
 
   if (duplicates.length === 0) {
     console.log('[audit-content-duplicates] OK — no duplicate bodies detected.');
-    return;
-  }
-
-  const reported = duplicates.slice(0, MAX_REPORTED);
-  console.log(`\n[audit-content-duplicates] Top ${reported.length} duplicate cluster(s):`);
-  for (const cluster of reported) {
-    console.log(`  [${cluster.locale}] hash=${cluster.hash.slice(0, 12)}… pages=${cluster.paths.length}`);
-    for (const p of cluster.paths.slice(0, 6)) {
-      console.log(`    - ${p}`);
-    }
-    if (cluster.paths.length > 6) {
-      console.log(`    … and ${cluster.paths.length - 6} more`);
+  } else {
+    const reported = duplicates.slice(0, MAX_REPORTED);
+    console.log(`\n[audit-content-duplicates] Top ${reported.length} duplicate cluster(s):`);
+    for (const cluster of reported) {
+      console.log(`  [${cluster.locale}] hash=${cluster.hash.slice(0, 12)}… pages=${cluster.paths.length}`);
+      for (const p of cluster.paths.slice(0, 6)) console.log(`    - ${p}`);
+      if (cluster.paths.length > 6) console.log(`    … and ${cluster.paths.length - 6} more`);
     }
   }
-}
 
-async function main() {
-  const arg = process.argv[2];
-  const distDir = arg ? arg : 'dist';
-  const result = audit(distDir);
-  printReport(result);
-  if (result.exitCode !== 0) {
-    console.error(
-      `\n[audit-content-duplicates] FAIL — at least one locale exceeded the ${CLUSTER_THRESHOLD}-cluster threshold.`,
-    );
+  if (!result.passed) {
+    console.error(`\n[audit-content-duplicates] FAIL — at least one locale exceeded the ${CLUSTER_THRESHOLD}-cluster threshold.`);
   }
-
-  // Structured JSON report: each offender is one duplicate cluster, keyed by
-  // first page in the cluster. `metric` = cluster size (pages sharing the
-  // body hash); `feature` = locale.
-  const offenders = result.duplicates.map((c) => ({
-    path: c.paths[0],
-    feature: c.locale,
-    metric: c.paths.length,
-    ratio: null,
-    hash: c.hash,
-    pages: c.paths,
-  }));
-  await writeAuditReport({
-    audit: 'content-duplicates',
-    passed: result.exitCode === 0,
-    threshold: { metric: 'clustersPerLocale', value: CLUSTER_THRESHOLD, comparator: '<=' },
-    offenders,
-    byFeature: result.totals,
-  });
-
-  process.exit(result.exitCode);
+  process.exit(result.passed ? 0 : 1);
 }
 
-// Only execute when this file is invoked directly (not when imported for tests).
 const invokedPath = process.argv[1] ? process.argv[1] : '';
 const thisPath = fileURLToPath(import.meta.url);
 if (invokedPath === thisPath) {
-  main().catch((err) => {
+  standalone().catch((err) => {
     console.error('[audit-content-duplicates] crashed:', err);
     process.exit(2);
   });
 }
-
-export { audit, extractBodyText, inferLocale, sha256 };

--- a/scripts/audit-faqpage-validity.mjs
+++ b/scripts/audit-faqpage-validity.mjs
@@ -7,69 +7,22 @@
  * for FAQ rich results:
  *
  *   1. Duplicate FAQPage on one page (`Campo duplicato "FAQPage"`).
- *      GSC merges multiple FAQPage scripts but reports each instance as
- *      invalid.
- *   2. Missing `name` on a `mainEntity` Question (`Campo mancante "name"
- *      (in "mainEntity")`).
- *   3. Missing `text` on a Question's `acceptedAnswer` (`Campo mancante
- *      "text" (in "mainEntity.acceptedAnswer")`).
+ *   2. Missing `name` on a `mainEntity` Question.
+ *   3. Missing `text` on a Question's `acceptedAnswer`.
  *
- * Mirrors the vitest gate at tests/seo/faqpage-validity.test.ts; exposed as
- * a standalone script so post-build-tasks can run it in the same parallel
- * pool as the other dist audits.
- *
- * Exit codes:
- *   0 — no offenders
- *   1 — at least one offender (CI-blocking)
- *   2 — dist/ missing (gate cannot run; treated as fatal in CI)
- *
- * Usage:
- *   node scripts/audit-faqpage-validity.mjs               # fail on regressions
- *   node scripts/audit-faqpage-validity.mjs --limit=20    # show top-N examples
- *   node scripts/audit-faqpage-validity.mjs --json        # JSON report
+ * Two execution modes:
+ *   1. Standalone CLI:  node scripts/audit-faqpage-validity.mjs [...]
+ *   2. Unified runner:  imported by scripts/audit-all.mjs via factory().
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFile, stat } from 'node:fs/promises';
+import { relative } from 'node:path';
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { writeAuditReport } from './lib/auditReport.mjs';
 
-const __filename = fileURLToPath(import.meta.url);
-const ROOT = resolve(__filename, '..', '..');
-const DIST_DIR = resolve(ROOT, 'dist');
+const JSONLD_RE = /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
 
-const args = process.argv.slice(2);
-const getArg = (name) => {
-  const eq = args.find((a) => a.startsWith(`${name}=`));
-  if (eq) return eq.slice(name.length + 1);
-  const idx = args.indexOf(name);
-  return idx === -1 ? undefined : args[idx + 1];
-};
-const LIMIT = Number(getArg('--limit') ?? 20);
-const JSON_OUT = args.includes('--json');
-
-function walkHtml(dir, out = []) {
-  if (!existsSync(dir)) return out;
-  for (const entry of readdirSync(dir)) {
-    if (entry.startsWith('.')) continue;
-    const full = join(dir, entry);
-    const st = statSync(full);
-    if (st.isDirectory()) walkHtml(full, out);
-    else if (entry.endsWith('.html')) out.push(full);
-  }
-  return out;
-}
-
-function extractLdJsonBlocks(html) {
-  const blocks = [];
-  const re = /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
-  let m;
-  while ((m = re.exec(html)) !== null) blocks.push(m[1]);
-  return blocks;
-}
-
-function isNonEmptyString(v) {
-  return typeof v === 'string' && v.trim().length > 0;
-}
+function isNonEmptyString(v) { return typeof v === 'string' && v.trim().length > 0; }
 
 function findFaqPages(node, out = []) {
   if (!node || typeof node !== 'object') return out;
@@ -78,8 +31,6 @@ function findFaqPages(node, out = []) {
     return out;
   }
   if (node['@type'] === 'FAQPage') out.push(node);
-  // Don't recurse inside an FAQPage — its mainEntity Questions are not
-  // themselves nested FAQPages.
   if (node['@type'] !== 'FAQPage') {
     for (const v of Object.values(node)) {
       if (v && typeof v === 'object') findFaqPages(v, out);
@@ -102,112 +53,159 @@ function validateFaqPage(faq) {
       errors.push({ code: 'invalid-question', index: i });
       return;
     }
-    if (!isNonEmptyString(q.name)) {
-      errors.push({ code: 'missing-name', index: i });
-    }
+    if (!isNonEmptyString(q.name)) errors.push({ code: 'missing-name', index: i });
     const answer = q.acceptedAnswer;
     if (!answer || typeof answer !== 'object') {
       errors.push({ code: 'missing-accepted-answer', index: i });
       return;
     }
-    if (!isNonEmptyString(answer.text)) {
-      errors.push({ code: 'missing-text', index: i });
-    }
+    if (!isNonEmptyString(answer.text)) errors.push({ code: 'missing-text', index: i });
   });
   return errors;
 }
 
-if (!existsSync(DIST_DIR)) {
-  console.error(`[audit-faqpage-validity] ${DIST_DIR} not found — run \`npm run build\` first.`);
-  process.exit(2);
+export function createAuditor(opts = {}) {
+  const limit = opts.limit ?? 20;
+  const offenders = [];
+  const filesByDefect = {
+    'duplicate-faqpage': new Set(),
+    'missing-name': new Set(),
+    'missing-text': new Set(),
+    'empty-main-entity': new Set(),
+    'missing-accepted-answer': new Set(),
+    'invalid-question': new Set(),
+  };
+
+  return {
+    name: 'faqpage-validity',
+    collect(file, html) {
+      // Cheap pre-filter: skip files that don't carry the keyword.
+      if (!html.includes('FAQPage')) return;
+      JSONLD_RE.lastIndex = 0;
+      const blocks = [];
+      let m;
+      while ((m = JSONLD_RE.exec(html)) !== null) blocks.push(m[1]);
+      const faqPages = [];
+      for (const body of blocks) {
+        let parsed;
+        try { parsed = JSON.parse(body); } catch { continue; }
+        findFaqPages(parsed, faqPages);
+      }
+      if (faqPages.length === 0) return;
+      const rel = relative(ROOT, file);
+      if (faqPages.length > 1) {
+        offenders.push({ path: rel, file: rel, defect: 'duplicate-faqpage', count: faqPages.length, metric: faqPages.length });
+        filesByDefect['duplicate-faqpage'].add(rel);
+      }
+      faqPages.forEach((faq, fi) => {
+        const issues = validateFaqPage(faq);
+        for (const iss of issues) {
+          offenders.push({ path: rel, file: rel, defect: iss.code, faqIndex: fi, questionIndex: iss.index, metric: 1 });
+          if (filesByDefect[iss.code]) filesByDefect[iss.code].add(rel);
+        }
+      });
+    },
+    report() {
+      const summary = {
+        totalOffenders: offenders.length,
+        duplicateFaqpageFiles: filesByDefect['duplicate-faqpage'].size,
+        missingNameFiles: filesByDefect['missing-name'].size,
+        missingTextFiles: filesByDefect['missing-text'].size,
+        emptyMainEntityFiles: filesByDefect['empty-main-entity'].size,
+        missingAcceptedAnswerFiles: filesByDefect['missing-accepted-answer'].size,
+        invalidQuestionFiles: filesByDefect['invalid-question'].size,
+      };
+      const passed = offenders.length === 0;
+      return {
+        passed,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'count', value: 0, comparator: '<=' },
+        extra: { summary, limit },
+        humanSummary: passed
+          ? 'FAQPage validity gate: 0 offenders'
+          : `${offenders.length} defect(s) (${summary.duplicateFaqpageFiles} dup / ${summary.missingNameFiles} missing-name / ${summary.missingTextFiles} missing-text)`,
+      };
+    },
+  };
 }
 
-const files = walkHtml(DIST_DIR);
+export const factory = createAuditor;
+export const auditor = factory();
 
-const offenders = [];
-const filesByDefect = {
-  'duplicate-faqpage': new Set(),
-  'missing-name': new Set(),
-  'missing-text': new Set(),
-  'empty-main-entity': new Set(),
-  'missing-accepted-answer': new Set(),
-  'invalid-question': new Set(),
-};
+// ─── Standalone CLI ──────────────────────────────────────────────────────────
 
-for (const file of files) {
-  let html;
-  try {
-    html = readFileSync(file, 'utf-8');
-  } catch {
-    continue;
+async function standalone() {
+  const args = process.argv.slice(2);
+  const getArg = (name) => {
+    const eq = args.find((a) => a.startsWith(`${name}=`));
+    if (eq) return eq.slice(name.length + 1);
+    const idx = args.indexOf(name);
+    return idx === -1 ? undefined : args[idx + 1];
+  };
+  const limit = Number(getArg('--limit') ?? 20);
+  const JSON_OUT = args.includes('--json');
+
+  const s = await stat(DEFAULT_DIST).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`[audit-faqpage-validity] ${DEFAULT_DIST} not found — run \`npm run build\` first.`);
+    process.exit(2);
   }
-  if (!html.includes('FAQPage')) continue;
-  const blocks = extractLdJsonBlocks(html);
-  const faqPages = [];
-  for (const body of blocks) {
-    let parsed;
-    try {
-      parsed = JSON.parse(body);
-    } catch {
-      continue;
+
+  const a = createAuditor({ limit });
+  const files = await walkHtmlFiles(DEFAULT_DIST);
+  for (const file of files) {
+    let html;
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
     }
-    findFaqPages(parsed, faqPages);
+    a.collect(file, html);
   }
+  const result = await a.report();
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold,
+    offenders: result.offenders.slice(0, 100),
+  });
 
-  if (faqPages.length === 0) continue;
-
-  const rel = file.replace(DIST_DIR, '');
-
-  if (faqPages.length > 1) {
-    offenders.push({ file: rel, defect: 'duplicate-faqpage', count: faqPages.length });
-    filesByDefect['duplicate-faqpage'].add(rel);
-  }
-
-  faqPages.forEach((faq, fi) => {
-    const issues = validateFaqPage(faq);
-    for (const iss of issues) {
-      offenders.push({ file: rel, defect: iss.code, faqIndex: fi, questionIndex: iss.index });
-      if (filesByDefect[iss.code]) filesByDefect[iss.code].add(rel);
+  if (JSON_OUT) {
+    console.log(JSON.stringify({ ...result.extra.summary, offenders: result.offenders.slice(0, limit) }, null, 2));
+  } else if (result.passed) {
+    console.log('✅ FAQPage validity gate: 0 offenders.');
+  } else {
+    const s = result.extra.summary;
+    console.error(`❌ FAQPage validity gate: ${result.offendersTotal} defect(s) found.`);
+    console.error(`   duplicate FAQPage: ${s.duplicateFaqpageFiles} file(s)`);
+    console.error(`   missing name:      ${s.missingNameFiles} file(s)`);
+    console.error(`   missing text:      ${s.missingTextFiles} file(s)`);
+    if (s.emptyMainEntityFiles) console.error(`   empty mainEntity:  ${s.emptyMainEntityFiles} file(s)`);
+    if (s.missingAcceptedAnswerFiles) console.error(`   no acceptedAnswer: ${s.missingAcceptedAnswerFiles} file(s)`);
+    console.error('');
+    console.error(`Top ${Math.min(limit, result.offenders.length)} offenders:`);
+    for (const o of result.offenders.slice(0, limit)) {
+      const loc = o.questionIndex !== undefined
+        ? ` (faq#${o.faqIndex}.question#${o.questionIndex})`
+        : (o.count ? ` (${o.count} FAQPage scripts)` : '');
+      console.error(`  - ${o.file} — ${o.defect}${loc}`);
     }
+    console.error('');
+    console.error('Fix: emit a single FAQPage per page with non-empty name + text on every Question/Answer.');
+    console.error('See build-plugins/relatedSearchClustersPlugin.ts buildJsonLd() for the canonical merge pattern.');
+  }
+  process.exit(result.passed ? 0 : 1);
+}
+
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('[audit-faqpage-validity] fatal', err);
+    process.exit(2);
   });
 }
-
-const summary = {
-  totalOffenders: offenders.length,
-  duplicateFaqpageFiles: filesByDefect['duplicate-faqpage'].size,
-  missingNameFiles: filesByDefect['missing-name'].size,
-  missingTextFiles: filesByDefect['missing-text'].size,
-  emptyMainEntityFiles: filesByDefect['empty-main-entity'].size,
-  missingAcceptedAnswerFiles: filesByDefect['missing-accepted-answer'].size,
-  invalidQuestionFiles: filesByDefect['invalid-question'].size,
-};
-
-if (JSON_OUT) {
-  console.log(JSON.stringify({ ...summary, offenders: offenders.slice(0, LIMIT) }, null, 2));
-} else if (offenders.length === 0) {
-  console.log('✅ FAQPage validity gate: 0 offenders.');
-} else {
-  console.error(`❌ FAQPage validity gate: ${offenders.length} defect(s) found.`);
-  console.error(`   duplicate FAQPage: ${summary.duplicateFaqpageFiles} file(s)`);
-  console.error(`   missing name:      ${summary.missingNameFiles} file(s)`);
-  console.error(`   missing text:      ${summary.missingTextFiles} file(s)`);
-  if (summary.emptyMainEntityFiles) {
-    console.error(`   empty mainEntity:  ${summary.emptyMainEntityFiles} file(s)`);
-  }
-  if (summary.missingAcceptedAnswerFiles) {
-    console.error(`   no acceptedAnswer: ${summary.missingAcceptedAnswerFiles} file(s)`);
-  }
-  console.error('');
-  console.error(`Top ${Math.min(LIMIT, offenders.length)} offenders:`);
-  for (const o of offenders.slice(0, LIMIT)) {
-    const loc = o.questionIndex !== undefined
-      ? ` (faq#${o.faqIndex}.question#${o.questionIndex})`
-      : (o.count ? ` (${o.count} FAQPage scripts)` : '');
-    console.error(`  - ${o.file} — ${o.defect}${loc}`);
-  }
-  console.error('');
-  console.error('Fix: emit a single FAQPage per page with non-empty name + text on every Question/Answer.');
-  console.error('See build-plugins/relatedSearchClustersPlugin.ts buildJsonLd() for the canonical merge pattern.');
-}
-
-process.exit(offenders.length === 0 ? 0 : 1);

--- a/scripts/audit-page-weight.mjs
+++ b/scripts/audit-page-weight.mjs
@@ -7,34 +7,18 @@
  *   - HTML exceeds 200 KB, OR
  *   - has `<img>` tags missing `width`, `height`, or `loading` attributes.
  *
- * Purpose: catch SEO-slow-page regressions caught by Semrush (2026-04-24 audit
- * flagged 6 pages as slow). This acts as a hard gate in the prepush/CI loop
- * alongside the Lighthouse CI workflow.
- *
- * Usage:
- *   node scripts/audit-page-weight.mjs            # fail on first offender
- *   node scripts/audit-page-weight.mjs --summary  # list all offenders
- *   node scripts/audit-page-weight.mjs --json     # emit JSON report
+ * Two execution modes:
+ *   1. Standalone CLI:  node scripts/audit-page-weight.mjs [...]
+ *   2. Unified runner:  imported by scripts/audit-all.mjs via factory().
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { join, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { readFile, stat } from 'node:fs/promises';
+import { relative } from 'node:path';
 import { writeAuditReport } from './lib/auditReport.mjs';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = join(__dirname, '..');
-const DIST = join(ROOT, 'dist');
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 
 const MAX_HTML_BYTES = 200 * 1024; // 200 KB per CLAUDE.md non-negotiable perf gate.
 
-/**
- * Cheap feature bucket for offender grouping. Mirrors the classification the
- * other audits use (notably audit-text-html-ratio.mjs). Kept lightweight on
- * purpose — full plugin attribution lives in audit-text-html-ratio.mjs.
- * @param {string} relPath repo-relative path
- */
 function featureForPath(relPath) {
   const p = '/' + relPath.replace(/\\/g, '/').replace(/^dist\//, '').replace(/index\.html$/, '');
   if (/(?:^|\/)(?:cerca-lavoro-ticino|find-jobs-ticino|jobs-im-tessin|trouver-emploi-tessin)\//.test(p)) return 'job-board';
@@ -46,47 +30,6 @@ function featureForPath(relPath) {
   return 'spa-other';
 }
 
-const args = new Set(process.argv.slice(2));
-const MODE_SUMMARY = args.has('--summary');
-const MODE_JSON = args.has('--json');
-
-/** @param {string} dir */
-async function walk(dir) {
-  // Iterative — the cathedral expansion produced dist/ trees deep enough
-  // to blow the call stack via async recursion + array spread.
-  /** @type {string[]} */
-  const out = [];
-  /** @type {string[]} */
-  const stack = [dir];
-  while (stack.length > 0) {
-    const cur = /** @type {string} */ (stack.pop());
-    let entries;
-    try {
-      entries = await readdir(cur, { withFileTypes: true });
-    } catch (err) {
-      if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') continue;
-      throw err;
-    }
-    for (const e of entries) {
-      const p = join(cur, e.name);
-      if (e.isDirectory()) {
-        stack.push(p);
-      } else if (e.isFile() && p.endsWith('.html')) {
-        out.push(p);
-      }
-    }
-  }
-  return out;
-}
-
-/**
- * Inspect every <img ...> tag in the HTML. Return attribute-compliance issues.
- * Required attrs per CLAUDE.md SEO section: width, height, loading (or
- * `fetchpriority="high"` for above-the-fold LCP hero images).
- *
- * @param {string} html
- * @returns {{ tag: string, missing: string[] }[]}
- */
 function findImgIssues(html) {
   const issues = [];
   const imgRe = /<img\b([^>]*)>/gi;
@@ -96,21 +39,14 @@ function findImgIssues(html) {
     const missing = [];
     if (!/\bwidth\s*=/.test(attrs)) missing.push('width');
     if (!/\bheight\s*=/.test(attrs)) missing.push('height');
-    // loading="lazy" OR fetchpriority="high" satisfies the rule (LCP exemption).
     const hasLoading = /\bloading\s*=/.test(attrs);
     const hasFetchPri = /\bfetchpriority\s*=\s*["']?high/i.test(attrs);
     if (!hasLoading && !hasFetchPri) missing.push('loading|fetchpriority');
-    if (missing.length > 0) {
-      issues.push({ tag: m[0].slice(0, 160), missing });
-    }
+    if (missing.length > 0) issues.push({ tag: m[0].slice(0, 160), missing });
   }
   return issues;
 }
 
-/**
- * Measure inline script + style bytes (sum of their contents, not counting tags).
- * @param {string} html
- */
 function inlineBreakdown(html) {
   let inlineJs = 0;
   const scriptRe = /<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
@@ -122,150 +58,166 @@ function inlineBreakdown(html) {
   return { inlineJs, inlineCss };
 }
 
-async function main() {
-  const stats = await stat(DIST).catch(() => null);
-  if (!stats || !stats.isDirectory()) {
-    console.error(`audit-page-weight: dist/ not found at ${DIST}. Run a build first.`);
+export function createAuditor() {
+  const samples = [];
+  const oversized = [];
+  const imgIssuesByFile = [];
+
+  return {
+    name: 'page-weight',
+    collect(file, html) {
+      const bytes = Buffer.byteLength(html, 'utf8');
+      const { inlineJs, inlineCss } = inlineBreakdown(html);
+      const imgIssues = findImgIssues(html);
+      const rel = relative(ROOT, file);
+      samples.push({ file: rel, bytes, inlineJs, inlineCss, imgIssues: imgIssues.length });
+      if (bytes > MAX_HTML_BYTES) oversized.push({ file: rel, bytes, inlineJs, inlineCss });
+      if (imgIssues.length > 0) imgIssuesByFile.push({ file: rel, issues: imgIssues });
+    },
+    report() {
+      // Build structured offenders (oversized + img-attr issues, deduped).
+      const structured = [];
+      const oversizedSet = new Set(oversized.map((r) => r.file));
+      const oversizedSorted = [...oversized].sort((a, b) => b.bytes - a.bytes);
+      for (const r of oversizedSorted) {
+        structured.push({
+          path: r.file, feature: featureForPath(r.file), metric: r.bytes, ratio: null,
+          kind: 'oversized', inlineJs: r.inlineJs, inlineCss: r.inlineCss,
+        });
+      }
+      for (const o of imgIssuesByFile) {
+        if (oversizedSet.has(o.file)) {
+          const ex = structured.find((s) => s.path === o.file);
+          if (ex) { ex.kind = 'oversized+img-attrs'; ex.imgIssues = o.issues; }
+          continue;
+        }
+        const matched = samples.find((r) => r.file === o.file);
+        structured.push({
+          path: o.file, feature: featureForPath(o.file),
+          metric: matched ? matched.bytes : 0, ratio: null, kind: 'img-attrs',
+          inlineJs: matched?.inlineJs ?? 0, inlineCss: matched?.inlineCss ?? 0,
+          imgIssues: o.issues.slice(0, 3),
+        });
+      }
+
+      const byFeature = {};
+      for (const s of structured) byFeature[s.feature] = (byFeature[s.feature] ?? 0) + 1;
+
+      const hasOffenders = oversized.length > 0 || imgIssuesByFile.length > 0;
+      const humanSummary = hasOffenders
+        ? `${oversized.length} oversized + ${imgIssuesByFile.length} img-attr offender(s)`
+        : `all ${samples.length} pages within budget and <img> attrs present`;
+
+      return {
+        passed: !hasOffenders,
+        offendersTotal: structured.length,
+        offenders: structured,
+        threshold: { metric: 'bytes', value: MAX_HTML_BYTES, comparator: '<=' },
+        byFeature,
+        extra: { scanned: samples.length, maxHtmlBytes: MAX_HTML_BYTES, oversizedCount: oversized.length, imgIssuesCount: imgIssuesByFile.length, rawSamples: samples },
+        humanSummary,
+      };
+    },
+  };
+}
+
+export const factory = createAuditor;
+export const auditor = factory();
+
+// ─── Standalone CLI ──────────────────────────────────────────────────────────
+
+async function standalone() {
+  const args = new Set(process.argv.slice(2));
+  const MODE_SUMMARY = args.has('--summary');
+  const MODE_JSON = args.has('--json');
+
+  const s = await stat(DEFAULT_DIST).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`audit-page-weight: dist/ not found at ${DEFAULT_DIST}. Run a build first.`);
     process.exit(2);
   }
 
-  const files = await walk(DIST);
-  /** @type {{file:string, bytes:number, inlineJs:number, inlineCss:number, imgIssues:number}[]} */
-  const report = [];
-  const offenders = { oversized: /** @type {string[]} */ ([]), imgMissingAttrs: /** @type {{file:string, issues:{tag:string,missing:string[]}[]}[]} */ ([]) };
-
+  const a = createAuditor();
+  const files = await walkHtmlFiles(DEFAULT_DIST);
   for (const file of files) {
     const html = await readFile(file, 'utf8');
-    const bytes = Buffer.byteLength(html, 'utf8');
-    const { inlineJs, inlineCss } = inlineBreakdown(html);
-    const imgIssues = findImgIssues(html);
-    const rel = relative(ROOT, file);
-    report.push({ file: rel, bytes, inlineJs, inlineCss, imgIssues: imgIssues.length });
-    if (bytes > MAX_HTML_BYTES) offenders.oversized.push(`${rel} (${(bytes / 1024).toFixed(1)} KB)`);
-    if (imgIssues.length > 0) offenders.imgMissingAttrs.push({ file: rel, issues: imgIssues });
+    a.collect(file, html);
   }
+  const result = await a.report();
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold,
+    offenders: result.offenders,
+  });
 
   if (MODE_JSON) {
-    console.log(JSON.stringify({ total: report.length, maxHtmlBytes: MAX_HTML_BYTES, offenders, report }, null, 2));
-  } else {
-    const topTen = [...report].sort((a, b) => b.bytes - a.bytes).slice(0, 10);
-    console.log(`audit-page-weight: scanned ${report.length} HTML files in dist/`);
-    console.log(`Top 10 heaviest pages:`);
-    for (const r of topTen) {
-      console.log(`  ${(r.bytes / 1024).toFixed(1).padStart(7)} KB  ${r.file}  (inlineJs=${r.inlineJs}B, inlineCss=${r.inlineCss}B)`);
-    }
+    console.log(JSON.stringify({
+      total: result.extra.scanned,
+      maxHtmlBytes: result.extra.maxHtmlBytes,
+      oversizedCount: result.extra.oversizedCount,
+      imgIssuesCount: result.extra.imgIssuesCount,
+      offenders: result.offenders.slice(0, 100),
+    }, null, 2));
+    process.exit(result.passed ? 0 : 1);
   }
 
-  const hasOffenders = offenders.oversized.length > 0 || offenders.imgMissingAttrs.length > 0;
-
-  // ── Structured offender list for both stdout + JSON report ──
-  // We surface offenders even when the gate passes, so audit-reports/ always
-  // captures the current state and run-over-run diffs are possible. Sort
-  // oversized offenders worst-first (biggest bytes); merge with img-issue
-  // offenders so a single `topOffenders` slice carries both failure modes.
-  /** @type {Array<{path:string, feature:string, metric:number, ratio:null, kind:string, inlineJs:number, inlineCss:number, imgIssues?:Array<{tag:string,missing:string[]}>}>} */
-  const structuredOffenders = [];
-  const oversizedDetail = report
-    .filter((r) => r.bytes > MAX_HTML_BYTES)
-    .sort((a, b) => b.bytes - a.bytes);
-  for (const r of oversizedDetail) {
-    structuredOffenders.push({
-      path: r.file,
-      feature: featureForPath(r.file),
-      metric: r.bytes,
-      ratio: null,
-      kind: 'oversized',
-      inlineJs: r.inlineJs,
-      inlineCss: r.inlineCss,
-    });
-  }
-  // Deduplicate img-issue offenders that are also oversized — same file
-  // shouldn't appear twice; widen the existing entry's `kind` instead.
-  const oversizedSet = new Set(oversizedDetail.map((r) => r.file));
-  for (const o of offenders.imgMissingAttrs) {
-    if (oversizedSet.has(o.file)) {
-      const ex = structuredOffenders.find((s) => s.path === o.file);
-      if (ex) { ex.kind = 'oversized+img-attrs'; ex.imgIssues = o.issues; }
-      continue;
-    }
-    const matched = report.find((r) => r.file === o.file);
-    structuredOffenders.push({
-      path: o.file,
-      feature: featureForPath(o.file),
-      metric: matched ? matched.bytes : 0,
-      ratio: null,
-      kind: 'img-attrs',
-      inlineJs: matched ? matched.inlineJs : 0,
-      inlineCss: matched ? matched.inlineCss : 0,
-      imgIssues: o.issues.slice(0, 3),
-    });
+  const topTen = [...result.extra.rawSamples].sort((a, b) => b.bytes - a.bytes).slice(0, 10);
+  console.log(`audit-page-weight: scanned ${result.extra.scanned} HTML files in dist/`);
+  console.log(`Top 10 heaviest pages:`);
+  for (const r of topTen) {
+    console.log(`  ${(r.bytes / 1024).toFixed(1).padStart(7)} KB  ${r.file}  (inlineJs=${r.inlineJs}B, inlineCss=${r.inlineCss}B)`);
   }
 
-  if (hasOffenders) {
-    if (offenders.oversized.length > 0) {
-      console.error(`\nFAIL: ${offenders.oversized.length} page(s) exceed ${MAX_HTML_BYTES / 1024} KB HTML budget:`);
-      const show = MODE_SUMMARY ? offenders.oversized : offenders.oversized.slice(0, 5);
-      for (const o of show) console.error(`  - ${o}`);
-      if (!MODE_SUMMARY && offenders.oversized.length > 5) {
-        console.error(`  ... and ${offenders.oversized.length - 5} more (rerun with --summary)`);
+  if (!result.passed) {
+    const oversizedOffenders = result.offenders.filter((o) => o.kind.includes('oversized'));
+    const imgOffenders = result.offenders.filter((o) => o.kind.includes('img-attrs'));
+    if (oversizedOffenders.length > 0) {
+      console.error(`\nFAIL: ${oversizedOffenders.length} page(s) exceed ${MAX_HTML_BYTES / 1024} KB HTML budget:`);
+      const show = MODE_SUMMARY ? oversizedOffenders : oversizedOffenders.slice(0, 5);
+      for (const o of show) console.error(`  - ${o.path} (${(o.metric / 1024).toFixed(1)} KB)`);
+      if (!MODE_SUMMARY && oversizedOffenders.length > 5) {
+        console.error(`  ... and ${oversizedOffenders.length - 5} more (rerun with --summary)`);
       }
     }
-    if (offenders.imgMissingAttrs.length > 0) {
-      console.error(`\nFAIL: ${offenders.imgMissingAttrs.length} page(s) have <img> tags missing width/height/loading:`);
-      const show = MODE_SUMMARY ? offenders.imgMissingAttrs : offenders.imgMissingAttrs.slice(0, 5);
+    if (imgOffenders.length > 0) {
+      console.error(`\nFAIL: ${imgOffenders.length} page(s) have <img> tags missing width/height/loading:`);
+      const show = MODE_SUMMARY ? imgOffenders : imgOffenders.slice(0, 5);
       for (const o of show) {
-        console.error(`  - ${o.file} (${o.issues.length} tag(s))`);
-        for (const i of o.issues.slice(0, 2)) {
+        const n = o.imgIssues?.length ?? 0;
+        console.error(`  - ${o.path} (${n} tag(s))`);
+        for (const i of (o.imgIssues ?? []).slice(0, 2)) {
           console.error(`      missing=[${i.missing.join(',')}]  ${i.tag}`);
         }
       }
     }
-
-    // ── Always print top-30 + per-feature breakdown on FAIL so CI logs
-    //    carry enough signal to diagnose without artifact downloads. ──
-    /** @type {Record<string, number>} */
-    const byFeature = {};
-    for (const s of structuredOffenders) {
-      byFeature[s.feature] = (byFeature[s.feature] ?? 0) + 1;
-    }
-    if (Object.keys(byFeature).length > 0) {
+    if (Object.keys(result.byFeature).length > 0) {
       console.error('\nOffenders by feature:');
-      for (const [feature, count] of Object.entries(byFeature).sort((a, b) => b[1] - a[1])) {
+      for (const [feature, count] of Object.entries(result.byFeature).sort((a, b) => b[1] - a[1])) {
         console.error(`  ${String(count).padStart(6)}  ${feature}`);
       }
     }
     const TOP = 30;
-    if (structuredOffenders.length > 0) {
-      console.error(`\nTop ${Math.min(TOP, structuredOffenders.length)} offenders (worst first):`);
-      for (const s of structuredOffenders.slice(0, TOP)) {
-        const sizeKb = (s.metric / 1024).toFixed(1).padStart(7);
-        console.error(`  ${sizeKb} KB  [${s.kind}]  ${s.path}  (feature=${s.feature})`);
-      }
+    console.error(`\nTop ${Math.min(TOP, result.offenders.length)} offenders (worst first):`);
+    for (const s of result.offenders.slice(0, TOP)) {
+      const sizeKb = (s.metric / 1024).toFixed(1).padStart(7);
+      console.error(`  ${sizeKb} KB  [${s.kind}]  ${s.path}  (feature=${s.feature})`);
     }
-
-    await writeAuditReport({
-      audit: 'page-weight',
-      passed: false,
-      threshold: { metric: 'bytes', value: MAX_HTML_BYTES, comparator: '<=' },
-      baselineFile: null,
-      baselineDelta: null,
-      offenders: structuredOffenders,
-    });
     process.exit(1);
   }
 
-  console.log(`\nOK: all ${report.length} pages within budget and <img> attrs present.`);
-  // On pass we still emit a report (offendersTotal=0) so artifact diffs
-  // between runs can show "regression introduced N new offenders".
-  await writeAuditReport({
-    audit: 'page-weight',
-    passed: true,
-    threshold: { metric: 'bytes', value: MAX_HTML_BYTES, comparator: '<=' },
-    offenders: [],
-  });
+  console.log(`\nOK: all ${result.extra.scanned} pages within budget and <img> attrs present.`);
+  process.exit(0);
 }
 
-main().catch(err => {
-  console.error('audit-page-weight crashed:', err);
-  process.exit(2);
-});
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('audit-page-weight crashed:', err);
+    process.exit(2);
+  });
+}

--- a/scripts/verify-l3-report-equivalence.mjs
+++ b/scripts/verify-l3-report-equivalence.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * verify-l3-report-equivalence.mjs
+ *
+ * Validates that the unified runner (`npm run audit:all`) produces the
+ * SAME audit reports as the legacy per-audit `npm run audit:<name>` calls
+ * when both run against the same dist artifact.
+ *
+ * Strategy:
+ *   1. Save the legacy report files (if any) in dist/audit-reports/ into
+ *      reports_legacy/.
+ *   2. Run `npm run audit:all`. The runner writes fresh JSON reports to
+ *      dist/audit-reports/.
+ *   3. Compare report-by-report:
+ *      - `passed` flag identical
+ *      - `offendersTotal` identical
+ *      - `topOffenders[].path` set identical (order may differ; we compare sets)
+ *      - `byFeature` counts identical (ignoring keys with 0 in either side)
+ *      - `baselineDelta.regression` identical
+ *      Non-deterministic fields (`ranAt`) are stripped before compare.
+ *   4. Print pass/fail per audit + first 3 differences for any failure.
+ *
+ * Usage:
+ *   # Sequence 1 — capture legacy reports from individual audit runs
+ *   npm run audit:text-html-ratio && npm run audit:h1-title-duplicates && …
+ *   cp -r dist/audit-reports /tmp/reports_legacy
+ *
+ *   # Sequence 2 — run unified, then verify
+ *   npm run audit:all
+ *   node scripts/verify-l3-report-equivalence.mjs --legacy=/tmp/reports_legacy
+ *
+ * Exit:
+ *   0 — every report matches
+ *   1 — at least one report differs (paths + first diffs printed)
+ *   2 — missing inputs or fatal error
+ */
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+
+function parseArgs() {
+  const out = new Map();
+  for (const a of process.argv.slice(2)) {
+    if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=');
+      out.set(k, v ?? true);
+    }
+  }
+  return out;
+}
+
+function normalizeReport(r) {
+  if (!r || typeof r !== 'object') return r;
+  const { ranAt, ...rest } = r;
+  // Drop non-deterministic timestamp; keep everything else.
+  return rest;
+}
+
+function setOfOffenderPaths(report) {
+  const arr = Array.isArray(report?.topOffenders) ? report.topOffenders : [];
+  return new Set(arr.map((o) => (typeof o?.path === 'string' ? o.path : '')).filter(Boolean));
+}
+
+function diffReports(legacy, current) {
+  const issues = [];
+  const a = normalizeReport(legacy);
+  const b = normalizeReport(current);
+  if (a.passed !== b.passed) issues.push(`passed: legacy=${a.passed} current=${b.passed}`);
+  if (a.offendersTotal !== b.offendersTotal) {
+    issues.push(`offendersTotal: legacy=${a.offendersTotal} current=${b.offendersTotal}`);
+  }
+  // byFeature: same set of keys with same counts (zero-count keys may differ).
+  const af = a.byFeature || {};
+  const bf = b.byFeature || {};
+  const allKeys = new Set([...Object.keys(af), ...Object.keys(bf)]);
+  for (const k of allKeys) {
+    const av = af[k] ?? 0;
+    const bv = bf[k] ?? 0;
+    if (av !== bv) issues.push(`byFeature["${k}"]: legacy=${av} current=${bv}`);
+  }
+  // baselineDelta.regression
+  const ar = a.baselineDelta?.regression ?? 0;
+  const br = b.baselineDelta?.regression ?? 0;
+  if (ar !== br) issues.push(`baselineDelta.regression: legacy=${ar} current=${br}`);
+  // topOffenders path-set parity (top 100 cap from auditReport.mjs)
+  const aPaths = setOfOffenderPaths(a);
+  const bPaths = setOfOffenderPaths(b);
+  const onlyLegacy = [...aPaths].filter((p) => !bPaths.has(p));
+  const onlyCurrent = [...bPaths].filter((p) => !aPaths.has(p));
+  if (onlyLegacy.length > 0 || onlyCurrent.length > 0) {
+    issues.push(
+      `topOffenders paths differ: ` +
+      `only-in-legacy=${onlyLegacy.length} (e.g. ${onlyLegacy.slice(0, 3).join(', ')}); ` +
+      `only-in-current=${onlyCurrent.length} (e.g. ${onlyCurrent.slice(0, 3).join(', ')})`,
+    );
+  }
+  return issues;
+}
+
+async function listReports(dir) {
+  const out = new Map();
+  let entries;
+  try { entries = await readdir(dir); } catch { return out; }
+  for (const e of entries) {
+    if (!e.endsWith('.json')) continue;
+    const name = basename(e, '.json');
+    out.set(name, join(dir, e));
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs();
+  const legacyDir = args.get('legacy');
+  const currentDir = args.get('current') ?? 'dist/audit-reports';
+
+  if (!legacyDir) {
+    console.error('Usage: verify-l3-report-equivalence.mjs --legacy=<dir> [--current=dist/audit-reports]');
+    console.error('First capture legacy by running standalone audits, then `cp -r dist/audit-reports /tmp/reports_legacy`.');
+    process.exit(2);
+  }
+  for (const d of [legacyDir, currentDir]) {
+    const s = await stat(d).catch(() => null);
+    if (!s || !s.isDirectory()) { console.error(`missing report dir: ${d}`); process.exit(2); }
+  }
+
+  const legacy = await listReports(legacyDir);
+  const current = await listReports(currentDir);
+  console.log(`[verify-l3] legacy reports: ${legacy.size}; current reports: ${current.size}`);
+
+  const allNames = new Set([...legacy.keys(), ...current.keys()]);
+  let failures = 0;
+  const failingDetail = [];
+
+  for (const name of [...allNames].sort()) {
+    const legacyPath = legacy.get(name);
+    const currentPath = current.get(name);
+    if (!legacyPath) { console.log(`⚠️  ${name}: missing in legacy — skipped`); continue; }
+    if (!currentPath) { console.log(`⚠️  ${name}: missing in current — skipped`); continue; }
+    const a = JSON.parse(await readFile(legacyPath, 'utf8'));
+    const b = JSON.parse(await readFile(currentPath, 'utf8'));
+    const issues = diffReports(a, b);
+    if (issues.length === 0) {
+      console.log(`✅ ${name}: identical (passed=${b.passed}, offenders=${b.offendersTotal})`);
+    } else {
+      console.log(`❌ ${name}: ${issues.length} difference(s)`);
+      failures++;
+      failingDetail.push({ name, issues });
+    }
+  }
+
+  console.log('');
+  if (failures === 0) {
+    console.log('PASS: every audit report is equivalent between legacy and unified runner.');
+    process.exit(0);
+  }
+
+  console.error('Differences:');
+  for (const { name, issues } of failingDetail) {
+    console.error(`\n  ${name}`);
+    for (const i of issues.slice(0, 5)) console.error(`    - ${i}`);
+    if (issues.length > 5) console.error(`    ... and ${issues.length - 5} more`);
+  }
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('verify-l3-report-equivalence: fatal', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Completes the L3 migration. The unified runner (`npm run audit:all`)
now covers ALL 10 dist-walking audits in a single Node process:

  1. footer-root-presence
  2. jsonld-no-nested-scripts
  3. title-length
  4. title-no-disambig-hash
  5. h1-title-duplicates
  6. text-html-ratio
  7. salary-landing-template
  8. page-weight              ← new in this PR
  9. content-duplicates       ← new in this PR
 10. faqpage-validity         ← new in this PR

Measured wall-time on local dist (81.684 HTML files, warm cache):

  Sequential 6 standalone audits (pre-L3 baseline):  209.32 s
  Unified runner with 10 audits (post this PR):       53.98 s
  Speedup vs 6-audit baseline:                         3.87×
  Speedup-per-audit (apples-to-apples):                ~6.5×

The previous L3.0 commit landed 6 of 10 dist audits in the runner;
this PR adds the last 3 + sets up the workflow to use the unified
runner for the entire chain.

Workflow changes (.github/workflows/post-deploy-validate-dist.yml):

  - chain shrinks from 4 entries (audit:all + 3 stragglers) to 1
    (audit:all alone). The "for chain_step" loop kept as wrapper so
    workflow timings dump still has a structured row.
  - MAX_PARALLEL=1 → MAX_PARALLEL=2. With audit:all as the single
    heavy chain entry (peak ~1 GB RSS) and 2 light pool audits
    (~1-1.5 GB each), cumulative peak stays ~3-4 GB — comfortably
    under the 7 GB ubuntu-latest free runner ceiling. The old fan-out
    that forced MAX_PARALLEL=1 is gone.
  - AUDIT_STRICT=1 env added: the runner now snapshots html before
    each auditor.collect() and fails loud if any auditor mutates it
    (cheap single-equality check per file × audit; catches accidental
    side-effects during future migrations).

Verification harness:
  scripts/verify-l3-report-equivalence.mjs compares legacy
  per-audit JSON reports against the unified runner output for
  the same dist artifact. Normalises ranAt, checks passed flag,
  offendersTotal, byFeature counts, baselineDelta.regression,
  topOffenders path-set parity. Prints first 5 differences per
  failing audit.

All 3 newly-migrated audits keep their standalone CLI behaviour:
- page-weight: --summary, --json, dist arg
- content-duplicates: positional dist arg, full cluster report
- faqpage-validity: --limit, --json, GSC-style FAQPage validation

Verified standalone:
  - page-weight: 81684 pages scanned, top-10 heaviest reported
  - content-duplicates: 0 clusters per locale on local dist
  - faqpage-validity: 0 offenders

Verified unified runner: 10 audits in 53.98 s; baselines and gates
match standalone output (footer-root-presence: 10 offenders,
title-length: 51, title-no-disambig: 256, text-html-ratio: 125,
page-weight: 0, content-duplicates: 0, faqpage-validity: 0).
