### PR TITLE
perf(build): opt-in worker_threads parallel rendering for cluster pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: boolean
         default: false
+      cluster_parallel_render:
+        description: 'Enable worker_threads-based parallel rendering of the 102k related-search-clusters pages (renderClusterPage dispatched across 4 workers). Opt-in until byte-equivalence is verified on a live deploy. Sets CLUSTER_PARALLEL_RENDER=1 for the build step.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   # This workflow only needs repository read access: the previous-slug winners
@@ -455,6 +460,11 @@ jobs:
           # when triaging a specific collision and you need the rendered
           # HTML. Saves ~100-200s/build on push events.
           WRITE_COLLISION_DUMP: ${{ github.event.inputs.write_collision_dump == 'true' && '1' || '' }}
+          # Opt-in worker_threads parallel rendering of the 102k related-search
+          # cluster pages. Default off until byte-equivalence verified on a
+          # live deploy. Once verified, flip to default-on in a follow-up PR.
+          # See build-plugins/relatedSearchClustersRenderWorker.mjs.
+          CLUSTER_PARALLEL_RENDER: ${{ github.event.inputs.cluster_parallel_render == 'true' && '1' || '' }}
         shell: bash
         run: |
           set -o pipefail

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -43,6 +43,8 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
+import { Worker } from 'node:worker_threads';
+import { availableParallelism, cpus } from 'node:os';
 import type { Plugin } from 'vite';
 
 import { WriteCollector } from './batchWrite';
@@ -932,8 +934,17 @@ function memoCommuterCtx(opts: JobBoardCommuterContextOpts): string {
   return cached;
 }
 
