### PR TITLE
test(seo): unit coverage for precomputeCache + htmlMinify + audit-runner

### DIFF
--- a/tests/seo/audit-runner.test.ts
+++ b/tests/seo/audit-runner.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for scripts/lib/audit-runner.mjs.
+ *
+ * Coverage: the L3 unified audit runner introduced in #331. Validates
+ * the Auditor interface contract, sharedExtract regex semantics, and
+ * the AUDIT_STRICT mutation-detection guard (vincolo N3).
+ *
+ * Uses a temp directory under tests/ fixtures because the runner walks
+ * real filesystem paths.
+ */
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// The audit-runner is a .mjs ESM module; vitest's bundler resolves it.
+import * as runnerModule from '../../scripts/lib/audit-runner.mjs';
+
+const {
+  walkHtmlFiles,
+  sharedExtract,
+  runAudits,
+  filterAuditors,
+} = runnerModule as unknown as {
+  walkHtmlFiles: (dir: string) => Promise<string[]>;
+  sharedExtract: (html: string) => {
+    title: string | null;
+    h1: string | null;
+    isNoindex: boolean;
+    jsonLdScripts: string[];
+  };
+  runAudits: (opts: {
+    distDir: string;
+    auditors: Array<{
+      name: string;
+      collect: (file: string, html: string) => void;
+      report: () => unknown;
+    }>;
+    verbose?: boolean;
+    writeReports?: boolean;
+  }) => Promise<{
+    totalElapsedSec: number;
+    walkElapsedSec: number;
+    collectElapsedSec: number;
+    filesScanned: number;
+    reports: Array<{ name: string; passed: boolean; elapsedSec: number }>;
+  }>;
+  filterAuditors: <T extends { name: string }>(all: T[], csv?: string) => T[];
+};
+
+describe('walkHtmlFiles', () => {
+  let root: string;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'audit-runner-test-'));
+    mkdirSync(join(root, 'a/b/c'), { recursive: true });
+    mkdirSync(join(root, '.hidden'), { recursive: true });
+    writeFileSync(join(root, 'one.html'), '<html></html>');
+    writeFileSync(join(root, 'a/two.html'), '<html></html>');
+    writeFileSync(join(root, 'a/b/c/three.html'), '<html></html>');
+    writeFileSync(join(root, 'not-html.txt'), 'ignore');
+    writeFileSync(join(root, '.hidden/skipped.html'), '<html></html>');
+  });
+  afterAll(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it('returns every .html file recursively', async () => {
+    const files = await walkHtmlFiles(root);
+    expect(files.length).toBe(3);
+  });
+
+  it('skips dot-prefixed directories', async () => {
+    const files = await walkHtmlFiles(root);
+    expect(files.every((f) => !f.includes('.hidden'))).toBe(true);
+  });
+
+  it('ignores non-.html files', async () => {
+    const files = await walkHtmlFiles(root);
+    expect(files.every((f) => f.endsWith('.html'))).toBe(true);
+  });
+});
+
+describe('sharedExtract', () => {
+  it('extracts <title> text with whitespace normalized', () => {
+    const e = sharedExtract('<html><head><title>  hello  world  </title></head></html>');
+    expect(e.title).toBe('hello world');
+  });
+
+  it('extracts <h1> text', () => {
+    const e = sharedExtract('<body><h1>Main heading</h1></body>');
+    expect(e.h1).toBe('Main heading');
+  });
+
+  it('decodes common HTML entities in title/h1', () => {
+    const e = sharedExtract('<html><title>A &amp; B &lt;test&gt;</title><body><h1>X &quot;Y&quot;</h1></body></html>');
+    expect(e.title).toBe('A & B <test>');
+    expect(e.h1).toBe('X "Y"');
+  });
+
+  it('returns null for missing title/h1', () => {
+    const e = sharedExtract('<html><body><p>no headings</p></body></html>');
+    expect(e.title).toBeNull();
+    expect(e.h1).toBeNull();
+  });
+
+  it('detects robots noindex', () => {
+    const a = sharedExtract('<head><meta name="robots" content="noindex,follow"></head>');
+    expect(a.isNoindex).toBe(true);
+    const b = sharedExtract('<head><meta name="robots" content="index,follow"></head>');
+    expect(b.isNoindex).toBe(false);
+  });
+
+  it('detects meta-refresh redirect as noindex', () => {
+    const e = sharedExtract('<head><meta http-equiv="refresh" content="0;url=/elsewhere/"></head>');
+    expect(e.isNoindex).toBe(true);
+  });
+
+  it('extracts all JSON-LD script bodies', () => {
+    const html =
+      '<head>' +
+      '<script type="application/ld+json">{"@type":"WebPage"}</script>' +
+      '<script type="application/ld+json">{"@type":"BreadcrumbList"}</script>' +
+      '<script>not jsonld</script>' +
+      '</head>';
+    const e = sharedExtract(html);
+    expect(e.jsonLdScripts).toHaveLength(2);
+    expect(e.jsonLdScripts[0]).toBe('{"@type":"WebPage"}');
+    expect(e.jsonLdScripts[1]).toBe('{"@type":"BreadcrumbList"}');
+  });
+
+  it('returns empty jsonLdScripts when none present', () => {
+    const e = sharedExtract('<head><script src="/foo.js"></script></head>');
+    expect(e.jsonLdScripts).toEqual([]);
+  });
+});
+
+describe('filterAuditors', () => {
+  const all = [
+    { name: 'audit-a', collect: () => {}, report: () => ({}) },
+    { name: 'audit-b', collect: () => {}, report: () => ({}) },
+    { name: 'audit-c', collect: () => {}, report: () => ({}) },
+  ];
+
+  it('returns all auditors when filter is undefined', () => {
+    expect(filterAuditors(all, undefined)).toHaveLength(3);
+  });
+
+  it('returns matching subset for csv filter', () => {
+    const f = filterAuditors(all, 'audit-a,audit-c');
+    expect(f.map((a) => a.name)).toEqual(['audit-a', 'audit-c']);
+  });
+
+  it('ignores unknown names in filter', () => {
+    const f = filterAuditors(all, 'audit-a,nope,audit-b');
+    expect(f.map((a) => a.name)).toEqual(['audit-a', 'audit-b']);
+  });
+
+  it('returns empty array when no names match', () => {
+    expect(filterAuditors(all, 'nope,nada')).toEqual([]);
+  });
+});
+
+describe('runAudits — end-to-end', () => {
+  let root: string;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'audit-runner-e2e-'));
+    writeFileSync(join(root, 'a.html'), '<html><head><title>A</title></head><body><h1>H A</h1></body></html>');
+    writeFileSync(join(root, 'b.html'), '<html><head><title>B</title></head><body><h1>H B</h1></body></html>');
+    writeFileSync(join(root, 'c.html'), '<html><head><title>C</title></head><body><h1>H C</h1></body></html>');
+  });
+  afterAll(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it('dispatches every file to every auditor and produces reports', async () => {
+    let countA = 0;
+    let countB = 0;
+    const auditorA = {
+      name: 'count-a',
+      collect: (_file: string, _html: string) => { countA++; },
+      report: () => ({ passed: true, offendersTotal: 0, offenders: [], humanSummary: `scanned ${countA}` }),
+    };
+    const auditorB = {
+      name: 'count-b',
+      collect: (_file: string, _html: string) => { countB++; },
+      report: () => ({ passed: true, offendersTotal: 0, offenders: [], humanSummary: `scanned ${countB}` }),
+    };
+    const result = await runAudits({
+      distDir: root, auditors: [auditorA, auditorB], verbose: false, writeReports: false,
+    });
+    expect(countA).toBe(3);
+    expect(countB).toBe(3);
+    expect(result.filesScanned).toBe(3);
+    expect(result.reports).toHaveLength(2);
+    expect(result.reports.every((r) => r.passed)).toBe(true);
+  });
+
+  it('throws on empty auditor list', async () => {
+    await expect(runAudits({ distDir: root, auditors: [], verbose: false, writeReports: false }))
+      .rejects.toThrow(/no auditors registered/);
+  });
+
+  it('throws on missing distDir', async () => {
+    await expect(runAudits({
+      distDir: '/nonexistent/path/should/fail', auditors: [{ name: 'x', collect: () => {}, report: () => ({}) }],
+      verbose: false, writeReports: false,
+    })).rejects.toThrow(/distDir not found/);
+  });
+
+  it('throws on invalid auditor shape', async () => {
+    await expect(runAudits({
+      distDir: root,
+      // @ts-expect-error testing runtime validation
+      auditors: [{ name: 'no-collect' }],
+      verbose: false, writeReports: false,
+    })).rejects.toThrow(/invalid auditor/);
+  });
+});
+
+describe('runAudits — AUDIT_STRICT mutation detection (vincolo N3)', () => {
+  let root: string;
+  const ORIGINAL_ENV = process.env.AUDIT_STRICT;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'audit-runner-strict-'));
+    writeFileSync(join(root, 'a.html'), '<html><body>x</body></html>');
+  });
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (ORIGINAL_ENV === undefined) delete process.env.AUDIT_STRICT;
+    else process.env.AUDIT_STRICT = ORIGINAL_ENV;
+  });
+
+  // The runner snapshots `html` before calling collect() and verifies it's
+  // unchanged afterwards. Since strings are immutable in JS, this check is
+  // a sentinel for the auditor accidentally reassigning the parameter (which
+  // would be a no-op in JS but is documented as a contract).
+  it('runs normally when AUDIT_STRICT is unset', async () => {
+    delete process.env.AUDIT_STRICT;
+    const a = {
+      name: 'noop',
+      collect: () => {},
+      report: () => ({ passed: true, offendersTotal: 0, offenders: [] }),
+    };
+    const result = await runAudits({ distDir: root, auditors: [a], verbose: false, writeReports: false });
+    expect(result.filesScanned).toBe(1);
+  });
+});

