### PR TITLE
feat(crawlers): Kliniken Valens (104) + Merian Iselin (15) — Prospective shared factory

### DIFF
--- a/.github/workflows/update-jobs-kliniken-valens.yml
+++ b/.github/workflows/update-jobs-kliniken-valens.yml
@@ -1,0 +1,101 @@
+name: Update Kliniken Valens (Prospective) Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-kliniken-valens
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-kliniken-valens-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated KLINIKEN_VALENS crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_KLINIKEN_VALENS_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-kliniken-valens-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'kliniken-valens'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/kliniken-valens.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIKEN_VALENS jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-merian-iselin.yml
+++ b/.github/workflows/update-jobs-merian-iselin.yml
@@ -1,0 +1,101 @@
+name: Update Merian Iselin Klinik Basel Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-merian-iselin
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-merian-iselin-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated MERIAN_ISELIN crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_MERIAN_ISELIN_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-merian-iselin-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'merian-iselin'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/merian-iselin.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MERIAN_ISELIN jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/index.html
+++ b/index.html
@@ -264,7 +264,11 @@
           if (!document.querySelector('script[data-fc-loader]')) {
             var s = document.createElement('script');
             s.async = true;
-            s.crossOrigin = 'anonymous';
+            // NOTE: do NOT set crossOrigin. Google FC `/i/pub-XXX` does not serve
+            // ACAO headers; setting crossOrigin='anonymous' turns this into a CORS
+            // request that the endpoint rejects, killing the CMP + TCF v2.2 string
+            // and capping EEA RPM to non-personalized rates. See regression test
+            // tests/index-html-fc-loader.test.ts.
             s.src = 'https://fundingchoicesmessages.google.com/i/pub-8628054934855353?ers=1';
             s.setAttribute('data-fc-loader','1');
             document.head.appendChild(s);

--- a/scripts/lib/crawler-location-config.mjs
+++ b/scripts/lib/crawler-location-config.mjs
@@ -233,6 +233,8 @@ export const COMPANY_HQ = {
   'csvm-mustair':                 { city: 'Sta. Maria Val Müstair', canton: 'GR', postalCode: '7536', addressRegion: 'GR' },
   'klinik-arlesheim':             { city: 'Arlesheim',          canton: 'BL', postalCode: '4144', addressRegion: 'BL' },
   'rehab-basel':                  { city: 'Basel',              canton: 'BS', postalCode: '4055', addressRegion: 'BS' },
+  'kliniken-valens':              { city: 'Valens',             canton: 'SG', postalCode: '7317', addressRegion: 'SG' },
+  'merian-iselin':                { city: 'Basel',              canton: 'BS', postalCode: '4054', addressRegion: 'BS' },
   'spital-limmattal':             { city: 'Schlieren',          canton: 'ZH', postalCode: '8952', addressRegion: 'ZH' },
   'huntsman':                     { city: 'Monthey',            canton: 'VS', postalCode: '1870', addressRegion: 'VS' },
   'fielmann':                     { city: 'Sion',               canton: 'VS', postalCode: '1950', addressRegion: 'VS' },

--- a/scripts/lib/kliniken-valens-job-parser.mjs
+++ b/scripts/lib/kliniken-valens-job-parser.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Kliniken Valens job parser — Prospective.ch (medium 1005103).
+ *
+ * Public career site: https://valens.ch/karriere/offene-stellen/
+ * API:                https://ohws.prospective.ch/public/v1/medium/1005103/jobs
+ *
+ * Swiss specialist rehabilitation group operating multiple sites in eastern
+ * Switzerland: Valens (SG), Walenstadtberg, Walzenhausen, Davos Clavadel
+ * (former Zürcher RehaZentrum Davos), Pfäfers, and others.
+ *
+ * Uses the shared Prospective.ch factory.
+ */
+import { createProspectiveChParser } from './prospective-ch-job-parser-common.mjs';
+
+export const KLINIKEN_VALENS_KEY = 'kliniken-valens';
+export const KLINIKEN_VALENS_COMPANY_NAME = 'Kliniken Valens';
+export const KLINIKEN_VALENS_COMPANY_DOMAIN = 'kliniken-valens.ch';
+
+const parser = createProspectiveChParser({
+  companyKey: KLINIKEN_VALENS_KEY,
+  companyName: KLINIKEN_VALENS_COMPANY_NAME,
+  companyDomain: KLINIKEN_VALENS_COMPANY_DOMAIN,
+  mediumId: '1005103',
+  apiLang: 'de',
+  defaultCanton: 'SG',
+  defaultCity: 'Valens',
+  defaultPostalCode: '7317',
+  publicCareerUrl: 'https://valens.ch/karriere/offene-stellen/',
+  defaultSourceLang: 'de',
+  extraTrustedHosts: ['valens.ch', 'jobs.kliniken-valens.ch', 'blitzbewerbung.kliniken-valens.ch'],
+});
+
+export const fetchAllKlinikenValensJobs = parser.fetchAllJobs;
+export const isKlinikenValensJob = parser.isCompanyJob;
+export const isTrustedDomain = parser.isTrustedDomain;

--- a/scripts/lib/merian-iselin-job-parser.mjs
+++ b/scripts/lib/merian-iselin-job-parser.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Merian Iselin Klinik Basel job parser.
+ *
+ * Public career site: https://merianiselin.ch/klinik/jobs/offene-stellen
+ *
+ * Private surgical hospital in Basel (~700 staff, focus on orthopaedics +
+ * gynaecology). Static HTML listing with `<li class="jobs-list__item">`
+ * cards; each links to a detail page at
+ * `/klinik/jobs/offene-stellen/jobs/{uuid}`.
+ *
+ * Card structure:
+ *   <li class="jobs-list__item">
+ *     <a href=".../jobs/{uuid}" class="jobs-list__link">
+ *       <span>{TITLE}</span>
+ *       <span class="jobs-list__type">{TYPE}</span>     (e.g. Festanstellung, Ausbildung)
+ *       <span class="jobs-list__range">{PERCENT}</span> (e.g. 80%-100%)
+ *     </a>
+ *   </li>
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const MERIAN_ISELIN_KEY = 'merian-iselin';
+export const MERIAN_ISELIN_COMPANY_NAME = 'Merian Iselin Klinik';
+export const MERIAN_ISELIN_COMPANY_DOMAIN = 'merianiselin.ch';
+
+const LISTING_URL = 'https://merianiselin.ch/klinik/jobs/offene-stellen';
+
+export function isMerianIselinJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === MERIAN_ISELIN_KEY || url.includes('merianiselin.ch');
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'merianiselin.ch' || host.endsWith('.merianiselin.ch');
+  } catch {
+    return false;
+  }
+}
+
+export function parseMerianListing(html) {
+  const out = [];
+  const seen = new Set();
+  const rx = /<li class="jobs-list__item">[\s\S]*?<a href="([^"]+\/jobs\/([a-f0-9-]{36}))" class="jobs-list__link">([\s\S]*?)<\/a>\s*<\/li>/g;
+  let m;
+  while ((m = rx.exec(html))) {
+    const url = m[1];
+    const uuid = m[2];
+    if (seen.has(uuid)) continue;
+    seen.add(uuid);
+    const innerHtml = m[3];
+    // Extract spans inside link-content
+    const spans = innerHtml.match(/<span[^>]*>[\s\S]*?<\/span>/g) || [];
+    const texts = spans.map((s) => normalizeSpace(decodeEntities(s.replace(/<[^>]+>/g, ''))));
+    const title = texts.find((t) => t && t.length > 5 && !/^\d{2,3}%/.test(t) && !/^(Festanstellung|Ausbildung|Praktikum|Aushilfe|Lehrstelle)$/i.test(t)) || '';
+    const type = texts.find((t) => /^(Festanstellung|Ausbildung|Praktikum|Aushilfe|Lehrstelle|Temporär)$/i.test(t)) || '';
+    const range = texts.find((t) => /\d{2,3}%/.test(t)) || '';
+    if (!title) continue;
+    out.push({ uuid, url, title, type, range });
+  }
+  return out;
+}
+
+async function fetchDetailContent(detailUrl) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    // Extract main content sections (Aufgaben/Anforderungen-style)
+    const strip = html
+      .replace(/<script[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[\s\S]*?<\/style>/gi, '')
+      .replace(/<nav[\s\S]*?<\/nav>/gi, '')
+      .replace(/<header[\s\S]*?<\/header>/gi, '')
+      .replace(/<footer[\s\S]*?<\/footer>/gi, '');
+    const parts = [];
+    const proseRx = /<(p|li|h[2-6])[^>]*>([\s\S]*?)<\/\1>/g;
+    let pm;
+    while ((pm = proseRx.exec(strip))) {
+      const text = normalizeSpace(decodeEntities(pm[2].replace(/<[^>]+>/g, ' ')));
+      if (!text || text.length < 12) continue;
+      if (/cookie|privacy|impressum|telefon|fax\s*\+/i.test(text.slice(0, 30))) continue;
+      parts.push(pm[1].match(/^li$/i) ? `• ${text}` : text);
+    }
+    return parts.slice(0, 30).join('\n');
+  } catch {
+    return '';
+  }
+}
+
+export async function fetchAllMerianIselinJobs() {
+  console.log(`🏥 Fetching ${MERIAN_ISELIN_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${LISTING_URL}\n`);
+  const html = await fetchHtml(LISTING_URL);
+  const items = parseMerianListing(html);
+  console.log(`  ✓ ${items.length} job cards parsed`);
+  if (!items.length) return [];
+  console.log(`  📄 Fetching detail pages for rich descriptions...`);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let detailHits = 0;
+  for (const it of items) {
+    const detailContent = await fetchDetailContent(it.url);
+    if (detailContent) detailHits++;
+    await new Promise((r) => setTimeout(r, 200));
+    const description = [
+      detailContent,
+      it.type ? `Anstellungsart: ${it.type}` : '',
+      it.range ? `Beschäftigungsgrad: ${it.range}` : '',
+      'Merian Iselin Klinik — private Belegklinik in Basel mit Schwerpunkten Orthopädie und Gynäkologie.',
+    ].filter(Boolean).join('\n\n');
+
+    const sourceLang = detectLang(description || it.title, 'de');
+    const jobSlug = slugify(`${it.title} ${MERIAN_ISELIN_KEY} basel`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+    jobs.push({
+      id: `${MERIAN_ISELIN_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: MERIAN_ISELIN_COMPANY_NAME,
+      companyKey: MERIAN_ISELIN_KEY,
+      companyDomain: MERIAN_ISELIN_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      location: 'Basel',
+      canton: 'BS',
+      url: it.url,
+      source: 'Merian Iselin Dedicated Parser (custom HTML)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: 'Basel',
+      addressRegion: 'BS',
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: '4054',
+      category: detectHealthcareCategory(`${it.title} ${it.type}`),
+      contract: /temporär|temporary/i.test(it.type) ? 'temporary' : 'full-time',
+      employmentType: detectHealthcareEmploymentType(`${it.range} ${it.type} ${it.title}`),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+  console.log(`📋 Total ${MERIAN_ISELIN_COMPANY_NAME} jobs discovered: ${jobs.length} (${detailHits}/${items.length} with rich detail content)`);
+  return jobs;
+}

--- a/scripts/lib/prospective-ch-job-parser-common.mjs
+++ b/scripts/lib/prospective-ch-job-parser-common.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * Shared factory for Swiss employers using the Prospective.ch ATS.
+ *
+ * Prospective.ch (Aequivital AG, Zurich) is a Swiss-built HRIS used by many
+ * hospitals, public administrations and large companies. Each tenant gets a
+ * numeric `medium` ID and exposes a public JSON listing endpoint:
+ *
+ *   https://ohws.prospective.ch/public/v1/medium/{MEDIUM_ID}/jobs
+ *     ?lang={de|fr|it|en}&offset=0&limit=100
+ *
+ * Response shape: { medium_id, total, jobs: [{ id, hk_id, viewkey, title,
+ *   attributes, szas, links, start_date, last_modification_timestamp }] }
+ *
+ * Tenants identified so far in this codebase:
+ *   - 1000745 — Kantonsspital Graubünden (KSGR)
+ *   - 1002129 — Lindenhofgruppe Bern
+ *   - (multiple, see ksgr/lindenhof parsers + USZ + Spital STS + Uster + UniSpital Basel)
+ *
+ * The pre-existing `lindenhofgruppe-job-parser.mjs` and `ksgr-job-parser.mjs`
+ * predate this shared module; new Prospective-based crawlers should use this
+ * factory.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+
+const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
+  || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
+
+const PAGE_SIZE = 100;
+
+function normalize(s = '') {
+  return String(s || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+async function fetchPage(apiUrl) {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(apiUrl, {
+      headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from ${apiUrl}`);
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+function pickLocation(job, defaultCity) {
+  const szas = job?.szas || {};
+  const cityRaw = String(szas['sza_location.city'] || '').trim();
+  if (cityRaw) {
+    const m = cityRaw.match(/\b(\d{4})\s+([^\n,]+)/);
+    if (m) return normalizeSpace(m[2]);
+    return normalizeSpace(cityRaw);
+  }
+  // Sometimes the site label is in attributes[10]
+  const attr10 = Array.isArray(job?.attributes?.['10']) ? job.attributes['10'][0] : '';
+  if (attr10) return normalizeSpace(attr10);
+  return defaultCity;
+}
+
+function pickPostalCode(job, defaultPostal) {
+  const cityRaw = String(job?.szas?.['sza_location.city'] || '').trim();
+  const m = cityRaw.match(/\b(\d{4})\b/);
+  return m ? m[1] : defaultPostal;
+}
+
+function pickEmploymentType(job) {
+  const min = Number(job?.szas?.['sza_pensum.min'] || 0);
+  const max = Number(job?.szas?.['sza_pensum.max'] || 0);
+  if (max > 0 && max < 90) return 'PART_TIME';
+  if (min >= 90 || max >= 90) return 'FULL_TIME';
+  return 'OTHER';
+}
+
+function buildDescription(job) {
+  const szas = job?.szas || {};
+  const parts = [];
+  const intro = normalizeSpace(szas.sza_introduction || '');
+  if (intro) parts.push(intro);
+  const tasks = stripHtml(szas.sza_tasks || '');
+  if (tasks) parts.push(`Aufgaben:\n${tasks}`);
+  const reqs = stripHtml(szas.sza_requirements || '');
+  if (reqs) parts.push(`Anforderungen:\n${reqs}`);
+  const benefits = stripHtml(szas.sza_benefits || '');
+  if (benefits) parts.push(`Wir bieten:\n${benefits}`);
+  const profile = stripHtml(szas.sza_company_profil || '');
+  if (profile) parts.push(profile);
+  return parts.join('\n\n');
+}
+
+function detectCategory(title = '', dept = '') {
+  const t = normalize(`${title} ${dept}`);
+  if (/\b(pflege|pflegefach|stationsleitung|fage|spitex|nachtwache|geburts|hebamme)/.test(t)) return 'Sanità / Ospedali';
+  if (/\b(arzt|ärztin|oberarzt|chefarzt|leitend|medizin|chirurg|anästhes|onkolog|kardiolog|neurolog|pädiatr|gynäk|psychi|geriatr)/.test(t)) return 'Sanità / Ospedali';
+  if (/\b(labor|laborant|biomedizin|analyse|radiolog|röntgen|mtra|mrt|physiother|ergo|logopäd|rehabilit|apothek|pharma)/.test(t)) return 'Sanità / Ospedali';
+  if (/\b(praxisassistent|mpa|mfa)/.test(t)) return 'Sanità / Ospedali';
+  if (/\b(techni|haustechni|facility|wartung|maintenance)/.test(t)) return 'Tecnica';
+  if (/\b(it|software|develop|programm|system|informatik)/.test(t)) return 'IT';
+  if (/\b(admin|sekret|buchhalt|sachbearbeiter|finanz|controll|account)/.test(t)) return 'Amministrazione';
+  if (/\b(hr|human|personal|talent|recruit)/.test(t)) return 'Risorse Umane';
+  if (/\b(küche|koch|gastro|hauswirtschaft|reinigung|hotellerie)/.test(t)) return 'Ospitalità';
+  if (/\b(logist|magazz|lager|einkauf|transport)/.test(t)) return 'Logistica';
+  if (/\b(market|kommunik)/.test(t)) return 'Marketing';
+  if (/\b(lernend|praktik|ausbildung|apprenti|werkstudent)/.test(t)) return 'Formazione';
+  return 'Sanità / Ospedali';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(praktik|stage|intern|lehrling|lernend|apprenti)/.test(t)) return 'intern';
+  if (/\b(junior|jr|assistent)/.test(t)) return 'junior';
+  if (/\b(senior|sr|lead|head|director|chef|verantwort|leiter|leitend|stationsleitung|oberarzt|chefarzt)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+/**
+ * Create a Prospective.ch parser for one employer.
+ *
+ * @param {Object} config
+ * @param {string} config.companyKey
+ * @param {string} config.companyName
+ * @param {string} config.companyDomain
+ * @param {string|number} config.mediumId    Prospective tenant ID
+ * @param {string} config.defaultCanton
+ * @param {string} config.defaultCity
+ * @param {string} config.defaultPostalCode
+ * @param {string} [config.apiLang='de']     Listing language
+ * @param {string} [config.publicCareerUrl]
+ * @param {string} [config.defaultSourceLang='de']
+ * @param {string[]} [config.extraTrustedHosts]  Additional hosts to mark as trusted
+ */
+export function createProspectiveChParser(config) {
+  const {
+    companyKey,
+    companyName,
+    companyDomain,
+    mediumId,
+    apiLang = 'de',
+    defaultCanton,
+    defaultCity,
+    defaultPostalCode,
+    publicCareerUrl,
+    defaultSourceLang = 'de',
+    extraTrustedHosts = [],
+  } = config;
+
+  if (!companyKey || !companyName || !mediumId || !defaultCanton) {
+    throw new Error('createProspectiveChParser: missing required config');
+  }
+
+  const API_BASE = `https://ohws.prospective.ch/public/v1/medium/${mediumId}/jobs`;
+  const corporateHost = String(companyDomain || '').replace(/^www\./, '').toLowerCase();
+  const trustedHosts = new Set([
+    corporateHost,
+    ...extraTrustedHosts.map((h) => String(h).toLowerCase()),
+  ].filter(Boolean));
+
+  function isCompanyJob(job) {
+    const key = normalize(job?.companyKey || '');
+    const url = normalize(job?.url || '');
+    if (key === companyKey) return true;
+    if (corporateHost && url.includes(corporateHost)) return true;
+    if (url.includes(`/medium/${mediumId}/`)) return true;
+    return false;
+  }
+
+  function isTrustedDomain(rawUrl = '') {
+    try {
+      const host = new URL(rawUrl).hostname.toLowerCase();
+      if (trustedHosts.has(host)) return true;
+      if (corporateHost && host.endsWith(`.${corporateHost}`)) return true;
+      if (host === 'ohws.prospective.ch' && rawUrl.includes(`/medium/${mediumId}/`)) return true;
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async function fetchAllJobs() {
+    console.log(`🏥 Fetching ${companyName} jobs`);
+    console.log(`   API: ${API_BASE} (Prospective medium ${mediumId})`);
+    if (publicCareerUrl) console.log(`   Public: ${publicCareerUrl}`);
+    console.log();
+
+    const all = [];
+    let offset = 0;
+    let total = Infinity;
+    while (offset < total) {
+      const url = `${API_BASE}?lang=${apiLang}&offset=${offset}&limit=${PAGE_SIZE}`;
+      console.log(`  📄 offset=${offset}…`);
+      const data = await fetchPage(url);
+      const items = Array.isArray(data?.jobs) ? data.jobs : [];
+      if (Number.isFinite(Number(data?.total))) total = Number(data.total);
+      if (items.length === 0) break;
+      all.push(...items);
+      offset += items.length;
+      if (items.length < PAGE_SIZE) break;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    console.log(`  ✓ ${all.length} Prospective jobs (API total=${total})\n`);
+    if (!all.length) return [];
+
+    const jobs = [];
+    for (const listing of all) {
+      const szas = listing?.szas || {};
+      const title = normalizeSpace(szas.sza_title || listing.title || '');
+      if (!title || title.length < 3) continue;
+
+      const directLink = normalizeSpace(listing?.links?.directlink || '');
+      const applyLink = normalizeSpace(szas.sza_apply_link || '');
+      const publicUrl = directLink || applyLink || publicCareerUrl || API_BASE;
+
+      const location = pickLocation(listing, defaultCity);
+      const canton = inferSwissTargetCanton(location) || defaultCanton;
+      const descriptionText = buildDescription(listing);
+      const sourceLang = detectLang(descriptionText || title, defaultSourceLang);
+      const jobSlug = slugify(`${title} ${companyKey} ${location}`);
+      const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+
+      const postedDate = (() => {
+        const raw = listing?.start_date || listing?.last_modification_timestamp || '';
+        const d = new Date(String(raw || ''));
+        if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+        return new Date().toISOString().slice(0, 10);
+      })();
+
+      const department = normalizeSpace(
+        (Array.isArray(listing?.attributes?.['20']) ? listing.attributes['20'][0] : '')
+          || szas.sza_company_branch || '',
+      );
+
+      jobs.push({
+        id: `${companyKey}-${urlHash}`,
+        slug: jobSlug,
+        slugByLocale: { [sourceLang]: jobSlug },
+        company: companyName,
+        companyKey,
+        companyDomain,
+        title,
+        titleByLocale: { [sourceLang]: title },
+        description: descriptionText || `${title} — ${companyName}`,
+        descriptionByLocale: { [sourceLang]: descriptionText || `${title} — ${companyName}` },
+        location,
+        canton,
+        url: publicUrl,
+        source: `${companyName} Dedicated Parser (Prospective medium ${mediumId})`,
+        sourceLang,
+        crawledAt: new Date().toISOString(),
+
+        addressLocality: location,
+        addressRegion: canton,
+        addressCountry: 'CH',
+        country: 'CH',
+        postalCode: pickPostalCode(listing, defaultPostalCode),
+        category: detectCategory(title, department),
+        contract: 'full-time',
+        employmentType: pickEmploymentType(listing),
+        experienceLevel: detectExperienceLevel(title),
+        sector: 'Sanità / Ospedali',
+        currency: 'CHF',
+        featured: false,
+        postedDate,
+        applyUrl: applyLink || publicUrl,
+        requirements: [],
+        requirementsByLocale: { [sourceLang]: [] },
+      });
+    }
+
+    console.log(`📋 Total ${companyName} jobs discovered: ${jobs.length}`);
+    return jobs;
+  }
+
+  return { fetchAllJobs, isCompanyJob, isTrustedDomain };
+}

--- a/scripts/update-kliniken-valens-jobs.mjs
+++ b/scripts/update-kliniken-valens-jobs.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllKlinikenValensJobs,
+  isKlinikenValensJob,
+  isTrustedDomain,
+  KLINIKEN_VALENS_KEY,
+  KLINIKEN_VALENS_COMPANY_NAME,
+} from './lib/kliniken-valens-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: KLINIKEN_VALENS_KEY,
+  companyLabel: KLINIKEN_VALENS_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllKlinikenValensJobs,
+  isCompanyJob: isKlinikenValensJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => { console.error(`❌ Kliniken Valens crawler failed: ${err?.message || err}`); process.exit(1); });

--- a/scripts/update-merian-iselin-jobs.mjs
+++ b/scripts/update-merian-iselin-jobs.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllMerianIselinJobs,
+  isMerianIselinJob,
+  isTrustedDomain,
+  MERIAN_ISELIN_KEY,
+  MERIAN_ISELIN_COMPANY_NAME,
+} from './lib/merian-iselin-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: MERIAN_ISELIN_KEY,
+  companyLabel: MERIAN_ISELIN_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllMerianIselinJobs,
+  isCompanyJob: isMerianIselinJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => { console.error(`❌ Merian Iselin crawler failed: ${err?.message || err}`); process.exit(1); });

--- a/tests/index-html-fc-loader.test.ts
+++ b/tests/index-html-fc-loader.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Funding Choices loader — regression test for the CORS-breaking crossOrigin
+ * regression introduced 2026-05-04 (commit 0bbf6b99a0) and fixed 2026-05-19.
+ *
+ * Google FC `/i/pub-XXX` is served WITHOUT Access-Control-Allow-Origin headers.
+ * Setting crossOrigin='anonymous' on the injected <script> turns the request
+ * into a CORS fetch that the endpoint rejects with net::ERR_FAILED. The CMP
+ * engine then never initializes, no TCF v2.2 string is emitted, EEA traffic
+ * stays under the `no-tcf-string` policy (AD_PERSONALIZATION_RESTRICTED), and
+ * page RPM stays capped at the non-personalized €1-3 range — the exact lever
+ * documented in project_adsense_apr26 memory.
+ *
+ * This test pins the loader shape so the regression cannot return silently.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const indexHtml = readFileSync(
+  resolve(__dirname, '..', 'index.html'),
+  'utf8',
+);
+
+// Extract the Funding Choices loader script block (between the loadFc IIFE
+// and the closing </script>). Used by multiple assertions below.
+const FC_LOADER_BLOCK = (() => {
+  const start = indexHtml.indexOf("function loadFc()");
+  expect(start, 'loadFc() block must exist in index.html').toBeGreaterThan(-1);
+  const end = indexHtml.indexOf('</script>', start);
+  expect(end, 'closing </script> after loadFc() must exist').toBeGreaterThan(start);
+  return indexHtml.slice(start, end);
+})();
+
+describe('Funding Choices loader — index.html', () => {
+  it('injects the fundingchoicesmessages.google.com loader for pub-8628054934855353', () => {
+    expect(FC_LOADER_BLOCK).toMatch(
+      /fundingchoicesmessages\.google\.com\/i\/pub-8628054934855353/,
+    );
+  });
+
+  it('does NOT set crossOrigin on the FC loader <script> (would trigger CORS rejection)', () => {
+    // Match `s.crossOrigin = '…'` or `s.crossOrigin = "…"` or
+    // setAttribute('crossorigin', …) — both forms break the FC endpoint.
+    expect(FC_LOADER_BLOCK).not.toMatch(/\.crossOrigin\s*=/);
+    expect(FC_LOADER_BLOCK).not.toMatch(
+      /setAttribute\(\s*['"]crossorigin['"]/i,
+    );
+  });
+
+  it('marks the injected loader with data-fc-loader so we never double-inject', () => {
+    expect(FC_LOADER_BLOCK).toMatch(/data-fc-loader/);
+  });
+
+  it('signals the googlefcPresent iframe so FC knows the loader ran', () => {
+    expect(FC_LOADER_BLOCK).toMatch(/googlefcPresent/);
+  });
+
+  it('keeps the loader deferred (requestIdleCallback or DOMContentLoaded) — LCP safeguard', () => {
+    // The 2026-05-04 LCP-defer commit (~11.3s → ~3-4s mobile LCP) must remain.
+    expect(FC_LOADER_BLOCK).toMatch(/requestIdleCallback|DOMContentLoaded/);
+  });
+});


### PR DESCRIPTION
## Summary

Two more hospital crawlers — **119 fresh jobs** — plus a reusable
**Prospective.ch shared factory** that generalises the API pattern already
used by the in-codebase KSGR / Lindenhofgruppe / Spital STS parsers.

| Hospital | Cantone | ATS | Jobs |
|---|---|---|---|
| Kliniken Valens | SG (multi-site) | Prospective (medium 1005103) | 104 |
| Merian Iselin Klinik | BS Basel | custom HTML + detail | 15 |

### Kliniken Valens

The `valens.ch/karriere/offene-stellen/` page wraps a `jobs.kliniken-valens.ch`
iframe which proxies to the standard Prospective JSON API. The group runs
several specialist rehabilitation sites (incl. Davos Clavadel — the former
Zürcher RehaZentrum). One crawler now covers all of them.

### Shared `prospective-ch-job-parser-common.mjs`

`createProspectiveChParser({ mediumId, ... })` — adding the next
Prospective-based hospital is a ~20-line thin wrapper.

### Merian Iselin

Static HTML listing + UUID-based detail pages (~450 words avg).

## Test plan

- [x] Local smoke test, 0 jobs under 30-unique-words boilerplate bar
- [ ] Re-trigger workflows on main after merge