### PR TITLE
feat(crawlers): batch 16c — SAP SuccessFactors CSB medtech/biotech (~112 CH jobs)

### DIFF
--- a/.github/workflows/update-jobs-bachem.yml
+++ b/.github/workflows/update-jobs-bachem.yml
@@ -1,0 +1,101 @@
+name: Update Bachem Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-bachem
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-bachem-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated BACHEM crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_BACHEM_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-bachem-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'bachem'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/bachem.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BACHEM jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-medartis.yml
+++ b/.github/workflows/update-jobs-medartis.yml
@@ -1,0 +1,101 @@
+name: Update Medartis Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-medartis
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-medartis-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated MEDARTIS crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_MEDARTIS_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-medartis-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'medartis'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/medartis.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MEDARTIS jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-octapharma.yml
+++ b/.github/workflows/update-jobs-octapharma.yml
@@ -1,0 +1,101 @@
+name: Update Octapharma Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-octapharma
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-octapharma-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated OCTAPHARMA crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_OCTAPHARMA_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-octapharma-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'octapharma'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/octapharma.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update OCTAPHARMA jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-tecan.yml
+++ b/.github/workflows/update-jobs-tecan.yml
@@ -1,0 +1,101 @@
+name: Update Tecan Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-tecan
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-tecan-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated TECAN crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_TECAN_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-tecan-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'tecan'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/tecan.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update TECAN jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/bachem-job-parser.mjs
+++ b/scripts/lib/bachem-job-parser.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Bachem AG job parser — SAP SuccessFactors Career Site Builder (CSB).
+ *
+ * Public career site:  https://careers.bachem.com/
+ * SF tenant code:      Bachem
+ *
+ * Bachem is a Swiss biotech company headquartered in Bubendorf (BL),
+ * specialising in the development and manufacture of peptides and
+ * oligonucleotides for the pharmaceutical and biotechnology industries
+ * (research / clinical / commercial scale). ~74 open positions in CH.
+ *
+ * The career portal is a public CSB instance with a `/search` listing
+ * endpoint — see `scripts/lib/successfactors-shared-job-parser-common.mjs`
+ * for the platform details.
+ *
+ * Notes:
+ *   - `searchParams: { locationsearch: 'Switzerland' }` restricts the
+ *     server-side query to CH jobs (Bachem's global portal lists US +
+ *     EU + APAC sites).
+ *   - Bachem detail pages only expose `title` + `description` propertyids
+ *     (no `location` block). The factory falls back to listing-cell location
+ *     parsing via the dedicated `colLocation` `<td>`.
+ */
+import { createSuccessFactorsParser } from './successfactors-shared-job-parser-common.mjs';
+
+export const BACHEM_KEY = 'bachem';
+export const BACHEM_COMPANY_NAME = 'Bachem AG';
+export const BACHEM_COMPANY_DOMAIN = 'bachem.com';
+
+const parser = createSuccessFactorsParser({
+  companyKey: BACHEM_KEY,
+  companyName: BACHEM_COMPANY_NAME,
+  companyDomain: BACHEM_COMPANY_DOMAIN,
+  sfCompanyId: 'Bachem',
+  publicCareerUrl: 'https://careers.bachem.com',
+  defaultCanton: 'BL',
+  defaultCity: 'Bubendorf',
+  defaultPostalCode: '4416',
+  defaultSourceLang: 'en',
+  searchParams: { locationsearch: 'Switzerland' },
+  sourceLabel: 'Bachem AG Dedicated Parser (SuccessFactors CSB)',
+});
+
+export const fetchAllBachemJobs = parser.fetchAllJobs;
+export const isBachemJob = parser.isCompanyJob;
+export const isTrustedDomain = parser.isTrustedDomain;