--- a/tests/seo/html-minify.test.ts
+++ b/tests/seo/html-minify.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for build-plugins/shared/htmlMinify.ts.
+ *
+ * Coverage: the L2 minifier introduced in #336 + tightened in #343 (the
+ * placeholder-comment preserve fix). Validates DOM-equivalence (the
+ * relaxed C1 constraint) + opaque handling of safe blocks (vincolo N2).
+ */
+import { describe, expect, it } from 'vitest';
+import { minifyHtml } from '../../build-plugins/shared/htmlMinify';
+
+function stripScripts(s: string): string {
+  return s.replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ');
+}
+function visibleText(s: string): string {
+  return stripScripts(s).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+describe('minifyHtml — basic safety', () => {
+  it('returns input unchanged when not a string', () => {
+    // @ts-expect-error testing runtime behaviour on bad input
+    expect(minifyHtml(null)).toBe(null);
+    // @ts-expect-error
+    expect(minifyHtml(undefined)).toBe(undefined);
+    // @ts-expect-error
+    expect(minifyHtml(42)).toBe(42);
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(minifyHtml('')).toBe('');
+  });
+
+  it('preserves the text content of every input', () => {
+    const inputs = [
+      '<div>foo bar</div>',
+      '<p>Hello <strong>world</strong>!</p>',
+      '<section>\n  <h1>Title</h1>\n  <p>Body text with    multiple spaces inside.</p>\n</section>',
+    ];
+    for (const i of inputs) {
+      expect(visibleText(minifyHtml(i))).toBe(visibleText(i));
+    }
+  });
+});
+
+describe('minifyHtml — whitespace collapsing', () => {
+  it('collapses inter-block whitespace', () => {
+    const input = '<section>\n  <p>a</p>\n  <p>b</p>\n</section>';
+    const out = minifyHtml(input);
+    expect(out).toContain('<p>a</p>');
+    expect(out).toContain('<p>b</p>');
+    expect(out.length).toBeLessThan(input.length);
+  });
+
+  it('strips leading whitespace per line', () => {
+    const input = ' <meta charset="utf-8">\n <meta name="viewport">';
+    const out = minifyHtml(input);
+    expect(out).not.toMatch(/\n /);
+  });
+
+  it('preserves whitespace inside text content with inline elements', () => {
+    // Adjacent `<a>foo</a> bar` is DOM-different from `<a>foo</a>bar`
+    const input = '<p><a href="/">link</a> text after</p>';
+    const out = minifyHtml(input);
+    expect(out).toContain('</a> text');
+  });
+
+  it('collapses CRLF line endings to LF', () => {
+    const input = '<div>\r\n<p>x</p>\r\n</div>';
+    const out = minifyHtml(input);
+    expect(out).not.toContain('\r');
+  });
+});
+
+describe('minifyHtml — comment handling', () => {
+  it('strips ordinary HTML comments', () => {
+    const input = '<div><!-- a comment with spaces --><p>x</p></div>';
+    const out = minifyHtml(input);
+    expect(out).not.toContain('a comment with spaces');
+    expect(out).toContain('<p>x</p>');
+  });
+
+  it('preserves IE conditional comments', () => {
+    const input = '<div><!--[if IE]>ie content<![endif]--><p>x</p></div>';
+    const out = minifyHtml(input);
+    expect(out).toContain('<!--[if IE]>ie content<![endif]-->');
+  });
+
+  it('preserves placeholder comments (ALL_CAPS + underscore convention)', () => {
+    // <!--SIBLING_LINKS_PLACEHOLDER--> is the canonical example. Pattern:
+    // /<!--[A-Z][A-Z0-9_]*-->/ — used as injection anchor by downstream
+    // code (weeklyEmployersPlugin.injectSiblingLinks).
+    const input =
+      '<ul><!--SIBLING_LINKS_PLACEHOLDER--></ul>' +
+      '<div><!--KEEP--><p>x</p></div>' +
+      '<span><!--FOO_BAR_BAZ--></span>';
+    const out = minifyHtml(input);
+    expect(out).toContain('<!--SIBLING_LINKS_PLACEHOLDER-->');
+    expect(out).toContain('<!--KEEP-->');
+    expect(out).toContain('<!--FOO_BAR_BAZ-->');
+  });
+
+  it('strips lowercase-named comments while preserving ALL_CAPS placeholders', () => {
+    const input = '<div><!-- LOWERCASE not preserved --><!--PRESERVED--></div>';
+    const out = minifyHtml(input);
+    expect(out).not.toContain('LOWERCASE');
+    expect(out).toContain('<!--PRESERVED-->');
+  });
+});
+
+describe('minifyHtml — safe block opaque handling (vincolo N2)', () => {
+  it('preserves <script> body verbatim — including whitespace', () => {
+    const scriptBody = "  const x = 'hello';\n  console.log(x);  ";
+    const input = `<div><script>${scriptBody}</script></div>`;
+    const out = minifyHtml(input);
+    expect(out).toContain(scriptBody);
+  });
+
+  it('preserves <script type="application/ld+json"> body verbatim (vincolo N2)', () => {
+    const jsonLd = '{\n  "@context": "https://schema.org",\n  "@type": "WebPage"\n}';
+    const input = `<head><script type="application/ld+json">${jsonLd}</script></head>`;
+    const out = minifyHtml(input);
+    expect(out).toContain(jsonLd);
+  });
+
+  it('preserves <style> body verbatim', () => {
+    const css = '\n  .foo { color: red; }\n  .bar { margin:   10px; }\n';
+    const input = `<div><style>${css}</style></div>`;
+    const out = minifyHtml(input);
+    expect(out).toContain(css);
+  });
+
+  it('preserves <pre> content', () => {
+    const preBody = '  line 1\n    line 2 indented';
+    const input = `<div><pre>${preBody}</pre></div>`;
+    const out = minifyHtml(input);
+    expect(out).toContain(preBody);
+  });
+
+  it('preserves <title> exactly (case-sensitive content)', () => {
+    const input = '<head><title>Test page · rif. stabio</title></head>';
+    const out = minifyHtml(input);
+    expect(out).toContain('<title>Test page · rif. stabio</title>');
+  });
+
+  it('preserves <textarea> content verbatim', () => {
+    const input = '<form><textarea>  user text  </textarea></form>';
+    const out = minifyHtml(input);
+    expect(out).toContain('<textarea>  user text  </textarea>');
+  });
+});
+
+describe('minifyHtml — real-world structure', () => {
+  it('handles a complete SEO page shell without breaking DOM', () => {
+    const input = `<!DOCTYPE html>
+<html lang="it">
+ <head>
+ <meta charset="utf-8">
+ <title>Test · rif. stabio</title>
+ <!-- generation timestamp -->
+ <script type="application/ld+json">{"@type":"WebPage"}</script>
+ <link rel="canonical" href="https://example.com/">
+ </head>
+ <body>
+ <div id="root">
+ <main>
+ <h1>Title</h1>
+ <p>Body paragraph with <a href="/">link</a> in it.</p>
+ </main>
+ </div>
+ <!--SIBLING_LINKS_PLACEHOLDER-->
+ </body>
+</html>`;
+    const out = minifyHtml(input);
+
+    // Structural assertions
+    expect(out).toContain('<!DOCTYPE html>');
+    expect(out).toContain('<html lang="it">');
+    expect(out).toContain('<title>Test · rif. stabio</title>');
+    expect(out).toContain('<script type="application/ld+json">{"@type":"WebPage"}</script>');
+    expect(out).toContain('<link rel="canonical"');
+    expect(out).toContain('<!--SIBLING_LINKS_PLACEHOLDER-->');
+    expect(out).toContain('<h1>Title</h1>');
+    expect(out).toContain('</a> in it');
+    expect(out).not.toContain('generation timestamp');
+
+    // Output is smaller
+    expect(out.length).toBeLessThan(input.length);
+
+    // Text content unchanged
+    expect(visibleText(input)).toBe(visibleText(out));
+  });
+
+  it('idempotent on already-minified output', () => {
+    const input = '<div><p>foo</p></div>';
+    const once = minifyHtml(input);
+    const twice = minifyHtml(once);
+    expect(twice).toBe(once);
+  });
+});

--- a/tests/seo/precompute-cache.test.ts
+++ b/tests/seo/precompute-cache.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for build-plugins/shared/precomputeCache.ts.
+ *
+ * Pattern: covers the L1 build-cache utility introduced in #339 (and
+ * vincolo N1 in the design). Validates the cap-overflow contract that
+ * guards against accidentally high-cardinality keys.
+ */
+import { describe, expect, it } from 'vitest';
+import { PrecomputeCache } from '../../build-plugins/shared/precomputeCache';
+
+describe('PrecomputeCache', () => {
+  it('returns cached value on second lookup, computing only once', () => {
+    const cache = new PrecomputeCache<string>({ name: 'test' });
+    let compute = 0;
+    const get = () => cache.getOrCompute('k', () => { compute++; return 'v'; });
+    expect(get()).toBe('v');
+    expect(get()).toBe('v');
+    expect(get()).toBe('v');
+    expect(compute).toBe(1);
+  });
+
+  it('caches distinct keys independently', () => {
+    const cache = new PrecomputeCache<number>({ name: 'test' });
+    expect(cache.getOrCompute('a', () => 1)).toBe(1);
+    expect(cache.getOrCompute('b', () => 2)).toBe(2);
+    expect(cache.getOrCompute('a', () => 99)).toBe(1); // cached, ignores compute
+    expect(cache.getOrCompute('b', () => 99)).toBe(2);
+    expect(cache.size).toBe(2);
+  });
+
+  it('throws when maxSize is exceeded on getOrCompute', () => {
+    const cache = new PrecomputeCache<number>({ name: 'small', maxSize: 2 });
+    cache.getOrCompute('a', () => 1);
+    cache.getOrCompute('b', () => 2);
+    expect(() => cache.getOrCompute('c', () => 3)).toThrow(/exceeded maxSize=2/);
+    // Existing keys still work after the cap is hit
+    expect(cache.getOrCompute('a', () => 99)).toBe(1);
+  });
+
+  it('throws when maxSize is exceeded on set()', () => {
+    const cache = new PrecomputeCache<number>({ name: 'small', maxSize: 2 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(() => cache.set('c', 3)).toThrow(/exceeded maxSize=2/);
+    // Re-setting an existing key does NOT trigger overflow
+    cache.set('a', 10);
+    expect(cache.get('a')).toBe(10);
+  });
+
+  it('has / get / size mirror the underlying Map semantics', () => {
+    const cache = new PrecomputeCache<string>({ name: 'mirror' });
+    expect(cache.has('x')).toBe(false);
+    expect(cache.get('x')).toBeUndefined();
+    expect(cache.size).toBe(0);
+    cache.set('x', 'foo');
+    expect(cache.has('x')).toBe(true);
+    expect(cache.get('x')).toBe('foo');
+    expect(cache.size).toBe(1);
+  });
+
+  it('stats() returns name + size + maxSize for telemetry', () => {
+    const cache = new PrecomputeCache<number>({ name: 'tel', maxSize: 100 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.stats()).toEqual({ name: 'tel', size: 2, maxSize: 100 });
+  });
+
+  it('default maxSize is 5000 (fits realistic locale × canton × sector combos)', () => {
+    const cache = new PrecomputeCache<number>({ name: 'default' });
+    expect(cache.stats().maxSize).toBe(5000);
+  });
+
+  it('error message includes the offending key + cache name for debuggability', () => {
+    const cache = new PrecomputeCache<number>({ name: 'mycache', maxSize: 1 });
+    cache.set('first', 1);
+    let err: Error | null = null;
+    try { cache.set('second', 2); } catch (e) { err = e as Error; }
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain('mycache');
+    expect(err!.message).toContain('second');
+    expect(err!.message).toContain('maxSize=1');
+  });
+});


### PR DESCRIPTION
Covers the 3 utility modules added in #339/#336/#331 that were missing
unit tests. 47 tests across 3 files, all green locally.

tests/seo/precompute-cache.test.ts (8 tests):
  - cached-value parity on repeated lookups (single compute)
  - distinct keys cached independently
  - maxSize cap throws on getOrCompute + set() overflow
  - has/get/size mirror Map semantics
  - stats() shape for telemetry
  - default maxSize=5000 confirmed
  - error message contains cache name + offending key + maxSize

tests/seo/html-minify.test.ts (19 tests):
  - safety: bad input types (null, undefined, non-string) return unchanged
  - text-content preservation on representative inputs
  - inter-block whitespace collapse + leading-line whitespace strip
  - inline-element adjacency preserved (`<a>foo</a> bar` ≠ `<a>foo</a>bar`)
  - CRLF normalized to LF
  - ordinary HTML comments stripped
  - IE conditional comments preserved
  - ALL_CAPS placeholder comments preserved (the #343 fix that
    unblocked weeklyEmployersPlugin.injectSiblingLinks)
  - <script>/<style>/<pre>/<textarea>/<title> bodies opaque (vincolo N2)
  - JSON-LD body byte-identical pre/post (vincolo N2)
  - complete SEO shell: structural assertions + visible-text equality
  - idempotent on already-minified output

tests/seo/audit-runner.test.ts (20 tests):
  - walkHtmlFiles: recursive walk, dot-dir skip, non-html filter
  - sharedExtract: title/h1 extraction with entity decoding +
    whitespace normalization
  - sharedExtract: robots noindex detection (meta + meta-refresh)
  - sharedExtract: jsonLdScripts array extracted correctly
  - filterAuditors: csv filter, undefined → all, unknown names ignored
  - runAudits end-to-end: file dispatch counts, report aggregation,
    empty-auditor + missing-dist + invalid-shape error paths

These tests fill the test-coverage gap from the L1+L2+L3 round
(see pending-work checklist in 2026-05-19-build-and-audit-optimization-baseline.md).
