### PR TITLE
feat: add Cereneo + Triaplus crawlers (batch 19m Innerschweiz)

### DIFF
--- a/.github/workflows/update-jobs-cereneo.yml
+++ b/.github/workflows/update-jobs-cereneo.yml
@@ -1,0 +1,101 @@
+name: Update Cereneo Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-cereneo
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-cereneo-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated CERENEO crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_CERENEO_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-cereneo-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'cereneo'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/cereneo.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CERENEO jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-triaplus.yml
+++ b/.github/workflows/update-jobs-triaplus.yml
@@ -1,0 +1,101 @@
+name: Update Triaplus Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-triaplus
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-triaplus-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated TRIAPLUS crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_TRIAPLUS_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-triaplus-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'triaplus'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/triaplus.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update TRIAPLUS jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/cereneo-job-parser.mjs
+++ b/scripts/lib/cereneo-job-parser.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * Cereneo (Centre for Neurology & Rehabilitation) job parser — Dualoo ATS
+ * (portal `muy5swcr`).
+ *
+ * Public career site: https://cereneo.ch/jobs-and-careers/open-positions/
+ *   → embeds Dualoo portal https://jobs.dualoo.com/portal/muy5swcr
+ *
+ * Cereneo is a premium Swiss neurorehabilitation clinic group with sites
+ * in Vitznau (LU, head office and head clinic) and Weggis/Hertenstein (LU,
+ * Hotel Hertenstein medical residency). Single Dualoo portal serves all
+ * legal entities:
+ *   - cereneo Schweiz AG (Vitznau / Weggis-Hertenstein clinic)
+ *   - cereneo International AG (corporate, Vitznau)
+ *   - cereneo Prevention AG (Vitznau, executive-prevention clinic)
+ *   - cereneo Home B.V. (mobile therapy unit — Amsterdam, NL: excluded as
+ *     not a Swiss-based opening)
+ *
+ * The portal mixes German and English postings; the listing rows expose
+ * the `lang` query in the `href` (e.g. `…/detail?lang=EN` vs `?lang=DE`),
+ * which we read to set `sourceLang`. Foreign-country sites are skipped
+ * upstream so this parser only emits CH-based vacancies.
+ *
+ * Modelled on `scripts/lib/uroviva-job-parser.mjs`.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const CERENEO_KEY = 'cereneo';
+export const CERENEO_COMPANY_NAME = 'Cereneo';
+export const CERENEO_COMPANY_DOMAIN = 'cereneo.ch';
+
+const DUALOO_PORTAL = 'muy5swcr';
+const PORTAL_URL = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}?lang=DE`;
+const DETAIL_BASE = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}`;
+const PUBLIC_CAREER_URL = 'https://cereneo.ch/jobs-and-careers/open-positions/';
+const DETAIL_DELAY_MS = 250;
+
+// Default to the head clinic in Vitznau (LU) when location can't be parsed.
+const DEFAULT_CITY = 'Vitznau';
+const DEFAULT_POSTAL_CODE = '6354';
+const DEFAULT_CANTON = 'LU';
+
+// Known Cereneo sites → city + postal. All locations are in Lucerne canton.
+const SITE_LOCATION_MAP = new Map([
+  ['vitznau', { city: 'Vitznau', postal: '6354', canton: 'LU' }],
+  ['weggis', { city: 'Weggis', postal: '6353', canton: 'LU' }],
+  ['hertenstein', { city: 'Weggis', postal: '6353', canton: 'LU' }],
+]);
+
+// Non-CH operating entities — skip these from the Swiss-jobs feed.
+const FOREIGN_COUNTRY_HINTS = [
+  'amsterdam', 'netherlands', 'nederland', 'home b.v.',
+  'london', 'united kingdom', 'germany', 'deutschland', 'usa',
+];
+
+export function isCereneoJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === CERENEO_KEY
+    || url.includes('cereneo.ch')
+    || url.includes(`/${DUALOO_PORTAL}/`);
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'cereneo.ch'
+      || host.endsWith('.cereneo.ch')
+      || host === 'jobs.dualoo.com';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse the Dualoo portal HTML listing.
+ *
+ * Each card uses `<a class="row jobElement">` with a `data-eventData` JSON blob
+ * carrying `jobName` and `location` (entity + city).
+ */
+export function parseDualooPortal(html) {
+  const out = [];
+  const seen = new Set();
+  const blockRe = /<a[^>]*class="[^"]*\bjobElement\b[^"]*"[^>]*>[\s\S]*?<\/a>/g;
+  let m;
+  while ((m = blockRe.exec(html))) {
+    const block = m[0];
+    const hrefMatch = block.match(/\shref="([^"]+)"/);
+    const evMatch = block.match(/\sdata-eventData="([^"]+)"/);
+    const spanMatch = block.match(/<span[^>]*class="jobName"[^>]*>([\s\S]*?)<\/span>/i);
+    if (!hrefMatch) continue;
+    const rel = hrefMatch[1];
+    let meta = {};
+    if (evMatch) {
+      const evRaw = evMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&');
+      try { meta = JSON.parse(evRaw); } catch { meta = {}; }
+    }
+    const spanTitle = spanMatch
+      ? normalizeSpace(decodeEntities(spanMatch[1].replace(/<[^>]+>/g, ' ')))
+      : '';
+    const evTitle = normalizeSpace(decodeEntities(String(meta.jobName || '')));
+    const title = spanTitle || evTitle;
+    if (!title || title.length < 3) continue;
+    const uuidMatch = rel.match(/([a-f0-9-]{36})\/detail/);
+    const uuid = uuidMatch ? uuidMatch[1] : rel;
+    if (seen.has(uuid)) continue;
+    seen.add(uuid);
+    const url = rel.startsWith('http')
+      ? rel
+      : `${DETAIL_BASE}/${rel.replace(new RegExp(`^${DUALOO_PORTAL}/`), '')}`;
+    // Lang hint from the URL query (?lang=DE / ?lang=EN)
+    const langMatch = url.match(/[?&]lang=([A-Za-z]{2,3})/i);
+    const linkLang = langMatch ? langMatch[1].toLowerCase() : '';
+    out.push({
+      uuid,
+      url,
+      title,
+      location: normalizeSpace(decodeEntities(String(meta.location || ''))),
+      startDate: normalizeSpace(decodeEntities(String(meta.startDate || ''))),
+      linkLang,
+    });
+  }
+  return out;
+}
+
+async function fetchDualooDetail(detailUrl) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    const sections = [];
+    const grab = (cls, label) => {
+      const rx = new RegExp(`class="${cls}"[^>]*>([\\s\\S]*?)</div>`, 'i');
+      const mm = html.match(rx);
+      if (!mm) return;
+      const text = mm[1]
+        .replace(/<li[^>]*>/gi, '\n• ')
+        .replace(/<\/li>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/\s+\n/g, '\n')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+      if (text) sections.push(`${label}\n${text}`);
+    };
+    grab('advertisementResponsibilitiesText', 'Aufgaben:');
+    grab('advertisementRequirementsText', 'Anforderungen:');
+    grab('advertisementBenefitsText', 'Wir bieten:');
+    return sections.join('\n\n');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Parse a "entity - city" location string. Cereneo formats it as
+ *   "cereneo Schweiz AG - Weggis"
+ *   "cereneo Home B.V. - Amsterdam"  (foreign — skipped)
+ */
+function parseLocation(rawLocation) {
+  if (!rawLocation) {
+    return { city: DEFAULT_CITY, postal: DEFAULT_POSTAL_CODE, canton: DEFAULT_CANTON, isForeign: false };
+  }
+  const lower = rawLocation.toLowerCase();
+  const isForeign = FOREIGN_COUNTRY_HINTS.some((h) => lower.includes(h));
+  if (isForeign) {
+    return { city: '', postal: '', canton: '', isForeign: true };
+  }
+  const parts = rawLocation.split(/\s*-\s*/).map((s) => s.trim()).filter(Boolean);
+  const last = (parts[parts.length - 1] || DEFAULT_CITY).toLowerCase();
+  const match = SITE_LOCATION_MAP.get(last)
+    || [...SITE_LOCATION_MAP.entries()].find(([k]) => last.includes(k));
+  if (Array.isArray(match)) {
+    return { ...match[1], isForeign: false };
+  }
+  if (match && typeof match === 'object' && !Array.isArray(match)) {
+    return { ...match, isForeign: false };
+  }
+  return { city: DEFAULT_CITY, postal: DEFAULT_POSTAL_CODE, canton: DEFAULT_CANTON, isForeign: false };
+}
+
+export async function fetchAllCereneoJobs() {
+  console.log(`🏥 Fetching ${CERENEO_COMPANY_NAME} jobs`);
+  console.log(`   Portal: ${PORTAL_URL}`);
+  console.log(`   Public: ${PUBLIC_CAREER_URL}\n`);
+
+  const html = await fetchHtml(PORTAL_URL);
+  const items = parseDualooPortal(html);
+  console.log(`  ✓ ${items.length} Dualoo job cards parsed (raw)`);
+
+  // Filter out foreign-country listings (e.g. cereneo Home B.V. - Amsterdam)
+  const chItems = items.filter((it) => !parseLocation(it.location).isForeign);
+  const droppedForeign = items.length - chItems.length;
+  if (droppedForeign > 0) {
+    console.log(`  ✓ ${chItems.length} CH-located jobs after filtering ${droppedForeign} foreign listings`);
+  }
+  if (!chItems.length) return [];
+
+  console.log(`  📄 Fetching detail pages for rich descriptions...`);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let detailHits = 0;
+  for (let i = 0; i < chItems.length; i += 1) {
+    const it = chItems[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+    const detailContent = await fetchDualooDetail(it.url);
+    if (detailContent) detailHits += 1;
+
+    const loc = parseLocation(it.location);
+    const description = [
+      detailContent,
+      it.location ? `Standort: ${it.location}` : '',
+      it.startDate ? `Eintritt: ${it.startDate}` : '',
+      `${CERENEO_COMPANY_NAME} — Centre for Neurology & Rehabilitation, ${loc.city} (${loc.canton}), Schweiz.`,
+    ].filter(Boolean).join('\n\n');
+
+    // The Dualoo detail page URL exposes a `lang=` query that mirrors the
+    // posting language. Use it as a fallback for short titles where
+    // automatic detection misfires.
+    const linkLangHint = it.linkLang === 'en' ? 'en' : (it.linkLang === 'fr' ? 'fr' : (it.linkLang === 'it' ? 'it' : 'de'));
+    const sourceLang = detectLang(description || it.title, linkLangHint);
+    const jobSlug = slugify(`${it.title} ${CERENEO_KEY} ${loc.city}`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${CERENEO_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: CERENEO_COMPANY_NAME,
+      companyKey: CERENEO_KEY,
+      companyDomain: CERENEO_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
+      location: loc.city,
+      canton: loc.canton,
+      url: it.url,
+      source: `${CERENEO_COMPANY_NAME} Dedicated Parser (Dualoo)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: loc.city,
+      addressRegion: loc.canton,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: loc.postal,
+      category: detectHealthcareCategory(it.title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(it.title),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(
+    `📋 Total ${CERENEO_COMPANY_NAME} jobs discovered: ${jobs.length} `
+    + `(${detailHits}/${chItems.length} with rich detail content)`,
+  );
+  return jobs;
+}
+
+export { PUBLIC_CAREER_URL, PORTAL_URL, DUALOO_PORTAL };

--- a/scripts/lib/triaplus-job-parser.mjs
+++ b/scripts/lib/triaplus-job-parser.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * Triaplus AG job parser — custom WordPress career site.
+ *
+ * Public career site: https://karriere.triaplus.ch/freie-stellen/
+ *   → paginated WP listing (`/freie-stellen/page/{N}/`) of job pages at
+ *     `/jobs/{slug}/`.
+ *
+ * Triaplus AG (formerly Psychiatrische Klinik Zugersee) operates four
+ * psychiatric clinics across central Switzerland under one umbrella:
+ *   - Klinik Zugersee, Oberwil b. Zug (ZG, head clinic)
+ *   - Klinik Meissenberg (sister entity — separate site)
+ *   - Outpatient centres in Zug, Lucerne, Schwyz
+ * The career portal serves the whole group from a single WordPress install.
+ *
+ * Each job page is a server-rendered `<article>` of type `single-jobs`
+ * with H2 sections ("Ihre Aufgaben beinhalten", "Sie bringen dafür mit",
+ * "Wir bieten Ihnen") that we concatenate into the description.
+ *
+ * Modelled on `scripts/lib/uroviva-job-parser.mjs` (multi-site Dualoo) and
+ * `scripts/lib/spital-affoltern-job-parser.mjs` (multi-portal listing).
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const TRIAPLUS_KEY = 'triaplus';
+export const TRIAPLUS_COMPANY_NAME = 'Triaplus AG';
+export const TRIAPLUS_COMPANY_DOMAIN = 'triaplus.ch';
+
+const BASE_URL = 'https://karriere.triaplus.ch';
+const LISTING_URL = `${BASE_URL}/freie-stellen/`;
+const PUBLIC_CAREER_URL = LISTING_URL;
+const DETAIL_DELAY_MS = 250;
+const MAX_PAGES = 10; // safety cap
+
+// Head clinic is Klinik Zugersee in Oberwil-Zug (ZG).
+const DEFAULT_CITY = 'Oberwil';
+const DEFAULT_POSTAL_CODE = '6317';
+const DEFAULT_CANTON = 'ZG';
+
+export function isTriaplusJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return job?.companyKey === TRIAPLUS_KEY
+    || url.includes('triaplus.ch');
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'triaplus.ch'
+      || host.endsWith('.triaplus.ch');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pull all `/jobs/{slug}/` hrefs from one listing page.
+ */
+export function parseListingPage(html) {
+  const out = new Set();
+  const rx = /href="(https:\/\/karriere\.triaplus\.ch\/jobs\/[a-z0-9-]+\/?)"/g;
+  let m;
+  while ((m = rx.exec(html))) {
+    let url = m[1];
+    if (!url.endsWith('/')) url += '/';
+    out.add(url);
+  }
+  return [...out];
+}
+
+/**
+ * Extract title + structured description sections from a job detail page.
+ */
+function parseJobDetail(html) {
+  // Title comes from the H1 (`<h1 class="… jobtitel">…</h1>`) or the <title>.
+  let title = '';
+  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1Match) {
+    title = normalizeSpace(decodeEntities(htmlToText(h1Match[1])));
+  }
+  if (!title) {
+    const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
+    if (titleMatch) {
+      title = normalizeSpace(decodeEntities(titleMatch[1]))
+        .replace(/\s*\|\s*Triaplus AG\s*$/i, '');
+    }
+  }
+
+  // The H3 sections of interest — each followed by a <ul>/<p> block of
+  // bullets/paragraphs. We capture everything between an H3 and the next
+  // H3 / closing block. Triaplus uses H2 for the page title only and H3
+  // for each content section.
+  const SECTION_LABELS = [
+    /ihre aufgaben/i,
+    /sie bringen/i,
+    /wir bieten/i,
+    /das erwartet sie/i,
+    /das bringen sie mit/i,
+    /unser angebot/i,
+    /viele gr[uü]nde/i,
+  ];
+
+  const sectionRx = /<h3[^>]*>([\s\S]*?)<\/h3>([\s\S]*?)(?=<h3[^>]*>|<div[^>]*class="[^"]*(?:cta-content|job-footer|person-item|brlbs)|<footer)/gi;
+  const sections = [];
+  let mm;
+  while ((mm = sectionRx.exec(html))) {
+    const headRaw = normalizeSpace(decodeEntities(htmlToText(mm[1])));
+    if (!SECTION_LABELS.some((re) => re.test(headRaw))) continue;
+    const bodyHtml = mm[2];
+    const bullets = [];
+    const liRx = /<li[^>]*>([\s\S]*?)<\/li>/g;
+    let lm;
+    while ((lm = liRx.exec(bodyHtml))) {
+      const t = normalizeSpace(decodeEntities(htmlToText(lm[1])));
+      if (t && t.length > 4) bullets.push(`• ${t}`);
+    }
+    let bodyText = '';
+    if (bullets.length) {
+      bodyText = bullets.join('\n');
+    } else {
+      bodyText = normalizeSpace(decodeEntities(htmlToText(bodyHtml)));
+    }
+    if (bodyText) sections.push(`${headRaw}\n${bodyText}`);
+  }
+
+  return { title, sections };
+}
+
+export async function fetchAllTriaplusJobs() {
+  console.log(`🏥 Fetching ${TRIAPLUS_COMPANY_NAME} jobs`);
+  console.log(`   Listing: ${LISTING_URL}`);
+  console.log(`   Public:  ${PUBLIC_CAREER_URL}\n`);
+
+  // Walk pagination until a page returns 0 new URLs.
+  const allUrls = new Set();
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const url = page === 1 ? LISTING_URL : `${LISTING_URL}page/${page}/`;
+    let html = '';
+    try {
+      html = await fetchHtml(url);
+    } catch (err) {
+      if (page === 1) throw err;
+      break;
+    }
+    const before = allUrls.size;
+    parseListingPage(html).forEach((u) => allUrls.add(u));
+    const added = allUrls.size - before;
+    console.log(`  ✓ page ${page}: ${added} new job URLs (total ${allUrls.size})`);
+    if (added === 0) break;
+  }
+
+  const detailUrls = [...allUrls];
+  if (!detailUrls.length) return [];
+
+  console.log(`  📄 Fetching ${detailUrls.length} job detail pages...`);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let detailHits = 0;
+  const seenIds = new Set();
+
+  for (let i = 0; i < detailUrls.length; i += 1) {
+    const detailUrl = detailUrls[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+
+    let html = '';
+    try {
+      html = await fetchHtml(detailUrl);
+    } catch {
+      continue;
+    }
+
+    const { title, sections } = parseJobDetail(html);
+    if (!title || title.length < 3) continue;
+
+    const rich = sections.join('\n\n').trim();
+    if (rich) detailHits += 1;
+
+    const description = [
+      rich,
+      `${TRIAPLUS_COMPANY_NAME} — Psychiatrische Klinik (Klinik Zugersee), ${DEFAULT_CITY} (${DEFAULT_CANTON}), Schweiz.`,
+      `Bewerbung über das Karriereportal: ${detailUrl}`,
+    ].filter(Boolean).join('\n\n');
+
+    const sourceLang = detectLang(description || title, 'de');
+    const slugFromUrl = (detailUrl.match(/\/jobs\/([a-z0-9-]+)\/?$/) || [])[1] || '';
+    const jobSlug = slugify(`${title} ${TRIAPLUS_KEY} ${slugFromUrl || DEFAULT_CITY}`);
+    const urlHash = createHash('sha1').update(detailUrl).digest('hex').slice(0, 12);
+    const id = `${TRIAPLUS_KEY}-${urlHash}`;
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
+
+    jobs.push({
+      id,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: TRIAPLUS_COMPANY_NAME,
+      companyKey: TRIAPLUS_KEY,
+      companyDomain: TRIAPLUS_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship with source-locale-only fields. The shared
+      // AI-localization step clears this flag when it fills the remaining 3
+      // locales; if it can't (cache miss + AI quota), the flag stays and
+      // `translate-pending.yml` picks the job up out-of-band. Without this
+      // flag the locale-completeness gate trips before translation can run.
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url: detailUrl,
+      source: `${TRIAPLUS_COMPANY_NAME} Dedicated Parser (WordPress career site)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL_CODE,
+      category: detectHealthcareCategory(title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(title),
+      experienceLevel: detectHealthcareExperienceLevel(title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: detailUrl,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(
+    `📋 Total ${TRIAPLUS_COMPANY_NAME} jobs discovered: ${jobs.length} `
+    + `(${detailHits}/${detailUrls.length} with rich detail content)`,
+  );
+  return jobs;
+}
+
+export { LISTING_URL, PUBLIC_CAREER_URL };

--- a/scripts/update-cereneo-jobs.mjs
+++ b/scripts/update-cereneo-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Cereneo crawler runner.
+ *
+ * Uses the standard crawler template with the Cereneo parser
+ * (Dualoo — single portal `muy5swcr`, foreign-country jobs filtered out).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllCereneoJobs,
+  isCereneoJob,
+  isTrustedDomain,
+  CERENEO_KEY,
+  CERENEO_COMPANY_NAME,
+} from './lib/cereneo-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: CERENEO_KEY,
+  companyLabel: CERENEO_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllCereneoJobs,
+  isCompanyJob: isCereneoJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Cereneo crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-triaplus-jobs.mjs
+++ b/scripts/update-triaplus-jobs.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Triaplus crawler runner.
+ *
+ * Uses the standard crawler template with the Triaplus parser
+ * (custom WordPress career site at karriere.triaplus.ch — multi-clinic
+ * psychiatric group in ZG with paginated listing).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllTriaplusJobs,
+  isTriaplusJob,
+  isTrustedDomain,
+  TRIAPLUS_KEY,
+  TRIAPLUS_COMPANY_NAME,
+} from './lib/triaplus-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: TRIAPLUS_KEY,
+  companyLabel: TRIAPLUS_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllTriaplusJobs,
+  isCompanyJob: isTriaplusJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Triaplus crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Covers 2 of 6 candidate Innerschweiz hospitals from §4 of the
HOSPITAL-CRAWLERS-INVENTORY (LU + ZG psychiatry/rehab). Skipped:
SPZ Nottwil (already in spz + paraplegie parsers), Therapiezentrum
Meggen (<5 jobs, PDFs only), Bürgenstock Waldhotel (44 jobs but
hospital roles indistinguishable from hotel postings via portal
metadata), Kantonsspital Obwalden (DNS unreachable; LUPS covers
Sarnen psychiatry), Klinik Meissenberg (no parseable listing, only
external Medicus.ch profile).

| tenant   | canton | ats               | smoke-count | source-lang |
|----------|--------|-------------------|-------------|-------------|
| cereneo  | LU     | Dualoo muy5swcr   | 7 CH jobs   | de + en     |
| triaplus | ZG     | WordPress (custom)| 28 jobs     | de          |

Cereneo runs 4 entities (Schweiz AG, International AG, Prevention AG,
Home B.V.) through one Dualoo portal — the Home B.V. NL-based mobile
unit is filtered out via FOREIGN_COUNTRY_HINTS so only Vitznau (6354)
and Weggis/Hertenstein (6353) jobs land in the CH dataset.

Triaplus AG (vorm. Psychiatrische Klinik Zugersee) uses a custom WP
career site at karriere.triaplus.ch with paginated /freie-stellen/.
Detail pages expose H3 sections (Ihre Aufgaben / Sie bringen / Wir
bieten) which we concatenate; 28/28 jobs produced rich descriptions
~1500 chars each. Default location = Oberwil-Zug (6317 ZG).

Both parsers tag every ParsedJob with needsRetranslation:true so the
locale-completeness gate doesn't trip before translate-pending.yml
fills EN/FR/IT. No touching crawler-location-config / known-company-
slugs / data/jobs*.json (those will pick up the new keys via the
auto-discovery path on first crawler-dispatch run).
