### PR TITLE
fix(adsense): drop crossOrigin on Funding Choices loader to unblock CMP + TCF v2.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,11 @@
           if (!document.querySelector('script[data-fc-loader]')) {
             var s = document.createElement('script');
             s.async = true;
-            s.crossOrigin = 'anonymous';
+            // NOTE: do NOT set crossOrigin. Google FC `/i/pub-XXX` does not serve
+            // ACAO headers; setting crossOrigin='anonymous' turns this into a CORS
+            // request that the endpoint rejects, killing the CMP + TCF v2.2 string
+            // and capping EEA RPM to non-personalized rates. See regression test
+            // tests/index-html-fc-loader.test.ts.
             s.src = 'https://fundingchoicesmessages.google.com/i/pub-8628054934855353?ers=1';
             s.setAttribute('data-fc-loader','1');
             document.head.appendChild(s);

--- a/tests/index-html-fc-loader.test.ts
+++ b/tests/index-html-fc-loader.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Funding Choices loader — regression test for the CORS-breaking crossOrigin
+ * regression introduced 2026-05-04 (commit 0bbf6b99a0) and fixed 2026-05-19.
+ *
+ * Google FC `/i/pub-XXX` is served WITHOUT Access-Control-Allow-Origin headers.
+ * Setting crossOrigin='anonymous' on the injected <script> turns the request
+ * into a CORS fetch that the endpoint rejects with net::ERR_FAILED. The CMP
+ * engine then never initializes, no TCF v2.2 string is emitted, EEA traffic
+ * stays under the `no-tcf-string` policy (AD_PERSONALIZATION_RESTRICTED), and
+ * page RPM stays capped at the non-personalized €1-3 range — the exact lever
+ * documented in project_adsense_apr26 memory.
+ *
+ * This test pins the loader shape so the regression cannot return silently.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const indexHtml = readFileSync(
+  resolve(__dirname, '..', 'index.html'),
+  'utf8',
+);
+
+// Extract the Funding Choices loader script block (between the loadFc IIFE
+// and the closing </script>). Used by multiple assertions below.
+const FC_LOADER_BLOCK = (() => {
+  const start = indexHtml.indexOf("function loadFc()");
+  expect(start, 'loadFc() block must exist in index.html').toBeGreaterThan(-1);
+  const end = indexHtml.indexOf('</script>', start);
+  expect(end, 'closing </script> after loadFc() must exist').toBeGreaterThan(start);
+  return indexHtml.slice(start, end);
+})();
+
+describe('Funding Choices loader — index.html', () => {
+  it('injects the fundingchoicesmessages.google.com loader for pub-8628054934855353', () => {
+    expect(FC_LOADER_BLOCK).toMatch(
+      /fundingchoicesmessages\.google\.com\/i\/pub-8628054934855353/,
+    );
+  });
+
+  it('does NOT set crossOrigin on the FC loader <script> (would trigger CORS rejection)', () => {
+    // Match `s.crossOrigin = '…'` or `s.crossOrigin = "…"` or
+    // setAttribute('crossorigin', …) — both forms break the FC endpoint.
+    expect(FC_LOADER_BLOCK).not.toMatch(/\.crossOrigin\s*=/);
+    expect(FC_LOADER_BLOCK).not.toMatch(
+      /setAttribute\(\s*['"]crossorigin['"]/i,
+    );
+  });
+
+  it('marks the injected loader with data-fc-loader so we never double-inject', () => {
+    expect(FC_LOADER_BLOCK).toMatch(/data-fc-loader/);
+  });
+
+  it('signals the googlefcPresent iframe so FC knows the loader ran', () => {
+    expect(FC_LOADER_BLOCK).toMatch(/googlefcPresent/);
+  });
+
+  it('keeps the loader deferred (requestIdleCallback or DOMContentLoaded) — LCP safeguard', () => {
+    // The 2026-05-04 LCP-defer commit (~11.3s → ~3-4s mobile LCP) must remain.
+    expect(FC_LOADER_BLOCK).toMatch(/requestIdleCallback|DOMContentLoaded/);
+  });
+});


### PR DESCRIPTION
## Summary
- One-line regression fix: remove `s.crossOrigin = 'anonymous'` from the deferred Funding Choices loader in `index.html:267`.
- Adds `tests/index-html-fc-loader.test.ts` (5 assertions, runs under existing `tests.yml` CI gate) so the regression cannot return silently.

## Root cause
Commit `0bbf6b99a0` (2026-05-04 "perf(lcp): defer Funding Choices scripts") refactored the FC `<script>` tag into JS-injected and added `s.crossOrigin = 'anonymous'`. Google FC `/i/pub-XXX` is served WITHOUT `Access-Control-Allow-Origin` headers — the CORS request is rejected with `net::ERR_FAILED`. Live evidence from prod (mobile 390×844, 2026-05-19):

```
Access to script at 'https://fundingchoicesmessages.google.com/i/pub-8628054934855353?ers=1'
from origin 'https://frontaliereticino.ch' has been blocked by CORS policy.
```

Cascade observed in DOM:
| Symbol | Before fix | Expected after fix |
|---|---|---|
| `window.googlefc` | `undefined` | object |
| `window.__tcfapi` | `undefined` | function |
| `window.adsbygoogle` | `undefined` | array |
| FC anti-adblock recovery DOM | never drawn | drawn when adblock detected |

## Monetization impact
Per `project_adsense_apr26` memory (Apr 26 CMP config was specifically meant to emit TCF v2.2):
- 94% of revenue is EEA traffic (CH 52% + IT 42%) capped at non-personalized RPM (€1–3) for 15 days.
- `no-tcf-string` policy (16k requests in `AD_PERSONALIZATION_RESTRICTED`) should resolve within ~1h after deploy.
- Page RPM €3.36 → target €5–10+ once personalized ads return.

## Test plan
- [x] `npx vitest run tests/index-html-fc-loader.test.ts` — 5/5 pass with the fix.
- [x] Same test fails on `main` (verified via `git stash`) — proves regression detection.
- [x] No adjacent tests regress (`adsense-lazy-load`, `adsense-hostname` green).
- [ ] Post-deploy: prod incognito mobile EEA → `typeof window.__tcfapi === 'function'` within 5s after `requestIdleCallback`.
- [ ] AdSense console → Privacy & messaging: `no-tcf-string` transitions "open" → "resolved" within ~1h.