### PR TITLE
perf(audit): migrate image-object-license + combine text-html-ratio regex + MAX_PARALLEL=4

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -257,22 +257,19 @@ jobs:
           # catches accidental side-effects during future audit migrations.
           AUDIT_STRICT: '1'
         run: |
-          # MAX_PARALLEL=2 — restored after the L3 unification.
-          # The previous MAX_PARALLEL=1 was forced by historical OOM kills
-          # (runs 25400905401, 25402597503, 25404549152, 25406916097,
-          # 25408263066): the old chain spawned 7 separate Node processes
-          # each walking 132k HTML files at 1-3 GB RSS, so two concurrent
-          # walkers blew past the 7 GB ceiling.
+          # MAX_PARALLEL=4 — bumped after live measurement on run
+          # 26087963151. audit:all peaked at ~1 GB RSS and held the whole
+          # 363 s wall window; the pool's heaviest light audit
+          # (orphan-sitemap-pages, 92 s) completed inside that window with
+          # MAX_PARALLEL=2 — cumulative observed peak ~3-4 GB, well under
+          # the 7 GB ubuntu-latest free runner ceiling.
           #
-          # The new chain is 4 entries (audit:all + page-weight +
-          # content-duplicates + faqpage-validity), but with `audit:all`
-          # covering 10 audits in a SINGLE V8 process (~1 GB peak instead
-          # of 10× ~1-3 GB), the cumulative RSS profile is much lower.
-          # MAX_PARALLEL=2 lets the pool tail overlap with the chain's
-          # remaining serial steps; cumulative peak ≈ chain (~1 GB) +
-          # 2× pool (~1-1.5 GB each) ≈ 3-4 GB, comfortably under 7 GB.
-          # If a regression OOMs the runner, drop back to 1 in a hotfix.
-          MAX_PARALLEL=2
+          # Lifting to 4 lets up to four light pool audits run in parallel.
+          # Doesn't shorten current wall time (audit:all remains the
+          # bottleneck) but compresses pool tail for future when audit:all
+          # gets faster, and gives headroom if more audits join the pool.
+          # If a regression OOMs the runner, drop back to 2 in a hotfix.
+          MAX_PARALLEL=4
           : > /tmp/post-build-timings.txt
           : > /tmp/post-build-failures.txt
 
@@ -369,8 +366,10 @@ jobs:
             npm run audit:sitemap-canonicals
           spawn_capped audit:news-sitemap            /tmp/g16.log \
             npm run audit:news-sitemap
-          spawn_capped audit:image-object-license    /tmp/g18.log \
-            npm run audit:image-object-license
+          # audit:image-object-license migrated into `npm run audit:all`
+          # (see scripts/audit-all.mjs REGISTRY). Single dist walk, in-process
+          # JSON-LD parse — removes 34 s of standalone wall time from the
+          # parallel pool. Removed from spawn pool.
           spawn_capped audit:max-bfs-depth           /tmp/g19.log \
             npm run audit:max-bfs-depth
           # audit:footer-root-presence + audit:jsonld-no-nested-scripts +

--- a/scripts/audit-all.mjs
+++ b/scripts/audit-all.mjs
@@ -40,6 +40,7 @@ import { factory as salaryLandingTemplate } from './audit-salary-landing-templat
 import { factory as pageWeight } from './audit-page-weight.mjs';
 import { factory as contentDuplicates } from './audit-content-duplicates.mjs';
 import { factory as faqpageValidity } from './audit-faqpage-validity.mjs';
+import { factory as imageObjectLicense } from './audit-image-object-license.mjs';
 
 const REGISTRY = [
   { factory: footerRootPresence, name: 'footer-root-presence' },
@@ -52,6 +53,7 @@ const REGISTRY = [
   { factory: pageWeight, name: 'page-weight' },
   { factory: contentDuplicates, name: 'content-duplicates' },
   { factory: faqpageValidity, name: 'faqpage-validity' },
+  { factory: imageObjectLicense, name: 'image-object-license' },
 ];
 
 // ─── CLI parsing ─────────────────────────────────────────────────────────────

--- a/scripts/audit-image-object-license.mjs
+++ b/scripts/audit-image-object-license.mjs
@@ -10,62 +10,18 @@
  *   - creator
  *   - creditText
  *
- * Mirrors the vitest gate at tests/seo/image-object-license-fields.test.ts;
- * exposed as a standalone script so post-deploy-validation can run it under
- * the same `spawn_capped` capped-parallel pool as the other dist audits.
- *
- * Exit codes:
- *   0  — no offenders
- *   1  — at least one offender (CI-blocking)
- *   2  — dist/ does not exist (gate cannot run; treated as fatal in CI)
- *
- * Usage:
- *   node scripts/audit-image-object-license.mjs               # fail on regressions
- *   node scripts/audit-image-object-license.mjs --limit=20    # show top-N examples
- *   node scripts/audit-image-object-license.mjs --json        # JSON report
+ * Two execution modes:
+ *   1. Standalone CLI:  node scripts/audit-image-object-license.mjs [...]
+ *   2. Unified runner:  imported by scripts/audit-all.mjs via factory().
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFile, stat } from 'node:fs/promises';
+import { relative } from 'node:path';
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { writeAuditReport } from './lib/auditReport.mjs';
 
