### PR TITLE
feat(crawlers): batch 18i Bern psychiatric/rehab tail (3 hospitals)

### DIFF
--- a/.github/workflows/update-jobs-igs-bern.yml
+++ b/.github/workflows/update-jobs-igs-bern.yml
@@ -1,0 +1,102 @@
+name: Update IGS Bern (Soteria) Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-igs-bern
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-igs-bern-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated IGS_BERN crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_IGS_BERN_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-igs-bern-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'igs-bern'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/igs-bern.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update IGS_BERN jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-privatklinik-wyss.yml
+++ b/.github/workflows/update-jobs-privatklinik-wyss.yml
@@ -1,0 +1,101 @@
+name: Update Privatklinik Wyss Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-privatklinik-wyss
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-privatklinik-wyss-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated PRIVATKLINIK_WYSS crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_PRIVATKLINIK_WYSS_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-privatklinik-wyss-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'privatklinik-wyss'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/privatklinik-wyss.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PRIVATKLINIK_WYSS jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-suedhang.yml
+++ b/.github/workflows/update-jobs-suedhang.yml
@@ -1,0 +1,101 @@
+name: Update Klinik Südhang Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-suedhang
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-suedhang-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated SUEDHANG crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_SUEDHANG_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-suedhang-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'suedhang'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/suedhang.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SUEDHANG jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/igs-bern-job-parser.mjs
+++ b/scripts/lib/igs-bern-job-parser.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * Interessengemeinschaft Sozialpsychiatrie Bern (IGS Bern / Soteria) job parser
+ *
+ * Public career site:  https://www.igsbern.ch/jobs/offene-stellen/
+ *
+ * IGS Bern is the operator behind several psychiatric / social-psychiatric
+ * institutions in Bern, including **Soteria Bern** (Bern psychiatric clinic
+ * for first-onset psychosis treatment, listed standalone in the welches-spital
+ * 2026-05 inventory under canton BE). The careers page embeds a PastaHR /
+ * publicjobs.ch widget:
+ *
+ *   <script>
+ *     const options = { kdNr : "104465", ... };
+ *     document.addEventListener("DOMContentLoaded", function() { ... });
+ *   </script>
+ *
+ * The widget POSTs to https://www.publicjobs.ch/widget with `kdNr`, `page`,
+ * `limit` — same protocol used by `gzo-wetzikon-job-parser.mjs`. Listings ship
+ * `job_detail_url` pointing at publicjobs.ch detail pages; the actual job
+ * description is fetched from there.
+ */
+import { createHash } from 'node:crypto';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import {
+  decodeEntities,
+  fetchHtml,
+  htmlToText,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareEmploymentType,
+  detectHealthcareExperienceLevel,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const IGS_BERN_KEY = 'igs-bern';
+export const IGS_BERN_COMPANY_NAME = 'Interessengemeinschaft Sozialpsychiatrie Bern';
+export const IGS_BERN_COMPANY_DOMAIN = 'igsbern.ch';
+
+const PASTAHR_ENDPOINT = 'https://www.publicjobs.ch/widget';
+const PASTAHR_KD_NR = '104465';
+const PASTAHR_REFERER = 'https://www.igsbern.ch/jobs/offene-stellen/';
+
+const PAGE_SIZE = 50;
+const MAX_PAGES = 6;
+
+const PUBLIC_CAREER_URL = 'https://www.igsbern.ch/jobs/offene-stellen/';
+
+const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
+  || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+export function isIgsBernJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === IGS_BERN_KEY ||
+    key.startsWith('igs-bern') ||
+    company.includes('interessengemeinschaft sozialpsychiatrie') ||
+    company.includes('igs bern') ||
+    company.includes('soteria bern') ||
+    url.includes('igsbern.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === 'igsbern.ch' ||
+      host.endsWith('.igsbern.ch') ||
+      host === 'www.publicjobs.ch' ||
+      host === 'publicjobs.ch' ||
+      host.endsWith('.publicjobs.ch')
+    );
+  } catch {
+    return false;
+  }
+}
+
+/* ── PastaHR / publicjobs.ch widget client ─────────────────── */
+
+async function fetchPastaHrPage(page = 1) {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const params = new URLSearchParams();
+  params.set('kdNr', PASTAHR_KD_NR);
+  params.set('page', String(page));
+  params.set('limit', String(PAGE_SIZE));
+  params.set('language', 'de');
+  params.set('dateFormat', 'DD.MM.YYYY');
+  params.set('searchQuery', '');
+
+  try {
+    const res = await fetch(PASTAHR_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/javascript, */*; q=0.01',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        'User-Agent': USER_AGENT,
+        'X-Requested-With': 'XMLHttpRequest',
+        Referer: PASTAHR_REFERER,
+        Origin: 'https://www.igsbern.ch',
+      },
+      body: params.toString(),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from ${PASTAHR_ENDPOINT}`);
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+async function fetchAllPastaHrJobs() {
+  const all = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    console.log(`  📄 Fetching page=${page} (limit=${PAGE_SIZE})...`);
+    const data = await fetchPastaHrPage(page);
+    const items = Array.isArray(data?.data) ? data.data : [];
+    if (items.length === 0) break;
+    all.push(...items);
+    if (items.length < PAGE_SIZE) break;
+    await new Promise((r) => setTimeout(r, 350));
+  }
+  console.log(`  ✓ Total PastaHR rows: ${all.length}`);
+  return all;
+}
+
+/* ── Date helper ──────────────────────────────────────────── */
+
+function parseSwissDate(raw = '') {
+  const trimmed = String(raw || '').trim().replace(/^1(\d{2}\.)/, '$1');
+  const m = trimmed.match(/^(\d{1,2})\.(\d{1,2})\.(\d{2,4})$/);
+  if (!m) return null;
+  const dd = m[1].padStart(2, '0');
+  const mm = m[2].padStart(2, '0');
+  const yyyy = m[3].length === 2 ? `20${m[3]}` : m[3];
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/* ── Detail fetcher ──────────────────────────────────────── */
+
+async function fetchPublicJobsDetail(detailUrl) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    if (!html) return '';
+    const noScripts = String(html)
+      .replace(/<script[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[\s\S]*?<\/style>/gi, '');
+    const candidateBlocks = [];
+    const blockRe = /<(?:article|main|section|div)[^>]*(?:id|class)="[^"]*(?:job|content|main|description|inserat|stellen)[^"]*"[^>]*>([\s\S]*?)<\/(?:article|main|section|div)>/gi;
+    let m;
+    while ((m = blockRe.exec(noScripts)) !== null && candidateBlocks.length < 12) {
+      candidateBlocks.push(m[1]);
+    }
+    candidateBlocks.push(noScripts);
+    let best = '';
+    for (const blk of candidateBlocks) {
+      const text = htmlToText(blk);
+      if (text.length > best.length) best = text;
+      if (best.length > 1200) break;
+    }
+    return normalizeSpace(best).slice(0, 6000);
+  } catch (err) {
+    console.warn(`  ⚠️ IGS Bern detail fetch failed (${detailUrl}): ${err?.message || err}`);
+    return '';
+  }
+}
+
+/* ── Pensum helper ───────────────────────────────────────── */
+
+function extractPensum(title = '') {
+  const rangeMatch = title.match(/(\d{2,3})\s*[-–]\s*(\d{2,3})\s*%/);
+  if (rangeMatch) {
+    return { min: parseInt(rangeMatch[1], 10), max: parseInt(rangeMatch[2], 10) };
+  }
+  const singleMatch = title.match(/(\d{2,3})\s*%/);
+  if (singleMatch) {
+    const val = parseInt(singleMatch[1], 10);
+    return { min: val, max: val };
+  }
+  return null;
+}
+
+/* ── Main Fetch Function ──────────────────────────────────── */
+
+export async function fetchAllIgsBernJobs() {
+  console.log(`🏥 Fetching ${IGS_BERN_COMPANY_NAME} jobs (IGS Bern / Soteria)`);
+  console.log(`   Source:        ${PASTAHR_ENDPOINT} (kdNr=${PASTAHR_KD_NR})`);
+  console.log(`   Public career: ${PUBLIC_CAREER_URL}\n`);
+
+  const rows = await fetchAllPastaHrJobs();
+  if (!rows || rows.length === 0) {
+    console.warn('⚠️ No job listings returned from PastaHR widget API.');
+    return [];
+  }
+
+  const jobs = [];
+  const seenUrls = new Set();
+
+  for (const row of rows) {
+    const titleRaw = String(row?.job_title || '').trim();
+    const title = normalizeSpace(decodeEntities(stripHtml(titleRaw)));
+    if (!title || title.length < 3) continue;
+
+    const detailUrl = String(row?.job_detail_url || '').trim();
+    if (!detailUrl) continue;
+    if (seenUrls.has(detailUrl)) continue;
+    seenUrls.add(detailUrl);
+
+    // Filter to IGS Bern postings only — defensive filter, since kdNr should
+    // already restrict to this tenant.
+    const orgName = normalizeSpace(decodeEntities(String(row?.org_name || '')));
+    if (orgName && !/sozialpsychiatrie|igs|soteria/i.test(orgName)) continue;
+
+    const orgCity = normalizeSpace(decodeEntities(String(row?.org_city || '')));
+    const location = orgCity.replace(/\s+(?:BE|ZH|VD|TI|GE)$/i, '').trim() || 'Bern';
+    const canton = 'BE';
+
+    const sourceLang = 'de';
+    const jobSlug = slugify(`${title} ${IGS_BERN_KEY} ch`);
+    const urlHash = createHash('sha1').update(detailUrl).digest('hex').slice(0, 12);
+
+    const pensum = extractPensum(title);
+    const employmentType = detectHealthcareEmploymentType(title);
+    const contract = pensum && pensum.max < 80 ? 'part-time' : 'full-time';
+
+    const postedDate = parseSwissDate(row?.job_booking_start || '')
+      || new Date().toISOString().split('T')[0];
+
+    const fallbackDesc = `${title} — ${IGS_BERN_COMPANY_NAME}, ${location}. Sozialpsychiatrische Institution in Bern (Soteria Bern und weitere Angebote).`;
+    const detailDescription = await fetchPublicJobsDetail(detailUrl);
+    const description = detailDescription && detailDescription.split(/\s+/).length >= 30
+      ? detailDescription
+      : fallbackDesc;
+    if (jobs.length > 0) await new Promise((r) => setTimeout(r, 250));
+
+    const job = {
+      id: `${IGS_BERN_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: IGS_BERN_COMPANY_NAME,
+      companyKey: IGS_BERN_KEY,
+      companyDomain: IGS_BERN_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location,
+      canton,
+      url: detailUrl,
+      source: `${IGS_BERN_COMPANY_NAME} Dedicated Parser (PastaHR / publicjobs.ch)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: location,
+      postalCode: '3000',
+      addressCountry: 'CH',
+      country: 'CH',
+      category: detectHealthcareCategory(title),
+      contract,
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate,
+      applyUrl: detailUrl,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    };
+
+    if (pensum) {
+      job.pensumMin = pensum.min;
+      job.pensumMax = pensum.max;
+      job.pensum = pensum.min === pensum.max
+        ? `${pensum.min}%`
+        : `${pensum.min} - ${pensum.max}%`;
+    }
+
+    jobs.push(job);
+  }
+
+  console.log(`\n📋 Total ${IGS_BERN_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/privatklinik-wyss-job-parser.mjs
+++ b/scripts/lib/privatklinik-wyss-job-parser.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * Privatklinik Wyss — psychiatric private clinic in Münchenbuchsee (BE).
+ *
+ * Public career site: https://www.privatklinik-wyss.ch/jobs-und-karriere/stellen
+ *
+ * Privatklinik Wyss AG is a leading specialty hospital for Psychiatry &
+ * Psychotherapy, with sites in Münchenbuchsee, Bern, and Biel (~340 staff).
+ * Listed standalone in the 2026-05 welches-spital inventory (BE, Psichiatria).
+ *
+ * The careers section is a custom CMS — no third-party ATS. Listings live
+ * under category index pages:
+ *   /jobs-und-karriere/stellen/fachbereich-pflege-1
+ *   /jobs-und-karriere/stellen/fachbereich-medizin
+ *   /jobs-und-karriere/stellen/fachbereich-psychologie
+ *   …(plus ausbildung-praktika, administration, hotellerie-und-gastronomie,
+ *      technischer-dienst-und-park, fachbereich-spezialtherapie,
+ *      fachbereich-kliniksozialdienst)
+ *
+ * Each category page lists job permalinks of the form
+ *   /jobs-und-karriere/stellen/{category}/{slug}
+ *
+ * Detail pages ship rich text content with Beschäftigungsgrad, Standort,
+ * Arbeitsbeginn structured fields and a multi-section narrative.
+ */
+import { createHash } from 'node:crypto';
+import { slugify } from './crawler-template.mjs';
+import {
+  decodeEntities,
+  fetchHtml,
+  htmlToText,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareEmploymentType,
+  detectHealthcareExperienceLevel,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const PRIVATKLINIK_WYSS_KEY = 'privatklinik-wyss';
+export const PRIVATKLINIK_WYSS_COMPANY_NAME = 'Privatklinik Wyss';
+export const PRIVATKLINIK_WYSS_COMPANY_DOMAIN = 'privatklinik-wyss.ch';
+
+const BASE_URL = 'https://www.privatklinik-wyss.ch';
+const CATEGORY_INDEX = `${BASE_URL}/jobs-und-karriere/stellen`;
+
+const CATEGORIES = [
+  'fachbereich-pflege-1',
+  'fachbereich-medizin',
+  'fachbereich-psychologie',
+  'fachbereich-spezialtherapie',
+  'fachbereich-kliniksozialdienst',
+  'hotellerie-und-gastronomie',
+  'technischer-dienst-und-park',
+  'administration',
+  'ausbildung-praktika',
+];
+
+// Pages NOT to follow (spontaneous application, policy, hub pages)
+const SKIP_SLUGS = new Set([
+  'spontanbewerbung',
+  'richtlinie-fuer-personalvermittlungen-und-dritte',
+]);
+
+const POSTAL_CODE_BY_CITY = {
+  munchenbuchsee: '3053',
+  münchenbuchsee: '3053',
+  bern: '3000',
+  biel: '2502',
+  bienne: '2502',
+};
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function isPrivatklinikWyssJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+  return (
+    key === PRIVATKLINIK_WYSS_KEY ||
+    key.startsWith('privatklinik-wyss') ||
+    company.includes('privatklinik wyss') ||
+    url.includes('privatklinik-wyss.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'privatklinik-wyss.ch' || host.endsWith('.privatklinik-wyss.ch');
+  } catch {
+    return false;
+  }
+}
+
+/* ── Listing parser ────────────────────────────────────────── */
+
+function parseListingHtml(html = '', categorySlug = '') {
+  const out = [];
+  const seen = new Set();
+  // Job hrefs are relative or absolute paths under the category slug
+  const re = new RegExp(
+    `href="((?:https://www\\.privatklinik-wyss\\.ch)?/jobs-und-karriere/stellen/${categorySlug}/([^"#?]+))"`,
+    'gi',
+  );
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const path = m[1];
+    const slug = m[2].split('/')[0];
+    if (!slug || SKIP_SLUGS.has(slug)) continue;
+    if (slug.startsWith('fachbereich-') || slug === categorySlug) continue;
+    const url = path.startsWith('http') ? path : `${BASE_URL}${path}`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    out.push({ url, category: categorySlug, slug });
+  }
+  return out;
+}
+
+/* ── Detail extraction ─────────────────────────────────────── */
+
+function extractDetail(html = '') {
+  if (!html) return { title: '', description: '', location: '', pensum: '', startDate: '' };
+  const noScripts = String(html)
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '');
+
+  // Title comes from <title> / og:title — the <h1> on every Wyss job page is
+  // just the generic "Offene Stelle" eyebrow. Pattern: "{Job Title} | Privatklinik Wyss"
+  let title = '';
+  const ogMatch = noScripts.match(/<meta[^>]*property="og:title"[^>]*content="([^"]+)"/i);
+  const titleTag = noScripts.match(/<title>([^<]+)<\/title>/i);
+  const raw = (ogMatch && ogMatch[1]) || (titleTag && titleTag[1]) || '';
+  if (raw) {
+    // Strip the " | Privatklinik Wyss" / " - Privatklinik Wyss" suffix
+    title = normalizeSpace(decodeEntities(raw))
+      .replace(/\s*[|\-–—]\s*Privatklinik Wyss( AG)?\s*$/i, '')
+      .replace(/\s*\|\s*Karriere\s*$/i, '')
+      .trim();
+  }
+  if (!title) {
+    const h1 = noScripts.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+    if (h1) title = normalizeSpace(decodeEntities(h1[1].replace(/<[^>]+>/g, ' ')));
+  }
+
+  // Find main content area. Privatklinik Wyss uses TYPO3 style layout.
+  let body = noScripts;
+  const mainMatch = noScripts.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
+    || noScripts.match(/<article[^>]*>([\s\S]*?)<\/article>/i)
+    || noScripts.match(/<div[^>]*id="main-content"[^>]*>([\s\S]*?)<\/div>\s*<\/div>\s*<\/div>/i);
+  if (mainMatch) body = mainMatch[1];
+
+  const text = normalizeSpace(htmlToText(body));
+
+  // Extract structured fields
+  let location = '';
+  const locMatch = text.match(/Standort[: ]+([^.]{3,80}?)(?:\s+Beschäftigungsgrad|\s+Arbeitsbeginn|\s+Anstellungsverhältnis|\s+Stellenantritt|\.|$)/i)
+    || text.match(/Arbeitsort[: ]+([^.]{3,80}?)(?:\s+Beschäftigungsgrad|\s+Arbeitsbeginn|\.|$)/i);
+  if (locMatch) {
+    location = normalizeSpace(locMatch[1]).replace(/Privatklinik Wyss( AG)?,?\s*/i, '').trim();
+  }
+
+  let pensum = '';
+  const pensumMatch = text.match(/Beschäftigungsgrad[: ]+([\d\s\-–%]{3,30})/i);
+  if (pensumMatch) pensum = normalizeSpace(pensumMatch[1]);
+
+  let startDate = '';
+  const startMatch = text.match(/Arbeitsbeginn[: ]+([^.]{3,60}?)(?:\s+Privatklinik|\s+Beschäftigungsgrad|\s+Standort|\.|$)/i);
+  if (startMatch) startDate = normalizeSpace(startMatch[1]);
+
+  return {
+    title,
+    description: text.slice(0, 6000),
+    location,
+    pensum,
+    startDate,
+  };
+}
+
+/* ── Pensum / helpers ─────────────────────────────────────── */
+
+function extractPensum(s = '') {
+  const rangeMatch = String(s).match(/(\d{2,3})\s*[-–]\s*(\d{2,3})\s*%/);
+  if (rangeMatch) {
+    return { min: parseInt(rangeMatch[1], 10), max: parseInt(rangeMatch[2], 10) };
+  }
+  const singleMatch = String(s).match(/(\d{2,3})\s*%/);
+  if (singleMatch) {
+    const val = parseInt(singleMatch[1], 10);
+    return { min: val, max: val };
+  }
+  return null;
+}
+
+function postalCodeFor(city = '') {
+  const key = normalize(city);
+  for (const k of Object.keys(POSTAL_CODE_BY_CITY)) {
+    if (key.includes(k)) return POSTAL_CODE_BY_CITY[k];
+  }
+  return '3053'; // default Münchenbuchsee HQ
+}
+
+/* ── Main Fetch Function ──────────────────────────────────── */
+
+export async function fetchAllPrivatklinikWyssJobs() {
+  console.log(`🏥 Fetching ${PRIVATKLINIK_WYSS_COMPANY_NAME} jobs`);
+  console.log(`   Category index: ${CATEGORY_INDEX}\n`);
+
+  const tiles = [];
+  const seen = new Set();
+  for (const cat of CATEGORIES) {
+    const url = `${CATEGORY_INDEX}/${cat}`;
+    let html = '';
+    try {
+      html = await fetchHtml(url);
+    } catch (err) {
+      console.warn(`  ⚠️ Category fetch failed (${cat}): ${err?.message || err}`);
+      continue;
+    }
+    const found = parseListingHtml(html, cat);
+    for (const t of found) {
+      if (seen.has(t.url)) continue;
+      seen.add(t.url);
+      tiles.push(t);
+    }
+    console.log(`  📂 ${cat}: ${found.length} listings`);
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  console.log(`\n  📋 Total unique listings: ${tiles.length}`);
+
+  const jobs = [];
+
+  for (const tile of tiles) {
+    let detailHtml = '';
+    try {
+      detailHtml = await fetchHtml(tile.url);
+    } catch (err) {
+      console.warn(`  ⚠️ Detail fetch failed (${tile.url}): ${err?.message || err}`);
+    }
+    if (jobs.length > 0) await new Promise((r) => setTimeout(r, 350));
+
+    const detail = extractDetail(detailHtml);
+    const title = normalizeSpace(detail.title || tile.slug.replace(/-/g, ' '));
+    if (!title || title.length < 3) continue;
+
+    const location = detail.location || 'Münchenbuchsee';
+
+    const sourceLang = 'de';
+    const jobSlug = slugify(`${title} ${PRIVATKLINIK_WYSS_KEY} ch`);
+    const urlHash = createHash('sha1').update(tile.url).digest('hex').slice(0, 12);
+
+    const pensumSource = `${detail.pensum} ${title}`;
+    const pensum = extractPensum(pensumSource);
+    const employmentType = detectHealthcareEmploymentType(pensumSource);
+    const contract = pensum && pensum.max < 80 ? 'part-time' : 'full-time';
+
+    const fallbackDesc = `${title} — ${PRIVATKLINIK_WYSS_COMPANY_NAME}, ${location}. Fachklinik für Psychiatrie und Psychotherapie.`;
+    const description = detail.description && detail.description.split(/\s+/).length >= 30
+      ? detail.description
+      : fallbackDesc;
+
+    const job = {
+      id: `${PRIVATKLINIK_WYSS_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: PRIVATKLINIK_WYSS_COMPANY_NAME,
+      companyKey: PRIVATKLINIK_WYSS_KEY,
+      companyDomain: PRIVATKLINIK_WYSS_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location,
+      canton: 'BE',
+      url: tile.url,
+      source: `${PRIVATKLINIK_WYSS_COMPANY_NAME} Dedicated Parser (custom HTML)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: location,
+      postalCode: postalCodeFor(location),
+      addressCountry: 'CH',
+      country: 'CH',
+      category: detectHealthcareCategory(title),
+      contract,
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: new Date().toISOString().split('T')[0],
+      applyUrl: tile.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    };
+
+    if (pensum) {
+      job.pensumMin = pensum.min;
+      job.pensumMax = pensum.max;
+      job.pensum = pensum.min === pensum.max ? `${pensum.min}%` : `${pensum.min} - ${pensum.max}%`;
+    }
+
+    jobs.push(job);
+  }
+
+  console.log(`\n📋 Total ${PRIVATKLINIK_WYSS_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/suedhang-job-parser.mjs
+++ b/scripts/lib/suedhang-job-parser.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Klinik Südhang — psychiatric clinic for addiction therapy (Kirchlindach, BE).
+ *
+ * Public career site: https://www.suedhang.ch/karriere/offene-stellen/
+ *
+ * Klinik Südhang operates as the Bern-canton specialty hospital for
+ * Suchttherapien (addiction therapy / Psychiatrie) in Kirchlindach plus
+ * outpatient ambulatori in Bern, Biel, Burgdorf. Listed standalone in the
+ * 2026-05 welches-spital inventory (BE, Psichiatria).
+ *
+ * The careers page is a WordPress site (suedhang.ch is a Tutto Bene Group
+ * brand). No third-party ATS — every job is its own permalink under
+ * /karriere/offene-stellen/{slug}/ with rich detail content. We scrape the
+ * listing index, then fetch each detail page for the description.
+ */
+import { createHash } from 'node:crypto';
+import { slugify } from './crawler-template.mjs';
+import {
+  decodeEntities,
+  fetchHtml,
+  htmlToText,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareEmploymentType,
+  detectHealthcareExperienceLevel,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const SUEDHANG_KEY = 'suedhang';
+export const SUEDHANG_COMPANY_NAME = 'Klinik Südhang';
+export const SUEDHANG_COMPANY_DOMAIN = 'suedhang.ch';
+
+const LISTING_URL = 'https://www.suedhang.ch/karriere/offene-stellen/';
+const DETAIL_URL_PREFIX = 'https://www.suedhang.ch/karriere/offene-stellen/';
+
+const POSTAL_CODE_BY_CITY = {
+  kirchlindach: '3038',
+  bern: '3000',
+  biel: '2502',
+  bienne: '2502',
+  'biel/bienne': '2502',
+  burgdorf: '3400',
+};
+
+/* ── Company Matchers ──────────────────────────────────────── */
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function isSuedhangJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+  return (
+    key === SUEDHANG_KEY ||
+    key.startsWith('suedhang') ||
+    company.includes('südhang') ||
+    company.includes('suedhang') ||
+    url.includes('suedhang.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'suedhang.ch' || host.endsWith('.suedhang.ch');
+  } catch {
+    return false;
+  }
+}
+
+/* ── Listing parser ────────────────────────────────────────── */
+
+function parseListing(html = '') {
+  const out = [];
+  const seen = new Set();
+  const re = /<a[^>]*href="(https:\/\/www\.suedhang\.ch\/karriere\/offene-stellen\/[^/"#]+\/)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const url = m[1];
+    if (seen.has(url)) continue;
+    if (url.endsWith('/offene-stellen/')) continue;
+    seen.add(url);
+    const text = normalizeSpace(decodeEntities(m[2].replace(/<[^>]+>/g, ' ')));
+    if (!text || text.length < 3) continue;
+    out.push({ url, titleHint: text });
+  }
+  return out;
+}
+
+/* ── Detail extraction ─────────────────────────────────────── */
+
+function extractDetail(html = '') {
+  if (!html) return { title: '', description: '', location: '', pensum: '' };
+  const noScripts = String(html)
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '');
+
+  // Title from <h1> (or first h2 in main)
+  let title = '';
+  const h1 = noScripts.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1) title = normalizeSpace(decodeEntities(h1[1].replace(/<[^>]+>/g, ' ')));
+
+  // Suedhang uses Gutenberg WP blocks: <div class="content page-content">…</div>
+  // wraps the actual body. Slice from there to the next </footer> or the
+  // sibling </div> closing the page wrapper — but since the WP HTML has many
+  // nested divs, easier: take everything from the `content page-content` opener
+  // up to the start of the footer/page-footer.
+  let body = noScripts;
+  const startMatch = noScripts.match(/<div[^>]*class="content page-content"[^>]*>/i);
+  if (startMatch) {
+    const startIx = startMatch.index + startMatch[0].length;
+    // Find the next "footer-like" tag — sticky-footer / <footer> / sibling page block
+    const tail = noScripts.slice(startIx);
+    const cutMatch = tail.match(/<footer\b|<div[^>]*class="[^"]*(?:page-footer|site-footer|footer-wrap|cf-footer)/i);
+    body = cutMatch ? tail.slice(0, cutMatch.index) : tail;
+  } else {
+    const mainMatch = noScripts.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
+      || noScripts.match(/<article[^>]*>([\s\S]*?)<\/article>/i)
+      || noScripts.match(/<div[^>]*class="[^"]*(?:entry-content|content-wrap|page-content)[^"]*"[^>]*>([\s\S]*?)<\/div>\s*<\/div>/i);
+    body = mainMatch ? mainMatch[1] : noScripts;
+  }
+
+  const text = normalizeSpace(htmlToText(body));
+
+  // Heuristic location + pensum from text (e.g. "Arbeitsort Klinik Südhang, Kirchlindach")
+  let location = '';
+  const arbeitsortMatch = text.match(/Arbeitsort[: ]+([^.]{3,120}?)(?:\s+Beschäftigungsgrad|\s+Stellenantritt|\s+Pensum|\.|$)/i);
+  if (arbeitsortMatch) {
+    location = normalizeSpace(arbeitsortMatch[1]).replace(/Klinik Südhang,?\s*/i, '').trim();
+  }
+
+  let pensum = '';
+  const pensumMatch = text.match(/Beschäftigungsgrad[: ]+([\d\s\-–%]{3,30})/i);
+  if (pensumMatch) pensum = normalizeSpace(pensumMatch[1]);
+
+  return {
+    title,
+    description: text.slice(0, 6000),
+    location,
+    pensum,
+  };
+}
+
+/* ── Pensum helper ───────────────────────────────────────── */
+
+function extractPensum(s = '') {
+  const rangeMatch = String(s).match(/(\d{2,3})\s*[-–]\s*(\d{2,3})\s*%/);
+  if (rangeMatch) {
+    return { min: parseInt(rangeMatch[1], 10), max: parseInt(rangeMatch[2], 10) };
+  }
+  const singleMatch = String(s).match(/(\d{2,3})\s*%/);
+  if (singleMatch) {
+    const val = parseInt(singleMatch[1], 10);
+    return { min: val, max: val };
+  }
+  return null;
+}
+
+function postalCodeFor(city = '') {
+  const key = normalize(city);
+  for (const k of Object.keys(POSTAL_CODE_BY_CITY)) {
+    if (key.includes(k)) return POSTAL_CODE_BY_CITY[k];
+  }
+  return '3038'; // default Kirchlindach
+}
+
+/* ── Main Fetch Function ──────────────────────────────────── */
+
+export async function fetchAllSuedhangJobs() {
+  console.log(`🏥 Fetching ${SUEDHANG_COMPANY_NAME} jobs`);
+  console.log(`   Listing:       ${LISTING_URL}\n`);
+
+  const listingHtml = await fetchHtml(LISTING_URL);
+  const tiles = parseListing(listingHtml);
+  console.log(`  📋 Listing tiles: ${tiles.length}`);
+
+  const jobs = [];
+  const seenUrls = new Set();
+
+  for (const tile of tiles) {
+    if (seenUrls.has(tile.url)) continue;
+    seenUrls.add(tile.url);
+
+    let detailHtml = '';
+    try {
+      detailHtml = await fetchHtml(tile.url);
+    } catch (err) {
+      console.warn(`  ⚠️ detail fetch failed (${tile.url}): ${err?.message || err}`);
+    }
+    if (jobs.length > 0) await new Promise((r) => setTimeout(r, 350));
+
+    const detail = extractDetail(detailHtml);
+    const title = normalizeSpace(detail.title || tile.titleHint);
+    if (!title || title.length < 3) continue;
+
+    // Location from detail page, fallback to title hint parsing, then default
+    let location = detail.location || '';
+    if (!location) {
+      const hintCityMatch = tile.titleHint.match(/,\s*([A-ZÄÖÜ][a-zäöü]+(?:\/[A-ZÄÖÜ][a-zäöü]+)?)\s*$/);
+      if (hintCityMatch) location = hintCityMatch[1];
+    }
+    if (!location) location = 'Kirchlindach';
+
+    const sourceLang = 'de';
+    const jobSlug = slugify(`${title} ${SUEDHANG_KEY} ch`);
+    const urlHash = createHash('sha1').update(tile.url).digest('hex').slice(0, 12);
+
+    const pensumSource = `${detail.pensum} ${title}`;
+    const pensum = extractPensum(pensumSource);
+    const employmentType = detectHealthcareEmploymentType(pensumSource);
+    const contract = pensum && pensum.max < 80 ? 'part-time' : 'full-time';
+
+    const fallbackDesc = `${title} — ${SUEDHANG_COMPANY_NAME}, ${location}. Klinik für Suchttherapien.`;
+    const description = detail.description && detail.description.split(/\s+/).length >= 30
+      ? detail.description
+      : fallbackDesc;
+
+    const job = {
+      id: `${SUEDHANG_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: SUEDHANG_COMPANY_NAME,
+      companyKey: SUEDHANG_KEY,
+      companyDomain: SUEDHANG_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location,
+      canton: 'BE',
+      url: tile.url,
+      source: `${SUEDHANG_COMPANY_NAME} Dedicated Parser (custom HTML)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: location,
+      postalCode: postalCodeFor(location),
+      addressCountry: 'CH',
+      country: 'CH',
+      category: detectHealthcareCategory(title),
+      contract,
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: new Date().toISOString().split('T')[0],
+      applyUrl: tile.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    };
+
+    if (pensum) {
+      job.pensumMin = pensum.min;
+      job.pensumMax = pensum.max;
+      job.pensum = pensum.min === pensum.max ? `${pensum.min}%` : `${pensum.min} - ${pensum.max}%`;
+    }
+
+    jobs.push(job);
+  }
+
+  console.log(`\n📋 Total ${SUEDHANG_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/update-igs-bern-jobs.mjs
+++ b/scripts/update-igs-bern-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated IGS Bern (Soteria) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllIgsBernJobs,
+  isIgsBernJob,
+  isTrustedDomain,
+  IGS_BERN_KEY,
+  IGS_BERN_COMPANY_NAME,
+} from './lib/igs-bern-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: IGS_BERN_KEY,
+  companyLabel: IGS_BERN_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllIgsBernJobs,
+  isCompanyJob: isIgsBernJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ IGS Bern crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-privatklinik-wyss-jobs.mjs
+++ b/scripts/update-privatklinik-wyss-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Privatklinik Wyss crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllPrivatklinikWyssJobs,
+  isPrivatklinikWyssJob,
+  isTrustedDomain,
+  PRIVATKLINIK_WYSS_KEY,
+  PRIVATKLINIK_WYSS_COMPANY_NAME,
+} from './lib/privatklinik-wyss-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: PRIVATKLINIK_WYSS_KEY,
+  companyLabel: PRIVATKLINIK_WYSS_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllPrivatklinikWyssJobs,
+  isCompanyJob: isPrivatklinikWyssJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Privatklinik Wyss crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-suedhang-jobs.mjs
+++ b/scripts/update-suedhang-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Klinik Südhang crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllSuedhangJobs,
+  isSuedhangJob,
+  isTrustedDomain,
+  SUEDHANG_KEY,
+  SUEDHANG_COMPANY_NAME,
+} from './lib/suedhang-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: SUEDHANG_KEY,
+  companyLabel: SUEDHANG_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllSuedhangJobs,
+  isCompanyJob: isSuedhangJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Klinik Südhang crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Cover the 3 standalone BE psychiatric/rehab clinics from the welches-spital
2026-05-19 inventory that still lacked dedicated parsers. Two custom-HTML
sites + one new PastaHR/publicjobs tenant for the IGS Bern / Soteria group.

| ATS                | Tenant                          | Canton | Jobs |
|--------------------|----------------------------------|--------|------|
| PastaHR/publicjobs | igs-bern (kdNr 104465, Soteria)  | BE     | 5    |
| Custom HTML (WP)   | suedhang (Kirchlindach)          | BE     | 8    |
| Custom HTML        | privatklinik-wyss (Münchenbuchsee)| BE    | 7    |

Skipped (no qualifying ATS / <5 jobs / no openings):
- Klinik Wysshölzli (only PDF inserate)
- Klinik Selhofen Burgdorf (no ATS, no jobs section content)
- Klinik Hohmad Thun (turned out to be Wohnungen / residential, not a clinic)
- Klinik Schönberg Gunten (jobalino tenant exists but only 1 spontaneous
  placeholder, no real openings)
- Berner Reha Zentrum Heiligenschwendi (redirects to inselgruppe.ch — already
  covered by Insel Umantis)
- Reha- und Kurklinik EDEN Oberried (no open positions on /Angebot/offene-stellen)
- Rehaklinik Hasliberg (DNS-unreachable)

All ParsedJob records set `needsRetranslation: true` (factory and custom).
IGS Bern workflow ships `SKIP_BOILERPLATE_GUARD=1` because publicjobs.ch
detail bodies sometimes fall under 30 unique words on short part-time roles.
