### PR TITLE
fix(tests): unbreak 4 test files broken by the L1+L2+L3 PR round

### DIFF
--- a/build-plugins/cityJobsAggregate.ts
+++ b/build-plugins/cityJobsAggregate.ts
@@ -369,10 +369,10 @@ export function _resetCityJobsAggregateCache(): void {
 // ── Job-board URL builders ───────────────────────────────────────────────────
 
 const JOB_BOARD_SECTION: Record<ColLocale, string> = {
-  it: 'cerca-lavoro-ticino',
-  en: 'find-jobs-ticino',
-  de: 'jobs-im-tessin',
-  fr: 'trouver-emploi-tessin',
+  it: 'cerca-lavoro-ticino', // cathedral-allow: job-board section→slug map source-of-truth, frozen IT slug
+  en: 'find-jobs-ticino', // cathedral-allow: see cerca-lavoro-ticino note
+  de: 'jobs-im-tessin', // cathedral-allow: see cerca-lavoro-ticino note
+  fr: 'trouver-emploi-tessin', // cathedral-allow: see cerca-lavoro-ticino note
 };
 
 const JOB_BOARD_LOCALE_PREFIX: Record<ColLocale, string> = {

--- a/build-plugins/shared/htmlMinify.ts
+++ b/build-plugins/shared/htmlMinify.ts
@@ -41,7 +41,15 @@ const SAFE_BLOCK_RX =
 // IE conditional comments — preserved verbatim (Outlook + legacy webmail
 // clients still parse them; AdSense + email-style snippets may rely on them).
 const IE_COND_COMMENT_RX = /<!--\[if[\s\S]*?<!\[endif\]-->/gi;
-// Regular HTML comments — stripped.
+// Project-internal placeholder comments that downstream code uses as
+// injection anchors (e.g. `<!--SIBLING_LINKS_PLACEHOLDER-->` in
+// weeklyEmployersPlugin.injectSiblingLinks). Convention: ALL_CAPS plus an
+// underscore (no spaces, no lowercase). Stripping these would break the
+// String.replace() calls that depend on the literal anchor, so we mask
+// them as opaque blocks like IE conditional comments.
+const PLACEHOLDER_COMMENT_RX = /<!--[A-Z][A-Z0-9_]*-->/g;
+// Regular HTML comments — stripped (after the two preserve regexes have
+// already masked their matches).
 const HTML_COMMENT_RX = /<!--[\s\S]*?-->/g;
 
 // Whitespace BETWEEN block-level tags is safe to collapse. Inline tags
@@ -81,6 +89,10 @@ export function minifyHtml(html: string): string {
   const placeholder = (i: number) => `\x00MINIF_SAFE_${i}\x00`;
 
   let masked = html.replace(IE_COND_COMMENT_RX, (m) => {
+    const i = safe.push(m) - 1;
+    return placeholder(i);
+  });
+  masked = masked.replace(PLACEHOLDER_COMMENT_RX, (m) => {
     const i = safe.push(m) - 1;
     return placeholder(i);
   });

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -4197,7 +4197,7 @@ export function renderTopCompaniesSectionForTest(
   const copy = COPY[locale];
   const cityDisplay = 'Test City';
   const hasHistoricalDelta = true;
-  const jobBoardSection = 'cerca-lavoro-ticino';
+  const jobBoardSection = 'cerca-lavoro-ticino'; // cathedral-allow: test-only fixture in renderTopCompaniesSectionForTest (TI is the original IT slug)
   const localePrefix = WEEKLY_EMPLOYERS_LOCALE_PREFIX[locale];
 
   if (topCompanies.length === 0) {

--- a/scripts/lib/audit-runner.mjs
+++ b/scripts/lib/audit-runner.mjs
@@ -35,11 +35,17 @@
 // more RAM, parallelism can be opted into via AUDIT_WORKERS=N (TODO).
 
 import { readFile, readdir, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { writeAuditReport, auditReportPath } from './auditReport.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+// Use the proven `dirname(fileURLToPath(import.meta.url))` pattern instead of
+// `fileURLToPath(new URL('.', import.meta.url))`. The latter throws
+// `ERR_INVALID_URL_SCHEME` when vitest loads this module via a non-file:
+// URL scheme (test runner uses its own bundler resolution). The former
+// works in both runtime + vitest because fileURLToPath() accepts file: URLs
+// directly without re-parsing them through the URL constructor.
+const __dirname = dirname(fileURLToPath(import.meta.url));
 export const ROOT = join(__dirname, '..', '..');
 export const DEFAULT_DIST = join(ROOT, 'dist');
 

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -20,6 +20,7 @@ const ROOT = resolve(import.meta.dirname, '..');
 const VALIDATION_YML = readFileSync(resolve(ROOT, '.github/workflows/post-deploy-validate-dist.yml'), 'utf-8');
 const PACKAGE_JSON = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8'));
 const BATCH_WRITE = readFileSync(resolve(ROOT, 'build-plugins/batchWrite.ts'), 'utf-8');
+const AUDIT_ALL_REGISTRY_SRC = readFileSync(resolve(ROOT, 'scripts/audit-all.mjs'), 'utf-8');
 
 // `audit:title-uniqueness` was moved to a separate weekly workflow because it
 // OOM-killed the parallel block. All remaining gates must stay in parallel.
@@ -32,6 +33,33 @@ const AUDIT_SCRIPTS_IN_PARALLEL_BLOCK = [
   'audit:title-length',
 ] as const;
 
+/**
+ * Parse the REGISTRY block of scripts/audit-all.mjs to extract the set of
+ * audit names that the unified runner wraps. Each entry has the shape
+ *   `{ factory: <ident>, name: '<audit-name>' }` — we match the `name: '…'`
+ * literal so additions to the registry are automatically picked up.
+ */
+function parseAuditAllRegistry(src: string): Set<string> {
+  const out = new Set<string>();
+  const re = /\bname:\s*['"]([a-z][a-z0-9-]*)['"]/g;
+  let m;
+  while ((m = re.exec(src)) !== null) out.add(`audit:${m[1]}`);
+  return out;
+}
+
+const AUDIT_ALL_WRAPS = parseAuditAllRegistry(AUDIT_ALL_REGISTRY_SRC);
+
+/**
+ * Returns true if the workflow invokes the audit either directly via
+ * `npm run audit:<name>` OR transitively via `npm run audit:all` (when the
+ * audit is registered in audit-all.mjs).
+ */
+function isInvokedDirectlyOrViaAuditAll(name: string): boolean {
+  const directRe = new RegExp(`npm run ${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'g');
+  if (directRe.test(VALIDATION_YML)) return true;
+  return AUDIT_ALL_WRAPS.has(name) && /npm run audit:all\b/.test(VALIDATION_YML);
+}
+
 describe('post-deploy-validate-dist.yml — parallel SEO audit gates', () => {
   it('every gate in the parallel block is defined in package.json', () => {
     const scripts = PACKAGE_JSON.scripts || {};
@@ -40,14 +68,15 @@ describe('post-deploy-validate-dist.yml — parallel SEO audit gates', () => {
     }
   });
 
-  it('every gate is invoked in post-deploy-validate-dist.yml', () => {
+  it('every gate is reachable from post-deploy-validate-dist.yml (directly or via audit:all)', () => {
     for (const name of AUDIT_SCRIPTS_IN_PARALLEL_BLOCK) {
-      const re = new RegExp(`npm run ${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'g');
-      const matches = VALIDATION_YML.match(re) || [];
       expect(
-        matches.length,
-        `"${name}" should appear in post-deploy-validate-dist.yml; found ${matches.length}`,
-      ).toBeGreaterThanOrEqual(1);
+        isInvokedDirectlyOrViaAuditAll(name),
+        `"${name}" is unreachable from post-deploy-validate-dist.yml. ` +
+        `Either invoke it directly via \`npm run ${name}\`, or register it in ` +
+        `scripts/audit-all.mjs REGISTRY (audit-all is invoked in workflow). ` +
+        `audit-all currently wraps: ${[...AUDIT_ALL_WRAPS].sort().join(', ')}`,
+      ).toBe(true);
     }
   });
 
@@ -58,25 +87,28 @@ describe('post-deploy-validate-dist.yml — parallel SEO audit gates', () => {
     ).toContain('spawn_capped()');
   });
 
-  it('any new audit:* script added to package.json must be wired into post-deploy-validate-dist.yml', () => {
+  it('any new audit:* script added to package.json must be reachable in post-deploy-validate-dist.yml (direct or via audit:all)', () => {
     // Gates intentionally NOT in the dist-validate parallel block:
     // - `:rebaseline` variants mutate the checked-in baseline; never CI.
     // - `audit:title-uniqueness` runs on a separate weekly workflow because
     //   it OOM-killed the parallel block.
     // - `audit:dist-multi*` are aggregators that wrap other audits.
     // - `audit:parser-quality` is a developer self-test, not gated in CI.
+    // - `audit:all` IS the wrapper itself; reachability check would be circular.
     const GATES_NOT_IN_DIST_PARALLEL = new Set([
       'audit:title-uniqueness',
       'audit:dist-multi',
       'audit:parser-quality',
+      'audit:all',
     ]);
     const allAuditScripts = Object.keys(PACKAGE_JSON.scripts || {}).filter((k) => {
       return /^audit:/.test(k) && !/:rebaseline$/.test(k) && !GATES_NOT_IN_DIST_PARALLEL.has(k);
     });
     for (const name of allAuditScripts) {
       expect(
-        VALIDATION_YML.includes(`npm run ${name}`),
-        `package.json defines "${name}" but post-deploy-validate-dist.yml never invokes it — gate would never run`,
+        isInvokedDirectlyOrViaAuditAll(name),
+        `package.json defines "${name}" but post-deploy-validate-dist.yml has no reachable invocation — ` +
+        `gate would never run. audit:all currently wraps: ${[...AUDIT_ALL_WRAPS].sort().join(', ')}`,
       ).toBe(true);
     }
   });


### PR DESCRIPTION
Four failing tests on main after #341 landed:

1. tests/seo/content-duplicates.test.ts — `ERR_INVALID_URL_SCHEME` at
   scripts/lib/audit-runner.mjs:42. Root cause: vitest loads .mjs via
   a non-file: URL scheme; `fileURLToPath(new URL('.', import.meta.url))`
   throws there. Switch to the proven `dirname(fileURLToPath(import.meta.url))`
   pattern used by every other audit script — works in both runtime + vitest.

2. tests/deploy-workflow.test.ts — gate-presence assertion expected every
   migrated audit (`audit:content-duplicates`, etc.) to appear directly via
   `npm run audit:<name>` in post-deploy-validate-dist.yml. After PR #340
   the workflow only invokes `npm run audit:all`, which wraps the 10
   migrated audits in one Node process. Update the test to parse the
   REGISTRY block of scripts/audit-all.mjs and recognise an audit as
   reachable if it's either invoked directly OR wrapped by audit:all.
   The new helper `isInvokedDirectlyOrViaAuditAll(name)` encapsulates
   both paths.

3. tests/weekly-employers-company-city.test.ts — "injects sibling links
   when siblings are provided" failed because the L2 minifier strips
   `<!--SIBLING_LINKS_PLACEHOLDER-->`, removing the anchor that
   injectSiblingLinks() does String.replace against. After buildSeoPageHtml
   minifies the output, the placeholder is gone, the replace is a no-op,
   and the resulting html doesn't contain the sibling URLs.

   Fix: add `PLACEHOLDER_COMMENT_RX = /<!--[A-Z][A-Z0-9_]*-->/g` to the
   minifier's mask pass, alongside the existing IE conditional comment
   preserve. Convention: ALL_CAPS + underscores (single-word style,
   no spaces) marks a placeholder comment used as an injection anchor.
   Normal comments (`<!-- mixed-case prose -->`) still get stripped.

   Verified end-to-end:
     input : <div><!-- normal --><!--SIBLING_LINKS_PLACEHOLDER--><!--[if IE]>x<![endif]--></div>
     output: <div><!--SIBLING_LINKS_PLACEHOLDER--><!--[if IE]>x<![endif]--></div>

4. tests/seo/cathedral-no-ti-hardcodes.test.ts — flagged 5 unallowlisted
   `cerca-lavoro-ticino`/`find-jobs-ticino`/`jobs-im-tessin`/`trouver-emploi-tessin`
   hardcodes introduced by PR #338:
     - build-plugins/weeklyEmployersPlugin.ts:4200 (test-only renderer fixture)
     - build-plugins/cityJobsAggregate.ts:372-375 (JOB_BOARD_SECTION map source-of-truth)

   These are legitimate source-of-truth literals (slug map definition +
   test fixture), so append `// cathedral-allow: <reason>` to each line
   per the test's documented escape hatch. Same pattern already in use
   throughout build-plugins/staticPagesPlugin.ts:1437-2379.

Verified locally: all 4 test files green (73/73 tests).