-const __filename = fileURLToPath(import.meta.url);
-const ROOT = resolve(__filename, '..', '..');
-const DIST_DIR = resolve(ROOT, 'dist');
-
 const REQUIRED_FIELDS = ['acquireLicensePage', 'copyrightNotice', 'license', 'creator', 'creditText'];
-
-const args = process.argv.slice(2);
-const getArg = (name) => {
-  const eq = args.find((a) => a.startsWith(`${name}=`));
-  if (eq) return eq.slice(name.length + 1);
-  const idx = args.indexOf(name);
-  return idx === -1 ? undefined : args[idx + 1];
-};
-const LIMIT = Number(getArg('--limit') ?? 20);
-const JSON_OUT = args.includes('--json');
-
-function walkHtml(dir, out = []) {
-  if (!existsSync(dir)) return out;
-  for (const entry of readdirSync(dir)) {
-    // Skip dot-prefixed dirs (debug artifacts, not deployed pages).
-    if (entry.startsWith('.')) continue;
-    const full = join(dir, entry);
-    const st = statSync(full);
-    if (st.isDirectory()) walkHtml(full, out);
-    else if (entry.endsWith('.html')) out.push(full);
-  }
-  return out;
-}
-
-function extractLdJsonBlocks(html) {
-  const blocks = [];
-  const re = /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
-  let m;
-  while ((m = re.exec(html)) !== null) blocks.push(m[1]);
-  return blocks;
-}
+const JSONLD_RE = /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
 
 function walkImageObjects(node, visit) {
   if (!node || typeof node !== 'object') return;
@@ -79,71 +35,127 @@ function walkImageObjects(node, visit) {
   }
 }
 
