### PR TITLE
fix(seo): per-canton city hub + TI-themed aggregator filter (blank-on-hydrate)

### DIFF
--- a/build-plugins/careerJobsAggregate.ts
+++ b/build-plugins/careerJobsAggregate.ts
@@ -26,6 +26,7 @@ import {
   CAREER_LOCALES,
   type CareerLocale,
 } from './careerLandingsData';
+import { resolveJobCanton } from './shared/cantonSection';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -547,7 +548,14 @@ export function aggregateCareerLandings(
     };
   }
 
-  const jobs = loadJobs(rootDir);
+  const allJobs = loadJobs(rootDir);
+  // Career landings (agenzie-lavoro-lugano, concorsi-pubblici-lugano, stage-
+  // lugano, contratti-lavoro-frontalieri) are editorially Lugano/Ticino-
+  // themed and link every employer chip at TI's job board
+  // (JOB_BOARD_BASE_PATH below). Filter to canton=TI so the aggregate
+  // (counts, top employers, featured jobs) matches the editorial scope —
+  // mirrors the fix in `aggregateProfessionJobs` / `aggregateNursingJobs`.
+  const jobs = allJobs.filter((job) => resolveJobCanton(job as { canton?: string; location?: string }) === 'TI');
   const staffing = buildStaffingSnapshot(rootDir, jobs, now);
   const publicSector = buildPublicSectorSnapshot(rootDir, jobs, now);
   const internship = buildInternshipSnapshot(jobs, now);

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -5406,7 +5406,18 @@ ${alternates}
  return `<p>${cityJobs.length} <strong>offres d'emploi</strong> sont actuellement disponibles à ${esc(cityDisplay)} (Canton de ${esc(cDisplay)}). Les annonces sont mises à jour quotidiennement. Pour les frontaliers avec un permis G, le Canton de ${esc(cDisplay)} applique un impôt à la source sur le revenu brut : utilisez notre <a href="${BASE_URL}/fr/">simulateur fiscal gratuit</a>.</p>`;
  })();
  const bodyHtml = `<h1>${esc(cityHubSeo.h1)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(backLabel)}</a></p>\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'city-landing', cantonEntityName: cityDisplay }))}`;
