### PR TITLE
feat(seo): validate-jsonld-shape script + visual regression design doc

### DIFF
--- a/docs/superpowers/specs/2026-05-19-visual-regression-design.md
+++ b/docs/superpowers/specs/2026-05-19-visual-regression-design.md
@@ -1,0 +1,182 @@
+# Visual regression Playwright suite — design doc
+
+**Status**: Designed, not implemented. Captured as actionable TODO.
+
+## Goal
+
+Detect any visual regression introduced by the L2 HTML minifier (or future
+HTML-emitting changes) on a representative set of pages. Vincolo C1 rilassato
+allows DOM-equivalent + content-equivalent changes, but renders should
+remain visually identical.
+
+## Why not implemented now (2026-05-19)
+
+The L2 minifier was integrated in PR #336 and has passed:
+- DOM-equivalence verification via `scripts/verify-l2-equivalence.mjs`
+  (cheerio.load() + .html() normalization on 1000 sample pages: all match)
+- Content equivalence: visible text byte-equal on every sample
+- Unit tests in `tests/seo/html-minify.test.ts` (19 tests) covering whitespace
+  collapse, comment handling, safe-block preservation
+- Live production measurement: 1000-file sample shows 0.87 % mean reduction
+  with no visual content change (only whitespace + HTML comments)
+
+For these guarantees, a full Playwright visual regression suite adds
+infrastructure (browser, screenshot service, snapshot storage) without
+catching anything the existing test layer doesn't already catch.
+
+The suite becomes valuable when we ship:
+- L2 aggressive mode (attribute quote stripping, optional close-tag
+  stripping) — where rendering could plausibly differ
+- New page templates that haven't been verified against L2
+
+## Architecture (when needed)
+
+### Playwright config: `playwright.visual.config.ts`
+
+```ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e/visual',
+  use: {
+    baseURL: process.env.VISUAL_BASE_URL || 'http://localhost:4173',
+    viewport: { width: 414, height: 896 }, // mobile-first per CLAUDE.md #15
+    deviceScaleFactor: 2,
+  },
+  expect: {
+    toHaveScreenshot: {
+      // Allow 0.5 % per-pixel + 0.1 % total diff — covers font-rendering
+      // jitter without missing real regressions.
+      maxDiffPixelRatio: 0.001,
+      threshold: 0.005,
+    },
+  },
+  projects: [
+    { name: 'mobile-it', use: { viewport: { width: 414, height: 896 } } },
+    { name: 'desktop-it', use: { viewport: { width: 1280, height: 800 } } },
+  ],
+});
+```
+
+### Sample selection: 20 representative URLs
+
+| Page-type | URL (IT) | Why representative |
+|---|---|---|
+| home | / | LCP path, common templates |
+| salary-landing | /calcola-stipendio/ | Main funnel page |
+| salary-landing leaf | /calcola-stipendio/stipendio-netto-80000-chf/ | Long-tail page |
+| job-board hub | /cerca-lavoro-ticino/ | Listing template |
+| job-detail (active) | /cerca-lavoro-ticino/<recent>/ | JSON-LD-heavy template |
+| job-detail (expired) | /cerca-lavoro-ticino/<expired>/ | Soft-landing template |
+| cost-of-living city | /costo-vita-lugano-ticino/ | Stat-tile + table layout (the page-type fixed in PR #355) |
+| fuel-daily | /prezzi-benzina-svizzera/lugano/ | Inline SVG chart |
+| weekly-employers | /aziende-che-assumono/lugano/eoc-ente-ospedaliero-cantonale/settimana-corrente/ | Detailed employer card layout |
+| health-premiums | /premi-cassa-malati/ticino/ | Hub page |
+| border-wait | /tempi-attesa-frontiera/chiasso-brogeda/oggi/ | Real-time data + map |
+| weather | /meteo-frontalieri/lugano/ | Inline SVG-heavy |
+| article (blog) | /articoli-frontaliere/<recent>/ | Long-form prose |
+| career landing | /cerca-lavoro-ticino/azienda-eoc-ente-ospedaliero-cantonale/ | Brand hub |
+| profession landing | /lavoro-infermieri-svizzera/ | Profession hub |
+| nursing landing | /lavoro-oss-svizzera/ | Profession hub variant |
+| FAQ hub | /faq/ | FAQ-heavy template |
+| comparisons hub | /confronti/ | Hub index |
+| about | /chi-siamo/ | Static brand page |
+| 404 (informational) | /this-does-not-exist/ | Error template |
+
+Add `/en/...`, `/de/...`, `/fr/...` variants of 4-5 representative pages
+for cross-locale coverage — total ~30-40 snapshots.
+
+### Test skeleton: `tests/e2e/visual/snapshot.spec.ts`
+
+```ts
+import { test, expect } from '@playwright/test';
+
+const PAGES = [
+  { name: 'home-it', url: '/' },
+  { name: 'salary-landing-it', url: '/calcola-stipendio/' },
+  // ... see table above
+];
+
+for (const { name, url } of PAGES) {
+  test(`${name}`, async ({ page }) => {
+    await page.goto(url, { waitUntil: 'networkidle' });
+    // Wait for any seo-static-content overlay to render
+    await page.waitForSelector('main', { state: 'attached' });
+    // Hide non-deterministic elements (e.g. timestamps, ad iframes)
+    await page.evaluate(() => {
+      document.querySelectorAll('.timestamp, ins.adsbygoogle').forEach((el) => {
+        (el as HTMLElement).style.visibility = 'hidden';
+      });
+    });
+    await expect(page).toHaveScreenshot(`${name}.png`, { fullPage: true });
+  });
+}
+```
+
+### CI integration
+
+`.github/workflows/visual-regression.yml`:
+
+```yaml
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ['Post-deploy Validate (dist)']
+    types: [completed]
+
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+      - run: npm ci
+      - run: npx playwright install chromium
+      - name: Serve dist
+        run: |
+          # Download github-pages artifact from the deploy run
+          # ... (mirror audit-dist-from-run.yml's artifact download step)
+          npx vite preview --port 4173 &
+          sleep 5
+      - run: npx playwright test --config=playwright.visual.config.ts
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: visual-regression-diffs
+          path: test-results/
+```
+
+Baseline snapshots committed to `tests/e2e/visual/__screenshots__/` — first
+run generates them; subsequent runs diff against committed baselines.
+
+## Estimated effort
+
+- Playwright config + sample URLs: 1 h
+- Per-page test cases (handle timestamps/ads/dynamic content): 2-3 h
+- Baseline capture + commit: 30 min
+- CI workflow + artifact upload: 1 h
+- First-pass debugging (font-rendering jitter, locale display): 1-2 h
+
+**Total: 5-8 hours** of focused work.
+
+## Why this design is captured but deferred
+
+- L2 minifier rendering equivalence is already covered by:
+  - `tests/seo/html-minify.test.ts` (19 unit tests including DOM serialization)
+  - `scripts/verify-l2-equivalence.mjs` (DOM + visible-text + JSON-LD diff
+    on 1000 sample pages)
+- Visual regression's main value is for L2 aggressive mode, not current L2
+- 5-8 h infrastructure cost vs ~0 expected regressions on current L2 surface
+
+When L2 aggressive mode lands (attribute quote stripping, optional close-tag
+stripping), this suite becomes necessary and the design above is ready.
+
+## Open questions for the implementer
+
+- Where to host baseline snapshots? Repo (git LFS) vs S3-style external store?
+- Snapshot stability vs locale: do we capture each of 4 locales separately
+  or just IT? Probably IT-only first, then per-locale as needed.
+- Handling of cron-updated content (fuel prices, border wait): mock the
+  data at build time OR exclude from visual regression OR use a frozen
+  dist snapshot.
+- AdSense/PostHog iframes: hide via CSS in test setup (done in skeleton above).

--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "audit:content-duplicates": "node scripts/audit-content-duplicates.mjs dist",
     "audit:dist-multi": "node scripts/audit-dist-multi.mjs",
     "audit:all": "node scripts/audit-all.mjs",
+    "validate:jsonld-shape": "node scripts/validate-jsonld-shape.mjs",
     "audit:page-weight": "node scripts/audit-page-weight.mjs",
     "audit:text-html-ratio": "node scripts/audit-text-html-ratio.mjs --baseline=data/text-html-ratio-baseline.json",
     "audit:text-html-ratio:rebaseline": "node scripts/audit-text-html-ratio.mjs --write-baseline=data/text-html-ratio-baseline.json",

--- a/scripts/validate-jsonld-shape.mjs
+++ b/scripts/validate-jsonld-shape.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/**
+ * validate-jsonld-shape.mjs
+ *
+ * Sanity-checks the JSON-LD blocks emitted in dist/ HTML for shape
+ * correctness per schema.org. Targets the most common types this site
+ * emits and verifies the required fields are present per Google's
+ * Rich Results documentation (subset thereof — full Rich Results Test
+ * requires a Google Cloud API key and rate limits at 1 req/sec, not
+ * usable in CI).
+ *
+ * What this script catches (without calling Google):
+ *   - JSON parse errors in `<script type="application/ld+json">` blocks
+ *   - Nested `<script>` wrappers (already covered by
+ *     audit-jsonld-no-nested-scripts but checked here for completeness)
+ *   - Missing required fields per @type:
+ *       JobPosting: title, description, datePosted, hiringOrganization,
+ *                   jobLocation, employmentType, baseSalary
+ *       Article / BlogPosting: headline, datePublished, author, publisher
+ *       Person: name
+ *       Organization: name
+ *       LocalBusiness: name, address
+ *       FAQPage: mainEntity[].name + mainEntity[].acceptedAnswer.text
+ *       BreadcrumbList: itemListElement[].position + .name + .item
+ *       ImageObject: contentUrl OR url
+ *
+ * What it does NOT catch (would require Google API):
+ *   - Whether Google's parser accepts the JSON-LD
+ *   - Whether the page qualifies for Rich Results in SERP
+ *   - SERP-specific validation rules
+ *
+ * Used for the vincolo N2 sanity check (HTML minifier must not break
+ * JSON-LD shape) and as a defensive pre-deploy gate.
+ *
+ * Usage:
+ *   node scripts/validate-jsonld-shape.mjs                  # sample 200 random files
+ *   node scripts/validate-jsonld-shape.mjs --sample=20      # smaller sample
+ *   node scripts/validate-jsonld-shape.mjs --strict         # fail on any missing field
+ *   node scripts/validate-jsonld-shape.mjs --dist=path      # alternate dist
+ *
+ * Exit:
+ *   0 — every sampled page's JSON-LD shape passes
+ *   1 — at least one shape violation (path + violation printed)
+ *   2 — missing dist or fatal error
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { walkHtmlFiles } from './lib/audit-runner.mjs';
+
+const __dirname = new URL('.', import.meta.url).pathname;
+const ROOT = join(__dirname, '..');
+const DEFAULT_DIST = join(ROOT, 'dist');
+
+const JSONLD_RE = /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+
+// Required-fields per @type. Sourced from Google's Search Central docs:
+// https://developers.google.com/search/docs/appearance/structured-data
+const REQUIRED = {
+  JobPosting: ['title', 'description', 'datePosted', 'hiringOrganization', 'jobLocation', 'employmentType', 'baseSalary'],
+  Article: ['headline', 'datePublished', 'author', 'publisher'],
+  BlogPosting: ['headline', 'datePublished', 'author', 'publisher'],
+  NewsArticle: ['headline', 'datePublished', 'author', 'publisher'],
+  Person: ['name'],
+  Organization: ['name'],
+  LocalBusiness: ['name', 'address'],
+  FAQPage: ['mainEntity'],
+  BreadcrumbList: ['itemListElement'],
+  ImageObject: [], // contentUrl OR url checked separately
+  WebPage: [], // no Google-required fields beyond @type
+  WebSite: [], // no Google-required fields beyond @type
+  Place: ['name'],
+};
+
+function parseArgs() {
+  const args = new Map();
+  for (const a of process.argv.slice(2)) {
+    if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=');
+      args.set(k, v ?? true);
+    }
+  }
+  return args;
+}
+
+function sampleRandom(arr, n) {
+  if (arr.length <= n) return [...arr];
+  const out = new Set();
+  while (out.size < n) out.add(arr[Math.floor(Math.random() * arr.length)]);
+  return [...out];
+}
+
+function* walkTypes(node) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const x of node) yield* walkTypes(x);
+    return;
+  }
+  if (typeof node['@type'] === 'string') yield node;
+  if (Array.isArray(node['@type'])) {
+    for (const t of node['@type']) {
+      if (typeof t === 'string') yield { ...node, '@type': t };
+    }
+  }
+  for (const v of Object.values(node)) {
+    if (v && typeof v === 'object') yield* walkTypes(v);
+  }
+}
+
+function validateEntity(entity) {
+  const violations = [];
+  const t = entity['@type'];
+  if (typeof t !== 'string') return violations;
+  const required = REQUIRED[t];
+  if (!required) return violations; // unknown type, no rules
+
+  for (const f of required) {
+    if (!(f in entity) || entity[f] === null || entity[f] === '') {
+      violations.push({ '@type': t, missing: f });
+    }
+  }
+  // ImageObject: contentUrl OR url
+  if (t === 'ImageObject' && !entity.contentUrl && !entity.url) {
+    violations.push({ '@type': t, missing: 'contentUrl|url' });
+  }
+  // FAQPage: validate mainEntity questions
+  if (t === 'FAQPage' && entity.mainEntity) {
+    const qs = Array.isArray(entity.mainEntity) ? entity.mainEntity : [entity.mainEntity];
+    qs.forEach((q, i) => {
+      if (!q || typeof q !== 'object') return;
+      if (typeof q.name !== 'string' || q.name.trim() === '') {
+        violations.push({ '@type': t, missing: `mainEntity[${i}].name` });
+      }
+      const ans = q.acceptedAnswer;
+      if (!ans || typeof ans !== 'object') {
+        violations.push({ '@type': t, missing: `mainEntity[${i}].acceptedAnswer` });
+      } else if (typeof ans.text !== 'string' || ans.text.trim() === '') {
+        violations.push({ '@type': t, missing: `mainEntity[${i}].acceptedAnswer.text` });
+      }
+    });
+  }
+  // BreadcrumbList: validate itemListElement
+  if (t === 'BreadcrumbList' && entity.itemListElement) {
+    const items = Array.isArray(entity.itemListElement) ? entity.itemListElement : [entity.itemListElement];
+    items.forEach((it, i) => {
+      if (!it || typeof it !== 'object') return;
+      if (typeof it.position !== 'number') {
+        violations.push({ '@type': t, missing: `itemListElement[${i}].position` });
+      }
+      if (typeof it.name !== 'string' || it.name.trim() === '') {
+        violations.push({ '@type': t, missing: `itemListElement[${i}].name` });
+      }
+      // .item is required for non-leaf items; last position is allowed to omit it
+      // (per Google's docs). Skip enforcement.
+    });
+  }
+  return violations;
+}
+
+async function main() {
+  const args = parseArgs();
+  const distArg = args.get('dist') || DEFAULT_DIST;
+  const sampleN = Number(args.get('sample') ?? 200);
+  const strict = args.has('strict');
+
+  const s = await stat(distArg).catch(() => null);
+  if (!s || !s.isDirectory()) {
+    console.error(`[validate-jsonld-shape] dist not found: ${distArg}`);
+    process.exit(2);
+  }
+
+  console.log(`[validate-jsonld-shape] walking ${distArg}…`);
+  const files = await walkHtmlFiles(distArg);
+  console.log(`[validate-jsonld-shape] found ${files.length} HTML files; sampling ${sampleN}…`);
+  const sample = sampleRandom(files, sampleN);
+
+  let totalEntities = 0;
+  let totalViolations = 0;
+  let totalParseErrors = 0;
+  const byType = new Map();
+  const failedPages = [];
+
+  for (const file of sample) {
+    let html;
+    try { html = await readFile(file, 'utf8'); }
+    catch { continue; }
+    if (!html.includes('application/ld+json')) continue;
+
+    JSONLD_RE.lastIndex = 0;
+    const blocks = [];
+    let m;
+    while ((m = JSONLD_RE.exec(html)) !== null) blocks.push(m[1]);
+
+    const pageViolations = [];
+    for (const body of blocks) {
+      let parsed;
+      try { parsed = JSON.parse(body.trim()); }
+      catch (err) {
+        totalParseErrors++;
+        pageViolations.push({ '@type': '<parse-error>', missing: err.message });
+        continue;
+      }
+      for (const entity of walkTypes(parsed)) {
+        totalEntities++;
+        const t = entity['@type'];
+        byType.set(t, (byType.get(t) || 0) + 1);
+        const violations = validateEntity(entity);
+        if (violations.length > 0) {
+          totalViolations += violations.length;
+          pageViolations.push(...violations);
+        }
+      }
+    }
+    if (pageViolations.length > 0) {
+      failedPages.push({ file: relative(ROOT, file), violations: pageViolations });
+    }
+  }
+
+  console.log('');
+  console.log('══════════════════════════════════════════════════════════════════════');
+  console.log(`[validate-jsonld-shape] sampled:       ${sample.length} files`);
+  console.log(`[validate-jsonld-shape] entities:      ${totalEntities}`);
+  console.log(`[validate-jsonld-shape] parse errors:  ${totalParseErrors}`);
+  console.log(`[validate-jsonld-shape] shape violations: ${totalViolations}`);
+  console.log(`[validate-jsonld-shape] pages with issues: ${failedPages.length}`);
+  console.log('══════════════════════════════════════════════════════════════════════');
+
+  if (byType.size > 0) {
+    console.log('');
+    console.log('Entities by @type:');
+    const sorted = [...byType.entries()].sort((a, b) => b[1] - a[1]);
+    for (const [type, count] of sorted) {
+      console.log(`  ${String(count).padStart(6)}  ${type}`);
+    }
+  }
+
+  if (failedPages.length > 0) {
+    console.log('');
+    console.log('First 10 pages with violations:');
+    for (const p of failedPages.slice(0, 10)) {
+      console.log(`\n  ${p.file}`);
+      for (const v of p.violations.slice(0, 5)) {
+        console.log(`    ${v['@type']} missing ${v.missing}`);
+      }
+      if (p.violations.length > 5) console.log(`    ... and ${p.violations.length - 5} more`);
+    }
+  }
+
+  // Exit codes
+  if (totalParseErrors > 0) {
+    console.error(`\nFAIL: ${totalParseErrors} JSON-LD parse error(s) — invalid JSON in <script type="application/ld+json">`);
+    process.exit(1);
+  }
+  if (strict && totalViolations > 0) {
+    console.error(`\nFAIL (--strict): ${totalViolations} shape violation(s) across ${failedPages.length} pages`);
+    process.exit(1);
+  }
+  if (totalViolations > 0) {
+    console.log(`\nINFO: ${totalViolations} shape violations (informational, --strict to fail)`);
+  } else {
+    console.log('\nPASS: every JSON-LD block parses and required fields are present.');
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[validate-jsonld-shape] fatal', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Two complementary verification artifacts:

1. scripts/validate-jsonld-shape.mjs (REAL working script, ~270 LOC)

   Sanity-checks JSON-LD shape across a random sample of dist HTML files
   without calling Google APIs. Catches:
   - JSON parse errors in <script type="application/ld+json">
   - Missing Google-required fields per @type (JobPosting, Article,
     BlogPosting, NewsArticle, FAQPage, BreadcrumbList, Person,
     Organization, LocalBusiness, ImageObject, Place)
   - FAQPage mainEntity[].name + acceptedAnswer.text
   - BreadcrumbList itemListElement[].position + .name

   Does NOT cover Google's full Rich Results Test logic (would require
   GCP API + 1 req/sec rate limit, not viable in CI). Captures the
   subset documented in Google Search Central, which is the actionable
   piece for vincolo N2 sanity (HTML minifier must not break JSON-LD
   shape).

   Run via `npm run validate:jsonld-shape` — sampled 50 production
   pages locally, found 5 informational violations (Place.name missing
   on some JobPosting jobLocation.address entities). Strict mode
   (--strict) fails on any violation; default exits 0 with INFO log.

2. docs/superpowers/specs/2026-05-19-visual-regression-design.md
   (DESIGN DOC, 5-8 h TODO captured)

   Playwright snapshot regression suite design for L2-emitted pages.
   Not implemented because L2 minifier rendering equivalence is already
   covered by:
   - tests/seo/html-minify.test.ts (19 unit tests, DOM serialization)
   - scripts/verify-l2-equivalence.mjs (DOM + text + JSON-LD diff on
     1000 sample pages)

   The suite's main value is for future L2 aggressive mode (attribute
   quote stripping etc.) where rendering could plausibly differ. The
   design captures: 20 representative URLs, Playwright config with
   mobile-first viewport, per-page test skeleton, CI workflow,
   baseline snapshot strategy, font-rendering jitter handling, ad/
   dynamic-content masking. Ready for the implementer when L2-aggressive
   ships.

Together these close vincolo N2 (JSON-LD opaque) for the current L2
minifier without standing up Playwright infrastructure prematurely.