-if (!existsSync(DIST_DIR)) {
-  console.error(`[audit-image-object-license] ${DIST_DIR} not found — run \`npm run build\` first.`);
-  process.exit(2);
-}
+export function createAuditor(opts = {}) {
+  const limit = opts.limit ?? 20;
+  const offenders = [];
+  const fileSet = new Set();
 
-const files = walkHtml(DIST_DIR);
-const offenders = [];
-const fileSet = new Set();
-
-for (const file of files) {
-  const html = readFileSync(file, 'utf-8');
-  const blocks = extractLdJsonBlocks(html);
-  for (const body of blocks) {
-    let parsed;
-    try {
-      parsed = JSON.parse(body);
-    } catch {
-      continue;
-    }
-    walkImageObjects(parsed, (img) => {
-      const missing = REQUIRED_FIELDS.filter((f) => !(f in img));
-      if (missing.length > 0) {
-        const rel = file.replace(DIST_DIR, '');
-        offenders.push({ file: rel, missing, keys: Object.keys(img) });
-        fileSet.add(rel);
+  return {
+    name: 'image-object-license',
+    collect(file, html) {
+      // Cheap pre-filter — most pages don't carry ImageObject markup.
+      if (!html.includes('"ImageObject"')) return;
+      JSONLD_RE.lastIndex = 0;
+      let m;
+      while ((m = JSONLD_RE.exec(html)) !== null) {
+        let parsed;
+        try { parsed = JSON.parse(m[1]); } catch { continue; }
+        walkImageObjects(parsed, (img) => {
+          const missing = REQUIRED_FIELDS.filter((f) => !(f in img));
+          if (missing.length > 0) {
+            const rel = relative(ROOT, file);
+            offenders.push({ path: rel, file: rel, missing, keys: Object.keys(img), metric: missing.length });
+            fileSet.add(rel);
+          }
+        });
       }
-    });
-  }
+    },
+    report() {
+      const passed = offenders.length === 0;
+      const humanSummary = passed
+        ? 'ImageObject license-fields gate: 0 offenders'
+        : `${offenders.length} ImageObject(s) missing license fields across ${fileSet.size} page(s)`;
+      return {
+        passed,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'count', value: 0, comparator: '<=' },
+        extra: { files: fileSet.size, limit, requiredFields: REQUIRED_FIELDS },
+        humanSummary,
+      };
+    },
+  };
 }
 
-if (JSON_OUT) {
-  console.log(JSON.stringify({ total: offenders.length, files: fileSet.size, offenders: offenders.slice(0, LIMIT) }, null, 2));
-} else if (offenders.length === 0) {
-  console.log('✅ ImageObject license-fields gate: 0 offenders.');
-} else {
-  console.error(
-    `❌ ImageObject license-fields gate: ${offenders.length} offending ImageObject(s) across ${fileSet.size} page(s).`,
-  );
-  console.error(`Required fields: ${REQUIRED_FIELDS.join(', ')}\n`);
-  // Dump the FULL offender list so the CI log alone is enough to diagnose
-  // without downloading the dist artifact (which can exceed 1 GB).
-  console.error(`Full offender list (${offenders.length} entries):`);
-  for (const o of offenders) {
-    console.error(`  - ${o.file}`);
-    console.error(`      missing: ${o.missing.join(', ')}`);
-    console.error(`      keys:    ${o.keys.join(', ')}`);
+export const factory = createAuditor;
+export const auditor = factory();
+
+// ─── Standalone CLI ──────────────────────────────────────────────────────────
+
+async function standalone() {
+  const args = process.argv.slice(2);
+  const getArg = (name) => {
+    const eq = args.find((a) => a.startsWith(`${name}=`));
+    if (eq) return eq.slice(name.length + 1);
+    const idx = args.indexOf(name);
+    return idx === -1 ? undefined : args[idx + 1];
+  };
+  const limit = Number(getArg('--limit') ?? 20);
+  const JSON_OUT = args.includes('--json');
+
+  const s = await stat(DEFAULT_DIST).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`[audit-image-object-license] ${DEFAULT_DIST} not found — run \`npm run build\` first.`);
+    process.exit(2);
   }
-  console.error(
-    `\nFix: route the ImageObject through services/seo/imageObjectLd.ts (or the create-article.mjs generator for blog content).`,
-  );
+
+  const a = createAuditor({ limit });
+  const files = await walkHtmlFiles(DEFAULT_DIST);
+  for (const file of files) {
+    let html;
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    a.collect(file, html);
+  }
+  const result = await a.report();
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold,
+    offenders: result.offenders.map((o) => ({
+      path: o.file,
+      feature: 'image-object',
+      metric: o.missing.length,
+      ratio: null,
+      missing: o.missing,
+      keys: o.keys,
+    })),
+  });
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({
+      total: result.offendersTotal,
+      files: result.extra.files,
+      offenders: result.offenders.slice(0, limit),
+    }, null, 2));
+  } else if (result.passed) {
+    console.log('✅ ImageObject license-fields gate: 0 offenders.');
+  } else {
+    console.error(`❌ ImageObject license-fields gate: ${result.offendersTotal} offending ImageObject(s) across ${result.extra.files} page(s).`);
+    console.error(`Required fields: ${REQUIRED_FIELDS.join(', ')}\n`);
+    console.error(`Full offender list (${result.offendersTotal} entries):`);
+    for (const o of result.offenders) {
+      console.error(`  - ${o.file}`);
+      console.error(`      missing: ${o.missing.join(', ')}`);
+      console.error(`      keys:    ${o.keys.join(', ')}`);
+    }
+    console.error(`\nFix: route the ImageObject through services/seo/imageObjectLd.ts (or the create-article.mjs generator for blog content).`);
+  }
+
+  process.exit(result.passed ? 0 : 1);
 }
 
-// Structured JSON report (always written, pass or fail).
-await writeAuditReport({
-  audit: 'image-object-license',
-  passed: offenders.length === 0,
-  threshold: { metric: 'count', value: 0, comparator: '<=' },
-  offenders: offenders.map((o) => ({
-    path: o.file,
-    feature: 'image-object',
-    metric: o.missing.length,
-    ratio: null,
-    missing: o.missing,
-    keys: o.keys,
-  })),
-});
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
 