- const html = buildSimplePage({
+ // Use buildSeoPageHtml (NOT buildSimplePage) so the page emits
+ // `<main class="seo-static-content">` OUTSIDE `<div id="root">` +
+ // `<div id="footer-root"></div>`. The legacy path (buildSimplePage default
+ // skipMainWrap=false + seoContentOutsideRoot=false) wraps the static body
+ // in `<main class="static-job-page">` INSIDE `#root`, and React hydration
+ // wipes that <main> when staticOverlay:true (App.tsx skips React <main>
+ // for staticOverlay routes) — leaving the page visibly blank for end users
+ // (header + sub-nav only). Bug surfaced on
+ // /cerca-lavoro-basilea/basel/ (and every other non-TI canton city hub).
+ // The company-hub sibling at line ~6344 already received the same fix in
+ // PR #376; this aligns per-canton city hubs to the same hydration-safe shell.
+ const html = buildSeoPageHtml({
  locale,
  title: pageTitle,
  description: pageDesc,
@@ -5414,9 +5425,8 @@ ${alternates}
  ogLocale: localeOg[locale],
  hreflangHtml: alternates,
  jsonLdScripts: [breadcrumbLd, collectionLd, itemListLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml,
+ distDir,
  });
  // Hard-fail guard mirroring TI city hubs (195 KB budget)
  const CITY_HUB_HARD_BUDGET_BYTES = 195 * 1024;

--- a/build-plugins/nursingJobsAggregate.ts
+++ b/build-plugins/nursingJobsAggregate.ts
@@ -23,6 +23,7 @@ import {
   type NursingLocale,
 } from './nursingLandingsData';
 import type { ProfessionJobsSnapshot, FeaturedJob } from './professionJobsAggregate';
+import { resolveJobCanton } from './shared/cantonSection';
 
 // Re-export the snapshot/featured types so the plugin imports a single
 // canonical shape — different alias keeps grep-ability without forking the
@@ -243,6 +244,12 @@ function buildSnapshotForId(
 /**
  * Aggregate jobs.json into per-nursing-id snapshots. Cached per `rootDir`.
  * Pass `now` to override the clock (used by tests); defaults to Date.now().
+ *
+ * Filters to canton=TI before aggregation — nursing landings link every
+ * employer chip at TI's job board (JOB_BOARD_BASE_PATH below). Without the
+ * filter, the cathedral dataset expansion (2026-05-10) surfaced non-TI
+ * employers under TI-themed copy with TI-search links that returned zero
+ * results. Mirrors the fix applied to `aggregateProfessionJobs`.
  */
 export function aggregateNursingJobs(
   rootDir: string,
@@ -250,7 +257,8 @@ export function aggregateNursingJobs(
 ): Record<NursingLandingId, NursingJobsSnapshot> {
   if (_snapshotCache && _cacheRootDir === rootDir) return _snapshotCache;
 
-  const jobs = loadJobs(rootDir);
+  const allJobs = loadJobs(rootDir);
+  const jobs = allJobs.filter((job) => resolveJobCanton(job as { canton?: string; location?: string }) === 'TI');
   const out = {} as Record<NursingLandingId, NursingJobsSnapshot>;
   for (const id of NURSING_LANDING_IDS) {
     out[id] = buildSnapshotForId(jobs, NURSING_MATCHERS[id], now);

--- a/build-plugins/professionJobsAggregate.ts
+++ b/build-plugins/professionJobsAggregate.ts
@@ -28,6 +28,7 @@ import {
   type ProfessionId,
   type ProfessionLocale,
 } from './professionLandingsData';
+import { resolveJobCanton } from './shared/cantonSection';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -307,6 +308,17 @@ function buildSnapshotForProfession(
 /**
  * Aggregate jobs.json into per-profession snapshots. Cached per `rootDir`.
  * Pass `now` to override the clock (used by tests); defaults to Date.now().
+ *
+ * Filters to canton=TI before aggregation. The profession landings
+ * (`/lavoro-ticino-{profession}/`) are editorially Ticino-themed: section
+ * titles say "Chi assume in Ticino" / "Principali datori di lavoro in
+ * Ticino" / "Il mestiere in Ticino", and the employer-chip URLs all point
+ * at `/cerca-lavoro-ticino/?q=<employer>`. Before this filter, the cathedral
+ * dataset expansion (2026-05-10) caused non-TI employers (Luzerner Psychiatrie,
+ * Psychiatrie Baselland, Stiftung Bachtelen, …) to surface in the TI section
+ * and link to a TI search that returned zero results — visible 2026-05-20 on
+ * /lavoro-ticino-educatore/. Filtering at the load boundary keeps content and
+ * link target consistent without rewriting every downstream call site.
  */
 export function aggregateProfessionJobs(
   rootDir: string,
@@ -314,7 +326,8 @@ export function aggregateProfessionJobs(
 ): Record<ProfessionId, ProfessionJobsSnapshot> {
   if (_snapshotCache && _cacheRootDir === rootDir) return _snapshotCache;
 
-  const jobs = loadJobs(rootDir);
+  const allJobs = loadJobs(rootDir);
+  const jobs = allJobs.filter((job) => resolveJobCanton(job as { canton?: string; location?: string }) === 'TI');
   const out = {} as Record<ProfessionId, ProfessionJobsSnapshot>;
   for (const id of PROFESSION_IDS) {
     out[id] = buildSnapshotForProfession(jobs, PROFESSION_MATCHERS[id], now);

--- a/tests/build-plugins/featured-job-projection.test.ts
+++ b/tests/build-plugins/featured-job-projection.test.ts
@@ -82,6 +82,35 @@ describe('profession aggregate FeaturedJob projection', () => {
     expect(result).not.toBeNull();
     expect(result!.companyDomain).toBeNull();
   });
+
+  // Regression — cathedral dataset expansion (2026-05-10) made jobs.json
+  // contain all 26 cantons, but the profession landings at
+  // `/lavoro-ticino-{profession}/` are editorially TI-themed: section
+  // titles say "Chi assume in Ticino" / "Principali datori di lavoro in
+  // Ticino", and every employer chip points at `/cerca-lavoro-ticino/?q=…`.
+  // Without filtering, non-TI employers (Luzerner Psychiatrie, Psychiatrie
+  // Baselland, Stiftung Bachtelen, Universitäts-Kinderspital Zürich, …)
+  // surfaced as "TI employers" with TI-search links that returned zero
+  // results (visible 2026-05-20 on /lavoro-ticino-educatore/). Lock the
+  // canton filter so this can't silently regress.
+  it('aggregateProfessionJobs filters jobs to canton TI before aggregation', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const src = readFileSync(
+      resolve(__dirname, '../../build-plugins/professionJobsAggregate.ts'),
+      'utf8',
+    );
+    // The filter MUST live in aggregateProfessionJobs, applied to loadJobs
+    // output BEFORE the PROFESSION_IDS loop. We assert both the import and
+    // the call so a future "let's broaden to all of CH" attempt fails this
+    // test with a clear diff instead of silently corrupting TI section copy.
+    expect(src, 'imports resolveJobCanton from cantonSection').toMatch(
+      /import\s*\{\s*resolveJobCanton\s*\}\s*from\s*'\.\/shared\/cantonSection'/,
+    );
+    expect(src, 'filters loadJobs output to canton TI inside aggregateProfessionJobs').toMatch(
+      /resolveJobCanton\([\s\S]*?\)\s*===\s*'TI'/,
+    );
+  });
 });
 
 // ── 2. careerJobsAggregate ───────────────────────────────────────────────────

--- a/tests/city-jobs-hub.test.ts
+++ b/tests/city-jobs-hub.test.ts
@@ -303,3 +303,58 @@ describe('buildCityHubSeo — non-TI cantonDisplay forwarded to title and meta',
     expect(legacyLugano.title).toContain('Ticino');
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────
+// Regression — per-canton city hub HTML shell must be hydration-safe.
+//
+// Bug surfaced 2026-05-20 on /cerca-lavoro-basilea/basel/ (and every other
+// non-TI city hub): the page emitted `<main class="static-job-page">`
+// INSIDE `<div id="root">`. React hydrates `#root` and wipes that static
+// `<main>`; App.tsx then skips rendering its own `<main id="main-content">`
+// because the route is `staticOverlay:true` — leaving end users with a blank
+// page (just header + sub-nav, no content, no footer because there is no
+// `<div id="footer-root">` portal target either). Crawlers (no JS) still saw
+// the SSR content, so audits passed; only SPA users were affected.
+//
+// Fix: emit via `buildSeoPageHtml` (the same shell PR #376 applied to the
+// per-canton COMPANY hub at line ~6344). That helper puts the static body in
+// `<main class="seo-static-content">` OUTSIDE `#root` AND adds the
+// `<div id="footer-root"></div>` portal target — both required by App.tsx +
+// useNavigationState for the lite-shell rendering path.
+// ──────────────────────────────────────────────────────────────────────
+describe('per-canton city hub — hydration-safe SPA shell', () => {
+  it('jobsSeoPagesPlugin per-canton city hub block calls buildSeoPageHtml (not buildSimplePage)', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const src = readFileSync(
+      resolve(__dirname, '../build-plugins/jobsSeoPagesPlugin.ts'),
+      'utf8',
+    );
+    const anchorStart = src.indexOf('Per-canton city hubs (Phase 3.1)');
+    const anchorEnd = src.indexOf('Static paginated listing pages');
+    expect(anchorStart, 'phase 3.1 anchor present').toBeGreaterThan(0);
+    expect(anchorEnd, 'next phase anchor present').toBeGreaterThan(anchorStart);
+    const block = src.slice(anchorStart, anchorEnd);
+    // Reverting to buildSimplePage at this site reintroduces the
+    // blank-on-hydrate bug on /cerca-lavoro-{canton}/{city}/.
+    expect(block, 'must call buildSeoPageHtml').toContain('buildSeoPageHtml({');
+    expect(block, 'must NOT call buildSimplePage').not.toContain('buildSimplePage({');
+  });
+
+  it('buildSeoPageHtml emits main.seo-static-content + footer-root portal', async () => {
+    const { buildSeoPageHtml } = await import('../build-plugins/shared/seoPageShell');
+    const html = buildSeoPageHtml({
+      locale: 'it',
+      title: 'Lavoro Basel 2026',
+      description: 'Test',
+      canonicalUrl: 'https://frontaliereticino.ch/cerca-lavoro-basilea/basel/',
+      bodyHtml: '<h1>373 Offerte di Lavoro a Basel</h1>',
+    });
+    expect(html).toMatch(/<main class="seo-static-content"/);
+    expect(html).toContain('<div id="footer-root">');
+    expect(html).toContain('<div id="root">');
+    // The legacy wrapper would put <main class="static-job-page"> INSIDE
+    // #root — confirm we are NOT emitting that shape for city hubs.
+    expect(html).not.toMatch(/<div id="root">\s*<main class="static-job-page"/);
+  });
+});


### PR DESCRIPTION
Two related user-visible bugs reported on 2026-05-20.

1) /cerca-lavoro-{canton}/{city}/ rendered blank for SPA users
   (e.g. /cerca-lavoro-basilea/basel/). The per-canton city-hub block
   in jobsSeoPagesPlugin still called buildSimplePage default-mode,
   emitting <main class="static-job-page"> INSIDE #root. React hydrates
   #root and wipes that <main>; App.tsx skips its own React <main> for
   staticOverlay:true routes, and the page has no #footer-root portal
   target either — so the user saw nothing but the sub-nav. Crawlers
   (no JS) still saw the SSR body, so audits passed. Switched to
   buildSeoPageHtml (the same shell PR #376 applied to the per-canton
   company hub) which emits <main class="seo-static-content"> OUTSIDE
   #root + <div id="footer-root"></div>. Same hydration-safe pattern.

2) /lavoro-ticino-{profession}/ employer chips linked to
   /cerca-lavoro-ticino/?q=<company> for non-TI companies, returning
   zero results. The cathedral dataset expansion (2026-05-10) made
   jobs.json hold all 26 cantons, but the profession/nursing/career
   aggregators read it whole — surfacing non-TI employers under TI-
   themed copy ("Chi assume in Ticino", "Principali datori di lavoro
   in Ticino"). Filter loadJobs() output to canton=TI inside the 3
   aggregators that feed TI-themed landings.

Regression tests:
- tests/city-jobs-hub.test.ts: source-grep + shell-output assertion
  that per-canton city hub uses buildSeoPageHtml and emits the
  hydration-safe shell.
- tests/build-plugins/featured-job-projection.test.ts: locks the
  TI filter in aggregateProfessionJobs in place.
