### PR TITLE
feat: batch 17f — ZH small clinics crawlers (Uroviva, Forel, Kispi)

### DIFF
--- a/.github/workflows/update-jobs-forel-klinik.yml
+++ b/.github/workflows/update-jobs-forel-klinik.yml
@@ -1,0 +1,101 @@
+name: Update Forel Klinik Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-forel-klinik
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-forel-klinik-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated FOREL_KLINIK crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_FOREL_KLINIK_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-forel-klinik-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'forel-klinik'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/forel-klinik.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update FOREL_KLINIK jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-kispi.yml
+++ b/.github/workflows/update-jobs-kispi.yml
@@ -1,0 +1,101 @@
+name: Update Kispi Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-kispi
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-kispi-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated KISPI crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_KISPI_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-kispi-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'kispi'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/kispi.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KISPI jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-uroviva.yml
+++ b/.github/workflows/update-jobs-uroviva.yml
@@ -1,0 +1,101 @@
+name: Update Uroviva Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-uroviva
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-uroviva-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated UROVIVA crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_UROVIVA_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-uroviva-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'uroviva'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/uroviva.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update UROVIVA jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/forel-klinik-job-parser.mjs
+++ b/scripts/lib/forel-klinik-job-parser.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Forel Klinik job parser — Dualoo ATS (portal w1f713hy).
+ *
+ * Public career site: https://www.forel-klinik.ch/jobs-und-entwicklung/stellenportal/
+ *   → embeds Dualoo portal https://jobs.dualoo.com/portal/w1f713hy
+ *
+ * Forel Klinik AG is a specialised psychiatric / addiction-medicine
+ * hospital in Ellikon an der Thur (canton Zürich) with an outpatient
+ * branch in Zürich-Oerlikon. ~6 open positions across nursing,
+ * therapies and medical staff.
+ *
+ * Modelled on `klinik-arlesheim-job-parser.mjs` (same Dualoo HTML shape).
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const FOREL_KLINIK_KEY = 'forel-klinik';
+export const FOREL_KLINIK_COMPANY_NAME = 'Forel Klinik';
+export const FOREL_KLINIK_COMPANY_DOMAIN = 'forel-klinik.ch';
+
+const DUALOO_PORTAL = 'w1f713hy';
+const PORTAL_URL = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}?lang=DE`;
+const DETAIL_BASE = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}`;
+const PUBLIC_CAREER_URL = 'https://www.forel-klinik.ch/jobs-und-entwicklung/stellenportal/';
+const DETAIL_DELAY_MS = 250;
+
+const DEFAULT_CITY = 'Ellikon an der Thur';
+const DEFAULT_POSTAL_CODE = '8548';
+const CITY_POSTAL_MAP = new Map([
+  ['Ellikon an der Thur', '8548'],
+  ['Zürich', '8050'],
+]);
+
+export function isForelKlinikJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === FOREL_KLINIK_KEY
+    || url.includes('forel-klinik.ch')
+    || url.includes(`/${DUALOO_PORTAL}/`);
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'forel-klinik.ch'
+      || host.endsWith('.forel-klinik.ch')
+      || host === 'jobs.dualoo.com';
+  } catch {
+    return false;
+  }
+}
+
+export function parseDualooPortal(html) {
+  const out = [];
+  const seen = new Set();
+  // Match the entire anchor block so we can extract the jobName SPAN (richer
+  // title incl. workload %) plus the data-eventData JSON (location/startDate).
+  const blockRe = /<a[^>]*class="[^"]*\bjobElement\b[^"]*"[^>]*>[\s\S]*?<\/a>/g;
+  let m;
+  while ((m = blockRe.exec(html))) {
+    const block = m[0];
+    const hrefMatch = block.match(/\shref="([^"]+)"/);
+    const evMatch = block.match(/\sdata-eventData="([^"]+)"/);
+    const spanMatch = block.match(/<span[^>]*class="jobName"[^>]*>([\s\S]*?)<\/span>/i);
+    if (!hrefMatch) continue;
+    const rel = hrefMatch[1];
+    let meta = {};
+    if (evMatch) {
+      const evRaw = evMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&');
+      try { meta = JSON.parse(evRaw); } catch { meta = {}; }
+    }
+    const spanTitle = spanMatch
+      ? normalizeSpace(decodeEntities(spanMatch[1].replace(/<[^>]+>/g, ' ')))
+      : '';
+    const evTitle = normalizeSpace(decodeEntities(String(meta.jobName || '')));
+    const title = spanTitle || evTitle;
+    if (!title || title.length < 3) continue;
+    const uuidMatch = rel.match(/([a-f0-9-]{36})\/detail/);
+    const uuid = uuidMatch ? uuidMatch[1] : rel;
+    if (seen.has(uuid)) continue;
+    seen.add(uuid);
+    const url = rel.startsWith('http')
+      ? rel
+      : `${DETAIL_BASE}/${rel.replace(new RegExp(`^${DUALOO_PORTAL}/`), '')}`;
+    out.push({
+      uuid,
+      url,
+      title,
+      location: normalizeSpace(decodeEntities(String(meta.location || ''))),
+      startDate: normalizeSpace(decodeEntities(String(meta.startDate || ''))),
+    });
+  }
+  return out;
+}
+
+async function fetchDualooDetail(detailUrl) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    const sections = [];
+    const grab = (cls, label) => {
+      const rx = new RegExp(`class="${cls}"[^>]*>([\\s\\S]*?)</div>`, 'i');
+      const mm = html.match(rx);
+      if (!mm) return;
+      const text = mm[1]
+        .replace(/<li[^>]*>/gi, '\n• ')
+        .replace(/<\/li>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/\s+\n/g, '\n')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+      if (text) sections.push(`${label}\n${text}`);
+    };
+    grab('advertisementResponsibilitiesText', 'Aufgaben:');
+    grab('advertisementRequirementsText', 'Anforderungen:');
+    grab('advertisementBenefitsText', 'Wir bieten:');
+    return sections.join('\n\n');
+  } catch {
+    return '';
+  }
+}
+
+function extractCity(rawLocation) {
+  if (!rawLocation) return DEFAULT_CITY;
+  const parts = rawLocation.split(/\s*-\s*/).map((s) => s.trim()).filter(Boolean);
+  const last = parts[parts.length - 1] || DEFAULT_CITY;
+  if (CITY_POSTAL_MAP.has(last)) return last;
+  // Fallback: keep last token of last segment
+  const tokens = last.split(/\s+/);
+  return tokens.length >= 3 ? last : (tokens[tokens.length - 1] || DEFAULT_CITY);
+}
+
+function postalFor(city) {
+  return CITY_POSTAL_MAP.get(city) || DEFAULT_POSTAL_CODE;
+}
+
+export async function fetchAllForelKlinikJobs() {
+  console.log(`🏥 Fetching ${FOREL_KLINIK_COMPANY_NAME} jobs`);
+  console.log(`   Portal: ${PORTAL_URL}`);
+  console.log(`   Public: ${PUBLIC_CAREER_URL}\n`);
+
+  const html = await fetchHtml(PORTAL_URL);
+  const items = parseDualooPortal(html);
+  console.log(`  ✓ ${items.length} Dualoo job cards parsed`);
+  if (!items.length) return [];
+  console.log(`  📄 Fetching detail pages for rich descriptions...`);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let detailHits = 0;
+  for (let i = 0; i < items.length; i += 1) {
+    const it = items[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+    const detailContent = await fetchDualooDetail(it.url);
+    if (detailContent) detailHits += 1;
+
+    const city = extractCity(it.location);
+    const description = [
+      detailContent,
+      it.location ? `Standort: ${it.location}` : '',
+      it.startDate ? `Eintritt: ${it.startDate}` : '',
+      `${FOREL_KLINIK_COMPANY_NAME} — Suchtmedizinische Fachklinik in Ellikon an der Thur (Kanton Zürich).`,
+    ].filter(Boolean).join('\n\n');
+
+    const sourceLang = detectLang(description || it.title, 'de');
+    const jobSlug = slugify(`${it.title} ${FOREL_KLINIK_KEY} ${city}`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${FOREL_KLINIK_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: FOREL_KLINIK_COMPANY_NAME,
+      companyKey: FOREL_KLINIK_KEY,
+      companyDomain: FOREL_KLINIK_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
+      location: city,
+      canton: 'ZH',
+      url: it.url,
+      source: `${FOREL_KLINIK_COMPANY_NAME} Dedicated Parser (Dualoo)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: city,
+      addressRegion: 'ZH',
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: postalFor(city),
+      category: detectHealthcareCategory(it.title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(it.title),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(
+    `📋 Total ${FOREL_KLINIK_COMPANY_NAME} jobs discovered: ${jobs.length} `
+    + `(${detailHits}/${items.length} with rich detail content)`,
+  );
+  return jobs;
+}
+
+export { PUBLIC_CAREER_URL, PORTAL_URL, DUALOO_PORTAL };

--- a/scripts/lib/kispi-job-parser.mjs
+++ b/scripts/lib/kispi-job-parser.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Universitäts-Kinderspital Zürich (Kispi) job parser — Prospective.ch career
+ * center (white-label HTML at `stellen.kispi-jobs.ch`).
+ *
+ * Public career site: https://www.kispi.uzh.ch/jobs/offene-stellen
+ *   → embeds iframe → https://stellen.kispi-jobs.ch/?lang=de
+ *   The iframe is a static HTML listing (one anchor per vacancy under
+ *   `/offene-stellen/{slug}/{uuid}`).
+ *
+ * Detail pages expose a single `schema.org/JobPosting` JSON-LD `<script>` tag
+ * with the full canonical fields (title via `<title>`, `description`,
+ * `datePosted`, `validThrough`, `jobLocation.address`, `employmentType`,
+ * `baseSalary`). We rely on JSON-LD as the source of truth.
+ *
+ * Note: there's no public JSON listing endpoint — the Prospective backend
+ * gates ohws.prospective.ch behind tenant credentials — but the HTML listing
+ * is fully server-rendered, so a single GET returns all open vacancies.
+ *
+ * Kispi has ~3'000 employees and is the largest paediatric hospital in
+ * Switzerland (canton Zürich); typically 50+ open positions.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const KISPI_KEY = 'kispi';
+export const KISPI_COMPANY_NAME = 'Universitäts-Kinderspital Zürich';
+export const KISPI_COMPANY_DOMAIN = 'kispi.uzh.ch';
+
+const LISTING_URL = 'https://stellen.kispi-jobs.ch/?lang=de';
+const PUBLIC_CAREER_URL = 'https://www.kispi.uzh.ch/jobs/offene-stellen';
+const DETAIL_DELAY_MS = 250;
+
+const DEFAULT_CITY = 'Zürich';
+const DEFAULT_POSTAL_CODE = '8032';
+const DEFAULT_STREET = 'Lenggstrasse 30';
+
+export function isKispiJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === KISPI_KEY
+    || url.includes('kispi.uzh.ch')
+    || url.includes('stellen.kispi-jobs.ch')
+    || url.includes('kispi-jobs.ch');
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'kispi.uzh.ch'
+      || host.endsWith('.kispi.uzh.ch')
+      || host === 'kispi-jobs.ch'
+      || host.endsWith('.kispi-jobs.ch');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse the white-label listing HTML and return all unique vacancy URLs.
+ *
+ * Anchor shape:
+ *   <a href="https://stellen.kispi-jobs.ch/offene-stellen/{slug}/{uuid}">
+ */
+export function parseKispiListing(html) {
+  const out = [];
+  const seen = new Set();
+  const rx = /href="(https:\/\/stellen\.kispi-jobs\.ch\/offene-stellen\/[^"]+)"/g;
+  let m;
+  while ((m = rx.exec(html))) {
+    const url = m[1];
+    const uuidMatch = url.match(/\/([a-f0-9-]{36})(?:\?|#|$)/);
+    const uuid = uuidMatch ? uuidMatch[1] : url;
+    if (seen.has(uuid)) continue;
+    seen.add(uuid);
+    out.push({ uuid, url });
+  }
+  return out;
+}
+
+/**
+ * Extract the JSON-LD JobPosting block from a detail page.
+ * Returns null if missing or unparseable.
+ */
+function extractJobPostingLd(html) {
+  const blocks = [];
+  const rx = /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
+  let m;
+  while ((m = rx.exec(html))) {
+    blocks.push(m[1].trim());
+  }
+  for (const raw of blocks) {
+    try {
+      const parsed = JSON.parse(raw);
+      const candidates = Array.isArray(parsed) ? parsed : [parsed];
+      for (const c of candidates) {
+        if (c && (c['@type'] === 'JobPosting' || (Array.isArray(c['@type']) && c['@type'].includes('JobPosting')))) {
+          return c;
+        }
+      }
+    } catch {
+      // Try a permissive cleanup pass: strip trailing commas
+      try {
+        const cleaned = raw.replace(/,\s*([}\]])/g, '$1');
+        const parsed = JSON.parse(cleaned);
+        if (parsed && parsed['@type'] === 'JobPosting') return parsed;
+      } catch {
+        // give up on this block
+      }
+    }
+  }
+  return null;
+}
+
+function extractTitleFromHtml(html) {
+  // <title>Kinderspital Zürich: {TITLE}</title>
+  const m = html.match(/<title>([\s\S]*?)<\/title>/i);
+  if (!m) return '';
+  const raw = normalizeSpace(decodeEntities(m[1])).replace(/<[^>]+>/g, '');
+  return raw.replace(/^Kinderspital\s+Zürich:\s*/i, '').trim();
+}
+
+function extractMetaDescription(html) {
+  const m = html.match(/<meta[^>]+name="description"[^>]+content="([^"]*)"/i);
+  if (!m) return '';
+  return normalizeSpace(decodeEntities(m[1]));
+}
+
+function normaliseEmploymentType(raw) {
+  if (!raw) return 'full-time';
+  const s = String(Array.isArray(raw) ? raw[0] : raw).toUpperCase();
+  if (s.includes('PART')) return 'part-time';
+  if (s.includes('TEMP') || s.includes('CONTRACT')) return 'contract';
+  if (s.includes('INTERN')) return 'internship';
+  return 'full-time';
+}
+
+async function fetchDetail(url) {
+  try {
+    const html = await fetchHtml(url);
+    if (!html) return null;
+    const ld = extractJobPostingLd(html);
+    const titleFromHtml = extractTitleFromHtml(html);
+    const metaDesc = extractMetaDescription(html);
+    return { html, ld, titleFromHtml, metaDesc };
+  } catch (err) {
+    console.warn(`  ⚠️ detail fetch failed (${url}): ${err?.message || err}`);
+    return null;
+  }
+}
+
+export async function fetchAllKispiJobs() {
+  console.log(`🏥 Fetching ${KISPI_COMPANY_NAME} jobs`);
+  console.log(`   Listing: ${LISTING_URL}`);
+  console.log(`   Public:  ${PUBLIC_CAREER_URL}\n`);
+
+  const listingHtml = await fetchHtml(LISTING_URL);
+  const items = parseKispiListing(listingHtml);
+  console.log(`  ✓ ${items.length} vacancy URLs parsed from listing`);
+  if (!items.length) return [];
+  console.log(`  📄 Fetching detail pages for JSON-LD JobPosting payloads...`);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let ldHits = 0;
+
+  for (let i = 0; i < items.length; i += 1) {
+    const it = items[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+    const detail = await fetchDetail(it.url);
+    if (!detail) continue;
+    const ld = detail.ld || {};
+    if (detail.ld) ldHits += 1;
+
+    const title = normalizeSpace(decodeEntities(String(ld.title || detail.titleFromHtml || '')));
+    if (!title || title.length < 3) continue;
+
+    const descriptionHtml = String(ld.description || '');
+    const descriptionText = descriptionHtml
+      ? normalizeSpace(htmlToText(descriptionHtml)).slice(0, 6000)
+      : detail.metaDesc;
+    const description = descriptionText
+      || `${title} — ${KISPI_COMPANY_NAME}, Zürich.`;
+
+    const address = (ld.jobLocation && ld.jobLocation.address) || {};
+    const city = normalizeSpace(decodeEntities(String(address.addressLocality || DEFAULT_CITY)));
+    const street = normalizeSpace(decodeEntities(String(address.streetAddress || DEFAULT_STREET)));
+    const postal = String(address.postalCode || DEFAULT_POSTAL_CODE);
+    const datePostedRaw = String(ld.datePosted || '').slice(0, 10);
+    const datePosted = /^\d{4}-\d{2}-\d{2}$/.test(datePostedRaw) ? datePostedRaw : todayIso;
+    const employmentType = normaliseEmploymentType(ld.employmentType);
+
+    const sourceLang = detectLang(description || title, 'de');
+    const jobSlug = slugify(`${title} ${KISPI_KEY} ${city}`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${KISPI_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: KISPI_COMPANY_NAME,
+      companyKey: KISPI_KEY,
+      companyDomain: KISPI_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
+      location: city,
+      canton: 'ZH',
+      url: it.url,
+      source: `${KISPI_COMPANY_NAME} Dedicated Parser (Prospective careercenter HTML)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: city,
+      addressRegion: 'ZH',
+      addressCountry: 'CH',
+      country: 'CH',
+      streetAddress: street,
+      postalCode: postal,
+      category: detectHealthcareCategory(title),
+      contract: employmentType === 'part-time' ? 'part-time' : 'full-time',
+      employmentType: employmentType === 'full-time'
+        ? detectHealthcareEmploymentType(title)
+        : employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: datePosted,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(
+    `📋 Total ${KISPI_COMPANY_NAME} jobs discovered: ${jobs.length} `
+    + `(${ldHits}/${items.length} via JSON-LD)`,
+  );
+  return jobs;
+}
+
+export { LISTING_URL, PUBLIC_CAREER_URL };

--- a/scripts/lib/uroviva-job-parser.mjs
+++ b/scripts/lib/uroviva-job-parser.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * Uroviva job parser — Dualoo ATS (portal nthmjmb4).
+ *
+ * Public career site: https://www.uroviva.ch/de/ueber-uns/offene-stellen
+ *   → embeds Dualoo portal https://jobs.dualoo.com/portal/nthmjmb4
+ *
+ * Uroviva AG is a Swiss specialist for urology with locations in
+ * Bülach (head office, Klinik für Urologie), Zürich (Stadelhofen,
+ * Andrologiezentrum, Wengistrasse), Horgen (See-Spital), and
+ * Schlieren (Spital Limmattal). Single Dualoo portal serves all sites.
+ *
+ * Modelled on `klinik-arlesheim-job-parser.mjs`.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const UROVIVA_KEY = 'uroviva';
+export const UROVIVA_COMPANY_NAME = 'Uroviva';
+export const UROVIVA_COMPANY_DOMAIN = 'uroviva.ch';
+
+const DUALOO_PORTAL = 'nthmjmb4';
+const PORTAL_URL = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}?lang=DE`;
+const DETAIL_BASE = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}`;
+const PUBLIC_CAREER_URL = 'https://www.uroviva.ch/de/ueber-uns/offene-stellen';
+const DETAIL_DELAY_MS = 250;
+
+// Most Uroviva positions are at the head clinic in Bülach (8180).
+const DEFAULT_CITY = 'Bülach';
+const DEFAULT_POSTAL_CODE = '8180';
+
+// City → postal code mapping for known Uroviva sites (best-effort defaults;
+// the AI translation step does not need this to be exact, but it improves
+// JSON-LD `jobLocation` quality on the static-page side).
+const CITY_POSTAL_MAP = new Map([
+  ['Bülach', '8180'],
+  ['Zürich', '8001'],
+  ['Stadelhofen', '8001'],
+  ['Horgen', '8810'],
+  ['Schlieren', '8952'],
+]);
+
+export function isUrovivaJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === UROVIVA_KEY
+    || url.includes('uroviva.ch')
+    || url.includes(`/${DUALOO_PORTAL}/`);
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'uroviva.ch'
+      || host.endsWith('.uroviva.ch')
+      || host === 'jobs.dualoo.com';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse the Dualoo portal HTML listing.
+ *
+ * Each card uses `<a class="row jobElement">` with a `data-eventData` JSON blob
+ * carrying `jobName`, `startDate`, and `location` (city + entity).
+ */
+export function parseDualooPortal(html) {
+  const out = [];
+  const seen = new Set();
+  // Match the entire anchor block so we can extract jobName SPAN (which carries
+  // the workload percentage, e.g. "… 40-50%") along with the data-eventData
+  // JSON (which carries location and startDate).
+  const blockRe = /<a[^>]*class="[^"]*\bjobElement\b[^"]*"[^>]*>[\s\S]*?<\/a>/g;
+  let m;
+  while ((m = blockRe.exec(html))) {
+    const block = m[0];
+    const hrefMatch = block.match(/\shref="([^"]+)"/);
+    const evMatch = block.match(/\sdata-eventData="([^"]+)"/);
+    const spanMatch = block.match(/<span[^>]*class="jobName"[^>]*>([\s\S]*?)<\/span>/i);
+    if (!hrefMatch) continue;
+    const rel = hrefMatch[1];
+    let meta = {};
+    if (evMatch) {
+      const evRaw = evMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&');
+      try { meta = JSON.parse(evRaw); } catch { meta = {}; }
+    }
+    const spanTitle = spanMatch
+      ? normalizeSpace(decodeEntities(spanMatch[1].replace(/<[^>]+>/g, ' ')))
+      : '';
+    const evTitle = normalizeSpace(decodeEntities(String(meta.jobName || '')));
+    const title = spanTitle || evTitle;
+    if (!title || title.length < 3) continue;
+    const uuidMatch = rel.match(/([a-f0-9-]{36})\/detail/);
+    const uuid = uuidMatch ? uuidMatch[1] : rel;
+    if (seen.has(uuid)) continue;
+    seen.add(uuid);
+    const url = rel.startsWith('http')
+      ? rel
+      : `${DETAIL_BASE}/${rel.replace(new RegExp(`^${DUALOO_PORTAL}/`), '')}`;
+    out.push({
+      uuid,
+      url,
+      title,
+      location: normalizeSpace(decodeEntities(String(meta.location || ''))),
+      startDate: normalizeSpace(decodeEntities(String(meta.startDate || ''))),
+    });
+  }
+  return out;
+}
+
+async function fetchDualooDetail(detailUrl) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    const sections = [];
+    const grab = (cls, label) => {
+      const rx = new RegExp(`class="${cls}"[^>]*>([\\s\\S]*?)</div>`, 'i');
+      const mm = html.match(rx);
+      if (!mm) return;
+      const text = mm[1]
+        .replace(/<li[^>]*>/gi, '\n• ')
+        .replace(/<\/li>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/\s+\n/g, '\n')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+      if (text) sections.push(`${label}\n${text}`);
+    };
+    grab('advertisementResponsibilitiesText', 'Aufgaben:');
+    grab('advertisementRequirementsText', 'Anforderungen:');
+    grab('advertisementBenefitsText', 'Wir bieten:');
+    return sections.join('\n\n');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Extract a clean city name from the Dualoo `location` field which is shaped
+ * like "Uroviva AG - Stadelhofen" or "Uroviva Klinik AG - Bülach".
+ */
+function extractCity(rawLocation) {
+  if (!rawLocation) return DEFAULT_CITY;
+  // Last "- xxx" segment is the city
+  const parts = rawLocation.split(/\s*-\s*/).map((s) => s.trim()).filter(Boolean);
+  const last = parts[parts.length - 1] || DEFAULT_CITY;
+  // Strip site prefixes like "See-Spital Horgen" → keep last token (city)
+  const tokens = last.split(/\s+/);
+  return tokens[tokens.length - 1] || DEFAULT_CITY;
+}
+
+function postalFor(city) {
+  return CITY_POSTAL_MAP.get(city) || DEFAULT_POSTAL_CODE;
+}
+
+export async function fetchAllUrovivaJobs() {
+  console.log(`🏥 Fetching ${UROVIVA_COMPANY_NAME} jobs`);
+  console.log(`   Portal: ${PORTAL_URL}`);
+  console.log(`   Public: ${PUBLIC_CAREER_URL}\n`);
+
+  const html = await fetchHtml(PORTAL_URL);
+  const items = parseDualooPortal(html);
+  console.log(`  ✓ ${items.length} Dualoo job cards parsed`);
+  if (!items.length) return [];
+  console.log(`  📄 Fetching detail pages for rich descriptions...`);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let detailHits = 0;
+  for (let i = 0; i < items.length; i += 1) {
+    const it = items[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+    const detailContent = await fetchDualooDetail(it.url);
+    if (detailContent) detailHits += 1;
+
+    const city = extractCity(it.location);
+    const description = [
+      detailContent,
+      it.location ? `Standort: ${it.location}` : '',
+      it.startDate ? `Eintritt: ${it.startDate}` : '',
+      `${UROVIVA_COMPANY_NAME} — Schweizer Spezialist für Urologie mit Sitz in Bülach.`,
+    ].filter(Boolean).join('\n\n');
+
+    const sourceLang = detectLang(description || it.title, 'de');
+    const jobSlug = slugify(`${it.title} ${UROVIVA_KEY} ${city}`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${UROVIVA_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: UROVIVA_COMPANY_NAME,
+      companyKey: UROVIVA_KEY,
+      companyDomain: UROVIVA_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
+      location: city,
+      canton: 'ZH',
+      url: it.url,
+      source: `${UROVIVA_COMPANY_NAME} Dedicated Parser (Dualoo)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: city,
+      addressRegion: 'ZH',
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: postalFor(city),
+      category: detectHealthcareCategory(it.title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(it.title),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(
+    `📋 Total ${UROVIVA_COMPANY_NAME} jobs discovered: ${jobs.length} `
+    + `(${detailHits}/${items.length} with rich detail content)`,
+  );
+  return jobs;
+}
+
+export { PUBLIC_CAREER_URL, PORTAL_URL, DUALOO_PORTAL };

--- a/scripts/update-forel-klinik-jobs.mjs
+++ b/scripts/update-forel-klinik-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Forel Klinik crawler runner.
+ *
+ * Uses the standard crawler template with the Forel Klinik parser
+ * (Dualoo — single portal `w1f713hy`).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllForelKlinikJobs,
+  isForelKlinikJob,
+  isTrustedDomain,
+  FOREL_KLINIK_KEY,
+  FOREL_KLINIK_COMPANY_NAME,
+} from './lib/forel-klinik-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: FOREL_KLINIK_KEY,
+  companyLabel: FOREL_KLINIK_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllForelKlinikJobs,
+  isCompanyJob: isForelKlinikJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Forel Klinik crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-kispi-jobs.mjs
+++ b/scripts/update-kispi-jobs.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Universitäts-Kinderspital Zürich (Kispi) crawler runner.
+ *
+ * Uses the standard crawler template with the Kispi parser
+ * (Prospective.ch career-center, white-label HTML at
+ * `stellen.kispi-jobs.ch`; JSON-LD JobPosting per detail page).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllKispiJobs,
+  isKispiJob,
+  isTrustedDomain,
+  KISPI_KEY,
+  KISPI_COMPANY_NAME,
+} from './lib/kispi-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: KISPI_KEY,
+  companyLabel: KISPI_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllKispiJobs,
+  isCompanyJob: isKispiJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Kispi crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-uroviva-jobs.mjs
+++ b/scripts/update-uroviva-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Uroviva crawler runner.
+ *
+ * Uses the standard crawler template with the Uroviva parser
+ * (Dualoo — single portal `nthmjmb4`).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllUrovivaJobs,
+  isUrovivaJob,
+  isTrustedDomain,
+  UROVIVA_KEY,
+  UROVIVA_COMPANY_NAME,
+} from './lib/uroviva-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: UROVIVA_KEY,
+  companyLabel: UROVIVA_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllUrovivaJobs,
+  isCompanyJob: isUrovivaJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Uroviva crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Three new dedicated hospital crawlers covering uncovered ZH-canton clinics
from docs/HOSPITAL-CRAWLERS-INVENTORY-2026-05-19.md §4:

| Crawler        | ATS                                       | Smoke count |
|----------------|-------------------------------------------|-------------|
| uroviva        | Dualoo (portal nthmjmb4)                  | 9           |
| forel-klinik   | Dualoo (portal w1f713hy)                  | 6           |
| kispi          | Prospective career-center (HTML+JSON-LD)  | 53          |

Each tenant ships parser + runner + workflow:
- scripts/lib/<key>-job-parser.mjs
- scripts/update-<key>-jobs.mjs
- .github/workflows/update-jobs-<key>.yml

Uroviva and Forel reuse the proven Dualoo HTML pattern (Klinik Arlesheim
template) with one small enhancement: titles are now sourced from the
<span class="jobName"> element so workload percentages (e.g. "40-50%")
are preserved — `data-eventData.jobName` strips them.

Kispi scrapes the white-label Prospective listing at stellen.kispi-jobs.ch
(server-rendered HTML, 50+ vacancies on one page) and pulls full job
content from per-detail schema.org/JobPosting JSON-LD blocks: title,
description, datePosted, jobLocation.address, employmentType, baseSalary.

All ParsedJob entries set `needsRetranslation: true` so the AI
localisation step fills EN/FR/IT.
