### PR TITLE
feat(crawlers): batch 20P — Leukerbad Clinic (VS), GHOL (VD), Clinica Holistica Engiadina (GR)

### DIFF
--- a/.github/workflows/update-jobs-clinica-holistica-engiadina.yml
+++ b/.github/workflows/update-jobs-clinica-holistica-engiadina.yml
@@ -1,0 +1,104 @@
+name: Update Clinica Holistica Engiadina (Susch) Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-30000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-clinica-holistica-engiadina
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-clinica-holistica-engiadina-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated CLINICA_HOLISTICA_ENGIADINA crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_CLINICA_HOLISTICA_ENGIADINA_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-clinica-holistica-engiadina-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'clinica-holistica-engiadina'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/clinica-holistica-engiadina.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLINICA_HOLISTICA_ENGIADINA jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-ghol.yml
+++ b/.github/workflows/update-jobs-ghol.yml
@@ -1,0 +1,101 @@
+name: Update GHOL (Nyon) Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-30000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-ghol
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-ghol-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated GHOL crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_GHOL_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-ghol-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'ghol'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/ghol.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update GHOL jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-leukerbad-clinic.yml
+++ b/.github/workflows/update-jobs-leukerbad-clinic.yml
@@ -1,0 +1,101 @@
+name: Update Leukerbad Clinic Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-30000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-leukerbad-clinic
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-leukerbad-clinic-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated LEUKERBAD_CLINIC crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_LEUKERBAD_CLINIC_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: node scripts/update-leukerbad-clinic-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'leukerbad-clinic'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/leukerbad-clinic.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update LEUKERBAD_CLINIC jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/clinica-holistica-engiadina-job-parser.mjs
+++ b/scripts/lib/clinica-holistica-engiadina-job-parser.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+/**
+ * Clinica Holistica Engiadina (Susch, GR) — Drupal job listing.
+ *
+ * Public career site: https://www.clinica-holistica.ch/de/karriere
+ *
+ * Background:
+ *   The site is a Drupal install behind an aggressive WAF/cache layer that
+ *   serves 403 to non-browser clients (the previously linked
+ *   `/de/offene-stellen` URL specifically returns 403 even via Playwright —
+ *   the Karriere index `/de/karriere` is the actually-reachable listing).
+ *
+ *   We render the Karriere page with Playwright, collect every `/de/job/`
+ *   AND `/de/node/NNN` anchor with the "Stellenausschreibung" label, then
+ *   visit each detail page and harvest `<h1>` + article body. No public
+ *   ATS or JSON feed is exposed.
+ *
+ * Tenant facts:
+ *   - Holistic / psychiatric / psychotherapeutic rehab clinic (~120 beds).
+ *   - Located in Susch, canton GR, postal code 7542.
+ *   - DE-only career content. FR carriere returns no offers.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const CLINICA_HOLISTICA_KEY = 'clinica-holistica-engiadina';
+export const CLINICA_HOLISTICA_COMPANY_NAME = 'Clinica Holistica Engiadina';
+export const CLINICA_HOLISTICA_COMPANY_DOMAIN = 'clinica-holistica.ch';
+
+const PUBLIC_CAREER_URL = 'https://www.clinica-holistica.ch/de/karriere';
+const LISTING_URLS = [
+  'https://www.clinica-holistica.ch/de/karriere',
+  // /de/offene-stellen is a known-403 trap; do NOT add it.
+];
+
+/**
+ * Playwright launch settings tuned to slip past the soft WAF block.
+ *
+ * Confirmed by manual probe 2026-05-20: with these settings the listing
+ * (`/de/karriere`) and detail pages (`/de/job/...`) both resolve to 200.
+ */
+const PW_LAUNCH_ARGS = ['--disable-blink-features=AutomationControlled'];
+const PW_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+async function loadPlaywright() {
+  try {
+    const mod = await import('playwright');
+    return mod.chromium;
+  } catch (err) {
+    throw new Error(
+      `Playwright not available — install with \`npx playwright install chromium\`. (${err?.message || err})`,
+    );
+  }
+}
+
+async function createStealthContext(browser) {
+  const ctx = await browser.newContext({
+    userAgent: PW_USER_AGENT,
+    viewport: { width: 1280, height: 800 },
+    locale: 'de-CH',
+    timezoneId: 'Europe/Zurich',
+    extraHTTPHeaders: {
+      'Accept-Language': 'de-CH,de;q=0.9,en;q=0.8',
+      Accept:
+        'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+    },
+  });
+  ctx.setDefaultNavigationTimeout(60_000);
+  await ctx.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    Object.defineProperty(navigator, 'languages', { get: () => ['de-CH', 'de', 'en'] });
+  });
+  return ctx;
+}
+
+/* ── Category detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = String(title || '').toLowerCase();
+  if (/\b(arzt|ärzt|oberarzt|chefarzt|m[eé]decin|psychiater|psychotherap)\b/.test(t))
+    return 'healthcare-medical';
+  if (/\b(pflege|fachfrau\s+gesundheit|fage|assc|pflegefach|krankenpfleg)\b/.test(t))
+    return 'healthcare-nursing';
+  if (/\b(physio|ergo|therap|massage|kinetik|kunst.?therapie)\b/.test(t)) return 'healthcare-therapy';
+  if (/\b(psycholog)\b/.test(t)) return 'healthcare-psychology';
+  if (/\b(koch|küch|kueche|hilfskoch)\b/.test(t)) return 'hospitality';
+  if (/\b(hotelle|service|hauswirt|reinig|housekeep|wäscherei|waescherei)\b/.test(t))
+    return 'hospitality';
+  if (/\b(administrat|verwaltung|secret|sekret|empfang|rezeption)\b/.test(t)) return 'administration';
+  if (/\b(technik|haustechn|elektri|sanitär|sanitar|maintenance)\b/.test(t)) return 'logistics';
+  return 'healthcare';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = String(title || '').toLowerCase();
+  if (/\b(praktik|intern|stagiair|lehrling|apprenti|trainee)\b/.test(t)) return 'intern';
+  if (/\b(junior|jr)\b/.test(t)) return 'junior';
+  if (/\b(leiter|chef|head|directeur|directrice|responsable|senior|sr|oberarzt|chefarzt)\b/.test(t))
+    return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(title = '') {
+  const t = String(title || '').toLowerCase();
+  const pctMatch = t.match(/(\d{1,3})\s*[-–]\s*(\d{1,3})\s*%/) || t.match(/(\d{1,3})\s*%/);
+  if (/\b(praktik|intern|stagiair)\b/.test(t)) return 'INTERN';
+  if (/\b(ferienvertret|vertretung|temporary|befristet|fixed|cdd)\b/.test(t)) return 'CONTRACTOR';
+  if (pctMatch) {
+    const hi = pctMatch[2] ? parseInt(pctMatch[2], 10) : parseInt(pctMatch[1], 10);
+    const lo = pctMatch[2] ? parseInt(pctMatch[1], 10) : hi;
+    if (hi === 100 && lo === 100) return 'FULL_TIME';
+    if (lo < 100) return 'PART_TIME';
+  }
+  return 'OTHER';
+}
+
+/* ── Job identity / trust ──────────────────────────────────── */
+
+export function isClinicaHolisticaJob(job) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === CLINICA_HOLISTICA_KEY ||
+    company.includes('clinica holistica') ||
+    url.includes('clinica-holistica.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return host === 'clinica-holistica.ch' || host === 'www.clinica-holistica.ch';
+  } catch {
+    return false;
+  }
+}
+
+/* ── Listing & detail scraping ─────────────────────────────── */
+
+async function discoverDetailUrls(context) {
+  const urls = new Map();
+  for (const listingUrl of LISTING_URLS) {
+    const page = await context.newPage();
+    try {
+      const resp = await page.goto(listingUrl, { waitUntil: 'networkidle', timeout: 45_000 });
+      const status = resp ? resp.status() : 0;
+      if (status >= 400) {
+        console.warn(`  ⚠️ ${listingUrl} returned status ${status} — skipping.`);
+        continue;
+      }
+      // Collect every /de/job/... and /de/node/<num> link whose anchor text is
+      // "Stellenausschreibung" (Drupal places that label on each job teaser).
+      const found = await page.evaluate(() => {
+        const anchors = Array.from(document.querySelectorAll('a'));
+        return anchors
+          .map((a) => ({
+            url: a.href || '',
+            text: (a.innerText || a.textContent || '').trim(),
+          }))
+          .filter((x) => {
+            if (!x.url) return false;
+            if (!/clinica-holistica\.ch/i.test(x.url)) return false;
+            if (!/\/de\/(job|node)\//.test(x.url)) return false;
+            return /stellenausschreibung/i.test(x.text);
+          });
+      });
+      for (const f of found) urls.set(f.url, true);
+    } catch (err) {
+      console.warn(`  ⚠️ Listing fetch failed for ${listingUrl}: ${err?.message || err}`);
+    } finally {
+      await page.close().catch(() => {});
+    }
+  }
+  return Array.from(urls.keys());
+}
+
+async function fetchDetail(context, detailUrl) {
+  const page = await context.newPage();
+  try {
+    const resp = await page.goto(detailUrl, { waitUntil: 'networkidle', timeout: 45_000 });
+    const status = resp ? resp.status() : 0;
+    if (status >= 400) {
+      console.warn(`    ⚠️ detail ${detailUrl} returned ${status} — skipping.`);
+      return null;
+    }
+    const data = await page.evaluate(() => {
+      const h1 = document.querySelector('h1');
+      // Drupal article body lives inside #block-mainpagecontent or article.node
+      const body =
+        document.querySelector('article.node, .node--type-job, [role="main"]') ||
+        document.querySelector('main') ||
+        document.body;
+      return {
+        title: h1 ? h1.innerText.trim() : '',
+        bodyText: body ? body.innerText : '',
+        canonical:
+          (document.querySelector('link[rel="canonical"]') &&
+            document.querySelector('link[rel="canonical"]').href) ||
+          location.href,
+      };
+    });
+    return data;
+  } catch (err) {
+    console.warn(`    ⚠️ detail ${detailUrl} failed: ${err?.message || err}`);
+    return null;
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+/* ── Build ParsedJob ───────────────────────────────────────── */
+
+function buildJob(detailUrl, detail) {
+  if (!detail) return null;
+  const title = normalizeSpace(detail.title || '');
+  if (!title || title.length < 3) return null;
+
+  // Body may already be plain-text from page.evaluate(innerText); run through
+  // stripHtml to neutralize residual entities and collapse blank lines.
+  const description = stripHtml(detail.bodyText || '') || `${title} — ${CLINICA_HOLISTICA_COMPANY_NAME}`;
+  const sourceLang = detectLang(description || title, 'de');
+
+  const urlHash = createHash('sha1').update(detailUrl).digest('hex').slice(0, 12);
+  const jobSlug = slugify(`${title} ${CLINICA_HOLISTICA_COMPANY_NAME} Susch`);
+
+  return {
+    id: `${CLINICA_HOLISTICA_KEY}-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [sourceLang]: jobSlug },
+    company: CLINICA_HOLISTICA_COMPANY_NAME,
+    companyKey: CLINICA_HOLISTICA_KEY,
+    companyDomain: CLINICA_HOLISTICA_COMPANY_DOMAIN,
+    title,
+    titleByLocale: { [sourceLang]: title },
+    description,
+    descriptionByLocale: { [sourceLang]: description },
+    location: 'Susch',
+    canton: 'GR',
+    addressLocality: 'Susch',
+    addressRegion: 'GR',
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode: '7542',
+    category: detectCategory(title),
+    sector: 'Salute / Psichiatria',
+    contract: 'full-time',
+    employmentType: detectEmploymentType(title),
+    experienceLevel: detectExperienceLevel(title),
+    currency: 'CHF',
+    featured: false,
+    postedDate: new Date().toISOString().slice(0, 10),
+    url: detailUrl,
+    applyUrl: detailUrl,
+    source: 'Clinica Holistica Engiadina Dedicated Parser (Playwright)',
+    sourceLang,
+    crawledAt: new Date().toISOString(),
+    needsRetranslation: true,
+  };
+}
+
+/* ── Main fetch function ───────────────────────────────────── */
+
+export async function fetchAllClinicaHolisticaJobs() {
+  console.log(`🏥 Fetching Clinica Holistica Engiadina jobs`);
+  console.log(`   Public career page: ${PUBLIC_CAREER_URL}\n`);
+
+  const chromium = await loadPlaywright();
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true, args: PW_LAUNCH_ARGS });
+  } catch (err) {
+    console.warn(`⚠️ chromium launch failed: ${err?.message || err}`);
+    return [];
+  }
+
+  try {
+    const context = await createStealthContext(browser);
+    const detailUrls = await discoverDetailUrls(context);
+    console.log(`  Discovered ${detailUrls.length} job URL(s)`);
+    if (detailUrls.length === 0) {
+      console.warn(`  ⚠️ No job links found at ${PUBLIC_CAREER_URL}`);
+      return [];
+    }
+
+    const jobs = [];
+    for (const detailUrl of detailUrls) {
+      const detail = await fetchDetail(context, detailUrl);
+      if (!detail) continue;
+      const job = buildJob(detailUrl, detail);
+      if (job) {
+        jobs.push(job);
+        console.log(`  ✅ ${detailUrl.replace('https://www.clinica-holistica.ch', '')} — ${job.title.slice(0, 60)}`);
+      }
+      // Light per-page delay so we stay polite.
+      await new Promise((r) => setTimeout(r, 600));
+    }
+
+    // Deduplicate by id.
+    const seen = new Set();
+    const deduped = [];
+    for (const job of jobs) {
+      if (seen.has(job.id)) continue;
+      seen.add(job.id);
+      deduped.push(job);
+    }
+    console.log(`\n📋 Total unique Clinica Holistica jobs: ${deduped.length}`);
+    return deduped;
+  } finally {
+    try {
+      await browser.close();
+    } catch {
+      /* no-op */
+    }
+  }
+}

--- a/scripts/lib/ghol-job-parser.mjs
+++ b/scripts/lib/ghol-job-parser.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * Groupement Hospitalier de l'Ouest Lémanique (GHOL) — Beehire ATS.
+ *
+ * Public career site:   https://www.ghol.ch/jcms/fr/le-ghol/espace-ghol/carrieres-p_5013.html
+ *                       (302 → https://app.beehire.com/career/ghol)
+ * Beehire public API:   https://app.beehire.com/users/getPublicCampaigns/ghol
+ *
+ * The Jalios JCMS landing redirects to Beehire, which is an AngularJS SPA.
+ * Rather than render the SPA we hit the public REST endpoint that the SPA
+ * itself uses (`/users/getPublicCampaigns/{slug}`) — it returns the complete
+ * campaign list with titles, descriptions (HTML), locations and contract
+ * details, no auth required.
+ *
+ * Campaign shape (relevant fields):
+ *   {
+ *     _id,                         // 24-hex Mongo id
+ *     title:       { "1": "..." }, // language id → string (1 = FR)
+ *     description: { "1": "..." }, // language id → HTML body
+ *     language:    1,
+ *     inviteKey:   "g2ZqgW6aZ",    // short URL token
+ *     inviteLink:  "https://app.beehire.com/invite/g2ZqgW6aZ",
+ *     location:    { city, state, country, zip, name, latitude, longitude },
+ *     details:     { contract: { duration, type, remote }, vacanciesNumber },
+ *   }
+ *
+ * GHOL operates in canton VD (Nyon, Rolle, Saint-Cergue). Default canton VD.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import {
+  slugify,
+  stripHtml,
+  normalizeSpace,
+  fetchJson,
+} from './crawler-template.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const GHOL_KEY = 'ghol';
+export const GHOL_COMPANY_NAME = "Groupement Hospitalier de l'Ouest Lémanique";
+export const GHOL_COMPANY_DOMAIN = 'ghol.ch';
+
+const BEEHIRE_SLUG = 'ghol';
+const BEEHIRE_API = `https://app.beehire.com/users/getPublicCampaigns/${BEEHIRE_SLUG}`;
+const PUBLIC_CAREER_URL =
+  'https://www.ghol.ch/jcms/fr/le-ghol/espace-ghol/carrieres-p_5013.html';
+const BEEHIRE_INVITE_BASE = 'https://app.beehire.com/invite/';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+/**
+ * Beehire stores localized strings keyed by language id. From the GHOL feed
+ * key "1" is French; "2"/"3" are English/German when defined. We always
+ * prefer the campaign's `language` id, then fall back to "1", then to the
+ * first non-empty value.
+ */
+function pickLocalized(map, langId) {
+  if (!map || typeof map !== 'object') return '';
+  const keys = [String(langId || ''), '1', '2', '3'];
+  for (const k of keys) {
+    const v = map[k];
+    if (typeof v === 'string' && v.trim().length > 0) return v;
+  }
+  for (const v of Object.values(map)) {
+    if (typeof v === 'string' && v.trim().length > 0) return v;
+  }
+  return '';
+}
+
+function languageIdToIso(id) {
+  switch (String(id || '')) {
+    case '1':
+      return 'fr';
+    case '2':
+      return 'en';
+    case '3':
+      return 'de';
+    case '4':
+      return 'it';
+    default:
+      return 'fr';
+  }
+}
+
+/**
+ * Map Beehire contract enum values into our employmentType convention.
+ */
+function detectEmploymentType(details = {}) {
+  const c = details.contract || {};
+  const duration = String(c.duration || '').toLowerCase();
+  const type = String(c.type || '').toLowerCase();
+  if (duration.includes('parttime') || duration.includes('partial')) return 'PART_TIME';
+  if (duration.includes('fulltime') || duration.includes('full')) {
+    if (type.includes('temp') || type.includes('cdd') || type.includes('fixed')) return 'CONTRACTOR';
+    if (type.includes('intern') || type.includes('stage')) return 'INTERN';
+    return 'FULL_TIME';
+  }
+  if (type.includes('intern') || type.includes('stage')) return 'INTERN';
+  if (type.includes('temp') || type.includes('cdd') || type.includes('fixed')) return 'CONTRACTOR';
+  return 'OTHER';
+}
+
+function detectContract(details = {}) {
+  const duration = String(details?.contract?.duration || '').toLowerCase();
+  if (duration.includes('part')) return 'part-time';
+  return 'full-time';
+}
+
+/* ── Category detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = String(title || '').toLowerCase();
+  if (/\b(m[eé]decin|chef.?de.?clinique|chefarzt|oberarzt|assistant?.?m[eé]dical)\b/.test(t))
+    return 'healthcare-medical';
+  if (/\b(infirmi[eè]r|aide.?soign|assc|asse|aide.?infirmi[eè]re|nurse)\b/.test(t))
+    return 'healthcare-nursing';
+  if (/\b(physio|ergo|kinetik|kin[eé]si|logop|orthophon)\b/.test(t)) return 'healthcare-therapy';
+  if (/\b(psycholog)\b/.test(t)) return 'healthcare-psychology';
+  if (/\b(pharma|preparat[eo]ur.?pharma)\b/.test(t)) return 'pharma';
+  if (/\b(secret[ae]ir|administrat|directeur|directrice|responsable)\b/.test(t))
+    return 'administration';
+  if (/\b(comptabl|financ|controll)\b/.test(t)) return 'finance';
+  if (/\b(informatique|informatik|developp|ingenieur|technicien.?syst[eè]me)\b/.test(t))
+    return 'technology';
+  if (/\b(technicien|maintenance|electric|sanitair|chauffage|menuis)\b/.test(t)) return 'logistics';
+  if (/\b(cuisinier|chef.?de.?rang|hotel|restaurat|servic|housekeep)\b/.test(t)) return 'hospitality';
+  if (/\b(codific|codif|codeur|laboratoire|laborantin|techn.?biom)\b/.test(t))
+    return 'healthcare-medtech';
+  if (/\b(rh|ressources.?humain|recrut|hr)\b/.test(t)) return 'human-resources';
+  if (/\b(stage|stagiair|apprenti)\b/.test(t)) return 'education';
+  return 'healthcare';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = String(title || '').toLowerCase();
+  if (/\b(stage|stagiair|apprenti|trainee|intern|praktik)\b/.test(t)) return 'intern';
+  if (/\b(junior|jr)\b/.test(t)) return 'junior';
+  if (/\b(directeur|directrice|responsable|chef|chefarzt|senior|sr|head)\b/.test(t)) return 'senior';
+  return 'mid';
+}
+
+/* ── Job identity / trust ──────────────────────────────────── */
+
+export function isGholJob(job) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === GHOL_KEY ||
+    company.includes('ghol') ||
+    company.includes("groupement hospitalier de l'ouest l") ||
+    company.includes("groupement hospitalier de l'ouest lemanique") ||
+    url.includes('ghol.ch') ||
+    url.includes('app.beehire.com/invite/') ||
+    url.includes('app.beehire.com/career/ghol')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === 'ghol.ch' ||
+      host === 'www.ghol.ch' ||
+      host === 'app.beehire.com' ||
+      host.endsWith('.beehire.com')
+    );
+  } catch {
+    return false;
+  }
+}
+
+/* ── Build job from API data ───────────────────────────────── */
+
+function buildJob(campaign) {
+  if (!campaign || typeof campaign !== 'object') return null;
+  const langId = campaign.language;
+  const sourceLang = languageIdToIso(langId);
+
+  const titleRaw = pickLocalized(campaign.title, langId);
+  const title = normalizeSpace(titleRaw);
+  if (!title || title.length < 3) return null;
+
+  const descriptionHtml = pickLocalized(campaign.description, langId);
+  const descriptionText = stripHtml(descriptionHtml || '') ||
+    `${title} — ${GHOL_COMPANY_NAME}`;
+
+  const location = campaign.location || {};
+  const cityRaw = normalizeSpace(location.city || '');
+  const city = cityRaw || 'Nyon';
+  // Canton: Beehire stores state="VD"/"VS"/... directly for Swiss locations.
+  const state = String(location.state || '').toUpperCase().slice(0, 2);
+  const canton = /^[A-Z]{2}$/.test(state) ? state : 'VD';
+  const country = String(location.country || '').toLowerCase();
+  const isCH =
+    country.includes('suisse') ||
+    country.includes('switzerland') ||
+    country === 'ch' ||
+    /^vd|vs|ge|fr|ne|ju|be|so|ti|gr|zh|bs|bl|ag|sg|sh|sz|nw|ow|ur|zg|tg|gl|ar|ai|li$/i.test(state);
+  if (!isCH) return null;
+
+  const postalCode = normalizeSpace(location.zip || '') || '1260';
+  const inviteKey = normalizeSpace(campaign.inviteKey || '');
+  const publicUrl = inviteKey
+    ? `${BEEHIRE_INVITE_BASE}${inviteKey}`
+    : `https://app.beehire.com/career/${BEEHIRE_SLUG}`;
+
+  const idForHash = String(campaign._id || campaign.inviteKey || title);
+  const urlHash = createHash('sha1').update(idForHash).digest('hex').slice(0, 12);
+
+  const jobSlug = slugify(`${title} ${GHOL_COMPANY_NAME} ${city}`);
+  // Beehire campaigns don't expose a posted-date — use today.
+  const postedDate = new Date().toISOString().slice(0, 10);
+
+  // The sourceLang sanity-check: if Beehire's language id doesn't match the
+  // text, recompute via detectLang. Cheap insurance against mis-tagged feeds.
+  const detectedLang = detectLang(descriptionText || title, sourceLang);
+  const effectiveLang =
+    detectedLang === 'fr' || detectedLang === 'de' || detectedLang === 'it' || detectedLang === 'en'
+      ? detectedLang
+      : sourceLang;
+
+  return {
+    id: `${GHOL_KEY}-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [effectiveLang]: jobSlug },
+    company: GHOL_COMPANY_NAME,
+    companyKey: GHOL_KEY,
+    companyDomain: GHOL_COMPANY_DOMAIN,
+    title,
+    titleByLocale: { [effectiveLang]: title },
+    description: descriptionText,
+    descriptionByLocale: { [effectiveLang]: descriptionText },
+    location: city,
+    canton,
+    addressLocality: city,
+    addressRegion: canton,
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode,
+    category: detectCategory(title),
+    sector: 'Salute / Ospedale',
+    contract: detectContract(campaign.details),
+    employmentType: detectEmploymentType(campaign.details),
+    experienceLevel: detectExperienceLevel(title),
+    currency: 'CHF',
+    featured: false,
+    postedDate,
+    url: publicUrl,
+    applyUrl: publicUrl,
+    source: 'GHOL Dedicated Parser (Beehire public API)',
+    sourceLang: effectiveLang,
+    crawledAt: new Date().toISOString(),
+    needsRetranslation: true,
+  };
+}
+
+/* ── Main fetch function ───────────────────────────────────── */
+
+/**
+ * Fetch all GHOL jobs from the Beehire public campaigns endpoint.
+ * Returns ParsedJob[] with source-locale fields only.
+ */
+export async function fetchAllGholJobs() {
+  console.log(`🏥 Fetching GHOL (Nyon) jobs from Beehire`);
+  console.log(`   Public career page: ${PUBLIC_CAREER_URL}`);
+  console.log(`   Beehire API: ${BEEHIRE_API}\n`);
+
+  let payload;
+  try {
+    payload = await fetchJson(BEEHIRE_API, {
+      timeoutMs: Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 25_000,
+      headers: { 'Accept-Language': 'fr-CH,fr;q=0.9' },
+    });
+  } catch (err) {
+    console.warn(`⚠️ Beehire API unreachable: ${err?.message || err}`);
+    return [];
+  }
+  const campaigns = Array.isArray(payload?.campaigns) ? payload.campaigns : [];
+  console.log(`   Beehire returned ${campaigns.length} campaign(s)\n`);
+
+  const jobs = [];
+  for (const campaign of campaigns) {
+    try {
+      const job = buildJob(campaign);
+      if (job) jobs.push(job);
+    } catch (err) {
+      console.warn(`   ⚠️ Skipping campaign ${campaign?._id}: ${err?.message || err}`);
+    }
+  }
+
+  // Deduplicate by id (Mongo _id is unique).
+  const seen = new Set();
+  const deduped = [];
+  for (const job of jobs) {
+    if (seen.has(job.id)) continue;
+    seen.add(job.id);
+    deduped.push(job);
+  }
+
+  console.log(`\n📋 Total unique GHOL jobs: ${deduped.length}`);
+  return deduped;
+}

--- a/scripts/lib/leukerbad-clinic-job-parser.mjs
+++ b/scripts/lib/leukerbad-clinic-job-parser.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+/**
+ * Leukerbad Clinic (RZL Rehabilitationszentrum Leukerbad AG) — Nuxt + Prismic CMS.
+ *
+ * Public career site:   https://leukerbadclinic.ch/de/page/jobs/
+ * Prismic repository:   leukerbad-clinic.cdn.prismic.io
+ * Prismic REST API:     https://leukerbad-clinic.cdn.prismic.io/api/v2
+ *
+ * The career page is a Nuxt SSG export pulling content from Prismic. Rather
+ * than render Nuxt with Playwright we go straight to the Prismic public REST
+ * API (no auth, no challenge) and query documents of type `job`.
+ *
+ * Pipeline:
+ *   1. GET /api/v2                 → master ref
+ *   2. GET /api/v2/documents/search?ref=<master>&q=[[at(document.type,"job")]]&lang=*&pageSize=100
+ *      → all job documents, both fr-ch and de-ch.
+ *   3. For each Prismic document, flatten the rich-text job_description blocks
+ *      into a plain-text body and build a ParsedJob.
+ *
+ * Notes:
+ *   - Master locale is `fr-ch`, secondary is `de-ch` (per /api/v2).
+ *   - VS canton (Leukerbad is in Wallis); default postal code 3954.
+ *   - We tag every job needsRetranslation: true so the translate-pending
+ *     pipeline runs the AI localizer on first sight.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml, normalizeSpace } from './crawler-template.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const LEUKERBAD_CLINIC_KEY = 'leukerbad-clinic';
+export const LEUKERBAD_CLINIC_COMPANY_NAME = 'Leukerbad Clinic';
+export const LEUKERBAD_CLINIC_COMPANY_DOMAIN = 'leukerbadclinic.ch';
+
+const PRISMIC_REPO = 'leukerbad-clinic';
+const PRISMIC_API_BASE = `https://${PRISMIC_REPO}.cdn.prismic.io/api/v2`;
+const PUBLIC_CAREER_URL = 'https://leukerbadclinic.ch/de/page/jobs/';
+
+const DEFAULT_UA =
+  process.env.JOBS_CRAWLER_USER_AGENT ||
+  'Mozilla/5.0 (compatible; FrontaliereTicinoBot/2.0; +https://frontaliereticino.ch/)';
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function fetchWithTimeout(url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return fetch(url, {
+    headers: { 'User-Agent': DEFAULT_UA, Accept: 'application/json' },
+    signal: controller.signal,
+  }).finally(() => clearTimeout(timer));
+}
+
+async function fetchJsonRetry(url, opts = {}) {
+  const timeoutMs = opts.timeoutMs || Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 25_000;
+  const maxAttempts = opts.maxAttempts || 3;
+  let lastErr;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetchWithTimeout(url, timeoutMs);
+      if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+      return await res.json();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxAttempts) {
+        await new Promise((r) => setTimeout(r, 500 * attempt));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Flatten Prismic rich-text array into a single text blob.
+ *
+ * Prismic rich-text is an array of blocks, each with type+text. We preserve
+ * structure by emitting newlines between blocks and a "• " prefix for
+ * list-items, then run the result through the standard stripHtml/normalize
+ * downstream.
+ */
+function richTextToText(blocks) {
+  if (!Array.isArray(blocks) || blocks.length === 0) return '';
+  const lines = [];
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue;
+    const text = String(block.text || '').trim();
+    if (!text) continue;
+    if (block.type === 'list-item' || block.type === 'o-list-item') {
+      lines.push(`• ${text}`);
+    } else if (/^heading/.test(block.type || '')) {
+      lines.push(`\n${text}\n`);
+    } else {
+      lines.push(text);
+    }
+  }
+  return lines.join('\n');
+}
+
+function richTextToPlainTitle(blocks) {
+  if (!Array.isArray(blocks)) return '';
+  for (const block of blocks) {
+    const text = normalizeSpace(String(block?.text || ''));
+    if (text) return text;
+  }
+  return '';
+}
+
+/* ── Category detection ────────────────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = String(title || '').toLowerCase();
+  if (/\b(arzt|ärzt|m[eé]decin|chefarzt|oberarzt|assistent.?arzt|cheffe?\s+de\s+clinique)\b/.test(t))
+    return 'healthcare-medical';
+  if (/\b(pflege|infirm|soins|assc|krankenpfleg|fachfrau\s+gesundheit|fage)\b/.test(t))
+    return 'healthcare-nursing';
+  if (/\b(physio|ergo|therap|logop|kinetik)\b/.test(t)) return 'healthcare-therapy';
+  if (/\b(psycholog)\b/.test(t)) return 'healthcare-psychology';
+  if (/\b(pharma|apothek)\b/.test(t)) return 'pharma';
+  if (/\b(administrat|verwaltung|secret|sekret)\b/.test(t)) return 'administration';
+  if (/\b(reinig|nettoy|cleaning|housekeep|hauswirt|economat|economes?)\b/.test(t)) return 'hospitality';
+  if (/\b(cuisin|k[uü]che|chef\s+de\s+rang|service|h[oô]tel|restaur)\b/.test(t)) return 'hospitality';
+  if (/\b(technique|technik|haustechn|elektri|sanit[aä]r|maintenance)\b/.test(t)) return 'logistics';
+  if (/\b(informatique|informatik|it[-\s]|systeme|reseau|réseau)\b/.test(t)) return 'technology';
+  return 'healthcare';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = String(title || '').toLowerCase();
+  if (/\b(stage|stagiair|praktik|intern|apprenti|lehre|trainee)\b/.test(t)) return 'intern';
+  if (/\b(junior|jr)\b/.test(t)) return 'junior';
+  if (/\b(chef|chefarzt|leiter|directeur|directrice|responsable|head|senior|sr)\b/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(title = '', timePct = '') {
+  const t = String(title || '').toLowerCase();
+  const pct = String(timePct || '').toLowerCase();
+  if (/\b(stage|stagiair|praktik|intern)\b/.test(t)) return 'INTERN';
+  if (/\b(temporaire|temporary|befristet|cdd|fixed.?term)\b/.test(t)) return 'CONTRACTOR';
+  // 100% only → FULL_TIME; explicit part-time band → PART_TIME; otherwise OTHER.
+  if (/^|^\s*100\s*%\s*$/.test(pct) && pct.trim() === '100%') return 'FULL_TIME';
+  if (/^\s*\d+\s*%\s*$/.test(pct)) {
+    const n = parseInt(pct, 10);
+    if (n === 100) return 'FULL_TIME';
+    if (n > 0 && n < 100) return 'PART_TIME';
+  }
+  return 'OTHER';
+}
+
+/* ── Job identity / trust ──────────────────────────────────── */
+
+export function isLeukerbadClinicJob(job) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === LEUKERBAD_CLINIC_KEY ||
+    company.includes('leukerbad clinic') ||
+    company.includes('rehabilitationszentrum leukerbad') ||
+    url.includes('leukerbadclinic.ch') ||
+    url.includes('leukerbad-clinic.prismic.io') ||
+    url.includes('leukerbad-clinic.cdn.prismic.io')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === 'leukerbadclinic.ch' ||
+      host.endsWith('.leukerbadclinic.ch') ||
+      host === 'leukerbad-clinic.cdn.prismic.io' ||
+      host === 'leukerbad-clinic.prismic.io'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/* ── Build ParsedJob from Prismic document ─────────────────── */
+
+function buildJob(doc) {
+  if (!doc || typeof doc !== 'object') return null;
+  const data = doc.data || {};
+
+  const title =
+    richTextToPlainTitle(data.job_title) ||
+    normalizeSpace(data.page_title || '') ||
+    normalizeSpace(doc.uid || '');
+  if (!title || title.length < 3) return null;
+
+  const workplace = normalizeSpace(data.workplace || '') || 'Leukerbad';
+  const timePct = normalizeSpace(data.time_percentage || '');
+  const startingDate = normalizeSpace(data.starting_date || '');
+  const supTitle = normalizeSpace(richTextToPlainTitle(data.sup_title) || '');
+
+  const descriptionRaw = richTextToText(data.job_description);
+  const descriptionParts = [];
+  if (supTitle) descriptionParts.push(supTitle);
+  if (timePct || startingDate) {
+    const meta = [];
+    if (timePct) meta.push(timePct);
+    if (startingDate) meta.push(startingDate);
+    descriptionParts.push(meta.join(' · '));
+  }
+  if (descriptionRaw) descriptionParts.push(descriptionRaw);
+
+  const description = stripHtml(descriptionParts.filter(Boolean).join('\n\n')) ||
+    `${title} — ${LEUKERBAD_CLINIC_COMPANY_NAME}`;
+
+  // Prismic lang format is 'fr-ch' / 'de-ch' — strip region.
+  const langRaw = String(doc.lang || '').toLowerCase();
+  const langPrefix = langRaw.split('-')[0] || '';
+  const sourceLang =
+    langPrefix === 'de' || langPrefix === 'fr' || langPrefix === 'it' || langPrefix === 'en'
+      ? langPrefix
+      : detectLang(description || title, 'fr');
+
+  // Build canonical URL. The Nuxt site exposes jobs at /{lang}/page/jobs/{uid}/
+  // We use the German page when source is de, otherwise fr.
+  const sitePath = sourceLang === 'de' ? 'de' : 'fr';
+  const publicUrl = `https://leukerbadclinic.ch/${sitePath}/page/jobs/${doc.uid || ''}/`;
+  const urlForHash = `${PRISMIC_REPO}:${doc.id || doc.uid || title}`;
+  const urlHash = createHash('sha1').update(urlForHash).digest('hex').slice(0, 12);
+
+  const jobSlug = slugify(`${title} ${LEUKERBAD_CLINIC_COMPANY_NAME} ${workplace}`);
+  const postedDate = (() => {
+    const candidates = [doc.last_publication_date, doc.first_publication_date];
+    for (const c of candidates) {
+      if (!c) continue;
+      const d = new Date(c);
+      if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+    }
+    return new Date().toISOString().slice(0, 10);
+  })();
+
+  return {
+    id: `${LEUKERBAD_CLINIC_KEY}-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [sourceLang]: jobSlug },
+    company: LEUKERBAD_CLINIC_COMPANY_NAME,
+    companyKey: LEUKERBAD_CLINIC_KEY,
+    companyDomain: LEUKERBAD_CLINIC_COMPANY_DOMAIN,
+    title,
+    titleByLocale: { [sourceLang]: title },
+    description,
+    descriptionByLocale: { [sourceLang]: description },
+    location: workplace,
+    canton: 'VS',
+    addressLocality: workplace,
+    addressRegion: 'VS',
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode: '3954',
+    category: detectCategory(title),
+    sector: 'Salute / Riabilitazione',
+    contract: 'full-time',
+    employmentType: detectEmploymentType(title, timePct),
+    experienceLevel: detectExperienceLevel(title),
+    currency: 'CHF',
+    featured: false,
+    postedDate,
+    url: publicUrl,
+    applyUrl: publicUrl,
+    source: 'Leukerbad Clinic Dedicated Parser (Prismic REST API)',
+    sourceLang,
+    crawledAt: new Date().toISOString(),
+    needsRetranslation: true,
+  };
+}
+
+/* ── Main fetch function ───────────────────────────────────── */
+
+/**
+ * Fetch all Leukerbad Clinic jobs from the Prismic REST API.
+ *
+ * Returns ParsedJob[] with source-locale fields only (no other-locale slugs
+ * or translations). Master locale is fr-ch; we also include de-ch.
+ */
+export async function fetchAllLeukerbadClinicJobs() {
+  console.log(`🏥 Fetching Leukerbad Clinic jobs from Prismic`);
+  console.log(`   Public career page: ${PUBLIC_CAREER_URL}`);
+  console.log(`   Prismic API: ${PRISMIC_API_BASE}\n`);
+
+  let masterRef = '';
+  try {
+    const apiInfo = await fetchJsonRetry(PRISMIC_API_BASE);
+    masterRef =
+      (apiInfo.refs || []).find((r) => r && r.isMasterRef)?.ref ||
+      (apiInfo.refs || [])[0]?.ref ||
+      '';
+  } catch (err) {
+    console.warn(`⚠️ Prismic /api/v2 unreachable: ${err?.message || err}`);
+    return [];
+  }
+  if (!masterRef) {
+    console.warn(`⚠️ Could not resolve Prismic master ref.`);
+    return [];
+  }
+  console.log(`   Resolved master ref: ${masterRef}`);
+
+  // Fetch all job docs in all langs. Prismic returns paginated results with
+  // page/results_size/total_results_size; iterate until exhausted.
+  const allDocs = [];
+  let page = 1;
+  const pageSize = 100;
+  while (true) {
+    const q = encodeURIComponent('[[at(document.type, "job")]]');
+    const url =
+      `${PRISMIC_API_BASE}/documents/search?ref=${encodeURIComponent(masterRef)}` +
+      `&q=${q}&lang=*&pageSize=${pageSize}&page=${page}`;
+    let payload;
+    try {
+      payload = await fetchJsonRetry(url);
+    } catch (err) {
+      console.warn(`⚠️ Prismic search page ${page} failed: ${err?.message || err}`);
+      break;
+    }
+    const results = Array.isArray(payload?.results) ? payload.results : [];
+    allDocs.push(...results);
+    const totalPages = Number(payload?.total_pages || 1);
+    console.log(`   📄 Page ${page}/${totalPages}: ${results.length} job docs`);
+    if (page >= totalPages || results.length === 0) break;
+    page += 1;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+
+  console.log(`\n   Prismic returned ${allDocs.length} job document(s) across all locales`);
+
+  const jobs = [];
+  for (const doc of allDocs) {
+    try {
+      const job = buildJob(doc);
+      if (job) jobs.push(job);
+    } catch (err) {
+      console.warn(`   ⚠️ Skipping doc ${doc?.id || doc?.uid}: ${err?.message || err}`);
+    }
+  }
+
+  // Deduplicate by id (one Prismic doc per (uid, lang) combination, so id is
+  // already unique — but the urlHash collapses by `id || uid || title`).
+  const seen = new Set();
+  const deduped = [];
+  for (const job of jobs) {
+    if (seen.has(job.id)) continue;
+    seen.add(job.id);
+    deduped.push(job);
+  }
+
+  console.log(`\n📋 Total unique Leukerbad Clinic jobs: ${deduped.length}`);
+  return deduped;
+}

--- a/scripts/update-clinica-holistica-engiadina-jobs.mjs
+++ b/scripts/update-clinica-holistica-engiadina-jobs.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Clinica Holistica Engiadina (Susch, GR) crawler runner.
+ *
+ * Source: https://www.clinica-holistica.ch/de/karriere (Drupal listing).
+ * The `/de/offene-stellen` page returns 403 even via Playwright; we use the
+ * Karriere index as the canonical entrypoint.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllClinicaHolisticaJobs,
+  isClinicaHolisticaJob,
+  isTrustedDomain,
+  CLINICA_HOLISTICA_KEY,
+  CLINICA_HOLISTICA_COMPANY_NAME,
+} from './lib/clinica-holistica-engiadina-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: CLINICA_HOLISTICA_KEY,
+  companyLabel: CLINICA_HOLISTICA_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllClinicaHolisticaJobs,
+  isCompanyJob: isClinicaHolisticaJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Clinica Holistica Engiadina crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-ghol-jobs.mjs
+++ b/scripts/update-ghol-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Groupement Hospitalier de l'Ouest Lémanique (GHOL) crawler runner.
+ *
+ * Source: https://www.ghol.ch/ (Jalios JCMS → 302 → Beehire ATS).
+ * Backed by the public Beehire campaigns API — no browser automation.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllGholJobs,
+  isGholJob,
+  isTrustedDomain,
+  GHOL_KEY,
+  GHOL_COMPANY_NAME,
+} from './lib/ghol-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: GHOL_KEY,
+  companyLabel: GHOL_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllGholJobs,
+  isCompanyJob: isGholJob,
+  isTrustedDomain,
+  defaultSourceLang: 'fr',
+}).catch((err) => {
+  console.error(`❌ GHOL crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-leukerbad-clinic-jobs.mjs
+++ b/scripts/update-leukerbad-clinic-jobs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Leukerbad Clinic (RZL Rehabilitationszentrum Leukerbad AG) crawler runner.
+ *
+ * Source: https://leukerbadclinic.ch/de/page/jobs/ (Nuxt SSG over Prismic CMS).
+ * Backed by the public Prismic REST API — no auth, no browser automation needed.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllLeukerbadClinicJobs,
+  isLeukerbadClinicJob,
+  isTrustedDomain,
+  LEUKERBAD_CLINIC_KEY,
+  LEUKERBAD_CLINIC_COMPANY_NAME,
+} from './lib/leukerbad-clinic-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: LEUKERBAD_CLINIC_KEY,
+  companyLabel: LEUKERBAD_CLINIC_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllLeukerbadClinicJobs,
+  isCompanyJob: isLeukerbadClinicJob,
+  isTrustedDomain,
+  defaultSourceLang: 'fr',
+}).catch((err) => {
+  console.error(`❌ Leukerbad Clinic crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Three new dedicated hospital crawlers covering Swiss healthcare tenants that
were previously deferred due to Nuxt SSG, Cloudflare/WAF challenges, or
silent server redirects.

| Tenant | Canton | Smoke jobs | Mechanism |
|---|---|---|---|
| **Leukerbad Clinic** (RZL Rehabilitationszentrum Leukerbad AG) | VS | **15** (mixed FR + DE) | Prismic public REST API (`leukerbad-clinic.cdn.prismic.io/api/v2`) — no Nuxt rendering needed |
| **GHOL** (Groupement Hospitalier de l'Ouest Lémanique) | VD | **11** (FR) | Beehire public campaigns endpoint (`app.beehire.com/users/getPublicCampaigns/ghol`) — JCMS landing redirects there |
| **Clinica Holistica Engiadina** (Susch) | GR | **6** (DE) | Playwright + stealth init script — the listed `/de/offene-stellen` URL is a 403 trap; we use `/de/karriere` instead |

All `ParsedJob`s emit `needsRetranslation: true` so the translate-pending pipeline picks them up on first sight.

### Skipped: Pôle Santé Vallée de Joux (PSVJ)

Every probed URL (`https://www.psvj.ch/jcms/c_5303/fr/emplois`, `https://psvj.ch/jcms/c_5303/fr/emplois`, `https://www.psvj.ch/`, `https://psvj.ch/`) timed out at 80 s through Playwright. The site appears to be down at the application layer (TLS handshake completes; the HTTP body never starts streaming). No parser shipped.

## Test plan

- [ ] Trigger `update-jobs-leukerbad-clinic.yml` via `workflow_dispatch` on `main` after merge; expect ≥10 jobs in `data/jobs/by-crawler/leukerbad-clinic.json`.
- [ ] Trigger `update-jobs-ghol.yml`; expect ≥10 jobs canton=VD.
- [ ] Trigger `update-jobs-clinica-holistica-engiadina.yml`; expect ≥5 jobs canton=GR. (The Karriere index sometimes lists only 5 if the site has removed a posting — `runStandardCrawlerPipeline` already enforces `failWhenNoJobs` and the worktree smoke counted 6.)
- [ ] After all three runs, confirm AI translation populated `titleByLocale.{it,en,de,fr}` and `descriptionByLocale.{...}` on the new jobs (translate-pending pipeline).