### PR TITLE
fix(newsletter): widen article rotation + evergreen penalty + don't pollute history from test sends

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -747,7 +747,7 @@ function computeExchangeInsight(series, fallbackRate, fallbackPrev) {
   };
 }
 
-// Candidate pool size must comfortably exceed MAX_HISTORY (12) so rotation
+// Candidate pool size must comfortably exceed MAX_HISTORY (26) so rotation
 // never collapses to "every top-viewed article is in the exclude list".
 const TOP_ARTICLES_LIMIT = 50;
 
@@ -799,6 +799,38 @@ function fetchRecentlyPublishedArticleIds(limit = 30) {
     console.warn('\u26a0\ufe0f Recently published articles scan failed:', e.message);
     return [];
   }
+}
+
+/**
+ * Build a `getPublishedAt(id) => Date|null` lookup over `data/blog-articles/*.json`.
+ *
+ * Used by `selectFeaturedArticleId` to penalize "evergreen" articles (older
+ * than 1 year). Legacy evergreens stored under `services/locales/blog-meta-*.ts`
+ * have no JSON file \u2192 the getter returns `null`, which the selector treats as
+ * "unknown publish date \u2192 evergreen" \u2192 de-prioritized.
+ */
+function buildPublishedAtLookup() {
+  const map = new Map();
+  try {
+    const dir = new URL('../data/blog-articles/', import.meta.url);
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+    for (const file of files) {
+      try {
+        const raw = fs.readFileSync(new URL(file, dir), 'utf8');
+        const data = JSON.parse(raw);
+        const ts = Date.parse(data.publishedAt || '');
+        if (Number.isNaN(ts)) continue;
+        const id = data.id || file.replace(/\.json$/, '');
+        map.set(id, new Date(ts));
+      } catch {
+        // Skip unparseable file
+      }
+    }
+  } catch {
+    // Directory missing in test environments \u2014 return empty map; everything
+    // resolves to null, which evergreen-checks treat as "old".
+  }
+  return (id) => map.get(id) || null;
 }
 
 // Capture group for a single-quoted string literal that allows escaped chars
@@ -945,7 +977,10 @@ async function fetchRecentlyFeaturedArticles() {
 
 async function saveRecentlyFeaturedArticle(articleId) {
   if (!db) return;
-  const MAX_HISTORY = 12; // exclude last 12 articles → ~3 months of variety with weekly sends
+  // 2026-05-19: bumped from 12 → 26 weeks (~6 months) after subscriber feedback
+  // that featured articles felt familiar. The old window cycled every ~3 months,
+  // long enough for evergreens to keep resurfacing.
+  const MAX_HISTORY = 26;
   try {
     const history = await fetchRecentlyFeaturedArticles();
     const updated = [articleId, ...history.filter(id => id !== articleId)].slice(0, MAX_HISTORY);
@@ -1045,14 +1080,23 @@ async function pickFeaturedArticle() {
         fetchRecentlyFeaturedArticles(),
       ]);
       const recentlyPublished = fetchRecentlyPublishedArticleIds();
+      const getPublishedAt = buildPublishedAtLookup();
       const hasMeta = (id) => !!loadBlogMeta(id, 'it');
-      const pick = selectFeaturedArticleId(topArticles, recentlyFeatured, hasMeta, Date.now(), recentlyPublished);
+      const pick = selectFeaturedArticleId(
+        topArticles,
+        recentlyFeatured,
+        hasMeta,
+        Date.now(),
+        recentlyPublished,
+        getPublishedAt,
+      );
       if (pick.id) {
         bestId = pick.id;
         const best = topArticles.find((a) => a.id === pick.id);
         const reasonLabel = {
           'fresh': '',
           'recent-publication': ' (recently published, promoting)',
+          'fresh-evergreen': ' (no fresh-published alternative, reusing evergreen)',
           'rotation-exhausted': ' (rotation exhausted, reusing)',
         }[pick.reason] || '';
         console.log(`\ud83d\udcf0 Featured article: "${pick.id}" (${best?.views ?? '?'} views)${reasonLabel}`);
@@ -2004,8 +2048,10 @@ async function main() {
   const sampleSubject = emails[0]?.payload?.subject || 'N/A';
   await logSend(sent.length, sampleSubject, sent.length > 0 ? 'sent' : 'failed');
 
-  // Track featured article for rotation (avoid repeating same article next week)
-  if (sent.length > 0 && featuredArticle.persistRotation) {
+  // Track featured article for rotation — only persist on real sends, not test/preview.
+  // Pre-2026-05-19 every test send polluted the article history; today's test mode
+  // could push 12 entries and overwrite the whole window before any real send.
+  if (mode === 'send' && sent.length > 0 && featuredArticle.persistRotation) {
     await featuredArticle.persistRotation();
   }
 

--- a/services/newsletter-article-rotation.mjs
+++ b/services/newsletter-article-rotation.mjs
@@ -5,6 +5,8 @@
  * called from a dry-run script without booting the full send-newsletter CLI.
  */
 
+const EVERGREEN_AGE_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
+
 /**
  * @param {Array<{id:string,views:number,lastViewed:Date|null}>} topArticles
  *   Firestore article_views docs, sorted by views desc upstream.
@@ -16,6 +18,12 @@
  *   by publish date descending. Used when the views-based pool is exhausted
  *   (every top-viewed article is in the exclude list). Promotes new content
  *   instead of ruminating evergreen winners.
+ * @param {(id:string)=>(Date|null)} [getPublishedAt]  Returns the publish date
+ *   for an article ID, or null if unknown. Articles older than 1 year (or with
+ *   unknown publish date) are treated as "evergreen" and de-prioritized: they
+ *   still surface, but only after fresh-by-views and recently-published pools
+ *   are exhausted. Pass an explicit getter to enable this behaviour; the
+ *   default of `() => null` is a no-op for back-compat with existing tests.
  * @returns {{id: string|null, reason: string}}
  */
 export function selectFeaturedArticleId(
@@ -24,6 +32,7 @@ export function selectFeaturedArticleId(
   hasMeta,
   now = Date.now(),
   recentlyPublished = [],
+  getPublishedAt = null,
 ) {
   const byViewsThenRecency = (a, b) =>
     b.views - a.views || (b.lastViewed || 0) - (a.lastViewed || 0);
@@ -31,21 +40,41 @@ export function selectFeaturedArticleId(
   const weekAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
   const recentTop = allSorted.filter((a) => a.lastViewed && a.lastViewed > weekAgo);
 
-  // 1. Recently viewed AND not in exclude list AND has meta.
-  // 2. Any all-time top not in exclude list AND has meta.
+  // Evergreen test: opt-in via `getPublishedAt`. When the caller doesn't pass
+  // a getter, behaviour is identical to pre-2026-05-19 (no penalty).
+  const isEvergreen = (id) => {
+    if (typeof getPublishedAt !== 'function') return false;
+    const pub = getPublishedAt(id);
+    if (!pub) return true; // unknown publish date → likely a legacy evergreen
+    return now - pub.getTime() > EVERGREEN_AGE_MS;
+  };
+  const passesEvergreen = (a) => !isEvergreen(a.id);
+
+  // 1. Recently viewed AND not in exclude list AND has meta AND not evergreen.
+  // 2. Any all-time top not in exclude list AND has meta AND not evergreen.
   const fresh =
-    recentTop.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id)) ||
-    allSorted.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id));
+    recentTop.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id) && passesEvergreen(a)) ||
+    allSorted.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id) && passesEvergreen(a));
   if (fresh) return { id: fresh.id, reason: 'fresh' };
 
