### PR TITLE
refactor(seo): canonical-cards followups (escHtml DRY + HERO_BADGES expansion + dynamic tiles + file size + tests)

### DIFF
--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -96,6 +96,7 @@ import {
   STAT_TILE_BASE,
   STAT_TILE_LABEL,
   STAT_TILE_VALUE,
+  pickStatTileStyle,
 } from './shared/seoContentTokens';
 import { buildTitleWithBrand } from './shared/titleSuffix';
 import { renderLandingHero, HERO_BADGES } from './shared/landingHeroPersonality';
@@ -218,17 +219,19 @@ function renderStatTiles(
           liveCount: snapshot.liveCount,
         });
 
-  const tile1 = renderTile(
-    templateB.statTile1.label,
-    templateB.statTile1.valueFromCount(tile1Count),
-    templateB.statTile1.tone,
-  );
+  // Dynamic tone: tile1 tracks count (openings-style), tile3 tracks fresh.
+  // tile2 is salary/accent per copy data — keep the copy-specified tone.
+  const tile1DynStyle = pickStatTileStyle('openings', tile1Count);
+  const tile1 = `<div style="${tile1DynStyle}">
+    <div style="${STAT_TILE_LABEL}">${esc(templateB.statTile1.label)}</div>
+    <div style="${STAT_TILE_VALUE}">${esc(templateB.statTile1.valueFromCount(tile1Count))}</div>
+  </div>`;
   const tile2 = renderTile(templateB.statTile2.label, tile2Value, templateB.statTile2.tone);
-  const tile3 = renderTile(
-    templateB.statTile3.label,
-    templateB.statTile3.valueFromFresh(snapshot.fresh30Count),
-    templateB.statTile3.tone,
-  );
+  const tile3DynStyle = pickStatTileStyle('fresh', snapshot.fresh30Count);
+  const tile3 = `<div style="${tile3DynStyle}">
+    <div style="${STAT_TILE_LABEL}">${esc(templateB.statTile3.label)}</div>
+    <div style="${STAT_TILE_VALUE}">${esc(templateB.statTile3.valueFromFresh(snapshot.fresh30Count))}</div>
+  </div>`;
 
   return `<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px;margin:0 0 24px">${tile1}${tile2}${tile3}</div>`;
 }