--- a/scripts/lib/medartis-job-parser.mjs
+++ b/scripts/lib/medartis-job-parser.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Medartis job parser — SAP SuccessFactors Career Site Builder (CSB).
+ *
+ * Public career site:  https://careers.medartis.com/
+ * SF tenant code:      medartis (vanity-portal only; no career5.* mirror)
+ *
+ * Medartis AG is a Swiss medtech company headquartered in Basel (BS),
+ * developing and manufacturing titanium implants and surgical
+ * instruments for trauma surgery, hand-surgery and CMF surgery.
+ * ~16 open positions in CH at any given time.
+ *
+ * The career portal is a public CSB instance with a `/search` listing
+ * endpoint — see `scripts/lib/successfactors-shared-job-parser-common.mjs`
+ * for the platform details.
+ *
+ * Notes:
+ *   - `searchParams: { locationsearch: 'Switzerland' }` restricts the
+ *     server-side query to CH jobs (Medartis is global with US / DE /
+ *     FR / AU / BR sites plus the Basel HQ).
+ *   - Medartis detail pages expose only `description` / `adcode` /
+ *     `customfield2` / `shifttype` propertyids — no `title` or
+ *     `location` blocks. The factory falls back to:
+ *       * `listing.title` (the `<a class="jobTitle-link">` text)
+ *       * defaultCity / defaultCanton (the BS HQ) for missing location
+ */
+import { createSuccessFactorsParser } from './successfactors-shared-job-parser-common.mjs';
+
+export const MEDARTIS_KEY = 'medartis';
+export const MEDARTIS_COMPANY_NAME = 'Medartis';
+export const MEDARTIS_COMPANY_DOMAIN = 'medartis.com';
+
+const parser = createSuccessFactorsParser({
+  companyKey: MEDARTIS_KEY,
+  companyName: MEDARTIS_COMPANY_NAME,
+  companyDomain: MEDARTIS_COMPANY_DOMAIN,
+  sfCompanyId: 'medartis',
+  publicCareerUrl: 'https://careers.medartis.com',
+  defaultCanton: 'BS',
+  defaultCity: 'Basel',
+  defaultPostalCode: '4057',
+  defaultSourceLang: 'en',
+  searchParams: { locationsearch: 'Switzerland' },
+  sourceLabel: 'Medartis Dedicated Parser (SuccessFactors CSB)',
+});
+
+export const fetchAllMedartisJobs = parser.fetchAllJobs;
+export const isMedartisJob = parser.isCompanyJob;
+export const isTrustedDomain = parser.isTrustedDomain;

--- a/scripts/lib/octapharma-job-parser.mjs
+++ b/scripts/lib/octapharma-job-parser.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Octapharma job parser — SAP SuccessFactors Career Site Builder (CSB).
+ *
+ * Public career site:  https://careers.octapharma.com/
+ * SF tenant code:      Octapharma
+ *
+ * Octapharma is a global, privately-owned plasma-derived medicine
+ * manufacturer headquartered in Lachen (SZ), Switzerland. The Swiss
+ * site hosts the executive team and the IBU Critical Care / Hematology
+ * teams. ~8 open positions in CH at any given time.
+ *
+ * The career portal is a public CSB instance with a `/search` listing
+ * endpoint — see `scripts/lib/successfactors-shared-job-parser-common.mjs`
+ * for the platform details.
+ *
+ * Notes:
+ *   - `searchParams: { locationsearch: 'Switzerland' }` restricts the
+ *     server-side query to CH jobs (Octapharma is a multi-country group
+ *     with sites in DE / SE / AT / FR / US plus the Swiss HQ).
+ *   - Detail pages expose the standard `title` / `location` / `description`
+ *     CSB propertyids; the factory handles them directly.
+ */
+import { createSuccessFactorsParser } from './successfactors-shared-job-parser-common.mjs';
+
+export const OCTAPHARMA_KEY = 'octapharma';
+export const OCTAPHARMA_COMPANY_NAME = 'Octapharma';
+export const OCTAPHARMA_COMPANY_DOMAIN = 'octapharma.com';
+
+const parser = createSuccessFactorsParser({
+  companyKey: OCTAPHARMA_KEY,
+  companyName: OCTAPHARMA_COMPANY_NAME,
+  companyDomain: OCTAPHARMA_COMPANY_DOMAIN,
+  sfCompanyId: 'Octapharma',
+  publicCareerUrl: 'https://careers.octapharma.com',
+  defaultCanton: 'SZ',
+  defaultCity: 'Lachen',
+  defaultPostalCode: '8853',
+  defaultSourceLang: 'de',
+  searchParams: { locationsearch: 'Switzerland' },
+  sourceLabel: 'Octapharma Dedicated Parser (SuccessFactors CSB)',
+});
+
+export const fetchAllOctapharmaJobs = parser.fetchAllJobs;
+export const isOctapharmaJob = parser.isCompanyJob;
+export const isTrustedDomain = parser.isTrustedDomain;

