### PR TITLE
fix(seo): sweep remaining 9 buildSimplePage emits → buildSeoPageHtml

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -5539,7 +5539,8 @@ ${alternates}
  pgNav.push(`<a href="${BASE_URL}${withSlash(`${pgSectionPath}/${paginationSlugs[locale]}-${np2}`.replace(/\/+/g, '/'))}" style="display:inline-flex;align-items:center;justify-content:center;min-height:44px;min-width:44px;padding:8px 12px">${np2}</a>`);
  }
  const pgBackLabel = locale === 'it' ? 'Torna alla lista completa' : locale === 'en' ? 'Back to full listing' : locale === 'de' ? 'Zur\u00fcck zur Liste' : 'Retour \u00e0 la liste';
- const pgHtml = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const pgHtml = buildSeoPageHtml({
  locale,
  title: pgTitle,
  description: pgDesc,
@@ -5548,9 +5549,8 @@ ${alternates}
  hreflangHtml: `${pgAlternates}\n${pgXDefault}`,
  extraHeadHtml: `${pgPrevLink}${pgNextLink}`,
  jsonLdScripts: [pgCollLd, pgItemLd, pgBreadcrumbLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml: `<h1>${esc(pgCopy.heading(pageNum))}</h1>\n <p>${esc(pgDesc)}</p>\n <ul style="list-style:none;padding:0;margin:16px 0">${pgListHtml}</ul>\n <nav style="margin:24px 0;text-align:center;font-size:14px">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: 'Ticino', omitCommute: true }))}`,
+ distDir,
  });
  const pgOutDir = np.join(distDir, pgCanonicalPath.slice(1));
  activeJobDirs.add(pgCanonicalPath.slice(1).replace(/\/+$/, ''));
@@ -5659,7 +5659,8 @@ ${alternates}
  pgNav.push(`<a href="${BASE_URL}${withSlash(`${pgSectionPath}/${paginationSlugs[locale]}-${np2}`.replace(/\/+/g, '/'))}" style="display:inline-flex;align-items:center;justify-content:center;min-height:44px;min-width:44px;padding:8px 12px">${np2}</a>`);
  }
  const pgBackLabel = locale === 'it' ? 'Torna alla lista completa' : locale === 'en' ? 'Back to full listing' : locale === 'de' ? 'Zur\u00fcck zur Liste' : 'Retour \u00e0 la liste';
- const pgHtml = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const pgHtml = buildSeoPageHtml({
  locale,
  title: pgTitle,
  description: pgDesc,
@@ -5668,9 +5669,8 @@ ${alternates}
  hreflangHtml: `${pgAlternates}\n${pgXDefault}`,
  extraHeadHtml: `${pgPrevLink}${pgNextLink}`,
  jsonLdScripts: [pgCollLd, pgItemLd, pgBreadcrumbLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml: `<h1>${esc(pgHeading)}</h1>\n <p>${esc(pgDesc)}</p>\n <ul style="list-style:none;padding:0;margin:16px 0">${pgListHtml}</ul>\n <nav style="margin:24px 0;text-align:center;font-size:14px">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, cantonDisplay: cDisplay, cantonSlot: 'canton-hub' }))}`,
+ distDir,
  });
  const pgOutDir = np.join(distDir, pgCanonicalPath.slice(1));
  activeJobDirs.add(pgCanonicalPath.slice(1).replace(/\/+$/, ''));
@@ -5791,7 +5791,8 @@ ${alternates}
  })();
  const catOpenAllLabel = locale === 'it' ? 'Apri il job board completo' : locale === 'en' ? 'Open the full job board' : locale === 'de' ? 'Komplettes Job Board \u00f6ffnen' : 'Ouvrir le job board complet';
  const catNavLabel = locale === 'it' ? 'Altre categorie' : locale === 'en' ? 'Other categories' : locale === 'de' ? 'Weitere Kategorien' : 'Autres cat\u00e9gories';
