### PR TITLE
fix(deploy): Vite cache key hashes components/services/hooks too

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -315,7 +315,17 @@ jobs:
           path: |
             node_modules/.vite
             .vite-cache
-          key: vite-${{ runner.os }}-${{ hashFiles('package-lock.json', 'vite.config.ts', 'build-plugins/**/*.ts') }}
+          # Hash MUST include every source path Vite/Rollup compile into the
+          # SPA bundle, otherwise stale optimized deps + AST cache produce
+          # the same chunk content-hash for new source (visible 2026-05-20:
+          # PR #380/#404 edits to components/community/JobBoard.tsx and
+          # services/router.ts kept emitting `JobBoard-lT8fKnYe.js` with
+          # pre-PR-380 content, so the SPA's bridge cross-canton lazy-fetch
+          # never landed despite being merged + redeployed multiple times).
+          # Add components/ + services/ + hooks/ + App.tsx + index.html so
+          # any source change invalidates the cache and forces a clean
+          # bundle pass.
+          key: vite-${{ runner.os }}-${{ hashFiles('package-lock.json', 'vite.config.ts', 'build-plugins/**/*.ts', 'components/**/*.{ts,tsx}', 'services/**/*.{ts,tsx}', 'hooks/**/*.{ts,tsx}', 'App.tsx', 'index.html') }}
           restore-keys: |
             vite-${{ runner.os }}-
 


### PR DESCRIPTION
Symptom (live 2026-05-20): JobBoard JS chunk JobBoard-lT8fKnYe.js was
emitted with pre-PR-380 content despite PR #380 + #404 being merged
and deploys completing. The chunk content-hash is meant to invalidate
on any source change, but Vite's reused optimized deps + AST cache
caused the same bundling output for new source.

Cache key only hashed: package-lock.json, vite.config.ts,
build-plugins/**/*.ts — so any change under components/, services/, or
hooks/ (i.e. ALL the SPA source) was a cache hit on stale state.

PR #380 added components/community/JobBoard.tsx F5 lazy-fetch +
services/router.ts getJobMetaForSlug; PR #404 added the slim-locale
index fallback. Both lived in source but never made it to the served
JS chunk on prod — the SPA still routes bridge URLs to JobOrphanView
on cross-canton cases.

Fix: extend the hashFiles glob to cover components/**/*.{ts,tsx},
services/**/*.{ts,tsx}, hooks/**/*.{ts,tsx}, App.tsx, index.html.
Any source change → fresh Vite cache → fresh chunk hashes.
