### PR TITLE
fix(jobs): bridge pages resolve cross-canton + canton-aware breadcrumb + backfill 792 orphan slugs

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -995,6 +995,21 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  };
  return map[locale] || map.it;
  };
+ // Canton-aware breadcrumb label. Reflects the JOB'S canton, not the URL
+ // canton segment — required for bridge pages where a job moved across
+ // cantons and the old URL slug still lives on. Without this, a page
+ // served at /cerca-lavoro-ticino/<bridge> for a job now in Appenzell
+ // displayed "Tutte le offerte di lavoro in Ticino" while linking to
+ // /cerca-lavoro-appenzello/ — a visible inconsistency for the user.
+ const allJobsLinkLabel = (locale: 'it' | 'en' | 'de' | 'fr', cantonDisplay: string): string => {
+ const map: Record<string, string> = {
+ it: `Tutte le offerte di lavoro in ${cantonDisplay}`,
+ en: `All job offers in ${cantonDisplay}`,
+ de: `Alle Stellenangebote ${germanCantonPrep(cantonDisplay)}`,
+ fr: `Toutes les offres d'emploi ${frenchCantonPrep(cantonDisplay)}`,
+ };
+ return map[locale] || map.it;
+ };
  const cantonPracticalNote0 = (locale: 'it' | 'en' | 'de' | 'fr', cantonDisplay: string): string => {
  const dePrep = germanCantonPrep(cantonDisplay);
  const frPrep = frenchCantonPrep(cantonDisplay);
@@ -2366,7 +2381,7 @@ ${hreflangHtml}
  <body>
  <div id="root">
  <main class="static-job-page">
- <nav class="bn"><a href="${BASE_URL}${withSlash(`${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}`.replace(/\/+/g, '/'))}">&larr; ${esc(localeCopy[locale].allJobsLink)}</a></nav>
+ <nav class="bn"><a href="${BASE_URL}${withSlash(`${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}`.replace(/\/+/g, '/'))}">&larr; ${esc(allJobsLinkLabel(locale, dc))}</a></nav>
  <article class="proposal">
  <section class="hero">
  <h1 class="hero-title">${esc(composeJobPageH1(localizedTitle, String(job.company || '')))}</h1>

--- a/build-plugins/localeJobsSplitPlugin.ts
+++ b/build-plugins/localeJobsSplitPlugin.ts
@@ -157,11 +157,18 @@ export function localeJobsSplitPlugin(rootDir: string): Plugin {
  );
  }
 
- // Slug map: minimal file for router.ts slug translation (~2MB vs 44MB full)
+ // Slug map: minimal file for router.ts slug translation (~2MB vs 44MB full).
+ // Also includes `id` + `canton` so the SPA can resolve a bridge URL whose
+ // target job lives in a canton shard that wasn't loaded by the initial
+ // referrer-aware fetch (e.g. /cerca-lavoro-ticino/<bridge>/ for a job now
+ // in AI — JobBoard would otherwise show JobOrphanView even though the job
+ // is alive). With id+canton the SPA can lazy-fetch /data/job-detail/{id}.json.
  const slugMap = jobs.map((j) => {
  const entry: Record<string, unknown> = {};
+ if (j.id) entry.id = j.id;
  if (j.slug) entry.slug = j.slug;
  if (j.slugByLocale) entry.slugByLocale = j.slugByLocale;
+ if (j.canton) entry.canton = j.canton;
  if (Array.isArray(j.previousSlugs) && j.previousSlugs.length) entry.previousSlugs = j.previousSlugs;
  if (j.previousSlugsByLocale) entry.previousSlugsByLocale = j.previousSlugsByLocale;
  return entry;

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -81,7 +81,7 @@ import {
 import { type Locale, useLocale, useTranslation, getCantonI18nParams } from '@/services/i18n';
 import { loadBlogMeta } from '@/services/i18n';
 import { Analytics } from '@/services/analytics';
-import { buildPath, registerJobSlugMap } from '@/services/router';
+import { buildPath, registerJobSlugMap, getJobMetaForSlug, ensureJobSlugMapLoaded } from '@/services/router';
 import { useNavigation } from '@/services/NavigationContext';
 import AdSenseBanner from '@/components/shared/AdSenseBanner';
 import Callout from '@/components/shared/Callout';
@@ -2897,6 +2897,53 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const lookupSlug = bridgeTargetSlug || initialJobSlug;
  return jobs.find((j) => matchesRouteSlug(j, lookupSlug)) || null;
  }, [jobs, initialJobSlug, bridgeTargetSlug, companySlugFilter, locationSlugFilter, searchSlugFilter, editorialLandingDescriptor]);
+
+ // Cross-canton bridge resolution: when a bridge URL (e.g.
+ // /cerca-lavoro-ticino/<old-slug>/) points to a job that now lives in a
+ // canton not included in the initial referrer-aware load (e.g. AI), the
+ // slim `jobs` array won't contain it and the SPA would otherwise fall
+ // through to `JobOrphanView` even though the job is alive. The static
+ // crawler-facing fallback (pre-rendered) shows the correct content, so
+ // there's an unacceptable mismatch between first-paint and hydration.
+ // Fix: when bridgeTargetSlug is set, jobs are loaded, and selectedJob is
+ // null, look up the target canton from the slug-map and lazy-fetch that
+ // canton's shard. On the next render selectedJob resolves correctly.
+ const [bridgeFetchAttempted, setBridgeFetchAttempted] = useState<string | null>(null);
+ useEffect(() => {
+ if (jobsLoading) return;
+ if (!initialJobSlug) return;
+ if (selectedJob) return;
+ const targetSlug = bridgeTargetSlug || initialJobSlug;
+ if (bridgeFetchAttempted === targetSlug) return;
+ let cancelled = false;
+ (async () => {
+ try {
+ await ensureJobSlugMapLoaded();
+ if (cancelled) return;
+ const meta = getJobMetaForSlug(targetSlug);
+ if (!meta?.canton) return;
+ // Skip if we already have any job from this canton — the target really
+ // is missing (expired or never crawled) and a re-fetch won't help.
+ const cantonCode = meta.canton;
+ if (jobs.some((j) => String(j.canton || '').toUpperCase() === cantonCode)) return;
+ const extra = await fetchJobsForCanton(cantonCode);
+ if (cancelled || !Array.isArray(extra) || extra.length === 0) return;
+ setJobs((prev) => {
+ const seen = new Set(prev.map((j) => j.id));
+ const merged = [...prev];
+ for (const j of extra) {
+ if (!seen.has(j.id)) merged.push(j as unknown as JobListing);
+ }
+ return merged;
+ });
+ } catch {
+ // Silently ignore — JobOrphanView is the acceptable fallback.
+ } finally {
+ if (!cancelled) setBridgeFetchAttempted(targetSlug);
+ }
+ })();
+ return () => { cancelled = true; };
+ }, [jobsLoading, initialJobSlug, selectedJob, bridgeTargetSlug, bridgeFetchAttempted, jobs]);
 
  // FRO-detail-split: Lazily enrich slim job with per-job detail data (~15KB)
  // instead of fetching the full locale file (~11MB). Merges detail fields into

--- a/data/jobs/by-crawler/abb-svizzera-sede-ticino.json
+++ b/data/jobs/by-crawler/abb-svizzera-sede-ticino.json
@@ -77,7 +77,8 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "senior-power-systems-computer-aided-ingegnere-abb-svizzera-sede-ticino-quartino-ticino-w5vlie"
+          "senior-power-systems-computer-aided-ingegnere-abb-svizzera-sede-ticino-quartino-ticino-w5vlie",
+          "senior-power-systems-computer-aided-engineer-abb-svizzera-sede-ticino-quartino-ticino"
         ],
         "fr": [
           "senior-power-systems-computer-aided-ingenieur-abb-svizzera-sede-ticino-quartino-ticino-w5vlie"
@@ -86,7 +87,8 @@
       "previousSlugs": [
         "senior-power-systems-computer-aided-ingegnere-abb-svizzera-sede-ticino-quartino-ticino-w5vlie",
         "senior-power-systems-computer-aided-ingenieur-abb-svizzera-sede-ticino-quartino-ticino-w5vlie",
-        "ingegnere-computerizzato-di-sistemi-di-potenza-senior-abb-svizzera-sede-ticino-quartino-ticino"
+        "ingegnere-computerizzato-di-sistemi-di-potenza-senior-abb-svizzera-sede-ticino-quartino-ticino",
+        "senior-power-systems-computer-aided-engineer-abb-svizzera-sede-ticino-quartino-ticino"
       ],
       "needsRetranslation": true
     },
@@ -156,11 +158,13 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "product-trainer-abb-svizzera-sede-ticino-ticino-1dk7xe",
-        "trainer-del-prodotto-abb-svizzera-sede-ticino-quartino"
+        "trainer-del-prodotto-abb-svizzera-sede-ticino-quartino",
+        "product-trainer-abb-svizzera-sede-ticino-ticino"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "product-trainer-abb-svizzera-sede-ticino-ticino-1dk7xe"
+          "product-trainer-abb-svizzera-sede-ticino-ticino-1dk7xe",
+          "product-trainer-abb-svizzera-sede-ticino-ticino"
         ]
       }
     },
@@ -231,8 +235,15 @@
       "employmentType": "FULL_TIME",
       "retranslationAttempts": 1,
       "previousSlugs": [
-        "r-d-senior-ingegnere-firmware-80-100-abb-svizzera-sede-ticino-quartino-ticino"
-      ]
+        "r-d-senior-ingegnere-firmware-80-100-abb-svizzera-sede-ticino-quartino-ticino",
+        "r-d-senior-engineer-firmware-80-100-abb-svizzera-sede-ticino-quartino",
+        "r-d-senior-engineer-firmware-80-100-abb-svizzera-sede-ticino-quartino-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "en": [
+          "r-d-senior-engineer-firmware-80-100-abb-svizzera-sede-ticino-quartino"
+        ]
+      }
     },
     {
       "id": "company-qkvhc4",
@@ -299,7 +310,15 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "retranslationAttempts": 1
+      "retranslationAttempts": 1,
+      "previousSlugs": [
+        "80-100-warehouse-internal-logistics-supervisor-abb-svizzera-sede-ticino-quartino-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "80-100-warehouse-internal-logistics-supervisor-abb-svizzera-sede-ticino-quartino-ticino"
+        ]
+      }
     },
     {
       "id": "company-u6aw32",
@@ -368,8 +387,18 @@
       "employmentType": "FULL_TIME",
       "retranslationAttempts": 1,
       "previousSlugs": [
-        "specialista-della-qualita-dei-processi-80-100-abb-svizzera-sede-ticino-quartino-ticino"
-      ]
+        "specialista-della-qualita-dei-processi-80-100-abb-svizzera-sede-ticino-quartino-ticino",
+        "process-quality-specialist-80-100-abb-svizzera-sede-ticino-quartino",
+        "process-quality-specialist-80-100-abb-svizzera-sede-ticino-quartino-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "en": [
+          "process-quality-specialist-80-100-abb-svizzera-sede-ticino-quartino"
+        ],
+        "it": [
+          "process-quality-specialist-80-100-abb-svizzera-sede-ticino-quartino-ticino"
+        ]
+      }
     },
     {
       "id": "company-d6wkr3",
@@ -438,8 +467,18 @@
       "employmentType": "FULL_TIME",
       "retranslationAttempts": 1,
       "previousSlugs": [
-        "test-ingegnere-80-100-abb-svizzera-sede-ticino-quartino-ticino"
-      ]
+        "test-ingegnere-80-100-abb-svizzera-sede-ticino-quartino-ticino",
+        "test-engineer-80-100-abb-svizzera-sede-ticino-quartino",
+        "test-engineer-80-100-abb-svizzera-sede-ticino-quartino-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "en": [
+          "test-engineer-80-100-abb-svizzera-sede-ticino-quartino"
+        ],
+        "it": [
+          "test-engineer-80-100-abb-svizzera-sede-ticino-quartino-ticino"
+        ]
+      }
     },
     {
       "id": "company-l7apjs",
@@ -506,7 +545,17 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "retranslationAttempts": 1
+      "retranslationAttempts": 1,
+      "previousSlugs": [
+        "80-100-r-d-hw-engineer-abb-svizzera-sede-ticino-quartino",
+        "80-100-r-d-hw-engineer-abb-svizzera-sede-ticino-quartino-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "80-100-r-d-hw-engineer-abb-svizzera-sede-ticino-quartino",
+          "80-100-r-d-hw-engineer-abb-svizzera-sede-ticino-quartino-ticino"
+        ]
+      }
     },
     {
       "id": "company-ouqirv",
@@ -575,8 +624,14 @@
       "employmentType": "FULL_TIME",
       "retranslationAttempts": 1,
       "previousSlugs": [
-        "specialista-di-ingegneria-di-produzione-80-100-abb-svizzera-sede-ticino-quartino"
-      ]
+        "specialista-di-ingegneria-di-produzione-80-100-abb-svizzera-sede-ticino-quartino",
+        "production-engineering-specialist-80-100-abb-svizzera-sede-ticino-quartino-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "production-engineering-specialist-80-100-abb-svizzera-sede-ticino-quartino-ticino"
+        ]
+      }
     },
     {
       "id": "company-b9qjfm",
@@ -628,7 +683,8 @@
         "inside-sales-service-specialista-80-100-abb-svizzera-sede-ticino-ticino",
         "specialista-di-vendita-interna-servizi-80-100-abb-svizzera-sede-ticino-quartino",
         "inside-sales-service-specialist-80-100-abb-svizzera-sede-ticino-ticino-b9qjfm",
-        "specialista-servizi-di-vendita-interna-80-100-abb-svizzera-sede-ticino-quartino"
+        "specialista-servizi-di-vendita-interna-80-100-abb-svizzera-sede-ticino-quartino",
+        "inside-sales-service-specialist-80-100-abb-svizzera-sede-ticino-ticino"
       ],
       "salaryMin": 72000,
       "salaryMax": 97000,

--- a/data/jobs/by-crawler/agie-charmilles.json
+++ b/data/jobs/by-crawler/agie-charmilles.json
@@ -643,8 +643,17 @@
       "firstSeenAt": "2026-05-06T10:13:20.681Z",
       "previousSlugs": [
         "software-engineer-expert-r-d-100-agie-charmilles-biel-bienne",
-        "expert-en-genie-logiciel-r-d-100-agie-charmilles-sa-biel-bienne"
-      ]
+        "expert-en-genie-logiciel-r-d-100-agie-charmilles-sa-biel-bienne",
+        "software-engineer-expert-r-d-agie-charmilles-losone",
+        "software-engineer-expert-r-d-agie-charmilles-sa-losone",
+        "software-engineer-expert-r-d-agie-charmilles-biel-bienne-un8xq7"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "software-engineer-expert-r-d-agie-charmilles-sa-losone",
+          "software-engineer-expert-r-d-agie-charmilles-biel-bienne-un8xq7"
+        ]
+      }
     },
     {
       "title": "Electronic Engineer - R&D",
@@ -778,8 +787,19 @@
       "firstSeenAt": "2026-05-06T10:13:20.681Z",
       "previousSlugs": [
         "software-plc-engineer-r-d-100-agie-charmilles-biel-bienne",
-        "ingenieur-du-logiciel-plc-r-d-100-agie-charmilles-sa-biel-bienne"
-      ]
+        "ingenieur-du-logiciel-plc-r-d-100-agie-charmilles-sa-biel-bienne",
+        "software-plc-engineer-r-d-agie-charmilles-losone",
+        "software-plc-engineer-r-d-agie-charmilles-sa-losone",
+        "software-plc-engineer-r-d-agie-charmilles-biel-bienne-xmeaf4"
+      ],
+      "previousSlugsByLocale": {
+        "en": [
+          "software-plc-engineer-r-d-agie-charmilles-sa-losone"
+        ],
+        "it": [
+          "software-plc-engineer-r-d-agie-charmilles-biel-bienne-xmeaf4"
+        ]
+      }
     },
     {
       "title": "Payroll Expert SAP",
@@ -3150,7 +3170,8 @@
       "firstSeenAt": "2026-05-10T20:53:37.027Z",
       "previousSlugsByLocale": {
         "it": [
-          "diagnosetechniker-100-agie-charmilles-biel-bienne"
+          "diagnosetechniker-100-agie-charmilles-biel-bienne",
+          "diagnosetechniker-w-m-d-100-agie-charmilles-biel-bienne"
         ],
         "en": [
           "diagnosetechniker-100-agie-charmilles-biel-bienne"
@@ -3160,7 +3181,8 @@
         ]
       },
       "previousSlugs": [
-        "diagnosetechniker-100-agie-charmilles-biel-bienne"
+        "diagnosetechniker-100-agie-charmilles-biel-bienne",
+        "diagnosetechniker-w-m-d-100-agie-charmilles-biel-bienne"
       ]
     },
     {

--- a/data/jobs/by-crawler/aldi-suisse.json
+++ b/data/jobs/by-crawler/aldi-suisse.json
@@ -79,11 +79,15 @@
       "sourceLang": "de",
       "crawledAt": "2026-05-19T11:01:35.706Z",
       "previousSlugs": [
-        "stellvertretender-filialleiter-m-w-d-aldi-suisse"
+        "stellvertretender-filialleiter-m-w-d-aldi-suisse",
+        "stellvertretender-filialleiter-m-w-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem"
       ],
       "previousSlugsByLocale": {
         "it": [
           "stellvertretender-filialleiter-m-w-d-aldi-suisse"
+        ],
+        "de": [
+          "stellvertretender-filialleiter-m-w-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem"
         ]
       },
       "needsRetranslation": true,
@@ -177,12 +181,14 @@
       "previousSlugs": [
         "addetto-vendite-m-f-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem",
         "mitarbeiter-verkauf-m-w-d-aldi-suisse",
-        "mitarbeiter-verkauf-m-w-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem-4n4np8"
+        "mitarbeiter-verkauf-m-w-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem-4n4np8",
+        "mitarbeiter-verkauf-m-w-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem"
       ],
       "previousSlugsByLocale": {
         "it": [
           "addetto-vendite-m-f-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem",
-          "mitarbeiter-verkauf-m-w-d-aldi-suisse"
+          "mitarbeiter-verkauf-m-w-d-aldi-suisse",
+          "mitarbeiter-verkauf-m-w-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem"
         ],
         "en": [
           "mitarbeiter-verkauf-m-w-d-aldi-suisse-en-in-elf-landern-weltweit-seit-dem-4n4np8"

--- a/data/jobs/by-crawler/allianz-suisse.json
+++ b/data/jobs/by-crawler/allianz-suisse.json
@@ -234,7 +234,8 @@
         "kundenberater-im-versicherungsbereich-m-w-d-zu-100-allianz-suisse-lugano",
         "versicherungskundenbetreuer-m-w-d-100-prozent-allianz-suisse-lugano",
         "customer-advisor-in-the-insurance-field-m-f-d-100-allianz-suisse-lugano",
-        "conseiller-a-la-clientele-dans-le-domaine-de-l-assurance-m-f-j-a-100-allianz-suisse-lugano"
+        "conseiller-a-la-clientele-dans-le-domaine-de-l-assurance-m-f-j-a-100-allianz-suisse-lugano",
+        "consulente-alla-clientela-in-ambito-assicurativo-m-f-d-al-100-allianz-suisse-lugano"
       ],
       "previousSlugsByLocale": {
         "en": [
@@ -245,6 +246,9 @@
         ],
         "fr": [
           "conseiller-a-la-clientele-dans-le-domaine-de-l-assurance-m-f-j-a-100-allianz-suisse-lugano"
+        ],
+        "it": [
+          "consulente-alla-clientela-in-ambito-assicurativo-m-f-d-al-100-allianz-suisse-lugano"
         ]
       }
     },
@@ -310,7 +314,8 @@
         "verkaufsleiter-aussendienst-m-w-d-100-bellinzona-allianz-suisse-bellinzona",
         "vorsorgeberater-im-aussendienst-m-w-d-100-allianz-suisse-bellinzona",
         "social-security-consultant-in-the-external-service-m-f-d-100-allianz-suisse-bellinzona",
-        "conseiller-en-prevoyance-dans-le-service-externe-m-f-j-100-allianz-suisse-bellinzona"
+        "conseiller-en-prevoyance-dans-le-service-externe-m-f-j-100-allianz-suisse-bellinzona",
+        "consulente-previdenziale-nel-servizio-esterno-m-f-d-100-allianz-suisse-bellinzona-ticino-s"
       ],
       "previousSlugsByLocale": {
         "en": [
@@ -321,6 +326,9 @@
         ],
         "fr": [
           "conseiller-en-prevoyance-dans-le-service-externe-m-f-j-100-allianz-suisse-bellinzona"
+        ],
+        "it": [
+          "consulente-previdenziale-nel-servizio-esterno-m-f-d-100-allianz-suisse-bellinzona-ticino-s"
         ]
       }
     },
@@ -460,8 +468,14 @@
       "postalCode": "6900",
       "firstSeenAt": "2026-05-14T21:15:28.707Z",
       "previousSlugs": [
-        "consulente-previdenziale-per-l-agenzia-generale-chur-100-allianz-suisse-chur-x29jc7"
-      ]
+        "consulente-previdenziale-per-l-agenzia-generale-chur-100-allianz-suisse-chur-x29jc7",
+        "consulente-previdenziale-per-l-agenzia-generale-chur-100-allianz-suisse-chur"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-previdenziale-per-l-agenzia-generale-chur-100-allianz-suisse-chur"
+        ]
+      }
     }
   ]
 }

--- a/data/jobs/by-crawler/amministrazione-cantonale-ti.json
+++ b/data/jobs/by-crawler/amministrazione-cantonale-ti.json
@@ -894,7 +894,8 @@
       },
       "sourceLang": "it",
       "previousSlugs": [
-        "concorso-generale-2026-personale-ai-servizi-generali-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-can"
+        "concorso-generale-2026-personale-ai-servizi-generali-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-can",
+        "concorso-generale-2026-personale-ai-servizi-generali-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-bellinzona"
       ],
       "baseSalary": {
         "@type": "MonetaryAmount",
@@ -914,7 +915,8 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "concorso-generale-2026-personale-ai-servizi-generali-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-can"
+          "concorso-generale-2026-personale-ai-servizi-generali-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-can",
+          "concorso-generale-2026-personale-ai-servizi-generali-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-bellinzona"
         ],
         "en": [
           "concorso-generale-2026-personale-ai-servizi-generali-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-can"
@@ -1133,7 +1135,8 @@
       "sourceLang": "it",
       "previousSlugs": [
         "stagiste-i-per-il-conseguimento-della-maturita-professionale-commerciale-52-settimane-presso-l-amministrazione-cantonale-amministrazione-can-213zbx",
-        "stage-pour-l-obtention-de-la-maturite-professionnelle-commerciale-52-semaines-au-sein-de-l"
+        "stage-pour-l-obtention-de-la-maturite-professionnelle-commerciale-52-semaines-au-sein-de-l",
+        "stagiste-i-per-il-conseguimento-della-maturita-professionale-commerciale-52-settimane-presso-l-amministrazione-cantonale-amministrazione-cantonale-ticino-bellinzona"
       ],
       "salaryMin": 54000,
       "salaryMax": 73000,
@@ -1155,7 +1158,8 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "stagiste-i-per-il-conseguimento-della-maturita-professionale-commerciale-52-settimane-presso-l-amministrazione-cantonale-amministrazione-can-213zbx"
+          "stagiste-i-per-il-conseguimento-della-maturita-professionale-commerciale-52-settimane-presso-l-amministrazione-cantonale-amministrazione-can-213zbx",
+          "stagiste-i-per-il-conseguimento-della-maturita-professionale-commerciale-52-settimane-presso-l-amministrazione-cantonale-amministrazione-cantonale-ticino-bellinzona"
         ],
         "en": [
           "stagiste-i-per-il-conseguimento-della-maturita-professionale-commerciale-52-settimane-presso-l-amministrazione-cantonale-amministrazione-can-213zbx"
@@ -1211,7 +1215,8 @@
       "previousSlugs": [
         "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione--213j0o",
         "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatric-213j0o",
-        "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-bellinzona"
+        "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-bellinzona",
+        "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-mendrisio"
       ],
       "salaryMin": 80000,
       "salaryMax": 108000,
@@ -1234,7 +1239,8 @@
       "previousSlugsByLocale": {
         "it": [
           "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione--213j0o",
-          "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatric-213j0o"
+          "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatric-213j0o",
+          "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-mendrisio"
         ],
         "en": [
           "concorso-generale-2026-medico-capo-clinica-in-psichiatria-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione--213j0o"
@@ -1297,7 +1303,8 @@
         "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-cantonale-osc-m",
         "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-mendrisio",
         "allgemeine-ausschreibung-2026-assistenzarzte-bei-der-kantonalen-sozialpsychiatrischen-organisation-osc-mendrisio-sociopsichiatrica-cantonale",
-        "concours-general-2026-medecins-assistants-a-l-organisation-socio-psychiatrique-cantonale-osc-mendrisio-sociopsichiatrica-cantonale-osc-mendr"
+        "concours-general-2026-medecins-assistants-a-l-organisation-socio-psychiatrique-cantonale-osc-mendrisio-sociopsichiatrica-cantonale-osc-mendr",
+        "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-"
       ],
       "salaryMin": 80000,
       "salaryMax": 108000,
@@ -1321,7 +1328,8 @@
         "it": [
           "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino--213j0g",
           "general-physician-assistant-competition-2026-amministrazione-cantonale-ticino-mendrisio",
-          "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-cantonale-osc-m-213j0g"
+          "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-sociopsichiatrica-cantonale-osc-m-213j0g",
+          "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino-"
         ],
         "en": [
           "concorso-generale-2026-medici-assistenti-presso-l-organizzazione-sociopsichiatrica-cantonale-osc-mendrisio-amministrazione-cantonale-ticino--213j0g",

--- a/data/jobs/by-crawler/arxada.json
+++ b/data/jobs/by-crawler/arxada.json
@@ -976,11 +976,13 @@
           "operator-in-2-schicht-arxada-ch"
         ],
         "it": [
-          "operator-in-2-schicht-arxada-ch"
+          "operator-in-2-schicht-arxada-ch",
+          "operator-in-2-schicht-arxada-ch-2"
         ]
       },
       "previousSlugs": [
-        "operator-in-2-schicht-arxada-ch"
+        "operator-in-2-schicht-arxada-ch",
+        "operator-in-2-schicht-arxada-ch-2"
       ],
       "firstSeenAt": "2026-04-13T09:59:01.346Z",
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/avaloq.json
+++ b/data/jobs/by-crawler/avaloq.json
@@ -405,11 +405,13 @@
       "firstSeenAt": "2026-05-05T10:08:39.456Z",
       "previousSlugsByLocale": {
         "it": [
-          "banking-specialist-payments-12-months-fixed-term-contract-avaloq-bioggio"
+          "banking-specialist-payments-12-months-fixed-term-contract-avaloq-bioggio",
+          "banking-specialist-in-payments-ch-10-month-fixed-term-contract-avaloq-bioggio"
         ]
       },
       "previousSlugs": [
-        "banking-specialist-payments-12-months-fixed-term-contract-avaloq-bioggio"
+        "banking-specialist-payments-12-months-fixed-term-contract-avaloq-bioggio",
+        "banking-specialist-in-payments-ch-10-month-fixed-term-contract-avaloq-bioggio"
       ]
     },
     {

--- a/data/jobs/by-crawler/axa-svizzera.json
+++ b/data/jobs/by-crawler/axa-svizzera.json
@@ -62,7 +62,15 @@
       "postalCode": "6901",
       "firstSeenAt": "2026-05-17T09:40:29.449Z",
       "retranslationAttempts": 1,
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-assicurativo-per-il-luganese-axa-svizzera-axa"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-assicurativo-per-il-luganese-axa-svizzera-axa"
+        ]
+      }
     },
     {
       "title": "Consulente Assicurativo",
@@ -124,7 +132,15 @@
       "postalCode": "6901",
       "firstSeenAt": "2026-05-17T09:40:29.449Z",
       "retranslationAttempts": 1,
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-assicurativo-axa-svizzera-axa"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-assicurativo-axa-svizzera-axa"
+        ]
+      }
     },
     {
       "title": "Consulente Assicurativo",
@@ -186,7 +202,19 @@
       "postalCode": "6901",
       "firstSeenAt": "2026-05-17T09:40:29.449Z",
       "retranslationAttempts": 1,
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-assicurativo-axa-svizzera-axa-agenzia-principale-nicola-locarnini-manno",
+        "consulente-assicurativo-axa-svizzera-axa-agenzia-principale-nicola-locarnini-manno-2",
+        "consulente-assicurativo-axa-svizzera-axa-agenzia-principale-nicola-locarnini-manno-3"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-assicurativo-axa-svizzera-axa-agenzia-principale-nicola-locarnini-manno",
+          "consulente-assicurativo-axa-svizzera-axa-agenzia-principale-nicola-locarnini-manno-2",
+          "consulente-assicurativo-axa-svizzera-axa-agenzia-principale-nicola-locarnini-manno-3"
+        ]
+      }
     },
     {
       "title": "Consulente Assicurativo per il Mendrisiotto",
@@ -248,7 +276,17 @@
       "postalCode": "6901",
       "firstSeenAt": "2026-05-17T09:40:29.449Z",
       "retranslationAttempts": 1,
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-assicurativo-per-il-mendrisiotto-axa-svizzera-axa",
+        "consulente-assicurativo-per-il-mendrisiotto-axa-svizzera-agenzia-generale-andrea-tarello-bkvc6m"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-assicurativo-per-il-mendrisiotto-axa-svizzera-axa",
+          "consulente-assicurativo-per-il-mendrisiotto-axa-svizzera-agenzia-generale-andrea-tarello-bkvc6m"
+        ]
+      }
     },
     {
       "title": "Fachführung Krankenzusatzversicherung (VVG) Schwerpunkt stationäre Mehrleistungen (all genders)",
@@ -665,14 +703,16 @@
       "id": "axa-svizzera-91fb6801250c",
       "previousSlugsByLocale": {
         "it": [
-          "fachberater-in-private-vorsorge-fur-die-generalagentur-vorsorge-vermogen-schaffhaus-79x7ku"
+          "fachberater-in-private-vorsorge-fur-die-generalagentur-vorsorge-vermogen-schaffhaus-79x7ku",
+          "fachberater-in-private-vorsorge-fur-die-generalagentur-vorsorge-vermogen-schaffhausen-axa-svizzera-70-arbeitsort-schaffh"
         ],
         "de": [
           "fachberater-in-private-vorsorge-fur-die-generalagentur-vorsorge-vermogen-schaffhaus-79x7ku"
         ]
       },
       "previousSlugs": [
-        "fachberater-in-private-vorsorge-fur-die-generalagentur-vorsorge-vermogen-schaffhaus-79x7ku"
+        "fachberater-in-private-vorsorge-fur-die-generalagentur-vorsorge-vermogen-schaffhaus-79x7ku",
+        "fachberater-in-private-vorsorge-fur-die-generalagentur-vorsorge-vermogen-schaffhausen-axa-svizzera-70-arbeitsort-schaffh"
       ],
       "salaryMin": 49500,
       "salaryMax": 75000,
@@ -1541,14 +1581,20 @@
       "id": "axa-svizzera-e64ce2409096",
       "previousSlugsByLocale": {
         "it": [
-          "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-arbeitsort-ymdiir"
+          "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-arbeitsort-ymdiir",
+          "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-svizzera-ticino"
         ],
         "de": [
           "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-arbeitsort-ymdiir"
+        ],
+        "en": [
+          "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-svizzera-axa"
         ]
       },
       "previousSlugs": [
-        "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-arbeitsort-ymdiir"
+        "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-arbeitsort-ymdiir",
+        "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-svizzera-axa",
+        "leiter-in-innendienst-fur-die-generalagentur-vorsorge-vermogen-chur-axa-svizzera-ticino"
       ],
       "salaryMin": 68000,
       "salaryMax": 103000,
@@ -1687,7 +1733,8 @@
       "id": "axa-svizzera-b548fd42935e",
       "previousSlugsByLocale": {
         "it": [
-          "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhau-xthz4l"
+          "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhau-xthz4l",
+          "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhausen-axa-svizzera-arbeitsort-schaffhau"
         ],
         "de": [
           "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhau-xthz4l"
@@ -1698,7 +1745,8 @@
       },
       "previousSlugs": [
         "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhau-xthz4l",
-        "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhausen-axa-svizzera-arbeitsort"
+        "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhausen-axa-svizzera-arbeitsort",
+        "mitarbeiter-in-innendienst-40-60-fur-die-generalagentur-vorsorge-vermogen-schaffhausen-axa-svizzera-arbeitsort-schaffhau"
       ],
       "salaryMin": 49500,
       "salaryMax": 75000,
@@ -1911,7 +1959,8 @@
       "id": "axa-svizzera-883a45a1c822",
       "previousSlugsByLocale": {
         "it": [
-          "vorsorgeberater-in-fur-die-geschaftsstelle-vorsorge-vermogen-glarus-axa-arbeitsorte-jerdl0"
+          "vorsorgeberater-in-fur-die-geschaftsstelle-vorsorge-vermogen-glarus-axa-arbeitsorte-jerdl0",
+          "vorsorgeberater-in-fur-die-geschaftsstelle-vorsorge-vermogen-glarus-axa-svizzera-arbeitsorte-glarus-lachen-uznach-sargan"
         ],
         "de": [
           "vorsorgeberater-in-fur-die-geschaftsstelle-vorsorge-vermogen-glarus-axa-arbeitsorte-jerdl0"
@@ -1919,7 +1968,8 @@
       },
       "previousSlugs": [
         "vorsorgeberater-in-fur-die-geschaftsstelle-vorsorge-vermogen-glarus-axa-arbeitsorte-jerdl0",
-        "vorsorgeberater-in-per-la-geschaftsstelle-previdenza-patrimonio-glarus-axa-svizzera-arbeitsorte-glarus-lachen-uznach-sar"
+        "vorsorgeberater-in-per-la-geschaftsstelle-previdenza-patrimonio-glarus-axa-svizzera-arbeitsorte-glarus-lachen-uznach-sar",
+        "vorsorgeberater-in-fur-die-geschaftsstelle-vorsorge-vermogen-glarus-axa-svizzera-arbeitsorte-glarus-lachen-uznach-sargan"
       ],
       "salaryMin": 49500,
       "salaryMax": 75000,

--- a/data/jobs/by-crawler/axpo-group.json
+++ b/data/jobs/by-crawler/axpo-group.json
@@ -3064,7 +3064,10 @@
       "previousSlugsByLocale": {
         "it": [
           "lernende-r-montage-elektriker-in-efz-w-m-d-2027-grosswangen-d33a3688-4518-4bfc-b746-074da6e13d86",
-          "apprendista-montage-elektriker-in-cfc-w-m-d-2027-grosswangen-ckw-grosswangen"
+          "apprendista-montage-elektriker-in-cfc-w-m-d-2027-grosswangen-ckw-grosswangen",
+          "lernende-r-montage-elektriker-in-efz-w-m-d-2027-beromunster-ckw-beromunster",
+          "lernende-r-montage-elektriker-in-efz-w-m-d-2027-ballwil-ckw-ballwil",
+          "lernende-r-montage-elektriker-in-efz-w-m-d-2027-lostorf-ckw-lostorf"
         ],
         "en": [
           "lernende-r-montage-elektriker-in-efz-w-m-d-2027-grosswangen-d33a3688-4518-4bfc-b746-074da6e13d86"
@@ -3075,7 +3078,10 @@
       },
       "previousSlugs": [
         "lernende-r-montage-elektriker-in-efz-w-m-d-2027-grosswangen-d33a3688-4518-4bfc-b746-074da6e13d86",
-        "apprendista-montage-elektriker-in-cfc-w-m-d-2027-grosswangen-ckw-grosswangen"
+        "apprendista-montage-elektriker-in-cfc-w-m-d-2027-grosswangen-ckw-grosswangen",
+        "lernende-r-montage-elektriker-in-efz-w-m-d-2027-beromunster-ckw-beromunster",
+        "lernende-r-montage-elektriker-in-efz-w-m-d-2027-ballwil-ckw-ballwil",
+        "lernende-r-montage-elektriker-in-efz-w-m-d-2027-lostorf-ckw-lostorf"
       ]
     },
     {

--- a/data/jobs/by-crawler/badrutts-palace.json
+++ b/data/jobs/by-crawler/badrutts-palace.json
@@ -125,11 +125,13 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "responsabile-it-badrutt-s-palace-hotel-st-moritz"
+        "responsabile-it-badrutt-s-palace-hotel-st-moritz",
+        "manager-m-w-d-badrutt-s-palace-hotel-st-moritz"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "responsabile-it-badrutt-s-palace-hotel-st-moritz"
+          "responsabile-it-badrutt-s-palace-hotel-st-moritz",
+          "manager-m-w-d-badrutt-s-palace-hotel-st-moritz"
         ]
       },
       "needsRetranslation": true,
@@ -266,11 +268,13 @@
       "requirementsByLocale": {},
       "previousSlugs": [
         "guest-experience-executive-m-w-d-teilzeit-50-badrutts-palace-ch",
-        "guest-experience-executive-m-w-d-teil-50-badrutt-s-palace-hotel-st-moritz"
+        "guest-experience-executive-m-w-d-teil-50-badrutt-s-palace-hotel-st-moritz",
+        "guest-experience-executive-m-w-d-badrutt-s-palace-hotel-st-moritz"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "guest-experience-executive-m-w-d-teilzeit-50-badrutts-palace-ch"
+          "guest-experience-executive-m-w-d-teilzeit-50-badrutts-palace-ch",
+          "guest-experience-executive-m-w-d-badrutt-s-palace-hotel-st-moritz"
         ]
       },
       "needsRetranslation": true,
@@ -410,7 +414,8 @@
           "head-of-technical-services-m-w-d-badrutts-palace-ch"
         ],
         "it": [
-          "responsabile-servizio-tecnico-badrutt-s-palace-hotel-st-moritz"
+          "responsabile-servizio-tecnico-badrutt-s-palace-hotel-st-moritz",
+          "head-of-technical-services-badrutt-s-palace-hotel-st-moritz"
         ],
         "de": [
           "leiter-technischer-dienst-m-w-d-badrutt-s-palace-hotel-st-moritz"
@@ -419,7 +424,8 @@
       "previousSlugs": [
         "head-of-technical-services-m-w-d-badrutts-palace-ch",
         "responsabile-servizio-tecnico-badrutt-s-palace-hotel-st-moritz",
-        "leiter-technischer-dienst-m-w-d-badrutt-s-palace-hotel-st-moritz"
+        "leiter-technischer-dienst-m-w-d-badrutt-s-palace-hotel-st-moritz",
+        "head-of-technical-services-badrutt-s-palace-hotel-st-moritz"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T09:42:03.470Z",

--- a/data/jobs/by-crawler/banca-raiffeisen-vedeggio-cassarate.json
+++ b/data/jobs/by-crawler/banca-raiffeisen-vedeggio-cassarate.json
@@ -145,10 +145,14 @@
       "previousSlugsByLocale": {
         "en": [
           "consulente-clientela-affluent-banca-raiffeisen-vedeggio-cassarate-gravesano-ticino-m99b74"
+        ],
+        "it": [
+          "consulente-clientela-affluent-banca-raiffeisen-vedeggio-cassarate-cadempino"
         ]
       },
       "previousSlugs": [
-        "consulente-clientela-affluent-banca-raiffeisen-vedeggio-cassarate-gravesano-ticino-m99b74"
+        "consulente-clientela-affluent-banca-raiffeisen-vedeggio-cassarate-gravesano-ticino-m99b74",
+        "consulente-clientela-affluent-banca-raiffeisen-vedeggio-cassarate-cadempino"
       ],
       "needsRetranslation": true
     },
@@ -216,9 +220,15 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "previousSlugs": [
-        "consulente-clientela-privata-individuale-banca-raiffeisen-vedeggio-cassarate-gravesano-ticino"
+        "consulente-clientela-privata-individuale-banca-raiffeisen-vedeggio-cassarate-gravesano-ticino",
+        "consulente-clientela-privata-individuale-banca-raiffeisen-vedeggio-cassarate-gravesano-tic"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-clientela-privata-individuale-banca-raiffeisen-vedeggio-cassarate-gravesano-tic"
+        ]
+      }
     }
   ]
 }

--- a/data/jobs/by-crawler/banca-sempione.json
+++ b/data/jobs/by-crawler/banca-sempione.json
@@ -114,7 +114,19 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "firstSeenAt": "2026-04-13T21:11:04.811Z"
+      "firstSeenAt": "2026-04-13T21:11:04.811Z",
+      "previousSlugs": [
+        "global-wealth-management-client-advisor-private-banker-banca-del-sempione-lugano",
+        "global-wealth-management-kundenberater-private-banker-banca-del-sempione-lugano"
+      ],
+      "previousSlugsByLocale": {
+        "en": [
+          "global-wealth-management-client-advisor-private-banker-banca-del-sempione-lugano"
+        ],
+        "de": [
+          "global-wealth-management-kundenberater-private-banker-banca-del-sempione-lugano"
+        ]
+      }
     },
     {
       "title": "Global Wealth Management – Private Banking Assistant (Zurich)",

--- a/data/jobs/by-crawler/bitfinex.json
+++ b/data/jobs/by-crawler/bitfinex.json
@@ -143,6 +143,28 @@
           "maxValue": 135000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-2",
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-3",
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-5",
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-4",
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-7",
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-6",
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-8",
+        "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-9"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-2",
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-3",
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-5",
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-4",
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-7",
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-6",
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-8",
+          "senior-backend-developer-node-js-fully-remote-worldwide-bitfinex-ch-9"
+        ]
       }
     },
     {
@@ -197,11 +219,29 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "content-marketing-manager-remoto-al-100-in-tutto-il-mondo-fuso-orario-cet-bitfinex-sydney"
+        "content-marketing-manager-remoto-al-100-in-tutto-il-mondo-fuso-orario-cet-bitfinex-sydney",
+        "content-marketing-manager-remote-100-worldwide-cet-zeitzone-bitfinex-london",
+        "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-2",
+        "content-marketing-manager-remote-100-worldwide-cet-zeitzone-bitfinex-toronto",
+        "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-3",
+        "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-4",
+        "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-5",
+        "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-6",
+        "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-7",
+        "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-8"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "content-marketing-manager-remoto-al-100-in-tutto-il-mondo-fuso-orario-cet-bitfinex-sydney"
+          "content-marketing-manager-remoto-al-100-in-tutto-il-mondo-fuso-orario-cet-bitfinex-sydney",
+          "content-marketing-manager-remote-100-worldwide-cet-zeitzone-bitfinex-london",
+          "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-2",
+          "content-marketing-manager-remote-100-worldwide-cet-zeitzone-bitfinex-toronto",
+          "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-3",
+          "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-4",
+          "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-5",
+          "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-6",
+          "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-7",
+          "content-marketing-manager-remote-100-worldwide-cet-timezone-bitfinex-ch-8"
         ]
       },
       "needsRetranslation": true,
@@ -271,11 +311,25 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "project-manager-content-manager-100-in-tutto-il-mondo-remoto-6-mesi-contratto-con-estensione-potenziale-bitfinex-ha-noi"
+        "project-manager-content-manager-100-in-tutto-il-mondo-remoto-6-mesi-contratto-con-estensione-potenziale-bitfinex-ha-noi",
+        "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-spain",
+        "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-london",
+        "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-dublin",
+        "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-singapore",
+        "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-mexico-city",
+        "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-caracas",
+        "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-ha-noi"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "project-manager-content-manager-100-in-tutto-il-mondo-remoto-6-mesi-contratto-con-estensione-potenziale-bitfinex-ha-noi"
+          "project-manager-content-manager-100-in-tutto-il-mondo-remoto-6-mesi-contratto-con-estensione-potenziale-bitfinex-ha-noi",
+          "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-spain",
+          "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-london",
+          "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-dublin",
+          "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-singapore",
+          "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-mexico-city",
+          "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-caracas",
+          "project-manager-content-manager-100-worldwide-remote-6-months-contract-with-potential-extension-bitfinex-ha-noi"
         ]
       },
       "needsRetranslation": true,
@@ -411,11 +465,27 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "sviluppatore-di-applicazioni-mobili-react-native-100-remoto-mondiale-bitfinex-budapest"
+        "sviluppatore-di-applicazioni-mobili-react-native-100-remoto-mondiale-bitfinex-budapest",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-2",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-3",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-4",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-5",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-6",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-7",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-8",
+        "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-9"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "sviluppatore-di-applicazioni-mobili-react-native-100-remoto-mondiale-bitfinex-budapest"
+          "sviluppatore-di-applicazioni-mobili-react-native-100-remoto-mondiale-bitfinex-budapest",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-2",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-3",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-4",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-5",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-6",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-7",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-8",
+          "mobile-developer-react-native-100-remote-worldwide-bitfinex-ch-9"
         ]
       },
       "needsRetranslation": true,
@@ -485,11 +555,13 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "analista-di-monitoraggio-del-rischio-junior-100-remoto-in-tutto-il-mondo-bitfinex-sao-paulo"
+        "analista-di-monitoraggio-del-rischio-junior-100-remoto-in-tutto-il-mondo-bitfinex-sao-paulo",
+        "junior-risk-monitoring-analyst-100-remote-worldwide-bitfinex-ch-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "analista-di-monitoraggio-del-rischio-junior-100-remoto-in-tutto-il-mondo-bitfinex-sao-paulo"
+          "analista-di-monitoraggio-del-rischio-junior-100-remoto-in-tutto-il-mondo-bitfinex-sao-paulo",
+          "junior-risk-monitoring-analyst-100-remote-worldwide-bitfinex-ch-2"
         ]
       },
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/board-international.json
+++ b/data/jobs/by-crawler/board-international.json
@@ -60,7 +60,15 @@
       "streetAddress": "Via Campagna 11",
       "postalCode": "6982",
       "firstSeenAt": "2026-05-17T09:46:35.164Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "rfx-proposal-manager-board-international-chiasso-switzerland-fzo8z7"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "rfx-proposal-manager-board-international-chiasso-switzerland-fzo8z7"
+        ]
+      }
     },
     {
       "title": "Sr. Account Manager",
@@ -455,10 +463,14 @@
         ],
         "fr": [
           "solution-developer-fp-a-board-international-chiasso-switzerland"
+        ],
+        "en": [
+          "solution-developer-board-international-chiasso-switzerland"
         ]
       },
       "previousSlugs": [
-        "solution-developer-fp-a-board-international-chiasso-switzerland"
+        "solution-developer-fp-a-board-international-chiasso-switzerland",
+        "solution-developer-board-international-chiasso-switzerland"
       ]
     },
     {

--- a/data/jobs/by-crawler/bosch-thermotechnik-ag.json
+++ b/data/jobs/by-crawler/bosch-thermotechnik-ag.json
@@ -317,7 +317,8 @@
       "id": "bosch-thermotechnik-ag-32c744378e61",
       "previousSlugsByLocale": {
         "it": [
-          "werkstudententatigkeit-im-bereich-finance-und-accounting-schweiz-w-m-div-ref285688g-bosch-solothurn-zuchwil"
+          "werkstudententatigkeit-im-bereich-finance-und-accounting-schweiz-w-m-div-ref285688g-bosch-solothurn-zuchwil",
+          "werkstudententatigkeit-im-bereich-finance-und-accounting-schweiz-w-m-div-ref285688g-bosch-thermotechnik-ag-solothurn-zuc"
         ],
         "en": [
           "werkstudententatigkeit-im-bereich-finance-und-accounting-schweiz-w-m-div-ref285688g-bosch-solothurn-zuchwil"
@@ -328,7 +329,8 @@
       },
       "previousSlugs": [
         "werkstudententatigkeit-im-bereich-finance-und-accounting-schweiz-w-m-div-ref285688g-bosch-solothurn-zuchwil",
-        "werkstudententatigkeit-im-bereich-finanza-e-accounting-schweiz-w-m-div-ref285688g-bosch-thermotechnik-ag-solothurn-zuchw"
+        "werkstudententatigkeit-im-bereich-finanza-e-accounting-schweiz-w-m-div-ref285688g-bosch-thermotechnik-ag-solothurn-zuchw",
+        "werkstudententatigkeit-im-bereich-finance-und-accounting-schweiz-w-m-div-ref285688g-bosch-thermotechnik-ag-solothurn-zuc"
       ],
       "salaryMin": 59000,
       "salaryMax": 90500,

--- a/data/jobs/by-crawler/burkhalter-group.json
+++ b/data/jobs/by-crawler/burkhalter-group.json
@@ -228,7 +228,8 @@
       },
       "previousSlugs": [
         "elektro-servicemonteur-in-100-elektro-bau-ag-rothrist-rothrist",
-        "elektro-servicemonteur-in-100-elektro-bau-ag-filiale-lenzburg-lenzburg"
+        "elektro-servicemonteur-in-100-elektro-bau-ag-filiale-lenzburg-lenzburg",
+        "elektro-servicemonteur-in-100-elektro-bau-ag-rothrist-rothrist-2"
       ]
     },
     {
@@ -5287,7 +5288,8 @@
       "postalCode": "6928",
       "previousSlugs": [
         "monteur-automaticien-cfc-monteuse-automaticienne-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electr",
-        "automation-fitter-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electro"
+        "automation-fitter-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electro",
+        "monteur-automaticien-cfc-monteuse-automaticienne-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electro-sa-martigny"
       ],
       "id": "burkhalter-group-4ed3538ad780",
       "previousSlugsByLocale": {
@@ -5301,7 +5303,8 @@
           "monteur-automaticien-cfc-monteuse-automaticienne-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electr"
         ],
         "fr": [
-          "monteur-automaticien-cfc-monteuse-automaticienne-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electr"
+          "monteur-automaticien-cfc-monteuse-automaticienne-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electr",
+          "monteur-automaticien-cfc-monteuse-automaticienne-cfc-80-100-c2b-electrotechnique-succursale-de-grichting-valterio-electro-sa-martigny"
         ]
       },
       "firstSeenAt": "2026-04-13T10:09:28.527Z"
@@ -5445,13 +5448,17 @@
       "postalCode": "6928",
       "previousSlugs": [
         "bauleiter-in-100-grichting-valterio-electro-sa-martigny",
-        "chef-fe-de-chantier-100-grichting-valterio-electro-sa-martigny"
+        "chef-fe-de-chantier-100-grichting-valterio-electro-sa-martigny",
+        "chef-de-chantier-100-grichting-valterio-electro-sa-martigny",
+        "chef-fe-de-chantier-100-grichting-valterio-electro-sa-martigny-z1psqh"
       ],
       "id": "burkhalter-group-430e814f321b",
       "previousSlugsByLocale": {
         "it": [
           "bauleiter-in-100-grichting-valterio-electro-sa-martigny",
-          "chef-fe-de-chantier-100-grichting-valterio-electro-sa-martigny"
+          "chef-fe-de-chantier-100-grichting-valterio-electro-sa-martigny",
+          "chef-de-chantier-100-grichting-valterio-electro-sa-martigny",
+          "chef-fe-de-chantier-100-grichting-valterio-electro-sa-martigny-z1psqh"
         ],
         "en": [
           "bauleiter-in-100-grichting-valterio-electro-sa-martigny",
@@ -9528,7 +9535,8 @@
         "projektleiter-in-gebaudetechnik-100-imwinkelried-luftung-und-klima-ag-visp",
         "project-manager-gebaudetechnik-100-imwinkelried-luftung-und-klima-ag-visp-s9psu1",
         "chef-de-projet-gebaudetechnik-100-imwinkelried-luftung-und-klima-ag-visp-s9psu1",
-        "automatisation-du-chef-de-projet-100-imwinkelried-luftung-und-klima-ag-visp"
+        "automatisation-du-chef-de-projet-100-imwinkelried-luftung-und-klima-ag-visp",
+        "projektleiter-in-gebaudetechnik-westwallis-80-100-imwinkelried-luftung-und-klima-ag-visp"
       ],
       "id": "burkhalter-group-b52e86e342d1",
       "previousSlugsByLocale": {
@@ -9543,6 +9551,9 @@
         "fr": [
           "chef-de-projet-gebaudetechnik-100-imwinkelried-luftung-und-klima-ag-visp-s9psu1",
           "automatisation-du-chef-de-projet-100-imwinkelried-luftung-und-klima-ag-visp"
+        ],
+        "de": [
+          "projektleiter-in-gebaudetechnik-westwallis-80-100-imwinkelried-luftung-und-klima-ag-visp"
         ]
       },
       "firstSeenAt": "2026-04-13T10:09:28.533Z"
@@ -15509,7 +15520,8 @@
         ]
       },
       "previousSlugs": [
-        "depanneur-installateur-electricien-avec-cfc-depanneuse-installatrice-electricienne-avec-cfc-100-merinat-s-a-vevey"
+        "depanneur-installateur-electricien-avec-cfc-depanneuse-installatrice-electricienne-avec-cfc-100-merinat-s-a-vevey",
+        "depanneur-installateur-electricien-avec-cfc-depanneuse-installatrice-electricienne-avec-cfc-100-merinat-s-a-succursale-d-2"
       ]
     },
     {
@@ -16097,7 +16109,8 @@
         "electrical-planner-oder-elektroinstallateur-in-additional-apprenticeship-als-electrical-planner-elektroinstallateur-efz-",
         "planificateur-trice-electrique-oder-elektroinstallateur-in-formation-complementaire-als-planificateur-trice-electrique-e",
         "elettricista-progettista-o-installatore-elettrico-con-esperienza-di-progettazione-tz-strom",
-        "electricien-planificateur-ou-installateur-electrique-avec-experience-de-planification-tz-s"
+        "electricien-planificateur-ou-installateur-electrique-avec-experience-de-planification-tz-s",
+        "elektroplaner-oder-elektroinstallateur-in-zusatzlehre-als-elektroplaner-elektroinstallateur-efz-mit-planerischer-erfahrung-100-tz-stromag-brig-glis"
       ],
       "salaryMin": 58000,
       "salaryMax": 78000,
@@ -16131,7 +16144,8 @@
           "progettista-elettrico-a-o-installatore-trice-elettrico-a-in-formazione-complementare-come-progettista-elettrico-a-instal",
           "electrical-planner-oder-elektroinstallateur-in-additional-apprenticeship-als-electrical-planner-elektroinstallateur-efz-",
           "planificateur-trice-electrique-oder-elektroinstallateur-in-formation-complementaire-als-planificateur-trice-electrique-e",
-          "progettista-elettrico-o-elettricista-installatore-in-apprendistato-complementare-come-progettista-elettrico-elettricista"
+          "progettista-elettrico-o-elettricista-installatore-in-apprendistato-complementare-come-progettista-elettrico-elettricista",
+          "elektroplaner-oder-elektroinstallateur-in-zusatzlehre-als-elektroplaner-elektroinstallateur-efz-mit-planerischer-erfahrung-100-tz-stromag-brig-glis"
         ],
         "fr": [
           "progettista-elettrico-a-o-installatore-trice-elettrico-a-in-formazione-complementare-come-progettista-elettrico-a-instal",

--- a/data/jobs/by-crawler/casale.json
+++ b/data/jobs/by-crawler/casale.json
@@ -229,7 +229,8 @@
         "electrical-ingenieur-casale-sa-lugano-ticino-oqzh90",
         "ingegnere-elettrotecnico-casale-sa-lugano",
         "electrical-engineer-casale-lugano",
-        "electrical-engineer-casale-sa-lugano-ticino-oqzh90"
+        "electrical-engineer-casale-sa-lugano-ticino-oqzh90",
+        "instrument-engineer-casale-sa-lugano-ticino"
       ],
       "salaryMin": 72000,
       "salaryMax": 97000,
@@ -246,7 +247,8 @@
       },
       "previousSlugsByLocale": {
         "it": [
-          "ingegnere-di-strumentazione-casale-sa-lugano"
+          "ingegnere-di-strumentazione-casale-sa-lugano",
+          "instrument-engineer-casale-sa-lugano-ticino"
         ],
         "en": [
           "instrument-engineer-casale-lugano",
@@ -311,7 +313,8 @@
         "hse-spezialist-casale-sa-lugano-ticino-b892fl",
         "hse-specialiste-casale-sa-lugano-ticino-b892fl",
         "hse-specialist-casale-lugano",
-        "hse-specialist-casale-sa-lugano-ticino-b892fl"
+        "hse-specialist-casale-sa-lugano-ticino-b892fl",
+        "hse-specialist-casale-sa-lugano-ticino"
       ],
       "salaryMin": 58000,
       "salaryMax": 78000,
@@ -330,7 +333,8 @@
         "it": [
           "specialista-hse-casale-sa-lugano",
           "hse-spezialist-casale-sa-lugano-ticino-b892fl",
-          "hse-specialiste-casale-sa-lugano-ticino-b892fl"
+          "hse-specialiste-casale-sa-lugano-ticino-b892fl",
+          "hse-specialist-casale-sa-lugano-ticino"
         ],
         "en": [
           "hse-specialist-casale-lugano",
@@ -475,7 +479,8 @@
       "previousSlugs": [
         "lavora-con-noi-casale-sa-lugano",
         "work-with-us-casale-sa-lugano-ticino-m65zo7",
-        "work-with-us-casale-lugano"
+        "work-with-us-casale-lugano",
+        "work-with-us-casale-sa-lugano-ticino"
       ],
       "salaryMin": 72000,
       "salaryMax": 97000,
@@ -493,7 +498,8 @@
       "previousSlugsByLocale": {
         "it": [
           "lavora-con-noi-casale-sa-lugano",
-          "work-with-us-casale-lugano"
+          "work-with-us-casale-lugano",
+          "work-with-us-casale-sa-lugano-ticino"
         ],
         "en": [
           "work-with-us-casale-sa-lugano-ticino-m65zo7"

--- a/data/jobs/by-crawler/citta-di-locarno.json
+++ b/data/jobs/by-crawler/citta-di-locarno.json
@@ -69,8 +69,14 @@
       "firstSeenAt": "2026-03-30T20:10:43.606Z",
       "previousSlugs": [
         "enseignant-de-cittadina-music-et-responsable-de-la-formation-des-jeunes-15-citta-di-locarn",
-        "enseignant-de-cittadina-music-et-responsable-de-la-formation-des-jeunes-15-citta-di-locarn"
-      ]
+        "enseignant-de-cittadina-music-et-responsable-de-la-formation-des-jeunes-15-citta-di-locarn",
+        "maestro-a-della-musica-cittadina-e-verantwortlicher-delle-formazioni-giovanili-15-citta-di-locarno-locarno"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "maestro-a-della-musica-cittadina-e-verantwortlicher-delle-formazioni-giovanili-15-citta-di-locarno-locarno"
+        ]
+      }
     },
     {
       "id": "citta-di-locarno-direttrice-direttore-30-locarno",

--- a/data/jobs/by-crawler/colin-cie.json
+++ b/data/jobs/by-crawler/colin-cie.json
@@ -132,7 +132,8 @@
         "consulente-m-f-d-nel-wealth-management-a-lugano-con-focus-sui-clienti-norditaliani-colin-cie-wealth-management-lugano",
         "berater-m-w-d-im-wealth-management-am-standort-lugano-mit-fokus-norditalienische-kunden-colin-cie-lugano",
         "consultant-m-f-d-in-wealth-management-in-lugano-with-a-focus-on-northern-italian-clients-colin-cie-wealth-management-lugano",
-        "berater-m-w-d-im-wealth-management-am-standort-lugano-mit-fokus-norditalienische-kunden-colin-cie-wealth-management-lugano"
+        "berater-m-w-d-im-wealth-management-am-standort-lugano-mit-fokus-norditalienische-kunden-colin-cie-wealth-management-lugano",
+        "berater-m-w-d-im-wealth-management-am-standort-lugano-con-fokus-norditalienische-kunden-colin-cie-wealth-management-lugano"
       ],
       "salaryMin": 77500,
       "salaryMax": 104500,
@@ -373,7 +374,8 @@
         "consulente-m-f-d-nel-wealth-management-a-schaffhausen-con-focus-sui-clienti-regionali-colin-cie-wealth-management-schaff",
         "berater-m-w-d-im-wealth-management-am-standort-schaffhausen-mit-fokus-regionale-kunden-colin-cie-schaffhausen",
         "consultant-m-f-d-in-wealth-management-at-the-schaffhausen-location-with-a-focus-on-regional-customers-colin-cie-wealth-management-schaffhaus",
-        "berater-m-w-d-im-wealth-management-am-standort-schaffhausen-mit-fokus-regionale-kunden-colin-cie-wealth-management-schaffhausen"
+        "berater-m-w-d-im-wealth-management-am-standort-schaffhausen-mit-fokus-regionale-kunden-colin-cie-wealth-management-schaffhausen",
+        "berater-m-w-d-im-wealth-management-am-standort-schaffhausen-con-fokus-regionale-kunden-colin-cie-wealth-management-schaffhausen"
       ],
       "salaryMin": 77500,
       "salaryMax": 104500,
@@ -463,7 +465,19 @@
       "streetAddress": "Via Nassa 15",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T09:57:04.753Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-deutsche-kunden-colin-cie-wealth-management-munsbach",
+        "berater-m-w-d-im-wealth-management-am-standort-luxemburg-mit-fokus-deutsche-kunden-colin-cie-wealth-management-munsbach"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-deutsche-kunden-colin-cie-wealth-management-munsbach"
+        ],
+        "en": [
+          "berater-m-w-d-im-wealth-management-am-standort-luxemburg-mit-fokus-deutsche-kunden-colin-cie-wealth-management-munsbach"
+        ]
+      }
     },
     {
       "title": "Berater (m/w/d) im Wealth Management am Standort Luxemburg mit Fokus  Benelux-Kunden",
@@ -522,7 +536,19 @@
       },
       "streetAddress": "Via Nassa 15",
       "postalCode": "6900",
-      "firstSeenAt": "2026-05-17T09:57:04.753Z"
+      "firstSeenAt": "2026-05-17T09:57:04.753Z",
+      "previousSlugs": [
+        "berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-benelux-kunden-colin-cie-wealth-management-munsbach",
+        "berater-m-w-d-im-wealth-management-am-standort-luxemburg-mit-fokus-benelux-kunden-colin-cie-wealth-management-munsbach"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-benelux-kunden-colin-cie-wealth-management-munsbach"
+        ],
+        "en": [
+          "berater-m-w-d-im-wealth-management-am-standort-luxemburg-mit-fokus-benelux-kunden-colin-cie-wealth-management-munsbach"
+        ]
+      }
     },
     {
       "title": "Berater (m/w/d) im Wealth Management am Standort Luxemburg mit Fokus  regionale Kunden",
@@ -581,7 +607,19 @@
       },
       "streetAddress": "Via Nassa 15",
       "postalCode": "6900",
-      "firstSeenAt": "2026-05-17T09:57:04.753Z"
+      "firstSeenAt": "2026-05-17T09:57:04.753Z",
+      "previousSlugs": [
+        "berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-regionale-kunden-colin-cie-wealth-management-munsbach",
+        "berater-m-w-d-im-wealth-management-am-standort-luxemburg-mit-fokus-regionale-kunden-colin-cie-wealth-management-munsbach"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "berater-m-w-d-im-wealth-management-am-standort-luxemburg-con-fokus-regionale-kunden-colin-cie-wealth-management-munsbach"
+        ],
+        "en": [
+          "berater-m-w-d-im-wealth-management-am-standort-luxemburg-mit-fokus-regionale-kunden-colin-cie-wealth-management-munsbach"
+        ]
+      }
     },
     {
       "title": "Berater (m/w/d) im Wealth Management am Standort Zürich mit Fokus niederländische Kunden",

--- a/data/jobs/by-crawler/confederazione-ticino.json
+++ b/data/jobs/by-crawler/confederazione-ticino.json
@@ -413,13 +413,15 @@
       "previousSlugsByLocale": {
         "it": [
           "raus-aus-der-routine-werde-berufsoffizier-in-confederazione-schweiz-und-ausland-abhangig-von-funktion-und-einsatzort",
-          "raus-aus-der-routine-werde-berufsoffizier-in-confederazione-svizzera-schweiz-und-ausland-abhangig-von-funktion-und-einsatzort"
+          "raus-aus-der-routine-werde-berufsoffizier-in-confederazione-svizzera-schweiz-und-ausland-abhangig-von-funktion-und-einsatzort",
+          "raus-aus-der-routine-werde-berufsoffizier-in-confederazione-svizzera-schweiz-und-ausland-abhangig-von-funktion-und-einsa"
         ]
       },
       "previousSlugs": [
         "raus-aus-der-routine-werde-berufsoffizier-in-confederazione-schweiz-und-ausland-abhangig-von-funktion-und-einsatzort",
         "raus-aus-der-routine-werde-berufsoffizier-in-confederazione-svizzera-schweiz-und-ausland-abhangig-von-funktion-und-einsatzort",
-        "esci-dalla-routine-diventa-un-ufficiale-professionista-confederazione-svizzera-schweiz-und-ausland-abhangig-von-funktion-und-einsatzort"
+        "esci-dalla-routine-diventa-un-ufficiale-professionista-confederazione-svizzera-schweiz-und-ausland-abhangig-von-funktion-und-einsatzort",
+        "raus-aus-der-routine-werde-berufsoffizier-in-confederazione-svizzera-schweiz-und-ausland-abhangig-von-funktion-und-einsa"
       ],
       "salaryMin": 51500,
       "salaryMax": 88000,
@@ -570,11 +572,15 @@
       "firstSeenAt": "2026-05-17T09:57:57.728Z",
       "previousSlugs": [
         "asyl-dolmetscher-in-confederazione-alle-standorte-des-sem",
-        "asylum-interprete-in-confederazione-svizzera-alle-standorte-des-sem"
+        "asylum-interprete-in-confederazione-svizzera-alle-standorte-des-sem",
+        "asyl-dolmetscher-in-confederazione-svizzera-alle-standorte-des-sem"
       ],
       "previousSlugsByLocale": {
         "it": [
           "asyl-dolmetscher-in-confederazione-alle-standorte-des-sem"
+        ],
+        "de": [
+          "asyl-dolmetscher-in-confederazione-svizzera-alle-standorte-des-sem"
         ]
       },
       "needsRetranslation": true

--- a/data/jobs/by-crawler/convit-holding.json
+++ b/data/jobs/by-crawler/convit-holding.json
@@ -60,7 +60,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "tirocinante-pianificazione-finanziaria-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-massagno"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "tirocinante-pianificazione-finanziaria-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-massagno"
+        ]
+      }
     },
     {
       "id": "convit-b4a4c8b586ae",
@@ -239,7 +247,19 @@
       },
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
-      "firstSeenAt": "2026-05-17T10:01:25.841Z"
+      "firstSeenAt": "2026-05-17T10:01:25.841Z",
+      "previousSlugs": [
+        "sales-consultant-previdenza-finanza-entrata-laterale-ibrido-convit-holding-gmbh-arbedo-castione",
+        "sales-consultant-previdenza-finanza-entrata-laterale-ibrido-convit-holding-gmbh-arbedo-cas"
+      ],
+      "previousSlugsByLocale": {
+        "en": [
+          "sales-consultant-previdenza-finanza-entrata-laterale-ibrido-convit-holding-gmbh-arbedo-castione"
+        ],
+        "it": [
+          "sales-consultant-previdenza-finanza-entrata-laterale-ibrido-convit-holding-gmbh-arbedo-cas"
+        ]
+      }
     },
     {
       "id": "convit-360d3278bd1b",
@@ -419,7 +439,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "pianificazione-finanziaria-junior-mentoring-convit-holding-gmbh-gordola"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "pianificazione-finanziaria-junior-mentoring-convit-holding-gmbh-gordola"
+        ]
+      }
     },
     {
       "id": "convit-73953b1cec9c",
@@ -479,7 +507,17 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "pianificatore-finanziario-regionale-junior-ibrido-convit-holding-gmbh-magadino",
+        "pianificatore-finanziario-regionale-junior-ibrido-convit-holding-gmbh-magadino-29vs6a"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "pianificatore-finanziario-regionale-junior-ibrido-convit-holding-gmbh-magadino",
+          "pianificatore-finanziario-regionale-junior-ibrido-convit-holding-gmbh-magadino-29vs6a"
+        ]
+      }
     },
     {
       "id": "convit-4935af8fcde3",
@@ -599,7 +637,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "pianificatore-finanziario-entrata-laterale-fisso-bonus-convit-holding-gmbh-cugnasco-gerra"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "pianificatore-finanziario-entrata-laterale-fisso-bonus-convit-holding-gmbh-cugnasco-gerra"
+        ]
+      }
     },
     {
       "id": "convit-49ead986df83",
@@ -719,7 +765,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "ingresso-consulenza-finanziaria-3a-3b-orari-flessibili-convit-holding-gmbh-giubiasco-monte"
+        ]
+      }
     },
     {
       "id": "convit-27b91666f795",
@@ -778,7 +832,15 @@
       },
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
-      "firstSeenAt": "2026-05-17T10:01:25.841Z"
+      "firstSeenAt": "2026-05-17T10:01:25.841Z",
+      "previousSlugs": [
+        "impiegato-a-di-finanza-entrata-laterale-previdenza-finanza-convit-holding-gmbh-novazzano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "impiegato-a-di-finanza-entrata-laterale-previdenza-finanza-convit-holding-gmbh-novazzano"
+        ]
+      }
     },
     {
       "id": "convit-42c11c5604d9",
@@ -1039,15 +1101,23 @@
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
       "previousSlugsByLocale": {
         "it": [
-          "consultant-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-via-al-mulino-22a-6814-cadempino"
+          "consultant-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-via-al-mulino-22a-6814-cadempino",
+          "consultant-previdenza-risparmio-entrata-laterale-ote-fino-a-7500-chf-convit-holding-gmbh-l",
+          "berater-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-holding-gmbh-via-al-mulino-22a-6814-cadempin"
         ],
         "de": [
           "consultant-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-via-al-mulino-22a-6814-cadempino"
+        ],
+        "en": [
+          "consultant-previdenza-risparmio-entrata-laterale-ote-fino-a-7500-chf-convit-holding-gmbh-lumino"
         ]
       },
       "previousSlugs": [
         "consultant-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-via-al-mulino-22a-6814-cadempino",
-        "consulente-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-holding-gmbh-via-al-mulino-22a-6814-cadem"
+        "consulente-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-holding-gmbh-via-al-mulino-22a-6814-cadem",
+        "consultant-previdenza-risparmio-entrata-laterale-ote-fino-a-7500-chf-convit-holding-gmbh-lumino",
+        "consultant-previdenza-risparmio-entrata-laterale-ote-fino-a-7500-chf-convit-holding-gmbh-l",
+        "berater-previdenza-e-risparmio-entrata-laterale-ote-fino-a-7-500-chf-convit-holding-gmbh-via-al-mulino-22a-6814-cadempin"
       ]
     },
     {
@@ -1297,7 +1367,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulenza-previdenziale-3a-3b-homeoffice-convit-holding-gmbh-pazzallo"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulenza-previdenziale-3a-3b-homeoffice-convit-holding-gmbh-pazzallo"
+        ]
+      }
     },
     {
       "id": "convit-cfded655d12b",
@@ -1357,7 +1435,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulenza-investimenti-previdenza-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-bellinzona"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulenza-investimenti-previdenza-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-bellinzona"
+        ]
+      }
     },
     {
       "id": "convit-e9d466895266",
@@ -1537,7 +1623,17 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulenza-finanziaria-online-entrata-laterale-ibrido-homeoffice-convit-holding-gmbh-arbedo-castione",
+        "consulenza-finanziaria-online-entrata-laterale-ibrido-homeoffice-convit-holding-gmbh-arbed"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulenza-finanziaria-online-entrata-laterale-ibrido-homeoffice-convit-holding-gmbh-arbedo-castione",
+          "consulenza-finanziaria-online-entrata-laterale-ibrido-homeoffice-convit-holding-gmbh-arbed"
+        ]
+      }
     },
     {
       "id": "convit-e470d47ccc0c",
@@ -2017,7 +2113,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-previdenziale-pianificazione-ibrido-convit-holding-gmbh-montagnola"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-previdenziale-pianificazione-ibrido-convit-holding-gmbh-montagnola"
+        ]
+      }
     },
     {
       "id": "convit-0ba4fc14f88e",
@@ -2077,7 +2181,17 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-previdenziale-per-la-vecchiaia-3a-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-biasca",
+        "consulente-previdenziale-per-la-vecchiaia-3a-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-biasca-hohte2"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-previdenziale-per-la-vecchiaia-3a-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-biasca",
+          "consulente-previdenziale-per-la-vecchiaia-3a-entrata-laterale-tempo-indeterminato-convit-holding-gmbh-biasca-hohte2"
+        ]
+      }
     },
     {
       "id": "convit-a39ca3976752",
@@ -2197,7 +2311,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-previdenziale-junior-percorso-di-carriera-bonus-convit-holding-gmbh-preonzo"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-previdenziale-junior-percorso-di-carriera-bonus-convit-holding-gmbh-preonzo"
+        ]
+      }
     },
     {
       "id": "convit-b6496a6408b9",
@@ -2317,7 +2439,17 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-previdenziale-junior-entrata-laterale-mentoring-coaching-convit-holding-gmbh-camorino",
+        "consulente-previdenziale-junior-entrata-laterale-mentoring-coaching-convit-holding-gmbh-ca"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-previdenziale-junior-entrata-laterale-mentoring-coaching-convit-holding-gmbh-camorino",
+          "consulente-previdenziale-junior-entrata-laterale-mentoring-coaching-convit-holding-gmbh-ca"
+        ]
+      }
     },
     {
       "id": "convit-ae8e2d729db0",
@@ -2497,7 +2629,19 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-holding-gmbh-biasca",
+        "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7500-chf-convit-holding-gmbh-losone",
+        "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-holding-gmbh-biasca-hohte1"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-holding-gmbh-biasca",
+          "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7500-chf-convit-holding-gmbh-losone",
+          "consulente-previdenziale-m-f-d-ingresso-senza-formazione-ote-fino-a-7-500-chf-convit-holding-gmbh-biasca-hohte1"
+        ]
+      }
     },
     {
       "id": "convit-7fd409506c68",
@@ -2557,7 +2701,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-previdenziale-ibrido-ingresso-senza-esperienza-convit-holding-gmbh-paradiso"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-previdenziale-ibrido-ingresso-senza-esperienza-convit-holding-gmbh-paradiso"
+        ]
+      }
     },
     {
       "id": "convit-f2b12fa24a77",
@@ -3217,7 +3369,19 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-privati-pianificazione-finanziaria-junior-orari-flessibili-convit-holding-gmbh-comano",
+        "consulente-privati-pianificazione-finanziaria-junior-orari-flessibili-convit-holding-gmbh-",
+        "consulente-privati-pianificazione-finanziaria-junior-orari-flessibili-convit-holding-gmbh-comano-29vs9q"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-privati-pianificazione-finanziaria-junior-orari-flessibili-convit-holding-gmbh-comano",
+          "consulente-privati-pianificazione-finanziaria-junior-orari-flessibili-convit-holding-gmbh-",
+          "consulente-privati-pianificazione-finanziaria-junior-orari-flessibili-convit-holding-gmbh-comano-29vs9q"
+        ]
+      }
     },
     {
       "id": "convit-3787e158a8d5",
@@ -3277,7 +3441,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-privati-piani-di-risparmio-junior-homeoffice-convit-holding-gmbh-origlio"
+      ],
+      "previousSlugsByLocale": {
+        "fr": [
+          "consulente-privati-piani-di-risparmio-junior-homeoffice-convit-holding-gmbh-origlio"
+        ]
+      }
     },
     {
       "id": "convit-1c1006f76a77",
@@ -3577,7 +3749,15 @@
       "streetAddress": "Via Balestra 12",
       "postalCode": "6900",
       "firstSeenAt": "2026-05-17T10:01:25.841Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "consulente-privati-finanza-entrata-laterale-convit-holding-gmbh-cresciano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "consulente-privati-finanza-entrata-laterale-convit-holding-gmbh-cresciano"
+        ]
+      }
     },
     {
       "id": "convit-b35bd71ca9f9",

--- a/data/jobs/by-crawler/coop-ticino.json
+++ b/data/jobs/by-crawler/coop-ticino.json
@@ -254,10 +254,22 @@
         ],
         "fr": [
           "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-lesziv"
+        ],
+        "it": [
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-mezzovico",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-bellinzona-0jqltq",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-bellinzona",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-bellinzona-e3zmz6"
         ]
       },
       "previousSlugs": [
-        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-lesziv"
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-lesziv",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-mezzovico",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-bellinzona-0jqltq",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-bellinzona",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-swiss-household-services-ag-bellinzona-e3zmz6"
       ]
     },
     {
@@ -718,6 +730,9 @@
         ],
         "fr": [
           "verkaufer-in-food-coop-city-chur-graubunden-e66ikm"
+        ],
+        "it": [
+          "verkaufer-in-food-coop-genossenschaft-chur"
         ]
       },
       "previousSlugs": [
@@ -730,7 +745,8 @@
         "verkaufer-in-food-coop-felsberg-graubunden",
         "verkaufer-in-food-coop-felsberg-graubunden-metayj",
         "seller-in-food-coop-genossenschaft-felsberg-6dde92",
-        "vendeur-dans-la-nourriture-coop-genossenschaft-felsberg-6dde92"
+        "vendeur-dans-la-nourriture-coop-genossenschaft-felsberg-6dde92",
+        "verkaufer-in-food-coop-genossenschaft-chur"
       ],
       "needsRetranslation": true
     },
@@ -862,6 +878,19 @@
           "maxValue": 90500,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-2",
+        "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-3",
+        "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-jegensdorf-4",
+        "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-di-acquisto-interdiscount-jegensdorf",
+        "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-di-acquisto-interdiscount-jegensdorf",
+          "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-interdiscount-ticino"
+        ]
       }
     },
     {
@@ -1007,9 +1036,15 @@
         }
       },
       "previousSlugs": [
-        "cambio-carriera-koch-kochin-in-der-systemgastronomie-f-m-d-coop-genossenschaft-graubunden"
+        "cambio-carriera-koch-kochin-in-der-systemgastronomie-f-m-d-coop-genossenschaft-graubunden",
+        "quereinstieg-koch-kochin-in-der-systemgastronomie-f-m-d-coop-genossenschaft-graubunden"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "quereinstieg-koch-kochin-in-der-systemgastronomie-f-m-d-coop-genossenschaft-graubunden"
+        ]
+      }
     },
     {
       "id": "company-rf7c8w",
@@ -1065,7 +1100,18 @@
           "unitText": "YEAR"
         }
       },
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-coop-city-lenzburg-1",
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-coop-city-lenzburg-1-2",
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-coop-city-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-coop-city-lenzburg-1",
+          "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-coop-city-ticino"
+        ]
+      }
     },
     {
       "id": "company-z0zxuf",
@@ -1136,10 +1182,19 @@
       "previousSlugsByLocale": {
         "fr": [
           "utilisation-standard-de-la-gastronomie-complement-gastronomique-standard-marche-dietlikon"
+        ],
+        "it": [
+          "impiegata-o-di-gastronomia-standardizzata-addettao-digastronomia-standardizzata-marche-dietlikon",
+          "impiegata-o-di-gastronomia-standardizzata-addettao-digastronomia-standardizzata-marche-ticino",
+          "impiegata-o-di-gastronomia-standardizzata-addettao-digastronomia-standardizzata-marche-mezzovico"
         ]
       },
       "previousSlugs": [
-        "utilisation-standard-de-la-gastronomie-complement-gastronomique-standard-marche-dietlikon"
+        "utilisation-standard-de-la-gastronomie-complement-gastronomique-standard-marche-dietlikon",
+        "impiegata-o-di-gastronomia-standardizzata-addettao-digastronomia-standardizzata-marche-dietlikon",
+        "impiegata-o-di-gastronomia-standardizzata-addettao-digastronomia-standardizzata-marche-dietlikon-2",
+        "impiegata-o-di-gastronomia-standardizzata-addettao-digastronomia-standardizzata-marche-ticino",
+        "impiegata-o-di-gastronomia-standardizzata-addettao-digastronomia-standardizzata-marche-mezzovico"
       ],
       "needsRetranslation": true
     },
@@ -1206,7 +1261,13 @@
         ]
       },
       "previousSlugs": [
-        "angestellter-a-interdiscount-jegensdorf-j301yl"
+        "angestellter-a-interdiscount-jegensdorf-j301yl",
+        "impiegato-a-interdiscount-jegensdorf-2",
+        "impiegato-a-interdiscount-jegensdorf-3",
+        "impiegato-a-interdiscount-jegensdorf-4",
+        "impiegato-a-interdiscount-jegensdorf-5",
+        "impiegato-a-interdiscount-jegensdorf-6",
+        "impiegato-a-interdiscount-jegensdorf-7"
       ]
     },
     {
@@ -1331,6 +1392,17 @@
           "maxValue": 75000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "addetta-o-di-gastronomia-standardizzata-cfp-marche-dietlikon",
+        "addetta-o-di-gastronomia-standardizzata-cfp-marche-dietlikon-2",
+        "addetta-o-di-gastronomia-standardizzata-cfp-marche-ticino"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "addetta-o-di-gastronomia-standardizzata-cfp-marche-dietlikon",
+          "addetta-o-di-gastronomia-standardizzata-cfp-marche-ticino"
+        ]
       }
     },
     {
@@ -1399,12 +1471,17 @@
         ],
         "fr": [
           "impiegata-employe-di-gastronomia-standardizzata-afc-marche-dietlikon-diq1rr"
+        ],
+        "it": [
+          "impiegata-impiegato-di-gastronomia-standardizzata-afc-marche-dietlikon"
         ]
       },
       "previousSlugs": [
         "impiegata-employee-di-gastronomia-standardizzata-afc-marche-dietlikon-diq1rr",
         "impiegata-angestellter-di-gastronomia-standardizzata-afc-marche-dietlikon-diq1rr",
-        "impiegata-employe-di-gastronomia-standardizzata-afc-marche-dietlikon-diq1rr"
+        "impiegata-employe-di-gastronomia-standardizzata-afc-marche-dietlikon-diq1rr",
+        "impiegata-impiegato-di-gastronomia-standardizzata-afc-marche-dietlikon",
+        "impiegata-impiegato-di-gastronomia-standardizzata-afc-marche-dietlikon-2"
       ]
     },
     {
@@ -1723,7 +1800,10 @@
           "unitText": "YEAR"
         }
       },
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-coop-grigioni-21"
+      ]
     },
     {
       "id": "company-ruhpr3",
@@ -2231,8 +2311,17 @@
         }
       },
       "previousSlugs": [
-        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-jumbo-lenzburg-1-n4f99v"
-      ]
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-jumbo-lenzburg-1-n4f99v",
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-jumbo-lenzburg-1",
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-jumbo-lenzburg-1-2",
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-jumbo-lenzburg-1-3",
+        "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-jumbo-lenzburg-1-4"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "impiegata-impiegato-del-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-jumbo-lenzburg-1"
+        ]
+      }
     },
     {
       "id": "company-n4f99v",
@@ -2586,7 +2675,8 @@
       },
       "previousSlugs": [
         "detailhandelsfachfrau-mann-assistent-in-coop-gossau",
-        "systemgastronomiefachfrau-mann-cfc-coop-ristorante-grigioni"
+        "systemgastronomiefachfrau-mann-cfc-coop-ristorante-grigioni",
+        "detailhandelsfachfrau-mann-assistent-in-coop-grigioni-18"
       ],
       "needsRetranslation": true
     },
@@ -2644,9 +2734,19 @@
       },
       "previousSlugs": [
         "systemgastronomiefachfrau-mann-cfc-coop-ristorante-gossau",
-        "detailhandelsassistent-in-eba-coop-grigioni-6"
+        "detailhandelsassistent-in-eba-coop-grigioni-6",
+        "systemgastronomiefachfrau-mann-efz-coop-ristorante-grigioni",
+        "systemgastronomiefachfrau-mann-efz-coop-ristorante-gossau"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "en": [
+          "systemgastronomiefachfrau-mann-efz-coop-ristorante-grigioni"
+        ],
+        "it": [
+          "systemgastronomiefachfrau-mann-efz-coop-ristorante-gossau"
+        ]
+      }
     },
     {
       "id": "company-tychyk",
@@ -2870,9 +2970,17 @@
         }
       },
       "previousSlugs": [
-        "detailhandelsassistent-in-eba-coop-grigioni-7"
+        "detailhandelsassistent-in-eba-coop-grigioni-7",
+        "backer-in-konditor-in-confiseur-in-coop-grigioni",
+        "backer-in-konditor-in-confiseur-in-coop-gossau"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "backer-in-konditor-in-confiseur-in-coop-grigioni",
+          "backer-in-konditor-in-confiseur-in-coop-gossau"
+        ]
+      }
     },
     {
       "id": "company-czukhm",
@@ -4264,7 +4372,8 @@
           "detailhandelsassistent-in-afp-coop-grigioni-uglo11"
         ],
         "de": [
-          "detailhandelsassistent-in-eba-coop-grigioni-uglo11"
+          "detailhandelsassistent-in-eba-coop-grigioni-uglo11",
+          "detailhandelsfachfrau-mann-interdiscount-jegensdorf"
         ]
       },
       "previousSlugs": [
@@ -4281,7 +4390,8 @@
         "detailhandelsfachfrau-mann-interdiscount-grigioni-d5xyy2",
         "retailer-man-coop-gossau-2cf7c7",
         "detaillant-homme-coop-gossau-2cf7c7",
-        "detailhandelsassistent-in-afp-coop-grigioni-uglo11"
+        "detailhandelsassistent-in-afp-coop-grigioni-uglo11",
+        "detailhandelsfachfrau-mann-interdiscount-jegensdorf"
       ]
     },
     {
@@ -5183,7 +5293,8 @@
         "retail-sales-specialist-efz-shaping-shopping-experiences-interdiscount-grigioni",
         "specialiste-de-vente-au-detail-efz-creer-des-experiences-d-achat-interdiscount-grigioni",
         "detailhandelsfachfrau-mann-cfc-gestalten-von-einkaufserlebnissen-interdiscount-jegensdorf",
-        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-interdiscount-grigioni"
+        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-interdiscount-grigioni",
+        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-interdiscount-grigioni-3"
       ],
       "needsRetranslation": true,
       "retranslationAttempts": 1
@@ -5823,7 +5934,8 @@
       },
       "previousSlugs": [
         "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-jumbo-grigioni-6kplqg",
-        "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-di-acquisto-jumbo-grigioni"
+        "specialista-del-commercio-al-dettaglio-afc-creazione-di-esperienze-di-acquisto-jumbo-grigioni",
+        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-jumbo-grigioni-2"
       ],
       "needsRetranslation": true,
       "retranslationAttempts": 1
@@ -8562,7 +8674,9 @@
       },
       "previousSlugsByLocale": {
         "it": [
-          "metzger-in-fleischfachfrau-fleischfachmann-coop-klosters-serneus-graubunden-uwtky9"
+          "metzger-in-fleischfachfrau-fleischfachmann-coop-klosters-serneus-graubunden-uwtky9",
+          "metzger-in-fleischfachfrau-fleischfachmann-coop-genossenschaft-scuol",
+          "metzger-in-fleischfachfrau-fleischfachmann-coop-genossenschaft-poschiavo"
         ],
         "en": [
           "metzger-in-fleischfachfrau-fleischfachmann-coop-klosters-serneus-graubunden-uwtky9"
@@ -8575,7 +8689,9 @@
         ]
       },
       "previousSlugs": [
-        "metzger-in-fleischfachfrau-fleischfachmann-coop-klosters-serneus-graubunden-uwtky9"
+        "metzger-in-fleischfachfrau-fleischfachmann-coop-klosters-serneus-graubunden-uwtky9",
+        "metzger-in-fleischfachfrau-fleischfachmann-coop-genossenschaft-scuol",
+        "metzger-in-fleischfachfrau-fleischfachmann-coop-genossenschaft-poschiavo"
       ]
     },
     {
@@ -9339,7 +9455,8 @@
       },
       "previousSlugsByLocale": {
         "it": [
-          "verkaufsberater-in-inkl-stellvertretung-der-geschaftsfuhrer-in-christ-orologi-gioielli-chur-graubunden-a9zoqf"
+          "verkaufsberater-in-inkl-stellvertretung-der-geschaftsfuhrer-in-christ-orologi-gioielli-chur-graubunden-a9zoqf",
+          "verkaufsberater-in-inkl-stellvertretung-der-geschaftsfuhrer-in-christ-uhren-schmuck-ag-chur-n3eyyx"
         ],
         "en": [
           "verkaufsberater-in-inkl-stellvertretung-der-geschaftsfuhrer-in-christ-orologi-gioielli-chur-graubunden-a9zoqf"
@@ -9352,7 +9469,8 @@
         ]
       },
       "previousSlugs": [
-        "verkaufsberater-in-inkl-stellvertretung-der-geschaftsfuhrer-in-christ-orologi-gioielli-chur-graubunden-a9zoqf"
+        "verkaufsberater-in-inkl-stellvertretung-der-geschaftsfuhrer-in-christ-orologi-gioielli-chur-graubunden-a9zoqf",
+        "verkaufsberater-in-inkl-stellvertretung-der-geschaftsfuhrer-in-christ-uhren-schmuck-ag-chur-n3eyyx"
       ],
       "needsRetranslation": true
     },
@@ -9503,7 +9621,8 @@
       },
       "previousSlugsByLocale": {
         "it": [
-          "metzger-in-fleischfachfrau-fleischfachmann-coop-chur-graubunden-zb8ot5"
+          "metzger-in-fleischfachfrau-fleischfachmann-coop-chur-graubunden-zb8ot5",
+          "metzger-in-fleischfachfrau-fleischfachmann-coop-genossenschaft-chur-v2cid8"
         ],
         "en": [
           "metzger-in-fleischfachfrau-fleischfachmann-coop-chur-graubunden-zb8ot5"
@@ -9516,7 +9635,8 @@
         ]
       },
       "previousSlugs": [
-        "metzger-in-fleischfachfrau-fleischfachmann-coop-chur-graubunden-zb8ot5"
+        "metzger-in-fleischfachfrau-fleischfachmann-coop-chur-graubunden-zb8ot5",
+        "metzger-in-fleischfachfrau-fleischfachmann-coop-genossenschaft-chur-v2cid8"
       ],
       "needsRetranslation": true
     },
@@ -10042,12 +10162,14 @@
         "specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni",
         "systemgastronomiefachfrau-mann-praktiker-in-marche-dietlikon",
         "system-gastronomy-specialist-practitioner-marche-grigioni",
-        "systemgastronomiefachfrau-mann-praktiker-in-marche-grigioni-2p2jlr"
+        "systemgastronomiefachfrau-mann-praktiker-in-marche-grigioni-2p2jlr",
+        "systemgastronomiefachfrau-mann-praktiker-in-marche-grigioni"
       ],
       "previousSlugsByLocale": {
         "it": [
           "specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni",
-          "systemgastronomiefachfrau-mann-praktiker-in-marche-dietlikon"
+          "systemgastronomiefachfrau-mann-praktiker-in-marche-dietlikon",
+          "systemgastronomiefachfrau-mann-praktiker-in-marche-grigioni"
         ],
         "en": [
           "specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni",
@@ -10208,7 +10330,8 @@
         "systemgastronomiefachfrau-mann-efz-marche-grigioni-7qutu2",
         "specialista-di-gastronomia-e-cucina-praticante-marche-grigioni",
         "systemgastronomia-donna-uomo-efz-marche-dietlikon",
-        "specialiste-en-gastronomie-systematique-efz-marche-grigioni"
+        "specialiste-en-gastronomie-systematique-efz-marche-grigioni",
+        "systemgastronomiefachfrau-mann-efz-marche-grigioni"
       ],
       "previousSlugsByLocale": {
         "en": [
@@ -10216,7 +10339,8 @@
           "systemgastronomiefachfrau-mann-praktiker-in-marche-grigioni-2p2jlr",
           "specialiste-en-gastronomie-et-cuisine-stagiaire-marche-grigioni",
           "systemgastronomiefachfrau-mann-efz-marche-dietlikon",
-          "systemgastronomiefachfrau-mann-efz-marche-grigioni-7qutu2"
+          "systemgastronomiefachfrau-mann-efz-marche-grigioni-7qutu2",
+          "systemgastronomiefachfrau-mann-efz-marche-grigioni"
         ],
         "it": [
           "specialista-di-gastronomia-e-cucina-praticante-marche-grigioni",
@@ -10456,11 +10580,13 @@
         "specialiste-du-retail-efz-pour-coop-city-coop-city-grigioni",
         "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-coop-city-grigioni-hm4hme",
         "detailhandelsfachfrau-mann-cfc-gestalten-von-einkaufserlebnissen-coop-city-dietlikon",
-        "detaillant-mann-efz-creer-des-experiences-d-achat-coop-city-dietlikon"
+        "detaillant-mann-efz-creer-des-experiences-d-achat-coop-city-dietlikon",
+        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-coop-city-grigioni"
       ],
       "previousSlugsByLocale": {
         "en": [
-          "retail-specialist-efz-for-coop-city-coop-city-grigioni"
+          "retail-specialist-efz-for-coop-city-coop-city-grigioni",
+          "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-coop-city-grigioni"
         ],
         "fr": [
           "specialiste-du-retail-efz-pour-coop-city-coop-city-grigioni"
@@ -10785,7 +10911,8 @@
       "previousSlugs": [
         "food-service-specialist-trainee-coop-ristorante-grigioni",
         "specialiste-en-gastronomie-stagiaire-coop-ristorante-grigioni",
-        "systemgastronomiefachfrau-mann-praktiker-in-coop-ristorante-grigioni-ebfo12"
+        "systemgastronomiefachfrau-mann-praktiker-in-coop-ristorante-grigioni-ebfo12",
+        "systemgastronomiefachfrau-mann-praktiker-in-coop-ristorante-grigioni"
       ],
       "previousSlugsByLocale": {
         "en": [
@@ -10793,7 +10920,8 @@
           "specialiste-en-gastronomie-stagiaire-coop-ristorante-grigioni"
         ],
         "it": [
-          "specialiste-en-gastronomie-stagiaire-coop-ristorante-grigioni"
+          "specialiste-en-gastronomie-stagiaire-coop-ristorante-grigioni",
+          "systemgastronomiefachfrau-mann-praktiker-in-coop-ristorante-grigioni"
         ],
         "de": [
           "specialiste-en-gastronomie-stagiaire-coop-ristorante-grigioni",
@@ -10942,11 +11070,13 @@
       "previousSlugs": [
         "retail-specialist-efz-for-shaping-shopping-experiences-livique-grigioni",
         "specialiste-de-la-vente-efz-pour-la-creation-d-experiences-d-achat-livique-grigioni",
-        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-livique-grigioni-86rxeu"
+        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-livique-grigioni-86rxeu",
+        "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-livique-grigioni"
       ],
       "previousSlugsByLocale": {
         "en": [
-          "retail-specialist-efz-for-shaping-shopping-experiences-livique-grigioni"
+          "retail-specialist-efz-for-shaping-shopping-experiences-livique-grigioni",
+          "detailhandelsfachfrau-mann-efz-gestalten-von-einkaufserlebnissen-livique-grigioni"
         ],
         "fr": [
           "specialiste-de-la-vente-efz-pour-la-creation-d-experiences-d-achat-livique-grigioni"

--- a/data/jobs/by-crawler/corner-banca.json
+++ b/data/jobs/by-crawler/corner-banca.json
@@ -240,12 +240,14 @@
       "previousSlugs": [
         "customer-advisor-40-corner-banca-wallisellen",
         "consulente-clienti-40-corner-banca-wallisellen",
-        "customer-advisor-evening-and-weekend-40-corner-banca-wallisellen"
+        "customer-advisor-evening-and-weekend-40-corner-banca-wallisellen",
+        "customer-advisor-60-corner-banca-wallisellen"
       ],
       "previousSlugsByLocale": {
         "it": [
           "customer-advisor-40-corner-banca-wallisellen",
-          "consulente-clienti-40-corner-banca-wallisellen"
+          "consulente-clienti-40-corner-banca-wallisellen",
+          "customer-advisor-60-corner-banca-wallisellen"
         ],
         "de": [
           "customer-advisor-evening-and-weekend-40-corner-banca-wallisellen"
@@ -678,11 +680,13 @@
       "sourceLang": "en",
       "crawledAt": "2026-05-19T11:30:12.706Z",
       "previousSlugs": [
-        "employee-front-office-collection-corner-banca-wallisellen"
+        "employee-front-office-collection-corner-banca-wallisellen",
+        "employee-front-office-corner-banca-wallisellen"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "employee-front-office-collection-corner-banca-wallisellen"
+          "employee-front-office-collection-corner-banca-wallisellen",
+          "employee-front-office-corner-banca-wallisellen"
         ],
         "de": [
           "employee-front-office-collection-corner-banca-wallisellen"
@@ -1086,11 +1090,13 @@
       "crawledAt": "2026-05-19T11:30:12.702Z",
       "previousSlugs": [
         "customer-advisor-100-team-zurich-corner-banca-wallisellen",
-        "customer-consulente-60-team-zurich-corner-banca-wallisellen"
+        "customer-consulente-60-team-zurich-corner-banca-wallisellen",
+        "customer-advisor-60-team-zurich-corner-banca-wallisellen"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "customer-advisor-100-team-zurich-corner-banca-wallisellen"
+          "customer-advisor-100-team-zurich-corner-banca-wallisellen",
+          "customer-advisor-60-team-zurich-corner-banca-wallisellen"
         ],
         "fr": [
           "customer-advisor-100-team-zurich-corner-banca-wallisellen"

--- a/data/jobs/by-crawler/cseb.json
+++ b/data/jobs/by-crawler/cseb.json
@@ -65,7 +65,8 @@
         "it": [
           "spontanbewerbung-pflegeberufe-langzeitpflege-cseb-ch",
           "assistent-in-gesundheit-e-soziales-pflegehelfer-in-sozialbetreuer-in-cpo-50-100-center-da-sanadad-engiadina-bassa-scuol",
-          "biomedizinische-analytiker-in-hf-med-techn-laborassistent-in-mtla-80-100-center-da-sanadad-engiadina-bassa-scuol"
+          "biomedizinische-analytiker-in-hf-med-techn-laborassistent-in-mtla-80-100-center-da-sanadad-engiadina-bassa-scuol",
+          "assistent-in-gesundheit-und-soziales-pflegehelfer-in-sozialbetreuer-in-cpo-50-100-center-da-sanadad-engiadina-bassa-scuo"
         ]
       },
       "previousSlugs": [
@@ -86,7 +87,8 @@
         "assistente-sanitario-pj-anno-center-da-sanadad-engiadina-bassa-scuol",
         "assistente-sanitaria-e-sociale-assistente-infermieristico-srk-o-assistente-sociale-50-90-center-da-sanadad-engiadina-bas",
         "dipl-soccorritore-sanitario-srk-hf-40-100-center-da-sanadad-engiadina-bassa-scuol",
-        "apprendistato-come-impiegata-impiegato-di-commercio-cfp-center-da-sanadad-engiadina-bassa-scuol"
+        "apprendistato-come-impiegata-impiegato-di-commercio-cfp-center-da-sanadad-engiadina-bassa-scuol",
+        "assistent-in-gesundheit-und-soziales-pflegehelfer-in-sozialbetreuer-in-cpo-50-100-center-da-sanadad-engiadina-bassa-scuo"
       ],
       "firstSeenAt": "2026-04-13T10:23:37.991Z",
       "salaryMin": 49500,

--- a/data/jobs/by-crawler/denner.json
+++ b/data/jobs/by-crawler/denner.json
@@ -164,21 +164,31 @@
       "sourceLang": "de",
       "crawledAt": "2026-05-19T11:34:24.331Z",
       "previousSlugs": [
+        "assistant-e-de-direction-de-succursale-denner-ebikon",
+        "assistant-store-manager-denner-ebikon",
         "assistent-in-filialleitung-denner",
+        "assistent-in-filialleitung-denner-ebikon",
+        "assistent-in-filialleitung-denner-flims-dorf",
         "assistent-in-filialleitung-denner-flims-dorf-gzl76k",
-        "assistent-in-filialleitung-denner-flims-dorf"
+        "assistente-alla-direzione-di-filiale-denner-ebikon",
+        "assistente-nella-gestione-delle-branche-denner-ebikon"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "assistent-in-filialleitung-denner"
+          "assistent-in-filialleitung-denner",
+          "assistente-alla-direzione-di-filiale-denner-ebikon",
+          "assistente-nella-gestione-delle-branche-denner-ebikon"
         ],
         "en": [
+          "assistant-store-manager-denner-ebikon",
           "assistent-in-filialleitung-denner-flims-dorf-gzl76k"
         ],
         "de": [
+          "assistent-in-filialleitung-denner-ebikon",
           "assistent-in-filialleitung-denner-flims-dorf"
         ],
         "fr": [
+          "assistant-e-de-direction-de-succursale-denner-ebikon",
           "assistent-in-filialleitung-denner-flims-dorf-gzl76k"
         ]
       },
@@ -752,7 +762,27 @@
       "previousSlugsByLocale": {
         "it": [
           "student-in-come-ferienaushilfe-denner-horw",
-          "student-in-als-ferienaushilfe-denner"
+          "student-in-als-ferienaushilfe-denner",
+          "student-in-als-ferienaushilfe-denner-ibach",
+          "student-in-als-ferienaushilfe-denner-mannedorf",
+          "student-in-als-ferienaushilfe-denner-thalwil",
+          "student-in-als-ferienaushilfe-denner-wetzikon",
+          "student-in-als-ferienaushilfe-denner-zurich",
+          "student-in-als-ferienaushilfe-denner-wadenswil",
+          "student-in-als-ferienaushilfe-denner-thun",
+          "student-in-als-ferienaushilfe-denner-oensingen",
+          "student-in-als-ferienaushilfe-denner-amriswil",
+          "student-in-als-ferienaushilfe-denner-frauenfeld",
+          "student-in-als-ferienaushilfe-denner-pfaffokon-sz",
+          "student-in-als-ferienaushilfe-denner-buchs-ag",
+          "student-in-als-ferienaushilfe-im-stundenlohn-denner",
+          "student-in-als-ferienaushilfe-denner-zug",
+          "student-in-als-ferienaushilfe-denner-gebenstorf",
+          "student-in-als-ferienaushilfe-denner-untersiggenthal",
+          "student-in-als-ferienaushilfe-denner-aarau",
+          "student-in-als-ferienaushilfe-denner-buchs-sg",
+          "student-in-als-ferienaushilfe-denner-flawil",
+          "student-in-als-ferienaushilfe-denner-dielsdorf"
         ],
         "en": [
           "student-in-als-ferienaushilfe-denner-horw"
@@ -761,7 +791,27 @@
       "previousSlugs": [
         "student-in-come-ferienaushilfe-denner-horw",
         "student-in-als-ferienaushilfe-denner",
-        "student-in-als-ferienaushilfe-denner-horw"
+        "student-in-als-ferienaushilfe-denner-horw",
+        "student-in-als-ferienaushilfe-denner-ibach",
+        "student-in-als-ferienaushilfe-denner-mannedorf",
+        "student-in-als-ferienaushilfe-denner-thalwil",
+        "student-in-als-ferienaushilfe-denner-wetzikon",
+        "student-in-als-ferienaushilfe-denner-zurich",
+        "student-in-als-ferienaushilfe-denner-wadenswil",
+        "student-in-als-ferienaushilfe-denner-thun",
+        "student-in-als-ferienaushilfe-denner-oensingen",
+        "student-in-als-ferienaushilfe-denner-amriswil",
+        "student-in-als-ferienaushilfe-denner-frauenfeld",
+        "student-in-als-ferienaushilfe-denner-pfaffokon-sz",
+        "student-in-als-ferienaushilfe-denner-buchs-ag",
+        "student-in-als-ferienaushilfe-im-stundenlohn-denner",
+        "student-in-als-ferienaushilfe-denner-zug",
+        "student-in-als-ferienaushilfe-denner-gebenstorf",
+        "student-in-als-ferienaushilfe-denner-untersiggenthal",
+        "student-in-als-ferienaushilfe-denner-aarau",
+        "student-in-als-ferienaushilfe-denner-buchs-sg",
+        "student-in-als-ferienaushilfe-denner-flawil",
+        "student-in-als-ferienaushilfe-denner-dielsdorf"
       ],
       "salaryMin": 59000,
       "salaryMax": 90500,
@@ -1283,12 +1333,14 @@
       "previousSlugs": [
         "vice-responsabile-di-filiale-in-formazione-denner-chur",
         "stv-filialleiter-in-in-ausbildung-denner",
-        "stv-filialleiter-in-in-ausbildung-denner-chur-c7igr5"
+        "stv-filialleiter-in-in-ausbildung-denner-chur-c7igr5",
+        "stv-filialleiter-in-in-ausbildung-denner-lyssach"
       ],
       "previousSlugsByLocale": {
         "it": [
           "vice-responsabile-di-filiale-in-formazione-denner-chur",
-          "stv-filialleiter-in-in-ausbildung-denner"
+          "stv-filialleiter-in-in-ausbildung-denner",
+          "stv-filialleiter-in-in-ausbildung-denner-lyssach"
         ],
         "en": [
           "stv-filialleiter-in-in-ausbildung-denner-chur-c7igr5"

--- a/data/jobs/by-crawler/efg-international.json
+++ b/data/jobs/by-crawler/efg-international.json
@@ -447,11 +447,17 @@
       "firstSeenAt": "2026-05-10T21:30:00.908Z",
       "previousSlugsByLocale": {
         "it": [
-          "operational-risk-and-advisory-it-and-information-security-specialist-efg-zurich"
+          "operational-risk-and-advisory-it-and-information-security-specialist-efg-zurich",
+          "operational-risk-and-advisory-it-and-information-security-specialista-efg-international-ag-zurich",
+          "operational-risk-and-advisory-it-and-information-security-spezialist-efg-international-ag-zurich",
+          "operational-risk-and-advisory-it-and-information-security-specialiste-efg-international-ag-zurich"
         ]
       },
       "previousSlugs": [
-        "operational-risk-and-advisory-it-and-information-security-specialist-efg-zurich"
+        "operational-risk-and-advisory-it-and-information-security-specialist-efg-zurich",
+        "operational-risk-and-advisory-it-and-information-security-specialista-efg-international-ag-zurich",
+        "operational-risk-and-advisory-it-and-information-security-spezialist-efg-international-ag-zurich",
+        "operational-risk-and-advisory-it-and-information-security-specialiste-efg-international-ag-zurich"
       ],
       "needsRetranslation": true
     },
@@ -571,7 +577,15 @@
       "postalCode": "6900",
       "addressRegion": "TI",
       "employmentType": "FULL_TIME",
-      "firstSeenAt": "2026-05-10T21:30:00.907Z"
+      "firstSeenAt": "2026-05-10T21:30:00.907Z",
+      "previousSlugs": [
+        "technology-cyber-information-security-risk-analista-temporary-efg-international-ag-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "technology-cyber-information-security-risk-analista-temporary-efg-international-ag-zurich"
+        ]
+      }
     },
     {
       "id": "efg-6190",
@@ -985,7 +999,8 @@
       "previousSlugsByLocale": {
         "it": [
           "pb-support-specialist-middle-east-ch-efg-geneve",
-          "pb-support-specialista-middle-east-ch-efg-international-ag-geneve"
+          "pb-support-specialista-middle-east-ch-efg-international-ag-geneve",
+          "pb-support-specialist-middle-east-ch-efg-international-ag-geneve"
         ],
         "de": [
           "pb-support-specialist-middle-east-ch-efg-geneve"
@@ -996,7 +1011,8 @@
       },
       "previousSlugs": [
         "pb-support-specialist-middle-east-ch-efg-geneve",
-        "pb-support-specialista-middle-east-ch-efg-international-ag-geneve"
+        "pb-support-specialista-middle-east-ch-efg-international-ag-geneve",
+        "pb-support-specialist-middle-east-ch-efg-international-ag-geneve"
       ],
       "needsRetranslation": true
     },
@@ -1187,7 +1203,8 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "talent-acquisition-internship-efg-lugano"
+          "talent-acquisition-internship-efg-lugano",
+          "talent-acquisition-internship-efg-international-ag-lugano"
         ],
         "de": [
           "talent-acquisition-internship-efg-lugano"
@@ -1200,7 +1217,8 @@
         ]
       },
       "previousSlugs": [
-        "talent-acquisition-internship-efg-lugano"
+        "talent-acquisition-internship-efg-lugano",
+        "talent-acquisition-internship-efg-international-ag-lugano"
       ],
       "firstSeenAt": "2026-04-13T21:36:50.620Z",
       "needsRetranslation": true
@@ -1746,7 +1764,8 @@
         "esg-verwaltungsassistent-in-efg-international-ag-lugano",
         "internationaler-gehaltsabrechnungsspezialist-efg-international-ag-lugano",
         "esg-administrative-assistant-efg-international-ag-lugano",
-        "specialiste-en-paie-internationale-efg-international-ag-lugano"
+        "specialiste-en-paie-internationale-efg-international-ag-lugano",
+        "international-payroll-specialist-efg-lugano"
       ],
       "salaryMin": 58000,
       "salaryMax": 78000,
@@ -2101,7 +2120,15 @@
       "addressRegion": "TI",
       "employmentType": "FULL_TIME",
       "firstSeenAt": "2026-05-10T21:30:00.895Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "client-services-officer-geneva-talent-pool-efg-international-ag-geneve"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "client-services-officer-geneva-talent-pool-efg-international-ag-geneve"
+        ]
+      }
     },
     {
       "id": "efg-6064",
@@ -4751,7 +4778,8 @@
         "temp-kontrakt-geschaftsanalytiker-entwickler-efg-international-ag-lugano",
         "temp-contract-business-analyst-entwickler-efg-international-ag-lugano",
         "temp-contract-business-analyst-developer-efg-international-ag-lugano",
-        "contrat-temporaire-analyste-developpeur-business-efg-international-ag-lugano"
+        "contrat-temporaire-analyste-developpeur-business-efg-international-ag-lugano",
+        "temp-contract-it-business-analyst-developer-efg-international-ag-lugano"
       ],
       "salaryMin": 72500,
       "salaryMax": 97500,
@@ -4774,7 +4802,8 @@
         "it": [
           "temp-contract-business-analista-sviluppatore-efg-international-ag-lugano-n9334f",
           "temp-contract-business-analista-sviluppatore-efg-international-ag-lugano",
-          "temp-contract-business-analyste-developpeur-efg-international-ag-lugano-n9334f"
+          "temp-contract-business-analyste-developpeur-efg-international-ag-lugano-n9334f",
+          "temp-contract-it-business-analyst-developer-efg-international-ag-lugano"
         ],
         "en": [
           "temp-contract-business-analista-sviluppatore-efg-international-ag-lugano-n9334f",

--- a/data/jobs/by-crawler/ems-chemie.json
+++ b/data/jobs/by-crawler/ems-chemie.json
@@ -45,7 +45,11 @@
       "previousSlugsByLocale": {
         "it": [
           "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-ems-chemie-domat-ems",
-          "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-ems-chemie-ag-domat-ems"
+          "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-ems-chemie-ag-domat-ems",
+          "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems",
+          "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-",
+          "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-domat-ems",
+          "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems-afk1jt"
         ],
         "en": [
           "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-ems-chemie-domat-ems"
@@ -56,7 +60,11 @@
       },
       "previousSlugs": [
         "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-ems-chemie-domat-ems",
-        "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-ems-chemie-ag-domat-ems"
+        "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-ems-chemie-ag-domat-ems",
+        "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems",
+        "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-",
+        "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-domat-ems",
+        "projektleiter-kunststoffanwendungen-automobil-m-w-d-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems-afk1jt"
       ],
       "salaryMin": 49500,
       "salaryMax": 75000,
@@ -458,11 +466,17 @@
       "firstSeenAt": "2026-05-11T21:58:29.653Z",
       "previousSlugsByLocale": {
         "it": [
-          "anwendungstechniker-technische-fasern-100-ems-chemie-domat-ems"
+          "anwendungstechniker-technische-fasern-100-ems-chemie-domat-ems",
+          "anwendungstechniker-technische-fasern-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems",
+          "anwendungstechniker-technische-fasern-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-domat-ems",
+          "anwendungstechniker-technische-fasern-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems-qslhdd"
         ]
       },
       "previousSlugs": [
-        "anwendungstechniker-technische-fasern-100-ems-chemie-domat-ems"
+        "anwendungstechniker-technische-fasern-100-ems-chemie-domat-ems",
+        "anwendungstechniker-technische-fasern-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems",
+        "anwendungstechniker-technische-fasern-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-domat-ems",
+        "anwendungstechniker-technische-fasern-100-domat-ems-ems-chemie-ag-domat-ems-ems-chemie-ag-domat-ems-qslhdd"
       ]
     },
     {

--- a/data/jobs/by-crawler/engel-voelkers.json
+++ b/data/jobs/by-crawler/engel-voelkers.json
@@ -672,7 +672,8 @@
       "previousSlugsByLocale": {
         "it": [
           "junior-immobilienmakler-in-50-100-engel-voelkers-schaffhausen",
-          "junior-immobilienmakler-in-50-100-buutiq-immobilien-ag-schaffhausen"
+          "junior-immobilienmakler-in-50-100-buutiq-immobilien-ag-schaffhausen",
+          "junior-immobilienmakler-in-50-100-buutiq-immobilien-ag-st-gallen"
         ],
         "en": [
           "junior-immobilienmakler-in-50-100-engel-voelkers-schaffhausen",
@@ -688,7 +689,8 @@
       },
       "previousSlugs": [
         "junior-immobilienmakler-in-50-100-engel-voelkers-schaffhausen",
-        "junior-immobilienmakler-in-50-100-buutiq-immobilien-ag-schaffhausen"
+        "junior-immobilienmakler-in-50-100-buutiq-immobilien-ag-schaffhausen",
+        "junior-immobilienmakler-in-50-100-buutiq-immobilien-ag-st-gallen"
       ],
       "salaryMin": 46500,
       "salaryMax": 71500,

--- a/data/jobs/by-crawler/eoc-ente-ospedaliero-cantonale.json
+++ b/data/jobs/by-crawler/eoc-ente-ospedaliero-cantonale.json
@@ -306,7 +306,21 @@
       "addressLocality": "Bellinzona",
       "addressRegion": "TI",
       "addressCountry": "CH",
-      "employmentType": "FULL_TIME"
+      "employmentType": "FULL_TIME",
+      "previousSlugs": [
+        "impiegato-a-amministrativo-a-80-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "impiegato-a-amministrativo-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+        "impiegato-a-amministrativo-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+        "impiegato-a-amministrativo-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "impiegato-a-amministrativo-a-80-eoc-ente-ospedaliero-cantonale-bellinzona",
+          "impiegato-a-amministrativo-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+          "impiegato-a-amministrativo-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+          "impiegato-a-amministrativo-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3"
+        ]
+      }
     },
     {
       "id": "company-x29n48",
@@ -366,7 +380,19 @@
       "addressLocality": "Novaggio",
       "addressRegion": "TI",
       "addressCountry": "CH",
-      "employmentType": "FULL_TIME"
+      "employmentType": "FULL_TIME",
+      "previousSlugs": [
+        "collaboratore-trice-dell-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "collaboratore-trice-dell-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzo-x29n47",
+        "collaboratore-trice-dell-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzo-x29n48"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "collaboratore-trice-dell-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzona",
+          "collaboratore-trice-dell-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzo-x29n47",
+          "collaboratore-trice-dell-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzo-x29n48"
+        ]
+      }
     },
     {
       "id": "company-uil2r1",
@@ -510,7 +536,43 @@
       "addressLocality": "Bellinzona",
       "addressRegion": "TI",
       "addressCountry": "CH",
-      "employmentType": "FULL_TIME"
+      "employmentType": "FULL_TIME",
+      "previousSlugs": [
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-lugano",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-novaggio",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-2",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-2",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-novaggio-2",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-3",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-3",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-novaggio-3",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uil178",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uil172",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-x29n5z",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-x29n2m",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uikzn5",
+        "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uil177"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-lugano",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-novaggio",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-2",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-2",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-novaggio-2",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-3",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-3",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-novaggio-3",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uil178",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uil172",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-x29n5z",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-x29n2m",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uikzn5",
+          "stage-servizio-infermieristico-eoc-ente-ospedaliero-cantonale-bellinzona-uil177"
+        ]
+      }
     },
     {
       "id": "company-uil17y",
@@ -773,7 +835,15 @@
       "addressLocality": "Novaggio",
       "addressRegion": "TI",
       "addressCountry": "CH",
-      "employmentType": "FULL_TIME"
+      "employmentType": "FULL_TIME",
+      "previousSlugs": [
+        "operatore-trice-socio-sanitario-a-eoc-ente-ospedaliero-cantonale-novaggio-x29n56"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "operatore-trice-socio-sanitario-a-eoc-ente-ospedaliero-cantonale-novaggio-x29n56"
+        ]
+      }
     },
     {
       "id": "company-x29n56",
@@ -1703,7 +1773,15 @@
       "addressLocality": "Bellinzona",
       "addressRegion": "TI",
       "addressCountry": "CH",
-      "employmentType": "FULL_TIME"
+      "employmentType": "FULL_TIME",
+      "previousSlugs": [
+        "collaboratore-trice-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzona-uikyu1"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "collaboratore-trice-economia-domestica-eoc-ente-ospedaliero-cantonale-bellinzona-uikyu1"
+        ]
+      }
     },
     {
       "id": "company-uikzov",
@@ -3246,12 +3324,16 @@
       "previousSlugsByLocale": {
         "de": [
           "praktikum-vor-der-supsi-ausbildung-eoc-ente-ospedaliero-cantonale-novaggio"
+        ],
+        "it": [
+          "stage-formativo-pre-supsi-eoc-ente-ospedaliero-cantonale-bellinzona"
         ]
       },
       "previousSlugs": [
         "praktikum-vor-der-supsi-ausbildung-eoc-ente-ospedaliero-cantonale-novaggio",
         "stadio-formativo-pre-supsi-eoc-ente-ospedaliero-cantonale-novaggio",
-        "stadio-formativo-pre-supsi-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "stadio-formativo-pre-supsi-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "stage-formativo-pre-supsi-eoc-ente-ospedaliero-cantonale-bellinzona"
       ]
     },
     {
@@ -3933,6 +4015,11 @@
         ],
         "fr": [
           "kinesitherapeute-qualifie-eoc-ente-ospedaliero-cantonale-bellinzona"
+        ],
+        "it": [
+          "fisioterapista-diplomato-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+          "fisioterapista-diplomato-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+          "fisioterapista-diplomato-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3"
         ]
       },
       "previousSlugs": [
@@ -3940,7 +4027,10 @@
         "ergoterapista-diplomato-a-eoc-ente-ospedaliero-cantonale-bellinzona-x29n6s",
         "qualified-physiotherapist-eoc-ente-ospedaliero-cantonale-novaggio",
         "diplomierter-physiotherapeut-eoc-ente-ospedaliero-cantonale-novaggio",
-        "physiotherapeute-qualifie-eoc-ente-ospedaliero-cantonale-novaggio"
+        "physiotherapeute-qualifie-eoc-ente-ospedaliero-cantonale-novaggio",
+        "fisioterapista-diplomato-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+        "fisioterapista-diplomato-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+        "fisioterapista-diplomato-a-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3"
       ],
       "salaryMin": 70500,
       "salaryMax": 98500,
@@ -4191,6 +4281,17 @@
         ],
         "fr": [
           "assistante-de-cabinet-medical-eoc-ente-ospedaliero-cantonale-bellinzona"
+        ],
+        "it": [
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-2",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-3",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-uikzou",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-uikyun",
+          "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-uil2r1"
         ]
       },
       "previousSlugs": [
@@ -4198,7 +4299,16 @@
         "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-lugano-uil2r1",
         "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-locarno-uikzou",
         "assistante-de-cabinet-medical-eoc-ente-ospedaliero-cantonale-locarno",
-        "arzthelferin-eoc-ente-ospedaliero-cantonale-locarno"
+        "arzthelferin-eoc-ente-ospedaliero-cantonale-locarno",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-2",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-3",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-uikzou",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-uikyun",
+        "assistente-di-studio-medico-eoc-ente-ospedaliero-cantonale-bellinzona-uil2r1"
       ]
     },
     {
@@ -4429,7 +4539,10 @@
       "previousSlugs": [
         "krankenschwester-in-der-allgemeinen-pflege-eoc-ente-ospedaliero-cantonale-mendrisio",
         "infirmiere-en-soins-generaux-eoc-ente-ospedaliero-cantonale-mendrisio",
-        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-2",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-3"
       ],
       "previousSlugsByLocale": {
         "de": [
@@ -4437,6 +4550,11 @@
         ],
         "fr": [
           "infirmiere-en-soins-generaux-eoc-ente-ospedaliero-cantonale-mendrisio"
+        ],
+        "it": [
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio",
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-2",
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-3"
         ]
       },
       "needsRetranslation": true
@@ -4519,13 +4637,21 @@
         ],
         "fr": [
           "infirmiere-specialisee-en-anesthesie-eoc-ente-ospedaliero-cantonale-mendrisio"
+        ],
+        "it": [
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio",
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-2",
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-3"
         ]
       },
       "previousSlugs": [
         "nurse-specialized-in-anesthesia-eoc-ente-ospedaliero-cantonale-mendrisio",
         "krankenschwester-mit-spezialisierung-auf-anasthesie-eoc-ente-ospedaliero-cantonale-mendrisio",
         "infirmiere-specialisee-en-anesthesie-eoc-ente-ospedaliero-cantonale-mendrisio",
-        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-2",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-mendrisio-3"
       ],
       "needsRetranslation": true
     },
@@ -4823,6 +4949,11 @@
         ],
         "fr": [
           "assistant-de-soins-ou-travailleur-socio-sanitaire-eoc-ente-ospedaliero-cantonale-lugano"
+        ],
+        "it": [
+          "assistente-di-cura-o-addetto-a-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-loc",
+          "assistente-di-cura-o-mitarbeiter-in-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-lugano",
+          "assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-lugano"
         ]
       },
       "previousSlugs": [
@@ -4830,7 +4961,10 @@
         "socio-health-care-workers-and-or-care-assistants-50-100-eoc-ente-ospedaliero-cantonale-lugano",
         "fachfrau-fachmann-gesundheits-und-sozialpflege-bzw-pflegeassistentin-pflegeassistent-50-100-eoc-ente-ospedaliero-cantonale-lugano",
         "assistant-e-socio-sanitaire-et-ou-assistant-e-de-soins-50-100-eoc-ente-ospedaliero-cantonale-lugano",
-        "assistente-di-cura-o-addetto-a-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "assistente-di-cura-o-addetto-a-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "assistente-di-cura-o-addetto-a-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-loc",
+        "assistente-di-cura-o-mitarbeiter-in-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-lugano",
+        "assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-lugano"
       ]
     },
     {
@@ -4894,7 +5028,10 @@
       "previousSlugs": [
         "krankenschwester-in-der-allgemeinen-pflege-eoc-ente-ospedaliero-cantonale-lugano",
         "infirmiere-en-soins-generaux-eoc-ente-ospedaliero-cantonale-lugano",
-        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-lugano",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-2",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-3"
       ],
       "previousSlugsByLocale": {
         "de": [
@@ -4902,6 +5039,11 @@
         ],
         "fr": [
           "infirmiere-en-soins-generaux-eoc-ente-ospedaliero-cantonale-lugano"
+        ],
+        "it": [
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-lugano",
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-2",
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-lugano-3"
         ]
       }
     },
@@ -4966,7 +5108,10 @@
       "previousSlugs": [
         "krankenschwester-in-der-allgemeinen-pflege-eoc-ente-ospedaliero-cantonale-locarno",
         "infirmiere-en-soins-generaux-eoc-ente-ospedaliero-cantonale-locarno",
-        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-locarno",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-2",
+        "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-3"
       ],
       "previousSlugsByLocale": {
         "de": [
@@ -4974,6 +5119,11 @@
         ],
         "fr": [
           "infirmiere-en-soins-generaux-eoc-ente-ospedaliero-cantonale-locarno"
+        ],
+        "it": [
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-locarno",
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-2",
+          "infermiere-a-in-cure-generali-eoc-ente-ospedaliero-cantonale-bellinzona-locarno-3"
         ]
       }
     },
@@ -5127,12 +5277,18 @@
         ],
         "fr": [
           "infirmiere-auxiliaire-ou-assistante-sociale-eoc-ente-ospedaliero-cantonale-locarno"
+        ],
+        "it": [
+          "assistente-di-cura-o-mitarbeiter-in-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-locarno",
+          "assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-locarno"
         ]
       },
       "previousSlugs": [
         "assistente-di-cura-o-addetto-a-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-locarno-uikzn3",
         "infirmiere-auxiliaire-ou-assistante-sociale-eoc-ente-ospedaliero-cantonale-locarno",
-        "assistente-di-cura-o-addetto-a-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "assistente-di-cura-o-addetto-a-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "assistente-di-cura-o-mitarbeiter-in-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-locarno",
+        "assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-locarno"
       ]
     },
     {
@@ -5761,6 +5917,10 @@
         "fr": [
           "aide-soignant-e-ou-personnel-de-soins-sociaux-eoc-ente-ospedaliero-cantonale-bellinzona",
           "assistant-de-soins-ou-travailleur-socio-sanitaire-eoc-ente-ospedaliero-cantonale-lugano"
+        ],
+        "it": [
+          "assistente-di-cura-o-mitarbeiter-in-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona",
+          "assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona"
         ]
       },
       "previousSlugs": [
@@ -5768,7 +5928,9 @@
         "addetti-e-alle-cure-sociosanitarie-e-o-assistenti-di-cura-50-100-eoc-ente-ospedaliero-cantonale-lugano",
         "socio-health-care-workers-and-or-care-assistants-50-100-eoc-ente-ospedaliero-cantonale-lugano",
         "fachfrau-fachmann-gesundheits-und-sozialpflege-bzw-pflegeassistentin-pflegeassistent-50-100-eoc-ente-ospedaliero-cantonale-lugano",
-        "assistant-e-socio-sanitaire-et-ou-assistant-e-de-soins-50-100-eoc-ente-ospedaliero-cantonale-lugano"
+        "assistant-e-socio-sanitaire-et-ou-assistant-e-de-soins-50-100-eoc-ente-ospedaliero-cantonale-lugano",
+        "assistente-di-cura-o-mitarbeiter-in-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-bellinzona"
       ]
     },
     {
@@ -5839,6 +6001,13 @@
         ],
         "fr": [
           "infirmier-ere-specialise-e-en-anesthesie-eoc-ente-ospedaliero-cantonale-bellinzona"
+        ],
+        "it": [
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3",
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-uikzlc",
+          "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-uil19q"
         ]
       },
       "previousSlugs": [
@@ -5846,7 +6015,12 @@
         "fachkrankenpfleger-in-fur-anasthesie-eoc-ente-ospedaliero-cantonale-bellinzona",
         "infirmier-ere-specialise-e-en-anesthesie-eoc-ente-ospedaliero-cantonale-bellinzona",
         "krankenschwester-mit-spezialisierung-auf-anasthesie-eoc-ente-ospedaliero-cantonale-mendrisio",
-        "infirmiere-specialisee-en-anesthesie-eoc-ente-ospedaliero-cantonale-mendrisio"
+        "infirmiere-specialisee-en-anesthesie-eoc-ente-ospedaliero-cantonale-mendrisio",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-2",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-bellinzona-3",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-uikzlc",
+        "infermiere-a-specializzato-a-in-anestesia-eoc-ente-ospedaliero-cantonale-bellinzona-uil19q"
       ]
     },
     {
@@ -6519,14 +6693,16 @@
       "previousSlugs": [
         "assistente-di-studio-medico-100-eoc-lugano-uilr0a",
         "assistente-di-studio-medico-100-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offe-uilr0a",
-        "assistente-di-studio-medico-100-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "assistente-di-studio-medico-100-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "apprendistato-assistente-di-studio-medico-100-eoc-ente-ospedaliero-cantonale-lugano"
       ],
       "sourceLang": "it",
       "previousSlugsByLocale": {
         "it": [
           "assistente-di-studio-medico-100-eoc-lugano-uilr0a",
           "assistente-di-studio-medico-100-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offe-uilr0a",
-          "assistente-di-studio-medico-100-eoc-ente-ospedaliero-cantonale-bellinzona"
+          "assistente-di-studio-medico-100-eoc-ente-ospedaliero-cantonale-bellinzona",
+          "apprendistato-assistente-di-studio-medico-100-eoc-ente-ospedaliero-cantonale-lugano"
         ],
         "en": [
           "assistente-di-studio-medico-100-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offe-uilr0a"
@@ -13472,13 +13648,19 @@
         "collaborateur-de-restauration-eoc-ente-ospedaliero-cantonale-bellinzona",
         "restaurant-assistant-eoc-ente-ospedaliero-cantonale-bellinzona",
         "restaurantmitarbeiter-in-eoc-ente-ospedaliero-cantonale-bellinzona",
-        "aide-en-restauration-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "aide-en-restauration-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "collaboratore-trice-della-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "collaboratore-trice-della-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona-x29n45",
+        "collaboratore-trice-della-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona-x29n46"
       ],
       "previousSlugsByLocale": {
         "it": [
           "collaboratore-trice-di-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona-uil175",
           "kuchenmitarbeiter-eoc-ente-ospedaliero-cantonale-bellinzona",
-          "collaborateur-de-restauration-eoc-ente-ospedaliero-cantonale-bellinzona"
+          "collaborateur-de-restauration-eoc-ente-ospedaliero-cantonale-bellinzona",
+          "collaboratore-trice-della-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona",
+          "collaboratore-trice-della-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona-x29n45",
+          "collaboratore-trice-della-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona-x29n46"
         ],
         "en": [
           "collaboratore-trice-di-ristorazione-eoc-ente-ospedaliero-cantonale-bellinzona-uil175",
@@ -15757,13 +15939,15 @@
         "pflegefachperson-allgemeine-pflege-50-100-eoc-ente-ospedaliero-cantonale-bellinzona",
         "pflegefachperson-allgemeine-pflege-eoc-ente-ospedaliero-cantonale-bellinzona",
         "pflegefachperson-in-der-allgemeinpflege-eoc-ente-ospedaliero-cantonale-bellinzona",
-        "spezialisierte-pflegefachperson-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "spezialisierte-pflegefachperson-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "infermiere-a-in-cure-generali-50-100-eoc-ente-ospedaliero-cantonale-2026"
       ],
       "previousSlugsByLocale": {
         "it": [
           "nurse-in-general-care-50-100-eoc-ente-ospedaliero-cantonale-bellinzona",
           "pflegefachperson-in-allgemeiner-pflege-50-100-eoc-ente-ospedaliero-cantonale-bellinzona",
-          "infermiere-a-in-cure-generali-50-100-eoc-ente-ospedaliero-cantonale-bellinzona-uilqeo"
+          "infermiere-a-in-cure-generali-50-100-eoc-ente-ospedaliero-cantonale-bellinzona-uilqeo",
+          "infermiere-a-in-cure-generali-50-100-eoc-ente-ospedaliero-cantonale-2026"
         ],
         "en": [
           "nurse-in-general-care-50-100-eoc-ente-ospedaliero-cantonale-bellinzona",
@@ -18296,13 +18480,15 @@
         "stationsleiterin-stationsleiter-innere-medizin-eoc-ente-ospedaliero-cantonale-bellinzona",
         "medecin-chef-de-clinique-en-medecine-interne-eoc-ente-ospedaliero-cantonale-bellinzona",
         "chief-physician-in-internal-medicine-eoc-ente-ospedaliero-cantonale-bellinzona",
-        "medecin-chef-de-clinique-medecine-d-urgence-eoc-ente-ospedaliero-cantonale-bellinzona"
+        "medecin-chef-de-clinique-medecine-d-urgence-eoc-ente-ospedaliero-cantonale-bellinzona",
+        "medico-capoclinica-medicina-interna-eoc-ente-ospedaliero-cantonale-bellinzona-uil1yp"
       ],
       "previousSlugsByLocale": {
         "it": [
           "head-clinician-in-internal-medicine-eoc-ente-ospedaliero-cantonale-bellinzona",
           "head-physician-in-internal-medicine-eoc-ente-ospedaliero-cantonale-bellinzona",
-          "stationsleiterin-stationsleiter-innere-medizin-eoc-ente-ospedaliero-cantonale-bellinzona"
+          "stationsleiterin-stationsleiter-innere-medizin-eoc-ente-ospedaliero-cantonale-bellinzona",
+          "medico-capoclinica-medicina-interna-eoc-ente-ospedaliero-cantonale-bellinzona-uil1yp"
         ],
         "en": [
           "head-clinician-in-internal-medicine-eoc-ente-ospedaliero-cantonale-bellinzona",

--- a/data/jobs/by-crawler/ferrovia-retica.json
+++ b/data/jobs/by-crawler/ferrovia-retica.json
@@ -513,7 +513,15 @@
           "unitText": "YEAR"
         }
       },
-      "firstSeenAt": "2026-05-17T10:12:45.371Z"
+      "firstSeenAt": "2026-05-17T10:12:45.371Z",
+      "previousSlugs": [
+        "gleismonteur-in-80-100-ferrovia-retica-rhb-chur-2"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "gleismonteur-in-80-100-ferrovia-retica-rhb-chur-2"
+        ]
+      }
     }
   ]
 }

--- a/data/jobs/by-crawler/fielmann.json
+++ b/data/jobs/by-crawler/fielmann.json
@@ -2234,6 +2234,14 @@
           "maxValue": 75000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "bachelor-of-science-fhnw-en-optometrie-w-m-d-suisse-fielmann-group-basel-steinenvorstadt"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "bachelor-of-science-fhnw-en-optometrie-w-m-d-suisse-fielmann-group-basel-steinenvorstadt"
+        ]
       }
     },
     {
@@ -2383,11 +2391,13 @@
           "opticien-ne-f-h-d-fielmann-ch"
         ],
         "it": [
-          "opticien-ne-f-h-d-fielmann-ch"
+          "opticien-ne-f-h-d-fielmann-ch",
+          "opticien-w-m-d-fielmann-group-st"
         ]
       },
       "previousSlugs": [
-        "opticien-ne-f-h-d-fielmann-ch"
+        "opticien-ne-f-h-d-fielmann-ch",
+        "opticien-w-m-d-fielmann-group-st"
       ],
       "firstSeenAt": "2026-05-13T11:02:19.380Z",
       "salaryMin": 49500,
@@ -2631,7 +2641,8 @@
       "previousSlugs": [
         "horakustikermeister-w-m-d-fielmann-ch",
         "horakustikermeister-w-m-d-fielmann-group-aarau",
-        "horakustikermeister-w-m-d-fielmann-ch-2"
+        "horakustikermeister-w-m-d-fielmann-ch-2",
+        "horakustikermeister-w-m-d-fielmann-group-aarau-2"
       ],
       "firstSeenAt": "2026-05-13T11:02:17.170Z",
       "salaryMin": 49500,

--- a/data/jobs/by-crawler/fincons-group.json
+++ b/data/jobs/by-crawler/fincons-group.json
@@ -481,14 +481,20 @@
       "firstSeenAt": "2026-05-08T09:54:10.263Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-java-engineer-fincons-group-lugano-ticino-switzerland"
+          "senior-java-engineer-fincons-group-lugano-ticino-switzerland",
+          "senior-software-engineer-java-fincons-group-lugano"
         ],
         "fr": [
           "senior-java-engineer-fincons-group-lugano-ticino-switzerland"
+        ],
+        "en": [
+          "java-senior-engineer-fincons-group-lugano"
         ]
       },
       "previousSlugs": [
-        "senior-java-engineer-fincons-group-lugano-ticino-switzerland"
+        "senior-java-engineer-fincons-group-lugano-ticino-switzerland",
+        "java-senior-engineer-fincons-group-lugano",
+        "senior-software-engineer-java-fincons-group-lugano"
       ]
     },
     {

--- a/data/jobs/by-crawler/flury-stiftung.json
+++ b/data/jobs/by-crawler/flury-stiftung.json
@@ -266,13 +266,15 @@
         "lehrstellen-fachperson-gesundheit-efz-ab-sommer-2026-flury-stiftung-ch",
         "apprendistato-fachperson-hotellerie-hauswirtschaft-cfc-ab-sommer-2026-flury-stiftung-schiers",
         "direction-departementale-tic-protection-des-donnees-100-flury-stiftung-schiers",
-        "lehrstellen-fachperson-gesundheit-cfc-ab-sommer-2026-flury-stiftung-schiers"
+        "lehrstellen-fachperson-gesundheit-cfc-ab-sommer-2026-flury-stiftung-schiers",
+        "lehrstelle-fachperson-hotellerie-hauswirtschaft-efz-ab-sommer-2027-flury-stiftung-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
           "departementsleitung-ict-datenschutz-100-flury-stiftung-ch",
           "lehrstellen-fachperson-gesundheit-efz-ab-sommer-2026-flury-stiftung-ch",
-          "apprendistato-fachperson-hotellerie-hauswirtschaft-cfc-ab-sommer-2026-flury-stiftung-schiers"
+          "apprendistato-fachperson-hotellerie-hauswirtschaft-cfc-ab-sommer-2026-flury-stiftung-schiers",
+          "lehrstelle-fachperson-hotellerie-hauswirtschaft-efz-ab-sommer-2027-flury-stiftung-ch"
         ],
         "en": [
           "departementsleitung-ict-datenschutz-100-flury-stiftung-ch"

--- a/data/jobs/by-crawler/fnz.json
+++ b/data/jobs/by-crawler/fnz.json
@@ -201,16 +201,22 @@
       "previousSlugsByLocale": {
         "it": [
           "consulente-soluzioni-crm-fnz-switzerland-ag-chiasso",
-          "solution-consultant-crm-fnz"
+          "solution-consultant-crm-fnz",
+          "solution-consultant-crm-fnz-switzerland-ag-lugano"
         ],
         "fr": [
           "solution-consultant-crm-fnz-switzerland-ag-chiasso-6k20bx"
+        ],
+        "en": [
+          "solution-consultant-crm-fnz-switzerland-ag-chiasso"
         ]
       },
       "previousSlugs": [
         "consulente-soluzioni-crm-fnz-switzerland-ag-chiasso",
         "solution-consultant-crm-fnz",
-        "solution-consultant-crm-fnz-switzerland-ag-chiasso-6k20bx"
+        "solution-consultant-crm-fnz-switzerland-ag-chiasso-6k20bx",
+        "solution-consultant-crm-fnz-switzerland-ag-chiasso",
+        "solution-consultant-crm-fnz-switzerland-ag-lugano"
       ],
       "salaryMin": 61000,
       "salaryMax": 97000,

--- a/data/jobs/by-crawler/fondation-domus.json
+++ b/data/jobs/by-crawler/fondation-domus.json
@@ -195,11 +195,13 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "travailleur-social-60-65-fondation-domus-ch"
+        "travailleur-social-60-65-fondation-domus-ch",
+        "travailleur-social-60-fondation-domus-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "travailleur-social-60-65-fondation-domus-ch"
+          "travailleur-social-60-65-fondation-domus-ch",
+          "travailleur-social-60-fondation-domus-ch"
         ],
         "en": [
           "travailleur-social-60-65-fondation-domus-ch"

--- a/data/jobs/by-crawler/fusalp.json
+++ b/data/jobs/by-crawler/fusalp.json
@@ -82,11 +82,13 @@
       },
       "previousSlugs": [
         "conseiller-de-vente-sales-consultant-h-f-fusalp-crans-montana",
-        "conseiller-de-vente-sales-consulente-h-f-fusalp-crans-montana"
+        "conseiller-de-vente-sales-consulente-h-f-fusalp-crans-montana",
+        "conseiller-de-vente-sales-consultant-h-f-fusalp-luxembourg"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "conseiller-de-vente-sales-consultant-h-f-fusalp-crans-montana"
+          "conseiller-de-vente-sales-consultant-h-f-fusalp-crans-montana",
+          "conseiller-de-vente-sales-consultant-h-f-fusalp-luxembourg"
         ]
       },
       "firstSeenAt": "2026-04-13T10:34:51.057Z",

--- a/data/jobs/by-crawler/fust.json
+++ b/data/jobs/by-crawler/fust.json
@@ -49,11 +49,19 @@
       "sourceLang": "it",
       "previousSlugsByLocale": {
         "it": [
-          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino"
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-0jqltq",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-e3zmz6",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-cadenazzo",
+          "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-ke4f2c"
         ]
       },
       "previousSlugs": [
-        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino"
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-0jqltq",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-e3zmz6",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-cadenazzo",
+        "montatore-trice-di-impianti-sanitari-per-cucine-bagni-fust-bellinzona-ticino-ke4f2c"
       ],
       "salaryMin": 70500,
       "salaryMax": 98500,

--- a/data/jobs/by-crawler/galenica.json
+++ b/data/jobs/by-crawler/galenica.json
@@ -57,7 +57,17 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-coop-vitality-galenica-bern",
+        "assistente-di-farmacia-afc-coop-vitality-galenica-tenero"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-coop-vitality-galenica-bern",
+          "assistente-di-farmacia-afc-coop-vitality-galenica-tenero"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -114,7 +124,17 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-sun-store-apotheke-galenica-bern",
+        "assistente-di-farmacia-afc-sun-store-apotheke-galenica-lugano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-sun-store-apotheke-galenica-bern",
+          "assistente-di-farmacia-afc-sun-store-apotheke-galenica-lugano"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -171,7 +191,15 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-sun-store-apotheke-galenica-locarno"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-sun-store-apotheke-galenica-locarno"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -228,7 +256,15 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-coop-vitality-galenica-s-antonino"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-coop-vitality-galenica-s-antonino"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -285,7 +321,15 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-coop-vitality-galenica-canobbio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-coop-vitality-galenica-canobbio"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -342,7 +386,16 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-amavita-apotheke-galenica-mendrisio",
+        "galenica-amavita-apotheke-assistente-di-farmacia-afc-mendrisio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-amavita-apotheke-galenica-mendrisio"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -399,7 +452,16 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-amavita-apotheke-galenica-ascona",
+        "galenica-amavita-apotheke-assistente-di-farmacia-afc-ascona"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-amavita-apotheke-galenica-ascona"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -456,7 +518,15 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-coop-vitality-galenica-mendrisio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-coop-vitality-galenica-mendrisio"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -513,7 +583,16 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-amavita-apotheke-galenica-balerna",
+        "galenica-amavita-apotheke-assistente-di-farmacia-afc-balerna"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-amavita-apotheke-galenica-balerna"
+        ]
+      }
     },
     {
       "title": "Impiegato/a in logistica AFC",
@@ -569,7 +648,17 @@
       "addressRegion": "BE",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "impiegato-a-in-logistica-afc-unione-farmaceutica-distribuzione-sa-galenica-bern",
+        "impiegato-a-in-logistica-afc-unione-farmaceutica-distribuzione-sa-galenica-lugano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "impiegato-a-in-logistica-afc-unione-farmaceutica-distribuzione-sa-galenica-bern",
+          "impiegato-a-in-logistica-afc-unione-farmaceutica-distribuzione-sa-galenica-lugano"
+        ]
+      }
     },
     {
       "title": "Assistente di farmacia AFC",
@@ -626,7 +715,16 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-04-13T21:44:00.314Z"
+      "firstSeenAt": "2026-04-13T21:44:00.314Z",
+      "previousSlugs": [
+        "assistente-di-farmacia-afc-amavita-apotheke-galenica-lugano",
+        "galenica-amavita-apotheke-assistente-di-farmacia-afc-lugano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-di-farmacia-afc-amavita-apotheke-galenica-lugano"
+        ]
+      }
     }
   ]
 }

--- a/data/jobs/by-crawler/gemeinde-st-moritz.json
+++ b/data/jobs/by-crawler/gemeinde-st-moritz.json
@@ -50,11 +50,13 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "wichtige-kontakte-gemeinde-st-moritz-ch"
+        "wichtige-kontakte-gemeinde-st-moritz-ch",
+        "wichtige-kontakte-gemeinde-st-moritz-ch-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "wichtige-kontakte-gemeinde-st-moritz-ch"
+          "wichtige-kontakte-gemeinde-st-moritz-ch",
+          "wichtige-kontakte-gemeinde-st-moritz-ch-2"
         ]
       },
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/gkb.json
+++ b/data/jobs/by-crawler/gkb.json
@@ -55,13 +55,21 @@
           "kauffrau-kaufmann-bank-in-davos-lehrbeginn-2027-gkb-ch"
         ],
         "it": [
-          "kauffrau-kaufmann-bank-in-davos-lehrbeginn-2027-graubundner-kantonalbank-davos-klosters"
+          "kauffrau-kaufmann-bank-in-davos-lehrbeginn-2027-graubundner-kantonalbank-davos-klosters",
+          "kauffrau-kaufmann-bank-in-poschiavo-lehrbeginn-2027-graubundner-kantonalbank-st-moritz",
+          "kauffrau-kaufmann-bank-in-arosa-lehrbeginn-2027-graubundner-kantonalbank-arosa",
+          "kauffrau-kaufmann-bank-in-scuol-lehrbeginn-2027-graubundner-kantonalbank-scuol",
+          "kauffrau-kaufmann-bank-in-st-moritz-lehrbeginn-2027-graubundner-kantonalbank-st-moritz"
         ]
       },
       "previousSlugs": [
         "kauffrau-kaufmann-bank-in-davos-lehrbeginn-2027-gkb-ch",
         "kauffrau-kaufmann-bank-in-davos-lehrbeginn-2027-graubundner-kantonalbank-davos-klosters",
-        "banca-kaufmann-a-davos-inizio-del-2027-graubundner-kantonalbank-davos-klosters"
+        "banca-kaufmann-a-davos-inizio-del-2027-graubundner-kantonalbank-davos-klosters",
+        "kauffrau-kaufmann-bank-in-poschiavo-lehrbeginn-2027-graubundner-kantonalbank-st-moritz",
+        "kauffrau-kaufmann-bank-in-arosa-lehrbeginn-2027-graubundner-kantonalbank-arosa",
+        "kauffrau-kaufmann-bank-in-scuol-lehrbeginn-2027-graubundner-kantonalbank-scuol",
+        "kauffrau-kaufmann-bank-in-st-moritz-lehrbeginn-2027-graubundner-kantonalbank-st-moritz"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T10:19:15.715Z",

--- a/data/jobs/by-crawler/grand-hotel-des-bains-kempinski.json
+++ b/data/jobs/by-crawler/grand-hotel-des-bains-kempinski.json
@@ -64,7 +64,8 @@
       "firstSeenAt": "2026-05-13T22:28:38.751Z",
       "previousSlugsByLocale": {
         "it": [
-          "cluster-sales-manager-m-w-451348"
+          "cluster-sales-manager-m-w-451348",
+          "cluster-sales-manager-m-w-kempinski-palace-engelberg-engelberg-h509ep"
         ],
         "de": [
           "cluster-sales-manager-m-w-451348"
@@ -74,7 +75,8 @@
         ]
       },
       "previousSlugs": [
-        "cluster-sales-manager-m-w-451348"
+        "cluster-sales-manager-m-w-451348",
+        "cluster-sales-manager-m-w-kempinski-palace-engelberg-engelberg-h509ep"
       ]
     },
     {
@@ -138,11 +140,19 @@
       "postalCode": "7500",
       "firstSeenAt": "2026-05-17T10:31:20.142Z",
       "previousSlugs": [
-        "pizza-chef-f-m-d-456455"
+        "pizza-chef-f-m-d-456455",
+        "pizza-chef-f-m-j-grand-hotel-des-bains-kempinski-st-moritz-st-moritz",
+        "pizza-chef-w-m-d-grand-hotel-des-bains-kempinski-st-moritz-st-moritz"
       ],
       "previousSlugsByLocale": {
         "it": [
           "pizza-chef-f-m-d-456455"
+        ],
+        "fr": [
+          "pizza-chef-f-m-j-grand-hotel-des-bains-kempinski-st-moritz-st-moritz"
+        ],
+        "de": [
+          "pizza-chef-w-m-d-grand-hotel-des-bains-kempinski-st-moritz-st-moritz"
         ]
       },
       "needsRetranslation": true
@@ -208,11 +218,15 @@
       "postalCode": "7500",
       "firstSeenAt": "2026-05-17T10:31:20.143Z",
       "previousSlugs": [
-        "chef-de-partie-f-m-d-458522"
+        "chef-de-partie-f-m-d-458522",
+        "chef-de-partie-w-m-d-grand-hotel-des-bains-kempinski-st-moritz-st-moritz"
       ],
       "previousSlugsByLocale": {
         "it": [
           "chef-de-partie-f-m-d-458522"
+        ],
+        "de": [
+          "chef-de-partie-w-m-d-grand-hotel-des-bains-kempinski-st-moritz-st-moritz"
         ]
       },
       "needsRetranslation": true

--- a/data/jobs/by-crawler/grand-hotel-kronenhof.json
+++ b/data/jobs/by-crawler/grand-hotel-kronenhof.json
@@ -62,7 +62,19 @@
       "streetAddress": "Via Maistra",
       "postalCode": "7504",
       "firstSeenAt": "2026-05-17T10:33:09.628Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "assistant-front-office-manager-m-w-d-kulm-hotel-st-moritz-st-moritz-620",
+        "assistant-front-office-manager-m-p-g-kulm-hotel-st-moritz-st-moritz",
+        "assistant-front-office-manager-m-w-d-kulm-hotel-st-moritz-st-moritz"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistant-front-office-manager-m-w-d-kulm-hotel-st-moritz-st-moritz-620",
+          "assistant-front-office-manager-m-p-g-kulm-hotel-st-moritz-st-moritz",
+          "assistant-front-office-manager-m-w-d-kulm-hotel-st-moritz-st-moritz"
+        ]
+      }
     },
     {
       "title": "Assistant Reservations Manager  (m/w/d)",
@@ -674,7 +686,23 @@
       "streetAddress": "Via Maistra",
       "postalCode": "7504",
       "firstSeenAt": "2026-05-17T10:33:09.631Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "food-and-beverage-assistant-m-w-d-kulm-hotel-st-moritz-st-moritz",
+        "food-and-beverage-assistant-m-w-d-kulm-hotel-st-moritz-st-moritz-608",
+        "food-and-beverage-assistant-m-p-g-kulm-hotel-st-moritz-st-moritz",
+        "food-and-beverage-assistant-m-w-d-kulm-hotel-st-moritz-st-moritz-ymxh98"
+      ],
+      "previousSlugsByLocale": {
+        "en": [
+          "food-and-beverage-assistant-m-w-d-kulm-hotel-st-moritz-st-moritz"
+        ],
+        "it": [
+          "food-and-beverage-assistant-m-w-d-kulm-hotel-st-moritz-st-moritz-608",
+          "food-and-beverage-assistant-m-p-g-kulm-hotel-st-moritz-st-moritz",
+          "food-and-beverage-assistant-m-w-d-kulm-hotel-st-moritz-st-moritz-ymxh98"
+        ]
+      }
     },
     {
       "title": "Luxury Spa Supervisor (m/w/d)",
@@ -905,7 +933,17 @@
       "streetAddress": "Via Maistra",
       "postalCode": "7504",
       "firstSeenAt": "2026-05-17T10:33:09.632Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "reservations-agent-m-w-d-kulm-hotel-st-moritz-st-moritz",
+        "agent-reservations-m-w-d-kulm-hotel-st-moritz-st-moritz"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "reservations-agent-m-w-d-kulm-hotel-st-moritz-st-moritz",
+          "agent-reservations-m-w-d-kulm-hotel-st-moritz-st-moritz"
+        ]
+      }
     },
     {
       "title": "Spa Therapist (m/w/d)",

--- a/data/jobs/by-crawler/groupe-mutuel.json
+++ b/data/jobs/by-crawler/groupe-mutuel.json
@@ -670,7 +670,10 @@
       "previousSlugsByLocale": {
         "it": [
           "versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel",
-          "versicherungs-e-vorsorgeberater-m-w-d-80-100-groupe-mutuel-bern"
+          "versicherungs-e-vorsorgeberater-m-w-d-80-100-groupe-mutuel-bern",
+          "versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel-2",
+          "versicherungs-e-vorsorgeberater-m-w-80-100-groupe-mutuel-aarau",
+          "versicherungs-e-vorsorgeberater-m-w-80-100-groupe-mutuel-bern"
         ],
         "en": [
           "versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel"
@@ -681,7 +684,10 @@
       },
       "previousSlugs": [
         "versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel",
-        "versicherungs-e-vorsorgeberater-m-w-d-80-100-groupe-mutuel-bern"
+        "versicherungs-e-vorsorgeberater-m-w-d-80-100-groupe-mutuel-bern",
+        "versicherungs-und-vorsorgeberater-m-w-80-100-groupe-mutuel-2",
+        "versicherungs-e-vorsorgeberater-m-w-80-100-groupe-mutuel-aarau",
+        "versicherungs-e-vorsorgeberater-m-w-80-100-groupe-mutuel-bern"
       ],
       "salaryMin": 53500,
       "salaryMax": 89000,
@@ -1611,11 +1617,13 @@
       },
       "addressRegion": "VD",
       "previousSlugs": [
-        "conseiller-en-prevoyance-h-f-80-100-groupe-mutuel"
+        "conseiller-en-prevoyance-h-f-80-100-groupe-mutuel",
+        "conseiller-en-prevoyance-m-f-80-100-groupe-mutuel-paradiso"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "conseiller-en-prevoyance-h-f-80-100-groupe-mutuel"
+          "conseiller-en-prevoyance-h-f-80-100-groupe-mutuel",
+          "conseiller-en-prevoyance-m-f-80-100-groupe-mutuel-paradiso"
         ],
         "en": [
           "conseiller-en-prevoyance-h-f-80-100-groupe-mutuel"

--- a/data/jobs/by-crawler/hamilton-bonaduz-ag.json
+++ b/data/jobs/by-crawler/hamilton-bonaduz-ag.json
@@ -314,10 +314,14 @@
         ],
         "fr": [
           "strategischer-beschaffer-metals-80-100-w-m-d-jr-5790"
+        ],
+        "de": [
+          "strategischer-beschaffer-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz"
         ]
       },
       "previousSlugs": [
-        "strategischer-beschaffer-metals-80-100-w-m-d-jr-5790"
+        "strategischer-beschaffer-metals-80-100-w-m-d-jr-5790",
+        "strategischer-beschaffer-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz"
       ]
     },
     {
@@ -986,7 +990,8 @@
       "firstSeenAt": "2026-04-21T21:45:45.124Z",
       "previousSlugsByLocale": {
         "it": [
-          "lean-project-manager-80-100-w-m-d-jr-5560"
+          "lean-project-manager-80-100-w-m-d-jr-5560",
+          "lean-project-manager-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz-rl9mr2"
         ],
         "fr": [
           "lean-project-manager-80-100-w-m-d-jr-5560"
@@ -996,7 +1001,8 @@
         ]
       },
       "previousSlugs": [
-        "lean-project-manager-80-100-w-m-d-jr-5560"
+        "lean-project-manager-80-100-w-m-d-jr-5560",
+        "lean-project-manager-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz-rl9mr2"
       ]
     },
     {
@@ -1909,7 +1915,10 @@
         "operateur-de-montage-80-100-m-j-hamilton-bonaduz-ag-bonaduz",
         "assemblage-operateur-termine-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
         "assembly-operateur-befristet-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
-        "operateur-d-assemblage-80-100-p-m-j-hamilton-bonaduz-ag-bonaduz"
+        "operateur-d-assemblage-80-100-p-m-j-hamilton-bonaduz-ag-bonaduz",
+        "assembly-operator-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
+        "assembly-operator-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz-lyq1ba",
+        "assembly-operator-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz-lyq1be"
       ],
       "id": "hamilton-bonaduz-ag-de10ccc90ef5",
       "previousSlugsByLocale": {
@@ -1919,7 +1928,10 @@
           "assembly-operateur-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
           "assembly-operator-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz-lyq5oy",
           "assembly-operator-80-100-w-m-d-jr-5182",
-          "assembly-operator-befristet-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz"
+          "assembly-operator-befristet-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
+          "assembly-operator-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",
+          "assembly-operator-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz-lyq1ba",
+          "assembly-operator-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz-lyq1be"
         ],
         "en": [
           "operatore-di-montaggio-80-100-w-m-d-hamilton-bonaduz-ag-bonaduz",

--- a/data/jobs/by-crawler/has-healthcare.json
+++ b/data/jobs/by-crawler/has-healthcare.json
@@ -75,7 +75,8 @@
         ]
       },
       "previousSlugs": [
-        "tecnica-o-diplomata-o-sss-costruzioni-meccaniche-has-healthcare-advanced-synthesis-biasca-068qa9"
+        "tecnica-o-diplomata-o-sss-costruzioni-meccaniche-has-healthcare-advanced-synthesis-biasca-068qa9",
+        "tecnica-o-diplomata-o-sss-costruzioni-meccaniche-has-healthcare-advanced-synthesis-biasca"
       ]
     },
     {
@@ -141,7 +142,8 @@
       "firstSeenAt": "2026-05-13T22:19:52.888Z",
       "previousSlugsByLocale": {
         "en": [
-          "assistente-di-produzione-has-healthcare-advanced-synthesis-biasca-068qb5"
+          "assistente-di-produzione-has-healthcare-advanced-synthesis-biasca-068qb5",
+          "assistente-di-produzione-has-healthcare-advanced-synthesis-biasca"
         ],
         "de": [
           "assistente-di-produzione-has-healthcare-advanced-synthesis-biasca-068qb5"
@@ -152,7 +154,8 @@
       },
       "previousSlugs": [
         "assistente-di-produzione-has-healthcare-advanced-synthesis-biasca-068qb5",
-        "assistente-di-produzione-has-healthcare-advanced-synthesis-lugano"
+        "assistente-di-produzione-has-healthcare-advanced-synthesis-lugano",
+        "assistente-di-produzione-has-healthcare-advanced-synthesis-biasca"
       ]
     },
     {
@@ -199,7 +202,8 @@
       "previousSlugs": [
         "production-manager-has-healthcare",
         "production-manager-has-healthcare-advanced-synthesis-biasca-068qc2",
-        "production-manager-has-healthcare-advanced-synthesis-lugano"
+        "production-manager-has-healthcare-advanced-synthesis-lugano",
+        "manager-de-production-has-healthcare-advanced-synthesis-biasca"
       ],
       "salaryMin": 72000,
       "salaryMax": 97000,
@@ -227,7 +231,8 @@
           "production-manager-has-healthcare-advanced-synthesis-lugano"
         ],
         "it": [
-          "production-manager-has-healthcare"
+          "production-manager-has-healthcare",
+          "manager-de-production-has-healthcare-advanced-synthesis-biasca"
         ],
         "de": [
           "production-manager-has-healthcare-advanced-synthesis-biasca-068qc2"

--- a/data/jobs/by-crawler/hilcona.json
+++ b/data/jobs/by-crawler/hilcona.json
@@ -1480,11 +1480,13 @@
       "crawledAt": "2026-05-19T11:53:04.947Z",
       "sourceLang": "de",
       "previousSlugs": [
-        "it-admin-client-management-m-w-d-hilcona-radolfzell"
+        "it-admin-client-management-m-w-d-hilcona-radolfzell",
+        "admin-client-management-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "it-admin-client-management-m-w-d-hilcona-radolfzell"
+          "it-admin-client-management-m-w-d-hilcona-radolfzell",
+          "admin-client-management-m-w-d-hugli-nahrungsmittel-gmbh-radolfzell"
         ]
       },
       "needsRetranslation": true,
@@ -2268,13 +2270,15 @@
           "bezirksleitung-im-aussendienst-food-service-m-w-d-region-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hilcona-radolfzell"
         ],
         "it": [
-          "bezirksleitung-im-aussendienst-food-service-m-w-d-region-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hugli-na"
+          "bezirksleitung-im-aussendienst-food-service-m-w-d-region-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hugli-na",
+          "department-of-food-service-m-w-d-region-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hugli-nahrungsmittel-gmbh"
         ]
       },
       "previousSlugs": [
         "bezirksleitung-im-aussendienst-food-service-m-w-d-region-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hilcona-radolfzell",
         "bezirksleitung-im-aussendienst-food-service-m-w-d-region-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hugli-na",
-        "dipartimento-di-servizio-alimentare-m-w-d-regione-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hugli-nahrungsm"
+        "dipartimento-di-servizio-alimentare-m-w-d-regione-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hugli-nahrungsm",
+        "department-of-food-service-m-w-d-region-schwarzwald-villingen-schwenningen-rottweil-tuttlingen-hugli-nahrungsmittel-gmbh"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T10:24:21.442Z",
@@ -3243,13 +3247,15 @@
           "ausbildung-zur-fachkraft-fuer-lebensmitteltechnik-m-w-d-hilcona-edewecht"
         ],
         "it": [
-          "ausbildung-zur-fachkraft-fuer-lebensmitteltechnik-m-w-d-bell-deutschland-gmbh-co-kg-edewecht"
+          "ausbildung-zur-fachkraft-fuer-lebensmitteltechnik-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
+          "ausbildung-zur-fachkraft-fuer-lebensmitteltechnik-m-w-d-bell-deutschland-gmbh-co-kg-edewec"
         ]
       },
       "previousSlugs": [
         "ausbildung-zur-fachkraft-fuer-lebensmitteltechnik-m-w-d-hilcona-edewecht",
         "ausbildung-zur-fachkraft-fuer-lebensmitteltechnik-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
-        "istruzione-lo-specialista-della-tecnologia-alimentare-m-w-d-bell-deutschland-gmbh-co-kg-edewecht"
+        "istruzione-lo-specialista-della-tecnologia-alimentare-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
+        "ausbildung-zur-fachkraft-fuer-lebensmitteltechnik-m-w-d-bell-deutschland-gmbh-co-kg-edewec"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T10:24:16.774Z",
@@ -4588,11 +4594,17 @@
       "sourceLang": "de",
       "previousSlugs": [
         "spezialist-operational-excellence-topx-lean-management-m-w-d-hilcona-undefined",
-        "specialista-eccellenza-operativa-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-harkebrugge"
+        "specialista-eccellenza-operativa-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-harkebrugge",
+        "specialist-operational-excellence-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-harkebrugge",
+        "specialist-operational-excellence-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-h",
+        "specialista-operational-excellence-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "spezialist-operational-excellence-topx-lean-management-m-w-d-hilcona-undefined"
+          "spezialist-operational-excellence-topx-lean-management-m-w-d-hilcona-undefined",
+          "specialist-operational-excellence-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-harkebrugge",
+          "specialist-operational-excellence-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-h",
+          "specialista-operational-excellence-topx-lean-management-m-w-d-bell-deutschland-gmbh-co-kg-"
         ]
       },
       "needsRetranslation": true,
@@ -5782,12 +5794,14 @@
       "sourceLang": "de",
       "previousSlugs": [
         "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hilcona-undefined",
-        "specialista-in-formazione-per-la-logistica-di-magazzino-magazziniere-specializzato-m-w-d-hugli-nahrungsmittel-gmbh"
+        "specialista-in-formazione-per-la-logistica-di-magazzino-magazziniere-specializzato-m-w-d-hugli-nahrungsmittel-gmbh",
+        "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hugli-nahrungsmittel-gmbh-ra"
       ],
       "previousSlugsByLocale": {
         "it": [
           "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hilcona-undefined",
-          "specialista-in-formazione-per-la-logistica-di-magazzino-magazziniere-specializzato-m-w-d-hugli-nahrungsmittel-gmbh"
+          "specialista-in-formazione-per-la-logistica-di-magazzino-magazziniere-specializzato-m-w-d-hugli-nahrungsmittel-gmbh",
+          "auszubildende-fachkraft-fuer-lagerlogistik-fachlagerist-m-w-d-hugli-nahrungsmittel-gmbh-ra"
         ]
       },
       "needsRetranslation": true,
@@ -6004,12 +6018,14 @@
       "previousSlugs": [
         "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-ag-bell-food-group-landquart",
         "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-sur-lausanne",
-        "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-undefined"
+        "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-undefined",
+        "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-su"
       ],
       "previousSlugsByLocale": {
         "it": [
           "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-ag-bell-food-group-landquart",
-          "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-sur-lausanne"
+          "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-sur-lausanne",
+          "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-bell-suisse-sa-cheseaux-su"
         ],
         "en": [
           "wartungstechnikerin-automatikerin-wartungstechniker-automatiker-hilcona-ag-bell-food-group-landquart",
@@ -6250,7 +6266,8 @@
         ],
         "it": [
           "fleischfachmann-fleischfachfrau-efz-2026-hilcona-ag-bell-food-group-landquart",
-          "fleischfachmann-fleischfachfrau-efz-2026-hilcona-basel"
+          "fleischfachmann-fleischfachfrau-efz-2026-hilcona-basel",
+          "fleischfachmann-fleischfachfrau-efz-2026-bell-schweiz-ag-oensingen"
         ],
         "en": [
           "fleischfachmann-fleischfachfrau-efz-2026-hilcona-ag-bell-food-group-landquart",
@@ -6264,7 +6281,8 @@
       "previousSlugs": [
         "fleischfachmann-fleischfachfrau-efz-2026-hilcona-ag-bell-food-group-landquart",
         "fleischfachmann-fleischfachfrau-efz-2026-hilcona-basel",
-        "fleischfachmann-fleischfachfrau-efz-2026-hilcona-undefined"
+        "fleischfachmann-fleischfachfrau-efz-2026-hilcona-undefined",
+        "fleischfachmann-fleischfachfrau-efz-2026-bell-schweiz-ag-oensingen"
       ],
       "firstSeenAt": "2026-04-13T10:42:41.293Z",
       "needsRetranslation": true,
@@ -7034,11 +7052,13 @@
       "crawledAt": "2026-05-19T11:52:44.246Z",
       "sourceLang": "de",
       "previousSlugs": [
-        "koch-koechin-baecker-baeckerin-o-metzger-metzgerin-hilcona-ag-bell-food-group-landquart"
+        "koch-koechin-baecker-baeckerin-o-metzger-metzgerin-hilcona-ag-bell-food-group-landquart",
+        "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-ag-schaan"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "koch-koechin-baecker-baeckerin-o-metzger-metzgerin-hilcona-ag-bell-food-group-landquart"
+          "koch-koechin-baecker-baeckerin-o-metzger-metzgerin-hilcona-ag-bell-food-group-landquart",
+          "koch-koechin-baecker-baeckerin-oder-metzger-metzgerin-hilcona-ag-schaan"
         ]
       },
       "needsRetranslation": true,
@@ -7256,7 +7276,8 @@
           "mitarbeiterin-mitarbeiter-betriebskalkulation-100-hilcona-zell"
         ],
         "it": [
-          "mitarbeiterin-collaboratore-trice-betriebskalkulation-100-hilcona-ag-bell-food-group-landquart"
+          "mitarbeiterin-collaboratore-trice-betriebskalkulation-100-hilcona-ag-bell-food-group-landquart",
+          "mitarbeiterin-betriebskalkulation-100-bell-schweiz-ag-zell"
         ],
         "en": [
           "mitarbeiterin-mitarbeiter-betriebskalkulation-100-hilcona-ag-bell-food-group-landquart"
@@ -7268,7 +7289,8 @@
       "previousSlugs": [
         "mitarbeiterin-mitarbeiter-betriebskalkulation-100-hilcona-zell",
         "mitarbeiterin-collaboratore-trice-betriebskalkulation-100-hilcona-ag-bell-food-group-landquart",
-        "mitarbeiterin-mitarbeiter-betriebskalkulation-100-hilcona-ag-bell-food-group-landquart"
+        "mitarbeiterin-mitarbeiter-betriebskalkulation-100-hilcona-ag-bell-food-group-landquart",
+        "mitarbeiterin-betriebskalkulation-100-bell-schweiz-ag-zell"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T10:23:59.677Z",
@@ -7336,7 +7358,8 @@
         ],
         "it": [
           "fleischfachassistent-fleischfachassistentin-eba-2026-hilcona-ag-bell-food-group-landquart",
-          "fleischfachassistent-fleischfachassistentin-eba-2026-hilcona-basel"
+          "fleischfachassistent-fleischfachassistentin-eba-2026-hilcona-basel",
+          "fleischfachassistent-fleischfachassistentin-eba-2026-bell-schweiz-ag-oensingen"
         ],
         "en": [
           "fleischfachassistent-fleischfachassistentin-eba-2026-hilcona-ag-bell-food-group-landquart",
@@ -7353,7 +7376,8 @@
         "fleischfachassistent-fleischfachassistentin-eba-2026-hilcona-ag-bell-food-group-landquart",
         "fleischfachassistent-fleischfachassistentin-eba-2026-hilcona-basel",
         "fleischfachassistent-fleischfachassistentin-eba-2026-hilcona-undefined",
-        "fleischfachassistent-fleischfachassistentin-eba-2026-bell-schweiz-ag-basel"
+        "fleischfachassistent-fleischfachassistentin-eba-2026-bell-schweiz-ag-basel",
+        "fleischfachassistent-fleischfachassistentin-eba-2026-bell-schweiz-ag-oensingen"
       ],
       "firstSeenAt": "2026-04-13T10:42:37.461Z",
       "salaryMin": 55500,

--- a/data/jobs/by-crawler/hitachi-energy.json
+++ b/data/jobs/by-crawler/hitachi-energy.json
@@ -972,7 +972,8 @@
       "firstSeenAt": "2026-05-18T22:09:07.624Z",
       "previousSlugsByLocale": {
         "it": [
-          "product-engineer-power-semiconductors-module-packaging-bimos-80-100-f-m-d-hitachi-energy-lenzburg-switzerland"
+          "product-engineer-power-semiconductors-module-packaging-bimos-80-100-f-m-d-hitachi-energy-lenzburg-switzerland",
+          "product-engineer-power-semiconductors-packaging-bimos-80-100-m-f-d-hitachi-energy-lenzburg-switzerland"
         ],
         "fr": [
           "product-engineer-power-semiconductors-module-packaging-bimos-80-100-f-m-d-hitachi-energy-lenzburg-switzerland"
@@ -982,7 +983,8 @@
         ]
       },
       "previousSlugs": [
-        "product-engineer-power-semiconductors-module-packaging-bimos-80-100-f-m-d-hitachi-energy-lenzburg-switzerland"
+        "product-engineer-power-semiconductors-module-packaging-bimos-80-100-f-m-d-hitachi-energy-lenzburg-switzerland",
+        "product-engineer-power-semiconductors-packaging-bimos-80-100-m-f-d-hitachi-energy-lenzburg-switzerland"
       ]
     },
     {
@@ -1045,14 +1047,16 @@
       "firstSeenAt": "2026-05-18T22:09:07.624Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-project-engineer-grid-automation-control-protection-80-100-f-m-d-hitachi-energy-baden-switzerland"
+          "senior-project-engineer-grid-automation-control-protection-80-100-f-m-d-hitachi-energy-baden-switzerland",
+          "project-engineer-grid-automation-control-protection-80-100-f-m-d-hitachi-energy-baden-switzerland"
         ],
         "de": [
           "senior-project-engineer-grid-automation-control-protection-80-100-f-m-d-hitachi-energy-baden-switzerland"
         ]
       },
       "previousSlugs": [
-        "senior-project-engineer-grid-automation-control-protection-80-100-f-m-d-hitachi-energy-baden-switzerland"
+        "senior-project-engineer-grid-automation-control-protection-80-100-f-m-d-hitachi-energy-baden-switzerland",
+        "project-engineer-grid-automation-control-protection-80-100-f-m-d-hitachi-energy-baden-switzerland"
       ]
     },
     {
@@ -1601,7 +1605,8 @@
       "firstSeenAt": "2026-05-18T22:09:07.624Z",
       "previousSlugsByLocale": {
         "it": [
-          "field-service-engineer-f-m-d-hitachi-energy-zurich-switzerland"
+          "field-service-engineer-f-m-d-hitachi-energy-zurich-switzerland",
+          "field-service-engineer-energy-power-f-m-d-hitachi-energy-zurich-switzerland"
         ],
         "de": [
           "field-service-engineer-f-m-d-hitachi-energy-zurich-switzerland"
@@ -1611,7 +1616,9 @@
         ]
       },
       "previousSlugs": [
-        "field-service-engineer-f-m-d-hitachi-energy-zurich-switzerland"
+        "field-service-engineer-f-m-d-hitachi-energy-zurich-switzerland",
+        "field-service-engineer-energy-power-f-m-d-hitachi-energy-zurich-switzerland",
+        "field-service-engineer-f-m-d-hitachi-energy-zurich-switzerland-2"
       ]
     },
     {
@@ -3653,7 +3660,8 @@
       "postalCode": "6900",
       "firstSeenAt": "2026-05-12T11:35:47.953Z",
       "previousSlugs": [
-        "assembler-80-100-w-m-d-hitachi-energy-zurich-switzerland"
+        "assembler-80-100-w-m-d-hitachi-energy-zurich-switzerland",
+        "assembler-80-100-w-m-d-hitachi-energy-zurich-switzerland-2"
       ],
       "previousSlugsByLocale": {
         "it": [
@@ -3869,7 +3877,8 @@
       },
       "previousSlugs": [
         "troubleshooting-process-quality-technician-80-100-f-m-d-hitachi-energy-zurich-switzerland",
-        "technico-qualita-processo-troubleshooting-80-100-f-m-d-hitachi-energy-zurich"
+        "technico-qualita-processo-troubleshooting-80-100-f-m-d-hitachi-energy-zurich",
+        "troubleshooting-process-quality-technician-80-100-f-m-d-hitachi-energy-zurich-switzerland-2"
       ]
     },
     {
@@ -4509,7 +4518,8 @@
       "firstSeenAt": "2026-05-12T11:35:47.953Z",
       "previousSlugsByLocale": {
         "it": [
-          "commissioning-engineer-80-100-f-m-d-hitachi-energy-zurich-switzerland"
+          "commissioning-engineer-80-100-f-m-d-hitachi-energy-zurich-switzerland",
+          "commissioning-engineer-80-100-f-m-d-hitachi-energy-baden-switzerland"
         ],
         "de": [
           "commissioning-engineer-80-100-f-m-d-hitachi-energy-zurich-switzerland"
@@ -4519,7 +4529,8 @@
         ]
       },
       "previousSlugs": [
-        "commissioning-engineer-80-100-f-m-d-hitachi-energy-zurich-switzerland"
+        "commissioning-engineer-80-100-f-m-d-hitachi-energy-zurich-switzerland",
+        "commissioning-engineer-80-100-f-m-d-hitachi-energy-baden-switzerland"
       ]
     },
     {
@@ -4803,11 +4814,15 @@
         ],
         "fr": [
           "electrical-engineer-standards-compliance-expert-for-dry-transformers-80-100-f-m-d-hitachi-energy-molinazzo-di-monteggio-switzerland"
+        ],
+        "en": [
+          "electrical-engineer-standards-compliance-expert-for-dry-transformers-80-100-f-m-d-hitachi-energy-molinazzo-di-monteggio"
         ]
       },
       "previousSlugs": [
         "electrical-engineer-standards-compliance-expert-for-dry-transformers-80-100-f-m-d-hitachi-energy-molinazzo-di-monteggio-switzerland",
-        "ingegnere-elettrico-standard-compliance-expert-per-trasformatori-a-secco-80-100-f-m-d-hitachi-energy-molinazzo-di-monteg"
+        "ingegnere-elettrico-standard-compliance-expert-per-trasformatori-a-secco-80-100-f-m-d-hitachi-energy-molinazzo-di-monteg",
+        "electrical-engineer-standards-compliance-expert-for-dry-transformers-80-100-f-m-d-hitachi-energy-molinazzo-di-monteggio"
       ]
     },
     {
@@ -4942,7 +4957,8 @@
       "postalCode": "6900",
       "firstSeenAt": "2026-05-12T11:35:47.953Z",
       "previousSlugs": [
-        "cnc-dreher-in-80-100-w-m-d-hitachi-energy-zurich-switzerland"
+        "cnc-dreher-in-80-100-w-m-d-hitachi-energy-zurich-switzerland",
+        "cnc-dreher-in-80-100-w-m-d-hitachi-energy-zurich-switzerland-2"
       ],
       "previousSlugsByLocale": {
         "it": [

--- a/data/jobs/by-crawler/hochgebirgsklinik-davos.json
+++ b/data/jobs/by-crawler/hochgebirgsklinik-davos.json
@@ -185,11 +185,13 @@
       "contactPhone": "+41 81 417 30 40",
       "previousSlugs": [
         "oberarzt-kinder-und-jugendpsychiatrie-m-w-d-50-100-hochgebirgsklinik-davos-ch",
-        "senior-physician-in-child-and-adolescent-psychiatry-m-f-d-50-100-hochgebirgsklinik-davos-davos"
+        "senior-physician-in-child-and-adolescent-psychiatry-m-f-d-50-100-hochgebirgsklinik-davos-davos",
+        "leitender-oberarzt-kinder-und-jugendpsychiatrie-m-w-d-80-100-hochgebirgsklinik-davos-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "oberarzt-kinder-und-jugendpsychiatrie-m-w-d-50-100-hochgebirgsklinik-davos-ch"
+          "oberarzt-kinder-und-jugendpsychiatrie-m-w-d-50-100-hochgebirgsklinik-davos-ch",
+          "leitender-oberarzt-kinder-und-jugendpsychiatrie-m-w-d-80-100-hochgebirgsklinik-davos-ch"
         ],
         "en": [
           "senior-physician-in-child-and-adolescent-psychiatry-m-f-d-50-100-hochgebirgsklinik-davos-davos"

--- a/data/jobs/by-crawler/hoval.json
+++ b/data/jobs/by-crawler/hoval.json
@@ -418,7 +418,21 @@
       },
       "streetAddress": "Via Pasquale Lucchini 4",
       "postalCode": "6900",
-      "firstSeenAt": "2026-05-17T10:26:05.869Z"
+      "firstSeenAt": "2026-05-17T10:26:05.869Z",
+      "previousSlugs": [
+        "tecnico-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-energy-r",
+        "tecnico-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-ticino",
+        "technician-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-ticino",
+        "tecnico-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-ticino-begew1"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "tecnico-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-energy-r",
+          "tecnico-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-ticino",
+          "technician-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-ticino",
+          "tecnico-di-servizio-per-impianti-di-riscaldamento-energie-rinnovabili-m-f-d-hoval-ticino-begew1"
+        ]
+      }
     },
     {
       "title": "Tecnico di servizio per impianti di riscaldamento olio/gas (m/f/d)",

--- a/data/jobs/by-crawler/hug.json
+++ b/data/jobs/by-crawler/hug.json
@@ -745,11 +745,13 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "chef-ou-cheffe-de-clinique-avec-ou-sans-titre-de-specialite-80-a-100-hug-collonge"
+        "chef-ou-cheffe-de-clinique-avec-ou-sans-titre-de-specialite-80-a-100-hug-collonge",
+        "chef-ou-cheffe-de-clinique-avec-ou-sans-titre-de-specialite-50-ou-100-hug-geneve"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "chef-ou-cheffe-de-clinique-avec-ou-sans-titre-de-specialite-80-a-100-hug-collonge"
+          "chef-ou-cheffe-de-clinique-avec-ou-sans-titre-de-specialite-80-a-100-hug-collonge",
+          "chef-ou-cheffe-de-clinique-avec-ou-sans-titre-de-specialite-50-ou-100-hug-geneve"
         ],
         "en": [
           "chef-ou-cheffe-de-clinique-avec-ou-sans-titre-de-specialite-80-a-100-hug-collonge"

--- a/data/jobs/by-crawler/interdiscount.json
+++ b/data/jobs/by-crawler/interdiscount.json
@@ -74,11 +74,13 @@
         ]
       },
       "previousSlugs": [
-        "gestionnaire-du-commerce-de-detail-interdiscount-sion"
+        "gestionnaire-du-commerce-de-detail-interdiscount-sion",
+        "gestionnaire-du-commerce-de-detail-interdiscount-collombey"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "gestionnaire-du-commerce-de-detail-interdiscount-sion"
+          "gestionnaire-du-commerce-de-detail-interdiscount-sion",
+          "gestionnaire-du-commerce-de-detail-interdiscount-collombey"
         ]
       },
       "firstSeenAt": "2026-04-13T10:46:25.929Z",

--- a/data/jobs/by-crawler/jysk.json
+++ b/data/jobs/by-crawler/jysk.json
@@ -55,7 +55,9 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "apprendista-impiegato-a-del-commercio-al-dettaglio-cfc-a-in-der-filiale-schattdorf-jysk-schattdorf-qrsmyr"
+          "apprendista-impiegato-a-del-commercio-al-dettaglio-cfc-a-in-der-filiale-schattdorf-jysk-schattdorf-qrsmyr",
+          "lernende-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf",
+          "lernende-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf-esp7om"
         ],
         "en": [
           "apprentice-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf-qrsmyr"
@@ -67,7 +69,9 @@
       "previousSlugs": [
         "apprendista-impiegato-a-del-commercio-al-dettaglio-cfc-a-in-der-filiale-schattdorf-jysk-schattdorf-qrsmyr",
         "apprentice-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf-qrsmyr",
-        "apprenti-e-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf-qrsmyr"
+        "apprenti-e-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf-qrsmyr",
+        "lernende-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf",
+        "lernende-detailhandelsfachfrau-mann-efz-a-in-der-filiale-schattdorf-jysk-schattdorf-esp7om"
       ],
       "salaryMin": 41600,
       "salaryMax": 63000
@@ -311,13 +315,15 @@
         "it": [
           "store-manager-trainee-a-80-100-fur-die-region-baden-jysk-baden",
           "store-manager-apprendista-a-80-100-per-la-region-baden-jysk-baden-dyd3i9",
-          "store-manager-trainee-a-80-100-per-la-regione-del-baden-jysk-baden"
+          "store-manager-trainee-a-80-100-per-la-regione-del-baden-jysk-baden",
+          "store-manager-trainee-a-100-fur-die-region-schwyz-jysk-seewen-schwyz"
         ]
       },
       "previousSlugs": [
         "store-manager-trainee-a-80-100-fur-die-region-baden-jysk-baden",
         "store-manager-apprendista-a-80-100-per-la-region-baden-jysk-baden-dyd3i9",
-        "store-manager-trainee-a-80-100-per-la-regione-del-baden-jysk-baden"
+        "store-manager-trainee-a-80-100-per-la-regione-del-baden-jysk-baden",
+        "store-manager-trainee-a-100-fur-die-region-schwyz-jysk-seewen-schwyz"
       ],
       "salaryMin": 41600,
       "salaryMax": 63000,

--- a/data/jobs/by-crawler/kantonsspital-graubuenden-ksgr.json
+++ b/data/jobs/by-crawler/kantonsspital-graubuenden-ksgr.json
@@ -1434,11 +1434,13 @@
       "previousSlugs": [
         "berufslehre-kochin-koch-kantonsspital-graubunden-chur",
         "cuoco-dietetico-cuoco-dietetico-kantonsspital-graubunden-chur",
-        "diet-chef-kantonsspital-graubunden-chur"
+        "diet-chef-kantonsspital-graubunden-chur",
+        "berufslehre-kochin-koch-kantonsspital-graubunden-chur-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "berufslehre-kochin-koch-kantonsspital-graubunden-chur"
+          "berufslehre-kochin-koch-kantonsspital-graubunden-chur",
+          "berufslehre-kochin-koch-kantonsspital-graubunden-chur-2"
         ]
       },
       "needsRetranslation": false,
@@ -6556,11 +6558,13 @@
       },
       "featured": false,
       "previousSlugs": [
-        "assistenzarztin-assistenzarzt-radio-onkologie-kantonsspital-graubunden-chur"
+        "assistenzarztin-assistenzarzt-radio-onkologie-kantonsspital-graubunden-chur",
+        "assistenzarztin-assistenzarzt-onkologie-kantonsspital-graubunden-chur"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "assistenzarztin-assistenzarzt-radio-onkologie-kantonsspital-graubunden-chur"
+          "assistenzarztin-assistenzarzt-radio-onkologie-kantonsspital-graubunden-chur",
+          "assistenzarztin-assistenzarzt-onkologie-kantonsspital-graubunden-chur"
         ]
       },
       "needsRetranslation": false,

--- a/data/jobs/by-crawler/kssg.json
+++ b/data/jobs/by-crawler/kssg.json
@@ -267,12 +267,32 @@
       "requirementsByLocale": {},
       "previousSlugs": [
         "dipl-pflegefachfrau-mann-40-100-kssg-ch",
-        "infermiere-a-diplomato-a-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+        "infermiere-a-diplomato-a-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-xmqepb",
+        "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-xmr2fj",
+        "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-l6z5hi",
+        "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-ka6ysp",
+        "dipl-pflegefachfrau-mann-60-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "dipl-pflegefachfrau-mann-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-ky5iky",
+        "dipl-pflegefachfrau-mann-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-mu6a0o",
+        "dipl-pflegefachfrau-mann-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "dipl-pflegefachfrau-mann-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-7i39or",
+        "dipl-pflegefachfrau-mann-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-m9fn1c"
       ],
       "previousSlugsByLocale": {
         "it": [
           "dipl-pflegefachfrau-mann-40-100-kssg-ch",
-          "infermiere-a-diplomato-a-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+          "infermiere-a-diplomato-a-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-xmqepb",
+          "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-xmr2fj",
+          "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-l6z5hi",
+          "dipl-pflegefachfrau-mann-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-ka6ysp",
+          "dipl-pflegefachfrau-mann-60-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "dipl-pflegefachfrau-mann-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-ky5iky",
+          "dipl-pflegefachfrau-mann-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-mu6a0o",
+          "dipl-pflegefachfrau-mann-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "dipl-pflegefachfrau-mann-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-7i39or",
+          "dipl-pflegefachfrau-mann-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-m9fn1c"
         ]
       },
       "needsRetranslation": true,
@@ -553,12 +573,16 @@
       "requirementsByLocale": {},
       "previousSlugs": [
         "dipl-fachfrau-mann-operationstechnik-80-100-kssg-ch",
-        "dipl-fachfrau-mann-operationstechnik-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+        "dipl-fachfrau-mann-operationstechnik-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "dipl-fachfrau-mann-operationstechnik-30-40-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "dipl-fachfrau-mann-operationstechnik-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
       ],
       "previousSlugsByLocale": {
         "it": [
           "dipl-fachfrau-mann-operationstechnik-80-100-kssg-ch",
-          "dipl-fachfrau-mann-operationstechnik-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+          "dipl-fachfrau-mann-operationstechnik-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "dipl-fachfrau-mann-operationstechnik-30-40-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "dipl-fachfrau-mann-operationstechnik-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
         ]
       },
       "needsRetranslation": true,
@@ -626,12 +650,14 @@
       "requirementsByLocale": {},
       "previousSlugs": [
         "dipl-pflegefachfrau-mann-springerpool-50-100-kssg-ch",
-        "dipl-pflegefachfrau-mann-springerpool-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+        "dipl-pflegefachfrau-mann-springerpool-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "dipl-pflegefachfrau-mann-springerpool-20-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
       ],
       "previousSlugsByLocale": {
         "it": [
           "dipl-pflegefachfrau-mann-springerpool-50-100-kssg-ch",
-          "dipl-pflegefachfrau-mann-springerpool-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+          "dipl-pflegefachfrau-mann-springerpool-50-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "dipl-pflegefachfrau-mann-springerpool-20-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
         ]
       },
       "needsRetranslation": true,
@@ -852,12 +878,20 @@
       "requirementsByLocale": {},
       "previousSlugs": [
         "fachfrau-mann-gesundheit-80-100-kssg-ch",
-        "fachfrau-mann-gesundheit-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+        "fachfrau-mann-gesundheit-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "fachfrau-mann-gesundheit-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "fachfrau-mann-gesundheit-60-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+        "fachfrau-mann-gesundheit-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-ky5nrt",
+        "fachfrau-mann-gesundheit-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-mu6dq5"
       ],
       "previousSlugsByLocale": {
         "it": [
           "fachfrau-mann-gesundheit-80-100-kssg-ch",
-          "fachfrau-mann-gesundheit-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung"
+          "fachfrau-mann-gesundheit-80-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "fachfrau-mann-gesundheit-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "fachfrau-mann-gesundheit-60-100-kantonsspital-st-gallen-kssg-hoch-festanstellung",
+          "fachfrau-mann-gesundheit-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-ky5nrt",
+          "fachfrau-mann-gesundheit-40-100-kantonsspital-st-gallen-kssg-hoch-festanstellung-mu6dq5"
         ]
       },
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/kulm-hotel.json
+++ b/data/jobs/by-crawler/kulm-hotel.json
@@ -793,11 +793,17 @@
       "department": "Grand Hotel Kronenhof",
       "pensum": "100%",
       "previousSlugs": [
-        "commis-de-cuisine-m-w-d-kulm-hotel-st-moritz"
+        "commis-de-cuisine-m-w-d-kulm-hotel-st-moritz",
+        "commis-de-cuisine-m-f-d-kulm-hotel-st-moritz-st-moritz",
+        "commis-de-cuisine-h-f-d-kulm-hotel-st-moritz-st-moritz",
+        "commis-de-cuisine-m-w-d-kulm-hotel-st-moritz-st-moritz"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "commis-de-cuisine-m-w-d-kulm-hotel-st-moritz"
+          "commis-de-cuisine-m-w-d-kulm-hotel-st-moritz",
+          "commis-de-cuisine-m-f-d-kulm-hotel-st-moritz-st-moritz",
+          "commis-de-cuisine-h-f-d-kulm-hotel-st-moritz-st-moritz",
+          "commis-de-cuisine-m-w-d-kulm-hotel-st-moritz-st-moritz"
         ]
       },
       "firstSeenAt": "2026-04-13T22:00:28.646Z",
@@ -898,7 +904,10 @@
       "department": "Grand Hotel Kronenhof",
       "pensum": "100%",
       "previousSlugs": [
-        "chef-de-rang-m-f-d-kulm-hotel-st-moritz-st-moritz"
+        "chef-de-rang-m-f-d-kulm-hotel-st-moritz-st-moritz",
+        "chef-de-rang-m-w-d-kulm-hotel-st-moritz-st-moritz",
+        "chef-de-rang-m-w-kulm-hotel-st-moritz-st-moritz",
+        "chef-de-rang-h-f-d-kulm-hotel-st-moritz-st-moritz"
       ],
       "firstSeenAt": "2026-04-13T22:00:28.646Z",
       "needsRetranslation": true,
@@ -913,6 +922,13 @@
           "maxValue": 75000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugsByLocale": {
+        "it": [
+          "chef-de-rang-m-w-d-kulm-hotel-st-moritz-st-moritz",
+          "chef-de-rang-m-w-kulm-hotel-st-moritz-st-moritz",
+          "chef-de-rang-h-f-d-kulm-hotel-st-moritz-st-moritz"
+        ]
       }
     },
     {

--- a/data/jobs/by-crawler/la-fonte.json
+++ b/data/jobs/by-crawler/la-fonte.json
@@ -64,9 +64,15 @@
       "addressCountry": "CH",
       "firstSeenAt": "2026-05-17T10:35:50.358Z",
       "previousSlugs": [
-        "supplenti-nell-area-abitativa-a-fonte-3-e-fonte-6-fondazione-la-fonte-neggio-agno"
+        "supplenti-nell-area-abitativa-a-fonte-3-e-fonte-6-fondazione-la-fonte-neggio-agno",
+        "supplenti-nell-area-abitativa-a-fonte-3-e-fonte-6-fondazione-la-fonte-lugano"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "supplenti-nell-area-abitativa-a-fonte-3-e-fonte-6-fondazione-la-fonte-lugano"
+        ]
+      }
     },
     {
       "title": "Stagiaire",
@@ -116,12 +122,16 @@
         ],
         "en": [
           "stagiaire-fondazione-la-fonte-luganese-malcantone-v4gbss"
+        ],
+        "fr": [
+          "stagiaire-fondazione-la-fonte-luganese-malcantone"
         ]
       },
       "previousSlugs": [
         "apprendistato-fondazione-la-fonte-luganese-malcantone",
         "stagiaire-fondazione-la-fonte-luganese-malcantone-v4gbss",
-        "apprendistato-fondazione-la-fonte-lugano"
+        "apprendistato-fondazione-la-fonte-lugano",
+        "stagiaire-fondazione-la-fonte-luganese-malcantone"
       ],
       "salaryMin": 41600,
       "salaryMax": 63000,
@@ -207,11 +217,17 @@
       "firstSeenAt": "2026-05-17T10:35:50.358Z",
       "previousSlugs": [
         "apprentice-socio-assistential-worker-afc-fondazione-la-fonte-lugano-neggio",
-        "apprendisti-e-operatori-trici-socioassistenziali-afc-fondazione-la-fonte-lugano"
+        "apprendisti-e-operatori-trici-socioassistenziali-afc-fondazione-la-fonte-lugano",
+        "apprendisti-e-operatori-trici-socioassistenziali-afc-fondazione-la-fonte-lugano-neggio",
+        "apprendisti-e-operatori-trici-socioassistenziali-afc-fondazione-la-fonte-lugano-neggio-dmcchv"
       ],
       "previousSlugsByLocale": {
         "en": [
           "apprentice-socio-assistential-worker-afc-fondazione-la-fonte-lugano-neggio"
+        ],
+        "it": [
+          "apprendisti-e-operatori-trici-socioassistenziali-afc-fondazione-la-fonte-lugano-neggio",
+          "apprendisti-e-operatori-trici-socioassistenziali-afc-fondazione-la-fonte-lugano-neggio-dmcchv"
         ]
       },
       "needsRetranslation": true

--- a/data/jobs/by-crawler/laderach.json
+++ b/data/jobs/by-crawler/laderach.json
@@ -1314,11 +1314,13 @@
         "salesperson-60-hourly-chocolaterie-house-of-laderach-w-m-d-laderach-schweiz-ag-bilten",
         "verkaufer-60-im-stundenlohn-chocolaterie-house-of-laderach-w-m-d-laderach-bilten",
         "vendeur-60-a-temps-partiel-chocolaterie-house-of-laderach-w-m-d-laderach-schweiz-ag-bilten",
-        "verkaufer-60-80-im-stundenlohn-chocolaterie-house-of-laderach-w-m-d-laderach-bilten"
+        "verkaufer-60-80-im-stundenlohn-chocolaterie-house-of-laderach-w-m-d-laderach-bilten",
+        "stv-filialleiter-100-chocolaterie-house-of-laderach-bilten-w-m-d-laderach-schweiz-ag-bilte"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "stv-filialleiter-100-chocolaterie-house-of-laderach-bilten-w-m-d-laderach-bilten"
+          "stv-filialleiter-100-chocolaterie-house-of-laderach-bilten-w-m-d-laderach-bilten",
+          "stv-filialleiter-100-chocolaterie-house-of-laderach-bilten-w-m-d-laderach-schweiz-ag-bilte"
         ],
         "en": [
           "stv-filialleiter-100-chocolaterie-house-of-laderach-bilten-w-m-d-laderach-bilten"
@@ -1459,11 +1461,13 @@
       "previousSlugs": [
         "tirocinio-nel-dettaglio-efz-da-agosto-2026-h-m-d-laderach-schweiz-ag-luzern",
         "lehrstelle-im-detailhandel-efz-ab-august-2026-w-m-d-laderach-luzern",
-        "apprendistato-im-commercio-al-dettaglio-cfc-ab-august-2026-w-m-d-laderach-schweiz-ag-luzer"
+        "apprendistato-im-commercio-al-dettaglio-cfc-ab-august-2026-w-m-d-laderach-schweiz-ag-luzer",
+        "lehrstelle-im-detailhandel-efz-ab-august-2026-w-m-d-laderach-schweiz-ag-bern"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "tirocinio-nel-dettaglio-efz-da-agosto-2026-h-m-d-laderach-schweiz-ag-luzern"
+          "tirocinio-nel-dettaglio-efz-da-agosto-2026-h-m-d-laderach-schweiz-ag-luzern",
+          "lehrstelle-im-detailhandel-efz-ab-august-2026-w-m-d-laderach-schweiz-ag-bern"
         ],
         "en": [
           "tirocinio-nel-dettaglio-efz-da-agosto-2026-h-m-d-laderach-schweiz-ag-luzern"

--- a/data/jobs/by-crawler/lastminute-com.json
+++ b/data/jobs/by-crawler/lastminute-com.json
@@ -65,16 +65,22 @@
       "previousSlugsByLocale": {
         "it": [
           "global-payroll-hr-systems-manager-chiasso",
-          "global-payroll-hr-systems-manager-switzerlandteam"
+          "global-payroll-hr-systems-manager-switzerlandteam",
+          "global-payroll-hr-systems-manager-lastminute-com-chiasso"
         ],
         "fr": [
           "global-payroll-ressources-humaines-systems-manager-chiasso"
+        ],
+        "en": [
+          "global-payroll-hr-systems-manager-lastminute-com-switzerlandteam"
         ]
       },
       "previousSlugs": [
         "global-payroll-hr-systems-manager-chiasso",
         "global-payroll-hr-systems-manager-switzerlandteam",
-        "global-payroll-ressources-humaines-systems-manager-chiasso"
+        "global-payroll-ressources-humaines-systems-manager-chiasso",
+        "global-payroll-hr-systems-manager-lastminute-com-chiasso",
+        "global-payroll-hr-systems-manager-lastminute-com-switzerlandteam"
       ],
       "salaryMin": 79500,
       "salaryMax": 135000,
@@ -263,11 +269,15 @@
         ],
         "fr": [
           "software-ingenieur-etls-microservices-chiasso"
+        ],
+        "en": [
+          "software-engineer-etls-microservices-lastminute-com-chiasso"
         ]
       },
       "previousSlugs": [
         "software-engineer-etls-microservices-chiasso",
-        "software-ingenieur-etls-microservices-chiasso"
+        "software-ingenieur-etls-microservices-chiasso",
+        "software-engineer-etls-microservices-lastminute-com-chiasso"
       ],
       "salaryMin": 51500,
       "salaryMax": 88000,

--- a/data/jobs/by-crawler/lidl-svizzera.json
+++ b/data/jobs/by-crawler/lidl-svizzera.json
@@ -158,7 +158,19 @@
       "employmentType": "FULL_TIME",
       "needsRetranslation": true,
       "salaryMin": 59000,
-      "salaryMax": 90500
+      "salaryMax": 90500,
+      "previousSlugs": [
+        "361-venditore-venditrice-m-f-d-20-40-lidl-svizzera-riazzino",
+        "361-venditore-venditrice-m-f-d-20-40-lidl-svizzera-cadenazzo",
+        "361-venditore-venditrice-m-w-d-20-40-lidl-svizzera-riazzino-xsgkjj"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "361-venditore-venditrice-m-f-d-20-40-lidl-svizzera-riazzino",
+          "361-venditore-venditrice-m-f-d-20-40-lidl-svizzera-cadenazzo",
+          "361-venditore-venditrice-m-w-d-20-40-lidl-svizzera-riazzino-xsgkjj"
+        ]
+      }
     },
     {
       "id": "company-alqha9",
@@ -225,11 +237,15 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "verkaufer-verkauferin-m-w-d-20-40-lidl-svizzera-st-moritz-alqha9",
-        "vendita-m-w-d-lidl-svizzera-st-moritz"
+        "vendita-m-w-d-lidl-svizzera-st-moritz",
+        "verkaufer-verkauferin-m-w-d-20-40-lidl-svizzera-st-moritz"
       ],
       "previousSlugsByLocale": {
         "it": [
           "verkaufer-verkauferin-m-w-d-20-40-lidl-svizzera-st-moritz-alqha9"
+        ],
+        "de": [
+          "verkaufer-verkauferin-m-w-d-20-40-lidl-svizzera-st-moritz"
         ]
       },
       "retranslationAttempts": 1,
@@ -301,11 +317,17 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-st-moritz-jb4io9",
-        "consulente-senior-m-w-d-80-100-lidl-svizzera-st-moritz"
+        "consulente-senior-m-w-d-80-100-lidl-svizzera-st-moritz",
+        "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-st-moritz-jc631q",
+        "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-cadenazzo",
+        "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-bioggio"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-st-moritz-jb4io9"
+          "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-st-moritz-jb4io9",
+          "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-st-moritz-jc631q",
+          "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-cadenazzo",
+          "filialleiter-filialleiterin-m-w-d-80-100-lidl-svizzera-bioggio"
         ]
       },
       "retranslationAttempts": 1,
@@ -376,10 +398,40 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo",
-        "erlernt-im-einzelhandel-cfp-oder-afc-start-2026-gravesano-lidl-svizzera-gravesano"
+        "erlernt-im-einzelhandel-cfp-oder-afc-start-2026-gravesano-lidl-svizzera-gravesano",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-bioggio",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-gravesano",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-gravesano-1zdp8x",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-gravesano",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-gravesano-2",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-gravesano-3",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-zdpsyo",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-1zdp8x",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-ethzl9",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-kp8dxh",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-3t5gz5",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-kscbfg",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-tyv50x"
       ],
       "salaryMin": 41600,
-      "salaryMax": 63000
+      "salaryMax": 63000,
+      "previousSlugsByLocale": {
+        "it": [
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-bioggio",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-gravesano",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-gravesano-1zdp8x",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-gravesano",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-gravesano-2",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-gravesano-3",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-zdpsyo",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-1zdp8x",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-ethzl9",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-kp8dxh",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-3t5gz5",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-kscbfg",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadena-tyv50x"
+        ]
+      }
     },
     {
       "id": "company-7p9uz6",
@@ -446,7 +498,11 @@
       "previousSlugsByLocale": {
         "it": [
           "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-locarno-7p9uz6",
-          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-cadenazzo-lidl-svizzera-cadenazzo"
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-cadenazzo-lidl-svizzera-cadenazzo",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-locarno-kscbfg",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-locarno",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-locarno-2",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-locarno-3"
         ],
         "en": [
           "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-locarno-7p9uz6"
@@ -461,7 +517,11 @@
       "previousSlugs": [
         "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-locarno-7p9uz6",
         "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-cadenazzo-lidl-svizzera-cadenazzo",
-        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-locarno"
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-locarno",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-locarno-kscbfg",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-locarno",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-locarno-2",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-locarno-3"
       ],
       "salaryMin": 41600,
       "salaryMax": 63000
@@ -561,6 +621,10 @@
         "fr": [
           "apprentissage-en-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-minusio",
           "stage-de-vente-debut-2026-lidl-svizzera-minusio"
+        ],
+        "it": [
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-minusio-2",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-minusio-3"
         ]
       },
       "previousSlugs": [
@@ -579,7 +643,9 @@
         "retail-trade-apprenticeship-cfp-or-afc-start-2026-lidl-svizzera-minusio",
         "einzelhandelslehre-cfp-oder-afc-beginn-2026-lidl-svizzera-minusio",
         "retail-apprentice-cfp-or-afc-starting-2026-lidl-svizzera-minusio",
-        "apprentissage-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-minusio"
+        "apprentissage-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-minusio",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-minusio-2",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-minusio-3"
       ],
       "firstSeenAt": "2026-04-12T09:43:42.513Z",
       "qualityScore": 97,
@@ -683,6 +749,10 @@
         "en": [
           "apprenticeship-in-retail-trade-cfp-or-afc-start-2026-lidl-svizzera-biasca",
           "retail-apprenticeship-vet-or-federal-vet-diploma-starting-2026-lidl-svizzera-biasca"
+        ],
+        "it": [
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-biasca-2",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-biasca-3"
         ]
       },
       "previousSlugs": [
@@ -694,7 +764,9 @@
         "retail-apprenticeship-cfp-or-afc-start-2026-lidl-svizzera-biasca",
         "retail-apprenticeship-cfp-or-afc-starting-2026-lidl-svizzera-biasca",
         "apprenticeship-in-retail-cfp-or-afc-start-2026-lidl-svizzera-biasca",
-        "apprentissage-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-biasca"
+        "apprentissage-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-biasca",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-biasca-2",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-biasca-3"
       ],
       "firstSeenAt": "2026-04-12T09:43:42.513Z",
       "qualityScore": 97,
@@ -802,11 +874,17 @@
         "retail-trade-apprenticeship-cfp-or-afc-starting-2026-lidl-svizzera-arbedo-castione",
         "einzelhandelslehre-cfp-oder-afc-start-2026-lidl-svizzera-arbedo-castione",
         "retail-apprentice-cfp-or-afc-start-2026-lidl-svizzera-arbedo-castione",
-        "apprenti-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-arbedo-castione"
+        "apprenti-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-arbedo-castione",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-arbedo-castione-2",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-arbedo-castione-3"
       ],
       "previousSlugsByLocale": {
         "de": [
           "einsteigerlehre-im-einzelhandel-cfp-oder-afc-start-2026-lidl-svizzera-arbedo-castione"
+        ],
+        "it": [
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-arbedo-castione-2",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-arbedo-castione-3"
         ]
       },
       "needsRetranslation": true,
@@ -906,6 +984,10 @@
         "de": [
           "lehre-im-einzelhandel-cfp-oder-efz-beginn-2026-lidl-svizzera-lugano",
           "einsteigerlehre-im-einzelhandel-cfp-oder-afc-start-2026-lidl-svizzera-lugano"
+        ],
+        "it": [
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-lugano-2",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-lugano-3"
         ]
       },
       "previousSlugs": [
@@ -922,7 +1004,9 @@
         "einzelhandelslehre-cfp-oder-afc-beginn-2026-lidl-svizzera-lugano",
         "retail-apprentice-cfp-or-afc-starting-2026-lidl-svizzera-lugano",
         "apprenti-e-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-lugano",
-        "apprenticeship-in-retail-trade-cfp-or-efz-start-of-2026-lidl-svizzera-lugano"
+        "apprenticeship-in-retail-trade-cfp-or-efz-start-of-2026-lidl-svizzera-lugano",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-lugano-2",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-lugano-3"
       ],
       "firstSeenAt": "2026-04-12T09:43:42.513Z",
       "qualityScore": 97,
@@ -1029,6 +1113,10 @@
         ],
         "fr": [
           "stage-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-sant-antonino"
+        ],
+        "it": [
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-sant-antonino-2",
+          "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-sant-antonino-3"
         ]
       },
       "previousSlugs": [
@@ -1048,7 +1136,9 @@
         "retail-trade-apprenticeship-cfp-or-afc-start-2026-lidl-svizzera-sant-antonino",
         "einzelhandelslehre-cfp-oder-afc-start-2026-lidl-svizzera-sant-antonino",
         "retail-apprentice-cfp-or-afc-start-2026-lidl-svizzera-sant-antonino",
-        "apprenti-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-sant-antonino"
+        "apprenti-dans-le-commerce-de-detail-cfp-ou-afc-debut-2026-lidl-svizzera-sant-antonino",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-sant-antonino-2",
+        "apprendistato-nel-commercio-al-dettaglio-cfp-o-afc-inizio-2026-lidl-svizzera-cadenazzo-sant-antonino-3"
       ],
       "firstSeenAt": "2026-04-12T09:43:42.513Z",
       "qualityScore": 97,

--- a/data/jobs/by-crawler/lis-lugano-istituti-sociali.json
+++ b/data/jobs/by-crawler/lis-lugano-istituti-sociali.json
@@ -47,7 +47,8 @@
       "previousSlugs": [
         "capireparto",
         "capireparto-lis-lugano-istituti-sociali-pregassona-845mpk",
-        "capo-reparto-lis-lugano-istituti-sociali-pregassona"
+        "capo-reparto-lis-lugano-istituti-sociali-pregassona",
+        "capireparto-lis-lugano-istituti-sociali-lugano"
       ],
       "sourceLang": "it",
       "currency": "CHF",
@@ -71,7 +72,8 @@
       "id": "lis-lugano-istituti-sociali-141ef52d04c5",
       "previousSlugsByLocale": {
         "it": [
-          "capireparto"
+          "capireparto",
+          "capireparto-lis-lugano-istituti-sociali-lugano"
         ],
         "en": [
           "capireparto-lis-lugano-istituti-sociali-pregassona-845mpk"
@@ -131,7 +133,8 @@
       "requirementsByLocale": {},
       "previousSlugs": [
         "infermieri",
-        "infermieri-lis-lugano-istituti-sociali-pregassona-isfspc"
+        "infermieri-lis-lugano-istituti-sociali-pregassona-isfspc",
+        "infermieri-lis-lugano-istituti-sociali-lugano"
       ],
       "sourceLang": "it",
       "currency": "CHF",
@@ -155,7 +158,8 @@
       "id": "lis-lugano-istituti-sociali-f650fe01210f",
       "previousSlugsByLocale": {
         "it": [
-          "infermieri"
+          "infermieri",
+          "infermieri-lis-lugano-istituti-sociali-lugano"
         ],
         "en": [
           "infermieri-lis-lugano-istituti-sociali-pregassona-isfspc"
@@ -333,12 +337,18 @@
         ],
         "fr": [
           "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona-d2blfr"
+        ],
+        "it": [
+          "assistenti-di-cura-lis-lugano-istituti-sociali-lugano",
+          "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona"
         ]
       },
       "previousSlugs": [
         "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona-d2blfr",
         "assistente-di-cura-lis-lugano-istituti-sociali-pregassona",
-        "assistente-di-cura-lis-lugano-istituti-sociali-pregassona"
+        "assistente-di-cura-lis-lugano-istituti-sociali-pregassona",
+        "assistenti-di-cura-lis-lugano-istituti-sociali-lugano",
+        "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona"
       ],
       "needsRetranslation": true
     },
@@ -1102,7 +1112,8 @@
       "requirementsByLocale": {},
       "previousSlugs": [
         "cuochi",
-        "cuochi-lis-lugano-istituti-sociali-pregassona-3l2ilu"
+        "cuochi-lis-lugano-istituti-sociali-pregassona-3l2ilu",
+        "cuochi-lis-lugano-istituti-sociali-lugano"
       ],
       "sourceLang": "it",
       "currency": "CHF",
@@ -1126,7 +1137,8 @@
       "id": "lis-lugano-istituti-sociali-8b7fd953ec8f",
       "previousSlugsByLocale": {
         "it": [
-          "cuochi"
+          "cuochi",
+          "cuochi-lis-lugano-istituti-sociali-lugano"
         ],
         "en": [
           "cuochi-lis-lugano-istituti-sociali-pregassona-3l2ilu"
@@ -1210,7 +1222,15 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "firstSeenAt": "2026-05-14T22:20:25.346Z"
+      "firstSeenAt": "2026-05-14T22:20:25.346Z",
+      "previousSlugs": [
+        "addetti-servizi-alla-casa-lis-lugano-istituti-sociali-pregassona"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "addetti-servizi-alla-casa-lis-lugano-istituti-sociali-pregassona"
+        ]
+      }
     }
   ]
 }

--- a/data/jobs/by-crawler/localsearch.json
+++ b/data/jobs/by-crawler/localsearch.json
@@ -80,11 +80,13 @@
         ]
       },
       "previousSlugs": [
-        "verkauferin-verkaufer-im-aussendienst-localsearch-ch"
+        "verkauferin-verkaufer-im-aussendienst-localsearch-ch",
+        "verkauferin-verkaufer-im-aussendienst-localsearch-ch-6"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "verkauferin-verkaufer-im-aussendienst-localsearch-ch"
+          "verkauferin-verkaufer-im-aussendienst-localsearch-ch",
+          "verkauferin-verkaufer-im-aussendienst-localsearch-ch-6"
         ]
       },
       "firstSeenAt": "2026-04-13T10:55:19.132Z",
@@ -1872,11 +1874,13 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "customer-success-manager-de-80-100-localsearch-ch"
+        "customer-success-manager-de-80-100-localsearch-ch",
+        "customer-success-manager-fr-80-100-localsearch-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "customer-success-manager-de-80-100-localsearch-ch"
+          "customer-success-manager-de-80-100-localsearch-ch",
+          "customer-success-manager-fr-80-100-localsearch-ch"
         ],
         "fr": [
           "customer-success-manager-de-80-100-localsearch-ch"
@@ -2295,12 +2299,18 @@
         ],
         "it": [
           "verkaufsberater-in-aussendienst-localsearch-ch",
-          "verkaufsberater-in-aussendienst-localsearch-aargau-schweiz"
+          "verkaufsberater-in-aussendienst-localsearch-aargau-schweiz",
+          "verkaufsberater-aussendienst-localsearch-ch",
+          "verkaufsberater-aussendienst-localsearch-ch-2",
+          "verkaufsberater-in-aussendienst-localsearch-ch-4"
         ]
       },
       "previousSlugs": [
         "verkaufsberater-in-aussendienst-localsearch-ch",
-        "verkaufsberater-in-aussendienst-localsearch-aargau-schweiz"
+        "verkaufsberater-in-aussendienst-localsearch-aargau-schweiz",
+        "verkaufsberater-aussendienst-localsearch-ch",
+        "verkaufsberater-aussendienst-localsearch-ch-2",
+        "verkaufsberater-in-aussendienst-localsearch-ch-4"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T10:38:20.626Z",
@@ -2446,7 +2456,8 @@
         ],
         "it": [
           "verkaufsberater-in-aussendienst-localsearch-ch-3",
-          "verkaufsberater-in-aussendienst-localsearch-zurich"
+          "verkaufsberater-in-aussendienst-localsearch-zurich",
+          "verkaufsberater-aussendienst-localsearch-zurich"
         ],
         "en": [
           "verkaufsberater-in-aussendienst-localsearch-zurich"
@@ -2458,7 +2469,8 @@
       "previousSlugs": [
         "verkaufsberater-in-aussendienst-localsearch-ch",
         "verkaufsberater-in-aussendienst-localsearch-zurich",
-        "verkaufsberater-in-aussendienst-localsearch-ch-3"
+        "verkaufsberater-in-aussendienst-localsearch-ch-3",
+        "verkaufsberater-aussendienst-localsearch-zurich"
       ],
       "firstSeenAt": "2026-05-13T11:26:58.141Z",
       "salaryMin": 49500,
@@ -2527,13 +2539,15 @@
         ],
         "it": [
           "verkaufsberater-in-aussendienst-localsearch-ch-3",
-          "verkaufsberater-in-aussendienst-localsearch-graubunden-schweiz"
+          "verkaufsberater-in-aussendienst-localsearch-graubunden-schweiz",
+          "verkaufsberater-aussendienst-localsearch-graubunden-schweiz"
         ]
       },
       "previousSlugs": [
         "verkaufsberater-in-aussendienst-localsearch-ch",
         "verkaufsberater-in-aussendienst-localsearch-graubunden-schweiz",
-        "verkaufsberater-in-aussendienst-localsearch-ch-3"
+        "verkaufsberater-in-aussendienst-localsearch-ch-3",
+        "verkaufsberater-aussendienst-localsearch-graubunden-schweiz"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T10:38:18.107Z",

--- a/data/jobs/by-crawler/lombardi-group.json
+++ b/data/jobs/by-crawler/lombardi-group.json
@@ -388,7 +388,8 @@
         "afc-auszubildender-zum-bauzeichner-m-w-d-lombardi-group-giubiasco",
         "auszubildender-zeichner-bauingenieur-efz-m-f-x-lombardi-group-giubiasco",
         "afc-civil-engineering-draftsman-apprentice-m-f-x-lombardi-group-giubiasco",
-        "apprenti-dessinateur-genie-civil-afc-h-f-x-lombardi-group-giubiasco"
+        "apprenti-dessinateur-genie-civil-afc-h-f-x-lombardi-group-giubiasco",
+        "apprendista-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco-22qcpn"
       ],
       "id": "lombardi-group-b3c25fb3c165",
       "previousSlugsByLocale": {
@@ -396,7 +397,8 @@
           "lernende-r-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco-22qcpn",
           "apprentice-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco-22qcpn",
           "lernende-r-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco",
-          "apprenti-e-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco-22qcpn"
+          "apprenti-e-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco-22qcpn",
+          "apprendista-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco-22qcpn"
         ],
         "en": [
           "lernende-r-disegnatore-ingegneria-civile-afc-m-f-x-lombardi-group-giubiasco-22qcpn",

--- a/data/jobs/by-crawler/lonza.json
+++ b/data/jobs/by-crawler/lonza.json
@@ -62,6 +62,14 @@
           "maxValue": 75000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "lab-equipment-expert-in-quality-control-m-f-d-80-100-lonza-ch"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "lab-equipment-expert-in-quality-control-m-f-d-80-100-lonza-ch"
+        ]
       }
     },
     {
@@ -660,11 +668,13 @@
       "crawledAt": "2026-05-19T12:11:22.124Z",
       "jobReqId": "R73688",
       "previousSlugs": [
-        "biotecnologo-m-f-d-lonza-ch"
+        "biotecnologo-m-f-d-lonza-ch",
+        "biotechnologist-f-m-d-lonza-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "biotecnologo-m-f-d-lonza-ch"
+          "biotecnologo-m-f-d-lonza-ch",
+          "biotechnologist-f-m-d-lonza-ch"
         ]
       },
       "needsRetranslation": true,
@@ -1000,11 +1010,13 @@
       "crawledAt": "2026-05-19T12:11:18.502Z",
       "jobReqId": "R75236",
       "previousSlugs": [
-        "istruttore-bioconjugates-f-m-d-lonza-ch"
+        "istruttore-bioconjugates-f-m-d-lonza-ch",
+        "bioconjugates-ausbildner-w-m-d-lonza"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "istruttore-bioconjugates-f-m-d-lonza-ch"
+          "istruttore-bioconjugates-f-m-d-lonza-ch",
+          "bioconjugates-ausbildner-w-m-d-lonza"
         ]
       },
       "needsRetranslation": true,
@@ -1072,12 +1084,14 @@
       "previousSlugs": [
         "praktikant-m-w-d-im-sustainability-team-visp-80-100-lonza-ch",
         "corso-di-laurea-triennale-integrato-nella-pratica-pibs-stage-nel-sustainability-team-40-100-m-f-d-lonza-ch",
-        "praxisintegriertes-bachelorstudium-pibs-praktikum-im-sustainability-team-visp-80-100-m-w-d-lonza-ch"
+        "praxisintegriertes-bachelorstudium-pibs-praktikum-im-sustainability-team-visp-80-100-m-w-d-lonza-ch",
+        "praxisintegriertes-bachelorstudium-pibs-praktikum-im-sustainability-team-visp-40-60-m-w-d-lonza-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
           "praktikant-m-w-d-im-sustainability-team-visp-80-100-lonza-ch",
-          "corso-di-laurea-triennale-integrato-nella-pratica-pibs-stage-nel-sustainability-team-40-100-m-f-d-lonza-ch"
+          "corso-di-laurea-triennale-integrato-nella-pratica-pibs-stage-nel-sustainability-team-40-100-m-f-d-lonza-ch",
+          "praxisintegriertes-bachelorstudium-pibs-praktikum-im-sustainability-team-visp-40-60-m-w-d-lonza-ch"
         ]
       },
       "needsRetranslation": true,
@@ -1231,6 +1245,16 @@
           "maxValue": 75000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "laboratory-analista-laborant-m-f-d-quality-control-4-schichtbetrieb-lonza-ch",
+        "laboratory-analyst-laborant-m-f-d-quality-control-4-schichtbetrieb-lonza"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "laboratory-analista-laborant-m-f-d-quality-control-4-schichtbetrieb-lonza-ch",
+          "laboratory-analyst-laborant-m-f-d-quality-control-4-schichtbetrieb-lonza"
+        ]
       }
     },
     {
@@ -2181,11 +2205,17 @@
       "crawledAt": "2026-05-19T12:11:06.453Z",
       "jobReqId": "R76397",
       "previousSlugs": [
-        "elektroinstallateur-efz-80-100-m-w-d-lonza-ch"
+        "elektroinstallateur-efz-80-100-m-w-d-lonza-ch",
+        "elektroinstallateur-efz-80-100-m-w-d-lonza",
+        "elektroinstallateur-efz-automatiker-efz-80-100-m-w-d-lonza-ch",
+        "elektroinstallateur-automatiker-efz-80-100-m-w-d-lonza-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "elektroinstallateur-efz-80-100-m-w-d-lonza-ch"
+          "elektroinstallateur-efz-80-100-m-w-d-lonza-ch",
+          "elektroinstallateur-efz-80-100-m-w-d-lonza",
+          "elektroinstallateur-efz-automatiker-efz-80-100-m-w-d-lonza-ch",
+          "elektroinstallateur-automatiker-efz-80-100-m-w-d-lonza-ch"
         ]
       },
       "needsRetranslation": true,
@@ -2448,11 +2478,13 @@
       "crawledAt": "2026-05-19T12:11:03.718Z",
       "jobReqId": "R69882",
       "previousSlugs": [
-        "berufslehre-chemie-und-pharmatechnologe-in-efz-per-01-august-2026-m-f-d-lonza-ch"
+        "berufslehre-chemie-und-pharmatechnologe-in-efz-per-01-august-2026-m-f-d-lonza-ch",
+        "berufslehre-chemie-und-pharmatechnologe-in-efz-per-01-august-2026-m-f-d-lonza"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "berufslehre-chemie-und-pharmatechnologe-in-efz-per-01-august-2026-m-f-d-lonza-ch"
+          "berufslehre-chemie-und-pharmatechnologe-in-efz-per-01-august-2026-m-f-d-lonza-ch",
+          "berufslehre-chemie-und-pharmatechnologe-in-efz-per-01-august-2026-m-f-d-lonza"
         ]
       },
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/lwphr.json
+++ b/data/jobs/by-crawler/lwphr.json
@@ -295,7 +295,8 @@
           "full-stack-developer-lwp-ledermann-wieting-partners-lugano",
           "full-stack-sviluppatore-lwp-ledermann-wieting-partners-lugano",
           "consulente-vendita-lwp-ledermann-wieting-partners-mendrisio",
-          "web-developer-lwp-ledermann-wieting-partners-lugano"
+          "web-developer-lwp-ledermann-wieting-partners-lugano",
+          "a-paralegal-o-legal-segretary-lwp-ledermann-wieting-partners-lugano"
         ],
         "en": [
           "full-stack-developer-lwp-ledermann-wieting-partners-lugano"
@@ -315,7 +316,8 @@
         "web-developer-lwp-ledermann-wieting-partners-lugano",
         "full-stack-entwickler-lwp-ledermann-wieting-partners-lugano",
         "consulente-verkauf-lwp-ledermann-wieting-partners-mendrisio",
-        "full-stack-developpeur-lwp-ledermann-wieting-partners-lugano"
+        "full-stack-developpeur-lwp-ledermann-wieting-partners-lugano",
+        "a-paralegal-o-legal-segretary-lwp-ledermann-wieting-partners-lugano"
       ],
       "firstSeenAt": "2026-04-13T22:04:42.089Z",
       "salaryMin": 51500,
@@ -633,7 +635,8 @@
           "full-stack-developer-lwp-ledermann-wieting-partners-lugano",
           "full-stack-sviluppatore-lwp-ledermann-wieting-partners-lugano",
           "consulente-vendita-lwp-ledermann-wieting-partners-mendrisio",
-          "web-developer-lwp-ledermann-wieting-partners-lugano"
+          "web-developer-lwp-ledermann-wieting-partners-lugano",
+          "senior-private-banker-lwp-ledermann-wieting-partners-lugano-6k80fn"
         ],
         "en": [
           "full-stack-developer-lwp-ledermann-wieting-partners-lugano"
@@ -649,7 +652,8 @@
         "consulente-vendita-lwp-ledermann-wieting-partners-mendrisio",
         "web-developer-lwp-ledermann-wieting-partners-lugano",
         "full-stack-entwickler-lwp-ledermann-wieting-partners-lugano",
-        "consulente-verkauf-lwp-ledermann-wieting-partners-mendrisio"
+        "consulente-verkauf-lwp-ledermann-wieting-partners-mendrisio",
+        "senior-private-banker-lwp-ledermann-wieting-partners-lugano-6k80fn"
       ],
       "firstSeenAt": "2026-04-13T22:04:42.089Z",
       "salaryMin": 79500,

--- a/data/jobs/by-crawler/manor.json
+++ b/data/jobs/by-crawler/manor.json
@@ -56,7 +56,15 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "firstSeenAt": "2026-04-13T22:05:21.455Z"
+      "firstSeenAt": "2026-04-13T22:05:21.455Z",
+      "previousSlugs": [
+        "apprendista-polydesigner-3d-afc-100-manor-ag-lugano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "apprendista-polydesigner-3d-afc-100-manor-ag-lugano"
+        ]
+      }
     },
     {
       "title": "Polydesigner 3D AFC 100%",
@@ -112,7 +120,27 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "firstSeenAt": "2026-04-13T22:05:21.455Z"
+      "firstSeenAt": "2026-04-13T22:05:21.455Z",
+      "previousSlugs": [
+        "polydesigner-3d-afc-100-manor-ag-lugano",
+        "3d-polydesigner-apprentice-afc-100-manor-ag-lugano",
+        "3d-polydesigner-lehrling-afc-100-manor-ag-lugano",
+        "apprenti-polydesigner-3d-afc-100-manor-ag-lugano",
+        "apprentice-polydesigner-3d-afc-100-manor-ag-lugano",
+        "lernende-r-polydesigner-3d-afc-100-manor-ag-lugano",
+        "3d-polydesigner-afc-100-manor-ag-lugano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "polydesigner-3d-afc-100-manor-ag-lugano",
+          "3d-polydesigner-apprentice-afc-100-manor-ag-lugano",
+          "3d-polydesigner-lehrling-afc-100-manor-ag-lugano",
+          "apprenti-polydesigner-3d-afc-100-manor-ag-lugano",
+          "apprentice-polydesigner-3d-afc-100-manor-ag-lugano",
+          "lernende-r-polydesigner-3d-afc-100-manor-ag-lugano",
+          "3d-polydesigner-afc-100-manor-ag-lugano"
+        ]
+      }
     }
   ]
 }

--- a/data/jobs/by-crawler/marriott.json
+++ b/data/jobs/by-crawler/marriott.json
@@ -3643,11 +3643,13 @@
         "publishEndDate": ""
       },
       "previousSlugs": [
-        "chef-de-partie-patisserie-marriott-geneva"
+        "chef-de-partie-patisserie-marriott-geneva",
+        "chef-de-partie-patisserie-marriott-international-zurich"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "chef-de-partie-patisserie-marriott-geneva"
+          "chef-de-partie-patisserie-marriott-geneva",
+          "chef-de-partie-patisserie-marriott-international-zurich"
         ],
         "de": [
           "chef-de-partie-patisserie-marriott-geneva"

--- a/data/jobs/by-crawler/matterhorn-gotthard-bahn.json
+++ b/data/jobs/by-crawler/matterhorn-gotthard-bahn.json
@@ -470,11 +470,13 @@
         "hiringOrganization": "Matterhorn Gotthard Bahn"
       },
       "previousSlugs": [
-        "quereinsteiger-rangierer-rangierlokfuhrer-m-w-d-80-100-matterhorn-gotthard-bahn-ch"
+        "quereinsteiger-rangierer-rangierlokfuhrer-m-w-d-80-100-matterhorn-gotthard-bahn-ch",
+        "rangierer-rangierlokfuhrer-m-w-d-80-100-matterhorn-gotthard-bahn-andermatt"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "quereinsteiger-rangierer-rangierlokfuhrer-m-w-d-80-100-matterhorn-gotthard-bahn-ch"
+          "quereinsteiger-rangierer-rangierlokfuhrer-m-w-d-80-100-matterhorn-gotthard-bahn-ch",
+          "rangierer-rangierlokfuhrer-m-w-d-80-100-matterhorn-gotthard-bahn-andermatt"
         ],
         "en": [
           "quereinsteiger-rangierer-rangierlokfuhrer-m-w-d-80-100-matterhorn-gotthard-bahn-ch"

--- a/data/jobs/by-crawler/medacta-international.json
+++ b/data/jobs/by-crawler/medacta-international.json
@@ -254,11 +254,13 @@
       "needsRetranslation": true,
       "previousSlugsByLocale": {
         "it": [
-          "r-d-project-engineer-hip-medacta-rancate"
+          "r-d-project-engineer-hip-medacta-rancate",
+          "r-d-project-engineer-hip-medacta-international-sa-rancate"
         ]
       },
       "previousSlugs": [
-        "r-d-project-engineer-hip-medacta-rancate"
+        "r-d-project-engineer-hip-medacta-rancate",
+        "r-d-project-engineer-hip-medacta-international-sa-rancate"
       ],
       "salaryMin": 58000,
       "salaryMax": 88000,
@@ -325,11 +327,13 @@
       "needsRetranslation": true,
       "previousSlugsByLocale": {
         "it": [
-          "r-d-project-engineer-spine-medacta-rancate"
+          "r-d-project-engineer-spine-medacta-rancate",
+          "r-d-project-engineer-spine-medacta-international-sa-rancate"
         ]
       },
       "previousSlugs": [
-        "r-d-project-engineer-spine-medacta-rancate"
+        "r-d-project-engineer-spine-medacta-rancate",
+        "r-d-project-engineer-spine-medacta-international-sa-rancate"
       ],
       "salaryMin": 58000,
       "salaryMax": 88000,
@@ -481,7 +485,15 @@
       "postalCode": "6874",
       "addressRegion": "TI",
       "employmentType": "FULL_TIME",
-      "firstSeenAt": "2026-05-19T12:14:58.238Z"
+      "firstSeenAt": "2026-05-19T12:14:58.238Z",
+      "previousSlugs": [
+        "tornitore-medacta-international-sa-castel-san-pietro-rancate"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "tornitore-medacta-international-sa-castel-san-pietro-rancate"
+        ]
+      }
     },
     {
       "id": "medacta-97004",
@@ -735,11 +747,13 @@
       "needsRetranslation": true,
       "previousSlugsByLocale": {
         "it": [
-          "fresatore-medacta-castel-san-pietro-rancate"
+          "fresatore-medacta-castel-san-pietro-rancate",
+          "fresatore-medacta-international-sa-castel-san-pietro"
         ]
       },
       "previousSlugs": [
-        "fresatore-medacta-castel-san-pietro-rancate"
+        "fresatore-medacta-castel-san-pietro-rancate",
+        "fresatore-medacta-international-sa-castel-san-pietro"
       ],
       "salaryMin": 58000,
       "salaryMax": 88000,

--- a/data/jobs/by-crawler/mks-pamp.json
+++ b/data/jobs/by-crawler/mks-pamp.json
@@ -127,13 +127,15 @@
         "metal-amp-inventory-controller-mks-pamp-castel-san-pietro",
         "controller-metallo-e-inventario-mks-pamp-castel-san-pietro",
         "metall-amp-inventar-controller-mks-pamp-castel-san-pietro",
-        "controleur-de-metal-et-d-inventaire-mks-pamp-castel-san-pietro"
+        "controleur-de-metal-et-d-inventaire-mks-pamp-castel-san-pietro",
+        "metal-inventory-controller-mks-pamp-castel-san-pietro-wfpikp"
       ],
       "id": "mks-pamp-3b2040222bc6",
       "previousSlugsByLocale": {
         "it": [
           "metal-amp-inventory-controller-mks-pamp-castel-san-pietro",
-          "controller-metallo-e-inventario-mks-pamp-castel-san-pietro"
+          "controller-metallo-e-inventario-mks-pamp-castel-san-pietro",
+          "metal-inventory-controller-mks-pamp-castel-san-pietro-wfpikp"
         ],
         "en": [
           "metal-amp-inventory-controller-mks-pamp-castel-san-pietro"

--- a/data/jobs/by-crawler/mobiliar.json
+++ b/data/jobs/by-crawler/mobiliar.json
@@ -145,11 +145,15 @@
       "needsRetranslation": true,
       "previousSlugsByLocale": {
         "it": [
-          "mitarbeiter-verkaufssupport-w-m-d-generalagentur-wil-mobiliar-ch"
+          "mitarbeiter-verkaufssupport-w-m-d-generalagentur-wil-mobiliar-ch",
+          "mitarbeiter-verkaufssupport-w-m-d-generalagentur-uster-mobiliar-ch",
+          "mitarbeiter-verkaufssupport-w-m-d-generalagentur-belp-mobiliar-ch"
         ]
       },
       "previousSlugs": [
-        "mitarbeiter-verkaufssupport-w-m-d-generalagentur-wil-mobiliar-ch"
+        "mitarbeiter-verkaufssupport-w-m-d-generalagentur-wil-mobiliar-ch",
+        "mitarbeiter-verkaufssupport-w-m-d-generalagentur-uster-mobiliar-ch",
+        "mitarbeiter-verkaufssupport-w-m-d-generalagentur-belp-mobiliar-ch"
       ],
       "salaryMin": 49500,
       "salaryMax": 75000,
@@ -1867,13 +1871,15 @@
       "previousSlugs": [
         "versicherungs-und-vorsorgeberater-m-w-generalagentur-winterthur-mobiliar-ch",
         "versicherungs-e-vorsorgeberater-m-w-d-agenzia-generale-winterthur-die-mobiliar-winterthur",
-        "senior-account-manager-m-w-die-mobiliar-winterthur"
+        "senior-account-manager-m-w-die-mobiliar-winterthur",
+        "versicherungs-und-vorsorgeberater-w-m-d-generalagentur-zurich-mobiliar-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
           "versicherungs-und-vorsorgeberater-m-w-generalagentur-winterthur-mobiliar-ch",
           "versicherungs-e-vorsorgeberater-m-w-d-agenzia-generale-winterthur-die-mobiliar-winterthur",
-          "senior-account-manager-m-w-die-mobiliar-winterthur"
+          "senior-account-manager-m-w-die-mobiliar-winterthur",
+          "versicherungs-und-vorsorgeberater-w-m-d-generalagentur-zurich-mobiliar-ch"
         ],
         "en": [
           "versicherungs-und-vorsorgeberater-m-w-generalagentur-winterthur-mobiliar-ch"
@@ -3210,11 +3216,13 @@
       },
       "sfJobId": "1164040155",
       "previousSlugs": [
-        "kv-lehrstelle-efz-2027-generalagentur-burgdorf-w-m-d-mobiliar-ch"
+        "kv-lehrstelle-efz-2027-generalagentur-burgdorf-w-m-d-mobiliar-ch",
+        "kv-lehrstelle-efz-2027-w-m-d-generalagentur-lachen-mobiliar-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "kv-lehrstelle-efz-2027-generalagentur-burgdorf-w-m-d-mobiliar-ch"
+          "kv-lehrstelle-efz-2027-generalagentur-burgdorf-w-m-d-mobiliar-ch",
+          "kv-lehrstelle-efz-2027-w-m-d-generalagentur-lachen-mobiliar-ch"
         ],
         "en": [
           "kv-lehrstelle-efz-2027-generalagentur-burgdorf-w-m-d-mobiliar-ch"
@@ -3288,12 +3296,14 @@
       "sfJobId": "1164039955",
       "previousSlugs": [
         "versicherungs-und-vorsorgeberater-w-m-d-generalagentur-biel-mobiliar-ch",
-        "m-d-generalagentur-biel-die-mobiliar-biel"
+        "m-d-generalagentur-biel-die-mobiliar-biel",
+        "versicherungs-und-vorsorgeberater-m-w-d-bei-der-generalagentur-bienne-die-mobiliar-biel"
       ],
       "previousSlugsByLocale": {
         "it": [
           "versicherungs-und-vorsorgeberater-w-m-d-generalagentur-biel-mobiliar-ch",
-          "m-d-generalagentur-biel-die-mobiliar-biel"
+          "m-d-generalagentur-biel-die-mobiliar-biel",
+          "versicherungs-und-vorsorgeberater-m-w-d-bei-der-generalagentur-bienne-die-mobiliar-biel"
         ],
         "en": [
           "versicherungs-und-vorsorgeberater-w-m-d-generalagentur-biel-mobiliar-ch"
@@ -6592,11 +6602,13 @@
       "requirementsByLocale": {},
       "sfJobId": "1164454055",
       "previousSlugs": [
-        "collaborateur-du-support-vente-f-h-d-agence-generale-de-neuchatel-mobiliar-ch"
+        "collaborateur-du-support-vente-f-h-d-agence-generale-de-neuchatel-mobiliar-ch",
+        "collaborateur-support-vente-f-m-d-agence-generale-de-sion-mobiliar-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "collaborateur-du-support-vente-f-h-d-agence-generale-de-neuchatel-mobiliar-ch"
+          "collaborateur-du-support-vente-f-h-d-agence-generale-de-neuchatel-mobiliar-ch",
+          "collaborateur-support-vente-f-m-d-agence-generale-de-sion-mobiliar-ch"
         ],
         "de": [
           "collaborateur-du-support-vente-f-h-d-agence-generale-de-neuchatel-mobiliar-ch"

--- a/data/jobs/by-crawler/oscam.json
+++ b/data/jobs/by-crawler/oscam.json
@@ -137,11 +137,15 @@
       "firstSeenAt": "2026-05-17T10:50:46.725Z",
       "previousSlugs": [
         "concorso-generale-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto-4r5k4c",
-        "concorso-generale-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto"
+        "concorso-generale-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto",
+        "concorso-generale-2026-oscam-ospedale-e-casa-anziani-malcantonese-taverne"
       ],
       "previousSlugsByLocale": {
         "en": [
           "concorso-generale-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto-4r5k4c"
+        ],
+        "it": [
+          "concorso-generale-2026-oscam-ospedale-e-casa-anziani-malcantonese-taverne"
         ]
       }
     },
@@ -210,10 +214,14 @@
       "previousSlugsByLocale": {
         "en": [
           "concorso-generale-per-medici-assistenti-2025-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto-95m99t"
+        ],
+        "it": [
+          "concorso-generale-per-medici-assistenti-2025-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto"
         ]
       },
       "previousSlugs": [
-        "concorso-generale-per-medici-assistenti-2025-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto-95m99t"
+        "concorso-generale-per-medici-assistenti-2025-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto-95m99t",
+        "concorso-generale-per-medici-assistenti-2025-2026-oscam-ospedale-e-casa-anziani-malcantonese-castelrotto"
       ]
     }
   ]

--- a/data/jobs/by-crawler/otis.json
+++ b/data/jobs/by-crawler/otis.json
@@ -114,11 +114,15 @@
       "source": "Otis Dedicated Parser (Workday)",
       "crawledAt": "2026-05-19T12:27:16.785Z",
       "previousSlugs": [
-        "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-chur"
+        "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-chur",
+        "aufzugsmonteur-modernisierung-e-ersatzanlagen-m-w-d-otis-sa-nenzlingerweg-2",
+        "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-nenzlingerweg-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-chur"
+          "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-chur",
+          "aufzugsmonteur-modernisierung-e-ersatzanlagen-m-w-d-otis-sa-nenzlingerweg-2",
+          "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-nenzlingerweg-2"
         ]
       },
       "firstSeenAt": "2026-05-12T11:49:06.760Z",
@@ -310,12 +314,14 @@
       "crawledAt": "2026-05-19T12:27:15.691Z",
       "previousSlugs": [
         "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-reinach",
-        "aufzugsmonteur-modernisierung-e-ersatzanlagen-m-w-d-otis-sa-reinach"
+        "aufzugsmonteur-modernisierung-e-ersatzanlagen-m-w-d-otis-sa-reinach",
+        "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-sa-reinach"
       ],
       "previousSlugsByLocale": {
         "it": [
           "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-reinach",
-          "aufzugsmonteur-modernisierung-e-ersatzanlagen-m-w-d-otis-sa-reinach"
+          "aufzugsmonteur-modernisierung-e-ersatzanlagen-m-w-d-otis-sa-reinach",
+          "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-sa-reinach"
         ],
         "en": [
           "aufzugsmonteur-modernisierung-und-ersatzanlagen-m-w-d-otis-reinach"
@@ -965,11 +971,13 @@
       "crawledAt": "2026-05-19T12:27:12.451Z",
       "previousSlugs": [
         "vivier-des-talents-service-technicien-monteur-repairman-otis-cp-464",
-        "vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-fribourg"
+        "vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-fribourg",
+        "vivier-des-talents-service-technicien-monteur-repairman-otis-sa-rue-des-sablons-15"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "vivier-des-talents-service-technicien-monteur-repairman-otis-cp-464"
+          "vivier-des-talents-service-technicien-monteur-repairman-otis-cp-464",
+          "vivier-des-talents-service-technicien-monteur-repairman-otis-sa-rue-des-sablons-15"
         ],
         "en": [
           "vivier-des-talents-service-technicien-monteur-repairman-otis-cp-464"
@@ -1116,12 +1124,14 @@
       "crawledAt": "2026-05-19T12:27:11.717Z",
       "previousSlugs": [
         "talent-pool-vaud-technician-fitter-repairman-service-otis-sa-1032",
-        "vivier-des-talents-vaud-service-technicien-monteur-repairman-otis-1032"
+        "vivier-des-talents-vaud-service-technicien-monteur-repairman-otis-1032",
+        "vivier-des-talents-vaud-service-technicien-monteur-repairman-otis-sa-1032"
       ],
       "previousSlugsByLocale": {
         "it": [
           "talent-pool-vaud-technician-fitter-repairman-service-otis-sa-1032",
-          "vivier-des-talents-vaud-service-technicien-monteur-repairman-otis-1032"
+          "vivier-des-talents-vaud-service-technicien-monteur-repairman-otis-1032",
+          "vivier-des-talents-vaud-service-technicien-monteur-repairman-otis-sa-1032"
         ],
         "en": [
           "talent-pool-vaud-technician-fitter-repairman-service-otis-sa-1032",
@@ -1951,11 +1961,13 @@
       "crawledAt": "2026-05-19T12:27:04.127Z",
       "previousSlugs": [
         "hr-business-partner-switzerland-m-w-x-otis-fribourg",
-        "risorse-umane-business-partner-switzerland-m-w-x-otis-sa-fribourg"
+        "risorse-umane-business-partner-switzerland-m-w-x-otis-sa-fribourg",
+        "hr-business-partner-switzerland-m-w-x-otis-cp-1136"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "hr-business-partner-switzerland-m-w-x-otis-fribourg"
+          "hr-business-partner-switzerland-m-w-x-otis-fribourg",
+          "hr-business-partner-switzerland-m-w-x-otis-cp-1136"
         ],
         "fr": [
           "hr-business-partner-switzerland-m-w-x-otis-fribourg"

--- a/data/jobs/by-crawler/pdgr.json
+++ b/data/jobs/by-crawler/pdgr.json
@@ -1696,11 +1696,13 @@
           "assistenz-oder-fachpsychologe-in-pdgr-ch"
         ],
         "it": [
-          "assistenz-oder-fachpsychologe-in-pdgr-ch"
+          "assistenz-oder-fachpsychologe-in-pdgr-ch",
+          "assistenz-oder-fachpsychologe-in-psychiatrische-dienste-graubunden-davos"
         ]
       },
       "previousSlugs": [
-        "assistenz-oder-fachpsychologe-in-pdgr-ch"
+        "assistenz-oder-fachpsychologe-in-pdgr-ch",
+        "assistenz-oder-fachpsychologe-in-psychiatrische-dienste-graubunden-davos"
       ],
       "firstSeenAt": "2026-04-14T10:28:30.371Z",
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/pemsa.json
+++ b/data/jobs/by-crawler/pemsa.json
@@ -1186,7 +1186,15 @@
       },
       "streetAddress": "Via Industria 20",
       "postalCode": "6807",
-      "firstSeenAt": "2026-05-15T11:40:31.010Z"
+      "firstSeenAt": "2026-05-15T11:40:31.010Z",
+      "previousSlugs": [
+        "idraulico-impianti-sanitari-pemsa-mendrisio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "idraulico-impianti-sanitari-pemsa-mendrisio"
+        ]
+      }
     },
     {
       "title": "Muratore",
@@ -2319,7 +2327,15 @@
       },
       "streetAddress": "Via Industria 20",
       "postalCode": "6807",
-      "firstSeenAt": "2026-05-11T22:43:47.219Z"
+      "firstSeenAt": "2026-05-11T22:43:47.219Z",
+      "previousSlugs": [
+        "idraulico-impianti-riscaldamento-pemsa-lugano"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "idraulico-impianti-riscaldamento-pemsa-lugano"
+        ]
+      }
     },
     {
       "title": "PIASTRELLISTA",
@@ -2496,7 +2512,15 @@
       },
       "streetAddress": "Via Industria 20",
       "postalCode": "6807",
-      "firstSeenAt": "2026-05-07T22:23:51.852Z"
+      "firstSeenAt": "2026-05-07T22:23:51.852Z",
+      "previousSlugs": [
+        "montatore-meccanico-di-macchinari-industriali-pemsa-lamone"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "montatore-meccanico-di-macchinari-industriali-pemsa-lamone"
+        ]
+      }
     },
     {
       "title": "MONTATORE/POSATORE DI BARRIERE DI SICUREZZA (AUTOSTRADALI)",

--- a/data/jobs/by-crawler/prada.json
+++ b/data/jobs/by-crawler/prada.json
@@ -46,11 +46,13 @@
       "crawledAt": "2026-05-19T12:26:19.809Z",
       "previousSlugs": [
         "miu-miu-store-manager-saint-moritz-prada-mendrisio",
-        "mui-mui-direttore-del-negozio-saint-moritz-prada-group-st-moritz"
+        "mui-mui-direttore-del-negozio-saint-moritz-prada-group-st-moritz",
+        "miu-miu-store-manager-saint-moritz-prada-group-mendrisio"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "miu-miu-store-manager-saint-moritz-prada-mendrisio"
+          "miu-miu-store-manager-saint-moritz-prada-mendrisio",
+          "miu-miu-store-manager-saint-moritz-prada-group-mendrisio"
         ]
       },
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/pwc.json
+++ b/data/jobs/by-crawler/pwc.json
@@ -252,7 +252,8 @@
       "firstSeenAt": "2026-05-15T22:28:03.990Z",
       "previousSlugsByLocale": {
         "it": [
-          "associate-karriereeinstieg-steuerberatung-80-100-pwc-zug"
+          "associate-karriereeinstieg-steuerberatung-80-100-pwc-zug",
+          "associate-karriereeinstieg-steuerberatung-80-100-pwc-switzerland-luzern"
         ],
         "fr": [
           "associate-karriereeinstieg-steuerberatung-80-100-pwc-zug"
@@ -262,7 +263,8 @@
         ]
       },
       "previousSlugs": [
-        "associate-karriereeinstieg-steuerberatung-80-100-pwc-zug"
+        "associate-karriereeinstieg-steuerberatung-80-100-pwc-zug",
+        "associate-karriereeinstieg-steuerberatung-80-100-pwc-switzerland-luzern"
       ]
     },
     {
@@ -394,7 +396,15 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-05-11T12:21:25.187Z"
+      "firstSeenAt": "2026-05-11T12:21:25.187Z",
+      "previousSlugs": [
+        "career-start-in-audit-as-environmental-social-and-governance-esg-auditor-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "career-start-in-audit-as-environmental-social-and-governance-esg-auditor-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Career Start in Audit as Environmental, Social and Governance (ESG) Auditor",
@@ -594,7 +604,17 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-05-08T10:28:56.294Z"
+      "firstSeenAt": "2026-05-08T10:28:56.294Z",
+      "previousSlugs": [
+        "tax-accounting-senior-associate-pwc-switzerland-zurich",
+        "senior-associate-tax-accounting-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "tax-accounting-senior-associate-pwc-switzerland-zurich",
+          "senior-associate-tax-accounting-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Senior Associate - Tax Accounting",
@@ -653,7 +673,15 @@
         }
       },
       "postalCode": "6003",
-      "firstSeenAt": "2026-05-08T10:28:56.294Z"
+      "firstSeenAt": "2026-05-08T10:28:56.294Z",
+      "previousSlugs": [
+        "senior-associate-tax-accounting-pwc-switzerland-luzern"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "senior-associate-tax-accounting-pwc-switzerland-luzern"
+        ]
+      }
     },
     {
       "title": "Senior Associate - Tax Accounting",
@@ -921,7 +949,8 @@
       "firstSeenAt": "2026-05-07T11:35:57.921Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-manager-tax-accounting-pwc-zurich"
+          "senior-manager-tax-accounting-pwc-zurich",
+          "tax-accounting-senior-manager-pwc-switzerland-zurich"
         ],
         "fr": [
           "senior-manager-tax-accounting-pwc-zurich"
@@ -931,7 +960,8 @@
         ]
       },
       "previousSlugs": [
-        "senior-manager-tax-accounting-pwc-zurich"
+        "senior-manager-tax-accounting-pwc-zurich",
+        "tax-accounting-senior-manager-pwc-switzerland-zurich"
       ]
     },
     {
@@ -1413,7 +1443,9 @@
       "firstSeenAt": "2026-05-04T22:28:38.904Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-associate-strategy-consulting-pwc-zurich"
+          "senior-associate-strategy-consulting-pwc-zurich",
+          "senior-associate-strategy-consulting-pwc-switzerland-zurich",
+          "senior-associate-strategy-consulting-pwc-switzerland-zurich-vg72de"
         ],
         "fr": [
           "senior-associate-strategy-consulting-pwc-zurich"
@@ -1423,7 +1455,9 @@
         ]
       },
       "previousSlugs": [
-        "senior-associate-strategy-consulting-pwc-zurich"
+        "senior-associate-strategy-consulting-pwc-zurich",
+        "senior-associate-strategy-consulting-pwc-switzerland-zurich",
+        "senior-associate-strategy-consulting-pwc-switzerland-zurich-vg72de"
       ]
     },
     {
@@ -1744,7 +1778,15 @@
           "unitText": "YEAR"
         }
       },
-      "firstSeenAt": "2026-04-29T11:19:03.170Z"
+      "firstSeenAt": "2026-04-29T11:19:03.170Z",
+      "previousSlugs": [
+        "manager-im-bereich-audit-trade-industries-services-us-gaap-pwc-switzerland-geneva"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "manager-im-bereich-audit-trade-industries-services-us-gaap-pwc-switzerland-geneva"
+        ]
+      }
     },
     {
       "title": "Associate - Junior Legal Counsel (Arbeitsrecht & Ethics) 80–100%",
@@ -1929,7 +1971,23 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-24T10:44:24.903Z"
+      "firstSeenAt": "2026-04-24T10:44:24.903Z",
+      "previousSlugs": [
+        "audit-senior-associate-assistant-manager-trade-industries-services-2026-pwc-switzerland-zurich",
+        "audit-senior-associate-assistent-manager-trade-industries-services-2026-pwc-switzerland-zurich",
+        "audit-senior-associate-assistant-manager-trade-industries-services-2026-pwc-switzerland-bern-6hetif",
+        "audit-senior-associate-assistant-manager-trade-industries-services-2026-pwc-switzerland-be",
+        "senior-associate-assistant-manager-audit-trade-industries-services-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "audit-senior-associate-assistant-manager-trade-industries-services-2026-pwc-switzerland-zurich",
+          "audit-senior-associate-assistent-manager-trade-industries-services-2026-pwc-switzerland-zurich",
+          "audit-senior-associate-assistant-manager-trade-industries-services-2026-pwc-switzerland-bern-6hetif",
+          "audit-senior-associate-assistant-manager-trade-industries-services-2026-pwc-switzerland-be",
+          "senior-associate-assistant-manager-audit-trade-industries-services-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Senior Associate / Assistant Manager - Audit Trade, Industries & Services",
@@ -2462,13 +2520,15 @@
           "gestionnaire-senior-manager-en-sciences-de-la-vie-quality-management-consulting-pwc-switzerland-zurich"
         ],
         "it": [
-          "manager-senior-manager-in-life-sciences-quality-management-consulting-pwc-zurich"
+          "manager-senior-manager-in-life-sciences-quality-management-consulting-pwc-zurich",
+          "manager-senior-manager-in-life-sciences-quality-management-consulting-pwc-switzerland-basel-xzdlvv"
         ]
       },
       "previousSlugs": [
         "gestionnaire-senior-manager-en-sciences-de-la-vie-quality-management-consulting-pwc-switzerland-zurich",
         "manager-senior-manager-in-life-sciences-quality-management-consulting-pwc-zurich",
-        "manager-senior-manager-di-life-sciences-quality-management-consulting-pwc-switzerland-zurich"
+        "manager-senior-manager-di-life-sciences-quality-management-consulting-pwc-switzerland-zurich",
+        "manager-senior-manager-in-life-sciences-quality-management-consulting-pwc-switzerland-basel-xzdlvv"
       ]
     },
     {
@@ -2534,14 +2594,26 @@
           "gestionnaire-et-gestionnaire-principal-en-conseil-en-gestion-de-la-r-d-en-sciences-de-la-vie-pwc-switzerland-basel"
         ],
         "it": [
-          "manager-and-senior-manager-in-life-sciences-r-d-management-consulting-pwc-zurich"
+          "manager-and-senior-manager-in-life-sciences-r-d-management-consulting-pwc-zurich",
+          "manager-and-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-basel",
+          "manager-und-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-basel",
+          "manager-et-senior-manager-en-life-sciences-r-d-management-consulting-pwc-switzerland-basel",
+          "manager-and-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-basel-tvjzcl",
+          "manager-und-senior-manager-im-bereich-life-sciences-r-d-management-consulting-pwc-switzerland-zurich",
+          "manager-et-senior-manager-en-consulting-r-d-life-sciences-pwc-switzerland-basel"
         ]
       },
       "previousSlugs": [
         "gestionnaire-et-gestionnaire-principal-en-sciences-de-la-vie-r-d-management-consulting-pwc-switzerland-basel",
         "gestionnaire-et-gestionnaire-principal-en-conseil-en-gestion-de-la-r-d-en-sciences-de-la-vie-pwc-switzerland-basel",
         "manager-and-senior-manager-in-life-sciences-r-d-management-consulting-pwc-zurich",
-        "manager-e-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-zurich"
+        "manager-e-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-zurich",
+        "manager-and-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-basel",
+        "manager-und-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-basel",
+        "manager-et-senior-manager-en-life-sciences-r-d-management-consulting-pwc-switzerland-basel",
+        "manager-and-senior-manager-in-life-sciences-r-d-management-consulting-pwc-switzerland-basel-tvjzcl",
+        "manager-und-senior-manager-im-bereich-life-sciences-r-d-management-consulting-pwc-switzerland-zurich",
+        "manager-et-senior-manager-en-consulting-r-d-life-sciences-pwc-switzerland-basel"
       ]
     },
     {
@@ -2603,7 +2675,11 @@
       "firstSeenAt": "2026-04-21T22:13:20.002Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-zurich"
+          "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-zurich",
+          "senior-manager-direttore-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich",
+          "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich-pxoxic",
+          "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich",
+          "senior-associate-manager-nella-consulenza-sap-supply-chain-operations-pwc-switzerland-zuri"
         ],
         "fr": [
           "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-zurich"
@@ -2613,7 +2689,11 @@
         ]
       },
       "previousSlugs": [
-        "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-zurich"
+        "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-zurich",
+        "senior-manager-direttore-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich",
+        "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich-pxoxic",
+        "senior-associate-manager-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich",
+        "senior-associate-manager-nella-consulenza-sap-supply-chain-operations-pwc-switzerland-zuri"
       ]
     },
     {
@@ -2676,10 +2756,14 @@
       "previousSlugsByLocale": {
         "fr": [
           "gestionnaire-principal-directeur-de-sap-supply-chain-operations-consulting-pwc-switzerland-zurich"
+        ],
+        "it": [
+          "senior-manager-director-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich"
         ]
       },
       "previousSlugs": [
-        "gestionnaire-principal-directeur-de-sap-supply-chain-operations-consulting-pwc-switzerland-zurich"
+        "gestionnaire-principal-directeur-de-sap-supply-chain-operations-consulting-pwc-switzerland-zurich",
+        "senior-manager-director-in-sap-supply-chain-operations-consulting-pwc-switzerland-zurich"
       ]
     },
     {
@@ -2799,7 +2883,9 @@
       "firstSeenAt": "2026-04-16T22:10:09.568Z",
       "previousSlugsByLocale": {
         "it": [
-          "audit-senior-manager-trade-industries-services-us-gaap-pwc-zurich"
+          "audit-senior-manager-trade-industries-services-us-gaap-pwc-zurich",
+          "audit-senior-manager-trade-industries-services-us-gaap-pwc-switzerland-geneva",
+          "audit-senior-manager-trade-industries-services-us-gaap-pwc-switzerland-geneve-7pthxc"
         ],
         "fr": [
           "audit-senior-manager-trade-industries-services-us-gaap-pwc-zurich"
@@ -2810,7 +2896,9 @@
       },
       "previousSlugs": [
         "audit-senior-manager-trade-industries-services-us-gaap-pwc-zurich",
-        "senior-associate-assistant-manager-audit-commercio-industrie-e-servizi-us-gaap-pwc-switzer"
+        "senior-associate-assistant-manager-audit-commercio-industrie-e-servizi-us-gaap-pwc-switzer",
+        "audit-senior-manager-trade-industries-services-us-gaap-pwc-switzerland-geneva",
+        "audit-senior-manager-trade-industries-services-us-gaap-pwc-switzerland-geneve-7pthxc"
       ]
     },
     {
@@ -2945,14 +3033,16 @@
       "firstSeenAt": "2026-04-26T21:57:56.602Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-transfer-pricing-financial-services-80-100-pwc-zurich"
+          "manager-transfer-pricing-financial-services-80-100-pwc-zurich",
+          "transfer-pricing-manager-financial-services-80-100-pwc-switzerland-zurich"
         ],
         "de": [
           "manager-transfer-pricing-financial-services-80-100-pwc-zurich"
         ]
       },
       "previousSlugs": [
-        "manager-transfer-pricing-financial-services-80-100-pwc-zurich"
+        "manager-transfer-pricing-financial-services-80-100-pwc-zurich",
+        "transfer-pricing-manager-financial-services-80-100-pwc-switzerland-zurich"
       ]
     },
     {
@@ -3011,7 +3101,19 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-13T22:16:12.621Z"
+      "firstSeenAt": "2026-04-13T22:16:12.621Z",
+      "previousSlugs": [
+        "audit-assistent-manager-financial-services-competence-center-pwc-switzerland-zurich",
+        "audit-assistant-manager-services-financiers-competence-center-pwc-switzerland-zurich",
+        "audit-assistant-manager-financial-services-competence-center-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "audit-assistent-manager-financial-services-competence-center-pwc-switzerland-zurich",
+          "audit-assistant-manager-services-financiers-competence-center-pwc-switzerland-zurich",
+          "audit-assistant-manager-financial-services-competence-center-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Audit (Assistant) Manager - Financial Services - Competence Center",
@@ -3072,14 +3174,18 @@
       "firstSeenAt": "2026-04-13T22:16:12.621Z",
       "previousSlugsByLocale": {
         "it": [
-          "audit-assistant-manager-financial-services-competence-center-pwc-bern"
+          "audit-assistant-manager-financial-services-competence-center-pwc-bern",
+          "audit-assistant-manager-financial-services-competence-center-pwc-switzerland-bern",
+          "audit-assistant-manager-services-financiers-competence-center-pwc-switzerland-bern"
         ],
         "fr": [
           "audit-assistant-manager-financial-services-competence-center-pwc-bern"
         ]
       },
       "previousSlugs": [
-        "audit-assistant-manager-financial-services-competence-center-pwc-bern"
+        "audit-assistant-manager-financial-services-competence-center-pwc-bern",
+        "audit-assistant-manager-financial-services-competence-center-pwc-switzerland-bern",
+        "audit-assistant-manager-services-financiers-competence-center-pwc-switzerland-bern"
       ]
     },
     {
@@ -3425,7 +3531,19 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-16T10:31:46.773Z"
+      "firstSeenAt": "2026-04-16T10:31:46.773Z",
+      "previousSlugs": [
+        "senior-manager-operations-manufacturing-strategy-transformation-80-100-pwc-switzerland-zurich",
+        "senior-manager-operations-manufacturing-strategy-transformation-80-100-pwc-switzerland-zurich-lus0vg",
+        "senior-manager-operations-manufacturing-strategy-transformation-80-100-pwc-switzerland-zur"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "senior-manager-operations-manufacturing-strategy-transformation-80-100-pwc-switzerland-zurich",
+          "senior-manager-operations-manufacturing-strategy-transformation-80-100-pwc-switzerland-zurich-lus0vg",
+          "senior-manager-operations-manufacturing-strategy-transformation-80-100-pwc-switzerland-zur"
+        ]
+      }
     },
     {
       "title": "Career Start in Audit – Vorsorgespezialist:in – September 2026",
@@ -3484,7 +3602,17 @@
         }
       },
       "postalCode": "3001",
-      "firstSeenAt": "2026-04-13T22:16:12.621Z"
+      "firstSeenAt": "2026-04-13T22:16:12.621Z",
+      "previousSlugs": [
+        "career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-bern",
+        "career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-bern-0fyqg3"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-bern",
+          "career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-bern-0fyqg3"
+        ]
+      }
     },
     {
       "title": "Career Start in Audit – Vorsorgespezialist:in – September 2026",
@@ -3543,7 +3671,15 @@
         }
       },
       "postalCode": "4001",
-      "firstSeenAt": "2026-04-13T22:16:12.621Z"
+      "firstSeenAt": "2026-04-13T22:16:12.621Z",
+      "previousSlugs": [
+        "career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-basel"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-basel"
+        ]
+      }
     },
     {
       "title": "Career Start in Audit – Vorsorgespezialist:in – September 2026",
@@ -3691,13 +3827,17 @@
         "praktikum-digital-assurance-it-audit-und-prozessanalyse-september-februar-finanzdienstleistungen-pwc-switzerland-zurich-kie620",
         "praktikum-digital-assurance-it-audit-and-process-analytics-sept-feb-financial-services-pwc-zurich",
         "internship-digital-assurance-it-audit-and-process-analytics-sept-feb-financial-services-pwc-switzerland-zurich",
-        "praktikum-digital-assurance-it-audit-and-process-analytics-sept-feb-financial-services-pwc"
+        "praktikum-digital-assurance-it-audit-and-process-analytics-sept-feb-financial-services-pwc",
+        "senior-associate-in-digital-assurance-it-audit-e-process-analytics-financial-services-pwc-switzerland-zurich",
+        "senior-associate-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-switzerland-zurich"
       ],
       "id": "pwc-88dc0dbaf301",
       "previousSlugsByLocale": {
         "it": [
           "senior-associate-in-digital-assurance-it-audit-und-prozessanalyse-finanzdienstleistungen-pwc-switzerland-zurich-t7triq",
-          "senior-associate-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich"
+          "senior-associate-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-zurich",
+          "senior-associate-in-digital-assurance-it-audit-e-process-analytics-financial-services-pwc-switzerland-zurich",
+          "senior-associate-in-digital-assurance-it-audit-and-process-analytics-financial-services-pwc-switzerland-zurich"
         ],
         "en": [
           "senior-associate-in-digital-assurance-it-audit-und-prozessanalyse-finanzdienstleistungen-pwc-switzerland-zurich-t7triq",
@@ -3772,7 +3912,8 @@
       "previousSlugs": [
         "leiter-der-audit-abteilung-fur-handel-industrie-und-dienstleistungen-pwc-switzerland-neuchatel-h3x7ix",
         "manager-en-audit-trade-industries-and-services-neuchatel-pwc-neuchatel",
-        "manager-of-audit-trade-industries-and-services-neuchatel-pwc-switzerland-neuchatel"
+        "manager-of-audit-trade-industries-and-services-neuchatel-pwc-switzerland-neuchatel",
+        "manager-in-audit-trade-industries-and-services-neuchatel-pwc-switzerland-neuchatel"
       ],
       "id": "pwc-e9bdc7f09f22",
       "previousSlugsByLocale": {
@@ -3785,7 +3926,8 @@
           "manager-of-audit-trade-industries-and-services-neuchatel-pwc-switzerland-neuchatel"
         ],
         "it": [
-          "manager-en-audit-trade-industries-and-services-neuchatel-pwc-neuchatel"
+          "manager-en-audit-trade-industries-and-services-neuchatel-pwc-neuchatel",
+          "manager-in-audit-trade-industries-and-services-neuchatel-pwc-switzerland-neuchatel"
         ],
         "fr": [
           "manager-en-audit-trade-industries-and-services-neuchatel-pwc-neuchatel"
@@ -3852,7 +3994,9 @@
       "firstSeenAt": "2026-04-16T10:31:46.773Z",
       "previousSlugsByLocale": {
         "it": [
-          "audit-senior-manager-trade-industries-services-us-gaap-pwc-lausanne"
+          "audit-senior-manager-trade-industries-services-us-gaap-pwc-lausanne",
+          "audit-senior-manager-commerce-industries-services-us-gaap-pwc-switzerland-lausanne",
+          "audit-senior-manager-trade-industries-services-us-gaap-pwc-switzerland-lausanne"
         ],
         "fr": [
           "audit-senior-manager-trade-industries-services-us-gaap-pwc-lausanne"
@@ -3862,7 +4006,9 @@
         ]
       },
       "previousSlugs": [
-        "audit-senior-manager-trade-industries-services-us-gaap-pwc-lausanne"
+        "audit-senior-manager-trade-industries-services-us-gaap-pwc-lausanne",
+        "audit-senior-manager-commerce-industries-services-us-gaap-pwc-switzerland-lausanne",
+        "audit-senior-manager-trade-industries-services-us-gaap-pwc-switzerland-lausanne"
       ]
     },
     {
@@ -3924,7 +4070,8 @@
       "firstSeenAt": "2026-04-16T10:31:46.773Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-senior-manager-strategy-consulting-pwc-zurich"
+          "manager-senior-manager-strategy-consulting-pwc-zurich",
+          "strategy-manager-senior-manager-strategy-consulting-pwc-switzerland-zurich"
         ],
         "fr": [
           "manager-senior-manager-strategy-consulting-pwc-zurich"
@@ -3934,7 +4081,8 @@
         ]
       },
       "previousSlugs": [
-        "manager-senior-manager-strategy-consulting-pwc-zurich"
+        "manager-senior-manager-strategy-consulting-pwc-zurich",
+        "strategy-manager-senior-manager-strategy-consulting-pwc-switzerland-zurich"
       ]
     },
     {
@@ -3995,13 +4143,17 @@
       "previousSlugs": [
         "associate-senior-associate-technologie-strategie-und-transformationsberatung-pwc-switzerland-zurich-00z079",
         "associate-senior-associate-technology-strategy-transformation-advisory-pwc-zurich",
-        "associate-senior-associate-strategia-tecnologica-e-consulenza-per-la-trasformazione-pwc-sw"
+        "associate-senior-associate-strategia-tecnologica-e-consulenza-per-la-trasformazione-pwc-sw",
+        "associato-senior-associate-technology-strategy-transformation-advisory-pwc-switzerland-zurich",
+        "associate-senior-associate-technology-strategy-transformation-advisory-pwc-switzerland-zurich"
       ],
       "id": "pwc-d4ffee80f769",
       "previousSlugsByLocale": {
         "it": [
           "associate-senior-associate-technologie-strategie-und-transformationsberatung-pwc-switzerland-zurich-00z079",
-          "associate-senior-associate-technology-strategy-transformation-advisory-pwc-zurich"
+          "associate-senior-associate-technology-strategy-transformation-advisory-pwc-zurich",
+          "associato-senior-associate-technology-strategy-transformation-advisory-pwc-switzerland-zurich",
+          "associate-senior-associate-technology-strategy-transformation-advisory-pwc-switzerland-zurich"
         ],
         "en": [
           "associate-senior-associate-technologie-strategie-und-transformationsberatung-pwc-switzerland-zurich-00z079"
@@ -4075,14 +4227,18 @@
       "id": "pwc-b7f13ba67750",
       "previousSlugsByLocale": {
         "it": [
-          "manager-senior-manager-technology-strategy-transformation-consulting-pwc-zurich"
+          "manager-senior-manager-technology-strategy-transformation-consulting-pwc-zurich",
+          "manager-senior-manager-technology-strategy-transformation-consulting-pwc-switzerland-zuric",
+          "manager-senior-manager-conseil-en-technology-strategy-transformation-pwc-switzerland-zurich"
         ],
         "de": [
           "manager-senior-manager-technology-strategy-transformation-consulting-pwc-zurich"
         ]
       },
       "previousSlugs": [
-        "manager-senior-manager-technology-strategy-transformation-consulting-pwc-zurich"
+        "manager-senior-manager-technology-strategy-transformation-consulting-pwc-zurich",
+        "manager-senior-manager-technology-strategy-transformation-consulting-pwc-switzerland-zuric",
+        "manager-senior-manager-conseil-en-technology-strategy-transformation-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     },
@@ -4224,7 +4380,8 @@
       "id": "pwc-14357198dc0e",
       "previousSlugsByLocale": {
         "it": [
-          "director-in-quality-regulatory-management-advisory-services-pwc-zurich"
+          "director-in-quality-regulatory-management-advisory-services-pwc-zurich",
+          "director-in-quality-regulatory-management-advisory-services-pwc-switzerland-basel"
         ],
         "en": [
           "director-in-quality-regulatory-management-advisory-services-pwc-zurich"
@@ -4241,7 +4398,8 @@
         "direktor-in-qualitat-regulatory-management-advisory-services-pwc-switzerland-basel",
         "directeur-in-qualite-regulatory-management-advisory-services-pwc-switzerland-basel",
         "direttore-in-quality-regulatory-management-advisory-services-pwc-switzerland-zurich",
-        "direttore-di-gestione-della-qualita-e-regolazione-servizi-consultivi-pwc-switzerland-zurich"
+        "direttore-di-gestione-della-qualita-e-regolazione-servizi-consultivi-pwc-switzerland-zurich",
+        "director-in-quality-regulatory-management-advisory-services-pwc-switzerland-basel"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     },
@@ -4289,7 +4447,8 @@
       "previousSlugs": [
         "assistent-manager-audit-asset-management-pwc-switzerland-geneva",
         "assistant-manager-audit-asset-management-pwc-geneva",
-        "assistant-manager-audit-asset-management-pwc-switzerland-geneve-2z283b"
+        "assistant-manager-audit-asset-management-pwc-switzerland-geneve-2z283b",
+        "assistant-manager-audit-asset-management-pwc-switzerland-geneve"
       ],
       "salaryMin": 72000,
       "salaryMax": 97000,
@@ -4311,7 +4470,8 @@
           "assistant-manager-audit-asset-management-pwc-geneva"
         ],
         "it": [
-          "assistant-manager-audit-asset-management-pwc-geneva"
+          "assistant-manager-audit-asset-management-pwc-geneva",
+          "assistant-manager-audit-asset-management-pwc-switzerland-geneve"
         ],
         "fr": [
           "assistant-manager-audit-asset-management-pwc-switzerland-geneve-2z283b"
@@ -4378,11 +4538,17 @@
       "firstSeenAt": "2026-05-17T10:54:12.475Z",
       "previousSlugs": [
         "manager-in-regulatory-compliance-pwc-geneva",
-        "manager-in-rischio-regolatore-conformita-pwc-switzerland-geneve"
+        "manager-in-rischio-regolatore-conformita-pwc-switzerland-geneve",
+        "manager-di-regulatory-risk-compliance-pwc-switzerland-geneva",
+        "manager-en-regulatory-risk-compliance-pwc-switzerland-geneva",
+        "manager-in-regulatory-risk-compliance-pwc-switzerland-geneva"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "manager-in-regulatory-compliance-pwc-geneva"
+          "manager-in-regulatory-compliance-pwc-geneva",
+          "manager-di-regulatory-risk-compliance-pwc-switzerland-geneva",
+          "manager-en-regulatory-risk-compliance-pwc-switzerland-geneva",
+          "manager-in-regulatory-risk-compliance-pwc-switzerland-geneva"
         ]
       },
       "retranslationAttempts": 2,
@@ -4529,7 +4695,11 @@
       "previousSlugsByLocale": {
         "it": [
           "senior-associate-in-audit-trade-industries-and-services-us-gaap-pwc-geneva",
-          "senior-associate-in-audit-commercio-industrie-e-servizi-ifrs-usa-pwc-switzerland-geneve"
+          "senior-associate-in-audit-commercio-industrie-e-servizi-ifrs-usa-pwc-switzerland-geneve",
+          "senior-associate-in-audit-trade-industries-and-services-ginevra-o-losanna-us-gaap-pwc-switzerland-geneva",
+          "senior-associate-en-audit-trade-industries-and-services-geneve-ou-lausanne-us-gaap-pwc-switzerland-geneve-5ckhm9",
+          "senior-associate-in-audit-trade-industries-and-services-geneva-or-lausanne-us-gaap-pwc-switzerland-geneve-5ckhm9",
+          "senior-associate-in-audit-trade-industries-and-services-geneva-or-lausanne-pwc-switzerland"
         ],
         "de": [
           "senior-associate-in-audit-trade-industries-and-services-us-gaap-pwc-geneva"
@@ -4542,7 +4712,11 @@
         "senior-associate-in-audit-trade-industries-and-services-us-gaap-pwc-geneva",
         "senior-associate-in-audit-commercio-industrie-e-servizi-ifrs-usa-pwc-switzerland-geneve",
         "senior-associate-in-audit-trade-industries-and-services-geneva-or-lausanne-us-gaap-pwc-swi",
-        "senior-associate-in-audit-commercio-industrie-e-servizi-us-gaap-pwc-switzerland-geneve"
+        "senior-associate-in-audit-commercio-industrie-e-servizi-us-gaap-pwc-switzerland-geneve",
+        "senior-associate-in-audit-trade-industries-and-services-ginevra-o-losanna-us-gaap-pwc-switzerland-geneva",
+        "senior-associate-en-audit-trade-industries-and-services-geneve-ou-lausanne-us-gaap-pwc-switzerland-geneve-5ckhm9",
+        "senior-associate-in-audit-trade-industries-and-services-geneva-or-lausanne-us-gaap-pwc-switzerland-geneve-5ckhm9",
+        "senior-associate-in-audit-trade-industries-and-services-geneva-or-lausanne-pwc-switzerland"
       ]
     },
     {
@@ -4604,7 +4778,12 @@
       "firstSeenAt": "2026-04-14T22:15:14.777Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-associate-in-audit-trade-industries-and-services-pwc-geneve"
+          "senior-associate-in-audit-trade-industries-and-services-pwc-geneve",
+          "senior-associate-in-audit-trade-industries-and-services-ginevra-o-losanna-pwc-switzerland-geneve",
+          "senior-associate-en-audit-commerce-industries-et-services-pwc-switzerland-geneve",
+          "audit-senior-associate-trade-industries-services-lugano-pwc-switzerland-lugano",
+          "senior-audit-associate-trade-industries-services-lugano-pwc-switzerland-lugano",
+          "audit-senior-associate-trade-industries-services-lugano-pwc-switzerland-lugano-jhx4ob"
         ],
         "de": [
           "senior-associate-in-audit-trade-industries-and-services-pwc-geneve"
@@ -4614,7 +4793,12 @@
         ]
       },
       "previousSlugs": [
-        "senior-associate-in-audit-trade-industries-and-services-pwc-geneve"
+        "senior-associate-in-audit-trade-industries-and-services-pwc-geneve",
+        "senior-associate-in-audit-trade-industries-and-services-ginevra-o-losanna-pwc-switzerland-geneve",
+        "senior-associate-en-audit-commerce-industries-et-services-pwc-switzerland-geneve",
+        "audit-senior-associate-trade-industries-services-lugano-pwc-switzerland-lugano",
+        "senior-audit-associate-trade-industries-services-lugano-pwc-switzerland-lugano",
+        "audit-senior-associate-trade-industries-services-lugano-pwc-switzerland-lugano-jhx4ob"
       ]
     },
     {
@@ -4676,7 +4860,8 @@
       "firstSeenAt": "2026-04-21T10:37:49.518Z",
       "previousSlugsByLocale": {
         "it": [
-          "associate-senior-associate-cloud-data-and-ai-cloud-ai-engineer-pwc-zurich"
+          "associate-senior-associate-cloud-data-and-ai-cloud-ai-engineer-pwc-zurich",
+          "associate-senior-associate-cloud-data-and-ai-cd-ai-cloud-ai-engineer-pwc-switzerland-zurich"
         ],
         "de": [
           "associate-senior-associate-cloud-data-and-ai-cloud-ai-engineer-pwc-zurich"
@@ -4686,7 +4871,8 @@
         ]
       },
       "previousSlugs": [
-        "associate-senior-associate-cloud-data-and-ai-cloud-ai-engineer-pwc-zurich"
+        "associate-senior-associate-cloud-data-and-ai-cloud-ai-engineer-pwc-zurich",
+        "associate-senior-associate-cloud-data-and-ai-cd-ai-cloud-ai-engineer-pwc-switzerland-zurich"
       ]
     },
     {
@@ -4746,7 +4932,19 @@
       },
       "firstSeenAt": "2026-05-17T10:54:12.475Z",
       "retranslationAttempts": 2,
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-switzerland-geneva",
+        "audit-senior-associate-assistent-manager-trade-industries-services-us-gaap-pwc-switzerland-geneva",
+        "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-switzerland-geneve-6kn7sj"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-switzerland-geneva",
+          "audit-senior-associate-assistent-manager-trade-industries-services-us-gaap-pwc-switzerland-geneva",
+          "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-switzerland-geneve-6kn7sj"
+        ]
+      }
     },
     {
       "title": "Senior Manager GBS",
@@ -4791,7 +4989,8 @@
       },
       "previousSlugs": [
         "senior-manager-gbs-pwc-zurich",
-        "gestionnaire-principal-de-l-abg-pwc-switzerland-zurich-uaynr0"
+        "gestionnaire-principal-de-l-abg-pwc-switzerland-zurich-uaynr0",
+        "senior-manager-gbs-pwc-switzerland-zurich-uaynr0"
       ],
       "salaryMin": 100500,
       "salaryMax": 136500,
@@ -4815,7 +5014,8 @@
         ],
         "it": [
           "gestionnaire-principal-de-l-abg-pwc-switzerland-zurich-uaynr0",
-          "senior-manager-gbs-pwc-zurich"
+          "senior-manager-gbs-pwc-zurich",
+          "senior-manager-gbs-pwc-switzerland-zurich-uaynr0"
         ],
         "de": [
           "gestionnaire-principal-de-l-abg-pwc-switzerland-zurich-uaynr0",
@@ -4888,7 +5088,8 @@
       "firstSeenAt": "2026-04-21T10:37:49.518Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-cloud-data-ai-cloud-data-platform-architect-pwc-zurich"
+          "manager-cloud-data-ai-cloud-data-platform-architect-pwc-zurich",
+          "cloud-data-ai-cd-ai-manager-cloud-data-platform-architect-pwc-switzerland-zurich"
         ],
         "de": [
           "manager-cloud-data-ai-cloud-data-platform-architect-pwc-zurich"
@@ -4898,7 +5099,8 @@
         ]
       },
       "previousSlugs": [
-        "manager-cloud-data-ai-cloud-data-platform-architect-pwc-zurich"
+        "manager-cloud-data-ai-cloud-data-platform-architect-pwc-zurich",
+        "cloud-data-ai-cd-ai-manager-cloud-data-platform-architect-pwc-switzerland-zurich"
       ]
     },
     {
@@ -5032,14 +5234,16 @@
       "firstSeenAt": "2026-04-26T21:57:56.602Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-associate-transfer-pricing-pwc-zurich"
+          "senior-associate-transfer-pricing-pwc-zurich",
+          "transfer-pricing-associate-senior-associate-pwc-switzerland-zurich"
         ],
         "de": [
           "senior-associate-transfer-pricing-pwc-zurich"
         ]
       },
       "previousSlugs": [
-        "senior-associate-transfer-pricing-pwc-zurich"
+        "senior-associate-transfer-pricing-pwc-zurich",
+        "transfer-pricing-associate-senior-associate-pwc-switzerland-zurich"
       ]
     },
     {
@@ -5099,7 +5303,17 @@
       "postalCode": "8001",
       "id": "pwc-445b68e57732",
       "firstSeenAt": "2026-04-13T22:16:12.621Z",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "manager-sap-master-data-governance-beratung-pwc-switzerland-zurich",
+        "manager-sap-master-data-governance-consulting-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "manager-sap-master-data-governance-beratung-pwc-switzerland-zurich",
+          "manager-sap-master-data-governance-consulting-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Audit Senior Associate / Assistant Manager - Trade, Industries & Services / US GAAP",
@@ -5159,14 +5373,16 @@
       "id": "pwc-bb925b2aeca6",
       "previousSlugsByLocale": {
         "it": [
-          "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-zurich"
+          "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-zurich",
+          "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-switzerland-zurich-z8ofel"
         ],
         "fr": [
           "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-zurich"
         ]
       },
       "previousSlugs": [
-        "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-zurich"
+        "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-zurich",
+        "audit-senior-associate-assistant-manager-trade-industries-services-us-gaap-pwc-switzerland-zurich-z8ofel"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     },
@@ -5227,7 +5443,15 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-30T11:20:06.387Z"
+      "firstSeenAt": "2026-04-30T11:20:06.387Z",
+      "previousSlugs": [
+        "associate-payroll-consulting-80-100-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "associate-payroll-consulting-80-100-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Associate - Payroll Consulting 80-100%",
@@ -5357,7 +5581,8 @@
       "id": "pwc-e63636c661ff",
       "previousSlugsByLocale": {
         "it": [
-          "manager-senior-manager-transaction-services-pwc-zurich"
+          "manager-senior-manager-transaction-services-pwc-zurich",
+          "manager-senior-manager-transaction-services-pwc-switzerland-zurich"
         ],
         "de": [
           "manager-senior-manager-transaction-services-pwc-zurich"
@@ -5367,7 +5592,8 @@
         ]
       },
       "previousSlugs": [
-        "manager-senior-manager-transaction-services-pwc-zurich"
+        "manager-senior-manager-transaction-services-pwc-zurich",
+        "manager-senior-manager-transaction-services-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z",
       "needsRetranslation": true
@@ -5507,11 +5733,13 @@
       "id": "pwc-f09dbbf675a7",
       "previousSlugsByLocale": {
         "it": [
-          "senior-manager-director-asset-management-strategy-transformation-pwc-zurich"
+          "senior-manager-director-asset-management-strategy-transformation-pwc-zurich",
+          "senior-manager-director-asset-management-strategy-transformation-pwc-switzerland-zurich"
         ]
       },
       "previousSlugs": [
-        "senior-manager-director-asset-management-strategy-transformation-pwc-zurich"
+        "senior-manager-director-asset-management-strategy-transformation-pwc-zurich",
+        "senior-manager-director-asset-management-strategy-transformation-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     },
@@ -5573,7 +5801,8 @@
       "id": "pwc-23db575fa74b",
       "previousSlugsByLocale": {
         "it": [
-          "manager-transaction-services-financial-services-pwc-zurich"
+          "manager-transaction-services-financial-services-pwc-zurich",
+          "manager-transaction-services-financial-services-pwc-switzerland-zurich"
         ],
         "de": [
           "manager-transaction-services-financial-services-pwc-zurich"
@@ -5583,7 +5812,8 @@
         ]
       },
       "previousSlugs": [
-        "manager-transaction-services-financial-services-pwc-zurich"
+        "manager-transaction-services-financial-services-pwc-zurich",
+        "manager-transaction-services-financial-services-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     },
@@ -5646,10 +5876,18 @@
       "previousSlugsByLocale": {
         "fr": [
           "associe-principal-cybersecurite-et-confidentialite-pwc-switzerland-geneve"
+        ],
+        "it": [
+          "senior-associate-per-cybersecurity-e-privacy-pwc-switzerland-geneva",
+          "cybersecurity-privacy-senior-associate-pwc-switzerland-geneve",
+          "cybersecurity-privacy-senior-associate-pwc-switzerland-geneva"
         ]
       },
       "previousSlugs": [
-        "associe-principal-cybersecurite-et-confidentialite-pwc-switzerland-geneve"
+        "associe-principal-cybersecurite-et-confidentialite-pwc-switzerland-geneve",
+        "senior-associate-per-cybersecurity-e-privacy-pwc-switzerland-geneva",
+        "cybersecurity-privacy-senior-associate-pwc-switzerland-geneve",
+        "cybersecurity-privacy-senior-associate-pwc-switzerland-geneva"
       ]
     },
     {
@@ -5710,11 +5948,13 @@
       "firstSeenAt": "2026-05-17T10:54:12.475Z",
       "previousSlugs": [
         "asset-management-audit-manager-pwc-geneva",
-        "audit-di-gestione-patrimoniale-manager-pwc-switzerland-geneva"
+        "audit-di-gestione-patrimoniale-manager-pwc-switzerland-geneva",
+        "asset-management-audit-manager-pwc-switzerland-geneva"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "asset-management-audit-manager-pwc-geneva"
+          "asset-management-audit-manager-pwc-geneva",
+          "asset-management-audit-manager-pwc-switzerland-geneva"
         ]
       },
       "retranslationAttempts": 2,
@@ -5778,7 +6018,9 @@
       "id": "pwc-3b01b66c9f7c",
       "previousSlugsByLocale": {
         "it": [
-          "digital-audit-manager-financial-services-pwc-zurich"
+          "digital-audit-manager-financial-services-pwc-zurich",
+          "digital-audit-manager-financial-services-pwc-switzerland-zurich-6xjv06",
+          "digital-audit-manager-financial-services-pwc-switzerland-zurich"
         ],
         "de": [
           "digital-audit-manager-financial-services-pwc-zurich"
@@ -5788,7 +6030,9 @@
         ]
       },
       "previousSlugs": [
-        "digital-audit-manager-financial-services-pwc-zurich"
+        "digital-audit-manager-financial-services-pwc-zurich",
+        "digital-audit-manager-financial-services-pwc-switzerland-zurich-6xjv06",
+        "digital-audit-manager-financial-services-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     },
@@ -5851,7 +6095,8 @@
       "firstSeenAt": "2026-04-26T21:57:56.602Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-corporate-tax-pwc-luzern"
+          "manager-corporate-tax-pwc-luzern",
+          "corporate-tax-manager-zentralschweiz-pwc-switzerland-luzern"
         ],
         "fr": [
           "manager-corporate-tax-pwc-luzern"
@@ -5861,7 +6106,8 @@
         ]
       },
       "previousSlugs": [
-        "manager-corporate-tax-pwc-luzern"
+        "manager-corporate-tax-pwc-luzern",
+        "corporate-tax-manager-zentralschweiz-pwc-switzerland-luzern"
       ]
     },
     {
@@ -5922,14 +6168,16 @@
       "id": "pwc-130c0c3e66f5",
       "previousSlugsByLocale": {
         "it": [
-          "senior-associate-regulatory-risk-and-compliance-pwc-geneve"
+          "senior-associate-regulatory-risk-and-compliance-pwc-geneve",
+          "senior-associate-regulatory-risk-and-compliance-pwc-switzerland-geneve"
         ],
         "de": [
           "senior-associate-regulatory-risk-and-compliance-pwc-geneve"
         ]
       },
       "previousSlugs": [
-        "senior-associate-regulatory-risk-and-compliance-pwc-geneve"
+        "senior-associate-regulatory-risk-and-compliance-pwc-geneve",
+        "senior-associate-regulatory-risk-and-compliance-pwc-switzerland-geneve"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z",
       "needsRetranslation": true
@@ -5993,7 +6241,9 @@
       "firstSeenAt": "2026-04-26T21:57:56.602Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-u-s-tax-private-clients-pwc-zurich"
+          "manager-u-s-tax-private-clients-pwc-zurich",
+          "u-s-tax-manager-private-clients-pwc-switzerland-zurich",
+          "u-s-tax-manager-private-clients-pwc-switzerland-zurich-ykmx83"
         ],
         "de": [
           "manager-u-s-tax-private-clients-pwc-zurich"
@@ -6003,7 +6253,9 @@
         ]
       },
       "previousSlugs": [
-        "manager-u-s-tax-private-clients-pwc-zurich"
+        "manager-u-s-tax-private-clients-pwc-zurich",
+        "u-s-tax-manager-private-clients-pwc-switzerland-zurich",
+        "u-s-tax-manager-private-clients-pwc-switzerland-zurich-ykmx83"
       ]
     },
     {
@@ -6063,7 +6315,19 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-13T22:16:12.621Z"
+      "firstSeenAt": "2026-04-13T22:16:12.621Z",
+      "previousSlugs": [
+        "career-start-in-audit-asset-management-autunno-2026-pwc-switzerland-zurich",
+        "career-start-in-audit-asset-management-autumn-2026-pwc-switzerland-zurich",
+        "career-start-in-audit-asset-management-herbst-2026-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "career-start-in-audit-asset-management-autunno-2026-pwc-switzerland-zurich",
+          "career-start-in-audit-asset-management-autumn-2026-pwc-switzerland-zurich",
+          "career-start-in-audit-asset-management-herbst-2026-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Career Start in Audit – Asset Management – Herbst 2026",
@@ -6188,12 +6452,14 @@
       "postalCode": "8001",
       "previousSlugs": [
         "career-start-in-audit-insurance-oktober-2026-pwc-zurich",
-        "career-start-in-audit-insurance-oktober-2026-pwc-switzerland-basel-7us1mn"
+        "career-start-in-audit-insurance-oktober-2026-pwc-switzerland-basel-7us1mn",
+        "career-start-in-audit-insurance-october-2026-pwc-switzerland-zurich"
       ],
       "id": "pwc-b1dc2eb2fc65",
       "previousSlugsByLocale": {
         "it": [
-          "career-start-in-audit-insurance-oktober-2026-pwc-zurich"
+          "career-start-in-audit-insurance-oktober-2026-pwc-zurich",
+          "career-start-in-audit-insurance-october-2026-pwc-switzerland-zurich"
         ],
         "en": [
           "career-start-in-audit-insurance-oktober-2026-pwc-zurich"
@@ -6275,10 +6541,24 @@
         "inizio-carriera-in-audit-banking-autunno-2026-pwc-switzerland-basel",
         "inizio-carriera-in-audit-banking-autunno-2026-pwc-switzerland-st-gallen",
         "career-start-in-audit-banking-herbst-2026-pwc-luzern",
-        "inizio-carriera-in-audit-banking-herbst-2026-pwc-switzerland-luzern"
+        "inizio-carriera-in-audit-banking-herbst-2026-pwc-switzerland-luzern",
+        "career-start-in-audit-banking-herbst-2026-pwc-switzerland-zurich",
+        "career-start-in-audit-banking-herbst-2026-pwc-switzerland-bern-sw9ll4",
+        "career-start-in-audit-banking-herbst-2026-pwc-switzerland-bern",
+        "career-start-in-audit-banking-herbst-2026-pwc-switzerland-basel",
+        "career-start-in-audit-banking-herbst-2026-pwc-switzerland-st-gallen"
       ],
       "retranslationAttempts": 2,
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "career-start-in-audit-banking-herbst-2026-pwc-switzerland-zurich",
+          "career-start-in-audit-banking-herbst-2026-pwc-switzerland-bern-sw9ll4",
+          "career-start-in-audit-banking-herbst-2026-pwc-switzerland-bern",
+          "career-start-in-audit-banking-herbst-2026-pwc-switzerland-basel",
+          "career-start-in-audit-banking-herbst-2026-pwc-switzerland-st-gallen"
+        ]
+      }
     },
     {
       "title": "Director - Cloud, Data & AI (CD&AI) - Generative AI",
@@ -6632,7 +6912,15 @@
         }
       },
       "postalCode": "1201",
-      "firstSeenAt": "2026-04-23T10:39:31.530Z"
+      "firstSeenAt": "2026-04-23T10:39:31.530Z",
+      "previousSlugs": [
+        "career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve"
+        ]
+      }
     },
     {
       "title": "Career start in Audit Trade, Industries and Services - Genève - October 2026",
@@ -6748,7 +7036,8 @@
         "apprendistato-come-kauffrau-kaufmann-cfc-treuhand-pwc-switzerland-basel",
         "apprenticeship-as-a-merchant-efz-treuhand-pwc-switzerland-basel",
         "apprentissage-en-tant-que-marchand-efz-treuhand-pwc-switzerland-basel",
-        "lehrstelle-als-kauffrau-kaufmann-efz-treuhand-pwc-basel"
+        "lehrstelle-als-kauffrau-kaufmann-efz-treuhand-pwc-basel",
+        "lehrstelle-als-kauffrau-kaufmann-efz-treuhand-pwc-switzerland-basel"
       ],
       "salaryMin": 48000,
       "salaryMax": 65000,
@@ -6770,7 +7059,8 @@
           "apprendistato-come-kauffrau-kaufmann-cfc-treuhand-pwc-switzerland-basel",
           "apprenticeship-as-a-merchant-efz-treuhand-pwc-switzerland-basel",
           "apprentissage-en-tant-que-marchand-efz-treuhand-pwc-switzerland-basel",
-          "lehrstelle-als-kauffrau-kaufmann-efz-treuhand-pwc-basel"
+          "lehrstelle-als-kauffrau-kaufmann-efz-treuhand-pwc-basel",
+          "lehrstelle-als-kauffrau-kaufmann-efz-treuhand-pwc-switzerland-basel"
         ],
         "en": [
           "apprendistato-come-kauffrau-kaufmann-cfc-treuhand-pwc-switzerland-basel",
@@ -6985,7 +7275,9 @@
       "firstSeenAt": "2026-04-16T10:31:46.773Z",
       "previousSlugsByLocale": {
         "it": [
-          "stagiaire-mpc-3-1-service-et-administration-pwc-lausanne"
+          "stagiaire-mpc-3-1-service-et-administration-pwc-lausanne",
+          "stagiaire-mpc-3-1-service-et-administration-pwc-switzerland-lausanne",
+          "stagiaire-mpc-3-1-service-et-administration-pwc-switzerland-lausanne-8lf9bn"
         ],
         "en": [
           "stagiaire-mpc-3-1-service-et-administration-pwc-lausanne"
@@ -6995,7 +7287,9 @@
         ]
       },
       "previousSlugs": [
-        "stagiaire-mpc-3-1-service-et-administration-pwc-lausanne"
+        "stagiaire-mpc-3-1-service-et-administration-pwc-lausanne",
+        "stagiaire-mpc-3-1-service-et-administration-pwc-switzerland-lausanne",
+        "stagiaire-mpc-3-1-service-et-administration-pwc-switzerland-lausanne-8lf9bn"
       ]
     },
     {
@@ -7057,7 +7351,8 @@
       "firstSeenAt": "2026-04-16T10:31:46.773Z",
       "previousSlugsByLocale": {
         "it": [
-          "apprenti-e-employe-e-de-commerce-service-et-administration-pwc-lausanne"
+          "apprenti-e-employe-e-de-commerce-service-et-administration-pwc-lausanne",
+          "apprenti-e-employe-e-de-commerce-service-et-administration-pwc-switzerland-lausanne"
         ],
         "en": [
           "apprenti-e-employe-e-de-commerce-service-et-administration-pwc-lausanne"
@@ -7067,7 +7362,8 @@
         ]
       },
       "previousSlugs": [
-        "apprenti-e-employe-e-de-commerce-service-et-administration-pwc-lausanne"
+        "apprenti-e-employe-e-de-commerce-service-et-administration-pwc-lausanne",
+        "apprenti-e-employe-e-de-commerce-service-et-administration-pwc-switzerland-lausanne"
       ]
     },
     {
@@ -7127,7 +7423,21 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-05-17T10:54:12.475Z"
+      "firstSeenAt": "2026-05-17T10:54:12.475Z",
+      "previousSlugs": [
+        "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-lugano-iuyeut",
+        "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-zurich",
+        "audit-career-start-in-trade-industries-services-fall-2026-pwc-switzerland-zurich",
+        "career-start-audit-trade-industries-services-from-autumn-2026-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-lugano-iuyeut",
+          "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-zurich",
+          "audit-career-start-in-trade-industries-services-fall-2026-pwc-switzerland-zurich",
+          "career-start-audit-trade-industries-services-from-autumn-2026-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Career Start - Audit Trade, Industries & Services ab Herbst 2026",
@@ -7186,7 +7496,17 @@
         }
       },
       "postalCode": "3001",
-      "firstSeenAt": "2026-05-17T10:54:12.475Z"
+      "firstSeenAt": "2026-05-17T10:54:12.475Z",
+      "previousSlugs": [
+        "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-bern-gikalb",
+        "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-bern"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-bern-gikalb",
+          "audit-career-start-im-bereich-trade-industries-services-herbst-2026-pwc-switzerland-bern"
+        ]
+      }
     },
     {
       "title": "Career Start - Audit Trade, Industries & Services ab Herbst 2026",
@@ -7304,7 +7624,17 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-21T10:37:49.518Z"
+      "firstSeenAt": "2026-04-21T10:37:49.518Z",
+      "previousSlugs": [
+        "associate-senior-associate-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich-soj134",
+        "associate-senior-associate-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "associate-senior-associate-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich-soj134",
+          "associate-senior-associate-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Life Transformation Aktuar/-in – Manager/in",
@@ -7363,7 +7693,8 @@
       "postalCode": "8001",
       "previousSlugs": [
         "attuario-a-life-transformation-manager-pwc-switzerland-zurich",
-        "life-transformation-aktuar-in-manager-in-pwc-zurich"
+        "life-transformation-aktuar-in-manager-in-pwc-zurich",
+        "life-transformation-aktuar-in-manager-in-pwc-switzerland-zurich-cu6clv"
       ],
       "id": "pwc-641dbfaf828d",
       "previousSlugsByLocale": {
@@ -7371,7 +7702,8 @@
           "attuario-a-life-transformation-manager-pwc-switzerland-zurich"
         ],
         "it": [
-          "life-transformation-aktuar-in-manager-in-pwc-zurich"
+          "life-transformation-aktuar-in-manager-in-pwc-zurich",
+          "life-transformation-aktuar-in-manager-in-pwc-switzerland-zurich-cu6clv"
         ],
         "fr": [
           "life-transformation-aktuar-in-manager-in-pwc-zurich"
@@ -7437,7 +7769,15 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-13T22:16:12.621Z"
+      "firstSeenAt": "2026-04-13T22:16:12.621Z",
+      "previousSlugs": [
+        "senior-auditor-treasury-and-commodity-trading-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "senior-auditor-treasury-and-commodity-trading-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Senior Auditor - Treasury and Commodity Trading",
@@ -7496,7 +7836,17 @@
         }
       },
       "postalCode": "4001",
-      "firstSeenAt": "2026-04-13T22:16:12.621Z"
+      "firstSeenAt": "2026-04-13T22:16:12.621Z",
+      "previousSlugs": [
+        "senior-auditor-treasury-and-commodity-trading-pwc-switzerland-basel-ki2xlt",
+        "senior-auditor-treasury-and-commodity-trading-pwc-switzerland-basel"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "senior-auditor-treasury-and-commodity-trading-pwc-switzerland-basel-ki2xlt",
+          "senior-auditor-treasury-and-commodity-trading-pwc-switzerland-basel"
+        ]
+      }
     },
     {
       "title": "Senior Auditor - Treasury and Commodity Trading",
@@ -7624,7 +7974,17 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-05-17T10:54:12.475Z"
+      "firstSeenAt": "2026-05-17T10:54:12.475Z",
+      "previousSlugs": [
+        "audit-career-start-im-bereich-financial-services-herbst-2026-pwc-switzerland-bern-r55tbe",
+        "audit-career-start-im-bereich-financial-services-herbst-2026-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "audit-career-start-im-bereich-financial-services-herbst-2026-pwc-switzerland-bern-r55tbe",
+          "audit-career-start-im-bereich-financial-services-herbst-2026-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Audit – Career Start im Bereich Financial Services - Herbst 2026",
@@ -7897,7 +8257,9 @@
       "firstSeenAt": "2026-04-26T21:57:56.602Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-associate-customs-and-trade-consulting-pwc-zurich"
+          "senior-associate-customs-and-trade-consulting-pwc-zurich",
+          "senior-associate-customs-trade-consulting-pwc-switzerland-zurich",
+          "senior-associate-customs-trade-consulting-pwc-switzerland-zurich-4956k3"
         ],
         "de": [
           "senior-associate-customs-and-trade-consulting-pwc-zurich"
@@ -7907,7 +8269,9 @@
         ]
       },
       "previousSlugs": [
-        "senior-associate-customs-and-trade-consulting-pwc-zurich"
+        "senior-associate-customs-and-trade-consulting-pwc-zurich",
+        "senior-associate-customs-trade-consulting-pwc-switzerland-zurich",
+        "senior-associate-customs-trade-consulting-pwc-switzerland-zurich-4956k3"
       ]
     },
     {
@@ -8028,7 +8392,15 @@
         }
       },
       "postalCode": "8001",
-      "firstSeenAt": "2026-04-13T22:16:12.621Z"
+      "firstSeenAt": "2026-04-13T22:16:12.621Z",
+      "previousSlugs": [
+        "manager-senior-manager-cyber-technology-and-transformation-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "manager-senior-manager-cyber-technology-and-transformation-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Manager / Senior Manager - Cyber Technology and Transformation",
@@ -8089,11 +8461,15 @@
       "firstSeenAt": "2026-04-13T22:16:12.621Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-senior-manager-cyber-technology-and-transformation-pwc-geneve"
+          "manager-senior-manager-cyber-technology-and-transformation-pwc-geneve",
+          "manager-senior-manager-cyber-technology-and-transformation-pwc-switzerland-geneve",
+          "manager-senior-manager-cyber-technology-and-transformation-pwc-switzerland-geneve-b0p3fj"
         ]
       },
       "previousSlugs": [
-        "manager-senior-manager-cyber-technology-and-transformation-pwc-geneve"
+        "manager-senior-manager-cyber-technology-and-transformation-pwc-geneve",
+        "manager-senior-manager-cyber-technology-and-transformation-pwc-switzerland-geneve",
+        "manager-senior-manager-cyber-technology-and-transformation-pwc-switzerland-geneve-b0p3fj"
       ]
     },
     {
@@ -8153,7 +8529,17 @@
       },
       "postalCode": "8001",
       "needsRetranslation": true,
-      "firstSeenAt": "2026-05-06T22:31:19.674Z"
+      "firstSeenAt": "2026-05-06T22:31:19.674Z",
+      "previousSlugs": [
+        "senior-cyber-security-architect-manager-senior-manager-pwc-switzerland-zurich",
+        "manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "senior-cyber-security-architect-manager-senior-manager-pwc-switzerland-zurich",
+          "manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich"
+        ]
+      }
     },
     {
       "title": "Manager/Senior Manager - Senior Cyber Security Architect",
@@ -8214,11 +8600,13 @@
       "firstSeenAt": "2026-05-06T22:31:19.674Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-senior-manager-senior-cyber-security-architect-pwc-geneve"
+          "manager-senior-manager-senior-cyber-security-architect-pwc-geneve",
+          "senior-cyber-security-architect-manager-senior-manager-pwc-switzerland-geneve"
         ]
       },
       "previousSlugs": [
-        "manager-senior-manager-senior-cyber-security-architect-pwc-geneve"
+        "manager-senior-manager-senior-cyber-security-architect-pwc-geneve",
+        "senior-cyber-security-architect-manager-senior-manager-pwc-switzerland-geneve"
       ]
     },
     {
@@ -8278,7 +8666,8 @@
       "postalCode": "8001",
       "previousSlugs": [
         "senior-manager-versicherungsberatung-pwc-switzerland-zurich-voteg3",
-        "senior-manager-insurance-consulting-pwc-zurich"
+        "senior-manager-insurance-consulting-pwc-zurich",
+        "senior-manager-insurance-consulting-pwc-switzerland-zurich"
       ],
       "id": "pwc-cfb6092ea1bc",
       "previousSlugsByLocale": {
@@ -8286,7 +8675,8 @@
           "senior-manager-versicherungsberatung-pwc-switzerland-zurich-voteg3"
         ],
         "it": [
-          "senior-manager-insurance-consulting-pwc-zurich"
+          "senior-manager-insurance-consulting-pwc-zurich",
+          "senior-manager-insurance-consulting-pwc-switzerland-zurich"
         ],
         "de": [
           "senior-manager-insurance-consulting-pwc-zurich"
@@ -8356,11 +8746,15 @@
       "firstSeenAt": "2026-05-17T10:54:12.475Z",
       "previousSlugs": [
         "senior-manager-corporate-tax-pwc-geneva",
-        "senior-manager-imposta-sulle-societa-pwc-switzerland-geneva"
+        "senior-manager-imposta-sulle-societa-pwc-switzerland-geneva",
+        "corporate-tax-senior-manager-pwc-switzerland-geneva",
+        "corporate-tax-senior-manager-pwc-switzerland-geneve"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "senior-manager-corporate-tax-pwc-geneva"
+          "senior-manager-corporate-tax-pwc-geneva",
+          "corporate-tax-senior-manager-pwc-switzerland-geneva",
+          "corporate-tax-senior-manager-pwc-switzerland-geneve"
         ]
       },
       "retranslationAttempts": 2,
@@ -8423,7 +8817,9 @@
       "id": "pwc-3db573481578",
       "previousSlugsByLocale": {
         "it": [
-          "senior-manager-sap-financial-services-consulting-pwc-zurich"
+          "senior-manager-sap-financial-services-consulting-pwc-zurich",
+          "senior-manager-sap-financial-services-conseil-pwc-switzerland-zurich",
+          "senior-manager-sap-financial-services-consulting-pwc-switzerland-zurich"
         ],
         "de": [
           "senior-manager-sap-financial-services-consulting-pwc-zurich"
@@ -8433,7 +8829,9 @@
         ]
       },
       "previousSlugs": [
-        "senior-manager-sap-financial-services-consulting-pwc-zurich"
+        "senior-manager-sap-financial-services-consulting-pwc-zurich",
+        "senior-manager-sap-financial-services-conseil-pwc-switzerland-zurich",
+        "senior-manager-sap-financial-services-consulting-pwc-switzerland-zurich"
       ],
       "postalCode": "8001",
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
@@ -8635,7 +9033,10 @@
       "id": "pwc-1420c8caa2e7",
       "previousSlugsByLocale": {
         "it": [
-          "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-zurich"
+          "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-zurich",
+          "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich-39tfcg",
+          "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich",
+          "manager-senior-manager-cloud-data-ia-cd-ai-data-engineering-pwc-switzerland-zurich"
         ],
         "fr": [
           "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-zurich"
@@ -8645,7 +9046,10 @@
         "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-zurich",
         "manager-senior-manager-cloud-data-ai-cd-ai-finops-pwc-zurich",
         "manager-senior-manager-cloud-daten-ki-cd-ai-finops-pwc-switzerland-zurich",
-        "gestionnaire-gestionnaire-principal-cloud-data-ai-cd-ai-finops-pwc-switzerland-zurich"
+        "gestionnaire-gestionnaire-principal-cloud-data-ai-cd-ai-finops-pwc-switzerland-zurich",
+        "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich-39tfcg",
+        "manager-senior-manager-cloud-data-ai-cd-ai-data-engineering-pwc-switzerland-zurich",
+        "manager-senior-manager-cloud-data-ia-cd-ai-data-engineering-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z",
       "needsRetranslation": true
@@ -8765,7 +9169,9 @@
       },
       "previousSlugs": [
         "audit-assistant-manager-revisioni-limitate-70-100-pwc-switzerland-bern",
-        "audit-assistant-manager-eingeschrankte-revisionen-70-100-pwc-bern"
+        "audit-assistant-manager-eingeschrankte-revisionen-70-100-pwc-bern",
+        "audit-assistant-manager-eingeschrankte-revisionen-70-100-pwc-switzerland-bern",
+        "responsable-d-audit-assistant-eingeschrankte-revisionen-70-100-pwc-switzerland-bern"
       ],
       "salaryMin": 72000,
       "salaryMax": 97000,
@@ -8787,7 +9193,9 @@
           "audit-assistant-manager-revisioni-limitate-70-100-pwc-switzerland-bern"
         ],
         "it": [
-          "audit-assistant-manager-eingeschrankte-revisionen-70-100-pwc-bern"
+          "audit-assistant-manager-eingeschrankte-revisionen-70-100-pwc-bern",
+          "audit-assistant-manager-eingeschrankte-revisionen-70-100-pwc-switzerland-bern",
+          "responsable-d-audit-assistant-eingeschrankte-revisionen-70-100-pwc-switzerland-bern"
         ],
         "fr": [
           "audit-assistant-manager-eingeschrankte-revisionen-70-100-pwc-bern"
@@ -9004,7 +9412,9 @@
       "firstSeenAt": "2026-04-26T21:57:56.602Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-corporate-tax-80-100-pwc-basel"
+          "manager-corporate-tax-80-100-pwc-basel",
+          "corporate-tax-manager-80-100-pwc-switzerland-basel-x7l09v",
+          "corporate-tax-manager-80-100-pwc-switzerland-basel"
         ],
         "fr": [
           "manager-corporate-tax-80-100-pwc-basel"
@@ -9014,7 +9424,9 @@
         ]
       },
       "previousSlugs": [
-        "manager-corporate-tax-80-100-pwc-basel"
+        "manager-corporate-tax-80-100-pwc-basel",
+        "corporate-tax-manager-80-100-pwc-switzerland-basel-x7l09v",
+        "corporate-tax-manager-80-100-pwc-switzerland-basel"
       ]
     },
     {
@@ -9076,7 +9488,8 @@
       "firstSeenAt": "2026-04-26T21:57:56.602Z",
       "previousSlugsByLocale": {
         "it": [
-          "manager-corporate-tax-80-100-pwc-zurich"
+          "manager-corporate-tax-80-100-pwc-zurich",
+          "corporate-tax-manager-80-100-pwc-switzerland-zurich"
         ],
         "fr": [
           "manager-corporate-tax-80-100-pwc-zurich"
@@ -9086,7 +9499,8 @@
         ]
       },
       "previousSlugs": [
-        "manager-corporate-tax-80-100-pwc-zurich"
+        "manager-corporate-tax-80-100-pwc-zurich",
+        "corporate-tax-manager-80-100-pwc-switzerland-zurich"
       ]
     },
     {
@@ -9147,11 +9561,13 @@
       "id": "pwc-d6043c710b72",
       "previousSlugsByLocale": {
         "it": [
-          "director-in-cybersecurity-technology-transformation-pwc-zurich"
+          "director-in-cybersecurity-technology-transformation-pwc-zurich",
+          "director-in-cybersecurity-technology-transformation-pwc-switzerland-zurich"
         ]
       },
       "previousSlugs": [
-        "director-in-cybersecurity-technology-transformation-pwc-zurich"
+        "director-in-cybersecurity-technology-transformation-pwc-zurich",
+        "director-in-cybersecurity-technology-transformation-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     },
@@ -9218,11 +9634,13 @@
         "senior-manager-transfer-pricing-pwc-geneva",
         "senior-manager-verrechnungspreise-pwc-switzerland-geneva",
         "senior-manager-prix-de-transfert-pwc-switzerland-geneva",
-        "responsabile-senior-prezzi-di-trasferimento-pwc-switzerland-geneve"
+        "responsabile-senior-prezzi-di-trasferimento-pwc-switzerland-geneve",
+        "transfer-pricing-manager-senior-manager-pwc-switzerland-zurich"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "senior-manager-transfer-pricing-80-100-pwc-zurich"
+          "senior-manager-transfer-pricing-80-100-pwc-zurich",
+          "transfer-pricing-manager-senior-manager-pwc-switzerland-zurich"
         ],
         "de": [
           "senior-manager-transfer-pricing-80-100-pwc-zurich"
@@ -9287,7 +9705,8 @@
       "id": "pwc-2fa4a53b33fb",
       "previousSlugsByLocale": {
         "it": [
-          "manager-insurance-consulting-p-c-retail-commercial-pwc-zurich"
+          "manager-insurance-consulting-p-c-retail-commercial-pwc-zurich",
+          "manager-insurance-consulting-p-c-retail-commercial-pwc-switzerland-zurich"
         ],
         "de": [
           "manager-insurance-consulting-p-c-retail-commercial-pwc-zurich"
@@ -9297,7 +9716,8 @@
         ]
       },
       "previousSlugs": [
-        "manager-insurance-consulting-p-c-retail-commercial-pwc-zurich"
+        "manager-insurance-consulting-p-c-retail-commercial-pwc-zurich",
+        "manager-insurance-consulting-p-c-retail-commercial-pwc-switzerland-zurich"
       ],
       "firstSeenAt": "2026-04-13T22:16:12.621Z"
     }

--- a/data/jobs/by-crawler/rapelli.json
+++ b/data/jobs/by-crawler/rapelli.json
@@ -194,7 +194,15 @@
           "unitText": "YEAR"
         }
       },
-      "postalCode": "6855"
+      "postalCode": "6855",
+      "previousSlugs": [
+        "buyer-ingredienti-trade-100-rapelli-orior-food-ag-stabio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "buyer-ingredienti-trade-100-rapelli-orior-food-ag-stabio"
+        ]
+      }
     },
     {
       "id": "rapelli-9f442deed99b",
@@ -375,7 +383,15 @@
           "unitText": "YEAR"
         }
       },
-      "postalCode": "6855"
+      "postalCode": "6855",
+      "previousSlugs": [
+        "supply-chain-planner-100-rapelli-orior-food-ag-stabio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "supply-chain-planner-100-rapelli-orior-food-ag-stabio"
+        ]
+      }
     },
     {
       "id": "rapelli-bdc3322ac1f6",
@@ -433,7 +449,15 @@
           "unitText": "YEAR"
         }
       },
-      "postalCode": "6855"
+      "postalCode": "6855",
+      "previousSlugs": [
+        "manutentore-maintenance-technician-100-rapelli-orior-food-ag-stabio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "manutentore-maintenance-technician-100-rapelli-orior-food-ag-stabio"
+        ]
+      }
     }
   ]
 }

--- a/data/jobs/by-crawler/reboot-monkey.json
+++ b/data/jobs/by-crawler/reboot-monkey.json
@@ -2850,7 +2850,15 @@
           "unitText": "YEAR"
         }
       },
-      "postalCode": "1950"
+      "postalCode": "1950",
+      "previousSlugs": [
+        "data-center-technician-switzerland-les-acacias-on-site-reboot-monkey-les-acacias-2"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "data-center-technician-switzerland-les-acacias-on-site-reboot-monkey-les-acacias-2"
+        ]
+      }
     },
     {
       "id": "reboot-monkey-cae64717c785",
@@ -2937,7 +2945,17 @@
           "unitText": "YEAR"
         }
       },
-      "postalCode": "1950"
+      "postalCode": "1950",
+      "previousSlugs": [
+        "data-center-technician-switzerland-leuk-stadt-on-site-reboot-monkey-ch-2",
+        "data-center-technician-switzerland-leuk-stadt-on-site-reboot-monkey-leuk-stadt-2"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "data-center-technician-switzerland-leuk-stadt-on-site-reboot-monkey-ch-2",
+          "data-center-technician-switzerland-leuk-stadt-on-site-reboot-monkey-leuk-stadt-2"
+        ]
+      }
     },
     {
       "id": "reboot-monkey-31d24e5d7ae3",
@@ -7668,7 +7686,15 @@
           "unitText": "YEAR"
         }
       },
-      "postalCode": "8400"
+      "postalCode": "8400",
+      "previousSlugs": [
+        "data-center-technician-svizzera-winterthur-on-site-reboot-monkey-winterthur"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "data-center-technician-svizzera-winterthur-on-site-reboot-monkey-winterthur"
+        ]
+      }
     },
     {
       "id": "reboot-monkey-32b67c1bd5ca",
@@ -9854,6 +9880,14 @@
           "maxValue": 75000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "data-center-technician-jura-on-site-reboot-monkey-jura-2"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "data-center-technician-jura-on-site-reboot-monkey-jura-2"
+        ]
       }
     },
     {
@@ -10395,11 +10429,13 @@
       },
       "remote": false,
       "previousSlugs": [
-        "data-center-technician-uri-on-site-reboot-monkey-uri"
+        "data-center-technician-uri-on-site-reboot-monkey-uri",
+        "data-center-technician-uri-on-site-reboot-monkey-uri-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "data-center-technician-uri-on-site-reboot-monkey-uri"
+          "data-center-technician-uri-on-site-reboot-monkey-uri",
+          "data-center-technician-uri-on-site-reboot-monkey-uri-2"
         ]
       },
       "firstSeenAt": "2026-04-13T11:09:46.762Z",
@@ -10520,11 +10556,13 @@
       },
       "remote": false,
       "previousSlugs": [
-        "data-center-technician-leuk-on-site-reboot-monkey-leuk"
+        "data-center-technician-leuk-on-site-reboot-monkey-leuk",
+        "data-center-technician-leuk-on-site-reboot-monkey-ch-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "data-center-technician-leuk-on-site-reboot-monkey-leuk"
+          "data-center-technician-leuk-on-site-reboot-monkey-leuk",
+          "data-center-technician-leuk-on-site-reboot-monkey-ch-2"
         ]
       },
       "firstSeenAt": "2026-04-13T11:09:46.761Z",
@@ -10645,11 +10683,13 @@
       },
       "remote": false,
       "previousSlugs": [
-        "data-center-technician-glarus-on-site-reboot-monkey-glarus"
+        "data-center-technician-glarus-on-site-reboot-monkey-glarus",
+        "data-center-technician-glarus-on-site-reboot-monkey-glarus-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "data-center-technician-glarus-on-site-reboot-monkey-glarus"
+          "data-center-technician-glarus-on-site-reboot-monkey-glarus",
+          "data-center-technician-glarus-on-site-reboot-monkey-glarus-2"
         ]
       },
       "firstSeenAt": "2026-04-13T11:09:46.760Z",
@@ -10769,11 +10809,13 @@
       },
       "remote": false,
       "previousSlugs": [
-        "data-center-technician-sursee-on-site-reboot-monkey-sursee"
+        "data-center-technician-sursee-on-site-reboot-monkey-sursee",
+        "data-center-technician-sursee-on-site-reboot-monkey-sursee-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "data-center-technician-sursee-on-site-reboot-monkey-sursee"
+          "data-center-technician-sursee-on-site-reboot-monkey-sursee",
+          "data-center-technician-sursee-on-site-reboot-monkey-sursee-2"
         ]
       },
       "firstSeenAt": "2026-04-13T11:09:46.759Z",
@@ -10910,7 +10952,15 @@
           "unitText": "YEAR"
         }
       },
-      "postalCode": "7000"
+      "postalCode": "7000",
+      "previousSlugs": [
+        "data-center-technician-chur-on-site-reboot-monkey-chur-2"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "data-center-technician-chur-on-site-reboot-monkey-chur-2"
+        ]
+      }
     },
     {
       "id": "reboot-monkey-62ea444ce0be",
@@ -11143,11 +11193,13 @@
       },
       "remote": false,
       "previousSlugs": [
-        "data-center-technician-switzerland-bellinzona-on-site-reboot-monkey-bellinzona"
+        "data-center-technician-switzerland-bellinzona-on-site-reboot-monkey-bellinzona",
+        "data-center-technician-switzerland-bellinzona-on-site-reboot-monkey-bellinzona-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "data-center-technician-switzerland-bellinzona-on-site-reboot-monkey-bellinzona"
+          "data-center-technician-switzerland-bellinzona-on-site-reboot-monkey-bellinzona",
+          "data-center-technician-switzerland-bellinzona-on-site-reboot-monkey-bellinzona-2"
         ]
       },
       "firstSeenAt": "2026-04-13T11:09:46.756Z",

--- a/data/jobs/by-crawler/rss-surselva.json
+++ b/data/jobs/by-crawler/rss-surselva.json
@@ -651,11 +651,15 @@
       "pensumMax": 100,
       "previousSlugs": [
         "dipl-experten-expertin-hf-notfallpflege-100-rss-surselva-ch",
-        "dipl-expert-expert-hf-emergency-care-100-regionalspital-surselva-ilanz"
+        "dipl-expert-expert-hf-emergency-care-100-regionalspital-surselva-ilanz",
+        "dipl-experten-expertin-nds-hf-notfallpflege-100-regionalspital-surselva-ilanz",
+        "dipl-ing-experten-expertin-nds-hf-notfallpflege-100-regionalspital-surselva-ilanz"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "dipl-experten-expertin-hf-notfallpflege-100-rss-surselva-ch"
+          "dipl-experten-expertin-hf-notfallpflege-100-rss-surselva-ch",
+          "dipl-experten-expertin-nds-hf-notfallpflege-100-regionalspital-surselva-ilanz",
+          "dipl-ing-experten-expertin-nds-hf-notfallpflege-100-regionalspital-surselva-ilanz"
         ]
       },
       "needsRetranslation": true,
@@ -958,12 +962,14 @@
           "chefarzt-arztin-innere-medizin-rss-surselva-ch"
         ],
         "it": [
-          "chefarzt-arztin-innere-medizin-rss-surselva-ch"
+          "chefarzt-arztin-innere-medizin-rss-surselva-ch",
+          "chefarzt-in-m-w-d-innere-medizin-regionalspital-surselva-ilanz"
         ]
       },
       "previousSlugs": [
         "chefarzt-arztin-innere-medizin-rss-surselva-ch",
-        "medicina-interna-regionalspital-surselva-ilanz"
+        "medicina-interna-regionalspital-surselva-ilanz",
+        "chefarzt-in-m-w-d-innere-medizin-regionalspital-surselva-ilanz"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T10:58:28.396Z",

--- a/data/jobs/by-crawler/sintetica.json
+++ b/data/jobs/by-crawler/sintetica.json
@@ -539,7 +539,8 @@
         "specialista-affari-regolatori-sede-di-mendrisio-ticino-sintetica-sa-mendrisio",
         "regulatory-affairs-specialiste-mendrisio-site-ticino-sintetica-sa-mendrisio-2kc1p0",
         "regulatory-affairs-specialist-mendrisio-site-ticino-sintetica",
-        "regulatory-affairs-spezialist-mendrisio-site-ticino-sintetica-sa-mendrisio"
+        "regulatory-affairs-spezialist-mendrisio-site-ticino-sintetica-sa-mendrisio",
+        "regulatory-affairs-specialist-mendrisio-site-ticino-sintetica-mendrisio-ticino-switzerland"
       ],
       "salaryMin": 76500,
       "salaryMax": 103500,
@@ -557,7 +558,8 @@
       "previousSlugsByLocale": {
         "it": [
           "specialista-affari-regolatori-sede-di-mendrisio-ticino-sintetica-sa-mendrisio",
-          "regulatory-affairs-specialiste-mendrisio-site-ticino-sintetica-sa-mendrisio-2kc1p0"
+          "regulatory-affairs-specialiste-mendrisio-site-ticino-sintetica-sa-mendrisio-2kc1p0",
+          "regulatory-affairs-specialist-mendrisio-site-ticino-sintetica-mendrisio-ticino-switzerland"
         ],
         "en": [
           "regulatory-affairs-specialist-mendrisio-site-ticino-sintetica",

--- a/data/jobs/by-crawler/somedia.json
+++ b/data/jobs/by-crawler/somedia.json
@@ -353,11 +353,13 @@
         "hiringOrganization": "Somedia AG"
       },
       "previousSlugs": [
-        "leiter-in-people-culture-leiter-in-hr-100-somedia-ch"
+        "leiter-in-people-culture-leiter-in-hr-100-somedia-ch",
+        "leiterin-leiter-people-culture-100-somedia-ch"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "leiter-in-people-culture-leiter-in-hr-100-somedia-ch"
+          "leiter-in-people-culture-leiter-in-hr-100-somedia-ch",
+          "leiterin-leiter-people-culture-100-somedia-ch"
         ]
       },
       "firstSeenAt": "2026-04-29T11:28:02.545Z",

--- a/data/jobs/by-crawler/spital-thurgau.json
+++ b/data/jobs/by-crawler/spital-thurgau.json
@@ -2369,11 +2369,13 @@
       "contractDuration": "permanent",
       "previousSlugs": [
         "medizinische-praxisassistentin-medizinischer-praxisassistent-mpa-fur-medizinische",
-        "pflegeassistent-in-o-pflegehelfer-in-medizinische-diagnostik-spital-thurgau-stgag-kantonsspital-munsterlingen"
+        "pflegeassistent-in-o-pflegehelfer-in-medizinische-diagnostik-spital-thurgau-stgag-kantonsspital-munsterlingen",
+        "medizinische-praxisassistentin-medizinischer-praxisassistent-mpa-fur-medizinische-diagnostik-spital-thurgau-stgag-kanton"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "medizinische-praxisassistentin-medizinischer-praxisassistent-mpa-fur-medizinische"
+          "medizinische-praxisassistentin-medizinischer-praxisassistent-mpa-fur-medizinische",
+          "medizinische-praxisassistentin-medizinischer-praxisassistent-mpa-fur-medizinische-diagnostik-spital-thurgau-stgag-kanton"
         ]
       },
       "needsRetranslation": true,
@@ -2597,12 +2599,14 @@
         "ausbildung-dipl-pflegefachmann-frau-hf-2-jahre-verkurzt-september-2027-generalist-bzgs",
         "ausbildung-dipl-pflegefachmann-frau-hf-2-jahre-verkurzt-september-2027-generalist-bzgs-spital-thurgau-stgag-kantonsspital-munsterlingen",
         "specialista-per-l-educazione-hf-2-anni-settembre-2027-kjff-bfgs-spital-thurgau-stgag-kantonsspital-munsterlingen",
-        "specialista-per-l-educazione-hf-2-anni-settembre-2027-generalista-bzgs-spital-thurgau-stgag-kantonsspital-munsterlingen"
+        "specialista-per-l-educazione-hf-2-anni-settembre-2027-generalista-bzgs-spital-thurgau-stgag-kantonsspital-munsterlingen",
+        "ausbildung-dipl-pflegefachmann-frau-hf-2-jahre-verkurzt-september-2027-generalist-bzgs-spital-thurgau-stgag-kantonsspita"
       ],
       "previousSlugsByLocale": {
         "it": [
           "ausbildung-dipl-pflegefachmann-frau-hf-2-jahre-verkurzt-september-2027-generalist-bzgs",
-          "ausbildung-dipl-pflegefachmann-frau-hf-2-jahre-verkurzt-september-2027-generalist-bzgs-spital-thurgau-stgag-kantonsspital-munsterlingen"
+          "ausbildung-dipl-pflegefachmann-frau-hf-2-jahre-verkurzt-september-2027-generalist-bzgs-spital-thurgau-stgag-kantonsspital-munsterlingen",
+          "ausbildung-dipl-pflegefachmann-frau-hf-2-jahre-verkurzt-september-2027-generalist-bzgs-spital-thurgau-stgag-kantonsspita"
         ]
       },
       "needsRetranslation": true,
@@ -3753,11 +3757,13 @@
       "contractDuration": "permanent",
       "previousSlugs": [
         "diplomierte-pflegefachperson-hf-fh-fur-ein-jahr-stationar-mit-option-fur-die-ambulante",
-        "dipl-pflegefachmann-frau-hf-fh-im-flexi-team-per-chirurgie-orthopala-spital-thurgau-stgag-kantonsspital-munsterlingen"
+        "dipl-pflegefachmann-frau-hf-fh-im-flexi-team-per-chirurgie-orthopala-spital-thurgau-stgag-kantonsspital-munsterlingen",
+        "diplomierte-pflegefachperson-hf-fh-fur-ein-jahr-stationar-mit-option-fur-die-ambulante-tagesklinik-spital-thurgau-stgag-"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "diplomierte-pflegefachperson-hf-fh-fur-ein-jahr-stationar-mit-option-fur-die-ambulante"
+          "diplomierte-pflegefachperson-hf-fh-fur-ein-jahr-stationar-mit-option-fur-die-ambulante",
+          "diplomierte-pflegefachperson-hf-fh-fur-ein-jahr-stationar-mit-option-fur-die-ambulante-tagesklinik-spital-thurgau-stgag-"
         ]
       },
       "needsRetranslation": true,
@@ -10411,11 +10417,15 @@
       "department": "Ärztliches Personal",
       "contractDuration": "permanent",
       "previousSlugs": [
-        "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und"
+        "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+        "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und-psychotherapie-spital-thurgau-stgag-kanto",
+        "assistenzarzt-arztin-in-facharztweiterbildung-kinder-e-jugendpsychiatrie-e-psychotherapie-spital-thurgau-stgag-kantonssp"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und"
+          "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+          "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und-psychotherapie-spital-thurgau-stgag-kanto",
+          "assistenzarzt-arztin-in-facharztweiterbildung-kinder-e-jugendpsychiatrie-e-psychotherapie-spital-thurgau-stgag-kantonssp"
         ]
       },
       "needsRetranslation": true,
@@ -10645,6 +10655,14 @@
           "maxValue": 75000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "dipl-expertin-experte-intensivpflege-nds-hf-mit-zusatzfunktion-implementierung-ficus-studie-70-100-spital-thurgau-stgag-"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "dipl-expertin-experte-intensivpflege-nds-hf-mit-zusatzfunktion-implementierung-ficus-studie-70-100-spital-thurgau-stgag-"
+        ]
       }
     },
     {

--- a/data/jobs/by-crawler/supsi-dti.json
+++ b/data/jobs/by-crawler/supsi-dti.json
@@ -113,12 +113,16 @@
       "previousSlugsByLocale": {
         "en": [
           "phd-student-in-dynamic-of-advanced-composite-materials-for-drones-supsi-dti-mendrisio-grado-d"
+        ],
+        "it": [
+          "dottoranda-dottorando-in-dinamica-dei-materiali-compositi-avanzati-per-droni-supsi-dti-manno"
         ]
       },
       "previousSlugs": [
         "phd-student-in-dynamic-of-advanced-composite-materials-for-drones-supsi-dti-mendrisio-grado-d",
         "dottoranda-dottorando-in-dinamica-dei-materiali-compositi-avanzati-per-droni-supsi-dti-men",
-        "dottoranda-dottorando-in-dinamica-dei-materiali-composti-avanzati-per-droni-supsi-dti-manno"
+        "dottoranda-dottorando-in-dinamica-dei-materiali-composti-avanzati-per-droni-supsi-dti-manno",
+        "dottoranda-dottorando-in-dinamica-dei-materiali-compositi-avanzati-per-droni-supsi-dti-manno"
       ],
       "salaryMin": 85500,
       "salaryMax": 150000,
@@ -470,7 +474,15 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "ricercatrice-ricercatore-con-phd-in-resource-constrained-nanorobotics-supsi-dti-manno"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "ricercatrice-ricercatore-con-phd-in-resource-constrained-nanorobotics-supsi-dti-manno"
+        ]
+      }
     },
     {
       "id": "company-l4ti32",
@@ -576,7 +588,15 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "direttrice-direttore-della-formazione-di-base-supsi-dti-manno"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "direttrice-direttore-della-formazione-di-base-supsi-dti-manno"
+        ]
+      }
     },
     {
       "id": "company-l4ti34",
@@ -800,9 +820,15 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "bachelor-of-science-in-engineering-mse-am-isteps-institut-supsi-dti-manno",
-        "bachelor-of-science-in-engineering-mse-am-isteps-institut-supsi-dti-lugano"
+        "bachelor-of-science-in-engineering-mse-am-isteps-institut-supsi-dti-lugano",
+        "assistente-bachelor-in-formazione-master-of-science-in-engineering-mse-presso-l-istituto-isteps-supsi-dti-manno"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-bachelor-in-formazione-master-of-science-in-engineering-mse-presso-l-istituto-isteps-supsi-dti-manno"
+        ]
+      }
     },
     {
       "id": "company-l4u549",
@@ -919,9 +945,15 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "previousSlugs": [
-        "bachelor-in-ausbildung-master-mse-in-informatik-supsi-dti-lugano"
+        "bachelor-in-ausbildung-master-mse-in-informatik-supsi-dti-lugano",
+        "assistenti-bachelor-in-formazione-master-mse-in-computer-science-o-data-science-supsi-dti-manno"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "assistenti-bachelor-in-formazione-master-mse-in-computer-science-o-data-science-supsi-dti-manno"
+        ]
+      }
     },
     {
       "id": "company-l4u54a",
@@ -1029,9 +1061,15 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "baccalaureat-en-education-master-mse-en-data-science-supsi-dti-manno",
-        "baccalaureat-en-education-master-mse-en-data-science-supsi-dti-lugano"
+        "baccalaureat-en-education-master-mse-en-data-science-supsi-dti-lugano",
+        "assistenti-bachelor-in-formazione-master-mse-in-data-science-supsi-dti-manno"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "assistenti-bachelor-in-formazione-master-mse-in-data-science-supsi-dti-manno"
+        ]
+      }
     },
     {
       "id": "company-l4ti33",
@@ -1249,7 +1287,15 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "assistente-con-master-nell-area-del-controllo-intelligente-per-sistemi-e-reti-supsi-dti-manno"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "assistente-con-master-nell-area-del-controllo-intelligente-per-sistemi-e-reti-supsi-dti-manno"
+        ]
+      }
     },
     {
       "id": "company-l4wp0m",
@@ -1340,7 +1386,9 @@
         "lernende-r-operatrice-informatica-operatore-informatico-afc-supsi-dti-ticino-l4wp0m",
         "apprentice-operatrice-informatica-operatore-informatico-afc-supsi-dti-manno",
         "lernende-r-operatrice-informatica-operatore-informatico-afc-supsi-dti-manno",
-        "apprenti-e-operatrice-informatica-operatore-informatico-afc-supsi-dti-manno"
+        "apprenti-e-operatrice-informatica-operatore-informatico-afc-supsi-dti-manno",
+        "lernende-r-operatrice-informatica-operatore-informatico-afc-supsi-dti-ticino",
+        "apprendista-operatrice-informatica-operatore-informatico-afc-supsi-dti-manno"
       ],
       "country": "CH",
       "sourceLang": "it",
@@ -1371,6 +1419,10 @@
         ],
         "fr": [
           "apprendista-operatrice-informatica-operatore-informatico-afc-supsi-dti-ticino-l4wp0m"
+        ],
+        "it": [
+          "lernende-r-operatrice-informatica-operatore-informatico-afc-supsi-dti-ticino",
+          "apprendista-operatrice-informatica-operatore-informatico-afc-supsi-dti-manno"
         ]
       },
       "needsRetranslation": true
@@ -1490,12 +1542,14 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "concorso-generale-personale-educativo-servizio-prima-infanzia-2026-supsi-dti-ticino-l4ti2z",
-        "personale-educativo-servizio-prima-infanzia-2026-supsi-dti-ticino"
+        "personale-educativo-servizio-prima-infanzia-2026-supsi-dti-ticino",
+        "concorso-generale-personale-educativo-servizio-prima-infanzia-2026-supsi-dti-manno"
       ],
       "previousSlugsByLocale": {
         "it": [
           "concorso-generale-personale-educativo-servizio-prima-infanzia-2026-supsi-dti-ticino-l4ti2z",
-          "personale-educativo-servizio-prima-infanzia-2026-supsi-dti-ticino"
+          "personale-educativo-servizio-prima-infanzia-2026-supsi-dti-ticino",
+          "concorso-generale-personale-educativo-servizio-prima-infanzia-2026-supsi-dti-manno"
         ],
         "en": [
           "concorso-generale-personale-educativo-servizio-prima-infanzia-2026-supsi-dti-ticino-l4ti2z",

--- a/data/jobs/by-crawler/swisscom-sede-ticino.json
+++ b/data/jobs/by-crawler/swisscom-sede-ticino.json
@@ -1148,11 +1148,13 @@
       "firstSeenAt": "2026-05-12T23:06:10.710Z",
       "previousSlugs": [
         "technical-product-owner-openshift-swisscom-zurich-s7ze68",
-        "proprietario-del-prodotto-openshift-swisscom-sede-ticino-zurich"
+        "proprietario-del-prodotto-openshift-swisscom-sede-ticino-zurich",
+        "product-owner-openshift-swisscom-sede-ticino-zurich"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "technical-product-owner-openshift-swisscom-zurich-s7ze68"
+          "technical-product-owner-openshift-swisscom-zurich-s7ze68",
+          "product-owner-openshift-swisscom-sede-ticino-zurich"
         ],
         "fr": [
           "technical-product-owner-openshift-swisscom-zurich-s7ze68"
@@ -2243,7 +2245,8 @@
       "previousSlugsByLocale": {
         "it": [
           "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-monthey-tves62",
-          "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-sede-ticino-monthey"
+          "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-sede-ticino-monthey",
+          "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-sede-ticino-grancia"
         ],
         "en": [
           "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-monthey-tves62"
@@ -2254,7 +2257,8 @@
       },
       "previousSlugs": [
         "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-monthey-tves62",
-        "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-sede-ticino-monthey"
+        "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-sede-ticino-monthey",
+        "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-sede-ticino-grancia"
       ],
       "salaryMin": 49500,
       "salaryMax": 75000,
@@ -3899,14 +3903,16 @@
         "lehre-digital-business-developer-developer-efz-swisscom-sede-ticino-bellinzona",
         "lehre-digital-business-developer-in-efz-swisscom-sede-ticino-bellinzona",
         "apprenticeship-digital-business-developer-afc-swisscom-sede-ticino-bellinzona",
-        "apprentissage-developpeur-developpeuse-d-affaires-numeriques-cfc-swisscom-sede-ticino-bellinzona"
+        "apprentissage-developpeur-developpeuse-d-affaires-numeriques-cfc-swisscom-sede-ticino-bellinzona",
+        "apprendistato-sviluppatore-sviluppatrice-business-digitale-afc-swisscom-sede-ticino-lugano"
       ],
       "id": "swisscom-sede-ticino-29f30582fa97",
       "previousSlugsByLocale": {
         "it": [
           "apprendistato-sviluppatore-sviluppatrice-business-digitale-afc-swisscom-sede-ticino-bellinzona-dnuo1f",
           "apprendistato-sviluppatore-sviluppatrice-business-digitale-afc-swisscom-bellinzona",
-          "apprendistato-sviluppatore-sviluppatrice-business-digitale-afc-swisscom-bellinzona-dnuo1f"
+          "apprendistato-sviluppatore-sviluppatrice-business-digitale-afc-swisscom-bellinzona-dnuo1f",
+          "apprendistato-sviluppatore-sviluppatrice-business-digitale-afc-swisscom-sede-ticino-lugano"
         ],
         "en": [
           "apprendistato-sviluppatore-sviluppatrice-business-digitale-afc-swisscom-sede-ticino-bellinzona-dnuo1f",
@@ -4060,7 +4066,8 @@
         "apprenticeship-ict-operator-afc-swisscom-sede-ticino-bellinzona",
         "apprenticeship-media-specialist-afc-swisscom-sede-ticino-bellinzona",
         "apprentissage-mediamaticien-ne-afc-swisscom-sede-ticino-bellinzona",
-        "apprentissage-operateur-operatrice-informatique-afc-swisscom-sede-ticino-bellinzona"
+        "apprentissage-operateur-operatrice-informatique-afc-swisscom-sede-ticino-bellinzona",
+        "apprendistato-operatore-operatrice-informatico-a-afc-swisscom-sede-ticino-lugano"
       ],
       "id": "swisscom-sede-ticino-fb1117c1ac70",
       "previousSlugsByLocale": {
@@ -4070,7 +4077,8 @@
           "lernen-computer-betreiber-afc-swisscom-sede-ticino-bellinzona",
           "apprentissage-operateur-informatique-afc-swisscom-sede-ticino-bellinzona",
           "apprendistato-operatore-operatrice-informatico-a-afc-swisscom-bellinzona",
-          "apprendistato-operatore-operatrice-informatico-a-afc-swisscom-bellinzona-tm4hbv"
+          "apprendistato-operatore-operatrice-informatico-a-afc-swisscom-bellinzona-tm4hbv",
+          "apprendistato-operatore-operatrice-informatico-a-afc-swisscom-sede-ticino-lugano"
         ],
         "en": [
           "apprendistato-operatore-operatrice-informatico-a-afc-swisscom-sede-ticino-bellinzona-tm4hbv",
@@ -4226,7 +4234,12 @@
         "apprendistato-employee-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-bellinzona",
         "apprentissage-employe-e-du-commerce-de-detail-cfc-swisscom-sede-ticino-bellinzona",
         "lehre-einzelhandelskaufmann-frau-afc-swisscom-sede-ticino-bellinzona",
-        "apprentissage-employe-e-du-commerce-de-detail-afc-swisscom-sede-ticino-bellinzona"
+        "apprentissage-employe-e-du-commerce-de-detail-afc-swisscom-sede-ticino-bellinzona",
+        "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-lugano",
+        "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-bellinzona-balerna-2",
+        "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-bellinzona-balerna-3",
+        "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-belli-56yj6w",
+        "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-belli-56yj6u"
       ],
       "id": "swisscom-sede-ticino-f9b5e9dfb848",
       "previousSlugsByLocale": {
@@ -4241,7 +4254,12 @@
           "apprentissage-gestionnaire-du-commerce-de-detail-cfc-swisscom-sede-ticino-bellinzona",
           "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-balerna",
           "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-balerna-56yj6u",
-          "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-balerna-56yj6u"
+          "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-balerna-56yj6u",
+          "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-lugano",
+          "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-bellinzona-balerna-2",
+          "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-bellinzona-balerna-3",
+          "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-belli-56yj6w",
+          "apprendistato-impiegato-a-del-commercio-al-dettaglio-afc-swisscom-sede-ticino-belli-56yj6u"
         ],
         "en": [
           "lehre-detailhandelsfachmann-frau-efz-swisscom-sede-ticino-bellinzona",
@@ -4560,7 +4578,8 @@
       "previousSlugs": [
         "apprendistato-mediamatico-a-afc-swisscom-bellinzona",
         "apprendistato-mediamatico-a-afc-swisscom-sede-ticino-bellinzona-b7f2l9",
-        "medienpraktikant-afc-swisscom-sede-ticino-bellinzona"
+        "medienpraktikant-afc-swisscom-sede-ticino-bellinzona",
+        "apprendistato-mediamatico-a-afc-swisscom-sede-ticino-lugano"
       ],
       "salaryMin": 46500,
       "salaryMax": 62500,
@@ -4584,7 +4603,8 @@
       "previousSlugsByLocale": {
         "it": [
           "apprendistato-mediamatico-a-afc-swisscom-bellinzona",
-          "apprendistato-mediamatico-a-afc-swisscom-sede-ticino-bellinzona-b7f2l9"
+          "apprendistato-mediamatico-a-afc-swisscom-sede-ticino-bellinzona-b7f2l9",
+          "apprendistato-mediamatico-a-afc-swisscom-sede-ticino-lugano"
         ],
         "en": [
           "apprendistato-mediamatico-a-afc-swisscom-bellinzona",

--- a/data/jobs/by-crawler/tally-weijl.json
+++ b/data/jobs/by-crawler/tally-weijl.json
@@ -625,11 +625,13 @@
       },
       "previousSlugs": [
         "store-manager-80-100-m-w-d-tally-weijl-chur",
-        "filialleiter-80-100-m-w-d-tally-weijl-chur"
+        "filialleiter-80-100-m-w-d-tally-weijl-chur",
+        "store-manager-100-m-w-d-tally-weijl-frauenfeld"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "store-manager-80-100-m-w-d-tally-weijl-chur"
+          "store-manager-80-100-m-w-d-tally-weijl-chur",
+          "store-manager-100-m-w-d-tally-weijl-frauenfeld"
         ],
         "de": [
           "filialleiter-80-100-m-w-d-tally-weijl-chur"
@@ -1384,11 +1386,13 @@
       },
       "previousSlugs": [
         "filialleiter-store-manager-w-m-d-tally-weijl-emmen",
-        "filialleiter-gestionnaire-de-magasins-w-m-d-tally-weijl-emmen"
+        "filialleiter-gestionnaire-de-magasins-w-m-d-tally-weijl-emmen",
+        "filialleiter-store-manager-w-m-d-tw-thun-tally-weijl-thun"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "filialleiter-store-manager-w-m-d-tally-weijl-emmen"
+          "filialleiter-store-manager-w-m-d-tally-weijl-emmen",
+          "filialleiter-store-manager-w-m-d-tw-thun-tally-weijl-thun"
         ],
         "fr": [
           "filialleiter-gestionnaire-de-magasins-w-m-d-tally-weijl-emmen"

--- a/data/jobs/by-crawler/tether.json
+++ b/data/jobs/by-crawler/tether.json
@@ -187,12 +187,26 @@
       },
       "previousSlugs": [
         "lead-software-engineer-mobile-development-crypto-wallets-100-remote-tether-ch-3",
-        "lead-software-engineer-mobile-development-crypto-wallets-100-remote-tether-ch-5"
+        "lead-software-engineer-mobile-development-crypto-wallets-100-remote-tether-ch-5",
+        "lead-software-engineer-mobile-entwicklung-crypto-wallets-100-remote-tether-operations-london",
+        "lead-software-engineer-mobile-entwicklung-crypto-wallets-100-remote-tether-operations-dubai",
+        "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-delhi",
+        "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-islamabad",
+        "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-dubai",
+        "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-london",
+        "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-barcelona"
       ],
       "previousSlugsByLocale": {
         "it": [
           "lead-software-engineer-mobile-development-crypto-wallets-100-remote-tether-ch-3",
-          "lead-software-engineer-mobile-development-crypto-wallets-100-remote-tether-ch-5"
+          "lead-software-engineer-mobile-development-crypto-wallets-100-remote-tether-ch-5",
+          "lead-software-engineer-mobile-entwicklung-crypto-wallets-100-remote-tether-operations-london",
+          "lead-software-engineer-mobile-entwicklung-crypto-wallets-100-remote-tether-operations-dubai",
+          "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-delhi",
+          "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-islamabad",
+          "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-dubai",
+          "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-london",
+          "lead-software-ingegnere-mobile-development-crypto-wallets-100-remote-tether-operations-barcelona"
         ]
       },
       "firstSeenAt": "2026-04-13T22:32:40.218Z",
@@ -658,6 +672,36 @@
           "maxValue": 103000,
           "unitText": "YEAR"
         }
+      },
+      "previousSlugs": [
+        "social-media-manager-ki-technik-100-remote-tether-operations-zurich",
+        "social-media-manager-ki-technik-100-remote-tether-operations-london",
+        "social-media-manager-ki-technik-100-remote-tether-operations-amsterdam",
+        "social-media-manager-ki-technik-100-remote-tether-operations-stockholm",
+        "social-media-manager-ki-technik-100-remote-tether-operations-lisbon",
+        "social-media-manager-ki-technik-100-remote-tether-operations-milano",
+        "social-media-manager-ki-technik-100-remote-tether-operations-bogota",
+        "social-media-manager-ki-technik-100-remote-tether-operations-montevideo",
+        "social-media-manager-ki-technik-100-remote-tether-operations-dublin",
+        "social-media-manager-ki-technik-100-remote-tether-operations-madrid",
+        "social-media-manager-ki-technik-100-remote-tether-operations-tallinn",
+        "social-media-manager-ki-technik-100-remote-tether-operations-warsaw"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "social-media-manager-ki-technik-100-remote-tether-operations-zurich",
+          "social-media-manager-ki-technik-100-remote-tether-operations-london",
+          "social-media-manager-ki-technik-100-remote-tether-operations-amsterdam",
+          "social-media-manager-ki-technik-100-remote-tether-operations-stockholm",
+          "social-media-manager-ki-technik-100-remote-tether-operations-lisbon",
+          "social-media-manager-ki-technik-100-remote-tether-operations-milano",
+          "social-media-manager-ki-technik-100-remote-tether-operations-bogota",
+          "social-media-manager-ki-technik-100-remote-tether-operations-montevideo",
+          "social-media-manager-ki-technik-100-remote-tether-operations-dublin",
+          "social-media-manager-ki-technik-100-remote-tether-operations-madrid",
+          "social-media-manager-ki-technik-100-remote-tether-operations-tallinn",
+          "social-media-manager-ki-technik-100-remote-tether-operations-warsaw"
+        ]
       }
     },
     {

--- a/data/jobs/by-crawler/trumpf-schweiz.json
+++ b/data/jobs/by-crawler/trumpf-schweiz.json
@@ -137,17 +137,23 @@
       "firstSeenAt": "2026-04-30T11:38:12.738Z",
       "previousSlugsByLocale": {
         "it": [
-          "senior-strategic-procurement-expert-m-w-d-trumpf-r00030810"
+          "senior-strategic-procurement-expert-m-w-d-trumpf-r00030810",
+          "senior-strategic-procurement-expert-m-f-d-trumpf-schweiz-ag-grusch",
+          "senior-strategic-procurement-expert-m-w-d-trumpf-schweiz-ag-grusch-i6pg5c"
         ],
         "en": [
           "senior-strategic-procurement-expert-m-w-d-trumpf-r00030810"
         ],
         "fr": [
-          "senior-strategic-procurement-expert-m-w-d-trumpf-r00030810"
+          "senior-strategic-procurement-expert-m-w-d-trumpf-r00030810",
+          "senior-strategic-procurement-expert-h-f-d-trumpf-schweiz-ag-grusch"
         ]
       },
       "previousSlugs": [
-        "senior-strategic-procurement-expert-m-w-d-trumpf-r00030810"
+        "senior-strategic-procurement-expert-m-w-d-trumpf-r00030810",
+        "senior-strategic-procurement-expert-h-f-d-trumpf-schweiz-ag-grusch",
+        "senior-strategic-procurement-expert-m-f-d-trumpf-schweiz-ag-grusch",
+        "senior-strategic-procurement-expert-m-w-d-trumpf-schweiz-ag-grusch-i6pg5c"
       ]
     },
     {

--- a/data/jobs/by-crawler/ubp.json
+++ b/data/jobs/by-crawler/ubp.json
@@ -2624,11 +2624,13 @@
           "cyber-risk-manager-second-line-controls-ubp-ch"
         ],
         "it": [
-          "cyber-risk-manager-second-line-controls-ubp-ch"
+          "cyber-risk-manager-second-line-controls-ubp-ch",
+          "cyber-risk-manager-second-line-kontrollen-union-bancaire-privee-geneva-switzerland"
         ]
       },
       "previousSlugs": [
-        "cyber-risk-manager-second-line-controls-ubp-ch"
+        "cyber-risk-manager-second-line-controls-ubp-ch",
+        "cyber-risk-manager-second-line-kontrollen-union-bancaire-privee-geneva-switzerland"
       ],
       "needsRetranslation": true,
       "firstSeenAt": "2026-05-17T11:17:17.192Z",

--- a/data/jobs/by-crawler/ubs.json
+++ b/data/jobs/by-crawler/ubs.json
@@ -772,11 +772,15 @@
         "jobType": ""
       },
       "previousSlugs": [
-        "internship-in-client-lifecycle-management-ubs"
+        "internship-in-client-lifecycle-management-ubs",
+        "internship-in-client-lifecycle-management-germany-ubs",
+        "internship-in-client-lifecycle-management-with-german-ubs"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "internship-in-client-lifecycle-management-ubs"
+          "internship-in-client-lifecycle-management-ubs",
+          "internship-in-client-lifecycle-management-germany-ubs",
+          "internship-in-client-lifecycle-management-with-german-ubs"
         ]
       },
       "needsRetranslation": true,
@@ -850,11 +854,15 @@
         "jobType": ""
       },
       "previousSlugs": [
-        "spezialist-in-hypotheken-und-grundbuchwesen-80-100-ubs"
+        "spezialist-in-hypotheken-und-grundbuchwesen-80-100-ubs",
+        "spezialist-in-hypotheken-und-grundbuchwesen-80-100-ubs-2",
+        "spezialist-in-hypotheken-e-grundbuchwesen-80-100-ubs-ug5obm"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "spezialist-in-hypotheken-und-grundbuchwesen-80-100-ubs"
+          "spezialist-in-hypotheken-und-grundbuchwesen-80-100-ubs",
+          "spezialist-in-hypotheken-und-grundbuchwesen-80-100-ubs-2",
+          "spezialist-in-hypotheken-e-grundbuchwesen-80-100-ubs-ug5obm"
         ]
       },
       "needsRetranslation": true,
@@ -928,11 +936,15 @@
         "jobType": ""
       },
       "previousSlugs": [
-        "conseiller-ere-clientele-privee-affluent-sion-80-100-ubs"
+        "conseiller-ere-clientele-privee-affluent-sion-80-100-ubs",
+        "conseiller-ere-a-la-clientele-privee-affluent-gstaad-80-100-ubs-gstaad",
+        "conseiller-ere-clientele-privee-affluent-martigny-80-100-ubs-martigny"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "conseiller-ere-clientele-privee-affluent-sion-80-100-ubs"
+          "conseiller-ere-clientele-privee-affluent-sion-80-100-ubs",
+          "conseiller-ere-a-la-clientele-privee-affluent-gstaad-80-100-ubs-gstaad",
+          "conseiller-ere-clientele-privee-affluent-martigny-80-100-ubs-martigny"
         ]
       },
       "needsRetranslation": true,
@@ -1614,11 +1626,15 @@
         "jobType": ""
       },
       "previousSlugs": [
-        "client-associate-ubs"
+        "client-associate-ubs",
+        "client-associate-ubs-2",
+        "client-associate-ubs-3"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "client-associate-ubs"
+          "client-associate-ubs",
+          "client-associate-ubs-2",
+          "client-associate-ubs-3"
         ]
       },
       "needsRetranslation": true,
@@ -2064,11 +2080,13 @@
         "jobType": ""
       },
       "previousSlugs": [
-        "client-account-manager-ubs"
+        "client-account-manager-ubs",
+        "client-account-manager-ubs-2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "client-account-manager-ubs"
+          "client-account-manager-ubs",
+          "client-account-manager-ubs-2"
         ]
       },
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/unispital-basel.json
+++ b/data/jobs/by-crawler/unispital-basel.json
@@ -1877,7 +1877,19 @@
           "unitText": "YEAR"
         }
       },
-      "firstSeenAt": "2026-05-19T12:50:29.688Z"
+      "firstSeenAt": "2026-05-19T12:50:29.688Z",
+      "previousSlugs": [
+        "dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-universitatsspital-basel-basel",
+        "dipl-pflegefachfrau-pflegefachmann-hf-fh-universitatsspital-basel-basel-4f1zbs",
+        "dipl-pflegefachfrau-pflegefachmann-hf-fh-universitatsspital-basel-basel-2ficdk"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-universitatsspital-basel-basel",
+          "dipl-pflegefachfrau-pflegefachmann-hf-fh-universitatsspital-basel-basel-4f1zbs",
+          "dipl-pflegefachfrau-pflegefachmann-hf-fh-universitatsspital-basel-basel-2ficdk"
+        ]
+      }
     },
     {
       "id": "unispital-basel-0cb5c3aab548",

--- a/data/jobs/by-crawler/usi-universita-della-svizzera-italiana.json
+++ b/data/jobs/by-crawler/usi-universita-della-svizzera-italiana.json
@@ -1220,7 +1220,8 @@
       "previousSlugs": [
         "senior-grant-writer-usi",
         "scrittore-di-sovvenzioni-senior-usi-universita-della-svizzera-italiana-lugano",
-        "redacteur-principal-usi-lugano"
+        "redacteur-principal-usi-lugano",
+        "senior-grant-writer-usi-universita-della-svizzera-italiana-lugano"
       ],
       "salaryMin": 72000,
       "salaryMax": 97000,
@@ -1247,7 +1248,8 @@
           "scrittore-di-sovvenzioni-senior-usi-universita-della-svizzera-italiana-lugano"
         ],
         "it": [
-          "scrittore-di-sovvenzioni-senior-usi-universita-della-svizzera-italiana-lugano"
+          "scrittore-di-sovvenzioni-senior-usi-universita-della-svizzera-italiana-lugano",
+          "senior-grant-writer-usi-universita-della-svizzera-italiana-lugano"
         ],
         "de": [
           "scrittore-di-sovvenzioni-senior-usi-universita-della-svizzera-italiana-lugano"
@@ -1525,7 +1527,8 @@
         "librarian-specialized-in-electronic-resources-e-resources-librarian-usi-lugano",
         "electronic-resources-specialist-e-resources-librarian-usi-lugano",
         "bibliotecaria-o-specializzata-o-risorse-elettroniche-e-risorse-bibliotecario-usi-universita-della-svizzera-italiana-luga",
-        "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-resources-librarian-usi-universi"
+        "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-resources-librarian-usi-universi",
+        "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-resources-librarian-usi-universita-della-svizzera-italiana-lug"
       ],
       "salaryMin": 58000,
       "salaryMax": 78000,
@@ -1551,7 +1554,8 @@
           "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-resources-librarian-usi",
           "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-risorse-bibliotecario-usi-universita-della-svizzera-italiana-lugano",
           "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-risorse-bibliotecario-usi-universita-della-svizzera-italiana-l",
-          "librarian-specialized-in-electronic-resources-e-resources-librarian-usi-lugano"
+          "librarian-specialized-in-electronic-resources-e-resources-librarian-usi-lugano",
+          "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-resources-librarian-usi-universita-della-svizzera-italiana-lug"
         ],
         "en": [
           "bibliotecaria-o-specializzata-o-in-risorse-elettroniche-e-resources-librarian-usi",
@@ -1626,7 +1630,9 @@
         "postdoctorat-posizione-nel-campo-della-sostenibilita-architecture-et-technologie-usi-mendr",
         "posizione-postdoc-nel-campo-del-supporto-dell-architettura-e-della-tecnologia-usi-universita-della-svizzera-italiana-mendrisio",
         "postdoc-stelle-im-bereich-support-architektur-und-technologie-usi-mendrisio",
-        "postdoc-position-im-bereich-nachhaltigkeit-architektur-und-technologie-usi-universita-dell"
+        "postdoc-position-im-bereich-nachhaltigkeit-architektur-und-technologie-usi-universita-dell",
+        "postdoc-posizione-nel-campo-della-sostenibilita-architettura-e-tecnologia-usi-universita-della-svizzera-italiana-lugano",
+        "postdoc-posizione-nel-campo-della-sostenibilita-architettura-e-tecnologia-usi-universita-della-svizzera-italiana"
       ],
       "salaryMin": 58000,
       "salaryMax": 78000,
@@ -1665,7 +1671,9 @@
           "postdoctorat-posizione-nel-campo-della-sostenibilita-architecture-et-technologie-usi-universita-della-svizzera-italiana-",
           "postdoc-posizione-nel-campo-della-sostenibilita-architettura-e-tecnologia-usi-universita-della-svizzera-italiana-mendris",
           "postdoctorat-posizione-nel-campo-della-sostenibilita-architecture-et-technologie-usi-mendr",
-          "posizione-postdoc-nel-campo-del-supporto-dell-architettura-e-della-tecnologia-usi-universita-della-svizzera-italiana-mendrisio"
+          "posizione-postdoc-nel-campo-del-supporto-dell-architettura-e-della-tecnologia-usi-universita-della-svizzera-italiana-mendrisio",
+          "postdoc-posizione-nel-campo-della-sostenibilita-architettura-e-tecnologia-usi-universita-della-svizzera-italiana-lugano",
+          "postdoc-posizione-nel-campo-della-sostenibilita-architettura-e-tecnologia-usi-universita-della-svizzera-italiana"
         ],
         "de": [
           "postdoc-stelle-im-bereich-support-architektur-und-technologie-usi-mendrisio"
@@ -1728,7 +1736,8 @@
         "tempo-pieno-position-of-an-instrumentation-scientist-ingegnere-usi-universita-della-svizze",
         "tempo-pieno-position-of-an-instrumentation-scientist-ingegnere-usi-universita-della-svizzera-italiana-lugano",
         "tempo-pieno-position-of-an-instrumentation-scientist-ingegnere-usi-universita-della-svizzera-italiana-lugano",
-        "poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano"
+        "poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-lugano",
+        "full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-lugano"
       ],
       "salaryMin": 58000,
       "salaryMax": 78000,
@@ -1762,7 +1771,8 @@
           "tempo-pieno-position-of-an-instrumentation-scientist-ingegnere-usi-universita-della-svizzera-italiana-locarno",
           "vollzeit-position-of-an-instrumentation-scientist-ingenieur-usi-universita-della-svizzera-italiana-locarno-0spog4",
           "temps-plein-position-of-an-instrumentation-scientist-ingenieur-usi-universita-della-svizzera-italiana-locarno-0spog4",
-          "posizione-a-tempo-pieno-di-uno-scienziato-ingegnere-di-strumentazione-usi-universita-della-svizzera-italiana-locarno"
+          "posizione-a-tempo-pieno-di-uno-scienziato-ingegnere-di-strumentazione-usi-universita-della-svizzera-italiana-locarno",
+          "full-time-position-of-an-instrumentation-scientist-engineer-usi-universita-della-svizzera-italiana-lugano"
         ],
         "fr": [
           "poste-a-temps-plein-d-un-scientifique-ingenieur-en-instrumentation-usi-universita-della-svizzera-italiana-locarno",

--- a/data/jobs/by-crawler/usz.json
+++ b/data/jobs/by-crawler/usz.json
@@ -981,11 +981,13 @@
       "requirements": [],
       "requirementsByLocale": {},
       "previousSlugs": [
-        "spezialpflege-fachperson-operationstechnik-hf-her-tho-vis-gef-und-hybrid-80-100-usz-ch"
+        "spezialpflege-fachperson-operationstechnik-hf-her-tho-vis-gef-und-hybrid-80-100-usz-ch",
+        "spezialpflege-fachperson-ot-hf-her-tho-vis-gef-e-hybrid-80-100-universitatsspital-zurich-usz-campus"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "spezialpflege-fachperson-operationstechnik-hf-her-tho-vis-gef-und-hybrid-80-100-usz-ch"
+          "spezialpflege-fachperson-operationstechnik-hf-her-tho-vis-gef-und-hybrid-80-100-usz-ch",
+          "spezialpflege-fachperson-ot-hf-her-tho-vis-gef-e-hybrid-80-100-universitatsspital-zurich-usz-campus"
         ]
       },
       "needsRetranslation": true,

--- a/data/jobs/by-crawler/vf-international-the-north-face-timberland.json
+++ b/data/jobs/by-crawler/vf-international-the-north-face-timberland.json
@@ -137,8 +137,16 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "previousSlugs": [
-        "responsabile-sviluppo-prodotti-e-materiali-vf-international-the-north-face-timberland-stabio"
-      ]
+        "responsabile-sviluppo-prodotti-e-materiali-vf-international-the-north-face-timberland-stabio",
+        "head-of-product-development-and-materials-vf-international-the-north-face-timberland-emea-",
+        "head-of-product-development-and-materials-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "head-of-product-development-and-materials-vf-international-the-north-face-timberland-emea-",
+          "head-of-product-development-and-materials-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+        ]
+      }
     },
     {
       "id": "company-i9cewk",
@@ -212,9 +220,19 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "previousSlugs": [
-        "pss-analista-the-north-face-vf-international-the-north-face-timberland-stabio"
+        "pss-analista-the-north-face-vf-international-the-north-face-timberland-stabio",
+        "pss-analyst-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-c",
+        "pss-analyst-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "pss-analyst-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-c"
+        ],
+        "en": [
+          "pss-analyst-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+        ]
+      }
     },
     {
       "id": "company-ws2kkv",
@@ -293,11 +311,13 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "digital-designer-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-ws2kkv",
-        "designer-digitale-the-north-face-vf-international-the-north-face-timberland-stabio"
+        "designer-digitale-the-north-face-vf-international-the-north-face-timberland-stabio",
+        "digital-designer-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "digital-designer-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-ws2kkv"
+          "digital-designer-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-ws2kkv",
+          "digital-designer-the-north-face-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
         ]
       },
       "needsRetranslation": true
@@ -383,9 +403,15 @@
         "analista-senior-statutario-record-to-report-vf-international-the-north-face-timberland-stabio",
         "record-da-allenatore-a-segnalare-vf-international-the-north-face-timberland-stabio",
         "analista-senior-record-to-report-vf-international-the-north-face-timberland-stabio",
-        "responsabile-statutario-record-to-report-vf-international-the-north-face-timberland-stabio"
+        "responsabile-statutario-record-to-report-vf-international-the-north-face-timberland-stabio",
+        "statutory-senior-analyst-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugsByLocale": {
+        "it": [
+          "statutory-senior-analyst-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+        ]
+      }
     },
     {
       "id": "company-mn7knl",
@@ -464,7 +490,15 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+        ]
+      }
     },
     {
       "id": "company-5ly39",
@@ -543,7 +577,17 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "senior-analyst-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1",
+        "senior-analyst-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "senior-analyst-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1",
+          "senior-analyst-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio"
+        ]
+      }
     },
     {
       "id": "company-x9a3hk",
@@ -624,11 +668,15 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-x9a3hk"
+          "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-x9a3hk",
+          "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1",
+          "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-sta"
         ]
       },
       "previousSlugs": [
-        "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-x9a3hk"
+        "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-x9a3hk",
+        "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1",
+        "statutory-manager-record-to-report-vf-international-the-north-face-timberland-emea-che-sta"
       ],
       "needsRetranslation": true
     },
@@ -773,11 +821,15 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "verkauferin-teilzeit-8-std-vf-international-the-north-face-timberland-emea-che-landquart-landquart-tnf-27nahc",
-        "venditore-orario-di-partenza-8-ore-vf-international-the-north-face-timberland-emea-che-landquart-landquart-tnf"
+        "venditore-orario-di-partenza-8-ore-vf-international-the-north-face-timberland-emea-che-landquart-landquart-tnf",
+        "verkauferin-teilzeit-8-std-vf-international-the-north-face-timberland-emea-che-landquart-landquart-tnf",
+        "verkauferin-teilzeit-8-std-vf-international-the-north-face-timberland-stabio"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "verkauferin-teilzeit-8-std-vf-international-the-north-face-timberland-emea-che-landquart-landquart-tnf-27nahc"
+          "verkauferin-teilzeit-8-std-vf-international-the-north-face-timberland-emea-che-landquart-landquart-tnf-27nahc",
+          "verkauferin-teilzeit-8-std-vf-international-the-north-face-timberland-emea-che-landquart-landquart-tnf",
+          "verkauferin-teilzeit-8-std-vf-international-the-north-face-timberland-stabio"
         ]
       },
       "needsRetranslation": true
@@ -851,8 +903,16 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "sviluppatore-abbigliamento-vf-international-the-north-face-timberland-stabio",
-        "analista-fp-a-vf-international-the-north-face-timberland-stabio"
-      ]
+        "analista-fp-a-vf-international-the-north-face-timberland-stabio",
+        "developer-apparel-vf-international-the-north-face-timberland-stabio",
+        "developer-apparel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "developer-apparel-vf-international-the-north-face-timberland-stabio",
+          "developer-apparel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+        ]
+      }
     },
     {
       "id": "company-rm634f",
@@ -912,7 +972,16 @@
       "addressRegion": "TI",
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
-      "needsRetranslation": true
+      "needsRetranslation": true,
+      "previousSlugs": [
+        "verkauferin-flexibel-teilzeit-oder-vollzeit-napapijri-landquart-fashion-outlet-vf-international-the-north-face-timberland-emea-che-landquart",
+        "verkauferin-flexibel-teilzeit-o-vollzeit-napapijri-landquart-fashion-outlet-vf-international-the-north-face-timberland-s"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "verkauferin-flexibel-teilzeit-oder-vollzeit-napapijri-landquart-fashion-outlet-vf-international-the-north-face-timberland-emea-che-landquart"
+        ]
+      }
     },
     {
       "id": "company-nzdhno",
@@ -1079,11 +1148,13 @@
       "previousSlugs": [
         "senior-manager-global-merchandising-icebreaker-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-0wi3k2",
         "senior-manager-global-merchandising-rompighiaccio-vf-international-the-north-face-timberland-stabio",
-        "specialista-delle-dogane-emea-vf-international-the-north-face-timberland-stabio"
+        "specialista-delle-dogane-emea-vf-international-the-north-face-timberland-stabio",
+        "senior-manager-global-merchandising-icebreaker-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "senior-manager-global-merchandising-icebreaker-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-0wi3k2"
+          "senior-manager-global-merchandising-icebreaker-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2-0wi3k2",
+          "senior-manager-global-merchandising-icebreaker-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf2"
         ]
       },
       "needsRetranslation": true
@@ -1160,7 +1231,15 @@
       "addressLocality": "EMEA · CHE · Stabio · VF Campus VF1",
       "addressRegion": "TI",
       "addressCountry": "CH",
-      "employmentType": "FULL_TIME"
+      "employmentType": "FULL_TIME",
+      "previousSlugs": [
+        "customs-specialist-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "customs-specialist-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
+        ]
+      }
     },
     {
       "id": "company-p4gsoi",
@@ -1237,14 +1316,16 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "regulatory-compliance-counsel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-p4gsoi"
+          "regulatory-compliance-counsel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-p4gsoi",
+          "regulatory-compliance-counsel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
         ],
         "fr": [
           "regulatory-compliance-counsel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-p4gsoi"
         ]
       },
       "previousSlugs": [
-        "regulatory-compliance-counsel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-p4gsoi"
+        "regulatory-compliance-counsel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-p4gsoi",
+        "regulatory-compliance-counsel-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
       "needsRetranslation": true
     },
@@ -1321,11 +1402,13 @@
       "employmentType": "FULL_TIME",
       "previousSlugs": [
         "senior-outerwear-designer-global-apparel-timberland-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-6sjj96",
-        "stilista-senior-di-capispalla-abbigliamento-globale-timberland-vf-international-the-north-face-timberland-emea-che-stabi"
+        "stilista-senior-di-capispalla-abbigliamento-globale-timberland-vf-international-the-north-face-timberland-emea-che-stabi",
+        "senior-outerwear-designer-global-apparel-timberland-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "senior-outerwear-designer-global-apparel-timberland-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-6sjj96"
+          "senior-outerwear-designer-global-apparel-timberland-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-6sjj96",
+          "senior-outerwear-designer-global-apparel-timberland-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
         ]
       },
       "needsRetranslation": true
@@ -1402,11 +1485,13 @@
       "previousSlugs": [
         "senior-manager-product-sustainability-circularity-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-q5yjnl",
         "senior-manager-sostenibilita-e-circolabilita-dei-prodotti-vf-international-the-north-face-timberland-emea-che-stabio-vf-",
-        "manager-gtm-strategia-marketplace-altra-gestendo-emea-vf-international-the-north-face-timberland-stabio"
+        "manager-gtm-strategia-marketplace-altra-gestendo-emea-vf-international-the-north-face-timberland-stabio",
+        "senior-manager-product-sustainability-circularity-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
       "previousSlugsByLocale": {
         "it": [
-          "senior-manager-product-sustainability-circularity-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-q5yjnl"
+          "senior-manager-product-sustainability-circularity-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-q5yjnl",
+          "senior-manager-product-sustainability-circularity-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
         ]
       },
       "needsRetranslation": true
@@ -1486,11 +1571,13 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "manager-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-kqop8j"
+          "manager-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-kqop8j",
+          "manager-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
         ]
       },
       "previousSlugs": [
-        "manager-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-kqop8j"
+        "manager-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-kqop8j",
+        "manager-gtm-marketplace-strategy-altra-running-emea-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
       "needsRetranslation": true
     },
@@ -1565,11 +1652,13 @@
       "employmentType": "FULL_TIME",
       "previousSlugsByLocale": {
         "it": [
-          "inventory-controller-temporary-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-a228r9"
+          "inventory-controller-temporary-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-a228r9",
+          "inventory-controller-temporary-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
         ]
       },
       "previousSlugs": [
-        "inventory-controller-temporary-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-a228r9"
+        "inventory-controller-temporary-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1-a228r9",
+        "inventory-controller-temporary-vf-international-the-north-face-timberland-emea-che-stabio-vf-campus-vf1"
       ],
       "needsRetranslation": true
     }

--- a/data/jobs/by-crawler/volg-fenaco.json
+++ b/data/jobs/by-crawler/volg-fenaco.json
@@ -711,7 +711,8 @@
       "previousSlugs": [
         "verkauferin-verkaufer-m-w-d-volg-vals",
         "verkauferin-verkaufer-m-w-d-volg-vals-shyscx",
-        "responsabile-vendite-m-w-d-volg-vals-5c52d7"
+        "responsabile-vendite-m-w-d-volg-vals-5c52d7",
+        "verkauferin-verkaufer-m-w-d-volg-vals-2"
       ],
       "previousSlugsByLocale": {
         "it": [
@@ -1076,7 +1077,8 @@
       "firstSeenAt": "2026-04-27T11:49:35.092Z",
       "previousSlugsByLocale": {
         "it": [
-          "verkauferin-verkaufer-topshop-w-m-d-landi-graubunden-ag-landquart"
+          "verkauferin-verkaufer-topshop-w-m-d-landi-graubunden-ag-landquart",
+          "verkauferin-verkaufer-topshop-w-m-d-landi-graubunden-ag-thusis"
         ],
         "en": [
           "verkauferin-verkaufer-topshop-w-m-d-landi-graubunden-ag-landquart"
@@ -1086,7 +1088,8 @@
         ]
       },
       "previousSlugs": [
-        "verkauferin-verkaufer-topshop-w-m-d-landi-graubunden-ag-landquart"
+        "verkauferin-verkaufer-topshop-w-m-d-landi-graubunden-ag-landquart",
+        "verkauferin-verkaufer-topshop-w-m-d-landi-graubunden-ag-thusis"
       ]
     },
     {
@@ -1228,7 +1231,8 @@
         "apprendistato-come-assistente-del-commercio-al-dettaglio-afp-alimentari-volg-lenzerheide",
         "apprendistato-come-assistente-del-commercio-al-dettaglio-afp-alimentari-volg-pany",
         "apprendistato-come-assistente-del-commercio-al-dettaglio-afc-alimentari-volg-fenaco-pany",
-        "lehrstelle-als-detailhandelsassistent-in-eba-lebensmittel-volg-pany"
+        "lehrstelle-als-detailhandelsassistent-in-eba-lebensmittel-volg-pany",
+        "lehrstelle-als-detailhandelsassistent-in-eba-lebensmittel-volg-lenzerheide"
       ],
       "id": "volg-fenaco-8a3b0a4e02de",
       "previousSlugsByLocale": {
@@ -1238,7 +1242,8 @@
           "apprendistato-come-assistente-del-commercio-al-dettaglio-afp-alimentari-volg-lenzerheide",
           "apprendistato-come-assistente-del-commercio-al-dettaglio-afp-alimentari-volg-pany",
           "apprendistato-come-assistente-del-commercio-al-dettaglio-afc-alimentari-volg-fenaco-pany",
-          "lehrstelle-als-detailhandelsassistent-in-eba-lebensmittel-volg-pany"
+          "lehrstelle-als-detailhandelsassistent-in-eba-lebensmittel-volg-pany",
+          "lehrstelle-als-detailhandelsassistent-in-eba-lebensmittel-volg-lenzerheide"
         ],
         "en": [
           "lehrstelle-in-dettaglio-assistente-a-eba-alimentari-volg-pany",
@@ -2382,7 +2387,15 @@
           "unitText": "YEAR"
         }
       },
-      "firstSeenAt": "2026-04-30T11:42:05.769Z"
+      "firstSeenAt": "2026-04-30T11:42:05.769Z",
+      "previousSlugs": [
+        "collaboratrice-polyvalente-collaborateur-polyvalent-secteur-agro-f-h-d-landi-rhone-lavaux-"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "collaboratrice-polyvalente-collaborateur-polyvalent-secteur-agro-f-h-d-landi-rhone-lavaux-"
+        ]
+      }
     },
     {
       "title": "Responsable de centre Agro (f/h/d)",
@@ -2521,10 +2534,14 @@
         ],
         "fr": [
           "verkauferin-verkaufer-topshop-w-m-d-landi-oberwallis-ag-steg-hohtenn"
+        ],
+        "de": [
+          "verkauferin-verkaufer-topshop-w-m-d-landi-oberwallis-ag-eyholz"
         ]
       },
       "previousSlugs": [
-        "verkauferin-verkaufer-topshop-w-m-d-landi-oberwallis-ag-steg-hohtenn"
+        "verkauferin-verkaufer-topshop-w-m-d-landi-oberwallis-ag-steg-hohtenn",
+        "verkauferin-verkaufer-topshop-w-m-d-landi-oberwallis-ag-eyholz"
       ]
     },
     {
@@ -3095,7 +3112,15 @@
         "luogo-d-apprentissage-de-gestionnaire-ou-assistente-e-du-commerce-de-detail-volg-orsieres",
         "posto-di-apprendistato-come-gestore-o-assistente-del-commercio-al-dettaglio-volg-fenaco-orsieres",
         "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-orsieres",
-        "posto-di-apprendistato-di-manager-o-assistente-a-del-commercio-al-dettaglio-volg-orsieres"
+        "posto-di-apprendistato-di-manager-o-assistente-a-del-commercio-al-dettaglio-volg-orsieres",
+        "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-anniviers",
+        "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-collombey-muraz",
+        "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-founex",
+        "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-vex",
+        "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-founex",
+        "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-vex",
+        "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-anniviers",
+        "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-collombey-muraz"
       ],
       "salaryMin": 58000,
       "salaryMax": 78000,
@@ -3117,7 +3142,11 @@
           "retail-management-or-assistant-training-position-volg-orsieres-4o5f3w",
           "luogo-d-apprentissage-de-gestionnaire-ou-assistente-e-du-commerce-de-detail-volg-orsieres",
           "posto-di-apprendistato-come-gestore-o-assistente-del-commercio-al-dettaglio-volg-fenaco-orsieres",
-          "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-orsieres"
+          "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-orsieres",
+          "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-founex",
+          "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-vex",
+          "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-anniviers",
+          "place-d-apprentissage-de-gestionnaire-or-assistant-e-du-commerce-de-detail-volg-collombey-muraz"
         ],
         "en": [
           "retail-management-or-assistant-training-position-volg-orsieres-4o5f3w",
@@ -3130,7 +3159,11 @@
         ],
         "fr": [
           "retail-management-or-assistant-training-position-volg-orsieres-4o5f3w",
-          "luogo-d-apprentissage-de-gestionnaire-ou-assistente-e-du-commerce-de-detail-volg-orsieres"
+          "luogo-d-apprentissage-de-gestionnaire-ou-assistente-e-du-commerce-de-detail-volg-orsieres",
+          "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-anniviers",
+          "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-collombey-muraz",
+          "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-founex",
+          "place-d-apprentissage-de-gestionnaire-ou-assistant-e-du-commerce-de-detail-volg-vex"
         ]
       },
       "firstSeenAt": "2026-04-13T11:30:02.827Z"

--- a/data/jobs/by-crawler/vtg.json
+++ b/data/jobs/by-crawler/vtg.json
@@ -696,7 +696,8 @@
       "previousSlugsByLocale": {
         "it": [
           "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern",
-          "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern-ef6h2c"
+          "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern-ef6h2c",
+          "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern-pytzmw"
         ],
         "en": [
           "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern-ef6h2c"
@@ -712,7 +713,8 @@
       "previousSlugs": [
         "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern",
         "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern-ef6h2c",
-        "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bellinzona"
+        "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bellinzona",
+        "chef-in-schneiderei-textilcenter-sursee-swiss-armed-forces-vtg-bern-pytzmw"
       ],
       "baseSalary": {
         "@type": "MonetaryAmount",
@@ -1183,7 +1185,8 @@
       "previousSlugsByLocale": {
         "it": [
           "mannschaft-und-kader-im-bereich-infrastruktur-m-w-d-swiss-armed-forces-vtg-bern",
-          "mannschaft-e-kader-im-bereich-infrastruktur-m-w-d-swiss-armed-forces-vtg-bern-6okqpl"
+          "mannschaft-e-kader-im-bereich-infrastruktur-m-w-d-swiss-armed-forces-vtg-bern-6okqpl",
+          "mannschaft-e-kader-im-bereich-infrastruktur-m-w-swiss-armed-forces-vtg-bellinzona"
         ],
         "de": [
           "mannschaft-und-kader-im-bereich-infrastruktur-m-w-d-swiss-armed-forces-vtg-bern-6okqpl",
@@ -1200,7 +1203,8 @@
         "mannschaft-und-kader-im-bereich-infrastruktur-m-w-d-swiss-armed-forces-vtg-bern",
         "mannschaft-e-kader-im-bereich-infrastruktur-m-w-d-swiss-armed-forces-vtg-bern-6okqpl",
         "mannschaft-und-kader-im-bereich-infrastruktur-m-w-d-swiss-armed-forces-vtg-bern-6okqpl",
-        "mannschaft-und-kader-im-bereich-infrastruktur-m-w-swiss-armed-forces-vtg-bellinzona"
+        "mannschaft-und-kader-im-bereich-infrastruktur-m-w-swiss-armed-forces-vtg-bellinzona",
+        "mannschaft-e-kader-im-bereich-infrastruktur-m-w-swiss-armed-forces-vtg-bellinzona"
       ],
       "salaryMin": 49500,
       "salaryMax": 75000,

--- a/scripts/backfill-orphan-slugs-from-registry.mjs
+++ b/scripts/backfill-orphan-slugs-from-registry.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * backfill-orphan-slugs-from-registry.mjs
+ *
+ * Reconciles "orphan" slugs registered in `data/all-known-job-slugs.json` but
+ * not owned by any current job (i.e. not in any `slug`, `slugByLocale`,
+ * `previousSlugs`, or `previousSlugsByLocale`).
+ *
+ * Many of these orphans come from rename-drift cases where a vendor moved a
+ * job between cities or cantons across crawler runs, before the stable-id
+ * matchKey fix (PR #161 / 2026-05-13) was in place. The old slug stays
+ * registered in the cathedral frozen-URL registry but the current job record
+ * no longer references it — so the bridge page emitter doesn't link them.
+ * Result: the SPA shows JobOrphanView for the old URL even though the job is
+ * still live under a new slug.
+ *
+ * This script:
+ *   1. Computes the set of orphan slugs (registered but unowned).
+ *   2. For each orphan, finds the best-matching current job using
+ *      title-only Jaccard similarity (company + location tokens subtracted as
+ *      noise — same algorithm as `slugMatchesTitle`).
+ *   3. Requires the job's company-token to appear in the orphan slug as a
+ *      sanity check before assigning.
+ *   4. If the best score >= THRESHOLD, adds the orphan slug to the matched
+ *      job's `previousSlugs` and (if a locale is inferable) the appropriate
+ *      `previousSlugsByLocale` bucket.
+ *
+ * Usage:
+ *   node scripts/backfill-orphan-slugs-from-registry.mjs --dry-run
+ *   node scripts/backfill-orphan-slugs-from-registry.mjs --apply
+ *
+ * Flags:
+ *   --threshold N   Jaccard cutoff (default 0.7).
+ *   --max N         Cap per-job previousSlugs growth (default 30).
+ *   --apply         Persist changes. Without it, only summary is printed.
+ *
+ * Idempotent: a slug already present in a job's previousSlugs/previousSlugsByLocale
+ * is skipped.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  slugify,
+  slugTokenSet,
+} from './lib/regenerate-slugs-helpers.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const BY_CRAWLER_DIR = path.resolve(ROOT, 'data', 'jobs', 'by-crawler');
+const REGISTRY_PATH = path.resolve(ROOT, 'data', 'all-known-job-slugs.json');
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const thresholdIdx = args.indexOf('--threshold');
+const THRESHOLD = thresholdIdx !== -1 ? parseFloat(args[thresholdIdx + 1]) || 0.7 : 0.7;
+const maxIdx = args.indexOf('--max');
+const MAX_PER_JOB = maxIdx !== -1 ? parseInt(args[maxIdx + 1], 10) || 30 : 30;
+const verbose = args.includes('--verbose');
+
+const LOCALES = ['it', 'en', 'de', 'fr'];
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeJson(p, v) {
+  fs.writeFileSync(p, `${JSON.stringify(v, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Infer locale of a slug by majority-locale of token suffixes.
+ * Heuristic: known IT/EN/DE/FR markers. Defaults to 'it'.
+ */
+function inferOrphanLocale(slug, registryRecord) {
+  if (!registryRecord || typeof registryRecord !== 'object') return null;
+  for (const loc of LOCALES) {
+    const v = registryRecord[loc];
+    if (typeof v === 'string' && v.includes(slug)) return loc;
+  }
+  return null;
+}
+
+function noiseTokensFor(company, location) {
+  const out = new Set();
+  for (const text of [company, location]) {
+    for (const t of slugTokenSet(slugify(text))) out.add(t);
+  }
+  return out;
+}
+
+function titleOnlyTokens(slug, noise) {
+  const out = new Set();
+  for (const t of slugTokenSet(slug)) if (!noise.has(t)) out.add(t);
+  return out;
+}
+
+function jaccard(setA, setB) {
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let inter = 0;
+  for (const t of setA) if (setB.has(t)) inter++;
+  return inter / (setA.size + setB.size - inter);
+}
+
+function buildOwnedSet(allJobs) {
+  const owned = new Set();
+  for (const job of allJobs) {
+    if (job.slug) owned.add(job.slug);
+    if (job.slugByLocale) {
+      for (const s of Object.values(job.slugByLocale)) if (s) owned.add(s);
+    }
+    if (Array.isArray(job.previousSlugs)) {
+      for (const s of job.previousSlugs) if (s) owned.add(s);
+    }
+    if (job.previousSlugsByLocale) {
+      for (const arr of Object.values(job.previousSlugsByLocale)) {
+        if (Array.isArray(arr)) for (const s of arr) if (s) owned.add(s);
+      }
+    }
+  }
+  return owned;
+}
+
+function loadAllJobs() {
+  const files = fs.readdirSync(BY_CRAWLER_DIR).filter((f) => f.endsWith('.json'));
+  const byFile = new Map();
+  const allJobs = [];
+  for (const f of files) {
+    const fp = path.join(BY_CRAWLER_DIR, f);
+    const data = readJson(fp);
+    const jobs = Array.isArray(data.jobs) ? data.jobs : [];
+    byFile.set(f, { fp, data, jobs });
+    for (const j of jobs) allJobs.push({ file: f, job: j });
+  }
+  return { byFile, allJobs };
+}
+
+function indexJobsByCompanyTokens(allJobs) {
+  // Map<companyToken, Array<{file, job, companyTokens, titleTokens, location}>>
+  const index = new Map();
+  for (const { file, job } of allJobs) {
+    const company = String(job.company || '');
+    if (!company) continue;
+    const companyTokens = slugTokenSet(slugify(company));
+    if (companyTokens.size === 0) continue;
+    const location = String(job.location || '');
+    const noise = noiseTokensFor(company, location);
+    const title = String(job.title || '');
+    const titleTokens = titleOnlyTokens(slugify(title), noise);
+    const entry = { file, job, companyTokens, titleTokens, location, noise };
+    for (const tok of companyTokens) {
+      let arr = index.get(tok);
+      if (!arr) {
+        arr = [];
+        index.set(tok, arr);
+      }
+      arr.push(entry);
+    }
+  }
+  return index;
+}
+
+function findBestMatch(orphanSlug, companyIndex) {
+  const orphanTokens = slugTokenSet(orphanSlug);
+  if (orphanTokens.size === 0) return null;
+  // Collect candidate jobs: any job whose ALL company-tokens are present in the orphan.
+  const candidateSet = new Set();
+  for (const tok of orphanTokens) {
+    const arr = companyIndex.get(tok);
+    if (!arr) continue;
+    for (const entry of arr) {
+      // Sanity: all company tokens of this entry must appear in the orphan.
+      let allPresent = true;
+      for (const ct of entry.companyTokens) {
+        if (!orphanTokens.has(ct)) {
+          allPresent = false;
+          break;
+        }
+      }
+      if (allPresent) candidateSet.add(entry);
+    }
+  }
+  if (candidateSet.size === 0) return null;
+  // Score by title-only Jaccard.
+  let best = null;
+  for (const entry of candidateSet) {
+    const orphanTitleTokens = titleOnlyTokens(orphanSlug, entry.noise);
+    const score = jaccard(orphanTitleTokens, entry.titleTokens);
+    if (!best || score > best.score) best = { entry, score };
+  }
+  return best;
+}
+
+async function main() {
+  console.log(`🔧 backfill-orphan-slugs-from-registry — ${APPLY ? 'APPLY' : 'DRY RUN'} (threshold=${THRESHOLD}, max=${MAX_PER_JOB}/job)`);
+
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    console.error(`❌ Registry not found: ${REGISTRY_PATH}`);
+    process.exit(1);
+  }
+  const registry = readJson(REGISTRY_PATH);
+  const registryKeys = Object.keys(registry);
+  console.log(`📋 Registry slugs: ${registryKeys.length}`);
+
+  const { byFile, allJobs } = loadAllJobs();
+  console.log(`📁 Current jobs: ${allJobs.length} across ${byFile.size} files`);
+
+  const owned = buildOwnedSet(allJobs.map((x) => x.job));
+  console.log(`✅ Slugs owned by current jobs: ${owned.size}`);
+
+  const orphans = registryKeys.filter((k) => !owned.has(k));
+  console.log(`👻 Orphan slugs (registered but unowned): ${orphans.length}`);
+
+  const companyIndex = indexJobsByCompanyTokens(allJobs);
+  console.log(`🏢 Companies indexed: ${companyIndex.size} unique company tokens`);
+
+  let matched = 0;
+  let belowThreshold = 0;
+  let noCandidate = 0;
+  const perFileMutations = new Map(); // file → Set<jobIndex>
+  const sample = [];
+
+  for (const orphan of orphans) {
+    const best = findBestMatch(orphan, companyIndex);
+    if (!best) {
+      noCandidate++;
+      continue;
+    }
+    if (best.score < THRESHOLD) {
+      belowThreshold++;
+      continue;
+    }
+    matched++;
+    const { entry } = best;
+    const job = entry.job;
+    // Add to previousSlugs (flat) — dedupe.
+    if (!Array.isArray(job.previousSlugs)) job.previousSlugs = [];
+    if (!job.previousSlugs.includes(orphan) && job.previousSlugs.length < MAX_PER_JOB) {
+      job.previousSlugs.push(orphan);
+    }
+    // Infer locale via registry record (e.g. record.it points to /cerca-lavoro-…/<orphan>).
+    const loc = inferOrphanLocale(orphan, registry[orphan]);
+    if (loc) {
+      if (!job.previousSlugsByLocale || typeof job.previousSlugsByLocale !== 'object') {
+        job.previousSlugsByLocale = {};
+      }
+      if (!Array.isArray(job.previousSlugsByLocale[loc])) job.previousSlugsByLocale[loc] = [];
+      const bucket = job.previousSlugsByLocale[loc];
+      if (!bucket.includes(orphan) && bucket.length < MAX_PER_JOB) {
+        bucket.push(orphan);
+      }
+    }
+    let set = perFileMutations.get(entry.file);
+    if (!set) {
+      set = new Set();
+      perFileMutations.set(entry.file, set);
+    }
+    set.add(job);
+    if (sample.length < 15) {
+      sample.push({ orphan, target: job.slug, score: best.score.toFixed(3), locale: loc || '?' });
+    }
+    if (verbose) {
+      console.log(`  ✓ ${orphan} → ${job.slug} (score=${best.score.toFixed(3)}, locale=${loc || '?'})`);
+    }
+  }
+
+  console.log('');
+  console.log(`📊 Results:`);
+  console.log(`   matched (>=${THRESHOLD}):     ${matched}`);
+  console.log(`   below threshold:    ${belowThreshold}`);
+  console.log(`   no company candidate: ${noCandidate}`);
+  console.log(`   files affected:     ${perFileMutations.size}`);
+  console.log('');
+  if (sample.length) {
+    console.log('🔍 Sample matches:');
+    for (const s of sample) {
+      console.log(`   ${s.orphan}`);
+      console.log(`     → ${s.target} (score=${s.score}, locale=${s.locale})`);
+    }
+    console.log('');
+  }
+
+  if (!APPLY) {
+    console.log('💡 Dry run. Re-run with --apply to persist.');
+    return;
+  }
+
+  // Persist mutated per-crawler files.
+  let writes = 0;
+  for (const [file, jobsSet] of perFileMutations) {
+    const meta = byFile.get(file);
+    writeJson(meta.fp, meta.data);
+    writes++;
+    if (verbose) console.log(`💾 wrote ${file} (${jobsSet.size} jobs touched)`);
+  }
+  console.log(`✅ Persisted ${writes} files.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/services/router.ts
+++ b/services/router.ts
@@ -1527,24 +1527,38 @@ function buildLocaleReverses<T extends string>(mapping: Record<T, keyof SlugTabl
 
 // ── Job slug cross-locale translation ──
 // Maps any-locale job slug → per-locale slugs (populated by JobBoard after loading jobs).
-let _jobSlugMap: Map<string, Record<string, string>> | null = null;
+export type JobSlugMapRecord = Record<string, string> & {
+ // Optional metadata used by SPA bridge resolution. `_id` is the job id, `_canton`
+ // the canton code (uppercase). Both are looked up via `getJobMetaForSlug` so the
+ // SPA can lazy-fetch the right canton shard when a bridge slug points to a job
+ // that isn't in the initial referrer-aware load (e.g. /cerca-lavoro-ticino/<bridge>
+ // for a job now in AI). Underscore-prefixed to avoid colliding with locale keys.
+ _id?: string;
+ _canton?: string;
+};
+
+let _jobSlugMap: Map<string, JobSlugMapRecord> | null = null;
 let _jobSlugMapPromise: Promise<void> | null = null;
 
 /** Register the job slug map so the router can translate job slugs across locales. */
-export function registerJobSlugMap(jobs: Array<{ slug?: string; slugByLocale?: Partial<Record<string, string>>; previousSlugs?: string[]; previousSlugsByLocale?: Partial<Record<string, string[]>> }>): void {
- const map = new Map<string, Record<string, string>>();
+export function registerJobSlugMap(jobs: Array<{ id?: string; canton?: string; slug?: string; slugByLocale?: Partial<Record<string, string>>; previousSlugs?: string[]; previousSlugsByLocale?: Partial<Record<string, string[]>> }>): void {
+ const map = new Map<string, JobSlugMapRecord>();
  for (const job of jobs) {
  const byLocale = job.slugByLocale;
  if (!byLocale) continue;
- const record: Record<string, string> = {};
+ const record: JobSlugMapRecord = {};
  for (const [loc, s] of Object.entries(byLocale)) {
  if (s) record[loc] = s;
  }
  // Also include the default slug
  if (job.slug) record['_default'] = job.slug;
- // Index by every locale slug + default slug
- for (const s of Object.values(record)) {
+ if (job.id) record._id = job.id;
+ if (job.canton) record._canton = String(job.canton).toUpperCase();
+ // Index by every locale slug + default slug (skip underscore-prefixed meta keys)
+ for (const [k, s] of Object.entries(record)) {
+ if (!k.startsWith('_') || k === '_default') {
  if (s) map.set(s, record);
+ }
  }
  // Index legacy slug aliases so old URLs resolve to current job
  if (Array.isArray(job.previousSlugs)) {
@@ -1590,12 +1604,25 @@ export function getLocalizedJobSlug(slug: string, targetLocale: string): string 
  return translateJobSlug(slug, targetLocale);
 }
 
+/**
+ * Look up metadata for a job slug (id + canton).
+ * Used by JobBoard to lazy-fetch the right canton shard when a bridge slug
+ * points to a job whose canton was not in the initial referrer-aware load.
+ * Returns undefined if the slug map is not yet loaded or the slug is not found.
+ */
+export function getJobMetaForSlug(slug: string): { id?: string; canton?: string; canonicalSlug?: string } | undefined {
+ if (!_jobSlugMap) return undefined;
+ const record = _jobSlugMap.get(slug);
+ if (!record) return undefined;
+ return { id: record._id, canton: record._canton, canonicalSlug: record['_default'] };
+}
+
 export async function ensureJobSlugMapLoaded(): Promise<void> {
  if (_jobSlugMap) return;
  if (!_jobSlugMapPromise) {
  _jobSlugMapPromise = fetch('/data/jobs-slug-map.json')
  .then(r => r.ok ? r.json() : Promise.reject(r.status))
- .then((data: Array<{ slug?: string; slugByLocale?: Partial<Record<string, string>>; previousSlugs?: string[]; previousSlugsByLocale?: Partial<Record<string, string[]>> }>) => {
+ .then((data: Array<{ id?: string; canton?: string; slug?: string; slugByLocale?: Partial<Record<string, string>>; previousSlugs?: string[]; previousSlugsByLocale?: Partial<Record<string, string[]>> }>) => {
  registerJobSlugMap(data);
  })
  .finally(() => {

--- a/tests/bridge-canton-aware.test.ts
+++ b/tests/bridge-canton-aware.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(__dirname, '..');
+
+describe('Bridge page canton-aware UX', () => {
+  // Read sources once at module load — keeps test runtime negligible.
+  const jobsSeoSrc = fs.readFileSync(
+    path.resolve(root, 'build-plugins/jobsSeoPagesPlugin.ts'),
+    'utf-8',
+  );
+  const slugSplitSrc = fs.readFileSync(
+    path.resolve(root, 'build-plugins/localeJobsSplitPlugin.ts'),
+    'utf-8',
+  );
+  const routerSrc = fs.readFileSync(
+    path.resolve(root, 'services/router.ts'),
+    'utf-8',
+  );
+  const jobBoardSrc = fs.readFileSync(
+    path.resolve(root, 'components/community/JobBoard.tsx'),
+    'utf-8',
+  );
+
+  describe('F3: canton-aware breadcrumb text', () => {
+    it('exports a helper that adapts the breadcrumb label to the canton display name', () => {
+      expect(jobsSeoSrc).toContain('allJobsLinkLabel');
+      // The IT label must be a template that includes the canton placeholder.
+      expect(jobsSeoSrc).toMatch(/Tutte le offerte di lavoro in \$\{cantonDisplay\}/);
+      expect(jobsSeoSrc).toMatch(/All job offers in \$\{cantonDisplay\}/);
+    });
+
+    it('uses the helper in the static job-detail breadcrumb (not the hardcoded "in Ticino" string)', () => {
+      // The job-detail breadcrumb nav must invoke allJobsLinkLabel with the
+      // job's canton display, not the hardcoded localeCopy.allJobsLink.
+      const breadcrumbLine = jobsSeoSrc.split('\n').find((l) =>
+        l.includes('class="bn"') && l.includes('jobCanton'),
+      );
+      expect(breadcrumbLine).toBeDefined();
+      expect(breadcrumbLine).toContain('allJobsLinkLabel(locale, dc)');
+      expect(breadcrumbLine).not.toContain('localeCopy[locale].allJobsLink');
+    });
+  });
+
+  describe('F5: slug-map carries id + canton for cross-canton bridge resolution', () => {
+    it('localeJobsSplitPlugin emits id + canton into jobs-slug-map.json entries', () => {
+      // The slug-map projection must include id and canton.
+      expect(slugSplitSrc).toContain('if (j.id) entry.id = j.id;');
+      expect(slugSplitSrc).toContain('if (j.canton) entry.canton = j.canton;');
+    });
+
+    it('router.registerJobSlugMap accepts and indexes id + canton meta', () => {
+      // Type signature must accept id + canton.
+      expect(routerSrc).toContain('id?: string');
+      expect(routerSrc).toContain('canton?: string');
+      // Meta is stored under reserved keys to avoid colliding with locale keys.
+      expect(routerSrc).toContain('record._id = job.id');
+      expect(routerSrc).toContain('record._canton');
+    });
+
+    it('router exports getJobMetaForSlug for SPA bridge resolution', () => {
+      expect(routerSrc).toContain('export function getJobMetaForSlug');
+      expect(routerSrc).toMatch(/getJobMetaForSlug\(slug: string\):\s*\{[^}]*id\?:\s*string;[^}]*canton\?:\s*string/);
+    });
+
+    it('JobBoard wires a cross-canton lazy fetch when bridgeTarget is in a different canton shard', () => {
+      // Must import the new router helper.
+      expect(jobBoardSrc).toContain('getJobMetaForSlug');
+      expect(jobBoardSrc).toContain('ensureJobSlugMapLoaded');
+      // Must call fetchJobsForCanton with the looked-up canton when selectedJob
+      // is missing but a bridge target slug is set.
+      expect(jobBoardSrc).toMatch(/getJobMetaForSlug\(targetSlug\)/);
+      expect(jobBoardSrc).toMatch(/fetchJobsForCanton\(cantonCode\)/);
+      // Must guard against re-firing for the same slug.
+      expect(jobBoardSrc).toContain('bridgeFetchAttempted');
+    });
+  });
+
+  describe('F1: backfilled previousSlugs for the canonical Denner case', () => {
+    const dennerSlicePath = path.resolve(root, 'data/jobs/by-crawler/denner.json');
+    const dennerSlice = JSON.parse(fs.readFileSync(dennerSlicePath, 'utf-8'));
+    const targetJob = (dennerSlice.jobs as Array<{
+      url?: string;
+      slug?: string;
+      previousSlugs?: string[];
+      previousSlugsByLocale?: Record<string, string[] | undefined>;
+    }>).find((j) => j.url?.includes('ebbde505-d2e5-4b59-82af-3663f4eaaf1f'));
+
+    it('finds the Denner Assistent*in Filialleitung job by stable UUID', () => {
+      expect(targetJob).toBeDefined();
+      expect(targetJob!.slug).toBe('assistente-nella-gestione-delle-branche-denner-appenzell');
+    });
+
+    it('includes the 5 Ebikon legacy slugs in previousSlugs', () => {
+      const expectedAliases = [
+        'assistente-nella-gestione-delle-branche-denner-ebikon',
+        'assistente-alla-direzione-di-filiale-denner-ebikon',
+        'assistant-store-manager-denner-ebikon',
+        'assistent-in-filialleitung-denner-ebikon',
+        'assistant-e-de-direction-de-succursale-denner-ebikon',
+      ];
+      for (const alias of expectedAliases) {
+        expect(targetJob!.previousSlugs).toContain(alias);
+      }
+    });
+
+    it('partitions the Ebikon aliases into the correct locale buckets', () => {
+      const byLocale = targetJob!.previousSlugsByLocale ?? {};
+      expect(byLocale.it).toContain('assistente-nella-gestione-delle-branche-denner-ebikon');
+      expect(byLocale.it).toContain('assistente-alla-direzione-di-filiale-denner-ebikon');
+      expect(byLocale.en).toContain('assistant-store-manager-denner-ebikon');
+      expect(byLocale.de).toContain('assistent-in-filialleitung-denner-ebikon');
+      expect(byLocale.fr).toContain('assistant-e-de-direction-de-succursale-denner-ebikon');
+    });
+  });
+});


### PR DESCRIPTION
Bridge URLs whose target job lives in a canton outside the initial
referrer-aware shard load (e.g. /cerca-lavoro-ticino/<bridge>/ for a job
now in AI) used to fall through to JobOrphanView in the SPA even though
the static crawler-facing fallback was correctly pre-rendered. Three
changes restore consistency between first paint and hydration.

- F1: scripts/backfill-orphan-slugs-from-registry.mjs — scans
  all-known-job-slugs.json for slugs registered but not owned by any
  current job and reconciles them via title-only Jaccard + company-token
  sanity check (threshold 0.7). Backfilled 792 cases across 96 crawler
  slices.
- F3: jobsSeoPagesPlugin allJobsLinkLabel(locale, cantonDisplay) — the
  static job-detail breadcrumb now reflects the JOB's canton, not the
  URL canton segment, eliminating the 'Tutte le offerte in Ticino' →
  /cerca-lavoro-appenzello/ visual inconsistency on bridge pages.
- F5: localeJobsSplitPlugin emits id + canton in jobs-slug-map.json;
  router.getJobMetaForSlug exposes the lookup; JobBoard lazy-fetches the
  target canton shard when bridgeTargetSlug is set but selectedJob is
  null, so the SPA renders the live job instead of the orphan view.

Regression: tests/bridge-canton-aware.test.ts (9 tests).