- const catHtml = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const catHtml = buildSeoPageHtml({
  locale,
  title: catTitle,
  description: catDescription,
@@ -5799,8 +5800,7 @@ ${alternates}
  ogLocale: localeOg[locale],
  hreflangHtml: catAlternates,
  jsonLdScripts: [catCollLd, catBreadcrumbLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
+ distDir,
  bodyHtml: (() => {
  const catLocaleParts: Parameters<typeof formatSeoH1>[0] = {
  keyword: catLabel,
@@ -5938,7 +5938,8 @@ ${alternates}
  })();
  const catOpenAllLabel = locale === 'it' ? 'Apri il job board completo' : locale === 'en' ? 'Open the full job board' : locale === 'de' ? 'Komplettes Job Board öffnen' : 'Ouvrir le job board complet';
  const catNavLabel = locale === 'it' ? 'Altre categorie' : locale === 'en' ? 'Other categories' : locale === 'de' ? 'Weitere Kategorien' : 'Autres catégories';
- const catHtml = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const catHtml = buildSeoPageHtml({
  locale,
  title: catTitle,
  description: catDescription,
@@ -5946,8 +5947,7 @@ ${alternates}
  ogLocale: localeOg[locale],
  hreflangHtml: catAlternates,
  jsonLdScripts: [catCollLd, catBreadcrumbLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
+ distDir,
  bodyHtml: (() => {
  const catLocaleParts: Parameters<typeof formatSeoH1>[0] = {
  keyword: catLabel,
@@ -6128,7 +6128,8 @@ ${alternates}
  const openAllLabel = locale === 'it' ? `Apri tutte le offerte in ${cDisplay}` : locale === 'en' ? `View all jobs in ${cDisplay}` : locale === 'de' ? `Alle Stellen ${cDisplay}` : `Voir toutes les offres à ${cDisplay}`;
  const listHtml = cappedJobs.map((job: any) => renderJobCardLi(job, locale)).join('');
  const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: sectorDisplay, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
- const html = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const html = buildSeoPageHtml({
  locale,
  title: pageTitle,
  description: pageDesc,
@@ -6136,9 +6137,8 @@ ${alternates}
  ogLocale: localeOg[locale],
  hreflangHtml: alternates,
  jsonLdScripts: [breadcrumbLd, collectionLd, itemListLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml,
+ distDir,
  });
  // Hard budget guard (mirror per-canton city hub 195 KB cap).
  const SECTOR_CANTON_HARD_BUDGET = 195 * 1024;
@@ -6556,7 +6556,8 @@ ${alternates}
  })();
  const openAllLabel = locale === 'it' ? `Vedi tutte le offerte presso ${companyName}` : locale === 'en' ? `View all jobs at ${companyName}` : locale === 'de' ? `Alle Stellen bei ${companyName}` : `Voir toutes les offres chez ${companyName}`;
  const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul style="list-style:none;padding:0;margin:16px 0">${listHtml}</ul>\n<p><a href="${companyHubUrl}">${esc(openAllLabel)}</a></p>\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'company-landing', cantonEntityName: `${companyName} — ${cityDisplay}` }))}`;
- const html = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const html = buildSeoPageHtml({
  locale,
  title: pageTitle,
  description: pageDesc,
@@ -6564,9 +6565,8 @@ ${alternates}
  ogLocale: localeOg[locale],
  hreflangHtml: alternates,
  jsonLdScripts: [breadcrumbLd, collectionLd, itemListLd, organizationLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml,
+ distDir,
  });
  const COMPANY_CITY_HARD_BUDGET = 195 * 1024;
  const htmlBytes = Buffer.byteLength(html, 'utf-8');
@@ -6723,7 +6723,8 @@ ${alternates}
  { '@type': 'ListItem', position: 3, name: kwTitle, item: kwCanonicalUrl },
  ],
  });
- const kwHtml = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const kwHtml = buildSeoPageHtml({
  locale,
  title: kwTitle,
  description: kwDesc,
@@ -6731,9 +6732,8 @@ ${alternates}
  ogLocale: localeOg[locale],
  hreflangHtml: kwAlternates,
  jsonLdScripts: [kwBreadcrumbLd, kwCollLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml: `<h1>${esc(itCopy.heading)}</h1>\n <p>${esc(kwDesc)}</p>\n ${kwQueryIntro}\n ${kwIntro}\n <p>${esc(kwCta)}</p>\n <ul style="list-style:none;padding:0;margin:16px 0">${kwListHtml}</ul>\n <p><a href="${kwSectionUrl}">${esc(kwOpenAllLabel)}</a></p>\n ${kwMarketSection}\n ${kwCommuterBlock}`,
+ distDir,
  });
  const kwOutDir = np.join(distDir, kwCanonicalPath.slice(1));
  activeJobDirs.add(kwRelDir);
@@ -6884,7 +6884,8 @@ ${alternates}
  // (e.g. `search-lugano-eoc-...` → company hub). Page still emitted at its
  // own path so backlinks resolve.
  const effectiveCanonicalUrl = resolveCanonicalUrl(fullSlug, canonicalUrl);
- const searchHtml = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const searchHtml = buildSeoPageHtml({
  locale,
  title,
  description,
@@ -6904,9 +6905,8 @@ ${alternates}
  hreflangHtml: alternates,
  extraHeadHtml: twitterCards,
  jsonLdScripts: [searchBreadcrumbLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml: `<h1>${esc(copy.heading(name))}</h1>\n <p>${esc(description)}</p>\n${searchBodyParts.join('\n')}`,
+ distDir,
  });
 
  const outDir = np.join(distDir, canonicalPath.slice(1));
@@ -7039,7 +7039,8 @@ ${alternates}
  { '@type': 'ListItem', position: 3, name: copy.heading, item: canonicalUrl },
  ],
  });
- const comboHtml = buildSimplePage({
+ // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ const comboHtml = buildSeoPageHtml({
  locale,
  title: copy.title,
  description,
@@ -7048,9 +7049,8 @@ ${alternates}
  hreflangHtml: alternates,
  extraHeadHtml: comboOgImage,
  jsonLdScripts: [comboBreadcrumbLd],
- entryJs: hasSpaBundle ? entryJs : undefined,
- entryCss: hasSpaBundle ? entryCss : undefined,
  bodyHtml: `<h1>${esc(copy.heading)}</h1>\n <p>${esc(description)}</p>\n${comboBodyParts.join('\n')}`,
+ distDir,
  });
 
  const outDir = np.join(distDir, canonicalPath.slice(1));

--- a/tests/city-jobs-hub.test.ts
+++ b/tests/city-jobs-hub.test.ts
@@ -357,4 +357,32 @@ describe('per-canton city hub — hydration-safe SPA shell', () => {
     // #root — confirm we are NOT emitting that shape for city hubs.
     expect(html).not.toMatch(/<div id="root">\s*<main class="static-job-page"/);
   });
+
+  // Anti-regression sweep — every staticOverlay page emit in jobsSeoPagesPlugin
+  // (pagination / categoria / sector / company-city / keyword / search / combo)
+  // must use buildSeoPageHtml. The legacy buildSimplePage default mode wraps
+  // body in <main class="static-job-page"> INSIDE #root; on hydration React
+  // wipes that node and App.tsx skips its own <main> for staticOverlay routes,
+  // leaving the page visibly blank. Crawlers (no JS) still see SSR content so
+  // audits pass — only SPA users are affected. PR #416 fixed city hubs;
+  // this PR fixed the remaining 9 sites in one sweep.
+  it('jobsSeoPagesPlugin emits ZERO buildSimplePage calls (all staticOverlay pages use buildSeoPageHtml)', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const src = readFileSync(
+      resolve(__dirname, '../build-plugins/jobsSeoPagesPlugin.ts'),
+      'utf8',
+    );
+    // buildSimplePage stays imported (and may appear in comments / type refs);
+    // what we lock down is the CALL — `buildSimplePage({` followed by args.
+    // Every staticOverlay-route emit must go through buildSeoPageHtml so the
+    // shell stays hydration-safe (seo-static-content + footer-root portal).
+    const callMatches = src.match(/\bbuildSimplePage\s*\(\s*\{/g) ?? [];
+    expect(
+      callMatches.length,
+      `jobsSeoPagesPlugin contains ${callMatches.length} buildSimplePage({ ... }) call(s). ` +
+        `All staticOverlay-route emits must use buildSeoPageHtml — otherwise the page ` +
+        `goes blank for SPA users after React hydration. See PR #416 + #418 for context.`,
+    ).toBe(0);
+  });
 });


### PR DESCRIPTION
PR #416 fixed only the per-canton city hub (line ~5420). The same
blank-on-hydrate bug affects every other staticOverlay-route emit in
jobsSeoPagesPlugin that still used buildSimplePage default-mode:

| line   | URL pattern                                                    |
|-------:|---------------------------------------------------------------|
| 5542   | TI pagination /cerca-lavoro-ticino/pagina-N/                   |
| 5662   | per-canton pagination /cerca-lavoro-{canton}/pagina-N/         |
| 5794   | TI category   /cerca-lavoro-ticino/categoria-{slug}/           |
| 5941   | per-canton category /cerca-lavoro-{canton}/categoria-{slug}/   |
| 6131   | per-canton sector   /cerca-lavoro-{canton}/{sector}/           |
| 6559   | per-canton company×city /cerca-lavoro-{canton}/azienda-{co}-{city}/ |
| 6726   | TI keyword hub /cerca-lavoro-ticino/ricerca-{kw}/              |
| 6887   | TI search hub  /cerca-lavoro-ticino/{search-slug}/             |
| 7042   | TI combo hub   /cerca-lavoro-ticino/{combo}/                   |

All resolve via services/router.ts:2542 `isCantonStaticOverlaySlug`
(or the per-canton sector branch at line 2452) to `staticOverlay: true`,
which makes App.tsx skip its React `<main>`. buildSimplePage default
mode wraps body in `<main class="static-job-page">` INSIDE `#root`;
React hydration wipes that node + nothing replaces it → user sees
header + sub-nav only. Crawlers (no JS) still see SSR content so
audits passed — bug surfaced only on real SPA navigation.

Each emit now goes through buildSeoPageHtml (the same shell PR #376
applied to the per-canton company hub and PR #416 to the city hub):
emits `<main class="seo-static-content">` OUTSIDE `#root` plus the
`<div id="footer-root"></div>` portal target.

Anti-regression: tests/city-jobs-hub.test.ts now asserts
`jobsSeoPagesPlugin` contains ZERO `buildSimplePage({` calls. A
future caller reverting to the legacy shell fails the test instead
of silently shipping a blank page.