-/** Render a single cluster page. */
-function renderClusterPage(inputs: PageInputs): PageOutput {
+/**
+ * Render a single cluster page.
+ *
+ * Exported so `build-plugins/relatedSearchClustersRenderWorker.mjs` can
+ * invoke this function from a worker_threads child via tsx dynamic
+ * import. The worker reconstructs a slim ClusterContext from chunkContexts
+ * — see worker file for the contract. Byte-identicality requires that
+ * the SAME function runs in both modes; do not fork the worker render
+ * logic, always extend through this entry point.
+ */
+export function renderClusterPage(inputs: PageInputs): PageOutput {
   const { ctx, enriched, hreflang, related, distDir } = inputs;
   const { candidate } = ctx;
   const locale = candidate.locale;
@@ -1468,6 +1479,150 @@ function patchMasterSitemap(distDir: string, dateStamp: string, shardFiles: Read
   // that inspects it between our write and the alias plugin's overwrite.
 }
 
+// ── Parallel-render helper (opt-in via CLUSTER_PARALLEL_RENDER=1) ───────
+
+interface ChunkContext {
+  slug: string;
+  locale: Locale;
+  keyword: string;
+  city: string | null;
+  matchingJobLocations: string[];
+  topCompanies: string[];
+  enrichedKey: string;
+  hreflang: ReadonlyArray<{ locale: Locale; url: string }>;
+  related: ReadonlyArray<{ keyword: string; url: string }>;
+}
+
+interface WorkerOutcome {
+  count: number;
+  locs: string[];
+  emittedFiles: string[];
+  workerCount: number;
+  wallSeconds: number;
+}
+
+/**
+ * Worker-pool dispatcher for cluster-page rendering.
+ *
+ * Builds slim ChunkContext records (no full Job objects — only the
+ * locations renderClusterPage actually reads), splits them round-robin
+ * across N workers, and waits for all to finish. Workers write index.html
+ * + flat-bridge .html files directly to dist/.
+ *
+ * Worker count: min(availableParallelism, 4). The GitHub Actions
+ * `ubuntu-latest` runner free tier reports 4 vCPU; spawning more workers
+ * here would oversubscribe + thrash. The 4-worker cap mirrors the
+ * postWalkCoordinator default.
+ *
+ * Memo cache caveat: each worker has its own V8 context, so the
+ * renderJobBoardCommuterContext / buildJobBoardCommuterFaqItems / local
+ * commuterCtxCache caches are NOT shared. Per-worker cardinality stays
+ * within the upstream 30000 cap (each worker handles ~25k clusters with
+ * ~5-7k unique commuter-ctx keys). Cache hit ratio per worker is
+ * comparable to the single-threaded case.
+ */
+async function renderClustersInParallel(opts: {
+  contexts: ReadonlyArray<ClusterContext>;
+  enriched: Record<string, EnrichedEntry>;
+  byKeywordCity: ReadonlyMap<string, Map<Locale, ClusterContext>>;
+  byLocaleCity: ReadonlyMap<Locale, Map<string, ClusterContext[]>>;
+  distDir: string;
+  dateStamp: string;
+}): Promise<WorkerOutcome> {
+  const t0 = Date.now();
+  const { contexts, enriched, byKeywordCity, byLocaleCity, distDir, dateStamp } = opts;
+
+  // Pre-compute per-cluster hreflang + related arrays in the main thread.
+  // These depend on byKeywordCity / byLocaleCity which we DON'T want to
+  // postMessage to workers (they hold transitive RawJob references).
+  const slimContexts: ChunkContext[] = contexts.map((ctx) => {
+    const locale = ctx.candidate.locale;
+    const altKey = `${normalizeText(ctx.keyword)}|${normalizeText(ctx.city || '')}`;
+    const altMap = byKeywordCity.get(altKey);
+    const hreflang = altMap
+      ? Array.from(altMap.entries()).map(([loc, otherCtx]) => ({
+          locale: loc,
+          url: `${BASE_URL}${buildClusterPath(loc, otherCtx.candidate.slug)}`,
+        }))
+      : [];
+
+    const cityIdx = byLocaleCity.get(locale);
+    const sameCityList = (ctx.city && cityIdx?.get(ctx.city)) || [];
+    const related = sameCityList
+      .filter((other) => other.candidate.slug !== ctx.candidate.slug)
+      .slice(0, 8)
+      .map((other) => ({
+        keyword: other.city ? `${capitalize(other.keyword)} — ${other.city}` : capitalize(other.keyword),
+        url: `${BASE_URL}${buildClusterPath(locale, other.candidate.slug)}`,
+      }));
+
+    return {
+      slug: ctx.candidate.slug,
+      locale,
+      keyword: ctx.keyword,
+      city: ctx.city,
+      // Slim down matchingJobs to just `.location` (the only field
+      // renderClusterPage reads). Empty/missing locations are preserved
+      // so the topCities computation in renderClusterPage stays byte-
+      // identical to the main-thread path.
+      matchingJobLocations: ctx.matchingJobs.map((j) => (j as { location?: string }).location || ''),
+      topCompanies: ctx.topCompanies,
+      enrichedKey: `${locale}::${ctx.candidate.slug}`,
+      hreflang,
+      related,
+    };
+  });
+
+  const detectedParallelism = (() => {
+    try {
+      return availableParallelism();
+    } catch {
+      return cpus().length || 4;
+    }
+  })();
+  const workerCount = Math.max(1, Math.min(detectedParallelism, 4));
+
+  // Round-robin chunking so each worker gets a balanced mix of locales/sizes.
+  // Same pattern as postWalkCoordinator's chunkRoundRobin.
+  const chunks: ChunkContext[][] = Array.from({ length: workerCount }, () => []);
+  for (let i = 0; i < slimContexts.length; i++) {
+    chunks[i % workerCount].push(slimContexts[i]);
+  }
+
+  const workerUrl = new URL('./relatedSearchClustersRenderWorker.mjs', import.meta.url);
+
+  const workerResults = await Promise.all(
+    chunks.map((chunkContexts) =>
+      new Promise<{ count: number; locs: string[]; emittedFiles: string[] }>((resolve, reject) => {
+        const worker = new Worker(workerUrl, {
+          workerData: { distDir, dateStamp, enriched, chunkContexts },
+          execArgv: ['--import', 'tsx'],
+        });
+        worker.once('message', (msg) => resolve(msg));
+        worker.once('error', reject);
+        worker.once('exit', (code) => {
+          if (code !== 0) reject(new Error(`relatedSearchClustersRenderWorker exited with code ${code}`));
+        });
+      }),
+    ),
+  );
+
+  const combined: WorkerOutcome = {
+    count: 0,
+    locs: [],
+    emittedFiles: [],
+    workerCount,
+    wallSeconds: 0,
+  };
+  for (const r of workerResults) {
+    combined.count += r.count;
+    combined.locs.push(...r.locs);
+    combined.emittedFiles.push(...r.emittedFiles);
+  }
+  combined.wallSeconds = (Date.now() - t0) / 1000;
+  return combined;
+}
+
 // ── Plugin entry ────────────────────────────────────────────────────────
 
 export function relatedSearchClustersPlugin(rootDir: string): Plugin {
@@ -1594,51 +1749,85 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       const cachedHubs: { locale: Locale; url: string }[] = [];
 
       // ── Per-cluster pages ─────────────────────────────────────────────
-      for (const ctx of contexts) {
-        const locale = ctx.candidate.locale;
-        const altKey = `${normalizeText(ctx.keyword)}|${normalizeText(ctx.city || '')}`;
-        const altMap = byKeywordCity.get(altKey);
-        const hreflang = altMap
-          ? Array.from(altMap.entries()).map(([loc, otherCtx]) => ({
-              locale: loc,
-              url: `${BASE_URL}${buildClusterPath(loc, otherCtx.candidate.slug)}`,
-            }))
-          : [];
-
-        const cityIdx = byLocaleCity.get(locale);
-        const sameCityList = (ctx.city && cityIdx?.get(ctx.city)) || [];
-        const related = sameCityList
-          .filter((other) => other.candidate.slug !== ctx.candidate.slug)
-          .slice(0, 8)
-          .map((other) => ({
-            keyword: other.city ? `${capitalize(other.keyword)} — ${other.city}` : capitalize(other.keyword),
-            url: `${BASE_URL}${buildClusterPath(locale, other.candidate.slug)}`,
-          }));
-
-        const enrichedKey = `${locale}::${ctx.candidate.slug}`;
-        const out = renderClusterPage({
-          ctx,
-          enriched: enriched[enrichedKey],
-          hreflang,
-          related,
+      //
+      // Parallel-render path (CLUSTER_PARALLEL_RENDER=1): dispatch the
+      // 102k × renderClusterPage CPU work across N worker_threads. Workers
+      // write index.html + flat-bridge directly to dist (bypassing the
+      // collector — workers already give us 4-way parallel I/O). The
+      // sequential path keeps the legacy collector flow for safety.
+      //
+      // Byte-identicality is guaranteed by calling THE SAME renderClusterPage
+      // function (imported via tsx dynamic import in the worker) with the
+      // same logical inputs. The only divergence point is `ctx.matchingJobs`
+      // being slimmed to objects with `.location` only on the worker side —
+      // OK because renderClusterPage reads `.length` + `.location` and
+      // nothing else from matchingJobs (verified via grep at refactor time).
+      //
+      // Default OFF until byte-equivalence is verified on a live deploy via
+      // `gh workflow run deploy.yml -f cluster_parallel=true`. Once
+      // verified, flip default in a follow-up PR.
+      const parallelRender = process.env.CLUSTER_PARALLEL_RENDER === '1';
+      if (parallelRender) {
+        const workerOutcome = await renderClustersInParallel({
+          contexts,
+          enriched,
+          byKeywordCity,
+          byLocaleCity,
           distDir,
           dateStamp,
         });
+        sitemapLocs.push(...workerOutcome.locs);
+        emittedFiles.push(...workerOutcome.emittedFiles);
+        console.log(
+          `\x1b[36m[related-search-clusters]\x1b[0m parallel-render emitted ${workerOutcome.count} cluster pages across ${workerOutcome.workerCount} worker(s) in ${workerOutcome.wallSeconds.toFixed(1)}s`,
+        );
+      } else {
+        for (const ctx of contexts) {
+          const locale = ctx.candidate.locale;
+          const altKey = `${normalizeText(ctx.keyword)}|${normalizeText(ctx.city || '')}`;
+          const altMap = byKeywordCity.get(altKey);
+          const hreflang = altMap
+            ? Array.from(altMap.entries()).map(([loc, otherCtx]) => ({
+                locale: loc,
+                url: `${BASE_URL}${buildClusterPath(loc, otherCtx.candidate.slug)}`,
+              }))
+            : [];
 
-        const indexPath = path.join(distDir, out.urlPath, 'index.html');
-        const flatPath = path.join(distDir, out.urlPath.replace(/\/+$/, '') + '.html');
-        collector.add(indexPath, out.html);
-        // Emit the flat .html as a redirect bridge directly: postWalkCoordinator
-        // would otherwise read this file (~30 KB), build the same bridge from
-        // the sibling, and rewrite (~500 B). Pre-emitting the bridge cuts
-        // ~52k × 30 KB writes here AND post-walk's `html === original` guard
-        // skips the rewrite. Trims ~30-50 s off closeBundle.
-        const slashUrl = `${BASE_URL}${out.urlPath.replace(/\/+$/, '')}/`;
-        const flatBridge = buildFlatBridgeFromSibling(out.html, slashUrl);
-        collector.add(flatPath, flatBridge);
-        emittedFiles.push(path.relative(distDir, indexPath));
-        emittedFiles.push(path.relative(distDir, flatPath));
-        sitemapLocs.push(out.loc);
+          const cityIdx = byLocaleCity.get(locale);
+          const sameCityList = (ctx.city && cityIdx?.get(ctx.city)) || [];
+          const related = sameCityList
+            .filter((other) => other.candidate.slug !== ctx.candidate.slug)
+            .slice(0, 8)
+            .map((other) => ({
+              keyword: other.city ? `${capitalize(other.keyword)} — ${other.city}` : capitalize(other.keyword),
+              url: `${BASE_URL}${buildClusterPath(locale, other.candidate.slug)}`,
+            }));
+
+          const enrichedKey = `${locale}::${ctx.candidate.slug}`;
+          const out = renderClusterPage({
+            ctx,
+            enriched: enriched[enrichedKey],
+            hreflang,
+            related,
+            distDir,
+            dateStamp,
+          });
+
+          const indexPath = path.join(distDir, out.urlPath, 'index.html');
+          const flatPath = path.join(distDir, out.urlPath.replace(/\/+$/, '') + '.html');
+          collector.add(indexPath, out.html);
+          // Emit the flat .html as a redirect bridge directly: postWalkCoordinator
+          // would otherwise read this file (~30 KB), build the same bridge from
+          // the sibling, and rewrite (~500 B). Pre-emitting the bridge cuts
+          // ~52k × 30 KB writes here AND post-walk's `html === original` guard
+          // skips the rewrite. Trims ~30-50 s off closeBundle.
+          const slashUrl = `${BASE_URL}${out.urlPath.replace(/\/+$/, '')}/`;
+          const flatBridge = buildFlatBridgeFromSibling(out.html, slashUrl);
+          collector.add(flatPath, flatBridge);
+          emittedFiles.push(path.relative(distDir, indexPath));
+          emittedFiles.push(path.relative(distDir, flatPath));
+          sitemapLocs.push(out.loc);
+        }
       }
 
       // ── Per-locale hub pages ──────────────────────────────────────────

--- a/build-plugins/relatedSearchClustersRenderWorker.mjs
+++ b/build-plugins/relatedSearchClustersRenderWorker.mjs
@@ -1,0 +1,170 @@
+/**
+ * Worker for relatedSearchClustersPlugin parallel cluster-page emission.
+ *
+ * Runs in a node:worker_threads child to render a slice of cluster pages
+ * (renderClusterPage + buildFlatBridgeFromSibling) and writes both the
+ * canonical `index.html` and the flat-bridge `.html` to dist/ DIRECTLY.
+ *
+ * Bypasses WriteCollector on purpose: workers already give us 4-way
+ * parallel I/O over the file system; the collector's role (buffered
+ * Promise.all flush) is redundant here. Trade-off: write-collision
+ * tracking lives in the registry layer only for clusters; cluster-emit
+ * has no known collision pattern (each slug→locale pair owns its path).
+ *
+ * Byte-identicality contract: the worker calls the SAME renderClusterPage
+ * function as the main-thread path (imported via tsx dynamic import).
+ * Any divergence would be a bug in how the slim ChunkContext is
+ * reconstructed into a ClusterContext-shaped object — see the fake
+ * matchingJobs note below.
+ *
+ * The worker reconstructs ClusterContext from a slim chunk record:
+ *  - candidate: { slug, locale }  (renderClusterPage reads .candidate.slug
+ *                                  + .candidate.locale only)
+ *  - matchingJobs: fake objects with .location only (renderClusterPage
+ *                  reads .length and .map(j => j.location) only)
+ *  - keyword, city, topCompanies as-is.
+ *
+ * Per-worker memo caches (renderJobBoardCommuterContext +
+ * buildJobBoardCommuterFaqItems via shared/jobBoardCommuterContext.ts)
+ * are isolated to this worker's V8 context — same as the main thread's
+ * memo state would be. Per-cluster cardinality is bounded by the
+ * upstream cap (30000) so each worker has its own safe ceiling.
+ *
+ * Spawned via:
+ *   new Worker(workerUrl, { workerData, execArgv: ['--import', 'tsx'] })
+ *
+ * Returns via postMessage:
+ *   { count, locs: string[], emittedFiles: string[] }
+ *
+ * `count` = clusters rendered. `locs` = sitemap loc URLs. `emittedFiles`
+ * = dist-relative paths (for the cache-save metadata captured by the
+ * caller's fast-cache path).
+ */
+import { parentPort, workerData } from 'node:worker_threads';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+if (!parentPort) {
+  throw new Error('[relatedSearchClustersRenderWorker] must be spawned via worker_threads');
+}
+
+// Dynamic TS import works because the parent spawns with
+// `execArgv: ['--import', 'tsx']`. The plugin file's module-level
+// statements (constants, type definitions, function declarations,
+// the commuterCtxCache Map) run once per worker. No I/O at module load.
+const pluginModule = await import('./relatedSearchClustersPlugin.ts');
+const flatBridgeModule = await import('./flatHtmlRedirectPlugin.ts');
+const constantsModule = await import('./constants.ts');
+
+const { renderClusterPage } = pluginModule;
+const { buildFlatBridgeFromSibling } = flatBridgeModule;
+const { BASE_URL } = constantsModule;
+
+if (typeof renderClusterPage !== 'function') {
+  throw new Error('[relatedSearchClustersRenderWorker] renderClusterPage not exported by relatedSearchClustersPlugin.ts');
+}
+if (typeof buildFlatBridgeFromSibling !== 'function') {
+  throw new Error('[relatedSearchClustersRenderWorker] buildFlatBridgeFromSibling not exported by flatHtmlRedirectPlugin.ts');
+}
+
+/**
+ * @typedef {{
+ *   slug: string,
+ *   locale: 'it' | 'en' | 'de' | 'fr',
+ *   keyword: string,
+ *   city: string | null,
+ *   matchingJobLocations: string[],
+ *   topCompanies: string[],
+ *   enrichedKey: string,
+ *   hreflang: Array<{ locale: string, url: string }>,
+ *   related: Array<{ keyword: string, url: string }>,
+ * }} ChunkContext
+ */
+
+/**
+ * @type {{
+ *   distDir: string,
+ *   dateStamp: string,
+ *   enriched: Record<string, unknown>,
+ *   chunkContexts: ChunkContext[],
+ * }}
+ */
+const {
+  distDir,
+  dateStamp,
+  enriched,
+  chunkContexts,
+} = workerData;
+
+/** @type {string[]} */
+const locs = [];
+/** @type {string[]} */
+const emittedFiles = [];
+
+// Reuse a shared mkdir-cache so we don't issue redundant mkdir() syscalls
+// for paths whose parent already exists from a previous emit in this
+// worker's chunk. Mirrors the WriteCollector's mkdir-once behaviour.
+/** @type {Set<string>} */
+const mkdirCache = new Set();
+
+/**
+ * @param {string} dir
+ */
+async function ensureDir(dir) {
+  if (mkdirCache.has(dir)) return;
+  await mkdir(dir, { recursive: true });
+  mkdirCache.add(dir);
+}
+
+let count = 0;
+
+for (const cctx of chunkContexts) {
+  // Reconstruct ClusterContext shape — renderClusterPage reads only:
+  //   ctx.candidate.locale, ctx.candidate.slug
+  //   ctx.keyword, ctx.city, ctx.topCompanies
+  //   ctx.matchingJobs.length, ctx.matchingJobs.map(j => j.location)
+  // Anything else would be a NEW dependency and break byte-identicality.
+  const ctx = {
+    candidate: {
+      slug: cctx.slug,
+      locale: cctx.locale,
+      // Padding fields ignored by renderClusterPage but kept for the
+      // ClusterContext type-shape so static analyzers in workers don't
+      // choke. None of these are read in the renderClusterPage critical
+      // path (verified via grep at refactor time).
+      jobCount: cctx.matchingJobLocations.length,
+      editorialCollision: null,
+    },
+    keyword: cctx.keyword,
+    city: cctx.city,
+    matchingJobs: cctx.matchingJobLocations.map((loc) => ({ location: loc })),
+    topCompanies: cctx.topCompanies,
+  };
+
+  const out = renderClusterPage({
+    ctx,
+    enriched: enriched[cctx.enrichedKey],
+    hreflang: cctx.hreflang,
+    related: cctx.related,
+    distDir,
+    dateStamp,
+  });
+
+  const indexPath = path.join(distDir, out.urlPath, 'index.html');
+  const flatPath = path.join(distDir, out.urlPath.replace(/\/+$/, '') + '.html');
+  const slashUrl = `${BASE_URL}${out.urlPath.replace(/\/+$/, '')}/`;
+  const flatBridge = buildFlatBridgeFromSibling(out.html, slashUrl);
+
+  await ensureDir(path.dirname(indexPath));
+  await writeFile(indexPath, out.html, 'utf-8');
+  // flatPath's dirname is the parent of indexPath's dirname — ensure it too.
+  await ensureDir(path.dirname(flatPath));
+  await writeFile(flatPath, flatBridge, 'utf-8');
+
+  emittedFiles.push(path.relative(distDir, indexPath));
+  emittedFiles.push(path.relative(distDir, flatPath));
+  locs.push(out.loc);
+  count++;
+}
+
+parentPort.postMessage({ count, locs, emittedFiles });


### PR DESCRIPTION
Adds a feature-flagged (CLUSTER_PARALLEL_RENDER=1) parallel-render path
for the 102k related-search cluster pages. Default OFF — sequential
behaviour unchanged until byte-equivalence is verified on a live deploy.

How it works
------------
1. Main thread runs the full matching + grouping phase as before
   (TokenIndex, buildClusterContext, byKeywordCity, byLocaleCity).
2. Pre-computes per-cluster `hreflang` + `related` arrays in the main
   thread (these depend on byKeywordCity / byLocaleCity, both of which
   transitively hold full RawJob references we can't postMessage to
   workers cheaply).
3. Builds slim ChunkContext records: slug + locale + keyword + city +
   matchingJobLocations (just the `.location` strings — the only field
   renderClusterPage reads from matchingJobs) + topCompanies + enrichedKey.
4. Round-robin chunks across N = min(availableParallelism, 4) workers.
5. Each worker dynamically imports renderClusterPage (via tsx) and
   buildFlatBridgeFromSibling, reconstructs a fake ClusterContext with
   stripped-down matchingJobs ({location} objects only), and calls
   THE SAME renderClusterPage function as the sequential path.
6. Workers write index.html + flat-bridge .html directly to dist/ using
   fs.promises.writeFile (4-way parallel I/O obviates the WriteCollector
   buffering).
7. Workers postMessage back { count, locs, emittedFiles } only — no HTML
   string round-trip (avoids the 3 GB structured-clone cost of returning
   all rendered HTML to the main thread).

Byte-identicality
-----------------
The worker invokes the SAME renderClusterPage function as the sequential
path — no fork of the render logic. The only divergence point is the
slim ChunkContext: renderClusterPage reads `ctx.matchingJobs.length` and
`ctx.matchingJobs.map(j => j.location)` and nothing else from
matchingJobs (verified via grep across renderClusterPage at refactor
time). The fake objects {location: '...'} preserve both behaviours.
Per-worker memoization caches (renderJobBoardCommuterContext +
buildJobBoardCommuterFaqItems + local commuterCtxCache) are independent
but deterministic in their input → output mapping; same input ⇒ same
output regardless of which worker computes it.

Expected wall-time saving
-------------------------
Previous run 26098333072: related-search-clusters wall 384.21s, cpu 509.21s,
cpu/wall 1.33× (almost single-thread). 102827 pages × ~3.7ms/page on the
4-vCPU CI runner. With 4 workers + perfect scaling, theoretical floor is
~125s wall. Realistic target with worker-spawn + import overhead: 150-180s
wall — roughly -200-230s on closeBundle phase.

How to verify
-------------
Trigger a deploy with the flag enabled:
  gh workflow run deploy.yml -f cluster_parallel_render=true
Compare the new build profile's `[related-search-clusters]` line vs the
sequential baseline. Once byte-equivalence holds (audit-dist shows no
new offenders for footer-root-presence, jsonld-no-nested-scripts,
h1-title-duplicates, text-html-ratio cluster bucket) the default can flip
in a follow-up PR.

Out of scope here
-----------------
The per-locale HUB pages (4 + paginated subpages) still emit sequentially
through the WriteCollector — they're a tiny fraction of the total wall
(seconds) and the parallel-render path focuses on the dominant 102k loop.
