### PR TITLE
fix(newsletter): broaden article + job rotation pools to stop weekly repetition

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -747,9 +747,13 @@ function computeExchangeInsight(series, fallbackRate, fallbackPrev) {
   };
 }
 
+// Candidate pool size must comfortably exceed MAX_HISTORY (12) so rotation
+// never collapses to "every top-viewed article is in the exclude list".
+const TOP_ARTICLES_LIMIT = 50;
+
 async function fetchTopArticles() {
   try {
-    const snap = await db.collection('article_views').orderBy('views', 'desc').limit(10).get();
+    const snap = await db.collection('article_views').orderBy('views', 'desc').limit(TOP_ARTICLES_LIMIT).get();
     if (snap.empty) return [];
     return snap.docs.map((d) => ({
       id: d.id,
@@ -760,6 +764,39 @@ async function fetchTopArticles() {
     }));
   } catch (e) {
     console.warn('\u26a0\ufe0f Top articles fetch failed:', e.message);
+    return [];
+  }
+}
+
+/**
+ * Second-tier featured-article pool: most recently *published* articles,
+ * regardless of views. Used by selectFeaturedArticleId when the views-based
+ * pool is exhausted \u2014 promotes new content instead of looping on evergreens.
+ *
+ * Reads data/blog-articles/*.json (each file carries a `publishedAt` ISO
+ * string) and returns at most {limit} article IDs sorted newest first.
+ */
+function fetchRecentlyPublishedArticleIds(limit = 30) {
+  try {
+    const dir = new URL('../data/blog-articles/', import.meta.url);
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+    const articles = [];
+    for (const file of files) {
+      try {
+        const raw = fs.readFileSync(new URL(file, dir), 'utf8');
+        const data = JSON.parse(raw);
+        const ts = Date.parse(data.publishedAt || '');
+        if (!Number.isNaN(ts)) {
+          articles.push({ id: data.id || file.replace(/\.json$/, ''), ts });
+        }
+      } catch {
+        // Skip unparseable file
+      }
+    }
+    articles.sort((a, b) => b.ts - a.ts);
+    return articles.slice(0, limit).map((a) => a.id);
+  } catch (e) {
+    console.warn('\u26a0\ufe0f Recently published articles scan failed:', e.message);
     return [];
   }
 }
@@ -920,7 +957,11 @@ async function saveRecentlyFeaturedArticle(articleId) {
 
 // \u2500\u2500\u2500 Job rotation (mirrors article rotation) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 const RECENTLY_FEATURED_JOBS_KEY = 'recently_featured_jobs';
-const MAX_FEATURED_JOBS_HISTORY = 8; // 2 weeks \u00d7 4 cards = 8 slots
+// Each weekly send flattens 4 cards across N subscribers into 100+ distinct
+// slugs (personalization expands the set). Keeping the window large enough to
+// cover ~3-4 weeks of distinct featured slugs prevents popular jobs from
+// resurfacing every other send.
+const MAX_FEATURED_JOBS_HISTORY = 100;
 
 async function fetchRecentlyFeaturedJobs() {
   if (!db) return [];
@@ -1003,13 +1044,18 @@ async function pickFeaturedArticle() {
         fetchTopArticles(),
         fetchRecentlyFeaturedArticles(),
       ]);
+      const recentlyPublished = fetchRecentlyPublishedArticleIds();
       const hasMeta = (id) => !!loadBlogMeta(id, 'it');
-      const pick = selectFeaturedArticleId(topArticles, recentlyFeatured, hasMeta);
+      const pick = selectFeaturedArticleId(topArticles, recentlyFeatured, hasMeta, Date.now(), recentlyPublished);
       if (pick.id) {
         bestId = pick.id;
         const best = topArticles.find((a) => a.id === pick.id);
-        const rotated = pick.reason === 'fresh' ? '' : ' (rotation exhausted, reusing)';
-        console.log(`\ud83d\udcf0 Featured article: "${pick.id}" (${best?.views ?? '?'} views)${rotated}`);
+        const reasonLabel = {
+          'fresh': '',
+          'recent-publication': ' (recently published, promoting)',
+          'rotation-exhausted': ' (rotation exhausted, reusing)',
+        }[pick.reason] || '';
+        console.log(`\ud83d\udcf0 Featured article: "${pick.id}" (${best?.views ?? '?'} views)${reasonLabel}`);
         if (recentlyFeatured.length > 0) {
           console.log(`   Recently featured (excluded): ${recentlyFeatured.join(', ')}`);
         }

--- a/services/newsletter-article-rotation.mjs
+++ b/services/newsletter-article-rotation.mjs
@@ -8,30 +8,54 @@
 /**
  * @param {Array<{id:string,views:number,lastViewed:Date|null}>} topArticles
  *   Firestore article_views docs, sorted by views desc upstream.
- * @param {string[]} recentlyFeatured  Article IDs to exclude (rotation history).
+ * @param {string[]} recentlyFeatured  Article IDs to exclude (rotation history),
+ *   most-recent first.
  * @param {(id:string)=>boolean} hasMeta  Whether a blog post exists for the ID.
  * @param {number} [now=Date.now()]  Injected for deterministic tests.
+ * @param {string[]} [recentlyPublished=[]]  Second-tier pool: article IDs sorted
+ *   by publish date descending. Used when the views-based pool is exhausted
+ *   (every top-viewed article is in the exclude list). Promotes new content
+ *   instead of ruminating evergreen winners.
  * @returns {{id: string|null, reason: string}}
  */
-export function selectFeaturedArticleId(topArticles, recentlyFeatured, hasMeta, now = Date.now()) {
-  if (!topArticles || topArticles.length === 0) return { id: null, reason: 'no-top-articles' };
+export function selectFeaturedArticleId(
+  topArticles,
+  recentlyFeatured,
+  hasMeta,
+  now = Date.now(),
+  recentlyPublished = [],
+) {
   const byViewsThenRecency = (a, b) =>
     b.views - a.views || (b.lastViewed || 0) - (a.lastViewed || 0);
+  const allSorted = [...(topArticles || [])].sort(byViewsThenRecency);
   const weekAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
-  const recentTop = topArticles
-    .filter((a) => a.lastViewed && a.lastViewed > weekAgo)
-    .sort(byViewsThenRecency);
-  const allSorted = [...topArticles].sort(byViewsThenRecency);
+  const recentTop = allSorted.filter((a) => a.lastViewed && a.lastViewed > weekAgo);
 
-  // Prefer a recently-viewed article that isn't in the rotation-exclude list.
-  // Fall back to all-time top if no recent article qualifies — otherwise a
-  // single fresh view on the currently-featured article would collapse the
-  // candidate pool to one and defeat rotation.
+  // 1. Recently viewed AND not in exclude list AND has meta.
+  // 2. Any all-time top not in exclude list AND has meta.
   const fresh =
     recentTop.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id)) ||
     allSorted.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id));
   if (fresh) return { id: fresh.id, reason: 'fresh' };
-  const reused = allSorted.find((a) => hasMeta(a.id));
-  if (reused) return { id: reused.id, reason: 'rotation-exhausted' };
-  return { id: null, reason: 'no-meta-for-any-top' };
+
+  // 3. Second-tier pool: recently-published article that hasn't been featured
+  //    yet. Promotes new content when the views-based pool is exhausted.
+  const freshlyPublished = recentlyPublished.find(
+    (id) => !recentlyFeatured.includes(id) && hasMeta(id),
+  );
+  if (freshlyPublished) return { id: freshlyPublished, reason: 'recent-publication' };
+
+  // 4. Rotation truly exhausted — reuse the LEAST recently featured among the
+  //    top-viewed (recentlyFeatured is most-recent first, so a higher index
+  //    means "featured longer ago"). Avoids picking the all-time #1 every week.
+  if (allSorted.length === 0) return { id: null, reason: 'no-top-articles' };
+  const eligible = allSorted.filter((a) => hasMeta(a.id));
+  if (eligible.length === 0) return { id: null, reason: 'no-meta-for-any-top' };
+  const stalenessRank = (id) => {
+    const idx = recentlyFeatured.indexOf(id);
+    // Never featured → most "stale" → highest rank.
+    return idx === -1 ? Number.POSITIVE_INFINITY : idx;
+  };
+  eligible.sort((a, b) => stalenessRank(b.id) - stalenessRank(a.id) || b.views - a.views);
+  return { id: eligible[0].id, reason: 'rotation-exhausted' };
 }

