### PR TITLE
feat(crawlers): batch 17g — AG + SO hospital coverage

### DIFF
--- a/.github/workflows/update-jobs-aarreha-schinznach.yml
+++ b/.github/workflows/update-jobs-aarreha-schinznach.yml
@@ -1,0 +1,101 @@
+name: Update aarReha Schinznach Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-aarreha-schinznach
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-aarreha-schinznach-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated aarReha Schinznach crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_AARREHA_SCHINZNACH_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-aarreha-schinznach-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'aarreha-schinznach'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/aarreha-schinznach.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update aarReha Schinznach jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-pallas-kliniken.yml
+++ b/.github/workflows/update-jobs-pallas-kliniken.yml
@@ -1,0 +1,101 @@
+name: Update Pallas Kliniken Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-pallas-kliniken
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-pallas-kliniken-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated Pallas Kliniken crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_PALLAS_KLINIKEN_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-pallas-kliniken-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'pallas-kliniken'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/pallas-kliniken.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Pallas Kliniken jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/aarreha-schinznach-job-parser.mjs
+++ b/scripts/lib/aarreha-schinznach-job-parser.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * aarReha Schinznach — Klinik für interdisziplinäre Rehabilitation (AG).
+ *
+ * Public career site: https://aarreha.ch/jobs/offene-stellen/
+ * Talentsoft portal:  https://aarreha-bewerber.talent-soft.com/
+ * All-jobs listing:   /stelle/liste-aller-stellen.aspx?all=1&mode=list
+ *
+ * Cegid/Talentsoft ATS (same family as REHAB Basel). The list page renders
+ * each offer as a server-rendered `<li class="ts-offer-list-item">` whose
+ * description `<ul>` carries the department (German label) and the city.
+ * No posted date in the listing, so we default to today. Detail page content
+ * lives under `id="contenu-ficheoffre"` and contains structured German prose
+ * (Funktion / Pensum / Aufgaben / Profil / Einsatzort).
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const AARREHA_SCHINZNACH_KEY = 'aarreha-schinznach';
+export const AARREHA_SCHINZNACH_COMPANY_NAME = 'aarReha Schinznach';
+export const AARREHA_SCHINZNACH_COMPANY_DOMAIN = 'aarreha.ch';
+
+const PORTAL_BASE = 'https://aarreha-bewerber.talent-soft.com';
+const LISTING_URL = `${PORTAL_BASE}/stelle/liste-aller-stellen.aspx?all=1&mode=list`;
+const DETAIL_DELAY_MS = 250;
+
+export function isAarrehaSchinznachJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === AARREHA_SCHINZNACH_KEY
+    || url.includes('aarreha.ch')
+    || url.includes('aarreha-bewerber.talent-soft.com');
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'aarreha.ch'
+      || host.endsWith('.aarreha.ch')
+      || host === 'aarreha-bewerber.talent-soft.com';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse the Talentsoft listing into `{ detailUrl, title, ref, department, city }`.
+ * Format (aarReha variant — no posted-date column):
+ *
+ *   <li class="ts-offer-list-item ..." onclick="location.href='{REL_URL}';">
+ *     <h3><a href="{REL_URL}" title="...">{TITLE}</a></h3>
+ *     <span ... data-reference="{YYYY-NNN}" ...></span>
+ *     <ul class="ts-offer-list-item__description">
+ *       <li>{DEPARTMENT}</li><li>{CITY}</li>
+ *     </ul>
+ *   </li>
+ */
+export function parseAarrehaListing(html) {
+  const out = [];
+  const seen = new Set();
+  const itemRe = /<li class="ts-offer-list-item[^"]*"[^>]*onclick="location\.href='([^']+)';"[^>]*>([\s\S]*?)<\/ul>\s*<\/li>/g;
+  let m;
+  while ((m = itemRe.exec(html))) {
+    const rel = m[1];
+    const block = m[2];
+    const detailUrl = rel.startsWith('http') ? rel : `${PORTAL_BASE}${rel}`;
+
+    const titleMatch = block.match(/<a\s+class="ts-offer-list-item__title-link[^"]*"[^>]*>([\s\S]*?)<\/a>/);
+    const title = titleMatch
+      ? normalizeSpace(decodeEntities(titleMatch[1].replace(/<[^>]+>/g, '')))
+      : '';
+    if (!title || title.length < 3) continue;
+
+    const refMatch = block.match(/data-reference="([0-9-]+)"/);
+    const ref = refMatch ? refMatch[1] : '';
+
+    const descLis = [];
+    const ulMatch = block.match(/<ul class="ts-offer-list-item__description[^"]*">([\s\S]*)$/);
+    if (ulMatch) {
+      const liRe = /<li[^>]*>([\s\S]*?)<\/li>/g;
+      let lm;
+      while ((lm = liRe.exec(ulMatch[1]))) {
+        descLis.push(normalizeSpace(decodeEntities(lm[1].replace(/<[^>]+>/g, ''))));
+      }
+    }
+    const [department = '', city = ''] = descLis;
+
+    const key = ref || detailUrl;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ detailUrl, title, ref, department, city });
+  }
+  return out;
+}
+
+async function fetchDetailDescription(detailUrl) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    if (!html) return '';
+    // The job-detail block sits inside id="contenu-ficheoffre". Take everything
+    // up to the share/actions/footer panel.
+    const startMatch = html.match(/id="contenu-ficheoffre"[^>]*>([\s\S]+)/);
+    if (!startMatch) return '';
+    const block = startMatch[1].slice(0, 14000);
+    // Cut off boilerplate footer (Sitemap / Rechtliche Hinweise / Cookies).
+    const cutMatch = block.match(/[\s\S]+?(?=Rechtliche\s+Hinweise|<\/main>|<footer)/);
+    const trimmed = cutMatch ? cutMatch[0] : block;
+    const text = htmlToText(trimmed);
+    return normalizeSpace(text).slice(0, 6000);
+  } catch (err) {
+    console.warn(`  ⚠️ aarReha detail fetch failed (${detailUrl}): ${err?.message || err}`);
+    return '';
+  }
+}
+
+export async function fetchAllAarrehaSchinznachJobs() {
+  console.log(`🏥 Fetching ${AARREHA_SCHINZNACH_COMPANY_NAME} jobs`);
+  console.log(`   Portal: ${LISTING_URL}\n`);
+
+  // Talentsoft paginates ~10 jobs per page; the listing title declares
+  // "(N Stellenangebote, Seite 1)". We walk pages until we get an empty page
+  // or hit the documented total. Cap at 20 pages for safety.
+  const MAX_PAGES = 20;
+  const rows = [];
+  const seenKeys = new Set();
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const url = page === 1 ? LISTING_URL : `${LISTING_URL}&page=${page}`;
+    const html = await fetchHtml(url);
+    const pageRows = parseAarrehaListing(html);
+    if (!pageRows.length) break;
+    let added = 0;
+    for (const r of pageRows) {
+      const key = r.ref || r.detailUrl;
+      if (seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      rows.push(r);
+      added += 1;
+    }
+    console.log(`  · page ${page}: ${pageRows.length} parsed (+${added} new)`);
+    if (added === 0) break;
+  }
+  console.log(`  ✓ ${rows.length} Talentsoft offers (deduped across pages)`);
+  if (!rows.length) return [];
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  for (let i = 0; i < rows.length; i += 1) {
+    const r = rows[i];
+    if (i > 0) await new Promise((res) => setTimeout(res, DETAIL_DELAY_MS));
+    const detailText = await fetchDetailDescription(r.detailUrl);
+
+    const summaryPieces = [
+      r.department ? `Bereich: ${r.department}` : '',
+      r.city ? `Standort: ${r.city}` : '',
+      r.ref ? `Referenz: ${r.ref}` : '',
+    ].filter(Boolean);
+    const description = detailText && detailText.split(/\s+/).length >= 30
+      ? detailText
+      : [
+        ...summaryPieces,
+        `${AARREHA_SCHINZNACH_COMPANY_NAME} — Zentrum für interdisziplinäre Rehabilitation in Schinznach-Bad (AG).`,
+      ].filter(Boolean).join('\n\n');
+
+    const sourceLang = detectLang(description || r.title, 'de');
+    const jobSlug = slugify(`${r.title} ${AARREHA_SCHINZNACH_KEY} ${r.city || 'schinznach'}`);
+    const urlHash = createHash('sha1').update(r.detailUrl).digest('hex').slice(0, 12);
+
+    // aarReha is fully in canton Aargau; "Schinznach-Bad" / "Zofingen" are the
+    // two sites. Default postal code follows the main Schinznach-Bad campus
+    // (5116). Detail pages can mention "Aargau, Schinznach-Bad" or "Zofingen".
+    const cityLabel = r.city || 'Schinznach-Bad';
+    const postalCode = /zofingen/i.test(cityLabel) ? '4800' : '5116';
+
+    jobs.push({
+      id: `${AARREHA_SCHINZNACH_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: AARREHA_SCHINZNACH_COMPANY_NAME,
+      companyKey: AARREHA_SCHINZNACH_KEY,
+      companyDomain: AARREHA_SCHINZNACH_COMPANY_DOMAIN,
+      title: r.title,
+      titleByLocale: { [sourceLang]: r.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: cityLabel,
+      canton: 'AG',
+      url: r.detailUrl,
+      source: `${AARREHA_SCHINZNACH_COMPANY_NAME} Dedicated Parser (Talentsoft)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: cityLabel,
+      addressRegion: 'AG',
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode,
+      category: detectHealthcareCategory(`${r.title} ${r.department}`),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(`${r.title} ${description}`),
+      experienceLevel: detectHealthcareExperienceLevel(r.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: r.detailUrl,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+  console.log(`\n📋 Total ${AARREHA_SCHINZNACH_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}
+
+export { LISTING_URL };

--- a/scripts/lib/pallas-kliniken-job-parser.mjs
+++ b/scripts/lib/pallas-kliniken-job-parser.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Pallas Kliniken AG (SO) — Augenheilkunde & Aesthetics, 17 standorte in CH.
+ *
+ * Public career site:   https://www.pallas-kliniken.ch/karriere/
+ * Flair HR ATS portal:  https://pallasjobs.careers.flair.hr/
+ * Detail page URLs:     /positions/{salesforceId}
+ *
+ * Flair HR is a Next.js + Salesforce-backed careers product. The listing page
+ * is server-rendered and exposes each position as a relative anchor
+ * `/positions/{a3LTG...}`. Each detail page embeds a clean
+ * `<script type="application/ld+json">` JobPosting with `title`, `description`
+ * (HTML-encoded), `datePosted`, `employmentType`, `jobLocation` (full address
+ * + postalCode + addressLocality + streetAddress), and `hiringOrganization`.
+ * No API endpoint is needed; the JSON-LD covers everything.
+ *
+ * Polite delay: 250 ms between detail fetches.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const PALLAS_KLINIKEN_KEY = 'pallas-kliniken';
+export const PALLAS_KLINIKEN_COMPANY_NAME = 'Pallas Kliniken';
+export const PALLAS_KLINIKEN_COMPANY_DOMAIN = 'pallas-kliniken.ch';
+
+const PORTAL_BASE = 'https://pallasjobs.careers.flair.hr';
+const LISTING_URL = `${PORTAL_BASE}/`;
+const DETAIL_DELAY_MS = 250;
+
+// Headquarters fallback when JSON-LD jobLocation is unusable. The group is
+// headquartered in Olten (SO), even though some sites span ZH, BE, AG, etc.
+const HQ = {
+  city: 'Olten',
+  canton: 'SO',
+  postalCode: '4600',
+  streetAddress: 'Louis Giroud-Strasse 20',
+};
+
+// Map Pallas site names → Swiss canton (where the JSON-LD jobLocation address
+// uses `addressCountry: 'Schweiz'` and we infer the canton from the city).
+const CITY_TO_CANTON = {
+  Olten: 'SO',
+  Bern: 'BE',
+  Basel: 'BS',
+  'Zürich': 'ZH',
+  Zurich: 'ZH',
+  Solothurn: 'SO',
+  Aarau: 'AG',
+  Baden: 'AG',
+  Brugg: 'AG',
+  Grenchen: 'SO',
+  Langenthal: 'BE',
+  Biel: 'BE',
+  Bienne: 'BE',
+  'Bern Wankdorf': 'BE',
+  Winterthur: 'ZH',
+  Luzern: 'LU',
+  'St. Gallen': 'SG',
+  'Schaffhausen': 'SH',
+  Wohlen: 'AG',
+  Lenzburg: 'AG',
+  Rheinfelden: 'AG',
+  Wettingen: 'AG',
+  Frauenfeld: 'TG',
+  Bellinzona: 'TI',
+  Lugano: 'TI',
+  Locarno: 'TI',
+  Sion: 'VS',
+  Lausanne: 'VD',
+  Vevey: 'VD',
+  Yverdon: 'VD',
+  Geneva: 'GE',
+  'Genève': 'GE',
+  Chur: 'GR',
+};
+
+export function isPallasKlinikenJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === PALLAS_KLINIKEN_KEY
+    || url.includes('pallas-kliniken.ch')
+    || url.includes('pallasjobs.careers.flair.hr');
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'pallas-kliniken.ch'
+      || host.endsWith('.pallas-kliniken.ch')
+      || host === 'pallasjobs.careers.flair.hr';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract the list of `/positions/{ID}` URLs from the Flair HR listing page.
+ * The page renders position cards as anchors; we collect unique IDs.
+ */
+export function parsePallasListing(html) {
+  const out = [];
+  const seen = new Set();
+  const rx = /href="\/positions\/([A-Za-z0-9]+)"/g;
+  let m;
+  while ((m = rx.exec(html))) {
+    const id = m[1];
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, detailUrl: `${PORTAL_BASE}/positions/${id}` });
+  }
+  return out;
+}
+
+/**
+ * Extract the JSON-LD JobPosting block from a Flair HR detail page.
+ * Returns `null` if not present or malformed.
+ */
+export function extractJobPostingLd(html) {
+  if (!html) return null;
+  const scripts = html.matchAll(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi);
+  for (const m of scripts) {
+    const raw = m[1].trim();
+    try {
+      const data = JSON.parse(raw);
+      if (data && (data['@type'] === 'JobPosting' || data['@type']?.includes?.('JobPosting'))) {
+        return data;
+      }
+    } catch {
+      // Salesforce sometimes wraps HTML in CDATA; ignore parse errors.
+    }
+  }
+  return null;
+}
+
+function htmlDescriptionToText(htmlDescription = '') {
+  // Flair HR HTML-encodes the description into a single JSON string, so we
+  // decode entities first, then strip tags.
+  const decoded = decodeEntities(String(htmlDescription));
+  const text = htmlToText(decoded);
+  return normalizeSpace(text);
+}
+
+function mapEmploymentTypeLd(value, fallbackText) {
+  const raw = String(value || '').toUpperCase();
+  if (raw.includes('PART')) return 'part-time';
+  if (raw.includes('FULL')) return 'full-time';
+  if (raw.includes('INTERN')) return 'internship';
+  if (raw.includes('TEMP') || raw.includes('CONTRACT')) return 'contract';
+  return detectHealthcareEmploymentType(fallbackText || '');
+}
+
+function pickCanton(addressLocality) {
+  if (!addressLocality) return HQ.canton;
+  const direct = CITY_TO_CANTON[addressLocality];
+  if (direct) return direct;
+  for (const [k, v] of Object.entries(CITY_TO_CANTON)) {
+    if (addressLocality.toLowerCase().includes(k.toLowerCase())) return v;
+  }
+  return HQ.canton;
+}
+
+export async function fetchAllPallasKlinikenJobs() {
+  console.log(`🏥 Fetching ${PALLAS_KLINIKEN_COMPANY_NAME} jobs`);
+  console.log(`   Portal: ${LISTING_URL}\n`);
+
+  const listingHtml = await fetchHtml(LISTING_URL);
+  const positions = parsePallasListing(listingHtml);
+  console.log(`  ✓ ${positions.length} Flair HR positions parsed`);
+  if (!positions.length) return [];
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  for (let i = 0; i < positions.length; i += 1) {
+    const p = positions[i];
+    if (i > 0) await new Promise((res) => setTimeout(res, DETAIL_DELAY_MS));
+    let html;
+    try {
+      html = await fetchHtml(p.detailUrl);
+    } catch (err) {
+      console.warn(`  ⚠️ Pallas detail fetch failed (${p.detailUrl}): ${err?.message || err}`);
+      continue;
+    }
+    const ld = extractJobPostingLd(html);
+    if (!ld || !ld.title) {
+      console.warn(`  ⚠️ Pallas JSON-LD missing for ${p.detailUrl}`);
+      continue;
+    }
+
+    const title = normalizeSpace(decodeEntities(ld.title));
+    const description = htmlDescriptionToText(ld.description || '');
+    if (!title || description.split(/\s+/).length < 30) {
+      console.warn(`  ⚠️ Pallas thin description for ${title || p.id}`);
+      continue;
+    }
+    const sourceLang = detectLang(description, 'de');
+
+    const addr = ld.jobLocation?.address || {};
+    const city = normalizeSpace(decodeEntities(addr.addressLocality || '')) || HQ.city;
+    const postalCode = String(addr.postalCode || HQ.postalCode);
+    const streetAddress = normalizeSpace(decodeEntities(addr.streetAddress || HQ.streetAddress));
+    const canton = pickCanton(city);
+
+    const datePosted = (ld.datePosted && /^\d{4}-\d{2}-\d{2}$/.test(ld.datePosted))
+      ? ld.datePosted
+      : todayIso;
+
+    const jobSlug = slugify(`${title} ${PALLAS_KLINIKEN_KEY} ${city}`);
+    const urlHash = createHash('sha1').update(p.detailUrl).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${PALLAS_KLINIKEN_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: PALLAS_KLINIKEN_COMPANY_NAME,
+      companyKey: PALLAS_KLINIKEN_KEY,
+      companyDomain: PALLAS_KLINIKEN_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: city,
+      canton,
+      url: p.detailUrl,
+      source: `${PALLAS_KLINIKEN_COMPANY_NAME} Dedicated Parser (Flair HR / JSON-LD)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: city,
+      addressRegion: canton,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode,
+      streetAddress,
+      category: detectHealthcareCategory(`${title} ${description.slice(0, 400)}`),
+      contract: 'full-time',
+      employmentType: mapEmploymentTypeLd(ld.employmentType, `${title} ${description.slice(0, 200)}`),
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: datePosted,
+      applyUrl: p.detailUrl,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+  console.log(`\n📋 Total ${PALLAS_KLINIKEN_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}
+
+export { LISTING_URL };

--- a/scripts/update-aarreha-schinznach-jobs.mjs
+++ b/scripts/update-aarreha-schinznach-jobs.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Dedicated aarReha Schinznach crawler runner.
+ *
+ * Uses the standard crawler template with the aarReha Talentsoft parser.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllAarrehaSchinznachJobs,
+  isAarrehaSchinznachJob,
+  isTrustedDomain,
+  AARREHA_SCHINZNACH_KEY,
+  AARREHA_SCHINZNACH_COMPANY_NAME,
+} from './lib/aarreha-schinznach-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: AARREHA_SCHINZNACH_KEY,
+  companyLabel: AARREHA_SCHINZNACH_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllAarrehaSchinznachJobs,
+  isCompanyJob: isAarrehaSchinznachJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ aarReha Schinznach crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-pallas-kliniken-jobs.mjs
+++ b/scripts/update-pallas-kliniken-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Pallas Kliniken crawler runner.
+ *
+ * Flair HR career portal (`pallasjobs.careers.flair.hr`) with JSON-LD
+ * JobPosting blocks per detail page.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllPallasKlinikenJobs,
+  isPallasKlinikenJob,
+  isTrustedDomain,
+  PALLAS_KLINIKEN_KEY,
+  PALLAS_KLINIKEN_COMPANY_NAME,
+} from './lib/pallas-kliniken-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: PALLAS_KLINIKEN_KEY,
+  companyLabel: PALLAS_KLINIKEN_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllPallasKlinikenJobs,
+  isCompanyJob: isPallasKlinikenJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Pallas Kliniken crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Two new dedicated crawlers covering uncovered AG/SO hospitals from
docs/HOSPITAL-CRAWLERS-INVENTORY-2026-05-19.md §4.

| ATS              | Tenant                | Canton | Jobs |
|------------------|-----------------------|--------|------|
| Talentsoft       | aarReha Schinznach    | AG     | 13   |
| Flair HR / JSON-LD | Pallas Kliniken AG  | SO     | 9    |

- aarReha (Talentsoft, paginated): listing under
  `aarreha-bewerber.talent-soft.com/stelle/liste-aller-stellen.aspx`. Walks
  pages 1..N until empty. Detail page text extracted from
  `id="contenu-ficheoffre"`. Canton AG, sites Schinznach-Bad (5116) and
  Zofingen (4800).
- Pallas Kliniken (Flair HR / Salesforce-backed Next.js): listing at
  `pallasjobs.careers.flair.hr/`, detail pages embed
  `<script type="application/ld+json">` JobPosting with full
  `jobLocation.address` (postalCode + streetAddress) and `datePosted`. Sites
  span SO (Olten HQ), AG (Wohlen, Lenzburg, ...), ZH (Winterthur, Zürich),
  BE — canton mapped via city table with SO fallback.

All ParsedJob records set `needsRetranslation: true`. No changes to
`crawler-location-config.mjs`, `known-company-slugs.json`, or `data/jobs*`.