-process.exit(offenders.length === 0 ? 0 : 1);
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('[audit-image-object-license] fatal', err);
+    process.exit(2);
+  });
+}

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -26,17 +26,27 @@ const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 const NOINDEX_RE = /<meta[^>]+name=["']robots["'][^>]+content=["'][^"']*noindex/i;
 const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
 
+// Single combined strip regex (was 8 sequential .replace() calls). Each
+// alternative captures one strip category: HTML comments, DOCTYPE, opaque
+// blocks (script/style/noscript/template/svg) via capturing-group + backref
+// so the closing tag matches the opening one, and finally any other tag.
+// JavaScript regex engines evaluate alternation left-to-right first-match,
+// so opaque-block matches consume the entire pair before the loose `<[^>]+>`
+// can chip away at the opening tag alone.
+//
+// Profiled on 200 production HTML pages (avg 17 KB):
+//   8-pass version: 0.098 ms/call
+//   1-pass version: 0.053 ms/call  ← 1.86× faster
+//   Byte-equal output: 200/200 (verified)
+//
+// At ~650k pages this saves ~29 s on the audit:all wall time without
+// changing the offender count or text byte measurement.
+const STRIP_RE =
+  /<!--[\s\S]*?-->|<!doctype[^>]*>|<(script|style|noscript|template|svg)\b[\s\S]*?<\/\1>|<[^>]+>/gi;
+
 /** @param {string} html */
 export function extractVisibleText(html) {
-  let s = html;
-  s = s.replace(/<!--[\s\S]*?-->/g, ' ');
-  s = s.replace(/<!doctype[^>]*>/gi, ' ');
-  s = s.replace(/<script\b[\s\S]*?<\/script>/gi, ' ');
-  s = s.replace(/<style\b[\s\S]*?<\/style>/gi, ' ');
-  s = s.replace(/<noscript\b[\s\S]*?<\/noscript>/gi, ' ');
-  s = s.replace(/<template\b[\s\S]*?<\/template>/gi, ' ');
-  s = s.replace(/<svg\b[\s\S]*?<\/svg>/gi, ' ');
-  s = s.replace(/<[^>]+>/g, ' ');
+  let s = html.replace(STRIP_RE, ' ');
   s = s
     .replace(/&nbsp;/gi, ' ')
     .replace(/&amp;/gi, '&')


### PR DESCRIPTION
Three orthogonal optimizations bundled in one PR. All measured locally.

1. audit-image-object-license migrated into unified runner

   Adds factory export + Auditor interface to scripts/audit-image-object-license.mjs
   alongside the existing standalone CLI. Registers in scripts/audit-all.mjs
   REGISTRY (11th audit). Removed from the spawn pool in
   post-deploy-validate-dist.yml.

   Wall-time benefit: zero on CI (it was running in parallel with audit:all
   anyway, finishing well within audit:all's 363 s window). The actual win is
   removing one Node process from the workflow — slightly less log noise,
   slightly less RSS footprint, and consistency (every dist-walking audit
   now in the runner except the BFS-graph one which has a different walk
   pattern).

   Verified: 0 offenders on local dist (same as standalone path).

2. text-html-ratio.extractVisibleText: 8 regex passes → 1

   The function was 8 sequential .replace() calls (HTML comments, DOCTYPE,
   <script>/<style>/<noscript>/<template>/<svg>, all other tags). Each
   scanned the full HTML string. Combined into a single alternation regex:

     /<!--[\s\S]*?-->|<!doctype[^>]*>|<(script|style|noscript|template|svg)\b[\s\S]*?<\/\1>|<[^>]+>/gi

   Capturing-group + \1 backref keeps the opaque-block matcher tight (the
   closing tag must match the opening one). JavaScript regex alternation is
   left-to-right first-match, so opaque-block matches consume the full pair
   before `<[^>]+>` can chip at the opening tag alone.

   Profiled on 200 production HTML pages (avg 17 KB):
     8-pass version: 0.098 ms/call
     1-pass version: 0.053 ms/call  ← 1.86× faster
     Byte-equal output: 200/200 (verified)

   At ~650 k pages on CI this saves ~29 s on audit:all wall time without
   changing the offender count or text-byte measurement. Locally on 82 k
   files the unified runner went from 53.98 s (previous PRs measurement) to
   39.47 s (this PR) — image-object-license added <0.1 s, regex combine
   saved the rest.

3. MAX_PARALLEL 2 → 4 in post-deploy-validate-dist.yml

   Live run 26087963151 measured audit:all peak RSS ~1 GB and the parallel
   pool's heaviest light audit (orphan-sitemap-pages 92 s) finished inside
   audit:all's 363 s window with MAX_PARALLEL=2. Cumulative peak observed
   ~3-4 GB, well under the 7 GB ubuntu-latest free runner ceiling.

   Lifting to 4 doesn't shorten current wall time (audit:all remains the
   bottleneck) but provides headroom for future pool expansions and
   compresses pool tail once audit:all gets faster (e.g. after eventual
   AUDIT_WORKERS=N work).

Verification on local dist (82k files):
  10 audits previous wall:  53.98 s
  11 audits this PR:         39.47 s
  Delta:                    -14.51 s (-27 %)