--- a/scripts/lib/successfactors-shared-job-parser-common.mjs
+++ b/scripts/lib/successfactors-shared-job-parser-common.mjs
@@ -111,6 +111,18 @@ export function parseCsbSearchResults(html) {
     const title = decodeEntities(normalizeSpace(stripHtml(linkMatch[3])));
     if (!title || title.length < 3) continue;
 
+    // Preferred: dedicated `<td class="colLocation hidden-phone">` cell or
+    // `<span class="jobLocation">…</span>` directly. This avoids picking up
+    // the title cell on layouts where mobile + desktop variants concatenate
+    // title + location + department text into a single `<td>`.
+    let location = '';
+    const colLocationMatch = rowHtml.match(
+      /<td[^>]*class="[^"]*colLocation[^"]*hidden-phone[^"]*"[^>]*>([\s\S]*?)<\/td>/i,
+    ) || rowHtml.match(/<td[^>]*headers="hdrLocation"[^>]*>([\s\S]*?)<\/td>/i);
+    if (colLocationMatch) {
+      location = decodeEntities(normalizeSpace(stripHtml(colLocationMatch[1])));
+    }
+
     const cells = [];
     const cellRe = /<td[^>]*>([\s\S]*?)<\/td>/gi;
     let cellMatch;
@@ -118,12 +130,12 @@ export function parseCsbSearchResults(html) {
       cells.push(decodeEntities(normalizeSpace(stripHtml(cellMatch[1]))));
     }
 