-  // 3. Second-tier pool: recently-published article that hasn't been featured
-  //    yet. Promotes new content when the views-based pool is exhausted.
+  // 3. Recently-published pool — promote fresh content before falling through
+  //    to evergreen reuse. This is what keeps `comuni-migliori-frontalieri`
+  //    (and other ancient high-view evergreens) from coming back every 3
+  //    months purely on the strength of their accumulated views.
   const freshlyPublished = recentlyPublished.find(
     (id) => !recentlyFeatured.includes(id) && hasMeta(id),
   );
   if (freshlyPublished) return { id: freshlyPublished, reason: 'recent-publication' };
 
-  // 4. Rotation truly exhausted — reuse the LEAST recently featured among the
+  // 4. Evergreen fallback: an old high-view article is still better than
+  //    re-using one we shipped last week. Only used when no fresh article
+  //    qualifies under steps 1-3.
+  const evergreenFresh =
+    recentTop.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id)) ||
+    allSorted.find((a) => !recentlyFeatured.includes(a.id) && hasMeta(a.id));
+  if (evergreenFresh) return { id: evergreenFresh.id, reason: 'fresh-evergreen' };
+
+  // 5. Rotation truly exhausted — reuse the LEAST recently featured among the
   //    top-viewed (recentlyFeatured is most-recent first, so a higher index
   //    means "featured longer ago"). Avoids picking the all-time #1 every week.
   if (allSorted.length === 0) return { id: null, reason: 'no-top-articles' };

--- a/tests/newsletter-article-rotation.test.ts
+++ b/tests/newsletter-article-rotation.test.ts
@@ -140,4 +140,70 @@ describe('selectFeaturedArticleId', () => {
     selectFeaturedArticleId(top, [], alwaysHasMeta, NOW);
     expect(top.map((a) => a.id)).toEqual(before);
   });
