### PR TITLE
feat(crawlers): add 3 SmartRecruiters healthcare crawlers (batch 16A)

### DIFF
--- a/.github/workflows/update-jobs-ardentis.yml
+++ b/.github/workflows/update-jobs-ardentis.yml
@@ -1,0 +1,101 @@
+name: Update Ardentis Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-ardentis
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-ardentis-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated ARDENTIS crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_ARDENTIS_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-ardentis-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'ardentis'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/ardentis.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ARDENTIS jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-imad.yml
+++ b/.github/workflows/update-jobs-imad.yml
@@ -1,0 +1,101 @@
+name: Update imad Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-imad
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-imad-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated IMAD crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_IMAD_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-imad-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'imad'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/imad.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update IMAD jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-sobi.yml
+++ b/.github/workflows/update-jobs-sobi.yml
@@ -1,0 +1,101 @@
+name: Update Sobi Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-sobi
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-sobi-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated SOBI crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_SOBI_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-sobi-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'sobi'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/sobi.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SOBI jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/ardentis-job-parser.mjs
+++ b/scripts/lib/ardentis-job-parser.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Ardentis — SmartRecruiters API job parser.
+ *
+ * Source: https://careers.smartrecruiters.com/Ardentis1
+ * API:    https://api.smartrecruiters.com/v1/companies/Ardentis1/postings
+ *
+ * Ardentis is a Swiss dental-clinic network operating ~20+ cliniques across
+ * Romandie (VD/VS/FR/GE) and parts of central Switzerland. Job postings cover
+ * dentists, dental hygienists, dental assistants, secretaries, and apprenticeships.
+ *
+ * SmartRecruiters tenant ID: `Ardentis1` (case-sensitive).
+ *
+ * Exports the 4 required functions for the crawler template:
+ *   - fetchAllArdentisJobs() — Fetch and parse all jobs
+ *   - isArdentisJob()        — Match jobs belonging to this company
+ *   - isTrustedDomain()      — Validate URLs belong to this company
+ *   - ARDENTIS_KEY / _COMPANY_NAME / _COMPANY_DOMAIN constants
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferSwissTargetCanton, isTargetSwissLocation } from './target-swiss-locations.mjs';
+import {
+  fetchSmartRecruitersJobs,
+  SmartRecruitersApiError,
+} from './ats-clients/smartrecruiters-client.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const ARDENTIS_KEY = 'ardentis';
+export const ARDENTIS_COMPANY_NAME = 'Ardentis';
+export const ARDENTIS_COMPANY_DOMAIN = 'ardentis.ch';
+
+const SR_TENANT = 'Ardentis1';
+const CAREER_URL = `https://careers.smartrecruiters.com/${SR_TENANT}`;
+const SR_PAGE_DELAY_MS = 2000;
+const SR_REQUEST_TIMEOUT_MS = 15000;
+const SR_USER_AGENT = 'FrontaliereTicino-Bot/1.0 (+https://frontaliereticino.ch/)';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+export function isArdentisJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === ARDENTIS_KEY ||
+    /^ardentis(-|$)/.test(key) ||
+    /\bardentis\b/.test(company) ||
+    url.includes('ardentis.ch') ||
+    url.includes('smartrecruiters.com/ardentis1')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const url = new URL(rawUrl);
+    const host = url.hostname.toLowerCase();
+    if (host === 'ardentis.ch' || host.endsWith('.ardentis.ch')) return true;
+    if (host === 'jobs.smartrecruiters.com' || host === 'careers.smartrecruiters.com' || host === 'smartrecruiters.com') {
+      return /\/ardentis1(\/|$)/i.test(url.pathname);
+    }
+    if (host === 'api.smartrecruiters.com') {
+      return /\/companies\/ardentis1(\/|$)/i.test(url.pathname);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/* ── Category Detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(dentiste|dentista|zahnarzt|orthodontiste|hygi[eè]niste|hygieniste|assistant.?e?\s*dentaire)/.test(t)) return 'Sanità';
+  if (/\b(m[ée]decin|doctor|chirurg|infirmi|nurse|aide.?soign|soin)/.test(t)) return 'Sanità';
+  if (/\b(secr[eé]taire|reception|admin|comptab|administra)/.test(t)) return 'Amministrazione';
+  if (/\b(apprenti|stage|stagiair|lehrling|lernend)/.test(t)) return 'Sanità';
+  if (/\b(it|software|develop|programm|informatique)/.test(t)) return 'IT';
+  if (/\b(market|kommunik|comunicaz|communication)/.test(t)) return 'Marketing';
+  if (/\b(hr|human|risorse|personal|ressources humaines)/.test(t)) return 'Risorse Umane';
+  if (/\b(finance|finanz|compt|account)/.test(t)) return 'Finanza';
+  return 'Sanità';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(apprenti|stage|stagiair|intern|lehrling|lernend)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|sr|chef|responsab|directeur|directrice|head|lead|leiter)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(text = '') {
+  const t = normalize(text);
+  if (/\b(part.?time|teilzeit|tempo parziale|temps partiel)/.test(t)) return 'PART_TIME';
+  if (/\b(full.?time|vollzeit|tempo pieno|temps plein)/.test(t)) return 'FULL_TIME';
+  if (/\b(stage|intern|stagiair|apprenti)/.test(t)) return 'INTERN';
+  if (/\b(cdd|temporary|tempor|befristet|fixed.?term)/.test(t)) return 'CONTRACTOR';
+  return 'OTHER';
+}
+
+/* ── SmartRecruiters Posting Helpers ───────────────────────── */
+
+function isSwissPosting(posting) {
+  const country = String(posting?.location?.country?.code || posting?.location?.country || '').toLowerCase();
+  if (country === 'ch') return true;
+  if (country && country !== 'ch') return false;
+  const text = composeLocationText(posting?.location);
+  if (!text) return false;
+  return isTargetSwissLocation(text, { includeGrigioni: true });
+}
+
+function composeLocationText(loc = {}) {
+  if (!loc || typeof loc !== 'object') return '';
+  if (typeof loc.fullLocation === 'string' && loc.fullLocation.trim()) {
+    return loc.fullLocation.trim();
+  }
+  const parts = [loc.city, loc.region, loc.country?.name || loc.country]
+    .filter((part) => typeof part === 'string' && part.trim().length > 0)
+    .map((part) => part.trim());
+  return parts.join(', ');
+}
+
+function extractPostingDescription(posting) {
+  const sections = posting?.jobAd?.sections;
+  if (!sections || typeof sections !== 'object') return '';
+  const parts = [];
+  for (const key of ['jobDescription', 'qualifications', 'additionalInformation']) {
+    const raw = typeof sections[key]?.text === 'string' ? sections[key].text : '';
+    if (raw && raw.trim().length > 0) parts.push(raw);
+  }
+  return parts.join('\n\n').trim();
+}
+
+/* ── Fetch + Parse ─────────────────────────────────────────── */
+
+export async function fetchAllArdentisJobs() {
+  console.log(`🔍 Fetching ${ARDENTIS_COMPANY_NAME} jobs (CH-wide via SmartRecruiters)`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || SR_REQUEST_TIMEOUT_MS;
+  const userAgent = process.env.JOBS_CRAWLER_USER_AGENT || SR_USER_AGENT;
+
+  const jobs = [];
+  let yielded = 0;
+  try {
+    const iter = fetchSmartRecruitersJobs(SR_TENANT, {
+      company: ARDENTIS_COMPANY_NAME,
+      locationCountryCodes: ['ch'],
+      filter: isSwissPosting,
+      fetchDetail: true,
+      maxPages: 20,
+      minDelayMs: SR_PAGE_DELAY_MS,
+      timeoutMs,
+      userAgent,
+    });
+
+    for await (const normalized of iter) {
+      yielded += 1;
+      const posting = normalized.rawPosting || {};
+      const title = normalizeSpace(posting?.name || '');
+      if (!title || title.length < 3) continue;
+
+      const locationText = composeLocationText(posting?.location) || 'Lausanne';
+      const city = (posting?.location?.city && String(posting.location.city).trim())
+        || locationText.split(',')[0].trim();
+      const canton = inferSwissTargetCanton(locationText)
+        || inferSwissTargetCanton(city)
+        || (posting?.location?.region && String(posting.location.region).trim().toUpperCase())
+        || 'VD';
+
+      const descriptionRaw = extractPostingDescription(posting) || normalized.descriptionHtml || '';
+      const descriptionText = stripHtml(descriptionRaw);
+
+      const postingId = String(posting?.id || '').trim();
+      const publicUrl =
+        (typeof posting?.applyUrl === 'string' && posting.applyUrl) ||
+        (typeof posting?.postingUrl === 'string' && posting.postingUrl) ||
+        (postingId ? `https://jobs.smartrecruiters.com/${SR_TENANT}/${postingId}` : CAREER_URL);
+
+      const sourceLang = detectLang(descriptionText || title, 'fr');
+      const jobSlug = slugify(`${title} ardentis ${city || 'romandie'}`);
+      const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+
+      const releasedRaw = posting?.releasedDate || posting?.createdOn || '';
+      const postedDate = (() => {
+        if (!releasedRaw) return new Date().toISOString().slice(0, 10);
+        const d = new Date(releasedRaw);
+        if (Number.isNaN(d.getTime())) return new Date().toISOString().slice(0, 10);
+        return d.toISOString().slice(0, 10);
+      })();
+
+      const postalCode = (posting?.location?.postalCode && String(posting.location.postalCode).trim()) || '';
+
+      const job = {
+        // ── Required fields ──
+        id: `${ARDENTIS_KEY}-${urlHash}`,
+        slug: jobSlug,
+        slugByLocale: { [sourceLang]: jobSlug },
+        company: ARDENTIS_COMPANY_NAME,
+        companyKey: ARDENTIS_KEY,
+        companyDomain: ARDENTIS_COMPANY_DOMAIN,
+        title,
+        titleByLocale: { [sourceLang]: title },
+        description: descriptionText || `${title} — ${ARDENTIS_COMPANY_NAME}`,
+        descriptionByLocale: { [sourceLang]: descriptionText || `${title} — ${ARDENTIS_COMPANY_NAME}` },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't, translate-pending.yml picks the job up.
+        needsRetranslation: true,
+        location: city || locationText,
+        canton,
+        url: publicUrl,
+        source: `${ARDENTIS_COMPANY_NAME} Dedicated Parser (SmartRecruiters API)`,
+        sourceLang,
+        crawledAt: new Date().toISOString(),
+
+        // ── Recommended fields ──
+        addressLocality: city || locationText,
+        addressRegion: canton,
+        addressCountry: 'CH',
+        country: 'CH',
+        category: detectCategory(title),
+        contract: 'full-time',
+        employmentType: detectEmploymentType(
+          `${posting?.typeOfEmployment?.id || ''} ${posting?.typeOfEmployment?.label || ''} ${title}`,
+        ),
+        experienceLevel: detectExperienceLevel(title),
+        sector: 'Sanità / Studi dentistici',
+        currency: 'CHF',
+        featured: false,
+        postedDate,
+        applyUrl: publicUrl,
+        jobReqId: postingId || null,
+        requirements: [],
+        requirementsByLocale: { [sourceLang]: [] },
+      };
+      if (postalCode) job.postalCode = postalCode;
+
+      jobs.push(job);
+    }
+  } catch (err) {
+    if (err instanceof SmartRecruitersApiError) {
+      console.warn(`  ⚠️ SmartRecruiters API error: ${err.message} (status=${err.statusCode ?? 'n/a'})`);
+    }
+    throw err;
+  }
+
+  console.log(`\n📋 Total ${ARDENTIS_COMPANY_NAME} jobs discovered: ${jobs.length} (yielded ${yielded})`);
+  return jobs;
+}

--- a/scripts/lib/imad-job-parser.mjs
+++ b/scripts/lib/imad-job-parser.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * imad (Institution genevoise de maintien à domicile) — SmartRecruiters API parser.
+ *
+ * Source: https://careers.smartrecruiters.com/Imad
+ * API:    https://api.smartrecruiters.com/v1/companies/Imad/postings
+ *
+ * imad is the public home-care (maintien à domicile) institution of Canton
+ * Geneva. It employs >3'000 nurses, aides, ergotherapists and home-help
+ * staff providing in-home medical and social care across the canton.
+ *
+ * All postings are Geneva-based — default canton GE.
+ *
+ * SmartRecruiters tenant ID: `Imad` (case-sensitive; the lowercase `imad` is
+ * also accepted by the API but we use the canonical capitalised form).
+ *
+ * Exports the 4 required functions for the crawler template:
+ *   - fetchAllImadJobs() — Fetch and parse all jobs
+ *   - isImadJob()        — Match jobs belonging to this company
+ *   - isTrustedDomain()  — Validate URLs belong to this company
+ *   - IMAD_KEY / _COMPANY_NAME / _COMPANY_DOMAIN constants
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferSwissTargetCanton, isTargetSwissLocation } from './target-swiss-locations.mjs';
+import {
+  fetchSmartRecruitersJobs,
+  SmartRecruitersApiError,
+} from './ats-clients/smartrecruiters-client.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const IMAD_KEY = 'imad';
+export const IMAD_COMPANY_NAME = 'imad';
+export const IMAD_COMPANY_DOMAIN = 'imad-ge.ch';
+
+const SR_TENANT = 'Imad';
+const CAREER_URL = `https://careers.smartrecruiters.com/${SR_TENANT}`;
+const SR_PAGE_DELAY_MS = 2000;
+const SR_REQUEST_TIMEOUT_MS = 15000;
+const SR_USER_AGENT = 'FrontaliereTicino-Bot/1.0 (+https://frontaliereticino.ch/)';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+export function isImadJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === IMAD_KEY ||
+    /^imad(-|$)/.test(key) ||
+    /\bimad\b/.test(company) ||
+    /maintien\s+(à|a)\s+domicile/.test(company) ||
+    url.includes('imad-ge.ch') ||
+    url.includes('smartrecruiters.com/imad')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const url = new URL(rawUrl);
+    const host = url.hostname.toLowerCase();
+    if (host === 'imad-ge.ch' || host.endsWith('.imad-ge.ch')) return true;
+    if (host === 'jobs.smartrecruiters.com' || host === 'careers.smartrecruiters.com' || host === 'smartrecruiters.com') {
+      return /\/imad(\/|$)/i.test(url.pathname);
+    }
+    if (host === 'api.smartrecruiters.com') {
+      return /\/companies\/imad(\/|$)/i.test(url.pathname);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/* ── Category Detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(infirmi|nurse|sage.?femme|aide.?soign|soin|soignant)/.test(t)) return 'Sanità';
+  if (/\b(m[ée]decin|doctor|chirurg|dentiste|psycholog)/.test(t)) return 'Sanità';
+  if (/\b(physioth[eé]rap|ergoth[eé]rap|kin[eé]si|di[eé]t[eé]ticien)/.test(t)) return 'Sanità';
+  if (/\b(assistant.?e?\s*social|service\s*social|travailleur.?social)/.test(t)) return 'Sanità';
+  if (/\b(ASSC|ASE|auxiliaire|aide\s*à\s*domicile)/i.test(title)) return 'Sanità';
+  if (/\b(secr[eé]taire|reception|admin|comptab|administra|gestion)/.test(t)) return 'Amministrazione';
+  if (/\b(logist|magazz|lager|transport)/.test(t)) return 'Logistica';
+  if (/\b(it|software|develop|programm|informatique|syst[eè]me)/.test(t)) return 'IT';
+  if (/\b(hr|human|risorse|personal|ressources humaines)/.test(t)) return 'Risorse Umane';
+  if (/\b(finance|finanz|compt|account)/.test(t)) return 'Finanza';
+  if (/\b(stage|stagiair|apprenti)/.test(t)) return 'Sanità';
+  return 'Sanità';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(stage|stagiair|intern|apprenti|lehrling|lernend)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|sr|chef|responsab|directeur|directrice|head|lead|leiter)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(text = '') {
+  const t = normalize(text);
+  if (/\b(part.?time|teilzeit|tempo parziale|temps partiel)/.test(t)) return 'PART_TIME';
+  if (/\b(full.?time|vollzeit|tempo pieno|temps plein)/.test(t)) return 'FULL_TIME';
+  if (/\b(stage|intern|stagiair)/.test(t)) return 'INTERN';
+  if (/\b(cdm|cdd|temporary|tempor|befristet|fixed.?term)/.test(t)) return 'CONTRACTOR';
+  return 'OTHER';
+}
+
+/* ── SmartRecruiters Posting Helpers ───────────────────────── */
+
+/**
+ * imad operates only in Canton Geneva — assume CH when country code missing.
+ */
+function isSwissPosting(posting) {
+  const country = String(posting?.location?.country?.code || posting?.location?.country || '').toLowerCase();
+  if (country === 'ch') return true;
+  if (country && country !== 'ch') return false;
+  const text = composeLocationText(posting?.location);
+  if (!text) return true; // imad is GE-only — assume CH when ambiguous.
+  return isTargetSwissLocation(text, { includeGrigioni: true });
+}
+
+function composeLocationText(loc = {}) {
+  if (!loc || typeof loc !== 'object') return '';
+  if (typeof loc.fullLocation === 'string' && loc.fullLocation.trim()) {
+    return loc.fullLocation.trim();
+  }
+  const parts = [loc.city, loc.region, loc.country?.name || loc.country]
+    .filter((part) => typeof part === 'string' && part.trim().length > 0)
+    .map((part) => part.trim());
+  return parts.join(', ');
+}
+
+function extractPostingDescription(posting) {
+  const sections = posting?.jobAd?.sections;
+  if (!sections || typeof sections !== 'object') return '';
+  const parts = [];
+  for (const key of ['jobDescription', 'qualifications', 'additionalInformation']) {
+    const raw = typeof sections[key]?.text === 'string' ? sections[key].text : '';
+    if (raw && raw.trim().length > 0) parts.push(raw);
+  }
+  return parts.join('\n\n').trim();
+}
+
+/* ── Fetch + Parse ─────────────────────────────────────────── */
+
+export async function fetchAllImadJobs() {
+  console.log(`🔍 Fetching ${IMAD_COMPANY_NAME} jobs (Genève via SmartRecruiters)`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || SR_REQUEST_TIMEOUT_MS;
+  const userAgent = process.env.JOBS_CRAWLER_USER_AGENT || SR_USER_AGENT;
+
+  const jobs = [];
+  let yielded = 0;
+  try {
+    const iter = fetchSmartRecruitersJobs(SR_TENANT, {
+      company: IMAD_COMPANY_NAME,
+      locationCountryCodes: ['ch'],
+      filter: isSwissPosting,
+      fetchDetail: true,
+      maxPages: 20,
+      minDelayMs: SR_PAGE_DELAY_MS,
+      timeoutMs,
+      userAgent,
+    });
+
+    for await (const normalized of iter) {
+      yielded += 1;
+      const posting = normalized.rawPosting || {};
+      const title = normalizeSpace(posting?.name || '');
+      if (!title || title.length < 3) continue;
+
+      const locationText = composeLocationText(posting?.location) || 'Genève';
+      const city = (posting?.location?.city && String(posting.location.city).trim())
+        || locationText.split(',')[0].trim();
+      const canton = inferSwissTargetCanton(locationText)
+        || inferSwissTargetCanton(city)
+        || (posting?.location?.region && String(posting.location.region).trim().toUpperCase())
+        || 'GE';
+
+      const descriptionRaw = extractPostingDescription(posting) || normalized.descriptionHtml || '';
+      const descriptionText = stripHtml(descriptionRaw);
+
+      const postingId = String(posting?.id || '').trim();
+      const publicUrl =
+        (typeof posting?.applyUrl === 'string' && posting.applyUrl) ||
+        (typeof posting?.postingUrl === 'string' && posting.postingUrl) ||
+        (postingId ? `https://jobs.smartrecruiters.com/${SR_TENANT}/${postingId}` : CAREER_URL);
+
+      const sourceLang = detectLang(descriptionText || title, 'fr');
+      const jobSlug = slugify(`${title} imad ${city || 'geneve'}`);
+      const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+
+      const releasedRaw = posting?.releasedDate || posting?.createdOn || '';
+      const postedDate = (() => {
+        if (!releasedRaw) return new Date().toISOString().slice(0, 10);
+        const d = new Date(releasedRaw);
+        if (Number.isNaN(d.getTime())) return new Date().toISOString().slice(0, 10);
+        return d.toISOString().slice(0, 10);
+      })();
+
+      const postalCode = (posting?.location?.postalCode && String(posting.location.postalCode).trim()) || '';
+
+      const job = {
+        // ── Required fields ──
+        id: `${IMAD_KEY}-${urlHash}`,
+        slug: jobSlug,
+        slugByLocale: { [sourceLang]: jobSlug },
+        company: IMAD_COMPANY_NAME,
+        companyKey: IMAD_KEY,
+        companyDomain: IMAD_COMPANY_DOMAIN,
+        title,
+        titleByLocale: { [sourceLang]: title },
+        description: descriptionText || `${title} — ${IMAD_COMPANY_NAME}`,
+        descriptionByLocale: { [sourceLang]: descriptionText || `${title} — ${IMAD_COMPANY_NAME}` },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't, translate-pending.yml picks the job up.
+        needsRetranslation: true,
+        location: city || locationText,
+        canton,
+        url: publicUrl,
+        source: `${IMAD_COMPANY_NAME} Dedicated Parser (SmartRecruiters API)`,
+        sourceLang,
+        crawledAt: new Date().toISOString(),
+
+        // ── Recommended fields ──
+        addressLocality: city || locationText,
+        addressRegion: canton,
+        addressCountry: 'CH',
+        country: 'CH',
+        category: detectCategory(title),
+        contract: 'full-time',
+        employmentType: detectEmploymentType(
+          `${posting?.typeOfEmployment?.id || ''} ${posting?.typeOfEmployment?.label || ''} ${title}`,
+        ),
+        experienceLevel: detectExperienceLevel(title),
+        sector: 'Sanità / Cure a domicilio',
+        currency: 'CHF',
+        featured: false,
+        postedDate,
+        applyUrl: publicUrl,
+        jobReqId: postingId || null,
+        requirements: [],
+        requirementsByLocale: { [sourceLang]: [] },
+      };
+      if (postalCode) job.postalCode = postalCode;
+
+      jobs.push(job);
+    }
+  } catch (err) {
+    if (err instanceof SmartRecruitersApiError) {
+      console.warn(`  ⚠️ SmartRecruiters API error: ${err.message} (status=${err.statusCode ?? 'n/a'})`);
+    }
+    throw err;
+  }
+
+  console.log(`\n📋 Total ${IMAD_COMPANY_NAME} jobs discovered: ${jobs.length} (yielded ${yielded})`);
+  return jobs;
+}

--- a/scripts/lib/sobi-job-parser.mjs
+++ b/scripts/lib/sobi-job-parser.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+/**
+ * Sobi (Swedish Orphan Biovitrum) — SmartRecruiters API job parser.
+ *
+ * Source: https://careers.smartrecruiters.com/Sobi
+ * API:    https://api.smartrecruiters.com/v1/companies/Sobi/postings
+ *
+ * Sobi is a Swedish biopharma group with a major Swiss footprint:
+ *   - Basel HQ for international commercial / supply / IT
+ *   - Zurich commercial office
+ *
+ * Therapeutic areas: rare diseases, haematology, immunology, specialty care.
+ *
+ * SmartRecruiters tenant ID: `Sobi` (case-sensitive).
+ *
+ * Exports the 4 required functions for the crawler template:
+ *   - fetchAllSobiJobs() — Fetch and parse all Swiss jobs
+ *   - isSobiJob()        — Match jobs belonging to this company
+ *   - isTrustedDomain()  — Validate URLs belong to this company
+ *   - SOBI_KEY / _COMPANY_NAME / _COMPANY_DOMAIN constants
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import { inferSwissTargetCanton, isTargetSwissLocation } from './target-swiss-locations.mjs';
+import {
+  fetchSmartRecruitersJobs,
+  SmartRecruitersApiError,
+} from './ats-clients/smartrecruiters-client.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const SOBI_KEY = 'sobi';
+export const SOBI_COMPANY_NAME = 'Sobi';
+export const SOBI_COMPANY_DOMAIN = 'sobi.com';
+
+const SR_TENANT = 'Sobi';
+const CAREER_URL = `https://careers.smartrecruiters.com/${SR_TENANT}`;
+const SR_PAGE_DELAY_MS = 2000;
+const SR_REQUEST_TIMEOUT_MS = 15000;
+const SR_USER_AGENT = 'FrontaliereTicino-Bot/1.0 (+https://frontaliereticino.ch/)';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+export function isSobiJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === SOBI_KEY ||
+    /^sobi(-|$)/.test(key) ||
+    /\bsobi\b/.test(company) ||
+    /swedish\s+orphan\s+biovitrum/.test(company) ||
+    url.includes('sobi.com') ||
+    url.includes('smartrecruiters.com/sobi')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const url = new URL(rawUrl);
+    const host = url.hostname.toLowerCase();
+    if (host === 'sobi.com' || host.endsWith('.sobi.com')) return true;
+    if (host === 'jobs.smartrecruiters.com' || host === 'careers.smartrecruiters.com' || host === 'smartrecruiters.com') {
+      return /\/sobi(\/|$)/i.test(url.pathname);
+    }
+    if (host === 'api.smartrecruiters.com') {
+      return /\/companies\/sobi(\/|$)/i.test(url.pathname);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/* ── Category Detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(regulatory|qualität|qualit|qa|qc|validation|compliance|gxp|gmp)/.test(t)) return 'Qualità / Compliance';
+  if (/\b(manufactur|production|fertigung|produktion|operator|technician|maint|wartung|msat|drug\s*substance)/.test(t)) return 'Tecnica';
+  if (/\b(engineer|ingenieur|developer|software|programm|informatik|r&d|research|scientist|biolog|chemist|technical)/.test(t)) return 'Ingegneria';
+  if (/\b(sales|account|vertrieb|representative|business\s*develop|territory|key\s*account|commercial)/.test(t)) return 'Vendite';
+  if (/\b(market|kommunikation|brand|product\s*manager|medical\s*affairs|launch)/.test(t)) return 'Marketing';
+  if (/\b(supply|logist|warehouse|lager|procurement|sourcing|purchas|einkauf|distribution)/.test(t)) return 'Logistica';
+  if (/\b(hr|human|talent|recruit|personal)/.test(t)) return 'Risorse Umane';
+  if (/\b(finance|controller|controlling|buchhalt|finanz|treasur|tax)/.test(t)) return 'Finanza';
+  if (/\b(legal|counsel|lawyer|attorney|compliance\s*officer)/.test(t)) return 'Legale';
+  if (/\b(it\b|sap|cloud|cyber|data|infrastructure|network|devops|digital|stack\s*developer|azure|ai)/.test(t)) return 'IT';
+  if (/\b(clinical|pharma|medical\s*manager|safety|drug\s*safety|pharmacovigilance)/.test(t)) return 'Sanità';
+  return 'Sanità';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(praktik|intern|stage|stagiair|apprenti|ausbildung|trainee|graduate)/.test(t)) return 'intern';
+  if (/\b(junior|jr\.?|entry|assistent)/.test(t)) return 'junior';
+  if (/\b(senior|sr\.?|lead|head|director|principal|chief|associate\s*director|leiter)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(text = '') {
+  const t = normalize(text);
+  if (/\b(part.?time|teilzeit|tempo parziale|temps partiel)/.test(t)) return 'PART_TIME';
+  if (/\b(full.?time|vollzeit|tempo pieno|temps plein)/.test(t)) return 'FULL_TIME';
+  if (/\b(intern|stage|stagiair|praktik|apprenti)/.test(t)) return 'INTERN';
+  if (/\b(contract|temporary|tempor|befristet|fixed.?term|interim|6\s*months)/.test(t)) return 'CONTRACTOR';
+  return 'FULL_TIME';
+}
+
+/* ── SmartRecruiters Posting Helpers ───────────────────────── */
+
+function isSwissPosting(posting) {
+  const country = String(posting?.location?.country?.code || posting?.location?.country || '').toLowerCase();
+  if (country === 'ch') return true;
+  if (country && country !== 'ch') return false;
+  const text = composeLocationText(posting?.location);
+  if (!text) return false;
+  return isTargetSwissLocation(text, { includeGrigioni: true });
+}
+
+function composeLocationText(loc = {}) {
+  if (!loc || typeof loc !== 'object') return '';
+  if (typeof loc.fullLocation === 'string' && loc.fullLocation.trim()) {
+    return loc.fullLocation.trim();
+  }
+  const parts = [loc.city, loc.region, loc.country?.name || loc.country]
+    .filter((part) => typeof part === 'string' && part.trim().length > 0)
+    .map((part) => part.trim());
+  return parts.join(', ');
+}
+
+function extractPostingDescription(posting) {
+  const sections = posting?.jobAd?.sections;
+  if (!sections || typeof sections !== 'object') return '';
+  const parts = [];
+  for (const key of ['jobDescription', 'qualifications', 'additionalInformation']) {
+    const raw = typeof sections[key]?.text === 'string' ? sections[key].text : '';
+    if (raw && raw.trim().length > 0) parts.push(raw);
+  }
+  return parts.join('\n\n').trim();
+}
+
+/* ── Fetch + Parse ─────────────────────────────────────────── */
+
+export async function fetchAllSobiJobs() {
+  console.log(`🔍 Fetching ${SOBI_COMPANY_NAME} jobs (CH via SmartRecruiters)`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || SR_REQUEST_TIMEOUT_MS;
+  const userAgent = process.env.JOBS_CRAWLER_USER_AGENT || SR_USER_AGENT;
+
+  const jobs = [];
+  let yielded = 0;
+  try {
+    const iter = fetchSmartRecruitersJobs(SR_TENANT, {
+      company: SOBI_COMPANY_NAME,
+      locationCountryCodes: ['ch'],
+      filter: isSwissPosting,
+      fetchDetail: true,
+      maxPages: 20,
+      minDelayMs: SR_PAGE_DELAY_MS,
+      timeoutMs,
+      userAgent,
+    });
+
+    for await (const normalized of iter) {
+      yielded += 1;
+      const posting = normalized.rawPosting || {};
+      const title = normalizeSpace(posting?.name || '');
+      if (!title || title.length < 3) continue;
+
+      const locationText = composeLocationText(posting?.location) || 'Basel';
+      const city = (posting?.location?.city && String(posting.location.city).trim())
+        || locationText.split(',')[0].trim();
+      const canton = inferSwissTargetCanton(locationText)
+        || inferSwissTargetCanton(city)
+        || (posting?.location?.region && String(posting.location.region).trim().toUpperCase())
+        || 'BS';
+
+      const descriptionRaw = extractPostingDescription(posting) || normalized.descriptionHtml || '';
+      const descriptionText = stripHtml(descriptionRaw);
+
+      const postingId = String(posting?.id || '').trim();
+      const publicUrl =
+        (typeof posting?.applyUrl === 'string' && posting.applyUrl) ||
+        (typeof posting?.postingUrl === 'string' && posting.postingUrl) ||
+        (postingId ? `https://jobs.smartrecruiters.com/${SR_TENANT}/${postingId}` : CAREER_URL);
+
+      const sourceLang = detectLang(descriptionText || title, 'en');
+      const jobSlug = slugify(`${title} sobi ${city || 'basel'}`);
+      const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+
+      const releasedRaw = posting?.releasedDate || posting?.createdOn || '';
+      const postedDate = (() => {
+        if (!releasedRaw) return new Date().toISOString().slice(0, 10);
+        const d = new Date(releasedRaw);
+        if (Number.isNaN(d.getTime())) return new Date().toISOString().slice(0, 10);
+        return d.toISOString().slice(0, 10);
+      })();
+
+      const postalCode = (posting?.location?.postalCode && String(posting.location.postalCode).trim()) || '';
+
+      const job = {
+        // ── Required fields ──
+        id: `${SOBI_KEY}-${urlHash}`,
+        slug: jobSlug,
+        slugByLocale: { [sourceLang]: jobSlug },
+        company: SOBI_COMPANY_NAME,
+        companyKey: SOBI_KEY,
+        companyDomain: SOBI_COMPANY_DOMAIN,
+        title,
+        titleByLocale: { [sourceLang]: title },
+        description: descriptionText || `${title} — ${SOBI_COMPANY_NAME}`,
+        descriptionByLocale: { [sourceLang]: descriptionText || `${title} — ${SOBI_COMPANY_NAME}` },
+        // Newly-discovered jobs ship with source-locale-only fields. The shared
+        // AI-localization step clears this flag when it fills the remaining 3
+        // locales; if it can't, translate-pending.yml picks the job up.
+        needsRetranslation: true,
+        location: city || locationText,
+        canton,
+        url: publicUrl,
+        source: `${SOBI_COMPANY_NAME} Dedicated Parser (SmartRecruiters API)`,
+        sourceLang,
+        crawledAt: new Date().toISOString(),
+
+        // ── Recommended fields ──
+        addressLocality: city || locationText,
+        addressRegion: canton,
+        addressCountry: 'CH',
+        country: 'CH',
+        category: detectCategory(title),
+        contract: 'full-time',
+        employmentType: detectEmploymentType(
+          `${posting?.typeOfEmployment?.id || ''} ${posting?.typeOfEmployment?.label || ''} ${title}`,
+        ),
+        experienceLevel: detectExperienceLevel(title),
+        sector: 'Sanità / Farmaceutico / Malattie rare',
+        currency: 'CHF',
+        featured: false,
+        postedDate,
+        applyUrl: publicUrl,
+        jobReqId: postingId || null,
+        requirements: [],
+        requirementsByLocale: { [sourceLang]: [] },
+      };
+      if (postalCode) job.postalCode = postalCode;
+
+      jobs.push(job);
+    }
+  } catch (err) {
+    if (err instanceof SmartRecruitersApiError) {
+      console.warn(`  ⚠️ SmartRecruiters API error: ${err.message} (status=${err.statusCode ?? 'n/a'})`);
+    }
+    throw err;
+  }
+
+  console.log(`\n📋 Total ${SOBI_COMPANY_NAME} jobs discovered: ${jobs.length} (yielded ${yielded})`);
+  return jobs;
+}

--- a/scripts/update-ardentis-jobs.mjs
+++ b/scripts/update-ardentis-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Ardentis (Swiss dental-clinic network) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllArdentisJobs,
+  isArdentisJob,
+  isTrustedDomain,
+  ARDENTIS_KEY,
+  ARDENTIS_COMPANY_NAME,
+} from './lib/ardentis-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: ARDENTIS_KEY,
+  companyLabel: ARDENTIS_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllArdentisJobs,
+  isCompanyJob: isArdentisJob,
+  isTrustedDomain,
+  defaultSourceLang: 'fr',
+}).catch((err) => {
+  console.error(`❌ Ardentis crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-imad-jobs.mjs
+++ b/scripts/update-imad-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated imad (Genève home-care) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllImadJobs,
+  isImadJob,
+  isTrustedDomain,
+  IMAD_KEY,
+  IMAD_COMPANY_NAME,
+} from './lib/imad-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: IMAD_KEY,
+  companyLabel: IMAD_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllImadJobs,
+  isCompanyJob: isImadJob,
+  isTrustedDomain,
+  defaultSourceLang: 'fr',
+}).catch((err) => {
+  console.error(`❌ imad crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-sobi-jobs.mjs
+++ b/scripts/update-sobi-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Sobi (Swedish Orphan Biovitrum) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllSobiJobs,
+  isSobiJob,
+  isTrustedDomain,
+  SOBI_KEY,
+  SOBI_COMPANY_NAME,
+} from './lib/sobi-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: SOBI_KEY,
+  companyLabel: SOBI_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllSobiJobs,
+  isCompanyJob: isSobiJob,
+  isTrustedDomain,
+  defaultSourceLang: 'en',
+}).catch((err) => {
+  console.error(`❌ Sobi crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Discovered 3 new Swiss healthcare tenants on SmartRecruiters via the
public job-search index (`jobs.smartrecruiters.com/sr-jobs/search`).
All 3 ship ≥5 CH jobs with rich descriptions; smoke-tested live.

| ATS              | Tenant     | Sector                        | Canton(s)       | Jobs |
|------------------|------------|-------------------------------|-----------------|------|
| SmartRecruiters  | Ardentis1  | Studi dentistici              | VS/VD/FR/GE     |   38 |
| SmartRecruiters  | Imad       | Cure a domicilio              | GE              |   12 |
| SmartRecruiters  | Sobi       | Farmaceutico / Malattie rare  | BS/ZH           |    7 |

- Ardentis: Romandie-wide dental chain (~20 cliniques).
- imad: Institution genevoise de maintien à domicile (Geneva home care).
- Sobi: Swedish Orphan Biovitrum (rare-disease biopharma, Basel HQ).

All parsers reuse `scripts/lib/ats-clients/smartrecruiters-client.mjs`
(`fetchSmartRecruitersJobs` with `locationCountryCodes: ['ch']` and a
Swiss-region fallback for postings missing the country code) and emit
`ParsedJob.needsRetranslation: true` per batch-16 convention.

Workflows are workflow_dispatch only (no cron); orchestrator will trigger
each one live after merge per CLAUDE.md rule #13.