-    // Find the cell that looks like a location: contains "CH" / a 4-digit
-    // postal code / a canton code, OR matches a known city pattern.
-    let location = '';
+    // Fallback: heuristic — find the cell that looks like a location ("City,
+    // CC[,…]"). We skip cells that contain the job title to avoid the
+    // dual-layout issue described above.
     let postedDate = '';
     for (const cell of cells) {
-      if (!location && /,\s*[A-Z]{2}(?:,|$)/.test(cell)) {
+      if (!location && /,\s*[A-Z]{2}(?:,|$)/.test(cell) && !cell.includes(title)) {
         location = cell;
         continue;
       }
@@ -150,11 +162,15 @@ function parseLooseDate(raw = '') {
 
 /**
  * Extract total result count from CSB `/search/` HTML.
- *   "Ergebnisse 1 – 25 von 78"  /  "Results 1 – 25 of 78"
+ *   "Ergebnisse 1 – 25 von 78"      /  "Results 1 – 25 of 78"
+ *   "Ergebnisse 1 bis 25 von 78"    /  "Results 1 to 25 of 78"   (Sonova etc.)
  */
 export function extractCsbTotal(html) {
   if (!html) return 0;
-  const m = html.match(/(?:Ergebnisse|Results|R[ée]sultats|Risultati)\s+\d+\s*[–\-‑]\s*\d+\s+(?:von|of|de|di)\s+(\d+)/i);
+  // Separator: en-dash, hyphen, non-breaking hyphen, OR "bis"/"to"/"a"/"à" word.
+  const m = html.match(
+    /(?:Ergebnisse|Results|R[ée]sultats|Risultati)\s+\d+\s*(?:[–\-‑]|bis|to|à|a)\s*\d+\s+(?:von|of|de|di)\s+(\d+)/i,
+  );
   return m ? parseInt(m[1], 10) : 0;
 }
 
@@ -173,6 +189,14 @@ function readPropertyBlock(html, propId) {
   if (!m) return '';
   const start = m.index + m[0].length;
   const rest = html.slice(start);
+  // Short fields (title, location, customfield5) live inside ONE span/element
+  // and close immediately. For those we cut at the matching `</span>` to avoid
+  // bleeding into the next sibling block (e.g. on Bachem, the title `<span>`
+  // closes right after the title text, then unrelated brand copy follows
+  // inside the layout div before the `description` propertyid). Long fields
+  // (description) keep the original heuristic that looks for the next
+  // propertyid / layout marker.
+  const isShortField = /^(?:title|location|customfield5|customfield2|customfield1|city|country|department|shifttype|jobtype|adcode)$/i.test(propId);
   const candidates = [
     rest.indexOf('data-careersite-propertyid'),
     rest.indexOf('<!-- WIDGET BUTTON -->'),
@@ -181,6 +205,12 @@ function readPropertyBlock(html, propId) {
     rest.indexOf('id="applyButton'),
     rest.indexOf('<!-- end of'),
   ].filter((x) => x > 0);
+  if (isShortField) {
+    // Prefer the first close-span as the boundary (the propertyid attribute
+    // sits on the inner span). Look in the first 4 KB to keep this cheap.
+    const closeSpan = rest.slice(0, 4096).search(/<\/span\b/i);
+    if (closeSpan > 0) candidates.unshift(closeSpan);
+  }
   let cut = candidates.length ? Math.min(...candidates) : 8000;
   // The propertyid attribute lives inside an HTML tag opener (`<span ... data-careersite-propertyid="..."...>`).
   // If we cut at the attribute position, we leave an unclosed `<span` in the
@@ -301,6 +331,14 @@ export function parseCsbDetailPage(html) {
  * @param {string} config.defaultPostalCode  Fallback postal code (e.g. '5330').
  * @param {string} [config.defaultSourceLang='de']
  * @param {string} [config.sourceLabel]      Optional source label override.
+ * @param {Object<string,string>} [config.searchParams] Extra query params for
+ *   the `/search/?...` listing endpoint (e.g. `{ locationsearch: 'Switzerland' }`
+ *   to restrict a multi-country SF tenant to CH jobs). The factory always sets
+ *   `startrow` itself; do not include it here.
+ * @param {(job: any) => boolean} [config.acceptJob] Optional final-stage filter.
+ *   When the listing endpoint cannot restrict to CH (or the filter is fuzzy),
+ *   return `false` to drop a parsed job. Receives the same shape as the final
+ *   ParsedJob (location, canton, addressLocality, addressCountry resolved).
  * @returns {{
  *   fetchAllJobs: () => Promise<ParsedJob[]>,
  *   isCompanyJob: (job: any) => boolean,
@@ -319,6 +357,8 @@ export function createSuccessFactorsParser(config) {
     defaultPostalCode,
     defaultSourceLang = 'de',
     sourceLabel,
+    searchParams = null,
+    acceptJob = null,
   } = config;
 
   if (!companyKey || !companyName || !sfCompanyId || !publicCareerUrl || !defaultCanton) {
@@ -369,7 +409,14 @@ export function createSuccessFactorsParser(config) {
     while (true) {
       pages += 1;
       if (pages > 200) break; // hard stop safety
-      const url = `${baseUrl}/search/?startrow=${startrow}`;
+      // Build URL with optional extra search params (e.g. locationsearch=Switzerland)
+      let url = `${baseUrl}/search/?startrow=${startrow}`;
+      if (searchParams && typeof searchParams === 'object') {
+        for (const [k, v] of Object.entries(searchParams)) {
+          if (k === 'startrow' || v == null) continue;
+          url += `&${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`;
+        }
+      }
       let html;
       try {
         html = await fetchHtml(url);
@@ -425,9 +472,18 @@ export function createSuccessFactorsParser(config) {
       const title = (detail?.title || listing.title || '').trim();
       if (!title) continue;
 
-      const city = detail?.city
-        || (listing.location ? listing.location.split(',')[0].trim() : '')
-        || defaultCity;
+      // Resolve city: prefer detail.city, then first comma-segment of the
+      // listing location, then defaultCity. Drop country-name fallbacks like
+      // "Switzerland" / "Schweiz" / "Suisse" that some SF tenants emit when
+      // a job has no specific city (e.g. Tecan remote / global roles).
+      const COUNTRY_TOKEN = /^(?:switzerland|schweiz|suisse|svizzera|ch)$/i;
+      const detailCity = detail?.city && !COUNTRY_TOKEN.test(detail.city) ? detail.city : '';
+      const listingCity = (() => {
+        if (!listing.location) return '';
+        const first = listing.location.split(',')[0].trim();
+        return COUNTRY_TOKEN.test(first) ? '' : first;
+      })();
+      const city = detailCity || listingCity || defaultCity;
       const region = detail?.region || defaultCanton;
       const canton = inferSwissTargetCanton(city) || region || defaultCanton;
       const postalCode = detail?.postalCode || defaultPostalCode;
@@ -498,6 +554,16 @@ export function createSuccessFactorsParser(config) {
         requirements: [],
         requirementsByLocale: { [sourceLang]: [] },
       };
+
+      // Optional caller-supplied filter: drop jobs that don't pass an
+      // employer-specific predicate (e.g. multi-country SF tenant restricted
+      // to CH). Applied AFTER detail fetch so the predicate can see the
+      // resolved city / location / language.
+      if (typeof acceptJob === 'function' && !acceptJob(job)) {
+        await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+        continue;
+      }
+
       jobs.push(job);
 
       await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));

--- a/scripts/lib/tecan-job-parser.mjs
+++ b/scripts/lib/tecan-job-parser.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Tecan job parser — SAP SuccessFactors Career Site Builder (CSB).
+ *
+ * Public career site:  https://careers.tecan.com/
+ * SF tenant code:      tecan (vanity-portal only; no career5.* mirror)
+ *
+ * Tecan is a Swiss medtech company headquartered in Männedorf (ZH),
+ * world-leader in laboratory automation and liquid-handling instruments
+ * for life-science, diagnostics and clinical research. ~14 open
+ * positions in CH at any given time.
+ *
+ * The career portal is a public CSB instance with a `/search` listing
+ * endpoint — see `scripts/lib/successfactors-shared-job-parser-common.mjs`
+ * for the platform details.
+ *
+ * Notes:
+ *   - `searchParams: { locationsearch: 'Switzerland' }` restricts the
+ *     server-side query to CH jobs (Tecan's global portal lists US +
+ *     EU + APAC sites).
+ *   - Tecan detail pages expose separate `city` + `country` propertyids
+ *     (not the canonical `location` block). When `city` is empty the
+ *     factory falls back to `defaultCity` (Männedorf) and skips the
+ *     country-only fallback automatically.
+ */
+import { createSuccessFactorsParser } from './successfactors-shared-job-parser-common.mjs';
+
+export const TECAN_KEY = 'tecan';
+export const TECAN_COMPANY_NAME = 'Tecan';
+export const TECAN_COMPANY_DOMAIN = 'tecan.com';
+
+const parser = createSuccessFactorsParser({
+  companyKey: TECAN_KEY,
+  companyName: TECAN_COMPANY_NAME,
+  companyDomain: TECAN_COMPANY_DOMAIN,
+  sfCompanyId: 'tecan',
+  publicCareerUrl: 'https://careers.tecan.com',
+  defaultCanton: 'ZH',
+  defaultCity: 'Männedorf',
+  defaultPostalCode: '8708',
+  defaultSourceLang: 'en',
+  searchParams: { locationsearch: 'Switzerland' },
+  sourceLabel: 'Tecan Dedicated Parser (SuccessFactors CSB)',
+});
+
+export const fetchAllTecanJobs = parser.fetchAllJobs;
+export const isTecanJob = parser.isCompanyJob;
+export const isTrustedDomain = parser.isTrustedDomain;

--- a/scripts/update-bachem-jobs.mjs
+++ b/scripts/update-bachem-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Bachem crawler runner.
+ *
+ * Uses the standard crawler template with the Bachem parser.
+ * All fetch/parse logic lives in ./lib/bachem-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllBachemJobs,
+  isBachemJob,
+  isTrustedDomain,
+  BACHEM_KEY,
+  BACHEM_COMPANY_NAME,
+} from './lib/bachem-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: BACHEM_KEY,
+  companyLabel: BACHEM_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllBachemJobs,
+  isCompanyJob: isBachemJob,
+  isTrustedDomain,
+  defaultSourceLang: 'en',
+}).catch((err) => {
+  console.error(`❌ Bachem crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-medartis-jobs.mjs
+++ b/scripts/update-medartis-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Medartis crawler runner.
+ *
+ * Uses the standard crawler template with the Medartis parser.
+ * All fetch/parse logic lives in ./lib/medartis-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllMedartisJobs,
+  isMedartisJob,
+  isTrustedDomain,
+  MEDARTIS_KEY,
+  MEDARTIS_COMPANY_NAME,
+} from './lib/medartis-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: MEDARTIS_KEY,
+  companyLabel: MEDARTIS_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllMedartisJobs,
+  isCompanyJob: isMedartisJob,
+  isTrustedDomain,
+  defaultSourceLang: 'en',
+}).catch((err) => {
+  console.error(`❌ Medartis crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-octapharma-jobs.mjs
+++ b/scripts/update-octapharma-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Octapharma crawler runner.
+ *
+ * Uses the standard crawler template with the Octapharma parser.
+ * All fetch/parse logic lives in ./lib/octapharma-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllOctapharmaJobs,
+  isOctapharmaJob,
+  isTrustedDomain,
+  OCTAPHARMA_KEY,
+  OCTAPHARMA_COMPANY_NAME,
+} from './lib/octapharma-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: OCTAPHARMA_KEY,
+  companyLabel: OCTAPHARMA_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllOctapharmaJobs,
+  isCompanyJob: isOctapharmaJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Octapharma crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-tecan-jobs.mjs
+++ b/scripts/update-tecan-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Tecan crawler runner.
+ *
+ * Uses the standard crawler template with the Tecan parser.
+ * All fetch/parse logic lives in ./lib/tecan-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllTecanJobs,
+  isTecanJob,
+  isTrustedDomain,
+  TECAN_KEY,
+  TECAN_COMPANY_NAME,
+} from './lib/tecan-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: TECAN_KEY,
+  companyLabel: TECAN_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllTecanJobs,
+  isCompanyJob: isTecanJob,
+  isTrustedDomain,
+  defaultSourceLang: 'en',
+}).catch((err) => {
+  console.error(`❌ Tecan crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
4 new dedicated crawlers, all reusing the existing `successfactors-shared-job-parser-common.mjs`
factory. Adds the missing SF CSB tenants on the Swiss medtech / biotech side
of the inventory.

| Employer | ATS | Canton | CH jobs |
|---|---|---|---|
| **Bachem AG** | SAP SF CSB (careers.bachem.com) | BL | **74** |
| **Medartis** | SAP SF CSB (careers.medartis.com) | BS | **16** |
| **Tecan** | SAP SF CSB (careers.tecan.com) | ZH | **14** |
| **Octapharma** | SAP SF CSB (careers.octapharma.com) | SZ | **8** |

## Discovery method

- Probed `career5.successfactors.eu/career?company=X` for healthcare tenant codes (Roche/Novartis/Sandoz/Galderma/Ferring/Galenica/Vifor/Lonza/Givaudan/CSL/AstraZeneca/Sanofi/GSK/Pfizer/B. Braun/Bayer/Acino/Helsana/Sanitas/CSS/Visana/Concordia/GroupeMutuel/Sonova/...) — 5 valid tenants (USZ, KSSG, USB, Tertianum already covered; Helsana out-of-scope as health insurer)
- Probed vanity `careers.{employer}.com/search` for medtech/biotech — 4 NEW healthy hits with ≥5 CH jobs each
- Sonova/Tertianum tenants exist but use j2w pure-JS render (no SSR job rows) → defer to Playwright batch
- B. Braun / Galderma / Ferring / Lonza / Givaudan / Galenica / Sanofi etc. → no public SF CSB endpoint or rendered jobs

## Factory improvements (`successfactors-shared-job-parser-common.mjs`)

Three small additions, regression-tested against ZURZACHCare (74 jobs, unchanged output):

1. **`config.searchParams`** — extra query params for the `/search/?...` listing endpoint (`{ locationsearch: 'Switzerland' }` restricts global SF tenants to CH server-side)
2. **`config.acceptJob`** — optional post-fetch filter (drop jobs after detail resolution)
3. **Listing parser** — prefer dedicated `<td class="colLocation hidden-phone">` for the location, fall back to the heuristic only when no dedicated cell exists. Fixes Bachem-style layouts where mobile+desktop variants concatenate title+location+department into one `<td>`
4. **`extractCsbTotal`** — accept "1 to 25 of 78" (English `to` separator, used by Sonova/Tecan) in addition to the en-dash format
5. **`readPropertyBlock`** — for short fields (`title`, `location`, `city`, `country`, `customfield*`, etc.) cut at the first `</span>` instead of walking to the next propertyid (fixes Bachem detail pages where the title `<span>` closes before unrelated brand copy)
6. **Country-name fallback skip** — drop city values that resolve to "Switzerland"/"Schweiz"/"Suisse"/"CH" alone (Tecan listing emits this); use `defaultCity` instead

## Implementation

- All `ParsedJob` records have `needsRetranslation: true` (factory-inherited; verified end-to-end)
- No `crawler-location-config.mjs` changes (skip-worktree)
- No data file changes
- Each parser/runner/workflow follows the ZURZACH Care / Bethesda template

## Test plan

- [x] Syntax check all 9 new/modified `.mjs` files (`node --check`)
- [x] Smoke-test each parser end-to-end (factory pulls listing + details + city + canton + postal + ≥30-word descriptions)
- [x] `needsRetranslation: true` confirmed on every ParsedJob from all 4 parsers
- [x] ZURZACHCare regression test: still returns 74 jobs with clean titles + correct cities
- [x] CH-only filter applied via `searchParams: { locationsearch: 'Switzerland' }`
- [ ] Trigger 4 workflows on main after merge to validate end-to-end CI + Firestore + Linear failure-issue wiring