--- a/services/newsletter-content.mjs
+++ b/services/newsletter-content.mjs
@@ -396,9 +396,13 @@ export function matchJobsForSubscriber(subscriber, jobs, limit = 3, locale = 'it
       (j.slug && recentSet.has(j.slug)) ||
       Object.values(j.slugByLocale || {}).some((s) => s && recentSet.has(s))
     );
-  // Only apply exclusion when enough non-recent jobs remain
+  // Prefer fresh jobs always; only mix in recent-featured ones at the END to
+  // backfill missing slots. This guarantees a popular evergreen job in the
+  // exclude list cannot displace fresh candidates just because the fresh pool
+  // is below {limit}.
   const freshPool = fullPool.filter((j) => !jobIsRecent(j));
-  const pool = freshPool.length >= limit ? freshPool : fullPool;
+  const recentPool = fullPool.filter((j) => jobIsRecent(j));
+  const pool = freshPool.length >= limit ? freshPool : [...freshPool, ...recentPool];
 
   // ── Build subscriber interest profile from available signals ──
   const jobSlug = subscriber?.job_slug || '';

--- a/tests/newsletter-article-rotation.test.ts
+++ b/tests/newsletter-article-rotation.test.ts
@@ -40,14 +40,69 @@ describe('selectFeaturedArticleId', () => {
     expect(pick).toEqual({ id: 'b', reason: 'fresh' });
   });
 
