### PR TITLE
feat: batch 21t crawlers for TI/GR/LU small clinics

### DIFF
--- a/.github/workflows/update-jobs-clinica-hildebrand.yml
+++ b/.github/workflows/update-jobs-clinica-hildebrand.yml
@@ -1,0 +1,104 @@
+name: Update Clinica Hildebrand Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-20000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-clinica-hildebrand
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-clinica-hildebrand-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated CLINICA_HILDEBRAND crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_CLINICA_HILDEBRAND_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          # Small clinic, each PDF carries the real content; the page-level
+          # boilerplate would otherwise be flagged by the duplicate-guard.
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-clinica-hildebrand-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'clinica-hildebrand'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/clinica-hildebrand.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLINICA_HILDEBRAND jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-clinica-varini.yml
+++ b/.github/workflows/update-jobs-clinica-varini.yml
@@ -1,0 +1,103 @@
+name: Update Clinica Varini Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-20000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-clinica-varini
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-clinica-varini-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated CLINICA_VARINI crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_CLINICA_VARINI_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          # Small clinic concorso boilerplate would otherwise trip the guard.
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-clinica-varini-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'clinica-varini'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/clinica-varini.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLINICA_VARINI jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-reha-andeer.yml
+++ b/.github/workflows/update-jobs-reha-andeer.yml
@@ -1,0 +1,104 @@
+name: Update Reha Andeer Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-20000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-reha-andeer
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-reha-andeer-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated REHA_ANDEER crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_REHA_ANDEER_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          # Small private clinic — PDF Stelleninserate share the clinic-level
+          # intro. Bypass the boilerplate guard to admit them.
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-reha-andeer-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'reha-andeer'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/reha-andeer.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update REHA_ANDEER jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-therapiezentrum-meggen.yml
+++ b/.github/workflows/update-jobs-therapiezentrum-meggen.yml
@@ -1,0 +1,104 @@
+name: Update Therapiezentrum Meggen Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-20000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-therapiezentrum-meggen
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-therapiezentrum-meggen-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated THERAPIEZENTRUM_MEGGEN crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_THERAPIEZENTRUM_MEGGEN_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          # Small institution; Stellenausschreibungen share the centre-level
+          # intro. Bypass the boilerplate guard.
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-therapiezentrum-meggen-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'therapiezentrum-meggen'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/therapiezentrum-meggen.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update THERAPIEZENTRUM_MEGGEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/clinica-hildebrand-job-parser.mjs
+++ b/scripts/lib/clinica-hildebrand-job-parser.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * Clinica Hildebrand — Centro di riabilitazione, Brissago (TI).
+ *
+ * Public career site (Italian only, Weebly/static HTML):
+ *   https://www.clinica-hildebrand.ch/collaborazione.html
+ *
+ * Open positions ("posti vacanti") are listed as PDF attachments hosted under
+ * /uploads/.../<filename>.pdf on the same domain. Each PDF is an annuncio with
+ * profilo, mansioni and procedura di candidatura.
+ *
+ * Strategy:
+ *   1. Fetch the careers page HTML
+ *   2. Regex out every <a href=".../uploads/...*.pdf"> link (skipping privacy /
+ *      regolamento attachments)
+ *   3. Fetch + extract each PDF text via pdf-job-content.mjs
+ *   4. Derive the title from the filename stem (or PDF first line when usable)
+ *   5. Build Italian description from PDF text + clinic-level boilerplate
+ *
+ * Brissago is in the Locarnese (TI) — directly on the frontaliere commuter axis.
+ *
+ * Inventory note: 1 PDF at probe time. Ship anyway — the parser will pick up new
+ * concorsi the moment they are uploaded.
+ */
+import { createHash } from 'node:crypto';
+import { buildPdfBackedDescription, extractPdfJobContentFromUrl } from './pdf-job-content.mjs';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const CLINICA_HILDEBRAND_KEY = 'clinica-hildebrand';
+export const CLINICA_HILDEBRAND_COMPANY_NAME =
+  'Clinica Hildebrand Centro di riabilitazione';
+export const CLINICA_HILDEBRAND_COMPANY_DOMAIN = 'clinica-hildebrand.ch';
+
+const PUBLIC_CAREER_URL = 'https://www.clinica-hildebrand.ch/collaborazione.html';
+const DEFAULT_CITY = 'Brissago';
+const DEFAULT_CANTON = 'TI';
+const DEFAULT_POSTAL = '6614';
+
+/** Minimum plain-text description length to surface a warning. */
+export const MIN_HILDEBRAND_DESC_LENGTH = 400;
+
+// Skip non-job PDFs (privacy notices, regolamenti, statuti).
+const NON_JOB_PDF_RE = /(informativa|privacy|protezione|regolamento|statuto|formulario|policy)/i;
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isClinicaHildebrandJob(job = {}) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === CLINICA_HILDEBRAND_KEY ||
+    key.startsWith('clinica-hildebrand') ||
+    company.includes('clinica hildebrand') ||
+    company.includes('hildebrand') ||
+    url.includes('clinica-hildebrand.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === CLINICA_HILDEBRAND_COMPANY_DOMAIN ||
+      host === `www.${CLINICA_HILDEBRAND_COMPANY_DOMAIN}` ||
+      host.endsWith(`.${CLINICA_HILDEBRAND_COMPANY_DOMAIN}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/* ── Title derivation from filename ───────────────────────── */
+
+function titleCaseWord(token) {
+  if (!token) return token;
+  if (/^\d+$/.test(token)) return token;
+  return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+/**
+ * Convert "annuncio_medico_assistente_25.pdf" → "Medico Assistente 25".
+ * Drops common leading markers (annuncio, bando, concorso).
+ */
+export function humanizeHildebrandFilename(filename = '') {
+  let stem = String(filename || '')
+    .replace(/\.pdf$/i, '')
+    .replace(/^(annuncio|bando|concorso|inserzione|posto)[_\s-]*/i, '');
+  if (!stem) return '';
+  stem = stem.replace(/[_-]+/g, ' ').replace(/\s{2,}/g, ' ').trim();
+  return stem
+    .split(/(\s+)/)
+    .map((part) => (/[a-zà-ÿ]/i.test(part) ? titleCaseWord(part.toLowerCase()) : part))
+    .join('')
+    .trim();
+}
+
+/* ── Parser ────────────────────────────────────────────────── */
+
+/**
+ * Extract job PDF listings from the Clinica Hildebrand careers page.
+ * Returns: [{ id, title, pdfUrl, filename }]
+ */
+export function parseClinicaHildebrandListing(html = '') {
+  if (!html || typeof html !== 'string') return [];
+
+  const out = [];
+  const seen = new Set();
+
+  // Match every <a href="...*.pdf" ...> reference. Weebly hosts PDFs under
+  // /uploads/<…ids…>/<filename>.pdf relative to root.
+  const anchorRe = /href="([^"]+\.pdf)"/gi;
+  let m;
+  while ((m = anchorRe.exec(html)) !== null) {
+    let href = m[1];
+    if (!href) continue;
+    if (NON_JOB_PDF_RE.test(href)) continue;
+
+    // Normalise to absolute URL.
+    if (href.startsWith('//')) {
+      href = `https:${href}`;
+    } else if (href.startsWith('/')) {
+      href = `https://www.clinica-hildebrand.ch${href}`;
+    } else if (!/^https?:\/\//i.test(href)) {
+      href = `https://www.clinica-hildebrand.ch/${href.replace(/^\.?\/?/, '')}`;
+    }
+
+    if (seen.has(href)) continue;
+    seen.add(href);
+
+    const filename = decodeURIComponent(href.split('/').pop() || '');
+    const title =
+      normalizeSpace(decodeEntities(humanizeHildebrandFilename(filename))) ||
+      filename.replace(/\.pdf$/i, '');
+
+    const id = slugify(filename.replace(/\.pdf$/i, '')).slice(0, 50);
+    if (!id) continue;
+
+    out.push({ id, title, pdfUrl: href, filename });
+  }
+  return out;
+}
+
+/* ── Description builder ───────────────────────────────────── */
+
+function buildHildebrandDescription({ title, pdfText = '', pdfUrl = '' }) {
+  const description = buildPdfBackedDescription({
+    introLines: [
+      `${title} presso ${CLINICA_HILDEBRAND_COMPANY_NAME}, Brissago (Locarnese, Canton Ticino).`,
+      'La Clinica Hildebrand è un centro di riabilitazione neurologica, ortopedica e cardiovascolare situato sul Lago Maggiore. Eroga prestazioni stazionarie e ambulatoriali per pazienti adulti e collabora con il sistema sanitario ticinese e nazionale.',
+    ],
+    pdfText,
+    fallbackText: `Posto vacante ${title} presso ${CLINICA_HILDEBRAND_COMPANY_NAME}. I dettagli completi su requisiti, mansioni e modalità di candidatura sono disponibili nel documento PDF ufficiale.`,
+    footerLines: [
+      `Annuncio ufficiale (PDF): ${pdfUrl}`,
+      `Pagina collaborazione: ${PUBLIC_CAREER_URL}`,
+      'Settore: Sanità / Riabilitazione',
+      'Candidature: candidature@clinica-hildebrand.ch (CV completo via e-mail)',
+    ],
+  });
+
+  const warnings = [];
+  if (pdfText && description.length < MIN_HILDEBRAND_DESC_LENGTH) {
+    warnings.push(
+      `Hildebrand description too short (${description.length} chars < ${MIN_HILDEBRAND_DESC_LENGTH}) for "${title}" — PDF may have changed.`
+    );
+  }
+  return { description, warnings };
+}
+
+/* ── Main fetch ────────────────────────────────────────────── */
+
+export async function fetchAllClinicaHildebrandJobs() {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+
+  console.log(`🏥 Fetching ${CLINICA_HILDEBRAND_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${PUBLIC_CAREER_URL} (Weebly HTML + PDF concorsi)\n`);
+
+  let html;
+  try {
+    html = await fetchHtml(PUBLIC_CAREER_URL, { timeoutMs });
+  } catch (err) {
+    throw new Error(`Failed to fetch Clinica Hildebrand career page: ${err?.message || err}`);
+  }
+
+  const listings = parseClinicaHildebrandListing(html);
+  console.log(`  📋 PDF concorsi found: ${listings.length}\n`);
+  if (listings.length === 0) {
+    console.warn('⚠️ No concorsi parsed from Clinica Hildebrand page.');
+    return [];
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+
+  for (const listing of listings) {
+    console.log(`  📄 Processing: ${listing.filename}`);
+    const pdf = await extractPdfJobContentFromUrl(listing.pdfUrl, { timeoutMs });
+    if (pdf.error) {
+      console.warn(`     ⚠️ PDF error: ${pdf.error}`);
+    }
+    const pdfText = pdf.rawText || pdf.text || '';
+
+    const { description, warnings } = buildHildebrandDescription({
+      title: listing.title,
+      pdfText,
+      pdfUrl: listing.pdfUrl,
+    });
+    for (const w of warnings) console.warn(`     ⚠️ ${w}`);
+
+    const sourceLang = 'it';
+    const haystack = `${listing.title} ${description}`;
+    const employmentType = detectHealthcareEmploymentType(haystack);
+    const jobSlug = slugify(`${listing.title} ${CLINICA_HILDEBRAND_KEY} ${DEFAULT_CITY}`);
+    const urlHash = createHash('sha1')
+      .update(`${listing.pdfUrl}|${listing.id}`)
+      .digest('hex')
+      .slice(0, 12);
+
+    jobs.push({
+      id: `${CLINICA_HILDEBRAND_KEY}-${listing.id}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: CLINICA_HILDEBRAND_COMPANY_NAME,
+      companyKey: CLINICA_HILDEBRAND_KEY,
+      companyDomain: CLINICA_HILDEBRAND_COMPANY_DOMAIN,
+      title: listing.title,
+      titleByLocale: { [sourceLang]: listing.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url: listing.pdfUrl,
+      applyUrl: PUBLIC_CAREER_URL,
+      source: 'Clinica Hildebrand Dedicated Parser (HTML + PDF annunci)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL,
+      category: detectHealthcareCategory(haystack),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(haystack),
+      sector: 'Sanità / Riabilitazione',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+
+    console.log(`  ✅ ${listing.title.substring(0, 70)} (${listing.id})`);
+  }
+
+  // Source-lang consistency check.
+  for (const j of jobs) {
+    const detected = detectLang(j.description || j.title, 'it');
+    if (detected !== j.sourceLang) {
+      j.sourceLang = detected;
+      j.titleByLocale = { [detected]: j.title };
+      j.descriptionByLocale = { [detected]: j.description };
+      j.slugByLocale = { [detected]: j.slug };
+      j.requirementsByLocale = { [detected]: [] };
+    }
+  }
+
+  console.log(
+    `\n📋 Total ${CLINICA_HILDEBRAND_COMPANY_NAME} jobs discovered: ${jobs.length}`
+  );
+  return jobs;
+}

--- a/scripts/lib/clinica-varini-job-parser.mjs
+++ b/scripts/lib/clinica-varini-job-parser.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * Clinica Varini, Orselina (TI).
+ *
+ * Public news/announcements page (WordPress):
+ *   https://clinicavarini.ch/notizie/
+ *
+ * Open positions ("concorsi") are published as PDF attachments under
+ * /wp-content/uploads/ alongside press releases ("comunicato_stampa"). Only the
+ * concorso PDFs are jobs — comunicati are filtered out.
+ *
+ * Orselina is in the Locarnese (TI). Clinica Varini is a private clinic for
+ * dermatologia/medicina estetica/chirurgia plastica (Fondazione Varini).
+ *
+ * Strategy:
+ *   1. Fetch /notizie/ HTML
+ *   2. Match every <a href=".../wp-content/uploads/...*.pdf"> link
+ *   3. Keep only filenames matching /concorso/i
+ *   4. Derive title from filename stem (date prefix dropped)
+ *   5. Pull PDF text + build Italian description
+ *
+ * Inventory note: 2 concorsi at probe time (concorso_contabile,
+ * concorso_dir_sanitario).
+ */
+import { createHash } from 'node:crypto';
+import { buildPdfBackedDescription, extractPdfJobContentFromUrl } from './pdf-job-content.mjs';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const CLINICA_VARINI_KEY = 'clinica-varini';
+export const CLINICA_VARINI_COMPANY_NAME = 'Clinica Varini';
+export const CLINICA_VARINI_COMPANY_DOMAIN = 'clinicavarini.ch';
+
+const PUBLIC_CAREER_URL = 'https://clinicavarini.ch/notizie/';
+const DEFAULT_CITY = 'Orselina';
+const DEFAULT_CANTON = 'TI';
+const DEFAULT_POSTAL = '6644';
+
+export const MIN_VARINI_DESC_LENGTH = 400;
+
+const JOB_PDF_RE = /concorso|bando|posto|annuncio/i;
+const NON_JOB_PDF_RE =
+  /(comunicato|stampa|press|informativa|privacy|policy|testi\/|attestato|presidente|vernissage)/i;
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isClinicaVariniJob(job = {}) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === CLINICA_VARINI_KEY ||
+    key.startsWith('clinica-varini') ||
+    company.includes('clinica varini') ||
+    company === 'varini' ||
+    url.includes('clinicavarini.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === CLINICA_VARINI_COMPANY_DOMAIN ||
+      host === `www.${CLINICA_VARINI_COMPANY_DOMAIN}` ||
+      host.endsWith(`.${CLINICA_VARINI_COMPANY_DOMAIN}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/* ── Title derivation ─────────────────────────────────────── */
+
+function titleCaseWord(token) {
+  if (!token) return token;
+  if (/^\d+$/.test(token)) return token;
+  return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+const ROLE_EXPANSIONS = new Map([
+  ['dir', 'Direttore/Direttrice'],
+  ['sanitario', 'Sanitario'],
+  ['sanitaria', 'Sanitaria'],
+  ['contabile', 'Contabile'],
+  ['infermiere', 'Infermiere/a'],
+  ['operatore', 'Operatore/Operatrice'],
+  ['medico', 'Medico'],
+  ['assistente', 'Assistente'],
+  ['amministrativo', 'Amministrativo/a'],
+]);
+
+/**
+ * Convert "20260508_concorso_contabile" → "Concorso: Contabile".
+ * Drops the YYYYMMDD prefix and expands a few common abbreviations.
+ */
+export function humanizeVariniFilename(filename = '') {
+  let stem = String(filename || '').replace(/\.pdf$/i, '');
+  // Strip YYYYMMDD or YYYY-MM-DD prefixes
+  stem = stem.replace(/^(\d{8}|\d{4}[-_]\d{2}[-_]\d{2})[_\s-]*/, '');
+  // Strip leading "concorso_" marker so we can rebuild "Concorso: ..."
+  const hasConcorsoMarker = /^concorso[_\s-]+/i.test(stem);
+  stem = stem.replace(/^(concorso|bando|posto|annuncio)[_\s-]+/i, '');
+  if (!stem) return 'Concorso';
+
+  const parts = stem.split(/[_\s-]+/).map((p) => {
+    const lower = p.toLowerCase();
+    if (ROLE_EXPANSIONS.has(lower)) return ROLE_EXPANSIONS.get(lower);
+    return titleCaseWord(lower);
+  });
+  const tail = parts.filter(Boolean).join(' ').replace(/\s{2,}/g, ' ').trim();
+  return hasConcorsoMarker ? `Concorso: ${tail}` : tail;
+}
+
+/* ── Parser ────────────────────────────────────────────────── */
+
+export function parseClinicaVariniListing(html = '') {
+  if (!html || typeof html !== 'string') return [];
+
+  const out = [];
+  const seen = new Set();
+  const anchorRe = /href="([^"]+\.pdf)"/gi;
+  let m;
+  while ((m = anchorRe.exec(html)) !== null) {
+    let href = m[1];
+    if (!href) continue;
+    // Force https + absolute
+    if (href.startsWith('http://')) href = href.replace('http://', 'https://');
+    if (href.startsWith('//')) href = `https:${href}`;
+    else if (href.startsWith('/')) href = `https://clinicavarini.ch${href}`;
+
+    const filename = decodeURIComponent(href.split('/').pop() || '');
+    if (!JOB_PDF_RE.test(filename)) continue;
+    if (NON_JOB_PDF_RE.test(filename) || NON_JOB_PDF_RE.test(href)) continue;
+    if (seen.has(href)) continue;
+    seen.add(href);
+
+    const title =
+      normalizeSpace(decodeEntities(humanizeVariniFilename(filename))) ||
+      filename.replace(/\.pdf$/i, '');
+    const id = slugify(filename.replace(/\.pdf$/i, '')).slice(0, 50);
+    if (!id) continue;
+    out.push({ id, title, pdfUrl: href, filename });
+  }
+  return out;
+}
+
+/* ── Description builder ───────────────────────────────────── */
+
+function buildVariniDescription({ title, pdfText = '', pdfUrl = '' }) {
+  const description = buildPdfBackedDescription({
+    introLines: [
+      `${title} presso ${CLINICA_VARINI_COMPANY_NAME}, Orselina (Locarnese, Canton Ticino).`,
+      'Clinica Varini è una struttura sanitaria del Locarnese che opera nei settori della medicina specialistica e della dermatologia, con prestazioni stazionarie e ambulatoriali per pazienti adulti.',
+    ],
+    pdfText,
+    fallbackText: `Concorso ${title} presso ${CLINICA_VARINI_COMPANY_NAME}. I dettagli completi su requisiti, profilo professionale, modalità di candidatura e termine di presentazione sono disponibili nel documento PDF allegato.`,
+    footerLines: [
+      `Bando ufficiale (PDF): ${pdfUrl}`,
+      `Pagina notizie: ${PUBLIC_CAREER_URL}`,
+      'Settore: Sanità / Clinica privata',
+    ],
+  });
+  const warnings = [];
+  if (pdfText && description.length < MIN_VARINI_DESC_LENGTH) {
+    warnings.push(
+      `Varini description too short (${description.length} chars < ${MIN_VARINI_DESC_LENGTH}) for "${title}" — PDF may have changed.`
+    );
+  }
+  return { description, warnings };
+}
+
+/* ── Main fetch ────────────────────────────────────────────── */
+
+export async function fetchAllClinicaVariniJobs() {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  console.log(`🏥 Fetching ${CLINICA_VARINI_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${PUBLIC_CAREER_URL} (WordPress notizie + PDF concorsi)\n`);
+
+  let html;
+  try {
+    html = await fetchHtml(PUBLIC_CAREER_URL, { timeoutMs });
+  } catch (err) {
+    throw new Error(`Failed to fetch Clinica Varini page: ${err?.message || err}`);
+  }
+
+  const listings = parseClinicaVariniListing(html);
+  console.log(`  📋 Job PDF concorsi found: ${listings.length}\n`);
+  if (listings.length === 0) {
+    console.warn('⚠️ No concorsi parsed from Clinica Varini page.');
+    return [];
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  for (const listing of listings) {
+    console.log(`  📄 Processing: ${listing.filename}`);
+    const pdf = await extractPdfJobContentFromUrl(listing.pdfUrl, { timeoutMs });
+    if (pdf.error) console.warn(`     ⚠️ PDF error: ${pdf.error}`);
+    const pdfText = pdf.rawText || pdf.text || '';
+
+    const { description, warnings } = buildVariniDescription({
+      title: listing.title,
+      pdfText,
+      pdfUrl: listing.pdfUrl,
+    });
+    for (const w of warnings) console.warn(`     ⚠️ ${w}`);
+
+    const sourceLang = 'it';
+    const haystack = `${listing.title} ${description}`;
+    const employmentType = detectHealthcareEmploymentType(haystack);
+    const jobSlug = slugify(`${listing.title} ${CLINICA_VARINI_KEY} ${DEFAULT_CITY}`);
+    const urlHash = createHash('sha1')
+      .update(`${listing.pdfUrl}|${listing.id}`)
+      .digest('hex')
+      .slice(0, 12);
+
+    jobs.push({
+      id: `${CLINICA_VARINI_KEY}-${listing.id}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: CLINICA_VARINI_COMPANY_NAME,
+      companyKey: CLINICA_VARINI_KEY,
+      companyDomain: CLINICA_VARINI_COMPANY_DOMAIN,
+      title: listing.title,
+      titleByLocale: { [sourceLang]: listing.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url: listing.pdfUrl,
+      applyUrl: PUBLIC_CAREER_URL,
+      source: 'Clinica Varini Dedicated Parser (WordPress HTML + PDF)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL,
+      category: detectHealthcareCategory(haystack),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(haystack),
+      sector: 'Sanità / Clinica privata',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+
+    console.log(`  ✅ ${listing.title.substring(0, 70)} (${listing.id})`);
+  }
+
+  for (const j of jobs) {
+    const detected = detectLang(j.description || j.title, 'it');
+    if (detected !== j.sourceLang) {
+      j.sourceLang = detected;
+      j.titleByLocale = { [detected]: j.title };
+      j.descriptionByLocale = { [detected]: j.description };
+      j.slugByLocale = { [detected]: j.slug };
+      j.requirementsByLocale = { [detected]: [] };
+    }
+  }
+
+  console.log(
+    `\n📋 Total ${CLINICA_VARINI_COMPANY_NAME} jobs discovered: ${jobs.length}`
+  );
+  return jobs;
+}

--- a/scripts/lib/reha-andeer-job-parser.mjs
+++ b/scripts/lib/reha-andeer-job-parser.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Reha Andeer — small private rehabilitation clinic in Andeer (GR).
+ *
+ * Public career page (WordPress, German only):
+ *   https://reha-andeer.ch/offene-stellen/
+ *
+ * Open positions ("offene Stellen") are listed as PDF Stelleninserate hosted under
+ * /wp-content/uploads/<YYYY>/<MM>/<filename>.pdf. Email applications.
+ *
+ * Strategy:
+ *   1. Fetch /offene-stellen/
+ *   2. Match every <a href=".../wp-content/uploads/...*.pdf"> link
+ *   3. Filter out non-job PDFs (datenschutz, agb, etc.)
+ *   4. Derive title from filename, extract body from PDF
+ *
+ * Inventory note: 2 PDF Stelleninserate at probe time (Pflegehelferin, med.
+ * Masseurin). Ship anyway.
+ */
+import { createHash } from 'node:crypto';
+import { buildPdfBackedDescription, extractPdfJobContentFromUrl } from './pdf-job-content.mjs';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const REHA_ANDEER_KEY = 'reha-andeer';
+export const REHA_ANDEER_COMPANY_NAME = 'Reha Andeer';
+export const REHA_ANDEER_COMPANY_DOMAIN = 'reha-andeer.ch';
+
+const PUBLIC_CAREER_URL = 'https://reha-andeer.ch/offene-stellen/';
+const DEFAULT_CITY = 'Andeer';
+const DEFAULT_CANTON = 'GR';
+const DEFAULT_POSTAL = '7440';
+
+export const MIN_REHA_ANDEER_DESC_LENGTH = 350;
+
+const NON_JOB_PDF_RE =
+  /(datenschutz|impressum|agb|preisliste|tarif|tarmed|broschure|brochure|leitbild|qualitaet|qualität|formular|policy)/i;
+// Accept any uploads PDF unless filtered above. Most are Stelleninserate by
+// keyword but some carry the role name directly (e.g. "Pflegehelferin").
+const ACCEPT_HINTS_RE = /(stelle|stelleninserat|inserat|bewerb|pflege|masseur|therap|köch|service|kuche|reinigung|nacht|sekret|leit)/i;
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isRehaAndeerJob(job = {}) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === REHA_ANDEER_KEY ||
+    key.startsWith('reha-andeer') ||
+    company.includes('reha andeer') ||
+    url.includes('reha-andeer.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === REHA_ANDEER_COMPANY_DOMAIN ||
+      host === `www.${REHA_ANDEER_COMPANY_DOMAIN}` ||
+      host.endsWith(`.${REHA_ANDEER_COMPANY_DOMAIN}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/* ── Title derivation ─────────────────────────────────────── */
+
+function titleCaseWord(token) {
+  if (!token) return token;
+  if (/^\d+$/.test(token)) return token;
+  return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+/**
+ * Convert "2026_Stelleninserat-med.-Masseurin.pdf" → "Med. Masseurin".
+ * Strips year prefix and "Stelleninserat" marker.
+ */
+export function humanizeRehaAndeerFilename(filename = '') {
+  let stem = String(filename || '').replace(/\.pdf$/i, '');
+  // Drop YYYY prefix or suffix
+  stem = stem.replace(/^(\d{4})[_\s-]+/, '').replace(/[_\s-]+(\d{4})$/, '');
+  // Drop Stelleninserat marker
+  stem = stem.replace(/[_\s-]*Stelleninserat[_\s-]*/i, ' ');
+  stem = stem.replace(/[_-]+/g, ' ').replace(/\s{2,}/g, ' ').trim();
+  if (!stem) return 'Offene Stelle';
+  return stem
+    .split(/(\s+|\.\s*|-)/)
+    .map((part) => (/[a-zäöüß]/i.test(part) ? titleCaseWord(part.toLowerCase()) : part))
+    .join('')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+/* ── Parser ────────────────────────────────────────────────── */
+
+export function parseRehaAndeerListing(html = '') {
+  if (!html || typeof html !== 'string') return [];
+
+  const out = [];
+  const seen = new Set();
+  const anchorRe = /href="([^"]+\.pdf)"/gi;
+  let m;
+  while ((m = anchorRe.exec(html)) !== null) {
+    let href = m[1];
+    if (!href) continue;
+    if (href.startsWith('//')) href = `https:${href}`;
+    else if (href.startsWith('/')) href = `https://reha-andeer.ch${href}`;
+
+    if (NON_JOB_PDF_RE.test(href)) continue;
+    // Require either /uploads/ in path OR a job hint in filename.
+    const filename = decodeURIComponent(href.split('/').pop() || '');
+    const isUploadsPath = /\/wp-content\/uploads\//i.test(href);
+    if (!isUploadsPath && !ACCEPT_HINTS_RE.test(filename)) continue;
+    // Extra filter: skip obviously-non-job uploads (e.g. Hausordnung).
+    if (NON_JOB_PDF_RE.test(filename)) continue;
+
+    if (seen.has(href)) continue;
+    seen.add(href);
+
+    const title =
+      normalizeSpace(decodeEntities(humanizeRehaAndeerFilename(filename))) ||
+      filename.replace(/\.pdf$/i, '');
+    const id = slugify(filename.replace(/\.pdf$/i, '')).slice(0, 50);
+    if (!id) continue;
+    out.push({ id, title, pdfUrl: href, filename });
+  }
+  return out;
+}
+
+/* ── Description builder ───────────────────────────────────── */
+
+function buildRehaAndeerDescription({ title, pdfText = '', pdfUrl = '' }) {
+  const description = buildPdfBackedDescription({
+    introLines: [
+      `${REHA_ANDEER_COMPANY_NAME} sucht eine engagierte Persönlichkeit für die Position: ${title}.`,
+      'Reha Andeer ist eine private Rehabilitationsklinik in Andeer (Kanton Graubünden) und bietet stationäre und ambulante Behandlungen in einem familiären Umfeld inmitten der Schamser Bergwelt an.',
+    ],
+    pdfText,
+    fallbackText: `Stelleninserat ${title} bei ${REHA_ANDEER_COMPANY_NAME}. Die vollständigen Angaben zu Aufgaben, Anforderungen und Bewerbungsweg entnehmen Sie dem offiziellen PDF.`,
+    footerLines: [
+      `Stelleninserat (PDF): ${pdfUrl}`,
+      `Karriere-Seite: ${PUBLIC_CAREER_URL}`,
+      'Sektor: Gesundheitswesen / Rehabilitation',
+      'Bewerbung: per E-Mail gemäss den Hinweisen im Stelleninserat',
+    ],
+  });
+  const warnings = [];
+  if (pdfText && description.length < MIN_REHA_ANDEER_DESC_LENGTH) {
+    warnings.push(
+      `Reha Andeer description too short (${description.length} chars < ${MIN_REHA_ANDEER_DESC_LENGTH}) for "${title}" — PDF may have changed.`
+    );
+  }
+  return { description, warnings };
+}
+
+/* ── Main fetch ────────────────────────────────────────────── */
+
+export async function fetchAllRehaAndeerJobs() {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  console.log(`🏥 Fetching ${REHA_ANDEER_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${PUBLIC_CAREER_URL} (WordPress HTML + PDF Stelleninserate)\n`);
+
+  let html;
+  try {
+    html = await fetchHtml(PUBLIC_CAREER_URL, { timeoutMs });
+  } catch (err) {
+    throw new Error(`Failed to fetch Reha Andeer page: ${err?.message || err}`);
+  }
+
+  const listings = parseRehaAndeerListing(html);
+  console.log(`  📋 Stelleninserat PDFs found: ${listings.length}\n`);
+  if (listings.length === 0) {
+    console.warn('⚠️ No Stelleninserate parsed from Reha Andeer page.');
+    return [];
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  for (const listing of listings) {
+    console.log(`  📄 Processing: ${listing.filename}`);
+    const pdf = await extractPdfJobContentFromUrl(listing.pdfUrl, { timeoutMs });
+    if (pdf.error) console.warn(`     ⚠️ PDF error: ${pdf.error}`);
+    const pdfText = pdf.rawText || pdf.text || '';
+
+    const { description, warnings } = buildRehaAndeerDescription({
+      title: listing.title,
+      pdfText,
+      pdfUrl: listing.pdfUrl,
+    });
+    for (const w of warnings) console.warn(`     ⚠️ ${w}`);
+
+    const sourceLang = 'de';
+    const haystack = `${listing.title} ${description}`;
+    const employmentType = detectHealthcareEmploymentType(haystack);
+    const jobSlug = slugify(`${listing.title} ${REHA_ANDEER_KEY} ${DEFAULT_CITY}`);
+    const urlHash = createHash('sha1')
+      .update(`${listing.pdfUrl}|${listing.id}`)
+      .digest('hex')
+      .slice(0, 12);
+
+    jobs.push({
+      id: `${REHA_ANDEER_KEY}-${listing.id}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: REHA_ANDEER_COMPANY_NAME,
+      companyKey: REHA_ANDEER_KEY,
+      companyDomain: REHA_ANDEER_COMPANY_DOMAIN,
+      title: listing.title,
+      titleByLocale: { [sourceLang]: listing.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url: listing.pdfUrl,
+      applyUrl: PUBLIC_CAREER_URL,
+      source: 'Reha Andeer Dedicated Parser (WordPress HTML + PDF)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL,
+      category: detectHealthcareCategory(haystack),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(haystack),
+      sector: 'Gesundheitswesen / Rehabilitation',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+    console.log(`  ✅ ${listing.title.substring(0, 70)} (${listing.id})`);
+  }
+
+  for (const j of jobs) {
+    const detected = detectLang(j.description || j.title, 'de');
+    if (detected !== j.sourceLang) {
+      j.sourceLang = detected;
+      j.titleByLocale = { [detected]: j.title };
+      j.descriptionByLocale = { [detected]: j.description };
+      j.slugByLocale = { [detected]: j.slug };
+      j.requirementsByLocale = { [detected]: [] };
+    }
+  }
+
+  console.log(
+    `\n📋 Total ${REHA_ANDEER_COMPANY_NAME} jobs discovered: ${jobs.length}`
+  );
+  return jobs;
+}

--- a/scripts/lib/therapiezentrum-meggen-job-parser.mjs
+++ b/scripts/lib/therapiezentrum-meggen-job-parser.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/**
+ * Therapiezentrum Meggen (TZM) — small psychotherapy / rehab centre in Meggen (LU).
+ *
+ * Public career page (Jimdo-hosted, German only):
+ *   https://www.tzm.ch/offene-stellen/
+ *   (also reachable via https://www.therapiezentrum-meggen.ch/offene-stellen/)
+ *
+ * Open positions are published as PDF Stellenausschreibungen hosted under
+ * /app/download/<id>/<filename>.pdf?t=<ts>. The anchor text carries the full job
+ * title (e.g. "Psychologische Psychotherapeutin, Psychologischer Psychotherapeut
+ * (60-100%)") while the filename is short.
+ *
+ * Strategy:
+ *   1. Fetch /offene-stellen/
+ *   2. Match every <a href="/app/download/...*.pdf?...">…</a>
+ *   3. Title preference: bold text inside the anchor → filename fallback
+ *   4. Skip stale/anchor-only links that wrap pure text (e.g. internal nav).
+ *
+ * Inventory note: 2 PDF Stellenausschreibungen at probe time. Ship anyway.
+ */
+import { createHash } from 'node:crypto';
+import { buildPdfBackedDescription, extractPdfJobContentFromUrl } from './pdf-job-content.mjs';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+/* ── Constants ─────────────────────────────────────────────── */
+
+export const TZM_KEY = 'therapiezentrum-meggen';
+export const TZM_COMPANY_NAME = 'Therapiezentrum Meggen';
+export const TZM_COMPANY_DOMAIN = 'tzm.ch';
+export const TZM_ALT_DOMAIN = 'therapiezentrum-meggen.ch';
+
+const PUBLIC_CAREER_URL = 'https://www.tzm.ch/offene-stellen/';
+const DEFAULT_CITY = 'Meggen';
+const DEFAULT_CANTON = 'LU';
+const DEFAULT_POSTAL = '6045';
+
+export const MIN_TZM_DESC_LENGTH = 350;
+
+/* ── Company matchers ──────────────────────────────────────── */
+
+export function isTzmJob(job = {}) {
+  const key = String(job?.companyKey || '').toLowerCase();
+  const company = String(job?.company || '').toLowerCase();
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    key === TZM_KEY ||
+    key.startsWith('therapiezentrum-meggen') ||
+    company.includes('therapiezentrum meggen') ||
+    company.includes('tzm') && company.length < 40 ||
+    url.includes('tzm.ch') ||
+    url.includes('therapiezentrum-meggen.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === TZM_COMPANY_DOMAIN ||
+      host === `www.${TZM_COMPANY_DOMAIN}` ||
+      host === TZM_ALT_DOMAIN ||
+      host === `www.${TZM_ALT_DOMAIN}` ||
+      host.endsWith(`.${TZM_COMPANY_DOMAIN}`) ||
+      host.endsWith(`.${TZM_ALT_DOMAIN}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/* ── Parser ────────────────────────────────────────────────── */
+
+function stripTags(html = '') {
+  return decodeEntities(String(html || '').replace(/<[^>]+>/g, ''));
+}
+
+/**
+ * Extract job listings from the Jimdo-hosted TZM careers page.
+ *
+ * Each anchor has the form:
+ *   <a href="/app/download/<id>/<filename>.pdf?t=<ts>" title="<full job title> (<filename>)">
+ *     <b><span ...>Title text</span></b>
+ *   </a>
+ *
+ * We prefer the anchor text (which carries the role + percentage), then the
+ * "title" attribute (strip the trailing "(filename.pdf)") as a fallback.
+ */
+export function parseTzmListing(html = '') {
+  if (!html || typeof html !== 'string') return [];
+
+  const out = [];
+  const seen = new Set();
+
+  // Capture: full <a …>inner</a>, href, title-attr, inner.
+  const anchorRe =
+    /<a\s+href="([^"]*\/app\/download\/[^"]+?\.pdf[^"]*)"([^>]*)>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = anchorRe.exec(html)) !== null) {
+    let href = m[1];
+    const attrs = m[2] || '';
+    const inner = m[3] || '';
+
+    if (!href) continue;
+    // Normalise to absolute https.
+    if (href.startsWith('//')) href = `https:${href}`;
+    else if (href.startsWith('/')) href = `https://www.tzm.ch${href}`;
+    // Percent-encode spaces (Jimdo filenames contain literal spaces).
+    href = href.replace(/ /g, '%20');
+
+    const innerText = normalizeSpace(stripTags(inner));
+    const titleAttrMatch = attrs.match(/title="([^"]+)"/i);
+    let titleFromAttr = titleAttrMatch ? decodeEntities(titleAttrMatch[1]) : '';
+    // Trim " (<filename>.pdf)" suffix that Jimdo appends.
+    titleFromAttr = titleFromAttr.replace(/\s*\([^)]*\.pdf\)\s*$/i, '').trim();
+
+    const title = innerText && innerText.length >= 5 ? innerText : titleFromAttr;
+    if (!title || title.length < 5) continue;
+    // Reject pure-text anchors (no real job hint).
+    if (!/(therapeut|psycholog|pflege|sozial|leit|fachperson|hausdienst|sekret|administration|reinigung|nacht|stelle|prakt)/i.test(title) &&
+        !/(therapeut|psycholog|pflege|stelle|prakt)/i.test(href)) {
+      continue;
+    }
+
+    // Stable id from filename (drop query string).
+    const filename = decodeURIComponent((href.split('?')[0].split('/').pop() || ''));
+    const id = slugify(filename.replace(/\.pdf$/i, '')).slice(0, 50);
+    if (!id) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    out.push({ id, title, pdfUrl: href, filename });
+  }
+  return out;
+}
+
+/* ── Description builder ───────────────────────────────────── */
+
+function buildTzmDescription({ title, pdfText = '', pdfUrl = '' }) {
+  const description = buildPdfBackedDescription({
+    introLines: [
+      `${TZM_COMPANY_NAME} sucht eine engagierte Persönlichkeit für die Position: ${title}.`,
+      'Das Therapiezentrum Meggen (TZM) ist eine sozialpsychiatrische Therapiestation in Meggen am Vierwaldstättersee (Kanton Luzern). Die Institution bietet stationäre und ambulante Behandlungen, integrative Psychotherapie und Milieutherapie für Erwachsene an.',
+    ],
+    pdfText,
+    fallbackText: `Stellenausschreibung ${title} im ${TZM_COMPANY_NAME}. Die vollständigen Angaben zu Aufgaben, Anforderungen, Pensum und Bewerbungsweg entnehmen Sie dem offiziellen PDF.`,
+    footerLines: [
+      `Stellenausschreibung (PDF): ${pdfUrl}`,
+      `Karriereseite: ${PUBLIC_CAREER_URL}`,
+      'Sektor: Gesundheitswesen / Psychotherapie / Sozialpsychiatrie',
+    ],
+  });
+  const warnings = [];
+  if (pdfText && description.length < MIN_TZM_DESC_LENGTH) {
+    warnings.push(
+      `TZM description too short (${description.length} chars < ${MIN_TZM_DESC_LENGTH}) for "${title}" — PDF may have changed.`
+    );
+  }
+  return { description, warnings };
+}
+
+/* ── Main fetch ────────────────────────────────────────────── */
+
+export async function fetchAllTzmJobs() {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  console.log(`🏥 Fetching ${TZM_COMPANY_NAME} jobs`);
+  console.log(`   Source: ${PUBLIC_CAREER_URL} (Jimdo HTML + PDF Stellenausschreibungen)\n`);
+
+  let html;
+  try {
+    html = await fetchHtml(PUBLIC_CAREER_URL, { timeoutMs });
+  } catch (err) {
+    throw new Error(`Failed to fetch TZM page: ${err?.message || err}`);
+  }
+
+  const listings = parseTzmListing(html);
+  console.log(`  📋 Stellenausschreibung PDFs found: ${listings.length}\n`);
+  if (listings.length === 0) {
+    console.warn('⚠️ No Stellenausschreibungen parsed from TZM page.');
+    return [];
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  for (const listing of listings) {
+    console.log(`  📄 Processing: ${listing.filename}`);
+    const pdf = await extractPdfJobContentFromUrl(listing.pdfUrl, { timeoutMs });
+    if (pdf.error) console.warn(`     ⚠️ PDF error: ${pdf.error}`);
+    const pdfText = pdf.rawText || pdf.text || '';
+
+    const { description, warnings } = buildTzmDescription({
+      title: listing.title,
+      pdfText,
+      pdfUrl: listing.pdfUrl,
+    });
+    for (const w of warnings) console.warn(`     ⚠️ ${w}`);
+
+    const sourceLang = 'de';
+    const haystack = `${listing.title} ${description}`;
+    const employmentType = detectHealthcareEmploymentType(haystack);
+    const jobSlug = slugify(`${listing.title} ${TZM_KEY} ${DEFAULT_CITY}`);
+    const urlHash = createHash('sha1')
+      .update(`${listing.pdfUrl}|${listing.id}`)
+      .digest('hex')
+      .slice(0, 12);
+
+    jobs.push({
+      id: `${TZM_KEY}-${listing.id}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: TZM_COMPANY_NAME,
+      companyKey: TZM_KEY,
+      companyDomain: TZM_COMPANY_DOMAIN,
+      title: listing.title,
+      titleByLocale: { [sourceLang]: listing.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url: listing.pdfUrl,
+      applyUrl: PUBLIC_CAREER_URL,
+      source: 'Therapiezentrum Meggen Dedicated Parser (Jimdo HTML + PDF)',
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL,
+      category: detectHealthcareCategory(haystack),
+      contract: employmentType === 'PART_TIME' ? 'part-time' : 'full-time',
+      employmentType,
+      experienceLevel: detectHealthcareExperienceLevel(haystack),
+      sector: 'Gesundheitswesen / Psychotherapie',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+    console.log(`  ✅ ${listing.title.substring(0, 70)} (${listing.id})`);
+  }
+
+  for (const j of jobs) {
+    const detected = detectLang(j.description || j.title, 'de');
+    if (detected !== j.sourceLang) {
+      j.sourceLang = detected;
+      j.titleByLocale = { [detected]: j.title };
+      j.descriptionByLocale = { [detected]: j.description };
+      j.slugByLocale = { [detected]: j.slug };
+      j.requirementsByLocale = { [detected]: [] };
+    }
+  }
+
+  console.log(
+    `\n📋 Total ${TZM_COMPANY_NAME} jobs discovered: ${jobs.length}`
+  );
+  return jobs;
+}

--- a/scripts/update-clinica-hildebrand-jobs.mjs
+++ b/scripts/update-clinica-hildebrand-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Clinica Hildebrand (Brissago, TI) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllClinicaHildebrandJobs,
+  isClinicaHildebrandJob,
+  isTrustedDomain,
+  CLINICA_HILDEBRAND_KEY,
+  CLINICA_HILDEBRAND_COMPANY_NAME,
+} from './lib/clinica-hildebrand-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: CLINICA_HILDEBRAND_KEY,
+  companyLabel: CLINICA_HILDEBRAND_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllClinicaHildebrandJobs,
+  isCompanyJob: isClinicaHildebrandJob,
+  isTrustedDomain,
+  defaultSourceLang: 'it',
+}).catch((err) => {
+  console.error(`❌ Clinica Hildebrand crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-clinica-varini-jobs.mjs
+++ b/scripts/update-clinica-varini-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Clinica Varini (Orselina, TI) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllClinicaVariniJobs,
+  isClinicaVariniJob,
+  isTrustedDomain,
+  CLINICA_VARINI_KEY,
+  CLINICA_VARINI_COMPANY_NAME,
+} from './lib/clinica-varini-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: CLINICA_VARINI_KEY,
+  companyLabel: CLINICA_VARINI_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllClinicaVariniJobs,
+  isCompanyJob: isClinicaVariniJob,
+  isTrustedDomain,
+  defaultSourceLang: 'it',
+}).catch((err) => {
+  console.error(`❌ Clinica Varini crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-reha-andeer-jobs.mjs
+++ b/scripts/update-reha-andeer-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Reha Andeer (Andeer, GR) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllRehaAndeerJobs,
+  isRehaAndeerJob,
+  isTrustedDomain,
+  REHA_ANDEER_KEY,
+  REHA_ANDEER_COMPANY_NAME,
+} from './lib/reha-andeer-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: REHA_ANDEER_KEY,
+  companyLabel: REHA_ANDEER_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllRehaAndeerJobs,
+  isCompanyJob: isRehaAndeerJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Reha Andeer crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-therapiezentrum-meggen-jobs.mjs
+++ b/scripts/update-therapiezentrum-meggen-jobs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Therapiezentrum Meggen (Meggen, LU) crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllTzmJobs,
+  isTzmJob,
+  isTrustedDomain,
+  TZM_KEY,
+  TZM_COMPANY_NAME,
+} from './lib/therapiezentrum-meggen-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+runStandardCrawlerPipeline({
+  companyKey: TZM_KEY,
+  companyLabel: TZM_COMPANY_NAME,
+  root: ROOT,
+  fetchJobs: fetchAllTzmJobs,
+  isCompanyJob: isTzmJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Therapiezentrum Meggen crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Add dedicated parsers + runners + workflows for four small healthcare
employers without minimum-job threshold per user instruction. Each
crawler emits source-locale-only ParsedJob objects with
needsRetranslation:true and SKIP_BOILERPLATE_GUARD=1 on the workflow.

| Tenant | Canton | Source | Probe jobs |
|---|---|---|---|
| Clinica Hildebrand (Brissago) | TI | HTML + PDF concorso | 1 |
| Clinica Varini (Orselina) | TI | WordPress notizie + concorso PDFs | 2 |
| Reha Andeer | GR | WordPress + PDF Stelleninserate | 2 |
| Therapiezentrum Meggen | LU | Jimdo HTML + PDF Stellenausschreibungen | 2 |

All four parsers verified live: descriptions 1300-3600 chars after PDF
extraction; titles humanised from filename (Varini, Hildebrand,
Reha Andeer) or anchor text (TZM). TZM URLs percent-encoded.
