### PR TITLE
fix(crawlers): set needsRetranslation=true at first crawl on 20 new parsers

### DIFF
--- a/scripts/lib/berner-klinik-montana-job-parser.mjs
+++ b/scripts/lib/berner-klinik-montana-job-parser.mjs
@@ -136,6 +136,12 @@ export async function fetchAllBernerKlinikMontanaJobs() {
       titleByLocale: { [sourceLang]: it.title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Crans-Montana',
       canton: 'VS',
       url: it.url,

--- a/scripts/lib/clinique-la-source-job-parser.mjs
+++ b/scripts/lib/clinique-la-source-job-parser.mjs
@@ -96,6 +96,10 @@ export async function fetchAllCliniqueLaSourceJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't, `translate-pending.yml` picks the job up.
+      needsRetranslation: true,
       location: 'Lausanne',
       canton: 'VD',
       url,

--- a/scripts/lib/cs-bregaglia-job-parser.mjs
+++ b/scripts/lib/cs-bregaglia-job-parser.mjs
@@ -95,6 +95,12 @@ export async function fetchAllCsBregagliaJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Promontogno',
       canton: 'GR',
       url: it.url,

--- a/scripts/lib/csvm-mustair-job-parser.mjs
+++ b/scripts/lib/csvm-mustair-job-parser.mjs
@@ -94,6 +94,12 @@ export async function fetchAllCsvmMustairJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Sta. Maria Val Müstair',
       canton: 'GR',
       url: it.url,

--- a/scripts/lib/csvp-poschiavo-job-parser.mjs
+++ b/scripts/lib/csvp-poschiavo-job-parser.mjs
@@ -101,6 +101,12 @@ export async function fetchAllCsvpPoschiavoJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Poschiavo',
       canton: 'GR',
       url: it.url,

--- a/scripts/lib/fielmann-job-parser.mjs
+++ b/scripts/lib/fielmann-job-parser.mjs
@@ -301,6 +301,13 @@ export async function fetchAllFielmannJobs() {
       titleByLocale: { [sourceLang]: title },
       description: descriptionText || `${title} — Fielmann Group`,
       descriptionByLocale: { [sourceLang]: descriptionText || `${title} — Fielmann Group` },
+      // Newly-discovered jobs ship with source-locale-only fields. The
+      // shared AI-localization step clears this flag when it fills the
+      // remaining locales; if it can't (cache miss + AI quota), the flag
+      // stays and `translate-pending.yml` picks the job up out-of-band.
+      // Without this flag the locale-completeness gate trips before the
+      // translation pipeline can run.
+      needsRetranslation: true,
       location: city,
       canton,
       url: publicUrl,

--- a/scripts/lib/hopital-de-lavaux-job-parser.mjs
+++ b/scripts/lib/hopital-de-lavaux-job-parser.mjs
@@ -113,6 +113,10 @@ export async function fetchAllHopitalDeLavauxJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't, `translate-pending.yml` picks the job up.
+      needsRetranslation: true,
       location: city,
       canton,
       url,

--- a/scripts/lib/institution-lavigny-job-parser.mjs
+++ b/scripts/lib/institution-lavigny-job-parser.mjs
@@ -204,6 +204,12 @@ export async function fetchAllInstitutionLavignyJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: city || 'Lavigny',
       canton,
       url: finalUrl,

--- a/scripts/lib/jobup-ch-feed-common.mjs
+++ b/scripts/lib/jobup-ch-feed-common.mjs
@@ -332,6 +332,12 @@ export function createJobupChFeedParser(config) {
         titleByLocale: { [sourceLang]: title },
         description,
         descriptionByLocale: { [sourceLang]: description },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't (cache miss + AI quota), the flag stays and
+        // `translate-pending.yml` picks the job up out-of-band. Without this
+        // flag the locale-completeness gate trips before translation can run.
+        needsRetranslation: true,
         location,
         canton,
         url: link,

--- a/scripts/lib/klinik-arlesheim-job-parser.mjs
+++ b/scripts/lib/klinik-arlesheim-job-parser.mjs
@@ -150,6 +150,12 @@ export async function fetchAllKlinikArlesheimJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Arlesheim',
       canton: 'BL',
       url: it.url,

--- a/scripts/lib/ksbl-job-parser.mjs
+++ b/scripts/lib/ksbl-job-parser.mjs
@@ -313,6 +313,12 @@ export async function fetchAllKsblJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location,
       canton,
       url: e.detailUrl,

--- a/scripts/lib/merian-iselin-job-parser.mjs
+++ b/scripts/lib/merian-iselin-job-parser.mjs
@@ -136,6 +136,12 @@ export async function fetchAllMerianIselinJobs() {
       titleByLocale: { [sourceLang]: it.title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Basel',
       canton: 'BS',
       url: it.url,

--- a/scripts/lib/ophtalmique-job-parser.mjs
+++ b/scripts/lib/ophtalmique-job-parser.mjs
@@ -98,6 +98,10 @@ export async function fetchAllOphtalmiqueJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't, `translate-pending.yml` picks the job up.
+      needsRetranslation: true,
       location: 'Lausanne',
       canton: 'VD',
       url,

--- a/scripts/lib/prospective-ch-job-parser-common.mjs
+++ b/scripts/lib/prospective-ch-job-parser-common.mjs
@@ -253,6 +253,12 @@ export function createProspectiveChParser(config) {
         titleByLocale: { [sourceLang]: title },
         description: descriptionText || `${title} — ${companyName}`,
         descriptionByLocale: { [sourceLang]: descriptionText || `${title} — ${companyName}` },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't (cache miss + AI quota), the flag stays and
+        // `translate-pending.yml` picks the job up out-of-band. Without this
+        // flag the locale-completeness gate trips before translation can run.
+        needsRetranslation: true,
         location,
         canton,
         url: publicUrl,

--- a/scripts/lib/rehab-basel-job-parser.mjs
+++ b/scripts/lib/rehab-basel-job-parser.mjs
@@ -105,6 +105,12 @@ export async function fetchAllRehabBaselJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Basel',
       canton: 'BS',
       url: it.detailUrl,

--- a/scripts/lib/riveneuve-job-parser.mjs
+++ b/scripts/lib/riveneuve-job-parser.mjs
@@ -189,6 +189,12 @@ export async function fetchAllRiveneuveJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location: 'Blonay',
       canton: 'VD',
       url: e.url,

--- a/scripts/lib/rsbj-job-parser.mjs
+++ b/scripts/lib/rsbj-job-parser.mjs
@@ -222,6 +222,12 @@ export async function fetchAllRsbjJobs() {
       titleByLocale: { [sourceLang]: title },
       description,
       descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
       location,
       canton,
       url: e.url,

--- a/scripts/lib/successfactors-shared-job-parser-common.mjs
+++ b/scripts/lib/successfactors-shared-job-parser-common.mjs
@@ -468,6 +468,12 @@ export function createSuccessFactorsParser(config) {
         titleByLocale: { [sourceLang]: title },
         description,
         descriptionByLocale: { [sourceLang]: description },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't (cache miss + AI quota), the flag stays and
+        // `translate-pending.yml` picks the job up out-of-band. Without this
+        // flag the locale-completeness gate trips before translation can run.
+        needsRetranslation: true,
         location: city,
         canton,
         url: fullUrl,

--- a/scripts/lib/umantis-listing-common.mjs
+++ b/scripts/lib/umantis-listing-common.mjs
@@ -460,6 +460,12 @@ export function createUmantisListingParser(config) {
         titleByLocale: { [sourceLang]: title },
         description,
         descriptionByLocale: { [sourceLang]: description },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't (cache miss + AI quota), the flag stays and
+        // `translate-pending.yml` picks the job up out-of-band. Without this
+        // flag the locale-completeness gate trips before translation can run.
+        needsRetranslation: true,
         location,
         canton,
         url: detailUrl,

--- a/scripts/lib/vd-emploi-platform-common.mjs
+++ b/scripts/lib/vd-emploi-platform-common.mjs
@@ -278,6 +278,12 @@ export function createVdEmploiPlatformParser(config) {
         titleByLocale: { [sourceLang]: decodedTitle },
         description: descriptionText || `${decodedTitle} — ${companyName}`,
         descriptionByLocale: { [sourceLang]: descriptionText || `${decodedTitle} — ${companyName}` },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't (cache miss + AI quota), the flag stays and
+        // `translate-pending.yml` picks the job up out-of-band. Without this
+        // flag the locale-completeness gate trips before translation can run.
+        needsRetranslation: true,
         location,
         canton,
         url: publicUrl,


### PR DESCRIPTION
Fixes `tests/job-locale-completeness.test.ts` failure on Fielmann. AI-localization step is expected to clear this flag when it fills all 4 locales; if it can't (cache miss + AI quota), the flag stays and the job is picked up by translate-pending.yml — meanwhile the completeness gate correctly skips it. Applied to Fielmann + 20 newly-shipped parsers/factories.