### PR TITLE
feat(crawlers): batch 19n TI/GR/VS hospital tail (3 custom-HTML)

### DIFF
--- a/.github/workflows/update-jobs-canton-ticino-osc.yml
+++ b/.github/workflows/update-jobs-canton-ticino-osc.yml
@@ -1,0 +1,101 @@
+name: Update Canton Ticino OSC Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-canton-ticino-osc
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-canton-ticino-osc-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated CANTON_TICINO_OSC crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_CANTON_TICINO_OSC_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-canton-ticino-osc-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'canton-ticino-osc'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/canton-ticino-osc.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CANTON_TICINO_OSC jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-klinik-gut.yml
+++ b/.github/workflows/update-jobs-klinik-gut.yml
@@ -1,0 +1,101 @@
+name: Update Klinik Gut Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-klinik-gut
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-klinik-gut-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated KLINIK_GUT crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_KLINIK_GUT_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-klinik-gut-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'klinik-gut'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/klinik-gut.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_GUT jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-oscam-castelrotto.yml
+++ b/.github/workflows/update-jobs-oscam-castelrotto.yml
@@ -1,0 +1,105 @@
+name: Update OSCAM Castelrotto Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-oscam-castelrotto
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-oscam-castelrotto-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated OSCAM_CASTELROTTO crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_OSCAM_CASTELROTTO_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          # Concorso descriptions are boilerplate-heavy (each PDF is the real
+          # content). Bypass the MIN_UNIQUE_WORDS guard during assembly so the
+          # 3 active concorsi flow into the dataset.
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-oscam-castelrotto-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'oscam-castelrotto'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/oscam-castelrotto.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update OSCAM_CASTELROTTO jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/canton-ticino-osc-job-parser.mjs
+++ b/scripts/lib/canton-ticino-osc-job-parser.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/**
+ * Canton Ticino — Organizzazione Sociopsichiatrica Cantonale (OSC)
+ * and other Dipartimento della Sanità e della Socialità (DSS) postings
+ * published on the official cantonal jobportal `concorsi.ti.ch`.
+ *
+ * The OSC operates the Clinica psichiatrica cantonale (CPC, Mendrisio) and
+ * regional outpatient psychiatric services across Ticino. These jobs are
+ * NOT discoverable via dedicated parsers (no standalone career page) — they
+ * flow through the cantonal `Foglio Ufficiale` aggregator (rexx-systems CMS).
+ *
+ * Source:
+ *   Listing: https://www.concorsi.ti.ch/
+ *   Detail : https://www.concorsi.ti.ch/offerte-d'impieghi.html?yid={N}&sid={sid}
+ *
+ * Workflow:
+ *  1. Fetch the listing index (~18 active concorsi).
+ *  2. Extract `yid` ids + anchor text (title preview).
+ *  3. For each yid, fetch the detail page.
+ *  4. Filter to entries where:
+ *       - body contains "Dipartimento della sanità e della socialità", OR
+ *       - title/body references OSC, Mendrisio, CPC, sociopsichiatric*, EOC,
+ *         ente ospedaliero, Clinica psichiatrica cantonale.
+ *  5. Skip "Candidature spontanee" (non-job placeholder).
+ *  6. Build description from the h2 sections (Compiti, Requisiti, Osservazioni,
+ *     Condizioni di presentazione, Condizioni d'impiego, Scadenza).
+ *
+ * Stable id = yid (cantonal record id, stable for the lifetime of the concorso).
+ *
+ * Note: jobs are sub-allocated to the right canton (TI) but the location text
+ * always reads "Mendrisio" for OSC; some DSS jobs may sit in Bellinzona/Lugano.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const CANTON_TICINO_OSC_KEY = 'canton-ticino-osc';
+export const CANTON_TICINO_OSC_COMPANY_NAME =
+  'Organizzazione Sociopsichiatrica Cantonale (OSC) — Cantone Ticino';
+export const CANTON_TICINO_OSC_COMPANY_DOMAIN = 'concorsi.ti.ch';
+
+const LISTING_URL = 'https://www.concorsi.ti.ch/';
+const BASE_URL = 'https://www.concorsi.ti.ch';
+
+// Health-or-OSC topical filter. Either:
+//  - the body lists the Dipartimento della Sanità e della Socialità (DSS), OR
+//  - title/body references OSC, Mendrisio, CPC, EOC, ente ospedaliero, sanità etc.
+const HEALTH_DEPT_RE = /Dipartimento\s+della\s+sanit[àa]\s+e\s+della\s+socialit[àa]/i;
+const HEALTH_TOPIC_RE =
+  /(\bOSC\b|sociopsichi|Clinica\s+psichiatrica\s+cantonale|\bCPC\b|\bEOC\b|ente\s+ospedaliero|Mendrisio|Casvegno|sanitario|infermier|medico|psicolog|operator[ei]\s+social)/i;
+
+// Drop these entirely (placeholders / cross-dept).
+const SKIP_TITLE_RE = /Candidatur[ae]\s+spontane|spontanbewerb/i;
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isCantonTicinoOscJob(job) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === CANTON_TICINO_OSC_KEY ||
+    key.startsWith('canton-ticino-osc') ||
+    url.includes('concorsi.ti.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'concorsi.ti.ch' || host.endsWith('.concorsi.ti.ch')
+      || host === 'www.concorsi.ti.ch';
+  } catch {
+    return false;
+  }
+}
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+/**
+ * Try to derive the city from the title/body text. Defaults to Mendrisio
+ * (OSC headquarters / Clinica Psichiatrica Cantonale).
+ */
+function inferLocation(haystack) {
+  const t = String(haystack || '');
+  const cities = [
+    ['Mendrisio', '6850'],
+    ['Casvegno', '6850'],   // CPC campus inside Mendrisio
+    ['Cademario', '6936'],  // OSC clinic
+    ['Lugano', '6900'],
+    ['Bellinzona', '6500'],
+    ['Locarno', '6600'],
+    ['Chiasso', '6830'],
+    ['Coldrerio', '6877'],
+  ];
+  for (const [city, postal] of cities) {
+    if (new RegExp(`\\b${city}\\b`, 'i').test(t)) return { city, postal };
+  }
+  return { city: 'Mendrisio', postal: '6850' };
+}
+
+/* ── Listing parser ────────────────────────────────────────── */
+
+/**
+ * Parse the index page; return [{ yid, anchorText }].
+ */
+export function parseConcorsiListingIndex(html = '') {
+  const out = [];
+  const seen = new Set();
+  // Anchor:  <a href="https://www.concorsi.ti.ch/offerte-d'impieghi.html?yid=4091&amp;sid=…">title</a>
+  const linkRe = /<a[^>]+href="([^"]*offerte-d[^"]*\?yid=(\d+)[^"]*)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = linkRe.exec(html)) !== null) {
+    const yid = m[2];
+    if (seen.has(yid)) continue;
+    seen.add(yid);
+    const anchorText = normalizeSpace(
+      decodeEntities(String(m[3]).replace(/<[^>]+>/g, '')),
+    );
+    out.push({ yid, anchorText });
+  }
+  return out;
+}
+
+/* ── Detail parser ─────────────────────────────────────────── */
+
+/**
+ * Extract structured fields from a detail page.
+ */
+export function parseConcorsiDetail(html = '') {
+  // h2 blocks in document order:
+  //   [0] = Dipartimento della sanità e della socialità (or other dept name)
+  //   [1] = concorso #/yy (e.g. 23/26)
+  //   [2] = full title (long sentence)
+  //   [3+] = Compiti, Requisiti, Osservazioni, Condizioni di presentazione,
+  //          Condizioni d'impiego, Scadenza
+  const heads = [];
+  const headRe = /<h2[^>]*>([\s\S]*?)<\/h2>/gi;
+  let hm;
+  while ((hm = headRe.exec(html)) !== null) {
+    const txt = normalizeSpace(
+      decodeEntities(String(hm[1]).replace(/<[^>]+>/g, '')),
+    );
+    if (!txt || txt === '&nbsp;') continue;
+    heads.push({ text: txt, start: hm.index, end: headRe.lastIndex });
+  }
+  if (heads.length === 0) return null;
+
+  // Department = first heading that mentions "Dipartimento" OR first heading
+  // (some non-DSS jobs use just the office name, e.g. "Controllo cantonale
+  // delle finanze").
+  let dept = '';
+  let titleIdx = -1;
+  for (let i = 0; i < heads.length; i += 1) {
+    if (/^\d+\/\d+/.test(heads[i].text)) {
+      titleIdx = i + 1; // title is the next non-empty h2
+      if (i > 0) dept = heads[i - 1].text;
+      break;
+    }
+  }
+  if (titleIdx < 0 || titleIdx >= heads.length) return null;
+
+  const title = heads[titleIdx].text;
+  if (!title || title.length < 10) return null;
+
+  // Body sections: everything from title.end to the next h2 (Compiti / etc),
+  // and concatenate Compiti…Scadenza for the description.
+  const sectionStart = heads[titleIdx].end;
+  const sectionEnd = html.search(/<\/?(footer|nav|aside)/i);
+  const bodyHtml = html.slice(sectionStart, sectionEnd > sectionStart ? sectionEnd : undefined);
+  const text = htmlToText(bodyHtml);
+
+  return { dept, title, text };
+}
+
+/* ── Description fallback ──────────────────────────────────── */
+
+function buildFallbackDescription(title, city) {
+  return [
+    `${title} presso l'Amministrazione cantonale del Ticino (sede di ${city}).`,
+    '',
+    "Il concorso è pubblicato dalla Sezione delle risorse umane del Cantone Ticino sul portale ufficiale www.concorsi.ti.ch (Foglio Ufficiale). L'Organizzazione sociopsichiatrica cantonale (OSC) gestisce la Clinica psichiatrica cantonale (CPC) di Mendrisio e i servizi psichiatrici e psicosociali ambulatoriali su tutto il territorio ticinese, inseriti nel Dipartimento della sanità e della socialità (DSS).",
+    '',
+    "Il dettaglio completo (compiti, requisiti, condizioni d'impiego, scadenza e modalità di candidatura) è disponibile sul bando ufficiale linkato. Le candidature avvengono tramite il portale concorsi.ti.ch oppure secondo le istruzioni del bando.",
+  ].join('\n');
+}
+
+/* ── Main fetch ────────────────────────────────────────────── */
+
+export async function fetchAllCantonTicinoOscJobs() {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const requestDelayMs = Number(process.env.JOBS_CRAWLER_DELAY_MS) || 350;
+
+  console.log(`🏥 Fetching ${CANTON_TICINO_OSC_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${LISTING_URL} (TI cantonal jobportal — filtered to DSS / OSC)\n`);
+
+  let indexHtml;
+  try {
+    indexHtml = await fetchHtml(LISTING_URL, { timeoutMs });
+  } catch (err) {
+    throw new Error(`Failed to fetch concorsi.ti.ch index: ${err?.message || err}`);
+  }
+  const candidates = parseConcorsiListingIndex(indexHtml);
+  console.log(`  📋 Found ${candidates.length} active concorsi on index\n`);
+  if (candidates.length === 0) return [];
+
+  const jobs = [];
+  const todayIso = new Date().toISOString().slice(0, 10);
+
+  for (const cand of candidates) {
+    if (SKIP_TITLE_RE.test(cand.anchorText)) {
+      console.log(`  ⏭  yid=${cand.yid} skipped (spontaneous): ${cand.anchorText.slice(0, 60)}`);
+      continue;
+    }
+
+    const detailUrl = `${BASE_URL}/offerte-d'impieghi.html?yid=${cand.yid}`;
+    let detailHtml;
+    try {
+      detailHtml = await fetchHtml(detailUrl, { timeoutMs });
+    } catch (err) {
+      console.warn(`  ⚠️  yid=${cand.yid} detail fetch failed: ${err?.message || err}`);
+      continue;
+    }
+
+    const detail = parseConcorsiDetail(detailHtml);
+    if (!detail) {
+      console.warn(`  ⚠️  yid=${cand.yid} no structured detail`);
+      continue;
+    }
+
+    // Apply DSS/OSC filter.
+    const haystack = `${detail.dept} ${detail.title} ${detail.text}`;
+    const isHealthDept = HEALTH_DEPT_RE.test(detail.dept) || HEALTH_DEPT_RE.test(haystack);
+    const isHealthTopic = HEALTH_TOPIC_RE.test(detail.title) || HEALTH_TOPIC_RE.test(haystack);
+    if (!isHealthDept && !isHealthTopic) {
+      console.log(`  ⏭  yid=${cand.yid} skipped (non-health: ${detail.dept || 'no dept'})`);
+      continue;
+    }
+
+    const title = detail.title;
+    const loc = inferLocation(`${title} ${detail.text}`);
+    let description = detail.text && detail.text.split(/\s+/).length >= 80
+      ? detail.text
+      : buildFallbackDescription(title, loc.city);
+    if (description.split(/\s+/).length < 100) {
+      description = `${description}\n\n${buildFallbackDescription(title, loc.city)}`;
+    }
+
+    const sourceLang = 'it';
+    const jobSlug = slugify(`${title} ${CANTON_TICINO_OSC_KEY} ${loc.city}`);
+    const urlHash = createHash('sha1').update(`${detailUrl}|${cand.yid}`).digest('hex').slice(0, 12);
+    const employmentType = detectHealthcareEmploymentType(haystack);
+
+    jobs.push({
+      id: `${CANTON_TICINO_OSC_KEY}-${cand.yid}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: CANTON_TICINO_OSC_COMPANY_NAME,
+      companyKey: CANTON_TICINO_OSC_KEY,
+      companyDomain: CANTON_TICINO_OSC_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: loc.city,
+      canton: inferSwissTargetCanton(loc.city) || 'TI',
+      url: detailUrl,
+      source: 'Canton Ticino OSC Dedicated Parser (rexx-systems jobportal, DSS filter)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: loc.city,
+      addressRegion: 'TI',
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: loc.postal,
+      category: detectHealthcareCategory(haystack),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(haystack),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: detailUrl,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+
+    console.log(`  ✅ yid=${cand.yid} ${title.substring(0, 75)} → ${loc.city}`);
+
+    // Polite pacing — cantonal site is small.
+    if (requestDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, requestDelayMs));
+    }
+  }
+
+  // Reconcile sourceLang via detectLang (Italian is canonical for TI canton).
+  for (const j of jobs) {
+    const detected = detectLang(j.description || j.title, 'it');
+    if (detected !== j.sourceLang) {
+      j.sourceLang = detected;
+      j.titleByLocale = { [detected]: j.title };
+      j.descriptionByLocale = { [detected]: j.description };
+      j.slugByLocale = { [detected]: j.slug };
+      j.requirementsByLocale = { [detected]: [] };
+    }
+  }
+
+  console.log(`\n📋 Total ${CANTON_TICINO_OSC_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/klinik-gut-job-parser.mjs
+++ b/scripts/lib/klinik-gut-job-parser.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Klinik Gut AG (Gruppe) — orthopaedic / accident private clinic group in
+ * Graubünden + Ascona. HQ in St. Moritz (postal 7500).
+ *
+ * Public career site (Drupal 11 — RZ theme), German source:
+ *   https://www.klinik-gut.ch/de/offene-stellen
+ *
+ * Layout:
+ *   <h2>Klinik Gut Standort St. Moritz</h2>      ← location boundary
+ *     <h2 class="accordion-header">              ← job (Bootstrap accordion)
+ *       <button data-bs-target="#drz-accordion-id-NNNN">{title}</button>
+ *     </h2>
+ *     <div id="drz-accordion-id-NNNN" class="accordion-collapse collapse">
+ *       <div class="accordion-body">…full posting body…</div>
+ *     </div>
+ *   <h2>Klinik Gut Standort Fläsch</h2>          ← next location
+ *     …more accordion items…
+ *
+ * The Drupal `drz-accordion-id-NNNN` is a stable CMS node id reused across
+ * crawls — perfect canonical job id.
+ *
+ * Group sites:
+ *   - Klinik St. Moritz (Plazza Paracelsus 2a, 7500 St. Moritz, GR)
+ *   - Klinik Fläsch (7306 Fläsch, GR)
+ *   - Praxis Chur / Buchs / Zürich / Ascona — listing-only entries (no openings)
+ *
+ * For each posting, derive the city from the most recent "Standort" header.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  htmlToText,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const KLINIK_GUT_KEY = 'klinik-gut';
+export const KLINIK_GUT_COMPANY_NAME = 'Klinik Gut AG';
+export const KLINIK_GUT_COMPANY_DOMAIN = 'klinik-gut.ch';
+
+const PUBLIC_CAREER_URL = 'https://www.klinik-gut.ch/de/offene-stellen';
+
+const STANDORT_PROFILE = {
+  'st. moritz': { city: 'St. Moritz', canton: 'GR', postal: '7500' },
+  'st moritz':  { city: 'St. Moritz', canton: 'GR', postal: '7500' },
+  'flaesch':    { city: 'Fläsch',     canton: 'GR', postal: '7306' },
+  'fläsch':     { city: 'Fläsch',     canton: 'GR', postal: '7306' },
+  'chur':       { city: 'Chur',       canton: 'GR', postal: '7000' },
+  'buchs':      { city: 'Buchs SG',   canton: 'SG', postal: '9470' },
+  'zürich':     { city: 'Zürich',     canton: 'ZH', postal: '8001' },
+  'zuerich':    { city: 'Zürich',     canton: 'ZH', postal: '8001' },
+  'ascona':     { city: 'Ascona',     canton: 'TI', postal: '6612' },
+};
+
+const DEFAULT_LOCATION = { city: 'St. Moritz', canton: 'GR', postal: '7500' };
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isKlinikGutJob(job) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === KLINIK_GUT_KEY ||
+    key.startsWith('klinik-gut') ||
+    company.includes('klinik gut') ||
+    url.includes('klinik-gut.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'klinik-gut.ch' || host.endsWith('.klinik-gut.ch');
+  } catch {
+    return false;
+  }
+}
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function resolveStandort(headerText) {
+  const lc = String(headerText || '').toLowerCase();
+  for (const key of Object.keys(STANDORT_PROFILE)) {
+    if (lc.includes(key)) return STANDORT_PROFILE[key];
+  }
+  return null;
+}
+
+/* ── Parser ────────────────────────────────────────────────── */
+
+/**
+ * Walk the page in document order, tracking the active Standort header. For
+ * each accordion h2 (`<button data-bs-target="#drz-accordion-id-NNNN">`),
+ * locate the matching `<div id="drz-accordion-id-NNNN">` body and emit a
+ * listing record.
+ */
+export function parseKlinikGutListing(html = '') {
+  if (!html || typeof html !== 'string') return [];
+
+  const out = [];
+  const seen = new Set();
+
+  // Build an ordered list of candidate events (standort headers + accordion buttons).
+  const events = [];
+
+  // Standort h2 = plain `<h2>…Standort…</h2>` (NOT `class="accordion-header"`).
+  const standortRe = /<h2>\s*((?:<[^>]+>)?[^<]+)/g;
+  let sm;
+  while ((sm = standortRe.exec(html)) !== null) {
+    const text = normalizeSpace(decodeEntities(sm[1].replace(/<[^>]+>/g, '')));
+    if (!/standort/i.test(text)) continue;
+    events.push({ pos: sm.index, kind: 'standort', text });
+  }
+
+  // Accordion buttons.
+  const buttonRe =
+    /<h2[^>]*class="accordion-header"[^>]*>\s*<button[^>]*data-bs-target="#drz-accordion-id-(\d+)"[^>]*>([\s\S]*?)<\/button>\s*<\/h2>/g;
+  let bm;
+  while ((bm = buttonRe.exec(html)) !== null) {
+    const id = bm[1];
+    const title = normalizeSpace(
+      decodeEntities(String(bm[2]).replace(/<[^>]+>/g, '')),
+    );
+    if (!title || title.length < 5) continue;
+    events.push({ pos: bm.index, kind: 'job', id, title, headEnd: buttonRe.lastIndex });
+  }
+
+  // Sort by document position so we can resolve the most recent standort.
+  events.sort((a, b) => a.pos - b.pos);
+
+  let activeStandort = null;
+  for (const ev of events) {
+    if (ev.kind === 'standort') {
+      activeStandort = resolveStandort(ev.text);
+      continue;
+    }
+    if (seen.has(ev.id)) continue;
+    seen.add(ev.id);
+
+    // Locate the body div for this accordion id (search forward only).
+    const bodyRe = new RegExp(
+      `<div[^>]*id="drz-accordion-id-${ev.id}"[^>]*>([\\s\\S]*?)</div>\\s*</div>\\s*</section>`,
+      'i',
+    );
+    const body = html.slice(ev.headEnd).match(bodyRe);
+    const bodyText = body ? htmlToText(body[1]) : '';
+
+    out.push({
+      id: ev.id,
+      title: ev.title,
+      body: bodyText,
+      location: activeStandort || DEFAULT_LOCATION,
+    });
+  }
+
+  return out;
+}
+
+/* ── Description fallback ──────────────────────────────────── */
+
+function buildFallbackDescription(title, cityName) {
+  return [
+    `${title} bei der Klinik Gut AG am Standort ${cityName}.`,
+    '',
+    'Die Klinik Gut ist eine etablierte private Klinik-Gruppe für Orthopädie, Unfallchirurgie und Sportmedizin mit Hauptstandorten in St. Moritz und Fläsch (Graubünden) sowie Praxisstandorten in Chur, Buchs SG, Zürich und Ascona. Sie betreut nationale und internationale Patientinnen und Patienten und legt Wert auf ein engagiertes Team und individuelle Versorgung.',
+  ].join('\n');
+}
+
+/* ── Main fetch ────────────────────────────────────────────── */
+
+export async function fetchAllKlinikGutJobs() {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+
+  console.log(`🏥 Fetching ${KLINIK_GUT_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${PUBLIC_CAREER_URL} (Drupal 11 — DE source)\n`);
+
+  let html;
+  try {
+    html = await fetchHtml(PUBLIC_CAREER_URL, { timeoutMs });
+  } catch (err) {
+    throw new Error(`Failed to fetch Klinik Gut career page: ${err?.message || err}`);
+  }
+
+  const listings = parseKlinikGutListing(html);
+  console.log(`  📋 Found ${listings.length} accordion vacancies\n`);
+  if (listings.length === 0) {
+    console.warn('⚠️ No vacancies parsed from Klinik Gut page.');
+    return [];
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+
+  for (const listing of listings) {
+    const title = listing.title;
+    const loc = listing.location;
+
+    let description = listing.body && listing.body.split(/\s+/).length >= 40
+      ? listing.body
+      : buildFallbackDescription(title, loc.city);
+    if (description.split(/\s+/).length < 80) {
+      description = `${description}\n\n${buildFallbackDescription(title, loc.city)}`;
+    }
+
+    const haystack = `${title} ${description}`;
+    const sourceLang = detectLang(description || title, 'de');
+    const jobSlug = slugify(`${title} ${KLINIK_GUT_KEY} ${loc.city}`);
+    const url = `${PUBLIC_CAREER_URL}#drz-accordion-id-${listing.id}`;
+    const urlHash = createHash('sha1')
+      .update(`${url}|${listing.id}`)
+      .digest('hex')
+      .slice(0, 12);
+    const employmentType = detectHealthcareEmploymentType(haystack);
+
+    jobs.push({
+      id: `${KLINIK_GUT_KEY}-${listing.id}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: KLINIK_GUT_COMPANY_NAME,
+      companyKey: KLINIK_GUT_KEY,
+      companyDomain: KLINIK_GUT_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: loc.city,
+      canton: inferSwissTargetCanton(loc.city) || loc.canton,
+      url,
+      source: 'Klinik Gut Dedicated Parser (Drupal accordion)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: loc.city,
+      addressRegion: loc.canton,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: loc.postal,
+      category: detectHealthcareCategory(haystack),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(haystack),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+
+    console.log(`  ✅ ${title.substring(0, 65)} → ${loc.city} (${listing.id})`);
+  }
+
+  console.log(`\n📋 Total ${KLINIK_GUT_COMPANY_NAME} jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/oscam-castelrotto-job-parser.mjs
+++ b/scripts/lib/oscam-castelrotto-job-parser.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Ospedale Malcantonese OSCAM (Fondazione Giuseppe Rossi), Castelrotto (TI).
+ *
+ * Public career site (Italian only, WordPress + ACF):
+ *   https://www.oscam.ch/lavoraconnoi/
+ *
+ * Each open competition ("concorso attivo") is published as:
+ *
+ *   <h2>CONCORSI ATTIVI</h2>
+ *   <h3>{concorso title}</h3>
+ *   <h4><a …> Apri il <a href="…YYYY/MM/{slug}.pdf">{concorso title (or short)}</a></h4>
+ *   <hr />
+ *   …repeats…
+ *   <h3>Certificato medico da compilare</h3>   ← boundary (form, not a job)
+ *   <h3>Autocertificazioni</h3>                ← boundary
+ *
+ * Strategy:
+ *  - Slice the page between `CONCORSI ATTIVI` and `Certificato medico da compilare`
+ *    (or `Autocertificazioni`, or `CANDIDATURE`, or end-of-section).
+ *  - Each `<h3>` inside that slice is a concorso.
+ *  - The associated PDF is the LAST anchor inside the next `<h4>…Apri il…</h4>` block
+ *    (skipping the static document-icon anchor that points to a placeholder).
+ *  - Title body uses the h3 text + boilerplate fallback (the page itself doesn't
+ *    expose body content; details live inside the PDF).
+ *
+ * Inventory note: 3 concorsi at probe time. OSCAM serves Malcantone (Castelrotto,
+ * postal 6989) — TI audience priority for the frontaliere job-board.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const OSCAM_CASTELROTTO_KEY = 'oscam-castelrotto';
+export const OSCAM_CASTELROTTO_COMPANY_NAME =
+  'Ospedale Malcantonese OSCAM (Fondazione Giuseppe Rossi)';
+export const OSCAM_CASTELROTTO_COMPANY_DOMAIN = 'oscam.ch';
+
+const PUBLIC_CAREER_URL = 'https://www.oscam.ch/lavoraconnoi/';
+const DEFAULT_CITY = 'Castelrotto';
+const DEFAULT_CANTON = 'TI';
+const DEFAULT_POSTAL = '6989';
+
+// Stale placeholder PDF that lives inside every h4 wrapper (icon anchor).
+const STATIC_PLACEHOLDER_RE = /\/Concorso_generale_medici_assistenti_01\.pdf$/i;
+
+// Section boundaries (concorsi end and admin forms begin).
+const SECTION_END_RE =
+  /Certificato medico da compilare|Autocertificazioni|CANDIDATURE|NORMATIVE INTERNE/i;
+
+// Concorso titles must contain at least one of these tokens — guards against
+// accidentally promoting "Autocertificazioni" et al. if section boundaries shift.
+const CONCORSO_TITLE_RE =
+  /(concorso|bando|assunzione|medico|infermier|operator|persona|reparto)/i;
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isOscamCastelrottoJob(job) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === OSCAM_CASTELROTTO_KEY ||
+    key.startsWith('oscam') ||
+    company.includes('ospedale malcantonese') ||
+    company.includes('oscam') ||
+    company.includes('fondazione giuseppe rossi') ||
+    url.includes('oscam.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'oscam.ch' || host.endsWith('.oscam.ch');
+  } catch {
+    return false;
+  }
+}
+
+/* ── Parser ────────────────────────────────────────────────── */
+
+/**
+ * Extract concorsi from the OSCAM "lavora con noi" page.
+ * Returns: [{ id, title, pdfUrl }]
+ */
+export function parseOscamCastelrottoListing(html = '') {
+  if (!html || typeof html !== 'string') return [];
+
+  const startIdx = html.search(/CONCORSI\s+ATTIVI/i);
+  if (startIdx < 0) return [];
+
+  // Slice to the first downstream section boundary.
+  const tail = html.slice(startIdx);
+  const endMatch = tail.match(SECTION_END_RE);
+  const slice = endMatch ? tail.slice(0, endMatch.index) : tail;
+
+  const out = [];
+  const seen = new Set();
+
+  // Index every <h3> within the slice.
+  const headRe = /<h3[^>]*>([\s\S]*?)<\/h3>/gi;
+  const heads = [];
+  let hm;
+  while ((hm = headRe.exec(slice)) !== null) {
+    heads.push({ start: hm.index, end: headRe.lastIndex, raw: hm[1] });
+  }
+  if (heads.length === 0) return [];
+
+  for (let i = 0; i < heads.length; i += 1) {
+    const head = heads[i];
+    const next = heads[i + 1];
+    const block = slice.slice(head.end, next ? next.start : Math.min(head.end + 4000, slice.length));
+
+    const title = normalizeSpace(
+      decodeEntities(String(head.raw).replace(/<[^>]+>/g, '')),
+    );
+    if (!title || title.length < 5) continue;
+    if (!CONCORSO_TITLE_RE.test(title)) continue;
+
+    // Collect all anchor PDFs in the next-h4 region; the real concorso PDF
+    // is the LAST one (the icon-anchor placeholder appears first).
+    const pdfHrefs = [...block.matchAll(/href="([^"]+\.pdf)"/gi)]
+      .map((m) => m[1])
+      .filter((href) => !STATIC_PLACEHOLDER_RE.test(href));
+
+    const pdfUrl = pdfHrefs.length > 0 ? pdfHrefs[pdfHrefs.length - 1] : '';
+
+    // Stable id from the PDF filename (preferred) or h3 slug fallback.
+    let stableId;
+    if (pdfUrl) {
+      const fileBase = pdfUrl.split('/').pop() || '';
+      stableId = slugify(fileBase.replace(/\.pdf$/i, '')).slice(0, 50);
+    } else {
+      stableId = slugify(title).slice(0, 50);
+    }
+    if (!stableId) continue;
+    if (seen.has(stableId)) continue;
+    seen.add(stableId);
+
+    out.push({ id: stableId, title, pdfUrl });
+  }
+
+  return out;
+}
+
+/* ── Description fallback ──────────────────────────────────── */
+
+function buildDescription(title, pdfUrl) {
+  const lines = [
+    `${title} presso l'Ospedale Malcantonese OSCAM (Fondazione Giuseppe Rossi), Castelrotto (Malcantone, Canton Ticino).`,
+    '',
+    "L'OSCAM è un ospedale di cure acute con sede a Castelrotto che serve la regione del Malcantone. La fondazione Giuseppe Rossi gestisce reparti di medicina interna, chirurgia, psichiatria, ostetricia-ginecologia e cure palliative, oltre a un pronto soccorso e a servizi ambulatoriali per la popolazione del distretto di Lugano-Malcantone.",
+    '',
+    'Il concorso è pubblicato come bando ufficiale. Il dettaglio completo (requisiti, profilo professionale, modalità di candidatura, termine di presentazione, contatti del personale di riferimento) è disponibile nel documento PDF allegato. Le candidature avvengono via posta o e-mail alla direzione amministrativa dell\'OSCAM secondo le istruzioni del bando.',
+  ];
+  if (pdfUrl) {
+    lines.push('');
+    lines.push(`Bando completo (PDF): ${pdfUrl}`);
+  }
+  return lines.join('\n');
+}
+
+/* ── Main fetch ────────────────────────────────────────────── */
+
+export async function fetchAllOscamCastelrottoJobs() {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+
+  console.log(`🏥 Fetching ${OSCAM_CASTELROTTO_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${PUBLIC_CAREER_URL} (custom HTML, IT source)\n`);
+
+  let html;
+  try {
+    html = await fetchHtml(PUBLIC_CAREER_URL, { timeoutMs });
+  } catch (err) {
+    throw new Error(`Failed to fetch OSCAM career page: ${err?.message || err}`);
+  }
+
+  const listings = parseOscamCastelrottoListing(html);
+  console.log(`  📋 Found ${listings.length} concorsi attivi\n`);
+  if (listings.length === 0) {
+    console.warn('⚠️ No concorsi parsed from OSCAM page.');
+    return [];
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+
+  for (const listing of listings) {
+    const title = listing.title;
+    const sourceLang = 'it';
+    const description = buildDescription(title, listing.pdfUrl);
+    const haystack = `${title} ${description}`;
+
+    const url = `${PUBLIC_CAREER_URL}#${listing.id}`;
+    const jobSlug = slugify(`${title} ${OSCAM_CASTELROTTO_KEY} ${DEFAULT_CITY}`);
+    const urlHash = createHash('sha1')
+      .update(`${url}|${listing.id}`)
+      .digest('hex')
+      .slice(0, 12);
+    const employmentType = detectHealthcareEmploymentType(haystack);
+
+    jobs.push({
+      id: `${OSCAM_CASTELROTTO_KEY}-${listing.id}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: OSCAM_CASTELROTTO_COMPANY_NAME,
+      companyKey: OSCAM_CASTELROTTO_KEY,
+      companyDomain: OSCAM_CASTELROTTO_COMPANY_DOMAIN,
+      title,
+      titleByLocale: { [sourceLang]: title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      // Newly-discovered jobs ship source-locale-only; AI step backfills
+      // EN/DE/FR. Without this flag the locale-completeness gate trips before
+      // translation runs (see L1 in docs/plans/crawlers-batch-16-and-followup.md).
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url,
+      source: 'OSCAM Castelrotto Dedicated Parser (WordPress HTML, PDF concorsi)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL,
+      category: detectHealthcareCategory(haystack),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(haystack),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: listing.pdfUrl || url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+
+    console.log(`  ✅ ${title.substring(0, 70)} (${listing.id})`);
+  }
+
+  // Force source-lang detection consistency even when the helper would prefer
+  // another language (the boilerplate footer is Italian).
+  for (const j of jobs) {
+    const detected = detectLang(j.description || j.title, 'it');
+    if (detected !== j.sourceLang) {
+      j.sourceLang = detected;
+      j.titleByLocale = { [detected]: j.title };
+      j.descriptionByLocale = { [detected]: j.description };
+      j.slugByLocale = { [detected]: j.slug };
+      j.requirementsByLocale = { [detected]: [] };
+    }
+  }
+
+  console.log(
+    `\n📋 Total ${OSCAM_CASTELROTTO_COMPANY_NAME} jobs discovered: ${jobs.length}`,
+  );
+  return jobs;
+}

--- a/scripts/update-canton-ticino-osc-jobs.mjs
+++ b/scripts/update-canton-ticino-osc-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Canton Ticino OSC / DSS crawler runner.
+ *
+ * Aggregator-style: pulls only health-relevant concorsi from concorsi.ti.ch
+ * (filtered to "Dipartimento della sanità e della socialità" or OSC topics).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllCantonTicinoOscJobs,
+  isCantonTicinoOscJob,
+  isTrustedDomain,
+  CANTON_TICINO_OSC_KEY,
+  CANTON_TICINO_OSC_COMPANY_NAME,
+} from './lib/canton-ticino-osc-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: CANTON_TICINO_OSC_KEY,
+  companyLabel: CANTON_TICINO_OSC_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllCantonTicinoOscJobs,
+  isCompanyJob: isCantonTicinoOscJob,
+  isTrustedDomain,
+  defaultSourceLang: 'it',
+}).catch((err) => {
+  console.error(`❌ Canton Ticino OSC crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-klinik-gut-jobs.mjs
+++ b/scripts/update-klinik-gut-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Klinik Gut AG crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllKlinikGutJobs,
+  isKlinikGutJob,
+  isTrustedDomain,
+  KLINIK_GUT_KEY,
+  KLINIK_GUT_COMPANY_NAME,
+} from './lib/klinik-gut-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: KLINIK_GUT_KEY,
+  companyLabel: KLINIK_GUT_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllKlinikGutJobs,
+  isCompanyJob: isKlinikGutJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Klinik Gut crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-oscam-castelrotto-jobs.mjs
+++ b/scripts/update-oscam-castelrotto-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated OSCAM Castelrotto crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllOscamCastelrottoJobs,
+  isOscamCastelrottoJob,
+  isTrustedDomain,
+  OSCAM_CASTELROTTO_KEY,
+  OSCAM_CASTELROTTO_COMPANY_NAME,
+} from './lib/oscam-castelrotto-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: OSCAM_CASTELROTTO_KEY,
+  companyLabel: OSCAM_CASTELROTTO_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllOscamCastelrottoJobs,
+  isCompanyJob: isOscamCastelrottoJob,
+  isTrustedDomain,
+  defaultSourceLang: 'it',
+}).catch((err) => {
+  console.error(`❌ OSCAM Castelrotto crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Three dedicated crawlers for residual TI/GR/VS hospitals from
docs/HOSPITAL-CRAWLERS-INVENTORY-2026-05-19.md §3.

| Key                  | Hospital                                                    | Canton | Smoke | Notes |
|----------------------|-------------------------------------------------------------|--------|-------|-------|
| oscam-castelrotto    | Ospedale Malcantonese OSCAM (Fondazione G. Rossi)          | TI     | 3     | WordPress + PDF concorsi; SKIP_BOILERPLATE_GUARD=1 |
| klinik-gut           | Klinik Gut AG (Gruppe St. Moritz / Fläsch)                  | GR     | 7     | Drupal 11 accordion, multi-Standort dispatch |
| canton-ticino-osc    | OSC + DSS jobs on concorsi.ti.ch                            | TI     | 9     | rexx-systems aggregator, filtered to Sanità+OSC |

All ParsedJob records set needsRetranslation: true.
All match runStandardCrawlerPipeline conventions; no edits to
crawler-location-config.mjs / known-company-slugs.json / data/jobs*.json.

OSCAM (3 concorsi): TI audience-priority — accepted at 3 jobs per the
batch-19 brief (≥3 acceptable for high-priority TI). Concorso PDF =
canonical apply URL.

Klinik Gut (7 vacancies): Drupal accordion with stable drz-accordion-id
node ids reused across crawls. Per-job city resolved from the most recent
"Klinik Gut Standort" h2 header (St. Moritz / Fläsch / Chur / Buchs SG /
Zürich / Ascona). Group-wide private orthopaedic / accident clinic.

Canton Ticino OSC (9 jobs): TI cantonal jobportal (concorsi.ti.ch on
rexx-systems) is an aggregator across all departments. Parser filters to:
  - body lists "Dipartimento della sanità e della socialità", OR
  - title/body references OSC / Mendrisio / CPC / sociopsichiatric /
    EOC / sanità.
Skips "Candidature spontanee" placeholders. Stable id = yid. 350ms polite
pacing between detail fetches.

Excluded after probing (under threshold or bot-blocked):
- Clinica Varini Orselina (2 concorsi, <5)
- Clinica Hildebrand Brissago (1)
- Reha Andeer (2)
- Clinica Holistica Engiadina Susch (403, full headers tried)
- Leukerbad Clinic (Nuxt SSG + Prismic — payload has no body content,
  detail URLs all 404; would need Prismic API key; deferred)

Already covered (skipped per ls scripts/lib check): cs-bregaglia,
csvm-mustair, csvp-poschiavo, berner-klinik-montana, crr-suva-sion,
lhm-luzerner-hohenklinik-montana, clinique-cic, moncucco, eoc (CCT).
