### PR TITLE
fix(audit): exclude legacy redirects + extract repeated inline styles to CSS classes (cost-of-living)

### DIFF
--- a/build-plugins/costOfLivingLandingsCopy.ts
+++ b/build-plugins/costOfLivingLandingsCopy.ts
@@ -22,10 +22,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ColCityId, ColLocale } from './costOfLivingLandingsData';
 import { COL_CITY_DISPLAY } from './costOfLivingLandingsData';
-import {
-  TABLE_HEAD_STYLE,
-  TABLE_CELL_STYLE,
-} from './shared/seoContentTokens';
+// Note: table head/cell styling now lives in a single <style> block emitted
+// at the top of <main> by costOfLivingLandingsPlugin.ts. The rendered HTML
+// uses class="t-h" / class="t-c" instead of inline `style="${TABLE_HEAD_STYLE}"`
+// — saves ~3-5 KB per page across the rent + basket + comparison tables.
+// See the `sharedStyleBlock` comment in costOfLivingLandingsPlugin.ts for the
+// text-html ratio rationale.
 
 // ── Types for the JSON payloads (narrowed at load time) ────────────
 
@@ -593,7 +595,7 @@ export function buildCitySections(
         ${L.rentTableHeaders
           .map(
             (h) =>
-              `<th style="${TABLE_HEAD_STYLE}">${h}</th>`,
+              `<th class="t-h">${h}</th>`,
           )
           .join('')}
       </tr></thead>
@@ -602,9 +604,9 @@ export function buildCitySections(
           .map(
             ([key, val]) => `
             <tr>
-              <td style="${TABLE_CELL_STYLE}">${L.rows[key as keyof typeof L.rows]}</td>
-              <td style="${TABLE_CELL_STYLE}"><strong>${rtFmtChf(val)}</strong>/${locale === 'it' ? 'mese' : locale === 'en' ? 'month' : locale === 'de' ? 'Monat' : 'mois'}</td>
-              <td style="${TABLE_CELL_STYLE}">${citeFso(FSO_LABEL)}</td>
+              <td class="t-c">${L.rows[key as keyof typeof L.rows]}</td>
+              <td class="t-c"><strong>${rtFmtChf(val)}</strong>/${locale === 'it' ? 'mese' : locale === 'en' ? 'month' : locale === 'de' ? 'Monat' : 'mois'}</td>
+              <td class="t-c">${citeFso(FSO_LABEL)}</td>
             </tr>
           `,
           )
@@ -633,7 +635,7 @@ export function buildCitySections(
         ${L.basketTableHeaders
           .map(
             (h) =>
-              `<th style="${TABLE_HEAD_STYLE}">${h}</th>`,
+              `<th class="t-h">${h}</th>`,
           )
           .join('')}
       </tr></thead>
@@ -642,9 +644,9 @@ export function buildCitySections(
           .map(
             ([key, val, src]) => `
             <tr>
-              <td style="${TABLE_CELL_STYLE}">${L.rows[key as keyof typeof L.rows]}</td>
-              <td style="${TABLE_CELL_STYLE}"><strong>${key === 'cpi' ? val.toFixed(1) : rtFmtEur(val as number)}</strong>${key === 'cpi' ? '' : key === 'restaurant' ? '' : locale === 'it' ? '/mese' : locale === 'en' ? '/month' : locale === 'de' ? '/Monat' : '/mois'}</td>
-              <td style="${TABLE_CELL_STYLE}">${src === 'OMI' ? citeOmi(src) : citeIstat(src)}</td>
+              <td class="t-c">${L.rows[key as keyof typeof L.rows]}</td>
+              <td class="t-c"><strong>${key === 'cpi' ? val.toFixed(1) : rtFmtEur(val as number)}</strong>${key === 'cpi' ? '' : key === 'restaurant' ? '' : locale === 'it' ? '/mese' : locale === 'en' ? '/month' : locale === 'de' ? '/Monat' : '/mois'}</td>
+              <td class="t-c">${src === 'OMI' ? citeOmi(src) : citeIstat(src)}</td>
             </tr>
           `,
           )
@@ -693,35 +695,35 @@ export function buildCitySections(
     return `
       <table class="seo-table" style="width:100%;border-collapse:collapse;margin:16px 0;font-size:15px">
         <thead><tr>
-          <th style="${TABLE_HEAD_STYLE}">${r.voice}</th>
-          <th style="${TABLE_HEAD_STYLE}">${r.ch}</th>
-          <th style="${TABLE_HEAD_STYLE}">${r.it}</th>
-          <th style="${TABLE_HEAD_STYLE}">${r.delta}</th>
+          <th class="t-h">${r.voice}</th>
+          <th class="t-h">${r.ch}</th>
+          <th class="t-h">${r.it}</th>
+          <th class="t-h">${r.delta}</th>
         </tr></thead>
         <tbody>
           <tr>
-            <td style="${TABLE_CELL_STYLE}">${r.rent}</td>
-            <td style="${TABLE_CELL_STYLE}">${rtFmtChf(fso.rooms_2_5.median_chf_month)}</td>
-            <td style="${TABLE_CELL_STYLE}">${rtFmtEur(istat.rent_eur_month.rooms_2)}</td>
-            <td style="${TABLE_CELL_STYLE}"><strong>−${rentPct}%</strong></td>
+            <td class="t-c">${r.rent}</td>
+            <td class="t-c">${rtFmtChf(fso.rooms_2_5.median_chf_month)}</td>
+            <td class="t-c">${rtFmtEur(istat.rent_eur_month.rooms_2)}</td>
+            <td class="t-c"><strong>−${rentPct}%</strong></td>
           </tr>
           <tr>
-            <td style="${TABLE_CELL_STYLE}">${r.lamal}</td>
-            <td style="${TABLE_CELL_STYLE}">${rtFmtChf(380)}</td>
-            <td style="${TABLE_CELL_STYLE}">${locale === 'it' ? 'SSN gratuito' : locale === 'en' ? 'SSN free' : locale === 'de' ? 'SSN kostenlos' : 'SSN gratuit'}</td>
-            <td style="${TABLE_CELL_STYLE}"><strong>−100%</strong></td>
+            <td class="t-c">${r.lamal}</td>
+            <td class="t-c">${rtFmtChf(380)}</td>
+            <td class="t-c">${locale === 'it' ? 'SSN gratuito' : locale === 'en' ? 'SSN free' : locale === 'de' ? 'SSN kostenlos' : 'SSN gratuit'}</td>
+            <td class="t-c"><strong>−100%</strong></td>
           </tr>
           <tr>
-            <td style="${TABLE_CELL_STYLE}">${r.grocery}</td>
-            <td style="${TABLE_CELL_STYLE}">${rtFmtChf(700)}</td>
-            <td style="${TABLE_CELL_STYLE}">${rtFmtEur(istat.grocery_basket_eur_month_single)}</td>
-            <td style="${TABLE_CELL_STYLE}"><strong>−${groceryPct}%</strong></td>
+            <td class="t-c">${r.grocery}</td>
+            <td class="t-c">${rtFmtChf(700)}</td>
+            <td class="t-c">${rtFmtEur(istat.grocery_basket_eur_month_single)}</td>
+            <td class="t-c"><strong>−${groceryPct}%</strong></td>
           </tr>
           <tr>
-            <td style="${TABLE_CELL_STYLE}">${r.transport}</td>
-            <td style="${TABLE_CELL_STYLE}">${rtFmtChf(75)}</td>
-            <td style="${TABLE_CELL_STYLE}">${rtFmtEur(istat.transport_monthly_pass_eur)}</td>
-            <td style="${TABLE_CELL_STYLE}"><strong>~par</strong></td>
+            <td class="t-c">${r.transport}</td>
+            <td class="t-c">${rtFmtChf(75)}</td>
+            <td class="t-c">${rtFmtEur(istat.transport_monthly_pass_eur)}</td>
+            <td class="t-c"><strong>~par</strong></td>
           </tr>
         </tbody>
       </table>`;

--- a/build-plugins/costOfLivingLandingsPlugin.ts
+++ b/build-plugins/costOfLivingLandingsPlugin.ts
@@ -77,6 +77,8 @@ import {
   HERO_EYEBROW_STYLE,
   LEDE_STYLE,
   SMALL_HEADING_STYLE,
+  TABLE_HEAD_STYLE,
+  TABLE_CELL_STYLE,
   renderStatGrid,
   pickStatTileTone,
   differentiateH1FromTitle,
@@ -392,7 +394,7 @@ function renderPage(opts: {
     .map(
       (s) => `
         <section style="margin:0 0 28px;max-width:960px">
-          <h2 style="${H2_STYLE}">${esc(s.title)}</h2>
+          <h2 class="col-h2">${esc(s.title)}</h2>
           ${s.html}
         </section>`,
     )
@@ -464,15 +466,23 @@ function renderPage(opts: {
   const employerGridHtml = renderEmployerGrid(snapshot, view, locale, city);
   const dividerHtml = renderApprofondisciDivider(view.approfondisciHeading);
 
-  // Extract FAQ <details> styling to a single <style> block + 3 classes
-  // (.cf, .cs, .ca). Inline-style variant cost ~500 B per FAQ × N items per
-  // page; on 16 cost-of-living locale pages this floored the text-to-HTML
-  // ratio in the 9.0-9.95% band (just under the Semrush 10% gate). The
-  // class-based variant costs ~250 B once + ~80 B per FAQ — saves ~6-10 KB
-  // per page, lifting the ratio above the threshold without rewriting the
-  // editorial content.
-  const faqStyleBlock = `<style>.cf{margin:0 0 10px;${CARD_STYLE};border-radius:12px}.cs{font-weight:700;cursor:pointer;color:var(--color-heading);line-height:1.45}.ca{margin:10px 0 0;color:var(--color-body);line-height:1.65}</style>`;
-  const faqHtml = faqStyleBlock + faqs
+  // Extract FAQ <details> + table cell styling to a single <style> block +
+  // ~5 classes. Each table cell + header had `style="..."` (~110-170 B
+  // inline) and there are ~25-35 such elements per page across the rent +
+  // basket + comparison tables in costOfLivingLandingsCopy.ts. After PR
+  // #338 added the DE/FR/EN locale variants, this floored text-html ratio
+  // at ~7.98-8.58% on cost-of-living city pages (just under the Semrush
+  // 10 % gate, baseline allowed 25 spa-locale offenders, observed 30).
+  //
+  // Resolution: define the shared style block ONCE at the top of <main>
+  // (so the rules apply to BOTH tables in sectionsHtml AND the FAQ block
+  // that follows), and replace `style="${TABLE_HEAD_STYLE}"` with
+  // `class="t-h"` in costOfLivingLandingsCopy.ts. Saves ~3-5 KB per page
+  // on top of the FAQ extraction already in place. Classes (.cf/.cs/.ca
+  // for FAQ; .t-h/.t-c for tables) intentionally short to minimise
+  // per-usage overhead.
+  const sharedStyleBlock = `<style>.cf{margin:0 0 10px;${CARD_STYLE};border-radius:12px}.cs{font-weight:700;cursor:pointer;color:var(--color-heading);line-height:1.45}.ca{margin:10px 0 0;color:var(--color-body);line-height:1.65}.t-h{${TABLE_HEAD_STYLE}}.t-c{${TABLE_CELL_STYLE}}.col-h2{${H2_STYLE}}.col-lede{${LEDE_STYLE}}.col-eyebrow{${HERO_EYEBROW_STYLE}}</style>`;
+  const faqHtml = faqs
     .map(
       (f) => `<details class="cf"><summary class="cs">${esc(f.question)}</summary><p class="ca">${esc(f.answer)}</p></details>`,
     )
@@ -486,6 +496,7 @@ function renderPage(opts: {
     .join('');
 
   const body = `
+    ${sharedStyleBlock}
     <nav style="${BREADCRUMB_STYLE}">
       <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(L.breadcrumbHome)}</a>
       <span> / </span>
@@ -500,9 +511,9 @@ function renderPage(opts: {
           city: cityName,
         }, h1, denseLede)
       : `<header style="margin-bottom:20px">
-      <p style="${HERO_EYEBROW_STYLE}">${esc(L.eyebrow(cityName))}</p>
+      <p class="col-eyebrow">${esc(L.eyebrow(cityName))}</p>
       <h1 style="${H1_STYLE}">${esc(h1)}</h1>
-      <p style="${LEDE_STYLE}">${esc(denseLede)}</p>
+      <p class="col-lede">${esc(denseLede)}</p>
     </header>`}
     <p style="${HERO_EYEBROW_STYLE};margin-top:4px;font-weight:500">${esc(L.updatedLabel)} ${esc(dateStamp)}</p>
     ${statTilesHtml}
@@ -512,11 +523,11 @@ function renderPage(opts: {
     ${dividerHtml}
     ${sectionsHtml}
     <section style="margin:0 0 28px;max-width:960px">
-      <h2 style="${H2_STYLE}">${esc(L.faqTitle)}</h2>
+      <h2 class="col-h2">${esc(L.faqTitle)}</h2>
       ${faqHtml}
     </section>
     <section style="margin:0 0 28px;max-width:960px">
-      <h2 style="${H2_STYLE}">${esc(L.relatedLabel)}</h2>
+      <h2 class="col-h2">${esc(L.relatedLabel)}</h2>
       <ul style="margin:0 0 0 20px;padding:0;color:var(--color-body);line-height:1.55">${relatedHtml}</ul>
     </section>
     <section style="display:flex;gap:12px;flex-wrap:wrap;margin:0 0 16px">

--- a/scripts/audit-salary-landing-template.mjs
+++ b/scripts/audit-salary-landing-template.mjs
@@ -58,6 +58,12 @@ const SEO_STATIC_RE = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b/i;
 const THIN_H1_RE = /<h1\s+style="font-size:1\.25rem;font-weight:700;margin-bottom:\.5rem">/i;
 // Empty calculator placeholder div from the default branch.
 const PLACEHOLDER_DIV_RE = /<div\s+style="[^"]*;height:38rem;margin-top:1\.5rem"><\/div>/i;
+// Legacy-redirect bridge detection: pages whose `<link rel="canonical">`
+// points to a different URL than the page's own path are intentional
+// redirects (handled by legacyRedirectsPlugin / shell helpers), NOT
+// salary-landing templates. Same exclusion pattern used by
+// audit-content-duplicates.mjs.
+const CANONICAL_RE = /<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i;
 
 /**
  * @param {{ limit?: number }} [opts]
@@ -74,6 +80,34 @@ export function createAuditor(opts = {}) {
       // Normalize to a posix-style path so the regex matches on Windows too.
       const posixPath = file.replace(/\\/g, '/');
       if (!SALARY_LANDING_PATH_RE.test(posixPath)) return;
+
+      // Skip legacy-redirect bridge pages. legacyRedirectsPlugin emits
+      // ~10 historical-slug-bridge HTML pages at /calcola-stipendio/{old}/
+      // whose canonical points to the new slug (`/calcola-stipendio/{new}/`)
+      // or to a target outside the salary-calculator hub. These are
+      // intentionally thin (meta-refresh + JS location.replace) — they're
+      // NOT salary-landing templates and must not trigger this audit.
+      //
+      // Detection: parse the canonical href, compare to the page's own
+      // URL path (derived from the file path). If they differ, skip.
+      // Mirror pattern used by audit-content-duplicates.mjs.
+      const canonicalMatch = html.match(CANONICAL_RE);
+      if (canonicalMatch) {
+        const canonicalHref = canonicalMatch[1].trim();
+        // Convert canonical absolute URL to a normalized path
+        const canonicalPath = canonicalHref
+          .replace(/^https?:\/\/[^/]+/, '')
+          .replace(/[?#].*$/, '')
+          .replace(/\/$/, '') || '/';
+        // Convert file path to URL path: dist/foo/bar/index.html → /foo/bar
+        const ownPath = ('/' + relative(ROOT, file)
+          .replace(/\\/g, '/')
+          .replace(/^dist\//, '')
+          .replace(/\/index\.html$/, '')
+          .replace(/\.html$/, '')).replace(/\/$/, '') || '/';
+        if (canonicalPath !== ownPath) return; // legacy redirect bridge, skip
+      }
+
       scanned++;
 
       const reasons = [];


### PR DESCRIPTION
Two audit failures from post-deploy-validate-dist run 26087963151
(commit c63185756c, PR #343):

1. audit:salary-landing-template flagged 3 of 1835 pages as "thin
   fallback". The 3 pages are LEGACY REDIRECTS emitted by
   legacyRedirectsPlugin (`/calcola-stipendio/what-if-scenario/` →
   `/calcola-stipendio/cosa-cambia-se/`, etc.) — intentionally thin
   meta-refresh + JS location.replace shells. The audit should NOT
   include them; they're not salary-landing templates.

   Fix: add canonical-URL self-check to scripts/audit-salary-landing-template.mjs
   collect(). When `<link rel="canonical">` points to a URL different
   from the page's own path, the page is a redirect bridge → skip.
   Same exclusion pattern already in use in audit-content-duplicates.mjs.

   Verified on 4 synthetic test cases (1 legacy redirect, 1 thin
   self-canonical, 1 full template, 1 out-of-scope): all classifications
   correct.

2. audit:text-html-ratio flagged 30 spa-locale offenders (baseline 25,
   regression +5). Visible topOffenders are all cost-of-living city
   pages (de/lebenshaltungskosten-*-tessin, fr/cout-vie-chiasso-tessin,
   en/cost-of-living-chiasso-ticino) at 7.98-8.58% ratio — just below
   the 10% Semrush gate.

   Root cause: PR #338 expanded cost-of-living landings to DE/FR/EN.
   The page template uses inline `style="${TABLE_HEAD_STYLE}"` (~165 B
   per usage) and `style="${TABLE_CELL_STYLE}"` (~110 B) on every cell
   of the rent + basket + comparison tables. 28 such inline references
   per page × ~110 B avg = ~3 KB of repeated style attributes that
   inflate HTML bytes without contributing visible text.

   Fix: define a single `<style>` block at the top of <main> with
   classes `.t-h` / `.t-c` (table head/cell) plus `.col-h2` / `.col-lede`
   / `.col-eyebrow` for the other repeating heading patterns. Replace
   28 inline `style="${TABLE_HEAD_STYLE}"` / `style="${TABLE_CELL_STYLE}"`
   in costOfLivingLandingsCopy.ts with `class="t-h"` / `class="t-c"`.
   Replace 5 inline H2/LEDE/HERO_EYEBROW references in plugin.ts.

   The pattern mirrors the existing FAQ-style extraction (.cf/.cs/.ca
   classes) already in costOfLivingLandingsPlugin.ts:474 that solved
   the same problem for FAQ <details> elements in a prior round.

   Estimated saving: ~3-5 KB per page × 24 cost-of-living locale
   pages = ~80-120 KB total. text-html ratio on the 8 visible
   offenders: 7.98% → ~9.5-10.5% (above gate).

Both fixes preserve DOM-equivalent rendering (CSS rules apply
regardless of selector position in the document). No content changes,
no editorial-text additions.
