### PR TITLE
chore(i18n+release): job-alert form keys in 4 locales + WhatsNew v3.48.0

### DIFF
--- a/components/community/WhatsNewModal.tsx
+++ b/components/community/WhatsNewModal.tsx
@@ -33,6 +33,53 @@ interface Release {
 
 export const RELEASES: Release[] = [
  {
+ version: '3.48.0',
+ date: '2026-05-19',
+ titleKey: 'whatsNew.v3480.title',
+ items: [
+ {
+ type: 'improvement',
+ titleKey: 'whatsNew.v3480.jobAlertSimpler.title',
+ descKey: 'whatsNew.v3480.jobAlertSimpler.desc',
+ link: { tab: 'job-board' },
+ },
+ {
+ type: 'fix',
+ titleKey: 'whatsNew.v3480.jobAlertNoPopup.title',
+ descKey: 'whatsNew.v3480.jobAlertNoPopup.desc',
+ link: { tab: 'job-board' },
+ },
+ {
+ type: 'feature',
+ titleKey: 'whatsNew.v3480.hospitalCrawlers.title',
+ descKey: 'whatsNew.v3480.hospitalCrawlers.desc',
+ link: { tab: 'job-board' },
+ },
+ {
+ type: 'improvement',
+ titleKey: 'whatsNew.v3480.blogOpen.title',
+ descKey: 'whatsNew.v3480.blogOpen.desc',
+ link: { tab: 'blog' },
+ },
+ {
+ type: 'improvement',
+ titleKey: 'whatsNew.v3480.newsletterRotation.title',
+ descKey: 'whatsNew.v3480.newsletterRotation.desc',
+ },
+ {
+ type: 'feature',
+ titleKey: 'whatsNew.v3480.salaryLocales.title',
+ descKey: 'whatsNew.v3480.salaryLocales.desc',
+ link: { tab: 'calcolatore' },
+ },
+ {
+ type: 'improvement',
+ titleKey: 'whatsNew.v3480.fasterLoads.title',
+ descKey: 'whatsNew.v3480.fasterLoads.desc',
+ },
+ ],
+ },
+ {
  version: '3.47.0',
  date: '2026-04-21',
  titleKey: 'whatsNew.v3470.title',

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -809,6 +809,8 @@ const deCore: Record<string, string> = {
  'jobAlert.cantonSelectedCount': 'Ausgewählt',
  'jobAlert.cantonSelectedAria': 'Ausgewählte Kantone',
  'jobAlert.cantonHint': 'Leer lassen, um Alerts aus allen Schweizer Kantonen zu erhalten.',
+ 'jobAlert.advancedShow': 'Erweiterte Filter (optional)',
+ 'jobAlert.advancedHide': 'Erweiterte Filter ausblenden',
 
  'search.placeholder': 'Bereiche, Tools, Funktionen suchen...',
  'search.hint': 'Tippen Sie, um alle Bereiche der Website zu durchsuchen',
@@ -2447,6 +2449,22 @@ Regeln:
  'seoContent.stats.check4': 'Historische CHF-EUR Kursentwicklung und Gemeinschaftsdaten',
 
  // ─── What's New / Feature Announcements ─────────────────────────────
+ 'whatsNew.v3480.title': 'Job-Alerts, die funktionieren + mehr Spitäler + offener Blog',
+ 'whatsNew.v3480.jobAlertSimpler.title': 'Job-Alerts mit einem Klick',
+ 'whatsNew.v3480.jobAlertSimpler.desc': 'Das Job-Alert-Formular fragt jetzt nur noch nach dem Stichwort. Ort, Branche, Vertragsart und Kantone sind optionale Filter hinter einem Toggle — Stichwort eingeben und abonnieren in einer Sekunde.',
+ 'whatsNew.v3480.jobAlertNoPopup.title': 'Kein lästiges Popup nach dem Login mehr',
+ 'whatsNew.v3480.jobAlertNoPopup.desc': 'Das Popup, das nach dem Login zur Alert-Erstellung aufforderte, wurde entfernt (88% schlossen es). Ersetzt durch eine sanfte Einladung auf der Detailseite eines Inserats, max. 2 pro Tag.',
+ 'whatsNew.v3480.hospitalCrawlers.title': '16 neue Schweizer Spitäler im Job Board',
+ 'whatsNew.v3480.hospitalCrawlers.desc': '~256 neue Stellen aus Spitälern in Waadt, Genf, Basel und weiteren Kantonen. Dedizierte Crawler pro Standort, jede Nacht aktualisiert.',
+ 'whatsNew.v3480.blogOpen.title': 'Blog ohne Login lesbar',
+ 'whatsNew.v3480.blogOpen.desc': 'Blog-Artikel sind jetzt auch ohne Konto lesbar. Keine Paywall mehr für News und Tiefenberichte.',
+ 'whatsNew.v3480.newsletterRotation.title': 'Newsletter ohne Wiederholungen',
+ 'whatsNew.v3480.newsletterRotation.desc': 'Der Rotationspool für Artikel und Stellen wurde erweitert: keine identischen Inserate und Artikel mehr Woche für Woche.',
+ 'whatsNew.v3480.salaryLocales.title': 'Lohnrechner auch auf EN/DE/FR',
+ 'whatsNew.v3480.salaryLocales.desc': 'Die Lohnrechner-Landingpages sind jetzt auf Englisch, Deutsch und Französisch übersetzt — nicht mehr nur auf Italienisch.',
+ 'whatsNew.v3480.fasterLoads.title': 'Schnellere Seitenladezeiten',
+ 'whatsNew.v3480.fasterLoads.desc': 'CSS, Skripte und Logo in separate Dateien ausgelagert für besseres Browser-Caching. Konservativer HTML-Minifier für den ersten Render. Vorteile besonders auf Mobile.',
+
  'whatsNew.v3470.title': 'Neue tägliche und wöchentliche SEO-Bereiche',
  'whatsNew.v3470.fuelDaily.title': 'Diesel- und Benzinpreise täglich aktualisiert',
  'whatsNew.v3470.fuelDaily.desc': 'Diesel- und Benzinpreise werden täglich für das gesamte Tessin und 5 Zonen (Lugano, Mendrisio, Bellinzona, Locarno, Chiasso) aktualisiert, mit 7-Tage-Trend.',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -809,6 +809,8 @@ const enCore: Record<string, string> = {
  'jobAlert.cantonSelectedCount': 'Selected',
  'jobAlert.cantonSelectedAria': 'Selected cantons',
  'jobAlert.cantonHint': 'Leave empty to receive alerts from every Swiss canton.',
+ 'jobAlert.advancedShow': 'Advanced filters (optional)',
+ 'jobAlert.advancedHide': 'Hide advanced filters',
 
  'search.placeholder': 'Search sections, tools, features...',
  'search.hint': 'Type to search across all site sections',
@@ -2447,6 +2449,22 @@ Rules:
  'seoContent.stats.check4': 'Historical CHF-EUR exchange trends and community data',
 
  // ─── What's New / Feature Announcements ─────────────────────────────
+ 'whatsNew.v3480.title': 'Job alerts that actually work + more hospitals + open blog',
+ 'whatsNew.v3480.jobAlertSimpler.title': '1-click job alerts',
+ 'whatsNew.v3480.jobAlertSimpler.desc': 'The job alert form now only asks for the keyword. Location, sector, contract and cantons became optional filters behind a toggle — type a word and subscribe in one second.',
+ 'whatsNew.v3480.jobAlertNoPopup.title': 'No more annoying post-login popup',
+ 'whatsNew.v3480.jobAlertNoPopup.desc': 'Removed the popup that asked you to create an alert right after sign-in (88% of people closed it). Replaced with a gentle invite on the single-job page, capped at 2 a day.',
+ 'whatsNew.v3480.hospitalCrawlers.title': '16 new Swiss hospitals on the job board',
+ 'whatsNew.v3480.hospitalCrawlers.desc': '~256 new openings from hospitals in Vaud, Geneva, Basel and other cantons. Dedicated crawlers per facility, refreshed every night.',
+ 'whatsNew.v3480.blogOpen.title': 'Blog readable without login',
+ 'whatsNew.v3480.blogOpen.desc': 'Blog articles are now readable without an account. No more paywall for news and deep dives.',
+ 'whatsNew.v3480.newsletterRotation.title': 'Newsletter without repetition',
+ 'whatsNew.v3480.newsletterRotation.desc': 'Broadened the rotation pool of articles and jobs: no more identical listings and articles coming back week after week.',
+ 'whatsNew.v3480.salaryLocales.title': 'Salary calculator in EN/DE/FR too',
+ 'whatsNew.v3480.salaryLocales.desc': 'Salary calculator landings are now translated into English, German and French — not Italian only.',
+ 'whatsNew.v3480.fasterLoads.title': 'Faster page loads',
+ 'whatsNew.v3480.fasterLoads.desc': 'CSS, scripts and logo extracted to separate files for better browser caching. Conservative HTML minifier for the first render. Wins are most visible on mobile.',
+
  'whatsNew.v3470.title': 'New daily and weekly SEO sections',
  'whatsNew.v3470.fuelDaily.title': 'Diesel and petrol prices updated daily',
  'whatsNew.v3470.fuelDaily.desc': 'Diesel and petrol prices updated every day for all of Ticino and 5 zones (Lugano, Mendrisio, Bellinzona, Locarno, Chiasso), with a 7-day trend.',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -809,6 +809,8 @@ const frCore: Record<string, string> = {
  'jobAlert.cantonSelectedCount': 'Sélectionnés',
  'jobAlert.cantonSelectedAria': 'Cantons sélectionnés',
  'jobAlert.cantonHint': 'Laissez vide pour recevoir des alertes de tous les cantons suisses.',
+ 'jobAlert.advancedShow': 'Filtres avancés (facultatifs)',
+ 'jobAlert.advancedHide': 'Masquer les filtres avancés',
 
  'search.placeholder': 'Rechercher sections, outils, fonctionnalités...',
  'search.hint': 'Tapez pour rechercher dans toutes les sections du site',
@@ -2447,6 +2449,22 @@ Règles :
  'seoContent.stats.check4': 'Historique du change CHF-EUR et données communauté frontalière',
 
  // ─── What's New / Feature Announcements ─────────────────────────────────
+ 'whatsNew.v3480.title': 'Alertes emploi qui fonctionnent + plus d\'hôpitaux + blog ouvert',
+ 'whatsNew.v3480.jobAlertSimpler.title': 'Alertes emploi en 1 clic',
+ 'whatsNew.v3480.jobAlertSimpler.desc': 'Le formulaire d\'alerte emploi ne demande plus que le mot-clé. Lieu, secteur, contrat et cantons sont devenus des filtres optionnels derrière un toggle — tapez un mot, abonnez-vous en une seconde.',
+ 'whatsNew.v3480.jobAlertNoPopup.title': 'Plus de popup gênant après la connexion',
+ 'whatsNew.v3480.jobAlertNoPopup.desc': 'Supprimé le popup qui demandait de créer une alerte juste après la connexion (88% le fermaient). Remplacé par une invitation discrète sur la page d\'une offre, limitée à 2 par jour.',
+ 'whatsNew.v3480.hospitalCrawlers.title': '16 nouveaux hôpitaux suisses sur le job board',
+ 'whatsNew.v3480.hospitalCrawlers.desc': '~256 nouvelles offres d\'hôpitaux en Vaud, Genève, Bâle et d\'autres cantons. Crawlers dédiés par établissement, rafraîchis chaque nuit.',
+ 'whatsNew.v3480.blogOpen.title': 'Blog lisible sans connexion',
+ 'whatsNew.v3480.blogOpen.desc': 'Les articles du blog sont maintenant lisibles sans compte. Plus de paywall pour les actualités et les dossiers.',
+ 'whatsNew.v3480.newsletterRotation.title': 'Newsletter sans répétition',
+ 'whatsNew.v3480.newsletterRotation.desc': 'Le pool de rotation des articles et offres a été élargi : fini les mêmes offres et articles qui revenaient semaine après semaine.',
+ 'whatsNew.v3480.salaryLocales.title': 'Calculateur de salaire aussi en EN/DE/FR',
+ 'whatsNew.v3480.salaryLocales.desc': 'Les landings du calculateur de salaire sont maintenant traduites en anglais, allemand et français — plus seulement en italien.',
+ 'whatsNew.v3480.fasterLoads.title': 'Pages plus rapides',
+ 'whatsNew.v3480.fasterLoads.desc': 'CSS, scripts et logo extraits dans des fichiers séparés pour un meilleur caching navigateur. Minifier HTML conservateur pour le premier rendu. Gains surtout visibles sur mobile.',
+
  'whatsNew.v3470.title': 'Nouvelles sections SEO quotidiennes et hebdomadaires',
  'whatsNew.v3470.fuelDaily.title': 'Prix du diesel et de l\'essence mis à jour chaque jour',
  'whatsNew.v3470.fuelDaily.desc': 'Prix du diesel et de l\'essence mis à jour quotidiennement pour tout le Tessin et 5 zones (Lugano, Mendrisio, Bellinzona, Locarno, Chiasso), avec tendance sur 7 jours.',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -846,6 +846,8 @@ const translations: Record<string, string> = {
  'jobAlert.cantonSelectedCount': 'Selezionati',
  'jobAlert.cantonSelectedAria': 'Cantoni selezionati',
  'jobAlert.cantonHint': 'Lascia vuoto per ricevere alert da tutti i cantoni svizzeri.',
+ 'jobAlert.advancedShow': 'Filtri avanzati (opzionali)',
+ 'jobAlert.advancedHide': 'Nascondi filtri avanzati',
 
  // Search
  'search.placeholder': 'Cerca sezioni, strumenti, funzionalità...',
@@ -2534,6 +2536,22 @@ Regole:
  'seoContent.stats.check4': 'Andamento storico cambio CHF-EUR e dati comunità frontaliera',
 
  // ─── What's New / Feature Announcements ─────────────────────────────
+ 'whatsNew.v3480.title': 'Job alert che funzionano + più ospedali + blog libero',
+ 'whatsNew.v3480.jobAlertSimpler.title': 'Job alert in 1 click',
+ 'whatsNew.v3480.jobAlertSimpler.desc': 'Il form per creare un job alert ora chiede solo la parola chiave. Zona, settore, contratto e cantoni sono diventati filtri opzionali sotto il bottone — chi vuole li apre, gli altri si iscrivono in un secondo.',
+ 'whatsNew.v3480.jobAlertNoPopup.title': 'Niente più popup molesti dopo il login',
+ 'whatsNew.v3480.jobAlertNoPopup.desc': 'Tolto il popup che chiedeva di creare un alert subito dopo l\'accesso (88% delle persone lo chiudeva). Sostituito da un invito gentile sulla pagina del singolo lavoro, con limite di 2 al giorno.',
+ 'whatsNew.v3480.hospitalCrawlers.title': '16 nuovi ospedali svizzeri sul job board',
+ 'whatsNew.v3480.hospitalCrawlers.desc': '~256 nuove offerte da ospedali in Vaud, Ginevra, Basilea e altri cantoni. Crawler dedicati per ogni struttura, aggiornati ogni notte.',
+ 'whatsNew.v3480.blogOpen.title': 'Blog accessibile senza login',
+ 'whatsNew.v3480.blogOpen.desc': 'Gli articoli del blog ora sono leggibili anche senza account. Niente più paywall per le notizie e gli approfondimenti.',
+ 'whatsNew.v3480.newsletterRotation.title': 'Newsletter senza ripetizioni',
+ 'whatsNew.v3480.newsletterRotation.desc': 'Allargato il pool di articoli e lavori in rotazione: stop alle stesse offerte e agli stessi articoli che tornavano settimana dopo settimana.',
+ 'whatsNew.v3480.salaryLocales.title': 'Calcolatore stipendio anche in EN/DE/FR',
+ 'whatsNew.v3480.salaryLocales.desc': 'Le landing del calcolatore stipendio sono ora tradotte anche in inglese, tedesco e francese — non solo italiano.',
+ 'whatsNew.v3480.fasterLoads.title': 'Pagine più veloci',
+ 'whatsNew.v3480.fasterLoads.desc': 'CSS, script e logo estratti in file separati per migliore caching del browser. Minifier HTML conservativo per il primo render. Risparmio di tempo soprattutto su mobile.',
+
  'whatsNew.v3470.title': 'Nuove sezioni SEO giornaliere e settimanali',
  'whatsNew.v3470.fuelDaily.title': 'Prezzi diesel e benzina aggiornati ogni giorno',
  'whatsNew.v3470.fuelDaily.desc': 'Prezzo diesel e benzina aggiornati quotidianamente per tutto il Ticino e 5 zone (Lugano, Mendrisio, Bellinzona, Locarno, Chiasso), con trend degli ultimi 7 giorni.',


### PR DESCRIPTION
i18n: add jobAlert.advancedShow / jobAlert.advancedHide to IT/EN/DE/FR core
chunks. Backs the "Filtri avanzati" toggle introduced in #353 (job-alert
form simplification), so non-IT locales stop falling through to the IT
inline fallback.

WhatsNew: cover all user-visible features since v3.47.0 (2026-04-21) in
a single 3.48.0 entry — job-alert funnel rework (#353), 16 new hospital
crawlers (#350), open blog (#325), newsletter rotation (#349),
salary-landing EN/DE/FR (#335/#337), faster page loads (#303/#308/#309/
#310/#311 + minifier #336).