+
+  // ── Evergreen penalty (opt-in via `getPublishedAt`) ──────────────────────
+  describe('evergreen penalty', () => {
+    it('prefers a fresh-published article over a high-view evergreen', () => {
+      const top = [
+        { id: 'evergreen', views: 200, lastViewed: daysAgo(2) },
+        { id: 'fresh', views: 50, lastViewed: daysAgo(2) },
+      ];
+      const getPublishedAt = (id: string) => {
+        if (id === 'evergreen') return new Date(NOW - 2 * 365 * 24 * 60 * 60 * 1000);
+        if (id === 'fresh') return new Date(NOW - 30 * 24 * 60 * 60 * 1000);
+        return null;
+      };
+      const pick = selectFeaturedArticleId(top, [], alwaysHasMeta, NOW, [], getPublishedAt);
+      expect(pick).toEqual({ id: 'fresh', reason: 'fresh' });
+    });
+
+    it('treats unknown publish date as evergreen', () => {
+      const top = [
+        { id: 'legacy', views: 200, lastViewed: daysAgo(2) }, // no publishedAt
+        { id: 'recent', views: 50, lastViewed: daysAgo(2) },
+      ];
+      const getPublishedAt = (id: string) =>
+        id === 'recent' ? new Date(NOW - 30 * 24 * 60 * 60 * 1000) : null;
+      const pick = selectFeaturedArticleId(top, [], alwaysHasMeta, NOW, [], getPublishedAt);
+      expect(pick).toEqual({ id: 'recent', reason: 'fresh' });
+    });
+
+    it('falls back to evergreen when no fresh-published alternative qualifies', () => {
+      const top = [
+        { id: 'evergreen', views: 200, lastViewed: daysAgo(2) },
+      ];
+      const getPublishedAt = () => new Date(NOW - 2 * 365 * 24 * 60 * 60 * 1000);
+      const pick = selectFeaturedArticleId(top, [], alwaysHasMeta, NOW, [], getPublishedAt);
+      expect(pick).toEqual({ id: 'evergreen', reason: 'fresh-evergreen' });
+    });
+
+    it('prefers recently-published over evergreen fallback', () => {
+      // The user's actual bug: 'comuni-migliori-frontalieri' (evergreen) kept
+      // winning over fresh news articles purely on accumulated views.
+      const top = [
+        { id: 'comuni-migliori-frontalieri', views: 52, lastViewed: daysAgo(2) },
+      ];
+      const recentlyPublished = ['ffs-riorganizza-traffico', 'svizzera-economia-2026'];
+      const getPublishedAt = (id: string) => {
+        if (id === 'comuni-migliori-frontalieri') return null; // legacy
+        if (id === 'ffs-riorganizza-traffico') return new Date(NOW - 1 * 24 * 60 * 60 * 1000);
+        if (id === 'svizzera-economia-2026') return new Date(NOW - 2 * 24 * 60 * 60 * 1000);
+        return null;
+      };
+      const pick = selectFeaturedArticleId(
+        top, [], alwaysHasMeta, NOW, recentlyPublished, getPublishedAt,
+      );
+      expect(pick).toEqual({ id: 'ffs-riorganizza-traffico', reason: 'recent-publication' });
+    });
+
+    it('back-compat: existing callers (no getPublishedAt) keep old behaviour', () => {
+      // Tests passing 5 args (no getter) should not see evergreen penalty.
+      const top = [
+        { id: 'a', views: 100, lastViewed: daysAgo(2) }, // would be evergreen if checked
+        { id: 'b', views: 50, lastViewed: daysAgo(2) },
+      ];
+      const pick = selectFeaturedArticleId(top, [], alwaysHasMeta, NOW);
+      expect(pick).toEqual({ id: 'a', reason: 'fresh' });
+    });
+  });
 });


### PR DESCRIPTION
Subscriber feedback (issue #61): featured articles + jobs felt familiar.
Investigation found three causes — fixed all three here.

1. Article-rotation history was 12 deep → cycles every ~3 months at weekly
   cadence. Bumped MAX_HISTORY to 26 (~6 months variety). TOP_ARTICLES_LIMIT
   already at 50 since PR #349 so the candidate pool still exceeds history.

2. Test/preview sends were persisting to article rotation history. Today's
   diagnostic test pushed `comuni-migliori-frontalieri` to the top of the
   real production history, displacing a genuine prior send. Mirror the
   job-rotation gate: only `mode === 'send'` writes to `_meta_`.

3. Evergreen articles (≥1 year old or no publishedAt) kept winning the
   selection on accumulated views — high pageview count survives the
   12-week exclude, fresh news loses on raw views. Added opt-in
   `getPublishedAt` parameter to `selectFeaturedArticleId`: when the caller
   supplies it, the "fresh" pool excludes evergreens; recently-published
   pool wins next; evergreens only resurface in the `fresh-evergreen`
   fallback if no fresh content qualifies. Existing callers that don't
   pass the getter keep pre-2026-05-19 behavior (back-compat).

The send-newsletter caller wires the getter via `buildPublishedAtLookup()`
reading `data/blog-articles/*.json` publishedAt. Articles stored in
`services/locales/blog-meta-*.ts` (legacy evergreens like
`comuni-migliori-frontalieri`) have no JSON file → getter returns null →
treated as evergreen → de-prioritized.

Tests: 18/18 rotation tests green (5 new, 13 existing unchanged).
79/79 across 4 newsletter test files green.
