### PR TITLE
ci(firebase): deploy firestore indexes alongside cloud functions

### DIFF
--- a/.github/workflows/deploy-cloud-functions.yml
+++ b/.github/workflows/deploy-cloud-functions.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'functions/**'
+      - 'firestore.indexes.json'
   workflow_dispatch:
 
 permissions:
@@ -50,6 +51,9 @@ jobs:
 
       - name: Deploy Cloud Functions
         run: firebase deploy --only functions --project frontaliere-ticino --force
+
+      - name: Deploy Firestore indexes
+        run: firebase deploy --only firestore:indexes --project frontaliere-ticino
 
       - name: Report failure to Linear
         if: failure()


### PR DESCRIPTION
The collection-group composite indexes declared in firestore.indexes.json
were never being deployed to the Firebase project. As a result,
send-newsletter.mjs and send-job-alerts.mjs collection-group queries on
'alerts' (where active == true) fail with FAILED_PRECONDITION and the
newsletter is silently sent without job-alert matching.

Add a 'Deploy Firestore indexes' step to the cloud-functions workflow
and trigger the workflow whenever firestore.indexes.json changes.
