### PR TITLE
feat(adsense): re-enable in-page Auto Ads on App.tsx (drop blanket no-auto-ads)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1600,22 +1600,22 @@ const App: React.FC = () => {
  <ErrorBoundary>
  <TabContentContext.Provider value={tabContentValue}>
  <NavigationContext.Provider value={navContextValue}>
- {/* AUTO ADS POLICY (CLS fix — FRO-CLS).
-  * Google AdSense Auto Ads is enabled at the account level. In-page auto ads
-  * inject content into the DOM AFTER first paint, which causes severe CLS
-  * (measured mobile p75 0.51, target <0.1). We opt the ENTIRE app out of
-  * in-page auto ads by setting `data-no-auto-ads="inside"` on the root
-  * layout container. This still allows:
-  *   - Anchor / overlay auto ads (position:fixed, no CLS — `data-overlays=bottom`
-  *     is set on the AdSense script in AdSenseBanner.tsx).
-  *   - Manual AdSenseBanner slots (explicit `<ins class="adsbygoogle">` with
-  *     reserved placeholder height in components/shared/AdSenseBanner.tsx —
-  *     these are honored regardless of the no-auto-ads directive).
-  * Revenue impact: loses in-page auto-ads (~€10/day RPM per adsenseSlots.ts
-  * header comment). Anchor auto ads (~€16/day) remain. Manual slots remain.
-  * SEO impact: removes the biggest CLS contributor, unblocking ranking
-  * improvements on job/blog pages. */}
- <div data-no-auto-ads="inside" className={`${staticOverlay ? '' : 'min-h-screen'} relative flex flex-col font-sans text-strong transition-colors duration-300 overflow-hidden`}>
+ {/* AUTO ADS POLICY (2026-05-19 reversal — RPM > CLS, see project_adsense_may19).
+  * Previously the whole app opted out of in-page Auto Ads via
+  * `data-no-auto-ads="inside"` to fix mobile p75 CLS 0.51. AdSense console
+  * audit on 2026-05-19 showed "0 in-page ads" in the site preview, with
+  * coverage stuck at 42-49% (was 65.7% pre-Apr 26). In-page Auto Ads are
+  * the single biggest unused revenue lever.
+  *
+  * The blanket opt-out is removed. CLS is bounded by:
+  *  - Manual AdSenseBanner slots reserve placeholderMinHeight 220-400px
+  *    (services/adsenseSlots.ts) before fill.
+  *  - Anchor + Vignette overlays are position:fixed (zero CLS).
+  *  - `data-ad-frequency-hint=120s` on the AdSense loader caps interstitial
+  *    churn during SPA navigation (AdSenseBanner.tsx:141).
+  *  - Per-page `disableAutoAds` in build-plugins/htmlTemplate.ts is preserved
+  *    for "drive-by" SEO landings where bounce ≥97% (F8/F6/F2). */}
+ <div className={`${staticOverlay ? '' : 'min-h-screen'} relative flex flex-col font-sans text-strong transition-colors duration-300 overflow-hidden`}>
  <div className="absolute inset-0 bg-surface-alt -z-20" style={{ contain: 'strict' }}></div>
 
  {/* LinkedIn OAuth2 callback processing overlay */}
@@ -2158,7 +2158,7 @@ const App: React.FC = () => {
   * sitemap links, weekly employers teaser) regardless of overlay mode.
   */}
  {!staticOverlay && (
- <main id="main-content" data-no-auto-ads="inside" className={`flex-grow mx-auto py-4 lg:py-8 transition-[max-width,padding] duration-300 ease-out relative z-10 ${
+ <main id="main-content" className={`flex-grow mx-auto py-4 lg:py-8 transition-[max-width,padding] duration-300 ease-out relative z-10 ${
  activeTab === 'admin' ? 'w-full px-3 sm:px-6' : '!max-w-[2400px] !w-[95%] px-3 sm:px-4'
  }`}>
  <Suspense fallback={<LazyFallback />}>

--- a/tests/app-no-blanket-no-auto-ads.test.ts
+++ b/tests/app-no-blanket-no-auto-ads.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Auto Ads policy regression — App.tsx must NOT carry blanket
+ * `data-no-auto-ads="inside"` on root layout or <main>.
+ *
+ * Background (2026-04-26 → 2026-05-19):
+ *  - Apr 26: blanket opt-out added to fix mobile p75 CLS 0.51.
+ *  - May 19: AdSense console audit showed coverage stuck at 42-49% (was
+ *    65.7%) and "0 in-page ads" in the site preview, with in-page Auto Ads
+ *    identified as the single biggest unused revenue lever.
+ *  - May 19: blanket opt-out removed. CLS is bounded by per-slot
+ *    placeholderMinHeight (services/adsenseSlots.ts) and overlay frequency
+ *    capping (AdSenseBanner.tsx:141).
+ *
+ * Per-page `disableAutoAds` flag in build-plugins/htmlTemplate.ts is still
+ * supported for drive-by SEO landings — this test scopes ONLY to App.tsx.
+ *
+ * Per-component scoping (e.g. JobExpiredView, sensitive auth flows) is also
+ * still allowed and intentional — this test only blocks the blanket pattern
+ * on the root layout container and the top-level <main>.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const appTsx = readFileSync(resolve(__dirname, '..', 'App.tsx'), 'utf8');
+
+describe('App.tsx — in-page Auto Ads must not be blanket-disabled', () => {
+  it('root <div> wrapper does NOT carry data-no-auto-ads', () => {
+    // The root wrapper is the <div> directly inside the NavigationContext
+    // Provider holding the staticOverlay / min-h-screen classes.
+    const rootDivRegex =
+      /<div[^>]*data-no-auto-ads[^>]*\$\{staticOverlay\s*\?\s*''\s*:\s*'min-h-screen'\}/;
+    expect(appTsx).not.toMatch(rootDivRegex);
+  });
+
+  it('top-level <main id="main-content"> does NOT carry data-no-auto-ads', () => {
+    const mainRegex = /<main\s+id=["']main-content["'][^>]*data-no-auto-ads/;
+    expect(appTsx).not.toMatch(mainRegex);
+  });
+
+  it('the placeholderMinHeight CLS guardrail still exists in adsenseSlots', () => {
+    // Removing the blanket opt-out is only safe because manual slots reserve
+    // layout space. Catch an accidental removal of that guardrail.
+    const adsenseSlots = readFileSync(
+      resolve(__dirname, '..', 'services', 'adsenseSlots.ts'),
+      'utf8',
+    );
+    expect(adsenseSlots).toMatch(/placeholderMinHeight\s*:\s*\d{3}/);
+  });
+});


### PR DESCRIPTION
## Summary
Removes the blanket `data-no-auto-ads="inside"` attribute from App.tsx root + `<main>`. AdSense console audit on 2026-05-19 showed "0 in-page ads" in the site preview and coverage stuck at 42–49% (was 65.7% on Apr 26) — the single biggest unused revenue lever.

## Files
- `App.tsx:1618` — root layout `<div>`: removed attribute.
- `App.tsx:2161` — top-level `<main id="main-content">`: removed attribute.
- `tests/app-no-blanket-no-auto-ads.test.ts` — new regression gate, 3 assertions wired to existing `tests.yml`.

## CLS bound by
| Guardrail | Where |
|---|---|
| `placeholderMinHeight` 220-400px on every manual slot | `services/adsenseSlots.ts` |
| Anchor + Vignette use `position:fixed` (zero CLS) | AdSense console config |
| `data-ad-frequency-hint=120s` caps interstitial churn | `components/shared/AdSenseBanner.tsx:141` |
| Per-page `disableAutoAds` for drive-by SEO landings (F8/F6/F2) | `build-plugins/htmlTemplate.ts` |
| Per-component opt-out (JobExpiredView) | `components/community/JobExpiredView.tsx:666` |

## Test plan
- [x] `npx vitest run tests/app-no-blanket-no-auto-ads.test.ts` — 3/3 pass.
- [x] Test FAILS on `main` (regression gate proven via `git stash`).
- [x] `npx tsc --noEmit` clean for the touched files.
- [x] Adjacent AdSense tests still green (`adsense-lazy-load`, `adsense-hostname`).
- [ ] Post-deploy (24-48h): AdSense console "Anteprima impostazioni" should show >0 in-page slots.
- [ ] Coverage in Reports → daily series rises above 50%.
- [ ] PostHog Web Vitals mobile p75 CLS stays <0.15. If it crosses, fall back to narrower opt-out (above-the-fold-only).