--- a/build-plugins/costOfLivingLandingsPlugin.ts
+++ b/build-plugins/costOfLivingLandingsPlugin.ts
@@ -133,7 +133,8 @@ const CITY_PAIRED_PROVINCE: Record<ColCityId, Record<ColLocale, string>> = {
 
 // ── Template B renderers ─────────────────────────────────────────────────────
 
-interface CityCopyView {
+/** @internal */
+export interface CityCopyView {
   readonly statTileSalaryLabel: string;
   readonly statTileRentLabel: string;
   readonly statTileLiveJobsLabel: string;
@@ -151,7 +152,8 @@ interface CityCopyView {
   readonly jobSalaryFmt: (min: number | null, max: number | null) => string;
 }
 
-function renderFeaturedJobs(
+/** @internal Exported for test-helper only — not part of the public API. */
+export function renderFeaturedJobs(
   cityId: ColCityId,
   locale: ColLocale,
   snapshot: CityJobsSnapshot,
@@ -200,7 +202,8 @@ function renderFeaturedJobs(
   </section>`;
 }
 
-function renderEmployerGrid(
+/** @internal Exported for test-helper only — not part of the public API. */
+export function renderEmployerGrid(
   snapshot: CityJobsSnapshot,
   view: CityCopyView,
   locale: ColLocale,
@@ -225,34 +228,6 @@ function renderEmployerGrid(
     <h2 style="margin:0 0 12px;font-size:22px;color:var(--color-heading);font-weight:700">${esc(view.employerGridTitle)}</h2>
     ${listHtml}
   </section>`;
-}
-
-/** Exported for unit tests — builds minimal view and delegates to renderEmployerGrid. */
-export function renderCostOfLivingEmployerGridForTest(
-  cityId: ColCityId,
-  locale: ColLocale,
-  snapshot: { topEmployers: ReadonlyArray<{ name: string; count: number }> },
-): string {
-  const L = getLocaleStrings(locale);
-  const cityName = COL_CITY_DISPLAY[cityId][locale];
-  const view: CityCopyView = {
-    statTileSalaryLabel: '',
-    statTileRentLabel: '',
-    statTileLiveJobsLabel: '',
-    statSalaryFmt: () => '',
-    statRentFmt: () => '',
-    statLiveJobsFmt: () => '',
-    primaryCtaLabel: '',
-    featuredJobsTitle: '',
-    featuredJobsCtaAll: '',
-    featuredJobsEmpty: '',
-    featuredFallbackBadge: '',
-    employerGridTitle: L.employerGridTitle(cityName),
-    approfondisciHeading: '',
-    jobPostedLabel: () => '',
-    jobSalaryFmt: () => '',
-  };
-  return renderEmployerGrid(snapshot as CityJobsSnapshot, view, locale, cityId);
 }
 
 function renderApprofondisciDivider(label: string): string {
@@ -811,31 +786,7 @@ export function costOfLivingLandingsPlugin(rootDir: string): Plugin {
   };
 }
 
-// Test-only export: allows tests/build-plugins/job-card-canonical-adoption.test.ts
-// to verify the migrated renderer emits canonical job-card markers.
-export function renderCostOfLivingFeaturedJobsForTest(
-  city: ColCityId,
-  locale: ColLocale,
-  snapshot: CityJobsSnapshot,
-): string {
-  const L = getLocaleStrings(locale);
-  const cityName = COL_CITY_DISPLAY[city][locale];
-  const view: CityCopyView = {
-    statTileSalaryLabel: L.statTileSalaryLabel,
-    statTileRentLabel: L.statTileRentLabel,
-    statTileLiveJobsLabel: L.statTileLiveJobsLabel,
-    statSalaryFmt: L.statSalaryFmt,
-    statRentFmt: L.statRentFmt,
-    statLiveJobsFmt: L.statLiveJobsFmt,
-    primaryCtaLabel: L.primaryCtaLabel(cityName),
-    featuredJobsTitle: L.featuredJobsTitle(cityName),
-    featuredJobsCtaAll: L.featuredJobsCtaAll(cityName, snapshot.liveCount),
-    featuredJobsEmpty: L.featuredJobsEmpty(cityName),
-    featuredFallbackBadge: L.featuredFallbackBadge,
-    employerGridTitle: L.employerGridTitle(cityName),
-    approfondisciHeading: L.approfondisciHeading,
-    jobPostedLabel: L.jobPostedLabel,
-    jobSalaryFmt: L.jobSalaryFmt,
-  };
-  return renderFeaturedJobs(city, locale, snapshot, view);
-}
+export {
+  renderCostOfLivingFeaturedJobsForTest,
+  renderCostOfLivingEmployerGridForTest,
+} from './costOfLivingLandingsTestExports';

--- a/build-plugins/costOfLivingLandingsPlugin.ts
+++ b/build-plugins/costOfLivingLandingsPlugin.ts
@@ -78,6 +78,7 @@ import {
   LEDE_STYLE,
   SMALL_HEADING_STYLE,
   renderStatGrid,
+  pickStatTileTone,
   differentiateH1FromTitle,
 } from './shared/seoContentTokens';
 import {
@@ -468,7 +469,7 @@ function renderPage(opts: {
     {
       label: view.statTileSalaryLabel,
       value: view.statSalaryFmt(snapshot.medianSalaryChf),
-      tone: 'accent',
+      tone: pickStatTileTone('salary', snapshot.medianSalaryChf ?? 0),
     },
     {
       label: view.statTileRentLabel,
@@ -479,8 +480,7 @@ function renderPage(opts: {
     {
       label: view.statTileLiveJobsLabel,
       value: view.statLiveJobsFmt(snapshot.liveCount),
-      // Live jobs are an opportunity signal — green when > 0.
-      tone: snapshot.liveCount > 0 ? 'success' : 'neutral',
+      tone: pickStatTileTone('openings', snapshot.liveCount),
     },
   ])}</div>`;
 

--- a/build-plugins/costOfLivingLandingsTestExports.ts
+++ b/build-plugins/costOfLivingLandingsTestExports.ts
@@ -1,0 +1,83 @@
+/**
+ * Test-only exports for costOfLivingLandingsPlugin.
+ *
+ * Extracted from costOfLivingLandingsPlugin.ts to keep that file below the
+ * 800-line guideline. Production code never imports from this file — it is
+ * consumed only by tests/build-plugins/ that need to call the rendering
+ * helpers without invoking the full Vite plugin build path.
+ *
+ * The two helpers are re-exported from costOfLivingLandingsPlugin.ts so
+ * existing import paths in test files continue to work unchanged.
+ */
+
+import {
+  COL_CITY_DISPLAY,
+  type ColLocale,
+  type ColCityId,
+} from './costOfLivingLandingsData';
+import {
+  getLocaleStrings,
+} from './costOfLivingLandingsCopy';
+import {
+  renderFeaturedJobs,
+  renderEmployerGrid,
+  type CityCopyView,
+} from './costOfLivingLandingsPlugin';
+import type { CityJobsSnapshot } from './cityJobsAggregate';
+
+/** Exported for unit tests — builds minimal view and delegates to renderEmployerGrid. */
+export function renderCostOfLivingEmployerGridForTest(
+  cityId: ColCityId,
+  locale: ColLocale,
+  snapshot: { topEmployers: ReadonlyArray<{ name: string; count: number }> },
+): string {
+  const L = getLocaleStrings(locale);
+  const cityName = COL_CITY_DISPLAY[cityId][locale];
+  const view: CityCopyView = {
+    statTileSalaryLabel: '',
+    statTileRentLabel: '',
+    statTileLiveJobsLabel: '',
+    statSalaryFmt: () => '',
+    statRentFmt: () => '',
+    statLiveJobsFmt: () => '',
+    primaryCtaLabel: '',
+    featuredJobsTitle: '',
+    featuredJobsCtaAll: '',
+    featuredJobsEmpty: '',
+    featuredFallbackBadge: '',
+    employerGridTitle: L.employerGridTitle(cityName),
+    approfondisciHeading: '',
+    jobPostedLabel: () => '',
+    jobSalaryFmt: () => '',
+  };
+  return renderEmployerGrid(snapshot as CityJobsSnapshot, view, locale, cityId);
+}
+
+// Test-only export: allows tests/build-plugins/job-card-canonical-adoption.test.ts
+// to verify the migrated renderer emits canonical job-card markers.
+export function renderCostOfLivingFeaturedJobsForTest(
+  city: ColCityId,
+  locale: ColLocale,
+  snapshot: CityJobsSnapshot,
+): string {
+  const L = getLocaleStrings(locale);
+  const cityName = COL_CITY_DISPLAY[city][locale];
+  const view: CityCopyView = {
+    statTileSalaryLabel: L.statTileSalaryLabel,
+    statTileRentLabel: L.statTileRentLabel,
+    statTileLiveJobsLabel: L.statTileLiveJobsLabel,
+    statSalaryFmt: L.statSalaryFmt,
+    statRentFmt: L.statRentFmt,
+    statLiveJobsFmt: L.statLiveJobsFmt,
+    primaryCtaLabel: L.primaryCtaLabel(cityName),
+    featuredJobsTitle: L.featuredJobsTitle(cityName),
+    featuredJobsCtaAll: L.featuredJobsCtaAll(cityName, snapshot.liveCount),
+    featuredJobsEmpty: L.featuredJobsEmpty(cityName),
+    featuredFallbackBadge: L.featuredFallbackBadge,
+    employerGridTitle: L.employerGridTitle(cityName),
+    approfondisciHeading: L.approfondisciHeading,
+    jobPostedLabel: L.jobPostedLabel,
+    jobSalaryFmt: L.jobSalaryFmt,
+  };
+  return renderFeaturedJobs(city, locale, snapshot, view);
+}

--- a/build-plugins/nursingLandingsPlugin.ts
+++ b/build-plugins/nursingLandingsPlugin.ts
@@ -61,6 +61,7 @@ import {
   LEDE_STYLE,
   SMALL_HEADING_STYLE,
   renderStatGrid,
+  pickStatTileTone,
 } from './shared/seoContentTokens';
 import {
   NURSING_LOCALES,
@@ -405,9 +406,9 @@ function renderPage(opts: {
   // ── Template B body ──────────────────────────────────────────────────────
 
   const statTilesHtml = `<div class="seo-fade-in">${renderStatGrid([
-    { label: copy.shell.statTileLiveLabel, value: copy.statLiveValue, tone: 'success' },
-    { label: copy.shell.statTileSalaryLabel, value: copy.statSalaryValue, tone: 'accent' },
-    { label: copy.shell.statTileFreshLabel, value: copy.statFreshValue, tone: 'warning' },
+    { label: copy.shell.statTileLiveLabel, value: copy.statLiveValue, tone: pickStatTileTone('openings', snapshot.liveCount) },
+    { label: copy.shell.statTileSalaryLabel, value: copy.statSalaryValue, tone: pickStatTileTone('salary', snapshot.medianSalaryChf ?? 0) },
+    { label: copy.shell.statTileFreshLabel, value: copy.statFreshValue, tone: pickStatTileTone('fresh', snapshot.fresh30Count) },
   ])}</div>`;
 
   const primaryCtaHtml = `<div style="margin:0 0 28px"><a href="${esc(calculatorUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.shell.primaryCtaLabel)} →</a></div>`;

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -55,6 +55,7 @@ import {
   LEDE_STYLE,
   SMALL_HEADING_STYLE,
   renderStatGrid,
+  pickStatTileTone,
 } from './shared/seoContentTokens';
 import { buildTitleWithBrand } from './shared/titleSuffix';
 import { renderLandingHero } from './shared/landingHeroPersonality';
@@ -486,9 +487,9 @@ function renderPage(opts: {
   };
 
   const statTilesHtml = `<div class="seo-fade-in">${renderStatGrid([
-    { label: copy.statTileLiveLabel, value: copy.statLiveValue, tone: 'success' },
-    { label: copy.statTileSalaryLabel, value: copy.statSalaryValue, tone: 'accent' },
-    { label: copy.statTileFreshLabel, value: copy.statFreshValue, tone: 'warning' },
+    { label: copy.statTileLiveLabel, value: copy.statLiveValue, tone: pickStatTileTone('openings', snapshot.liveCount) },
+    { label: copy.statTileSalaryLabel, value: copy.statSalaryValue, tone: pickStatTileTone('salary', snapshot.medianSalaryChf ?? 0) },
+    { label: copy.statTileFreshLabel, value: copy.statFreshValue, tone: pickStatTileTone('fresh', snapshot.fresh30Count) },
   ])}</div>`;
 
   const primaryCtaHtml = `<div style="margin:0 0 28px"><a href="${esc(calculatorUrl)}" style="${CTA_PRIMARY_STYLE}">${esc(copy.primaryCtaLabel)} →</a></div>`;

--- a/build-plugins/shared/employerCardHtml.ts
+++ b/build-plugins/shared/employerCardHtml.ts
@@ -9,6 +9,7 @@
  * Tailwind (`./build-plugins/**\/*.{js,ts}` in tailwind.config.js) so every
  * class used here is preserved in the production CSS bundle.
  */
+import { escHtml } from './htmlEscape';
 import {
   resolveJobLogoSrc,
   generateInitialsLogo,
@@ -51,14 +52,6 @@ export interface EmployerCardOptions {
   locale: EmployerCardLocale;
   variant?: 'compact' | 'detailed';
   openingsLabel?: (n: number) => string;
-}
-
-function escHtml(value: unknown): string {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }
 
 const OPENINGS_DEFAULT_LABEL: Record<EmployerCardLocale, (n: number) => string> = {

--- a/build-plugins/shared/htmlEscape.ts
+++ b/build-plugins/shared/htmlEscape.ts
@@ -1,0 +1,15 @@
+/**
+ * HTML entity escaping for static-page build plugins.
+ *
+ * Replaces the local `escHtml`/`esc` helpers that were independently
+ * defined in jobCardHtml, employerCardHtml, landingHeroPersonality and
+ * relatedLinks. All four had identical implementations — extracting
+ * removes the DRY violation flagged in the canonical-card review.
+ */
+export function escHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/build-plugins/shared/jobCardHtml.ts
+++ b/build-plugins/shared/jobCardHtml.ts
@@ -16,13 +16,14 @@
  *  - orphanQueryLandingPlugin (GSC orphan-query landings)
  */
 
+import { escHtml } from './htmlEscape';
 import {
   resolveJobLogoSrc as resolveJobCardLogo,
   generateInitialsLogo,
   LOGO_FALLBACK_SRC,
 } from './companyLogoResolver';
 
-export { resolveJobCardLogo };
+export { resolveJobCardLogo, escHtml };
 
 export type JobCardLocale = 'it' | 'en' | 'de' | 'fr';
 
@@ -65,16 +66,6 @@ export interface JobCardOptions {
   linkifyLocation?: (raw: string, locale: JobCardLocale) => string;
   /** Explicit logo override; bypasses the auto-resolver. */
   logoUrl?: string | null;
-}
-
-// ── HTML escaping ────────────────────────────────────────────────────
-
-export function escHtml(value: unknown): string {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }
 
 // ── Locale labels ────────────────────────────────────────────────────

--- a/build-plugins/shared/landingHeroPersonality.ts
+++ b/build-plugins/shared/landingHeroPersonality.ts
@@ -188,6 +188,207 @@ export const HERO_BADGES: Record<string, LandingHeroBadge> = {
       fr: (v) => withSalary(`Installations, sites: ${v.openings} postes`, v, 'fr'),
     },
   },
+
+  // ── Career landings ────────────────────────────────────────────────
+  'agenzie-lavoro-lugano': {
+    emoji: '🏢',
+    eyebrowLabel: {
+      it: 'Agenzie di lavoro · Lugano',
+      en: 'Recruitment agencies · Lugano',
+      de: 'Personalvermittler · Lugano',
+      fr: 'Agences de placement · Lugano',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Agenzie attive a Lugano: ${v.openings} posti rapidi`, v, 'it'),
+      en: (v) => withSalary(`Active agencies in Lugano: ${v.openings} fast openings`, v, 'en'),
+      de: (v) => withSalary(`Aktive Agenturen in Lugano: ${v.openings} schnelle Stellen`, v, 'de'),
+      fr: (v) => withSalary(`Agences actives à Lugano: ${v.openings} postes rapides`, v, 'fr'),
+    },
+  },
+  'concorsi-pubblici-lugano': {
+    emoji: '🏛️',
+    eyebrowLabel: {
+      it: 'Concorsi pubblici · Lugano',
+      en: 'Public competitions · Lugano',
+      de: 'Öffentliche Stellen · Lugano',
+      fr: 'Concours publics · Lugano',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`OSC, EOC e città: ${v.openings} concorsi aperti`, v, 'it'),
+      en: (v) => withSalary(`OSC, EOC, city hall: ${v.openings} competitions`, v, 'en'),
+      de: (v) => withSalary(`OSC, EOC, Stadt: ${v.openings} öffentliche Stellen`, v, 'de'),
+      fr: (v) => withSalary(`OSC, EOC, ville: ${v.openings} concours ouverts`, v, 'fr'),
+    },
+  },
+  'stage-lugano': {
+    emoji: '📚',
+    eyebrowLabel: {
+      it: 'Stage e tirocini · Lugano',
+      en: 'Internships · Lugano',
+      de: 'Praktika · Lugano',
+      fr: 'Stages · Lugano',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Tirocini retribuiti e curricolari: ${v.openings} aperti`, v, 'it'),
+      en: (v) => withSalary(`Paid & curricular internships: ${v.openings} open`, v, 'en'),
+      de: (v) => withSalary(`Bezahlte & Pflichtpraktika: ${v.openings} offen`, v, 'de'),
+      fr: (v) => withSalary(`Stages rémunérés et obligatoires: ${v.openings} ouverts`, v, 'fr'),
+    },
+  },
+  'contratti-lavoro-frontalieri': {
+    emoji: '📄',
+    eyebrowLabel: {
+      it: 'Contratti frontalieri · CCL e accordo fiscale',
+      en: 'Cross-border contracts · CCL & tax deal',
+      de: 'Grenzgänger-Verträge · GAV & Steuer',
+      fr: 'Contrats frontaliers · CCT & fiscal',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`CCL, permesso G, fisco: ${v.openings} offerte conformi`, v, 'it'),
+      en: (v) => withSalary(`CCL, G permit, tax: ${v.openings} compliant offers`, v, 'en'),
+      de: (v) => withSalary(`GAV, G-Bewilligung, Steuer: ${v.openings} Angebote`, v, 'de'),
+      fr: (v) => withSalary(`CCT, permis G, fiscal: ${v.openings} offres conformes`, v, 'fr'),
+    },
+  },
+
+  // ── Nursing landings ───────────────────────────────────────────────
+  nurses: {
+    emoji: '🩺',
+    eyebrowLabel: {
+      it: 'Infermieri · Svizzera',
+      en: 'Nurses · Switzerland',
+      de: 'Pflege · Schweiz',
+      fr: 'Infirmiers · Suisse',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Ospedali, cliniche, case anziani: ${v.openings} posti`, v, 'it'),
+      en: (v) => withSalary(`Hospitals, clinics, care homes: ${v.openings} open`, v, 'en'),
+      de: (v) => withSalary(`Spitäler, Kliniken, Pflegeheime: ${v.openings} offen`, v, 'de'),
+      fr: (v) => withSalary(`Hôpitaux, cliniques, EMS: ${v.openings} postes`, v, 'fr'),
+    },
+  },
+  oss: {
+    emoji: '🤝',
+    eyebrowLabel: {
+      it: 'OSS · Operatore socio-sanitario',
+      en: 'Healthcare assistants · Switzerland',
+      de: 'Pflegehelfer · Schweiz',
+      fr: 'Aides-soignants · Suisse',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Assistenza, cura, supporto: ${v.openings} posti aperti`, v, 'it'),
+      en: (v) => withSalary(`Care, support, assistance: ${v.openings} open`, v, 'en'),
+      de: (v) => withSalary(`Pflege, Unterstützung: ${v.openings} offen`, v, 'de'),
+      fr: (v) => withSalary(`Soins, aide, accompagnement: ${v.openings} postes`, v, 'fr'),
+    },
+  },
+  'healthcare-ticino': {
+    emoji: '🏥',
+    eyebrowLabel: {
+      it: 'Sanità · Ticino',
+      en: 'Healthcare · Ticino',
+      de: 'Gesundheit · Tessin',
+      fr: 'Santé · Tessin',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Tutta la sanità ticinese: ${v.openings} posti aperti`, v, 'it'),
+      en: (v) => withSalary(`All Ticino healthcare: ${v.openings} open`, v, 'en'),
+      de: (v) => withSalary(`Tessiner Gesundheitswesen: ${v.openings} offen`, v, 'de'),
+      fr: (v) => withSalary(`Toute la santé tessinoise: ${v.openings} postes`, v, 'fr'),
+    },
+  },
+
+  // ── CostOfLiving cities ────────────────────────────────────────────
+  lugano: {
+    emoji: '🏙️',
+    eyebrowLabel: {
+      it: 'Costo della vita · Lugano',
+      en: 'Cost of living · Lugano',
+      de: 'Lebenshaltung · Lugano',
+      fr: 'Coût de la vie · Lugano',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Affitti, spesa, netto: ${v.openings} lavori a Lugano`, v, 'it'),
+      en: (v) => withSalary(`Rent, food, net pay: ${v.openings} Lugano jobs`, v, 'en'),
+      de: (v) => withSalary(`Miete, Einkauf, Netto: ${v.openings} Jobs Lugano`, v, 'de'),
+      fr: (v) => withSalary(`Loyer, courses, net: ${v.openings} emplois Lugano`, v, 'fr'),
+    },
+  },
+  mendrisio: {
+    emoji: '🏙️',
+    eyebrowLabel: {
+      it: 'Costo della vita · Mendrisio',
+      en: 'Cost of living · Mendrisio',
+      de: 'Lebenshaltung · Mendrisio',
+      fr: 'Coût de la vie · Mendrisio',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Mendrisiotto: affitti più bassi, ${v.openings} lavori`, v, 'it'),
+      en: (v) => withSalary(`Mendrisio: lower rents, ${v.openings} jobs`, v, 'en'),
+      de: (v) => withSalary(`Mendrisio: tiefe Mieten, ${v.openings} Jobs`, v, 'de'),
+      fr: (v) => withSalary(`Mendrisio: loyers bas, ${v.openings} emplois`, v, 'fr'),
+    },
+  },
+  chiasso: {
+    emoji: '🏙️',
+    eyebrowLabel: {
+      it: 'Costo della vita · Chiasso',
+      en: 'Cost of living · Chiasso',
+      de: 'Lebenshaltung · Chiasso',
+      fr: 'Coût de la vie · Chiasso',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Chiasso al confine: ${v.openings} lavori vicino casa`, v, 'it'),
+      en: (v) => withSalary(`Chiasso border city: ${v.openings} jobs near home`, v, 'en'),
+      de: (v) => withSalary(`Chiasso Grenze: ${v.openings} Jobs nahe`, v, 'de'),
+      fr: (v) => withSalary(`Chiasso frontière: ${v.openings} emplois proches`, v, 'fr'),
+    },
+  },
+  bellinzona: {
+    emoji: '🏙️',
+    eyebrowLabel: {
+      it: 'Costo della vita · Bellinzona',
+      en: 'Cost of living · Bellinzona',
+      de: 'Lebenshaltung · Bellinzona',
+      fr: 'Coût de la vie · Bellinzona',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Capitale ticinese: ${v.openings} lavori amministrazione`, v, 'it'),
+      en: (v) => withSalary(`Ticino capital: ${v.openings} admin jobs`, v, 'en'),
+      de: (v) => withSalary(`Tessiner Hauptstadt: ${v.openings} Verwaltungsjobs`, v, 'de'),
+      fr: (v) => withSalary(`Capitale tessinoise: ${v.openings} emplois admin`, v, 'fr'),
+    },
+  },
+  locarno: {
+    emoji: '🏙️',
+    eyebrowLabel: {
+      it: 'Costo della vita · Locarno',
+      en: 'Cost of living · Locarno',
+      de: 'Lebenshaltung · Locarno',
+      fr: 'Coût de la vie · Locarno',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Lago Maggiore: ${v.openings} lavori turismo+industria`, v, 'it'),
+      en: (v) => withSalary(`Lake Maggiore: ${v.openings} tourism+industry jobs`, v, 'en'),
+      de: (v) => withSalary(`Lago Maggiore: ${v.openings} Jobs Tourismus+Industrie`, v, 'de'),
+      fr: (v) => withSalary(`Lac Majeur: ${v.openings} emplois tourisme+industrie`, v, 'fr'),
+    },
+  },
+  ticino: {
+    emoji: '🏞️',
+    eyebrowLabel: {
+      it: 'Costo della vita · tutto il Ticino',
+      en: 'Cost of living · all Ticino',
+      de: 'Lebenshaltung · ganzes Tessin',
+      fr: 'Coût de la vie · tout le Tessin',
+    },
+    taglineTemplate: {
+      it: (v) => withSalary(`Tutto il cantone: ${v.openings} lavori in Ticino`, v, 'it'),
+      en: (v) => withSalary(`Whole canton: ${v.openings} jobs in Ticino`, v, 'en'),
+      de: (v) => withSalary(`Ganzer Kanton: ${v.openings} Jobs im Tessin`, v, 'de'),
+      fr: (v) => withSalary(`Tout le canton: ${v.openings} emplois au Tessin`, v, 'fr'),
+    },
+  },
 };
 
 export function renderLandingHero(

--- a/build-plugins/shared/landingHeroPersonality.ts
+++ b/build-plugins/shared/landingHeroPersonality.ts
@@ -6,6 +6,8 @@
  * Emoji palette: curated, universal-coverage emoji (🎓🚑🍳⚙️👶📊🏗️💼🩺🏠🚛🍽️🔌).
  */
 
+import { escHtml } from './htmlEscape';
+
 export type HeroLocale = 'it' | 'en' | 'de' | 'fr';
 
 export interface HeroVars {
@@ -208,10 +210,3 @@ export function renderLandingHero(
   return `<header>${eyebrow}<h1 class="text-2xl sm:text-3xl font-display font-bold text-heading mt-2">${escHtml(title)}</h1>${taglineHtml}</header>`;
 }
 
-function escHtml(value: unknown): string {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}

--- a/build-plugins/shared/relatedLinks.ts
+++ b/build-plugins/shared/relatedLinks.ts
@@ -41,6 +41,7 @@
  *     fall back to the legacy 5-link list to avoid thin link blocks.
  */
 
+import { escHtml } from './htmlEscape';
 import {
   FUEL_ITALIAN_CITIES,
   FUEL_ZONES,
@@ -527,14 +528,6 @@ const COPY: Record<LinkLocale, Copy> = {
 };
 
 // ── Helpers ─────────────────────────────────────────────────────
-
-function escHtml(s: unknown): string {
-  return String(s ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
 
 function humanizeSlug(slug: string): string {
   return slug

--- a/build-plugins/shared/seoContentTokens.ts
+++ b/build-plugins/shared/seoContentTokens.ts
@@ -92,6 +92,54 @@ export const STAT_TILE_LABEL =
 export const STAT_TILE_VALUE =
   'margin-top:8px;font-size:28px;font-weight:700;color:var(--color-heading);line-height:1.1';
 
+/**
+ * Pick a stat-tile style based on a numeric value and threshold semantics.
+ * Used by SEO landings to color metric tiles by meaning instead of fixed tone.
+ *
+ *   'openings': SUCCESS if >20, WARNING if 5-20, BASE if <5 (many = green)
+ *   'fresh':    SUCCESS if >0, BASE if 0
+ *   'salary':   ACCENT (always — it's the headline metric)
+ *   'count':    BASE always (informational, no good/bad direction)
+ */
+export type StatTileMetric = 'openings' | 'fresh' | 'salary' | 'count';
+
+export function pickStatTileStyle(metric: StatTileMetric, value: number): string {
+  switch (metric) {
+    case 'openings':
+      if (value > 20) return STAT_TILE_SUCCESS;
+      if (value >= 5) return STAT_TILE_WARNING;
+      return STAT_TILE_BASE;
+    case 'fresh':
+      return value > 0 ? STAT_TILE_SUCCESS : STAT_TILE_BASE;
+    case 'salary':
+      return STAT_TILE_ACCENT;
+    case 'count':
+    default:
+      return STAT_TILE_BASE;
+  }
+}
+
+/**
+ * Same semantics as {@link pickStatTileStyle} but returns a `StatTileTone`
+ * compatible with `renderStatGrid`'s `tone` property.
+ * Callers that use `renderStatGrid` should prefer this over `pickStatTileStyle`.
+ */
+export function pickStatTileTone(metric: StatTileMetric, value: number): StatTileTone {
+  switch (metric) {
+    case 'openings':
+      if (value > 20) return 'success';
+      if (value >= 5) return 'warning';
+      return 'neutral';
+    case 'fresh':
+      return value > 0 ? 'success' : 'neutral';
+    case 'salary':
+      return 'accent';
+    case 'count':
+    default:
+      return 'neutral';
+  }
+}
+
 // ── Links / CTAs ──────────────────────────────────────────────────────────────
 
 export const CTA_PRIMARY_STYLE =

--- a/tests/build-plugins/landing-hero-integration.test.ts
+++ b/tests/build-plugins/landing-hero-integration.test.ts
@@ -1,14 +1,61 @@
 import { describe, it, expect } from 'vitest';
+import { renderLandingHero, HERO_BADGES } from '../../build-plugins/shared/landingHeroPersonality';
 
-describe('professionLandings integrates renderLandingHero', () => {
-  it('renders the educatore page with emoji eyebrow', async () => {
-    const mod: any = await import('../../build-plugins/professionLandingsPlugin');
-    expect(typeof mod.renderProfessionEmployerGridForTest).toBe('function');
-    // We're just checking that the hero personality module is imported and
-    // wired — the smoke test for the full page render path would need to
-    // call the plugin's main render() which depends on aggregateProfessionJobs
-    // (which needs data/jobs.json). Skip that and just verify the import works.
-    const hero = await import('../../build-plugins/shared/landingHeroPersonality');
-    expect(hero.HERO_BADGES.educatore.emoji).toBe('🎓');
+describe('renderLandingHero — full rendering', () => {
+  it('renders eyebrow with emoji, h1, and tagline for educatore', () => {
+    const html = renderLandingHero(
+      'educatore',
+      'it',
+      { openings: 47, medianSalary: 65000 },
+      'Lavoro come educatore in Ticino',
+    );
+    expect(html).toMatch(/<span aria-hidden="true">🎓<\/span>/);
+    expect(html).toContain('Professione · Educatore in Ticino');
+    expect(html).toContain('<h1');
+    expect(html).toContain('Lavoro come educatore in Ticino');
+    expect(html).toContain('bambini');           // tagline mentions kids
+    expect(html).toContain('~CHF 65k');           // median salary in tagline
+    expect(html).toContain('text-accent');        // semantic token, no hex
+  });
+
+  it('renders eyebrow + tagline for all 4 locales of educatore', () => {
+    const locales = ['it', 'en', 'de', 'fr'] as const;
+    for (const loc of locales) {
+      const html = renderLandingHero('educatore', loc, { openings: 5 }, 'X');
+      expect(html, `${loc} missing eyebrow`).toMatch(/<span aria-hidden="true">🎓<\/span>/);
+      expect(html, `${loc} missing h1`).toContain('<h1');
+    }
+  });
+
+  it('falls back to fallbackTagline when id is unknown', () => {
+    const html = renderLandingHero(
+      'NONEXISTENT_ID',
+      'it',
+      { openings: 1 },
+      'Test page',
+      'Custom fallback tagline here',
+    );
+    expect(html).toContain('Custom fallback tagline here');
+    expect(html).toContain('Test page');
+    expect(html).not.toMatch(/<span aria-hidden="true">/);  // no emoji for unknown id
+  });
+
+  it('omits tagline when no badge AND no fallback', () => {
+    const html = renderLandingHero('NONEXISTENT_ID', 'it', { openings: 1 }, 'Just title');
+    expect(html).toContain('Just title');
+    // No tagline paragraph after the h1
+    expect(html.match(/<p[^>]*>/g)?.length ?? 0).toBe(0);
+  });
+
+  it('escapes HTML in title to prevent injection', () => {
+    const html = renderLandingHero('educatore', 'it', { openings: 5 }, '<script>x</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).not.toMatch(/<script>/);
+  });
+});
+
+describe('HERO_BADGES total count after extension', () => {
+  it('has at least 23 entries (10 professions + 4 careers + 3 nursing + 6 cities)', () => {
+    expect(Object.keys(HERO_BADGES).length).toBeGreaterThanOrEqual(23);
   });
 });

--- a/tests/build-plugins/landing-hero-personality.test.ts
+++ b/tests/build-plugins/landing-hero-personality.test.ts
@@ -18,6 +18,28 @@ describe('HERO_BADGES coverage', () => {
     }
   });
 
+  it('includes all 4 career landing ids', () => {
+    const required = [
+      'agenzie-lavoro-lugano', 'concorsi-pubblici-lugano',
+      'stage-lugano', 'contratti-lavoro-frontalieri',
+    ];
+    for (const id of required) {
+      expect(HERO_BADGES, `missing badge for career ${id}`).toHaveProperty(id);
+    }
+  });
+
+  it('includes all 3 nursing landing ids', () => {
+    for (const id of ['nurses', 'oss', 'healthcare-ticino']) {
+      expect(HERO_BADGES, `missing badge for nursing ${id}`).toHaveProperty(id);
+    }
+  });
+
+  it('includes all 6 costOfLiving city ids', () => {
+    for (const id of ['lugano', 'mendrisio', 'chiasso', 'bellinzona', 'locarno', 'ticino']) {
+      expect(HERO_BADGES, `missing badge for col city ${id}`).toHaveProperty(id);
+    }
+  });
+
   it('every badge has emoji + all 4 locale eyebrows + all 4 locale taglines', () => {
     for (const [id, badge] of Object.entries(HERO_BADGES)) {
       expect(badge.emoji.length, `${id} emoji empty`).toBeGreaterThan(0);


### PR DESCRIPTION
Followups from PR #338:
- #3: extract escHtml to shared/htmlEscape (DRY across 4 modules)
- #2: HERO_BADGES +13 entries (career 4 + nursing 3 + cost-of-living cities 6) — emoji hero on all SEO landings now
- #1: dynamic stat-tile tone by metric semantics (openings>20=SUCCESS, salary=ACCENT, fresh>0=SUCCESS)
- #4: costOfLivingLandingsPlugin 841 → 792 lines (extract test exports)
- #5: landing-hero-integration test expanded (6 real rendering assertions)

135/135 vitest pass; tsc baseline stable at 7.