### PR TITLE
fix(router): TI legacy parsing checks isCantonStaticOverlaySlug

### DIFF
--- a/services/router.ts
+++ b/services/router.ts
@@ -2785,6 +2785,21 @@ export function parsePath(pathname: string): ParseResult {
  // bar + result grid. Returning `staticOverlay: true` here breaks the page
  // because the static body is intentionally sr-only (crawler-only) — the
  // SPA must hydrate the interactive search view for users.
+ //
+ // Build-time static SEO pages emitted under /cerca-lavoro-ticino/:
+ // company hubs (azienda-/company-/unternehmen-/entreprise-), category
+ // listings (categoria-/category-/kategorie-/categorie-), and pagination
+ // (pagina-N / page-N / seite-N). Mirrored from the canton-aware branch
+ // (~line 2542). Without this check, the legacy TI parsing fell through
+ // to `jobSlug = rawSecond` → JobBoard parseCompanySlugFilter treats the
+ // azienda- prefix as a runtime company filter → React main replaces the
+ // static main → user sees an empty filtered list (the TI shard often
+ // doesn't contain the cross-canton entity, e.g. Genossenschaft Migros
+ // Ostschweiz on `/cerca-lavoro-ticino/azienda-migros/` — the static
+ // page lists 26 SG/GR/VS jobs but the SPA filtered list shows 0).
+ if (rawSecond && isCantonStaticOverlaySlug(rawSecond)) {
+ return { route: { activeTab: 'job-board', jobBoardCanton: 'TI', staticOverlay: true }, locale };
+ }
  const jobSlug = rawSecond;
  // P7.1 — legacy /cerca-lavoro-ticino/{slug?} → always TI canton filter.
  return { route: { activeTab: 'job-board', jobBoardCanton: 'TI', ...(jobSlug ? { jobSlug } : {}) }, locale };

--- a/tests/router/canton-static-overlay-slugs.test.ts
+++ b/tests/router/canton-static-overlay-slugs.test.ts
@@ -101,6 +101,52 @@ describe('per-canton static-overlay slugs', () => {
     expect(parsed.route.jobSlug).toBe('software-engineer-acme-basel');
   });
 
+  // 2026-05-20: legacy TI parsing branch (the `first === table.jobBoard`
+  // path at ~router.ts:2705) had no isCantonStaticOverlaySlug() check,
+  // so company/category/pagination slugs under /cerca-lavoro-ticino/
+  // fell through to `jobSlug = rawSecond` → JobBoard treated the
+  // azienda- prefix as a runtime company filter via
+  // parseCompanySlugFilter → React main replaced the static main →
+  // user saw an empty filtered SERP instead of the hub page.
+  // Visible bug 2026-05-20 on /cerca-lavoro-ticino/azienda-migros/.
+  // The non-TI canton-aware branch (~router.ts:2542) already had the
+  // guard; this restores parity.
+  it('TI azienda-* hub → staticOverlay (no jobSlug)', () => {
+    const parsed = parsePath('/cerca-lavoro-ticino/azienda-migros/');
+    expect(parsed.route.activeTab).toBe('job-board');
+    expect(parsed.route.jobBoardCanton).toBe('TI');
+    expect(parsed.route.staticOverlay).toBe(true);
+    expect(parsed.route.jobSlug).toBeUndefined();
+  });
+
+  it('TI categoria-* hub → staticOverlay (no jobSlug)', () => {
+    const parsed = parsePath('/cerca-lavoro-ticino/categoria-sanita/');
+    expect(parsed.route.activeTab).toBe('job-board');
+    expect(parsed.route.jobBoardCanton).toBe('TI');
+    expect(parsed.route.staticOverlay).toBe(true);
+    expect(parsed.route.jobSlug).toBeUndefined();
+  });
+
+  it('TI pagina-N pagination → staticOverlay (no jobSlug)', () => {
+    const parsed = parsePath('/cerca-lavoro-ticino/pagina-2/');
+    expect(parsed.route.staticOverlay).toBe(true);
+    expect(parsed.route.jobSlug).toBeUndefined();
+  });
+
+  it('TI hub exact slugs (tutti/settori/aziende) → staticOverlay', () => {
+    for (const slug of ['tutti', 'settori', 'aziende']) {
+      const parsed = parsePath(`/cerca-lavoro-ticino/${slug}/`);
+      expect(parsed.route.staticOverlay).toBe(true);
+      expect(parsed.route.jobSlug).toBeUndefined();
+    }
+  });
+
+  it('TI job-detail still falls through as jobSlug (no false positive)', () => {
+    const parsed = parsePath('/cerca-lavoro-ticino/software-engineer-acme-lugano/');
+    expect(parsed.route.staticOverlay).toBeFalsy();
+    expect(parsed.route.jobSlug).toBe('software-engineer-acme-lugano');
+  });
+
   // 2026-05-19: city hubs now ALSO carry staticOverlay:true (parity with
   // company hubs / categories). The build emits a real per-city HTML
   // (city-jobs-hub plugin) with jobs already filtered to the city and the


### PR DESCRIPTION
The non-TI canton-aware branch (~router.ts:2542) checked
isCantonStaticOverlaySlug(rawSecond) before falling through to
jobSlug — so /cerca-lavoro-zurigo/azienda-X/ etc. correctly returned
staticOverlay:true and the SPA kept the static hub page visible.

The legacy TI branch (~router.ts:2705, hit when first === table.jobBoard)
lacked the same check. /cerca-lavoro-ticino/azienda-* /categoria-* /pagina-N
slugs fell through to jobSlug = rawSecond. The SPA then:
  1. parseCompanySlugFilter('azienda-migros') → 'migros' (matches prefix)
  2. JobBoard renders with companySlugFilter='migros' instead of jobSlug
  3. takeover useEffect: staticOverlay is falsy → hides main.seo-static-content
  4. React main shows a TI-scoped jobs list filtered by company 'migros'
  5. Migros Ticino has 0 jobs in the loaded TI shard → empty SERP

Visible bug 2026-05-20 on /cerca-lavoro-ticino/azienda-migros/: the
static page lists 26 SG/GR/VS Migros jobs but the user sees a blank
filtered SPA list. Same class of bug as PR #294 fixed for non-TI
canton sub-pages (clicks from inside the SPA fell into jobSlug); this
restores the TI branch to parity.

Fix: in the legacy TI branch, mirror the canton-aware guard — if
isCantonStaticOverlaySlug(rawSecond) returns true, return
staticOverlay:true (no jobSlug) before the generic fallthrough.

Regression: tests/router/canton-static-overlay-slugs.test.ts adds 5
TI-specific cases (azienda-, categoria-, pagina-N, hub exact slugs,
plus a negative for real job-detail slugs).
