### PR TITLE
feat: ZH residual hospital crawlers — NSN Medical + Klinik Susenberg + Vista

### DIFF
--- a/.github/workflows/update-jobs-klinik-susenberg.yml
+++ b/.github/workflows/update-jobs-klinik-susenberg.yml
@@ -1,0 +1,101 @@
+name: Update Klinik Susenberg Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-klinik-susenberg
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-klinik-susenberg-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated Klinik Susenberg crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_KLINIK_SUSENBERG_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-klinik-susenberg-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'klinik-susenberg'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/klinik-susenberg.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Klinik Susenberg jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-nsn-medical.yml
+++ b/.github/workflows/update-jobs-nsn-medical.yml
@@ -1,0 +1,101 @@
+name: Update NSN Medical Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-nsn-medical
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-nsn-medical-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated NSN Medical crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_NSN_MEDICAL_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-nsn-medical-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'nsn-medical'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/nsn-medical.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update NSN Medical jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-vista.yml
+++ b/.github/workflows/update-jobs-vista.yml
@@ -1,0 +1,101 @@
+name: Update Vista Augenpraxen & Kliniken Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-vista
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-vista-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated Vista crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_VISTA_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-vista-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'vista'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/vista.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Vista jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/klinik-susenberg-job-parser.mjs
+++ b/scripts/lib/klinik-susenberg-job-parser.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Klinik Susenberg job parser — custom TYPO3 HTML.
+ *
+ * Public career site: https://www.susenbergklinik.ch/jobs/offene-stellen
+ *
+ * The page is server-rendered TYPO3 markup. Each open position is published
+ * as a PDF on `/fileadmin/user_upload/Stellen/`, surfaced in the HTML as:
+ *
+ *   <a class="download-link-linkicon"
+ *      href="/fileadmin/user_upload/Stellen/<file>.pdf"
+ *      target="_blank"
+ *      title="{HUMAN_READABLE_TITLE}">
+ *
+ * Grouping is implicit via `<h2 class="hf-header">{SECTION}</h2>` siblings
+ * (e.g. "Pflege", "Therapien", "Ärztlicher Dienst"). We carry the most
+ * recent section heading forward to build a department label for each PDF.
+ *
+ * Klinik Susenberg is a privately-run acute-geriatric / palliative-care /
+ * oncological-rehab Klinik at Schreberweg 9, 8044 Zürich (canton ZH). Founded
+ * 1899, ~80 beds, ~150 employees. Body length is short (3-5 jobs), so we
+ * synthesise a richer fallback description so the locale-completeness gate
+ * has enough text to translate from.
+ *
+ * Domain note: the historic `www.klinik-susenberg.ch` 301-redirects to
+ * `https://www.susenbergklinik.ch/`.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/**
+ * The Susenberg TYPO3 backend rejects the bot User-Agent with HTTP 406. Fall
+ * back to a stock browser UA + a permissive Accept header. Same trick used by
+ * a handful of other Swiss hospital parsers behind ModSecurity / TYPO3
+ * dynamic-cache rules.
+ */
+const BROWSER_USER_AGENT = process.env.JOBS_CRAWLER_BROWSER_USER_AGENT
+  || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36';
+
+async function fetchHtml(url) {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      redirect: 'follow',
+      headers: {
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
+        'User-Agent': BROWSER_USER_AGENT,
+      },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+    return await res.text();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+export const KLINIK_SUSENBERG_KEY = 'klinik-susenberg';
+export const KLINIK_SUSENBERG_COMPANY_NAME = 'Klinik Susenberg';
+export const KLINIK_SUSENBERG_COMPANY_DOMAIN = 'susenbergklinik.ch';
+
+const CAREER_URL = 'https://www.susenbergklinik.ch/jobs/offene-stellen';
+const BASE_URL = 'https://www.susenbergklinik.ch';
+const DEFAULT_CITY = 'Zürich';
+const DEFAULT_POSTAL_CODE = '8044';
+const DEFAULT_STREET = 'Schreberweg 9';
+const DEFAULT_CANTON = 'ZH';
+
+const COMPANY_BOILERPLATE = "Die Klinik Susenberg ist eine privat geführte Klinik am Zürichberg, spezialisiert auf Akutgeriatrie, internistisch-onkologische Rehabilitation und Palliative Care. Wir bieten attraktive Anstellungsbedingungen und ein angenehmes Arbeitsklima in interprofessionellen Teams an schönster Lage in Zürich.";
+
+export function isKlinikSusenbergJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  if (job?.companyKey === KLINIK_SUSENBERG_KEY) return true;
+  if (url.includes('susenbergklinik.ch')) return true;
+  if (url.includes('klinik-susenberg.ch')) return true;
+  const company = String(job?.company || '').toLowerCase();
+  if (/\bklinik susenberg\b/.test(company)) return true;
+  return false;
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'susenbergklinik.ch' || host.endsWith('.susenbergklinik.ch')) return true;
+    if (host === 'klinik-susenberg.ch' || host.endsWith('.klinik-susenberg.ch')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse the HTML of `/jobs/offene-stellen` into a list of
+ * `{ url, title, department }` rows. Department is the most recent
+ * `<h2 class="hf-header">` heading encountered before the PDF link.
+ */
+export function parseSusenbergJobsPage(html = '') {
+  const out = [];
+  const seen = new Set();
+  // Scan top-down, tracking the active department heading. Anchors are emitted
+  // inside `<ul class="ce-uploads">` blocks that come right after the H2.
+  const pattern = /<h2[^>]*class="hf-header"[^>]*>\s*([^<]+?)\s*<\/h2>|<a[^>]*class="[^"]*download-link-linkicon[^"]*"[^>]*href="(\/fileadmin\/user_upload\/Stellen\/[^"]+\.pdf)"[^>]*title="([^"]+)"/g;
+  let department = '';
+  let m;
+  while ((m = pattern.exec(html)) !== null) {
+    if (m[1]) {
+      department = normalizeSpace(decodeEntities(m[1]));
+      continue;
+    }
+    const href = m[2];
+    const title = normalizeSpace(decodeEntities(m[3]));
+    if (!title || title.length < 3) continue;
+    const url = href.startsWith('http') ? href : `${BASE_URL}${href}`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    out.push({ url, title, department });
+  }
+  return out;
+}
+
+function buildDescription(row) {
+  const sentences = [
+    `${row.title} bei der ${KLINIK_SUSENBERG_COMPANY_NAME}, ${DEFAULT_STREET}, ${DEFAULT_POSTAL_CODE} ${DEFAULT_CITY}, Schweiz.`,
+  ];
+  if (row.department) {
+    sentences.push(`Tätigkeitsbereich: ${row.department}.`);
+  }
+  sentences.push(COMPANY_BOILERPLATE);
+  sentences.push('Detailliertes Stellenprofil und Bewerbungsunterlagen siehe verlinktes PDF.');
+  return sentences.join(' ');
+}
+
+function parsePostedDate(href = '') {
+  // PDFs frequently end with `_YYYY-MM-DD.pdf` — use that as the post date when present.
+  const m = String(href).match(/_(\d{4})-(\d{2})-(\d{2})\.pdf$/i);
+  if (m) {
+    const iso = `${m[1]}-${m[2]}-${m[3]}`;
+    if (!Number.isNaN(new Date(iso).getTime())) return iso;
+  }
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function fetchAllKlinikSusenbergJobs() {
+  console.log(`🏥 Fetching ${KLINIK_SUSENBERG_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  const html = await fetchHtml(CAREER_URL);
+  const rows = parseSusenbergJobsPage(html);
+  console.log(`  ✓ ${rows.length} job PDFs discovered`);
+  if (!rows.length) return [];
+
+  const jobs = [];
+  for (const r of rows) {
+    const description = buildDescription(r);
+    const sourceLang = detectLang(description || r.title, 'de');
+    const jobSlug = slugify(`${r.title} ${KLINIK_SUSENBERG_KEY} ${DEFAULT_CITY}`);
+    const urlHash = createHash('sha1').update(r.url).digest('hex').slice(0, 12);
+    const postedDate = parsePostedDate(r.url);
+
+    jobs.push({
+      id: `${KLINIK_SUSENBERG_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: KLINIK_SUSENBERG_COMPANY_NAME,
+      companyKey: KLINIK_SUSENBERG_KEY,
+      companyDomain: KLINIK_SUSENBERG_COMPANY_DOMAIN,
+      title: r.title,
+      titleByLocale: { [sourceLang]: r.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url: r.url,
+      source: `${KLINIK_SUSENBERG_COMPANY_NAME} Dedicated Parser (TYPO3 PDF listing)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL_CODE,
+      streetAddress: DEFAULT_STREET,
+      category: detectHealthcareCategory(r.title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(r.title),
+      experienceLevel: detectHealthcareExperienceLevel(r.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate,
+      applyUrl: CAREER_URL,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+      ...(r.department ? { department: r.department } : {}),
+    });
+  }
+
+  console.log(`\n📋 Total ${KLINIK_SUSENBERG_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}
+
+export { CAREER_URL, BASE_URL };

--- a/scripts/lib/nsn-medical-job-parser.mjs
+++ b/scripts/lib/nsn-medical-job-parser.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * NSN Medical Group job parser — Umantis tenant 2884.
+ *
+ * NSN medical AG (https://nsn.ch/) is a Zürich-based medical services group
+ * whose career portal hosts open positions for several affiliated entities
+ * under a single Umantis tenant:
+ *   - NSN medical AG            (group HQ, Zürich)
+ *   - Zentrum für integrative Onkologie (ZIO) — Zürichsee, Zürich-Oerlikon
+ *   - narkose.ch                (mobile anaesthesia, Raum Zürich/Winterthur)
+ *   - Limmatklinik              (acute private clinic, Zürich) — linked via nsn.ch/jobs/
+ *   - Eulachklinik Winterthur   (acute private clinic, Winterthur) — linked via nsn.ch/jobs/
+ *
+ * Public career hub: https://nsn.ch/jobs/
+ *   → iframes / embeds  https://recruitingapp-2884.umantis.com/Jobs/All?lang=ger
+ *
+ * Older Umantis UI (`tableaslist_contentrow{1|2}`): the per-row company name is
+ * surfaced in `tableaslist_element_1152486` (first text span); the parser
+ * factory picks that up as `entry.companyValue`. Region label is always
+ * "Region Zürich" — `inferSwissTargetCanton()` resolves to ZH.
+ *
+ * Both Limmatklinik (www.limmatklinik.ch) and Eulachklinik (eulachklinik.ch)
+ * point their public "Jobs" CTA to https://nsn.ch/jobs/, so this single parser
+ * is the canonical entry point for the whole NSN Medical group regardless of
+ * which sister site advertises a vacancy.
+ */
+import { createUmantisListingParser } from './umantis-listing-common.mjs';
+
+export const NSN_MEDICAL_KEY = 'nsn-medical';
+export const NSN_MEDICAL_COMPANY_NAME = 'NSN Medical Group';
+export const NSN_MEDICAL_COMPANY_DOMAIN = 'nsn.ch';
+
+const parser = createUmantisListingParser({
+  companyKey: NSN_MEDICAL_KEY,
+  companyName: NSN_MEDICAL_COMPANY_NAME,
+  companyDomain: NSN_MEDICAL_COMPANY_DOMAIN,
+  tenantId: 2884,
+  lang: 'ger',
+  defaultCanton: 'ZH',
+  defaultCity: 'Zürich',
+  defaultPostalCode: '8001',
+  publicCareerUrl: 'https://nsn.ch/jobs/',
+  defaultSourceLang: 'de',
+});
+
+export const fetchAllNsnMedicalJobs = parser.fetchAllJobs;
+export const isNsnMedicalJob = parser.isCompanyJob;
+export const isTrustedDomain = parser.isTrustedDomain;

--- a/scripts/lib/vista-job-parser.mjs
+++ b/scripts/lib/vista-job-parser.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+/**
+ * Vista Augenpraxen & Kliniken job parser — Ostendis JobPublisher API.
+ *
+ * Public career site: https://vista.ch/ueber-uns/karriere/
+ *
+ * Vista is a national network of ophthalmology practices and clinics,
+ * headquartered in Binningen (BL). The career page embeds the Ostendis
+ * JobPublisher widget, which fetches structured listings from:
+ *
+ *   GET https://odm.ostendis.com/ojp/data/v54/jobs/{token}/DE?domain=vista.ch
+ *
+ * Each Ostendis job entry carries `city` and `zip`, so we resolve the canton
+ * per job via `inferAnyCanton()` instead of falling back to the company HQ.
+ * Vista vacancies span ZH (Zürich), BL (Binningen, Liestal), AG (Brugg,
+ * Dättwil), BS (Basel), BE (Burgdorf), etc.
+ *
+ * Detail pages are at `link.ostendis.com/publication/{slug}/{hash}` and
+ * carry a JSON-LD `JobPosting` block — the same enrichment pattern used by
+ * RSS Surselva.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
+import { inferAnyCanton } from './target-swiss-locations.mjs';
+
+export const VISTA_KEY = 'vista';
+export const VISTA_COMPANY_NAME = 'Vista Augenpraxen & Kliniken';
+export const VISTA_COMPANY_DOMAIN = 'vista.ch';
+
+const CAREER_URL = 'https://vista.ch/ueber-uns/karriere/';
+const OSTENDIS_API_BASE = 'https://odm.ostendis.com/ojp/data/v54/jobs';
+const OSTENDIS_TOKEN = '748a5e05dbc2494dacd27e76040385cc';
+const OSTENDIS_LANG = 'DE';
+const OSTENDIS_DOMAIN = 'vista.ch';
+
+const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
+  || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
+
+/**
+ * link.ostendis.com (detail-page CDN) is fronted by mod_security and returns
+ * HTTP 406 to the default bot UA. The Ostendis API itself accepts the bot UA
+ * but detail-page hydration needs a stock browser fingerprint.
+ */
+const BROWSER_USER_AGENT = process.env.JOBS_CRAWLER_BROWSER_USER_AGENT
+  || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36';
+
+const COMPANY_BOILERPLATE = "Vista Augenpraxen & Kliniken ist eine schweizweit tätige Gruppe für Augenheilkunde mit Standorten in den Kantonen Zürich, Basel-Stadt, Basel-Landschaft, Aargau, Bern und weiteren. Wir bieten ein interdisziplinäres Team, moderne Infrastruktur und attraktive Anstellungsbedingungen für Fachpersonen in Augenoptik, Pflege, MTRA/MPA, Ophthalmologie und Verwaltung.";
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function isVistaJob(job) {
+  const key = normalize(job?.companyKey || '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+  if (key === VISTA_KEY) return true;
+  if (/\bvista\b/.test(company) && /(augen|ophtalm|ophthalm)/.test(company)) return true;
+  if (url.includes('vista.ch')) return true;
+  return false;
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'vista.ch' || host.endsWith('.vista.ch')) return true;
+    if (host === 'link.ostendis.com') return true;
+    if (host === 'odm.ostendis.com') return true;
+    if (host.endsWith('.ostendis.com')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function detectCategory(title = '', department = '') {
+  const t = normalize(title);
+  const d = normalize(department);
+  const combined = `${t} ${d}`;
+  if (/\b(arztsekret|sekretär|admin|verwaltung|controlling|buchhalt|empfang|rezept)/.test(combined)) return 'Amministrazione';
+  if (/\b(augenoptiker|optiker|optician)/.test(combined)) return 'Sanità';
+  if (/\b(arzt|ärztin|ober[aä]rzt|medizin|ophthalm|ophtalm|chirurg)/.test(combined)) return 'Medicina';
+  if (/\b(pflege|fachperson gesundheit|fage|betreu|hebamme)/.test(combined)) return 'Infermieristica';
+  if (/\b(orthoptist)/.test(combined)) return 'Sanità';
+  if (/\b(praxisassist|mpa|mfa)/.test(combined)) return 'Sanità';
+  if (/\b(operationstech|toa|technik|techniker)/.test(combined)) return 'Tecnica';
+  if (/\b(labor|biomedizin|mtla|radiolog|röntgen|mtra)/.test(combined)) return 'Laboratorio';
+  if (/\b(it|software|informatik)/.test(combined)) return 'IT';
+  return 'Sanità';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(praktik|stage|intern|apprendist|lehrling|lernend|apprenti)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|sr|lead|head|director|dirett|chef|verantwort|responsab|leiter|leitend|co-leit|oberarzt|oberärztin|facharzt|fachärztin)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function inferEmploymentType(title = '') {
+  const t = normalize(title);
+  const rangeMatch = t.match(/(\d+)\s*[-–]\s*(\d+)\s*%/);
+  if (rangeMatch) {
+    const max = parseInt(rangeMatch[2], 10);
+    return max >= 90 ? 'FULL_TIME' : 'PART_TIME';
+  }
+  const singleMatch = t.match(/(\d+)\s*%/);
+  if (singleMatch) {
+    const pct = parseInt(singleMatch[1], 10);
+    return pct >= 90 ? 'FULL_TIME' : 'PART_TIME';
+  }
+  return 'FULL_TIME';
+}
+
+async function fetchOstendisListings() {
+  const url = `${OSTENDIS_API_BASE}/${OSTENDIS_TOKEN}/${OSTENDIS_LANG}?domain=${OSTENDIS_DOMAIN}`;
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': USER_AGENT,
+        'Accept-Language': 'de-CH,de;q=0.9',
+      },
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from Ostendis API`);
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+async function fetchDetailPage(detailUrl) {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(detailUrl, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: {
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'User-Agent': BROWSER_USER_AGENT,
+        'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
+      },
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from detail page: ${detailUrl}`);
+    return await res.text();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+export function parseDetailPageJsonLd(html = '') {
+  const result = {
+    description: '',
+    datePosted: '',
+    employmentType: '',
+    streetAddress: '',
+    addressLocality: '',
+    postalCode: '',
+    addressRegion: '',
+  };
+  const jsonLdMatch = String(html).match(/<script\s+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/i);
+  if (!jsonLdMatch) return result;
+  try {
+    const data = JSON.parse(jsonLdMatch[1]);
+    if (data['@type'] !== 'JobPosting') return result;
+    if (data.description) {
+      result.description = normalizeSpace(stripHtml(data.description));
+    }
+    if (data.datePosted) result.datePosted = data.datePosted;
+    if (data.employmentType) {
+      const types = Array.isArray(data.employmentType) ? data.employmentType : [data.employmentType];
+      if (types.includes('FULL_TIME')) result.employmentType = 'FULL_TIME';
+      else if (types.includes('PART_TIME')) result.employmentType = 'PART_TIME';
+    }
+    const address = data.jobLocation?.address;
+    if (address) {
+      result.streetAddress = address.streetAddress || '';
+      result.addressLocality = address.addressLocality || '';
+      result.postalCode = address.postalCode || '';
+      result.addressRegion = address.addressRegion || '';
+    }
+  } catch {
+    /* swallow JSON-LD parse failures */
+  }
+  return result;
+}
+
+export function parseVistaOstendisJob(entry, detailData = {}) {
+  const title = normalizeSpace(entry?.title || '');
+  if (!title || title.length < 3) return null;
+
+  const location = normalizeSpace(entry.city || detailData.addressLocality || 'Binningen');
+  const canton = inferAnyCanton(location) || detailData.addressRegion || 'BL';
+  const postalCode = entry.zip || detailData.postalCode || '4102';
+  const streetAddress = detailData.streetAddress || 'Hauptstrasse 55';
+
+  const publicUrl = entry.detail || CAREER_URL;
+  const applyUrl = entry.action || publicUrl;
+  const idSource = entry.id ? String(entry.id) : publicUrl;
+  const urlHash = createHash('sha1').update(idSource).digest('hex').slice(0, 12);
+
+  let descriptionText = detailData.description || '';
+  if (!descriptionText || descriptionText.length < 150) {
+    const parts = [`${title} bei ${VISTA_COMPANY_NAME}`];
+    if (entry.department) parts.push(`Abteilung: ${entry.department}`);
+    parts.push(`Arbeitsort: ${location} (${postalCode}, ${canton})`);
+    parts.push(COMPANY_BOILERPLATE);
+    descriptionText = parts.join('. ');
+  }
+
+  const employmentType = detailData.employmentType || inferEmploymentType(title);
+  const rangeMatch = normalize(title).match(/(\d+)\s*[-–]\s*(\d+)\s*%/);
+  const singleMatch = normalize(title).match(/(\d+)\s*%/);
+  let pensumMin;
+  let pensumMax;
+  let pensum;
+  if (rangeMatch) {
+    pensumMin = parseInt(rangeMatch[1], 10);
+    pensumMax = parseInt(rangeMatch[2], 10);
+    pensum = pensumMin === pensumMax ? `${pensumMin}%` : `${pensumMin} - ${pensumMax}%`;
+  } else if (singleMatch) {
+    pensumMin = parseInt(singleMatch[1], 10);
+    pensumMax = pensumMin;
+    pensum = `${pensumMin}%`;
+  }
+  const contract = (pensumMax && pensumMax < 90) ? 'part-time' : 'full-time';
+  const sourceLang = detectLang(descriptionText || title, 'de');
+  const jobSlug = slugify(`${title} ${VISTA_KEY} ${location}`);
+  const datePosted = detailData.datePosted || new Date().toISOString().slice(0, 10);
+
+  return {
+    id: `${VISTA_KEY}-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [sourceLang]: jobSlug },
+    company: VISTA_COMPANY_NAME,
+    companyKey: VISTA_KEY,
+    companyDomain: VISTA_COMPANY_DOMAIN,
+    title,
+    titleByLocale: { [sourceLang]: title },
+    description: descriptionText,
+    descriptionByLocale: { [sourceLang]: descriptionText },
+    // Newly-discovered jobs ship with source-locale-only fields. The shared
+    // AI-localization step clears this flag when it fills the remaining 3
+    // locales; if it can't (cache miss + AI quota), the flag stays and
+    // `translate-pending.yml` picks the job up out-of-band. Without this
+    // flag the locale-completeness gate trips before translation can run.
+    needsRetranslation: true,
+    location,
+    canton,
+    url: publicUrl,
+    source: `${VISTA_COMPANY_NAME} Dedicated Parser (Ostendis JobPublisher)`,
+    sourceLang,
+    crawledAt: new Date().toISOString(),
+
+    addressLocality: location,
+    addressRegion: canton,
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode,
+    streetAddress,
+    category: detectCategory(title, entry.department || ''),
+    contract,
+    employmentType,
+    experienceLevel: detectExperienceLevel(title),
+    sector: 'Sanità / Ospedali',
+    currency: 'CHF',
+    featured: false,
+    postedDate: datePosted,
+    applyUrl,
+    requirements: [],
+    requirementsByLocale: { [sourceLang]: [] },
+    ...(entry.department ? { department: entry.department } : {}),
+    ...(pensum ? { pensum, pensumMin, pensumMax } : {}),
+  };
+}
+
+export async function fetchAllVistaJobs() {
+  console.log(`🏥 Fetching ${VISTA_COMPANY_NAME} jobs`);
+  console.log(`   Source: Ostendis JobPublisher API (token ${OSTENDIS_TOKEN.slice(0, 8)}…)\n`);
+
+  const data = await fetchOstendisListings();
+  const listings = data?.jobs;
+  if (!listings || !Array.isArray(listings) || listings.length === 0) {
+    console.warn('⚠️ No job listings returned from Ostendis API.');
+    return [];
+  }
+  console.log(`  📋 Ostendis listings found: ${listings.length}`);
+
+  const jobs = [];
+  const delayMs = Number(process.env.JOBS_CRAWLER_DELAY_MS) || 500;
+  for (const entry of listings) {
+    const title = normalizeSpace(entry?.title || '');
+    if (!title || title.length < 3) continue;
+
+    let detailData = {};
+    if (entry.detail) {
+      try {
+        const detailHtml = await fetchDetailPage(entry.detail);
+        detailData = parseDetailPageJsonLd(detailHtml);
+        await new Promise((r) => setTimeout(r, delayMs));
+      } catch (err) {
+        console.warn(`  ⚠️ Failed to fetch detail for "${title}": ${err?.message || err}`);
+      }
+    }
+
+    const job = parseVistaOstendisJob(entry, detailData);
+    if (!job) continue;
+
+    jobs.push(job);
+    console.log(`  ✅ ${title.substring(0, 60)} — ${job.location} (${job.canton}, ${job.employmentType})`);
+  }
+
+  console.log(`\n📋 Total ${VISTA_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}
+
+export {
+  CAREER_URL,
+  OSTENDIS_API_BASE,
+  OSTENDIS_TOKEN,
+  OSTENDIS_DOMAIN,
+};

--- a/scripts/update-klinik-susenberg-jobs.mjs
+++ b/scripts/update-klinik-susenberg-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Klinik Susenberg crawler runner.
+ *
+ * Uses the standard crawler template with the Klinik Susenberg parser
+ * (custom TYPO3 HTML scraping — PDF stellenausschreibungen).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllKlinikSusenbergJobs,
+  isKlinikSusenbergJob,
+  isTrustedDomain,
+  KLINIK_SUSENBERG_KEY,
+  KLINIK_SUSENBERG_COMPANY_NAME,
+} from './lib/klinik-susenberg-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: KLINIK_SUSENBERG_KEY,
+  companyLabel: KLINIK_SUSENBERG_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllKlinikSusenbergJobs,
+  isCompanyJob: isKlinikSusenbergJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Klinik Susenberg crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-nsn-medical-jobs.mjs
+++ b/scripts/update-nsn-medical-jobs.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Dedicated NSN Medical Group crawler runner (Umantis tenant 2884).
+ *
+ * Covers NSN medical AG plus the affiliated entities advertising under the
+ * same Umantis tenant: Zentrum für integrative Onkologie (ZIO), narkose.ch,
+ * Limmatklinik and Eulachklinik.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllNsnMedicalJobs,
+  isNsnMedicalJob,
+  isTrustedDomain,
+  NSN_MEDICAL_KEY,
+  NSN_MEDICAL_COMPANY_NAME,
+} from './lib/nsn-medical-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: NSN_MEDICAL_KEY,
+  companyLabel: NSN_MEDICAL_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllNsnMedicalJobs,
+  isCompanyJob: isNsnMedicalJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ NSN Medical crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-vista-jobs.mjs
+++ b/scripts/update-vista-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Vista Augenpraxen & Kliniken crawler runner.
+ *
+ * Uses the standard crawler template with the Vista parser
+ * (Ostendis JobPublisher API).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllVistaJobs,
+  isVistaJob,
+  isTrustedDomain,
+  VISTA_KEY,
+  VISTA_COMPANY_NAME,
+} from './lib/vista-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: VISTA_KEY,
+  companyLabel: VISTA_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllVistaJobs,
+  isCompanyJob: isVistaJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Vista crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Batch 18L wraps three ZH-canton tenants flagged uncovered in the
2026-05-19 hospital crawler inventory (§4 ZH):

| Crawler         | Source                                 | Jobs | Cantons          |
|-----------------|----------------------------------------|------|------------------|
| nsn-medical     | Umantis tenant 2884 (recruitingapp-…)  | 10   | ZH               |
| klinik-susenberg| susenbergklinik.ch (TYPO3 PDF listing) | 5    | ZH               |
| vista           | Ostendis JobPublisher (vista.ch)       | 9    | BE/BL/AG/ZH/BS   |

NSN Medical is the canonical entry point for the NSN family at nsn.ch/jobs/
(NSN medical AG, ZIO Zentrum für integrative Onkologie, narkose.ch — and the
Limmatklinik / Eulachklinik public sites both link their job CTA here).

Klinik Susenberg surfaces vacancies as TYPO3-hosted PDFs grouped under
"Pflege", "Therapien" and "Ärztlicher Dienst" headings; the parser carries
the active heading forward as department metadata and parses the trailing
_YYYY-MM-DD.pdf suffix as postedDate. Browser-UA fetch override required
because the TYPO3 backend rejects the bot UA with HTTP 406.

Vista mirrors the rss-surselva Ostendis API pattern, with detail-page
enrichment via JSON-LD JobPosting blocks; link.ostendis.com also needs the
browser-UA override for detail fetches.

All ParsedJob objects set needsRetranslation: true so the locale-completeness
gate defers to translate-pending out-of-band processing.

No changes to crawler-location-config.mjs, known-company-slugs.json or
data/jobs*.json — wrappers only. Verified locally via node --check and
direct fetchAll*() smoke tests; CI (tests.yml) + the dedicated update-jobs-*
workflows remain the authoritative gates.
