### PR TITLE
feat(crawlers): batch 17h — niche ATS Tier 4 (BS/BL hospitals)

### DIFF
--- a/.github/workflows/update-jobs-pbl.yml
+++ b/.github/workflows/update-jobs-pbl.yml
@@ -1,0 +1,101 @@
+name: Update Psychiatrie Baselland Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-pbl
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-pbl-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated PBL crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_PBL_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-pbl-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'pbl'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/pbl.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PBL jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-rennbahnklinik.yml
+++ b/.github/workflows/update-jobs-rennbahnklinik.yml
@@ -1,0 +1,101 @@
+name: Update Rennbahnklinik Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-rennbahnklinik
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-rennbahnklinik-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated RENNBAHNKLINIK crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_RENNBAHNKLINIK_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-rennbahnklinik-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'rennbahnklinik'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/rennbahnklinik.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update RENNBAHNKLINIK jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-ukbb.yml
+++ b/.github/workflows/update-jobs-ukbb.yml
@@ -1,0 +1,101 @@
+name: Update UKBB Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-ukbb
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-ukbb-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated UKBB crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_UKBB_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-ukbb-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'ukbb'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/ukbb.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update UKBB jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/pbl-job-parser.mjs
+++ b/scripts/lib/pbl-job-parser.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Psychiatrie Baselland (PBL) — dedicated job parser.
+ *
+ * Public career site: https://jobs.pbl.ch/
+ *
+ * PBL is the cantonal psychiatric hospital network of Basel-Landschaft (BL),
+ * spanning Liestal, Bruderholz and Münchenstein. ~1'500 staff. Career portal
+ * runs on the Prospective.ch "careercenter" SSR shell (template ID
+ * `careercenter/1002053/...` visible in the page assets), but the public
+ * `/medium/{ID}/jobs` JSON API returns HTTP 400 — same pattern as Spital STS
+ * AG. We therefore scrape the SSR listing pages directly.
+ *
+ * Listing pattern (paginated 10 per page, `?offset={0,10,20,...}`):
+ *   <div class="job job-N">
+ *     <a class="job-title"
+ *        href="https://jobs.pbl.ch/offene-stellen/{slug}/{uuid}"
+ *        title="...">
+ *       {Title} <p class="job-meta">{Location detail}</p>
+ *     </a>
+ *
+ * Detail pattern (one URL per job — slug + uuid combo):
+ *   <section id="topTitleArea"><h1>{Title}</h1>
+ *     <div class="abteilungen"><h2>{Workplace}</h2><h2>{Team}</h2></div></section>
+ *   <section id="tasks"><h3>Ihre Aufgaben</h3>{prose}</section>
+ *   <section id="profile"><h3>Ihr Profil</h3>{prose}</section>
+ *   <section><h3>Stellenantritt</h3>{prose}</section>
+ *   <a href="https://jobs.pbl.ch/apply/ats/{uuid}"> ← apply URL
+ *
+ * Pattern is the standard Prospective Aequivital shell, similar to
+ * `spital-sts-job-parser.mjs` (which uses the same SSR fallback after the
+ * /medium API was deprecated).
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const PBL_KEY = 'pbl';
+export const PBL_COMPANY_NAME = 'Psychiatrie Baselland';
+export const PBL_COMPANY_DOMAIN = 'pbl.ch';
+
+const LISTING_BASE = 'https://jobs.pbl.ch/';
+const MAX_PAGES = 12; // safety cap; each page holds 10 jobs
+const PAGE_SIZE = 10;
+const DETAIL_DELAY_MS = 220;
+const POSTAL_CODE_LIESTAL = '4410';
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isPblJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const key = String(job?.companyKey || '').toLowerCase();
+  return (
+    key === PBL_KEY ||
+    url.includes('jobs.pbl.ch') ||
+    url.includes('pbl.ch') ||
+    company.includes('psychiatrie baselland') ||
+    company.includes('upk baselland') ||
+    company === 'pbl'
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'pbl.ch' || host.endsWith('.pbl.ch')) return true;
+    // The Prospective ATS endpoint is the canonical "Jetzt bewerben" target
+    if (host === 'ohws.prospective.ch') return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/* ── Listing parser ────────────────────────────────────────── */
+
+export function parseJobListHtml(html = '') {
+  const out = [];
+  const seen = new Set();
+  // Match each `<a class="job-title" href=".../offene-stellen/{slug}/{uuid}"` anchor.
+  // The listing markup is bare HTML; we don't need the surrounding `<div>` because
+  // every job row contains exactly one such anchor.
+  const rx = /<a\s+class="job-title"\s+href="(https:\/\/jobs\.pbl\.ch\/offene-stellen\/([a-z0-9-]+)\/([a-f0-9-]{36}))"[\s\S]*?title="([^"]*)"[\s\S]*?>([\s\S]*?)<\/a>/g;
+  let m;
+  while ((m = rx.exec(html))) {
+    const detailUrl = m[1];
+    const slug = m[2];
+    const uuid = m[3];
+    const titleAttr = decodeEntities(m[4]).replace(/\s*%\s*$/, '').trim();
+    const inner = m[5];
+    if (seen.has(uuid)) continue;
+    seen.add(uuid);
+
+    // Inside the anchor: text node = headline title, `<p class="job-meta">` = workplace.
+    const metaMatch = inner.match(/<p\s+class="job-meta">([\s\S]*?)<\/p>/i);
+    const metaText = metaMatch ? normalizeSpace(decodeEntities(metaMatch[1])) : '';
+    const headline = normalizeSpace(decodeEntities(inner.replace(/<p\s+class="job-meta">[\s\S]*?<\/p>/i, '').replace(/<[^>]+>/g, ' ')));
+    const title = headline || titleAttr;
+    if (!title || title.length < 3) continue;
+
+    out.push({ uuid, slug, detailUrl, title, workplace: metaText, titleAttr });
+  }
+  return out;
+}
+
+/* ── Detail extractor ──────────────────────────────────────── */
+
+function extractSectionContent(html, id) {
+  const re = new RegExp(`<section[^>]*\\bid="${id}"[^>]*>([\\s\\S]*?)<\\/section>`, 'i');
+  const m = html.match(re);
+  if (!m) return '';
+  return htmlToText(m[1]);
+}
+
+function extractGenericSection(html, headlineRx) {
+  // Generic `<section><h3>{headline}</h3>{...}</section>` block extractor.
+  // Used for Stellenantritt + Weitere Informationen which don't have an `id`.
+  const re = new RegExp(
+    `<section[^>]*>\\s*(?:<div[^>]*>\\s*)?<h3>\\s*(${headlineRx.source})\\s*<\\/h3>([\\s\\S]*?)<\\/section>`,
+    'i'
+  );
+  const m = html.match(re);
+  if (!m) return '';
+  return htmlToText(m[2]);
+}
+
+async function fetchDetailDescription(detailUrl, fallbackTeaser) {
+  if (!detailUrl) return fallbackTeaser || '';
+  try {
+    const html = await fetchHtml(detailUrl);
+    if (!html) return fallbackTeaser || '';
+
+    const parts = [];
+    // The introduction block lives inside `topTitleArea` (the Abteilungen)
+    const topTitle = normalizeSpace(extractSectionContent(html, 'topTitleArea'));
+    // Filter out the always-present "Jetzt bewerben" button text
+    const intro = topTitle.replace(/^\s*Jetzt bewerben\s*/i, '').trim();
+    if (intro) parts.push(intro);
+
+    const tasks = normalizeSpace(extractSectionContent(html, 'tasks'));
+    if (tasks) parts.push(tasks);
+
+    const profile = normalizeSpace(extractSectionContent(html, 'profile'));
+    if (profile) parts.push(profile);
+
+    const stellenantritt = normalizeSpace(extractGenericSection(html, /Stellenantritt/));
+    if (stellenantritt) parts.push(`Stellenantritt: ${stellenantritt}`);
+
+    const text = parts.filter(Boolean).join('\n\n').trim();
+    if (text && text.split(/\s+/).length >= 30) return text.slice(0, 6000);
+    return [fallbackTeaser, text].filter(Boolean).join('\n\n').trim();
+  } catch (err) {
+    console.warn(`  ⚠️ PBL detail fetch failed (${detailUrl}): ${err?.message || err}`);
+    return fallbackTeaser || '';
+  }
+}
+
+/* ── Location heuristics ───────────────────────────────────── */
+
+function pickPostalCode(workplace) {
+  const w = String(workplace || '').toLowerCase();
+  if (w.includes('liestal')) return '4410';
+  if (w.includes('bruderholz')) return '4101';
+  if (w.includes('münchenstein') || w.includes('muenchenstein')) return '4142';
+  if (w.includes('binningen')) return '4102';
+  if (w.includes('arlesheim')) return '4144';
+  return POSTAL_CODE_LIESTAL;
+}
+
+function pickCity(workplace) {
+  const w = String(workplace || '');
+  if (/Liestal/i.test(w)) return 'Liestal';
+  if (/Bruderholz/i.test(w)) return 'Bruderholz';
+  if (/M(ü|ue)nchenstein/i.test(w)) return 'Münchenstein';
+  if (/Binningen/i.test(w)) return 'Binningen';
+  if (/Arlesheim/i.test(w)) return 'Arlesheim';
+  return 'Liestal';
+}
+
+/* ── Main entry ────────────────────────────────────────────── */
+
+export async function fetchAllPblJobs() {
+  console.log(`🏥 Fetching ${PBL_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${LISTING_BASE} (SSR career list, paginated by ?offset=)\n`);
+
+  // Collect rows across paginated career-list pages until we see a page that
+  // contains only already-seen UUIDs (Prospective recycles results past the
+  // last real page).
+  const all = [];
+  const seen = new Set();
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const offset = page * PAGE_SIZE;
+    const url = offset === 0 ? LISTING_BASE : `${LISTING_BASE}?offset=${offset}`;
+    let html = '';
+    try {
+      html = await fetchHtml(url);
+    } catch (err) {
+      console.warn(`  ⚠️ PBL list fetch failed at offset=${offset}: ${err?.message || err}`);
+      break;
+    }
+    const rows = parseJobListHtml(html);
+    const fresh = rows.filter((r) => !seen.has(r.uuid));
+    if (!fresh.length) {
+      console.log(`  ✓ offset=${offset}: no new jobs → stop`);
+      break;
+    }
+    fresh.forEach((r) => { seen.add(r.uuid); all.push(r); });
+    console.log(`  ✓ offset=${offset}: ${rows.length} rows (${fresh.length} new, ${all.length} total)`);
+    if (rows.length < PAGE_SIZE) break; // last partial page
+    if (page > 0) await new Promise((res) => setTimeout(res, 200));
+  }
+
+  console.log(`  ✓ Parsed ${all.length} unique job rows from career list HTML`);
+  if (!all.length) return [];
+
+  const jobs = [];
+  const todayIso = new Date().toISOString().slice(0, 10);
+  let detailHits = 0;
+  for (let i = 0; i < all.length; i += 1) {
+    const r = all[i];
+    if (i > 0) await new Promise((res) => setTimeout(res, DETAIL_DELAY_MS));
+
+    const fallback = `${r.title} — ${PBL_COMPANY_NAME}, ${r.workplace || 'Liestal'}.`;
+    const desc = await fetchDetailDescription(r.detailUrl, fallback);
+    if (desc && desc.length > fallback.length + 20) detailHits += 1;
+    const safeDescription = desc && desc.split(/\s+/).length >= 30
+      ? desc
+      : [fallback, desc].filter(Boolean).join('\n\n');
+
+    const city = pickCity(r.workplace);
+    const canton = inferSwissTargetCanton(city) || 'BL';
+    const sourceLang = detectLang(safeDescription || r.title, 'de');
+    const jobSlug = slugify(`${r.title} ${PBL_KEY} ${city}`);
+    const urlHash = createHash('sha1').update(r.detailUrl).digest('hex').slice(0, 12);
+
+    const employmentType = detectHealthcareEmploymentType(`${r.titleAttr || r.title} ${safeDescription}`);
+    const applyUrl = `https://jobs.pbl.ch/apply/ats/${r.uuid}`;
+
+    jobs.push({
+      id: `${PBL_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: PBL_COMPANY_NAME,
+      companyKey: PBL_KEY,
+      companyDomain: PBL_COMPANY_DOMAIN,
+      title: r.title,
+      titleByLocale: { [sourceLang]: r.title },
+      description: safeDescription,
+      descriptionByLocale: { [sourceLang]: safeDescription },
+      needsRetranslation: true,
+      location: city,
+      canton,
+      url: r.detailUrl,
+      source: 'Psychiatrie Baselland Dedicated Parser (SSR + career detail)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: city,
+      addressRegion: canton,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: pickPostalCode(r.workplace),
+      category: detectHealthcareCategory(`${r.title} ${safeDescription}`),
+      contract: 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(r.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(`📋 Total ${PBL_COMPANY_NAME} jobs discovered: ${jobs.length} (${detailHits}/${all.length} with rich detail content)`);
+  return jobs;
+}

--- a/scripts/lib/rennbahnklinik-job-parser.mjs
+++ b/scripts/lib/rennbahnklinik-job-parser.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Praxisklinik Rennbahn / Rennbahnklinik (Muttenz, BL) — dedicated job parser.
+ *
+ * Public career site: https://www.rennbahnklinik.ch/offene-stellen
+ *
+ * Private specialty clinic focused on orthopaedics, sports medicine,
+ * physiotherapy and biomechanics in Muttenz (BL). ~250 staff. Custom static
+ * site (Craft CMS) with predictable URLs:
+ *
+ *   Listing:  https://www.rennbahnklinik.ch/offene-stellen
+ *               → `<a href="/jobs/{slug}">` cards
+ *   Detail:   https://www.rennbahnklinik.ch/jobs/{slug}
+ *               → JSON-LD WebPage + standard prose (Deine Aufgaben, Du
+ *                 bringst mit, Wir bieten an) in `<div class="component-text">`
+ *
+ * Each card on the listing is just an anchor; the detail page carries the
+ * actual job body. No ATS — we scrape HTML directly.
+ *
+ * Note: There's a sister portal `Berufsbildung / Lehrstellen` rolled into the
+ * same offene-stellen page; we treat those as regular jobs since they are
+ * paid trainee positions with full structured descriptions.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const RENNBAHNKLINIK_KEY = 'rennbahnklinik';
+export const RENNBAHNKLINIK_COMPANY_NAME = 'Rennbahnklinik';
+export const RENNBAHNKLINIK_COMPANY_DOMAIN = 'rennbahnklinik.ch';
+
+const LISTING_URL = 'https://www.rennbahnklinik.ch/offene-stellen';
+const BASE = 'https://www.rennbahnklinik.ch';
+const DETAIL_DELAY_MS = 250;
+const POSTAL_CODE_MUTTENZ = '4132';
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isRennbahnklinikJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const key = String(job?.companyKey || '').toLowerCase();
+  return (
+    key === RENNBAHNKLINIK_KEY ||
+    url.includes('rennbahnklinik.ch') ||
+    company.includes('rennbahnklinik') ||
+    company.includes('praxisklinik rennbahn')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'rennbahnklinik.ch' || host.endsWith('.rennbahnklinik.ch');
+  } catch {
+    return false;
+  }
+}
+
+/* ── Listing parser ────────────────────────────────────────── */
+
+const SKIP_SLUGS = new Set(['benefits']); // sub-pages, not jobs
+
+export function parseListingHtml(html = '') {
+  const out = [];
+  const seen = new Set();
+  const rx = /href="(https:\/\/www\.rennbahnklinik\.ch\/jobs\/([^"\/?#]+))"/g;
+  let m;
+  while ((m = rx.exec(html))) {
+    const url = m[1];
+    const slug = decodeURIComponent(m[2]);
+    if (SKIP_SLUGS.has(slug.toLowerCase())) continue;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push({ url, slug });
+  }
+  return out;
+}
+
+/* ── Detail extractor ──────────────────────────────────────── */
+
+function extractH1(html) {
+  // The detail page wraps the headline in a `<div class="component-headline">`
+  // or as a plain `<h1>` in the lead block.
+  const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  return m ? normalizeSpace(decodeEntities(m[1].replace(/<[^>]+>/g, ' '))) : '';
+}
+
+function extractLeadText(html) {
+  // `<p class="leadtext">{intro}</p>` sits just below the H1.
+  const m = html.match(/<p\s+class="leadtext"[^>]*>([\s\S]*?)<\/p>/i);
+  return m ? normalizeSpace(decodeEntities(m[1].replace(/<[^>]+>/g, ' '))) : '';
+}
+
+function extractDetailBody(html) {
+  // Capture all `<div class="component-text">` and `<div class="component-headline">`
+  // blocks in document order. They contain the meat: Aufgaben, Anforderungen, Angebot.
+  const parts = [];
+  const rx = /<div\s+class="component\s+(component-headline|component-text)"[^>]*>([\s\S]*?)<\/div>\s*(?=<div\s+class="component|<\/main|<footer)/gi;
+  let m;
+  while ((m = rx.exec(html))) {
+    const inner = m[2];
+    // Strip nested wrappers, keep text + bullet markers from <li>
+    const cleaned = inner
+      .replace(/<li[^>]*>/g, '\n• ')
+      .replace(/<\/li>/g, '')
+      .replace(/<br\s*\/?\s*>/g, '\n')
+      .replace(/<[^>]+>/g, ' ');
+    const text = normalizeSpace(decodeEntities(cleaned).replace(/\s*\n\s*/g, '\n')).trim();
+    if (!text || text.length < 6) continue;
+    parts.push(text);
+  }
+  return parts.join('\n\n');
+}
+
+async function fetchDetailContent(detailUrl, fallbackTitle) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    if (!html) return { title: '', description: '' };
+
+    const h1 = extractH1(html) || fallbackTitle;
+    const lead = extractLeadText(html);
+    const body = extractDetailBody(html);
+
+    const parts = [lead, body].filter(Boolean).map((s) => s.trim());
+    const description = parts.join('\n\n').slice(0, 6000);
+    return { title: h1, description };
+  } catch (err) {
+    console.warn(`  ⚠️ Rennbahnklinik detail fetch failed (${detailUrl}): ${err?.message || err}`);
+    return { title: '', description: '' };
+  }
+}
+
+/* ── Main entry ────────────────────────────────────────────── */
+
+export async function fetchAllRennbahnklinikJobs() {
+  console.log(`🏥 Fetching ${RENNBAHNKLINIK_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${LISTING_URL}\n`);
+
+  let listingHtml = '';
+  try {
+    listingHtml = await fetchHtml(LISTING_URL);
+  } catch (err) {
+    console.warn(`  ⚠️ Rennbahnklinik listing fetch failed: ${err?.message || err}. Returning [].`);
+    return [];
+  }
+
+  const items = parseListingHtml(listingHtml);
+  console.log(`  ✓ ${items.length} job links parsed`);
+  if (!items.length) return [];
+
+  const jobs = [];
+  const todayIso = new Date().toISOString().slice(0, 10);
+  let detailHits = 0;
+  for (let i = 0; i < items.length; i += 1) {
+    const it = items[i];
+    if (i > 0) await new Promise((res) => setTimeout(res, DETAIL_DELAY_MS));
+
+    const fallbackTitle = it.slug
+      .replace(/-/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+    const detail = await fetchDetailContent(it.url, fallbackTitle);
+    const title = detail.title || fallbackTitle;
+    if (detail.description && detail.description.length > 100) detailHits += 1;
+
+    const baseFallback = `${title} — ${RENNBAHNKLINIK_COMPANY_NAME}, Muttenz BL.`;
+    const safeDescription = detail.description && detail.description.split(/\s+/).length >= 30
+      ? detail.description
+      : `${baseFallback}\n\n${detail.description || ''}`.trim();
+
+    const sourceLang = detectLang(safeDescription || title, 'de');
+    const jobSlug = slugify(`${title} ${RENNBAHNKLINIK_KEY} muttenz`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+    const employmentType = detectHealthcareEmploymentType(`${title} ${safeDescription}`);
+
+    jobs.push({
+      id: `${RENNBAHNKLINIK_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: RENNBAHNKLINIK_COMPANY_NAME,
+      companyKey: RENNBAHNKLINIK_KEY,
+      companyDomain: RENNBAHNKLINIK_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description: safeDescription,
+      descriptionByLocale: { [sourceLang]: safeDescription },
+      needsRetranslation: true,
+      location: 'Muttenz',
+      canton: 'BL',
+      url: it.url,
+      source: 'Rennbahnklinik Dedicated Parser (custom HTML)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: 'Muttenz',
+      addressRegion: 'BL',
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: POSTAL_CODE_MUTTENZ,
+      streetAddress: 'Kriegackerstrasse 100',
+      category: detectHealthcareCategory(`${title} ${safeDescription}`),
+      contract: employmentType === 'temporary' ? 'temporary' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(`📋 Total ${RENNBAHNKLINIK_COMPANY_NAME} jobs discovered: ${jobs.length} (${detailHits}/${items.length} with rich detail content)`);
+  return jobs;
+}

--- a/scripts/lib/ukbb-job-parser.mjs
+++ b/scripts/lib/ukbb-job-parser.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * Universitäts-Kinderspital beider Basel (UKBB) — dedicated job parser.
+ *
+ * Public career site: https://jobs.ukbb.ch/
+ *
+ * UKBB's career portal is powered by Concludis / my-job-shop.com (CareerRevolution).
+ * The listing UI is fully JS-rendered (Nuxt + Typesense), so we cannot scrape
+ * the home page directly. Instead we read the SEO sitemap, which always lists
+ * every active offer:
+ *
+ *   https://jobs.ukbb.ch/sitemap.xml
+ *     → <loc>https://jobs.ukbb.ch/offer/{slug}/{uuid}</loc>
+ *
+ * Each `offer/{slug}/{uuid}` page is SSR'd with a complete JSON-LD JobPosting
+ * payload embedded inside `<script type="application/ld+json">`:
+ *
+ *   {"@context":"https://schema.org","@type":"JobPosting",
+ *    "title":"...", "description":"...", "datePosted":"...",
+ *    "jobLocation":{...}, "hiringOrganization":{...}, "employmentType":"...", ...}
+ *
+ * We fetch the sitemap → filter `/offer/` URLs → fetch each detail page →
+ * extract the JSON-LD JobPosting object. This is robust against template
+ * changes because we lean on schema.org rather than DOM scraping.
+ *
+ * UKBB is the cantonal paediatric university hospital in Basel (BS), ~1'500
+ * staff, ≈20 active offers at any time. Its workforce includes frontaliere
+ * commuters from neighbouring departements (Haut-Rhin, Sundgau) — relevant
+ * for our IT audience.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const UKBB_KEY = 'ukbb';
+export const UKBB_COMPANY_NAME = 'Universitäts-Kinderspital beider Basel';
+export const UKBB_COMPANY_DOMAIN = 'ukbb.ch';
+
+const SITEMAP_URL = 'https://jobs.ukbb.ch/sitemap.xml';
+const DETAIL_DELAY_MS = 250;
+const POSTAL_CODE_BASEL = '4056'; // UKBB main campus, Spitalstrasse 33
+const STREET_ADDRESS = 'Spitalstrasse 33';
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isUkbbJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const key = String(job?.companyKey || '').toLowerCase();
+  return (
+    key === UKBB_KEY ||
+    url.includes('jobs.ukbb.ch') ||
+    url.includes('ukbb.ch') ||
+    company.includes('kinderspital beider basel') ||
+    company.includes('ukbb')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'ukbb.ch' || host.endsWith('.ukbb.ch');
+  } catch {
+    return false;
+  }
+}
+
+/* ── Sitemap + JSON-LD extraction ──────────────────────────── */
+
+export function parseSitemapOfferUrls(xml = '') {
+  const out = [];
+  const seen = new Set();
+  const rx = /<loc>(https:\/\/jobs\.ukbb\.ch\/offer\/[^<]+)<\/loc>/g;
+  let m;
+  while ((m = rx.exec(xml))) {
+    const url = decodeEntities(m[1].trim());
+    // canonical UUID lives at the tail of the URL
+    const uuid = (url.match(/\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})(?:[/?#]|$)/i) || [])[1];
+    if (!uuid || seen.has(uuid)) continue;
+    seen.add(uuid);
+    out.push({ url, uuid });
+  }
+  return out;
+}
+
+/**
+ * Extract the first JobPosting JSON-LD object embedded in an offer page.
+ * Returns the parsed JSON object or `null`.
+ */
+export function extractJobPostingLd(html = '') {
+  const rx = /<script\s+type="application\/ld\+json">([\s\S]*?)<\/script>/gi;
+  let m;
+  while ((m = rx.exec(html))) {
+    const raw = m[1].trim();
+    if (!raw) continue;
+    try {
+      const obj = JSON.parse(raw);
+      // The portal sometimes emits a @graph array
+      const candidates = Array.isArray(obj?.['@graph']) ? obj['@graph'] : [obj];
+      for (const c of candidates) {
+        if (c?.['@type'] === 'JobPosting') return c;
+      }
+    } catch {
+      // ignore non-JSON or partial JSON-LD blocks
+    }
+  }
+  return null;
+}
+
+function unescapeLooseHtml(s = '') {
+  // JSON-LD bodies on this portal contain `<` already decoded by JSON.parse
+  // plus literal `\n` and `<br>` tags. Flatten to clean text.
+  return htmlToText(String(s));
+}
+
+function pickEmploymentType(rawType, fallbackText) {
+  if (typeof rawType === 'string' && rawType.trim()) {
+    const t = rawType.toUpperCase();
+    if (t.includes('FULL')) return 'full-time';
+    if (t.includes('PART')) return 'part-time';
+    if (t.includes('TEMP') || t.includes('CONTRACT')) return 'temporary';
+    if (t.includes('INTERN')) return 'internship';
+  }
+  if (Array.isArray(rawType) && rawType.length) {
+    return pickEmploymentType(rawType[0], fallbackText);
+  }
+  return detectHealthcareEmploymentType(fallbackText || '');
+}
+
+function pickLocation(jobLocation) {
+  if (!jobLocation) return { city: 'Basel', postalCode: POSTAL_CODE_BASEL, street: STREET_ADDRESS };
+  const loc = Array.isArray(jobLocation) ? jobLocation[0] : jobLocation;
+  const addr = loc?.address || loc || {};
+  return {
+    city: normalizeSpace(decodeEntities(addr.addressLocality || 'Basel')),
+    postalCode: normalizeSpace(decodeEntities(addr.postalCode || POSTAL_CODE_BASEL)),
+    street: normalizeSpace(decodeEntities(addr.streetAddress || STREET_ADDRESS)),
+  };
+}
+
+function pickPostedDate(raw) {
+  const s = typeof raw === 'string' ? raw.slice(0, 10) : '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
+  return new Date().toISOString().slice(0, 10);
+}
+
+/* ── Main entry ────────────────────────────────────────────── */
+
+export async function fetchAllUkbbJobs() {
+  console.log(`🏥 Fetching ${UKBB_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${SITEMAP_URL} → per-offer JSON-LD JobPosting\n`);
+
+  let xml = '';
+  try {
+    xml = await fetchHtml(SITEMAP_URL);
+  } catch (err) {
+    console.warn(`  ⚠️ UKBB sitemap fetch failed: ${err?.message || err}. Returning [].`);
+    return [];
+  }
+
+  const offers = parseSitemapOfferUrls(xml);
+  console.log(`  ✓ Sitemap lists ${offers.length} offer URLs`);
+  if (!offers.length) return [];
+
+  const jobs = [];
+  let ldHits = 0;
+  for (let i = 0; i < offers.length; i += 1) {
+    if (i > 0) await new Promise((res) => setTimeout(res, DETAIL_DELAY_MS));
+    const { url, uuid } = offers[i];
+
+    let html = '';
+    try {
+      html = await fetchHtml(url);
+    } catch (err) {
+      console.warn(`  ⚠️ Detail fetch failed (${url}): ${err?.message || err}`);
+      continue;
+    }
+    const ld = extractJobPostingLd(html);
+    if (!ld) {
+      console.warn(`  ⚠️ No JobPosting JSON-LD on ${url}`);
+      continue;
+    }
+    ldHits += 1;
+
+    const title = normalizeSpace(decodeEntities(ld.title || ''));
+    if (!title || title.length < 3) continue;
+    // Skip non-job entries (unsolicited applications + pool-closed placeholders).
+    // The portal sometimes lists a notice page as if it were a JobPosting.
+    if (/^initiativbewerbung\b/i.test(title)) continue;
+    if (title.length > 80 && /vielen dank|job-abo|momentan|im moment/i.test(title)) continue;
+
+    const description = unescapeLooseHtml(ld.description || '');
+    const safeDescription = description && description.split(/\s+/).length >= 30
+      ? description
+      : `${title} — ${UKBB_COMPANY_NAME}, Basel.\n\n${description || ''}`.trim();
+
+    const loc = pickLocation(ld.jobLocation);
+    const employmentType = pickEmploymentType(ld.employmentType, `${title} ${description}`);
+    const sourceLang = detectLang(safeDescription || title, 'de');
+    const jobSlug = slugify(`${title} ${UKBB_KEY} ${loc.city}`);
+    const urlHash = createHash('sha1').update(url).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${UKBB_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: UKBB_COMPANY_NAME,
+      companyKey: UKBB_KEY,
+      companyDomain: UKBB_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description: safeDescription,
+      descriptionByLocale: { [sourceLang]: safeDescription },
+      // Source-locale-only payload. Shared AI-localize step clears the flag
+      // when it fills IT/EN/FR; if it can't, translate-pending picks it up.
+      needsRetranslation: true,
+      location: loc.city,
+      canton: 'BS',
+      url,
+      source: 'UKBB Dedicated Parser (sitemap + JSON-LD)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: loc.city,
+      addressRegion: 'BS',
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: loc.postalCode || POSTAL_CODE_BASEL,
+      streetAddress: loc.street || STREET_ADDRESS,
+      category: detectHealthcareCategory(`${title} ${safeDescription}`),
+      contract: employmentType === 'temporary' ? 'temporary' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: pickPostedDate(ld.datePosted),
+      applyUrl: url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(`📋 Total ${UKBB_COMPANY_NAME} jobs discovered: ${jobs.length} (${ldHits}/${offers.length} with rich JSON-LD)`);
+  return jobs;
+}

--- a/scripts/update-pbl-jobs.mjs
+++ b/scripts/update-pbl-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Psychiatrie Baselland (PBL) crawler runner.
+ *
+ * Uses the standard crawler template with the PBL parser. All fetch/parse
+ * logic lives in ./lib/pbl-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllPblJobs,
+  isPblJob,
+  isTrustedDomain,
+  PBL_KEY,
+  PBL_COMPANY_NAME,
+} from './lib/pbl-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: PBL_KEY,
+  companyLabel: PBL_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllPblJobs,
+  isCompanyJob: isPblJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Psychiatrie Baselland crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-rennbahnklinik-jobs.mjs
+++ b/scripts/update-rennbahnklinik-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Rennbahnklinik (Muttenz, BL) crawler runner.
+ *
+ * Uses the standard crawler template with the Rennbahnklinik parser. All
+ * fetch/parse logic lives in ./lib/rennbahnklinik-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllRennbahnklinikJobs,
+  isRennbahnklinikJob,
+  isTrustedDomain,
+  RENNBAHNKLINIK_KEY,
+  RENNBAHNKLINIK_COMPANY_NAME,
+} from './lib/rennbahnklinik-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: RENNBAHNKLINIK_KEY,
+  companyLabel: RENNBAHNKLINIK_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllRennbahnklinikJobs,
+  isCompanyJob: isRennbahnklinikJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Rennbahnklinik crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-ukbb-jobs.mjs
+++ b/scripts/update-ukbb-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated UKBB (Universitäts-Kinderspital beider Basel) crawler runner.
+ *
+ * Uses the standard crawler template with the UKBB parser. All fetch/parse
+ * logic lives in ./lib/ukbb-job-parser.mjs.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllUkbbJobs,
+  isUkbbJob,
+  isTrustedDomain,
+  UKBB_KEY,
+  UKBB_COMPANY_NAME,
+} from './lib/ukbb-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: UKBB_KEY,
+  companyLabel: UKBB_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllUkbbJobs,
+  isCompanyJob: isUkbbJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ UKBB crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Three new dedicated hospital crawlers covering Basel-Stadt and Basel-Landschaft
hospitals on niche ATS (job-shop.com Concludis, Prospective SSR fallback,
custom Craft CMS). All ParsedJob records emitted with `needsRetranslation: true`.

| Key             | Company                                      | Canton | ATS / pattern                        | Live jobs |
|-----------------|----------------------------------------------|--------|--------------------------------------|-----------|
| ukbb            | Universitäts-Kinderspital beider Basel       | BS     | jobs.ukbb.ch sitemap + JSON-LD       | 19        |
| pbl             | Psychiatrie Baselland                        | BL     | jobs.pbl.ch SSR (Prospective shell)  | 47        |
| rennbahnklinik  | Rennbahnklinik (Muttenz)                     | BL     | rennbahnklinik.ch custom HTML        | 12        |

Net unlock: ~78 jobs once the workflows run live.

Notes:
- UKBB filters out the always-present "Initiativbewerbung" and "pool-closed"
  placeholder offers (non-jobs the portal emits as JobPosting JSON-LD).
- PBL pattern mirrors `spital-sts-job-parser.mjs`: the Prospective `/medium/`
  JSON API returns HTTP 400, so we scrape the SSR career-list pages and
  per-job detail HTML (`<section id="tasks|profile|topTitleArea">`).
  Pagination is `?offset={0,10,20,...}`; loop stops when no new UUIDs surface.
- Rennbahnklinik exposes plain `<a href="/jobs/{slug}">` cards; each detail
  page carries full prose inside `<div class="component-text">` blocks.

Skipped from Tier 4 list (did not meet ≥5-jobs threshold or no listing):
- Vista Klinik (Binningen): Ostendis OJP is CV-dropper only, no listing.
- Palliativklinik im Park (Arlesheim): 5 PDFs only — too thin to parse safely.
- Clinique de la Plaine (GE): 1 active offer.
- GMO Cité générations (GE): redirects to arsante.ch/emploi (already covered).
- Clinique du Grand-Salève (GE): 2 active offers on a single static page.
- Berner Klinik Montana (VS): already covered as `berner-klinik-montana`.
- St. Claraspital (BS): already covered as `claraspital`.