-  it('marks reason=rotation-exhausted only when every article is in the exclude list', () => {
+  it('uses recently-published pool when every top-viewed is excluded', () => {
     const top = [
       { id: 'a', views: 100, lastViewed: daysAgo(10) },
       { id: 'b', views: 90, lastViewed: daysAgo(20) },
     ];
-    const pick = selectFeaturedArticleId(top, ['a', 'b'], alwaysHasMeta, NOW);
+    const recentlyPublished = ['new-1', 'new-2'];
+    const pick = selectFeaturedArticleId(top, ['a', 'b'], alwaysHasMeta, NOW, recentlyPublished);
+    expect(pick).toEqual({ id: 'new-1', reason: 'recent-publication' });
+  });
+
+  it('skips recently-published articles already in the exclude list', () => {
+    const top = [
+      { id: 'a', views: 100, lastViewed: daysAgo(10) },
+    ];
+    const recentlyPublished = ['new-1', 'new-2'];
+    const pick = selectFeaturedArticleId(top, ['a', 'new-1'], alwaysHasMeta, NOW, recentlyPublished);
+    expect(pick).toEqual({ id: 'new-2', reason: 'recent-publication' });
+  });
+
+  it('skips recently-published articles without blog meta', () => {
+    const top = [
+      { id: 'a', views: 100, lastViewed: daysAgo(10) },
+    ];
+    const recentlyPublished = ['has-no-meta', 'has-meta'];
+    const hasMeta = (id: string) => id === 'has-meta' || id === 'a';
+    const pick = selectFeaturedArticleId(top, ['a'], hasMeta, NOW, recentlyPublished);
+    expect(pick).toEqual({ id: 'has-meta', reason: 'recent-publication' });
+  });
+
+  it('marks reason=rotation-exhausted only when top-viewed AND recently-published are all in exclude', () => {
+    const top = [
+      { id: 'a', views: 100, lastViewed: daysAgo(10) },
+      { id: 'b', views: 90, lastViewed: daysAgo(20) },
+    ];
+    const pick = selectFeaturedArticleId(top, ['a', 'b'], alwaysHasMeta, NOW, []);
     expect(pick.reason).toBe('rotation-exhausted');
     expect(['a', 'b']).toContain(pick.id);
+  });
+
+  it('exhausted fallback picks the LEAST recently featured, not the all-time #1', () => {
+    const top = [
+      { id: 'a', views: 200, lastViewed: daysAgo(2) }, // featured last week (idx 0)
+      { id: 'b', views: 150, lastViewed: daysAgo(8) }, // featured 5 weeks ago (idx 4)
+      { id: 'c', views: 120, lastViewed: daysAgo(10) }, // featured 2 weeks ago (idx 1)
+    ];
+    // recentlyFeatured ordered most-recent first: [a, c, ..., b]
+    const recentlyFeatured = ['a', 'c', 'x', 'y', 'b'];
+    const pick = selectFeaturedArticleId(top, recentlyFeatured, alwaysHasMeta, NOW, []);
+    expect(pick).toEqual({ id: 'b', reason: 'rotation-exhausted' });
+  });
+
+  it('exhausted fallback prefers a never-featured top article over any reused one', () => {
+    const top = [
+      { id: 'a', views: 200, lastViewed: daysAgo(2) },
+      { id: 'b', views: 150, lastViewed: daysAgo(8) },
+      { id: 'unseen', views: 50, lastViewed: daysAgo(50) },
+    ];
+    const recentlyFeatured = ['a', 'b'];
+    // 'unseen' is in top-viewed but never featured AND not in recentlyPublished.
+    const pick = selectFeaturedArticleId(top, recentlyFeatured, alwaysHasMeta, NOW, []);
+    // With no recentlyPublished pool, 'unseen' should still come out as fresh
+    // because it isn't in the exclude list.
+    expect(pick).toEqual({ id: 'unseen', reason: 'fresh' });
   });
 
   it('skips articles without blog meta', () => {

--- a/tests/newsletter-template-tracking.test.ts
+++ b/tests/newsletter-template-tracking.test.ts
@@ -119,6 +119,23 @@ describe('newsletter content v2', () => {
     expect(matched.length).toBe(2);
   });
 
+  // Regression: recentlyFeaturedSlugs must never displace fresh candidates
+  // just because the fresh pool is shorter than `limit`. Older logic
+  // (freshPool.length >= limit ? freshPool : fullPool) wholesale fell back to
+  // the full pool, so an evergreen popular job in the exclude list could win
+  // again. New logic puts fresh first and only backfills missing slots.
+  it('matchJobsForSubscriber prefers fresh over recently-featured even when fresh pool is short', () => {
+    const jobs = [
+      { title: 'Evergreen', company: 'BigCo', location: 'Lugano', slug: 'evergreen', publishedAt: new Date().toISOString() },
+      { title: 'Fresh', company: 'NewCo', location: 'Lugano', slug: 'fresh-job', publishedAt: new Date().toISOString() },
+    ];
+
+    const matched = matchJobsForSubscriber({ locationInterest: null, sectorInterest: null }, jobs, 4, 'it', ['evergreen']);
+    expect(matched[0].slug).toBe('fresh-job');
+    expect(matched.length).toBe(2);
+    expect(matched.map((j) => j.slug)).toEqual(['fresh-job', 'evergreen']);
+  });
+
   it('getFallbackBriefing returns HTML for all locales', () => {
     for (const locale of ['it', 'en', 'de', 'fr']) {
       const html = getFallbackBriefing(locale, SAMPLE_EXCHANGE);


### PR DESCRIPTION
The newsletter was reusing the same featured article and overlapping job
cards across consecutive sends. Three independent causes, all fixed here:

1. Article candidate pool was top-10 by views, exclude history was 12
   deep, so the pool was *always* a subset of the exclude list →
   'rotation exhausted, reusing' fell back to the all-time #1 every
   week. Bumped TOP_ARTICLES_LIMIT to 50 and added a second-tier pool
   of recently-published articles (data/blog-articles/*.json publishedAt
   field) that kicks in before the exhausted-fallback. Exhausted
   fallback now picks the LEAST recently featured eligible article
   instead of the all-time #1.

2. MAX_FEATURED_JOBS_HISTORY was 8 with a comment saying '2 weeks x 4
   cards' but each subscriber sees 4 personalized cards, so a single
   send already produces 100+ distinct slugs that get truncated to 8.
   Bumped to 100 so 3-4 weeks of distinct featured slugs are remembered.

3. matchJobsForSubscriber discarded the whole freshPool when shorter
   than {limit} and fell back to the full pool, letting evergreen
   excluded jobs win the top slot. Now fresh always comes first and the
   exclude-list jobs only backfill missing slots.

Added regression tests for the second-tier pool, the smarter exhausted
fallback ordering, and the fresh-over-recent ordering in
matchJobsForSubscriber.
