### PR TITLE
feat: batch 21u — ZH/TG/LU small hospital crawlers

### DIFF
--- a/.github/workflows/update-jobs-klinik-aadorf.yml
+++ b/.github/workflows/update-jobs-klinik-aadorf.yml
@@ -1,0 +1,103 @@
+name: Update Klinik Aadorf Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-klinik-aadorf
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-klinik-aadorf-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated KLINIK_AADORF crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_KLINIK_AADORF_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-klinik-aadorf-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'klinik-aadorf'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/klinik-aadorf.json'
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_AADORF jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-klinik-seeschau.yml
+++ b/.github/workflows/update-jobs-klinik-seeschau.yml
@@ -1,0 +1,103 @@
+name: Update Klinik Seeschau Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-klinik-seeschau
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-klinik-seeschau-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated KLINIK_SEESCHAU crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_KLINIK_SEESCHAU_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-klinik-seeschau-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'klinik-seeschau'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/klinik-seeschau.json'
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_SEESCHAU jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-modellstation-somosa.yml
+++ b/.github/workflows/update-jobs-modellstation-somosa.yml
@@ -1,0 +1,103 @@
+name: Update Modellstation SOMOSA Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-modellstation-somosa
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-modellstation-somosa-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated MODELLSTATION_SOMOSA crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_MODELLSTATION_SOMOSA_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-modellstation-somosa-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'modellstation-somosa'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/modellstation-somosa.json'
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MODELLSTATION_SOMOSA jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-therapiezentrum-meggen.yml
+++ b/.github/workflows/update-jobs-therapiezentrum-meggen.yml
@@ -1,0 +1,103 @@
+name: Update Therapiezentrum Meggen Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-therapiezentrum-meggen
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-therapiezentrum-meggen-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated THERAPIEZENTRUM_MEGGEN crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_THERAPIEZENTRUM_MEGGEN_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-therapiezentrum-meggen-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'therapiezentrum-meggen'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/therapiezentrum-meggen.json'
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update THERAPIEZENTRUM_MEGGEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/scripts/lib/klinik-aadorf-job-parser.mjs
+++ b/scripts/lib/klinik-aadorf-job-parser.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Klinik Aadorf job parser — Dualoo ATS (portal 3ibnwlo9).
+ *
+ * Public career site: https://jobs.dualoo.com/portal/3ibnwlo9?lang=DE
+ *
+ * Klinik Aadorf AG is a private psychiatric and psychotherapeutic
+ * specialist clinic (Privatklinik für Psychiatrie und Psychotherapie)
+ * in Aadorf (canton Thurgau). Small Dualoo portal, ~4-5 vacancies,
+ * mostly medical & residential staff (Assistenzarzt, Facharzt /
+ * Oberarzt, Koch, Praktikant Psychologie).
+ *
+ * Modelled on `scripts/lib/klinik-arlesheim-job-parser.mjs` (same
+ * Dualoo HTML shape).
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const KLINIK_AADORF_KEY = 'klinik-aadorf';
+export const KLINIK_AADORF_COMPANY_NAME = 'Klinik Aadorf';
+export const KLINIK_AADORF_COMPANY_DOMAIN = 'klinik-aadorf.ch';
+
+const DUALOO_PORTAL = '3ibnwlo9';
+const PORTAL_URL = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}?lang=DE`;
+const DETAIL_BASE = `https://jobs.dualoo.com/portal/${DUALOO_PORTAL}`;
+const DETAIL_DELAY_MS = 250;
+
+// Aadorf, Thurgau — single site.
+const DEFAULT_CITY = 'Aadorf';
+const DEFAULT_POSTAL_CODE = '8355';
+const DEFAULT_CANTON = 'TG';
+
+export function isKlinikAadorfJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    job?.companyKey === KLINIK_AADORF_KEY ||
+    url.includes('klinik-aadorf.ch') ||
+    url.includes(`/${DUALOO_PORTAL}/`)
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === 'klinik-aadorf.ch' ||
+      host.endsWith('.klinik-aadorf.ch') ||
+      host === 'jobs.dualoo.com'
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function parseDualooPortal(html) {
+  const out = [];
+  const seen = new Set();
+  const blockRe = /<a[^>]*class="[^"]*\bjobElement\b[^"]*"[^>]*>[\s\S]*?<\/a>/g;
+  let m;
+  while ((m = blockRe.exec(html))) {
+    const block = m[0];
+    const hrefMatch = block.match(/\shref="([^"]+)"/);
+    const evMatch = block.match(/\sdata-eventData="([^"]+)"/);
+    const spanMatch = block.match(/<span[^>]*class="jobName"[^>]*>([\s\S]*?)<\/span>/i);
+    const cityMatch = block.match(/<span[^>]*class="cityName"[^>]*>([\s\S]*?)<\/span>/i);
+    const catMatch = block.match(/<span[^>]*class="badge[^"]*jobCategory"[^>]*>([\s\S]*?)<\/span>/i);
+    if (!hrefMatch) continue;
+    const rel = hrefMatch[1];
+    let meta = {};
+    if (evMatch) {
+      const evRaw = evMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&');
+      try {
+        meta = JSON.parse(evRaw);
+      } catch {
+        meta = {};
+      }
+    }
+    const spanTitle = spanMatch
+      ? normalizeSpace(decodeEntities(spanMatch[1].replace(/<[^>]+>/g, ' ')))
+      : '';
+    const evTitle = normalizeSpace(decodeEntities(String(meta.jobName || '')));
+    const title = spanTitle || evTitle;
+    if (!title || title.length < 3) continue;
+    const uuidMatch = rel.match(/([a-f0-9-]{36})\/detail/);
+    const uuid = uuidMatch ? uuidMatch[1] : rel;
+    if (seen.has(uuid)) continue;
+    seen.add(uuid);
+    const url = rel.startsWith('http')
+      ? rel
+      : `${DETAIL_BASE}/${rel.replace(new RegExp(`^${DUALOO_PORTAL}/`), '')}`;
+    const cityName = cityMatch
+      ? normalizeSpace(decodeEntities(cityMatch[1].replace(/<[^>]+>/g, ' ')))
+      : '';
+    const category = catMatch
+      ? normalizeSpace(decodeEntities(catMatch[1].replace(/<[^>]+>/g, ' ')))
+      : '';
+    const langMatch = url.match(/[?&]lang=([A-Za-z]{2,3})/i);
+    const linkLang = langMatch ? langMatch[1].toLowerCase() : '';
+    out.push({
+      uuid,
+      url,
+      title,
+      cityName,
+      category,
+      location: normalizeSpace(decodeEntities(String(meta.location || ''))),
+      startDate: normalizeSpace(decodeEntities(String(meta.startDate || ''))),
+      linkLang,
+    });
+  }
+  return out;
+}
+
+async function fetchDualooDetail(detailUrl) {
+  try {
+    const html = await fetchHtml(detailUrl);
+    const sections = [];
+    const grab = (cls, label) => {
+      const rx = new RegExp(`class="${cls}"[^>]*>([\\s\\S]*?)</div>`, 'i');
+      const mm = html.match(rx);
+      if (!mm) return;
+      const text = mm[1]
+        .replace(/<li[^>]*>/gi, '\n• ')
+        .replace(/<\/li>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/\s+\n/g, '\n')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+      if (text) sections.push(`${label}\n${text}`);
+    };
+    grab('advertisementResponsibilitiesText', 'Aufgaben:');
+    grab('advertisementRequirementsText', 'Anforderungen:');
+    grab('advertisementBenefitsText', 'Wir bieten:');
+    return sections.join('\n\n');
+  } catch {
+    return '';
+  }
+}
+
+export async function fetchAllKlinikAadorfJobs() {
+  console.log(`🏥 Fetching ${KLINIK_AADORF_COMPANY_NAME} jobs`);
+  console.log(`   Portal: ${PORTAL_URL}\n`);
+  const html = await fetchHtml(PORTAL_URL);
+  const items = parseDualooPortal(html);
+  console.log(`  ✓ ${items.length} Dualoo job cards parsed`);
+  if (!items.length) return [];
+  console.log(`  📄 Fetching detail pages for rich descriptions...`);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let detailHits = 0;
+  for (let i = 0; i < items.length; i += 1) {
+    const it = items[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+    const detailContent = await fetchDualooDetail(it.url);
+    if (detailContent) detailHits += 1;
+
+    const description = [
+      detailContent,
+      it.cityName || it.location ? `Standort: ${it.cityName || it.location}` : '',
+      it.category ? `Kategorie: ${it.category}` : '',
+      it.startDate ? `Eintritt: ${it.startDate}` : '',
+      `${KLINIK_AADORF_COMPANY_NAME} — Privatklinik für Psychiatrie und Psychotherapie, ${DEFAULT_CITY} (${DEFAULT_CANTON}), Schweiz.`,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const linkLangHint =
+      it.linkLang === 'en'
+        ? 'en'
+        : it.linkLang === 'fr'
+          ? 'fr'
+          : it.linkLang === 'it'
+            ? 'it'
+            : 'de';
+    const sourceLang = detectLang(description || it.title, linkLangHint);
+    const jobSlug = slugify(`${it.title} ${KLINIK_AADORF_KEY} ${DEFAULT_CITY}`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${KLINIK_AADORF_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: KLINIK_AADORF_COMPANY_NAME,
+      companyKey: KLINIK_AADORF_KEY,
+      companyDomain: KLINIK_AADORF_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: DEFAULT_CITY,
+      canton: DEFAULT_CANTON,
+      url: it.url,
+      source: `${KLINIK_AADORF_COMPANY_NAME} Dedicated Parser (Dualoo)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: DEFAULT_CITY,
+      addressRegion: DEFAULT_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: DEFAULT_POSTAL_CODE,
+      category: detectHealthcareCategory(`${it.title} ${it.category}`),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(it.title),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+  console.log(
+    `📋 Total ${KLINIK_AADORF_COMPANY_NAME} jobs discovered: ${jobs.length} (${detailHits}/${items.length} with rich detail content)`,
+  );
+  return jobs;
+}
+
+export { PORTAL_URL, DUALOO_PORTAL };

--- a/scripts/lib/klinik-seeschau-job-parser.mjs
+++ b/scripts/lib/klinik-seeschau-job-parser.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Klinik Seeschau (Kreuzlingen, TG) job parser.
+ *
+ * Public career page: https://www.klinik-seeschau.ch/karriere/offene-stellen.html/59
+ *
+ * Klinik Seeschau AG is an independent private acute hospital with 56 beds
+ * and ~110 staff in Kreuzlingen on Lake Constance (canton Thurgau). Member
+ * of SLH (Swiss Leading Hospitals). Specialities: gynaecology, orthopaedics,
+ * visceral & hand surgery, plastic/reconstructive surgery, urology and
+ * anaesthesia/pain therapy.
+ *
+ * The career page is a Joomla SP Page Builder listing. Each job lives in a
+ * `<li class="mod-entry">` block. The H2 carries the title; the
+ * `<div class="mod-entry-desc news-description">` carries the full posting
+ * body (Aufgaben, Profil, Angebot, Über uns, Bewerbungsadresse). No detail
+ * page — the listing IS the detail. The last entry is a generic
+ * "Spontanbewerbung" which we skip.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const KLINIK_SEESCHAU_KEY = 'klinik-seeschau';
+export const KLINIK_SEESCHAU_COMPANY_NAME = 'Klinik Seeschau';
+export const KLINIK_SEESCHAU_COMPANY_DOMAIN = 'klinik-seeschau.ch';
+export const KLINIK_SEESCHAU_CAREERS_URL =
+  'https://www.klinik-seeschau.ch/karriere/offene-stellen.html/59';
+
+const HQ_CITY = 'Kreuzlingen';
+const HQ_POSTAL = '8280';
+const HQ_CANTON = 'TG';
+
+// Generic / non-vacancy entries we don't want to index as real jobs.
+const SKIP_TITLE_PATTERNS = [
+  /^spontanbewerbung/i,
+  /^initiativbewerbung/i,
+];
+
+export function isKlinikSeeschauJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    job?.companyKey === KLINIK_SEESCHAU_KEY ||
+    url.includes('klinik-seeschau.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === KLINIK_SEESCHAU_COMPANY_DOMAIN ||
+      host.endsWith(`.${KLINIK_SEESCHAU_COMPANY_DOMAIN}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isSkipTitle(title) {
+  return SKIP_TITLE_PATTERNS.some((rx) => rx.test(String(title || '').trim()));
+}
+
+/**
+ * Block-text extraction with whitespace normalisation and bullet preservation.
+ */
+function blockToText(htmlFragment = '') {
+  return decodeEntities(
+    String(htmlFragment || '')
+      .replace(/<li[^>]*>/gi, '\n• ')
+      .replace(/<\/li>/gi, '')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(p|div|h\d|tr|table|ul|ol)>/gi, '\n')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/[ \t]+/g, ' ')
+      .replace(/\n[ \t]+/g, '\n')
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim(),
+  );
+}
+
+/**
+ * Parse the Seeschau career listing HTML.
+ * @returns {Array<{title:string, descriptionHtml:string, descriptionText:string, anchorId:string}>}
+ */
+export function parseKlinikSeeschauListing(html = '') {
+  const out = [];
+  // 1) Operate on the full HTML. `<li class="mod-entry">` is unique to the
+  //    listing widget, so we don't need to bound it inside the outer `<ul>`.
+  //    Bounding inside the outer `<ul>` is unreliable because each entry can
+  //    nest its own `<ul>` bullet lists, which trip naive non-greedy matchers.
+  const listing = html;
+
+  // 2) Split the listing by the entry-open token. The first chunk before the
+  //    first `<li class="mod-entry">` is dropped.
+  const entryOpen = /<li[^>]*class="[^"]*\bmod-entry\b[^"]*"[^>]*>/g;
+  const positions = [];
+  let m;
+  while ((m = entryOpen.exec(listing))) positions.push(m.index + m[0].length);
+  if (positions.length === 0) return out;
+
+  // 3) For each entry, take the slice from the open-tag's end to the next
+  //    open-tag's start (or end of listing for the last entry). The slice
+  //    embeds the entry's <h2> title + <div class="mod-entry-desc"> body,
+  //    plus any nested <ul>/<li>/<div class="news-bewerbung">.
+  let idx = 0;
+  for (let i = 0; i < positions.length; i += 1) {
+    const start = positions[i];
+    const end =
+      i + 1 < positions.length
+        ? listing.lastIndexOf('<li', positions[i + 1])
+        : listing.length;
+    const inner = listing.slice(start, end);
+
+    const titleMatch = inner.match(
+      /<h2[^>]*class="[^"]*\bmod-entry-title\b[^"]*"[^>]*>([\s\S]*?)<\/h2>/i,
+    );
+    if (!titleMatch) continue;
+    const title = normalizeSpace(
+      decodeEntities(titleMatch[1].replace(/<[^>]+>/g, ' ')),
+    );
+    if (!title || isSkipTitle(title)) continue;
+
+    // The desc <div> can contain a nested <div class="news-bewerbung"> at the
+    // very end. Take everything from the opening `<div class="mod-entry-desc">`
+    // up to the LAST closing `</div>` in the entry slice.
+    const descOpen = inner.search(
+      /<div[^>]*class="[^"]*\bmod-entry-desc\b[^"]*"[^>]*>/i,
+    );
+    let descriptionHtml = '';
+    if (descOpen !== -1) {
+      const afterOpen = inner.slice(descOpen).replace(
+        /^<div[^>]*class="[^"]*\bmod-entry-desc\b[^"]*"[^>]*>/i,
+        '',
+      );
+      const closeIdx = afterOpen.lastIndexOf('</div>');
+      descriptionHtml = closeIdx === -1 ? afterOpen : afterOpen.slice(0, closeIdx);
+    }
+    const descriptionText = blockToText(descriptionHtml);
+    out.push({
+      title,
+      descriptionHtml,
+      descriptionText,
+      anchorIndex: idx,
+    });
+    idx += 1;
+  }
+  return out;
+}
+
+export async function fetchAllKlinikSeeschauJobs() {
+  console.log(`🏥 Fetching ${KLINIK_SEESCHAU_COMPANY_NAME} jobs`);
+  console.log(`   Careers: ${KLINIK_SEESCHAU_CAREERS_URL}\n`);
+  const html = await fetchHtml(KLINIK_SEESCHAU_CAREERS_URL);
+  const items = parseKlinikSeeschauListing(html);
+  console.log(`  ✓ ${items.length} job entries parsed (skipping Spontanbewerbung)`);
+  if (!items.length) return [];
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  for (const it of items) {
+    const baseText = it.descriptionText || it.title;
+    const description = [
+      it.descriptionText,
+      `${KLINIK_SEESCHAU_COMPANY_NAME} — Akutspital, ${HQ_CITY} (${HQ_CANTON}), Schweiz.`,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+    const sourceLang = detectLang(baseText, 'de');
+    const jobSlug = slugify(`${it.title} ${KLINIK_SEESCHAU_KEY} ${HQ_CITY}`);
+    // Stable per-title hash → if the listing reorders, anchor index drifts
+    // but title-based hash stays stable.
+    const stableId = createHash('sha1')
+      .update(`${KLINIK_SEESCHAU_KEY}:${it.title.toLowerCase()}`)
+      .digest('hex')
+      .slice(0, 12);
+    const jobUrl = `${KLINIK_SEESCHAU_CAREERS_URL}#job-${stableId}`;
+
+    jobs.push({
+      id: `${KLINIK_SEESCHAU_KEY}-${stableId}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: KLINIK_SEESCHAU_COMPANY_NAME,
+      companyKey: KLINIK_SEESCHAU_KEY,
+      companyDomain: KLINIK_SEESCHAU_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: HQ_CITY,
+      canton: HQ_CANTON,
+      url: jobUrl,
+      source: `${KLINIK_SEESCHAU_COMPANY_NAME} Dedicated Parser (Joomla SPB)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: HQ_CITY,
+      addressRegion: HQ_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: HQ_POSTAL,
+      category: detectHealthcareCategory(it.title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(it.title),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: KLINIK_SEESCHAU_CAREERS_URL,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+  console.log(
+    `📋 Total ${KLINIK_SEESCHAU_COMPANY_NAME} jobs discovered: ${jobs.length}`,
+  );
+  return jobs;
+}

--- a/scripts/lib/modellstation-somosa-job-parser.mjs
+++ b/scripts/lib/modellstation-somosa-job-parser.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * Modellstation SOMOSA (Winterthur, ZH) job parser.
+ *
+ * Public career page: https://www.somosa.ch/offene-stellen
+ * Detail pages:       https://www.somosa.ch/offene-stellen-detail/{slug}
+ *
+ * SOMOSA is a child-and-adolescent psychiatric clinic + residential home
+ * combining inpatient psychiatry, social pedagogy and ambulatory care for
+ * adolescents 6–18 years. The site is built on Contao CMS; listings expose
+ * <article>-style rows with a "Weiterlesen" anchor → /offene-stellen-detail/{slug}.
+ *
+ * No ATS — direct HTML scraping. Each detail page renders the canonical
+ * job title in an <h1> + Aufgaben / Profil / Wir bieten sections in
+ * `<div class="ce_text">` blocks.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+
+export const MODELLSTATION_SOMOSA_KEY = 'modellstation-somosa';
+export const MODELLSTATION_SOMOSA_COMPANY_NAME = 'Modellstation SOMOSA';
+export const MODELLSTATION_SOMOSA_COMPANY_DOMAIN = 'somosa.ch';
+export const MODELLSTATION_SOMOSA_CAREERS_URL =
+  'https://www.somosa.ch/offene-stellen';
+
+const DETAIL_BASE = 'https://www.somosa.ch';
+const DETAIL_DELAY_MS = 250;
+
+// Modellstation SOMOSA is based in Winterthur (canton Zürich).
+const HQ_CITY = 'Winterthur';
+const HQ_POSTAL = '8400';
+const HQ_CANTON = 'ZH';
+
+export function isModellstationSomosaJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    job?.companyKey === MODELLSTATION_SOMOSA_KEY ||
+    url.includes('somosa.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === MODELLSTATION_SOMOSA_COMPANY_DOMAIN ||
+      host.endsWith(`.${MODELLSTATION_SOMOSA_COMPANY_DOMAIN}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function blockToText(htmlFragment = '') {
+  return decodeEntities(
+    String(htmlFragment || '')
+      .replace(/<li[^>]*>/gi, '\n• ')
+      .replace(/<\/li>/gi, '')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(p|div|h\d|tr|table|ul|ol)>/gi, '\n')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/[ \t]+/g, ' ')
+      .replace(/\n[ \t]+/g, '\n')
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim(),
+  );
+}
+
+/**
+ * Parse the SOMOSA listing page. Each job exposes a "Weiterlesen" link
+ * (`href="offene-stellen-detail/{slug}" title="Den Artikel lesen: {TITLE}"`).
+ */
+export function parseSomosaListing(html = '') {
+  const out = [];
+  const seen = new Set();
+  const rx =
+    /href="(offene-stellen-detail\/[^"]+)"[^>]*\stitle="Den Artikel lesen:\s*([^"]+)"/g;
+  let m;
+  while ((m = rx.exec(html))) {
+    const rel = m[1];
+    const title = normalizeSpace(decodeEntities(m[2].replace(/&#40;|&#41;/g, (c) => (c === '&#40;' ? '(' : ')'))));
+    if (!title || title.length < 3) continue;
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    const url = `${DETAIL_BASE}/${rel}`;
+    out.push({ url, title });
+  }
+  return out;
+}
+
+/**
+ * Extract the main posting body from a detail page. SOMOSA uses Contao —
+ * the meaningful content lives under <main> in a series of <div class="ce_text">
+ * blocks, separated by section headers ("Ihr Aufgabengebiet", "Ihr Profil", …).
+ */
+function extractDetailContent(html = '') {
+  const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+  const region = mainMatch ? mainMatch[1] : html;
+
+  const blocks = [];
+  const blockRe =
+    /<div[^>]*class="[^"]*\bce_(?:text|headline|rsce_[a-z_]+)\b[^"]*"[^>]*>([\s\S]*?)<\/div>(?=\s*<(?:div|\/div|section|footer|aside|main)|\s*$)/gi;
+  let m;
+  while ((m = blockRe.exec(region))) {
+    const text = blockToText(m[1]);
+    if (text && text.length > 8) blocks.push(text);
+  }
+  // Fallback: take all visible text under <main>
+  if (blocks.length === 0) blocks.push(blockToText(region));
+
+  // De-duplicate and drop UI scaffolding lines.
+  const seen = new Set();
+  const dedup = [];
+  for (const b of blocks) {
+    const key = b.toLowerCase();
+    if (seen.has(key)) continue;
+    if (/^(weiterlesen|drucken|teilen)$/i.test(b.trim())) continue;
+    seen.add(key);
+    dedup.push(b);
+  }
+  return dedup.join('\n\n').trim();
+}
+
+export async function fetchAllModellstationSomosaJobs() {
+  console.log(`🏥 Fetching ${MODELLSTATION_SOMOSA_COMPANY_NAME} jobs`);
+  console.log(`   Careers: ${MODELLSTATION_SOMOSA_CAREERS_URL}\n`);
+
+  const listingHtml = await fetchHtml(MODELLSTATION_SOMOSA_CAREERS_URL);
+  const items = parseSomosaListing(listingHtml);
+  console.log(`  ✓ ${items.length} listing entries parsed`);
+  if (!items.length) return [];
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let detailHits = 0;
+  for (let i = 0; i < items.length; i += 1) {
+    const it = items[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, DETAIL_DELAY_MS));
+    let detailContent = '';
+    try {
+      const detailHtml = await fetchHtml(it.url);
+      detailContent = extractDetailContent(detailHtml);
+      if (detailContent) detailHits += 1;
+    } catch (err) {
+      console.warn(`  ⚠️ Detail fetch failed for ${it.url}: ${err?.message || err}`);
+    }
+
+    const description = [
+      detailContent,
+      `${MODELLSTATION_SOMOSA_COMPANY_NAME} — jugendpsychiatrische Klinik und Jugendheim für Adoleszente (6–18 Jahre), ${HQ_CITY} (${HQ_CANTON}), Schweiz.`,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const sourceLang = detectLang(detailContent || it.title, 'de');
+    const jobSlug = slugify(`${it.title} ${MODELLSTATION_SOMOSA_KEY} ${HQ_CITY}`);
+    const urlHash = createHash('sha1').update(it.url).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${MODELLSTATION_SOMOSA_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: MODELLSTATION_SOMOSA_COMPANY_NAME,
+      companyKey: MODELLSTATION_SOMOSA_KEY,
+      companyDomain: MODELLSTATION_SOMOSA_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: HQ_CITY,
+      canton: HQ_CANTON,
+      url: it.url,
+      source: `${MODELLSTATION_SOMOSA_COMPANY_NAME} Dedicated Parser (Contao)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: HQ_CITY,
+      addressRegion: HQ_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: HQ_POSTAL,
+      category: detectHealthcareCategory(it.title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(it.title),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: it.url,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(
+    `📋 Total ${MODELLSTATION_SOMOSA_COMPANY_NAME} jobs discovered: ${jobs.length} (${detailHits}/${items.length} with detail content)`,
+  );
+  return jobs;
+}

--- a/scripts/lib/therapiezentrum-meggen-job-parser.mjs
+++ b/scripts/lib/therapiezentrum-meggen-job-parser.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Therapiezentrum Meggen (TZM, LU) job parser.
+ *
+ * Public careers page: https://www.tzm.ch/offene-stellen/
+ *
+ * TZM is a small private addiction / psychiatric therapy centre on Lake
+ * Lucerne (Meggen, LU). The site is a Jimdo CMS and lists job postings
+ * as direct PDF downloads under `/app/download/...`. The PDF carries the
+ * full posting; the HTML link text (or `title` attribute) carries the
+ * canonical job title.
+ *
+ * Each posting renders as:
+ *   <a href="/app/download/{id}/{Filename}.pdf?t=..." title="{ATTR_TITLE}">
+ *     <span>{ANCHOR_TEXT}</span>
+ *   </a>
+ *
+ * Where ANCHOR_TEXT may be empty (then ATTR_TITLE is the source of truth)
+ * or carry the human-readable role (preferred).
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify } from './crawler-template.mjs';
+import {
+  fetchHtml,
+  decodeEntities,
+  normalizeSpace,
+  detectHealthcareCategory,
+  detectHealthcareExperienceLevel,
+  detectHealthcareEmploymentType,
+} from './hospital-custom-html-helpers.mjs';
+import {
+  extractPdfJobContentFromUrl,
+  buildPdfBackedDescription,
+} from './pdf-job-content.mjs';
+
+export const THERAPIEZENTRUM_MEGGEN_KEY = 'therapiezentrum-meggen';
+export const THERAPIEZENTRUM_MEGGEN_COMPANY_NAME = 'Therapiezentrum Meggen';
+export const THERAPIEZENTRUM_MEGGEN_COMPANY_DOMAIN = 'tzm.ch';
+export const THERAPIEZENTRUM_MEGGEN_CAREERS_URL =
+  'https://www.tzm.ch/offene-stellen/';
+
+const PDF_DELAY_MS = 350;
+
+// HQ in Meggen (Lake Lucerne, canton Luzern).
+const HQ_CITY = 'Meggen';
+const HQ_POSTAL = '6045';
+const HQ_CANTON = 'LU';
+
+export function isTherapiezentrumMeggenJob(job) {
+  const url = String(job?.url || '').toLowerCase();
+  return (
+    job?.companyKey === THERAPIEZENTRUM_MEGGEN_KEY ||
+    url.includes('tzm.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      host === THERAPIEZENTRUM_MEGGEN_COMPANY_DOMAIN ||
+      host.endsWith(`.${THERAPIEZENTRUM_MEGGEN_COMPANY_DOMAIN}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clean a "title attribute" value of the form
+ *   "Stellenausschreibung Psychotherapie (Stellenausschreibung Psychotherapie ab August 2026.pdf)"
+ * → "Stellenausschreibung Psychotherapie"
+ */
+function cleanAttrTitle(raw = '') {
+  return normalizeSpace(
+    decodeEntities(String(raw || '').replace(/\s*\([^)]*\.pdf\)\s*$/i, '')),
+  );
+}
+
+function absolutizeUrl(href = '') {
+  if (!href) return '';
+  let abs;
+  if (/^https?:\/\//i.test(href)) abs = href;
+  else if (href.startsWith('//')) abs = `https:${href}`;
+  else if (href.startsWith('/')) abs = `https://www.${THERAPIEZENTRUM_MEGGEN_COMPANY_DOMAIN}${href}`;
+  else abs = `https://www.${THERAPIEZENTRUM_MEGGEN_COMPANY_DOMAIN}/${href}`;
+  // Jimdo PDF filenames contain literal spaces — encode them so the URL is
+  // RFC-3986 compliant and survives URL validation + JSON-LD serialization.
+  // Only re-encode if the URL is currently un-encoded.
+  if (/ /.test(abs)) {
+    try {
+      const u = new URL(abs);
+      u.pathname = u.pathname.split('/').map((seg) => encodeURIComponent(decodeURIComponent(seg))).join('/');
+      abs = u.toString();
+    } catch {
+      abs = encodeURI(abs);
+    }
+  }
+  return abs;
+}
+
+/**
+ * Parse the careers page HTML for `<a>` anchors pointing to `/app/download/...pdf`.
+ */
+export function parseTherapiezentrumMeggenListing(html = '') {
+  const out = [];
+  const seen = new Set();
+  // Match anchors carrying a `/app/download/.../*.pdf` href, capturing optional
+  // body text. We post-process to strip nested tags.
+  const rx =
+    /<a[^>]*href="([^"]*\/app\/download\/[^"]+\.pdf[^"]*)"[^>]*(?:\stitle="([^"]*)")?[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = rx.exec(html))) {
+    const href = m[1];
+    const attrTitle = cleanAttrTitle(m[2] || '');
+    const innerText = normalizeSpace(
+      decodeEntities((m[3] || '').replace(/<[^>]+>/g, ' ')),
+    );
+    const title = innerText && innerText.length > 3 ? innerText : attrTitle;
+    if (!title || title.length < 3) continue;
+    const pdfUrl = absolutizeUrl(href);
+    if (seen.has(pdfUrl)) continue;
+    seen.add(pdfUrl);
+    const filename = decodeURIComponent(
+      pdfUrl.split('?')[0].split('/').pop() || '',
+    );
+    out.push({ pdfUrl, filename, title });
+  }
+  return out;
+}
+
+export async function fetchAllTherapiezentrumMeggenJobs() {
+  console.log(`🏥 Fetching ${THERAPIEZENTRUM_MEGGEN_COMPANY_NAME} jobs`);
+  console.log(`   Careers: ${THERAPIEZENTRUM_MEGGEN_CAREERS_URL}\n`);
+
+  const html = await fetchHtml(THERAPIEZENTRUM_MEGGEN_CAREERS_URL);
+  const items = parseTherapiezentrumMeggenListing(html);
+  console.log(`  ✓ ${items.length} PDF Stellenausschreibungen parsed`);
+  if (!items.length) return [];
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const jobs = [];
+  let pdfHits = 0;
+  for (let i = 0; i < items.length; i += 1) {
+    const it = items[i];
+    if (i > 0) await new Promise((r) => setTimeout(r, PDF_DELAY_MS));
+    console.log(`  📄 Extracting PDF: ${it.filename}`);
+    const pdf = await extractPdfJobContentFromUrl(it.pdfUrl, { timeoutMs: 30000 });
+    if (pdf.error) console.warn(`     ⚠️ PDF error: ${pdf.error}`);
+    const pdfText = pdf.text || '';
+    if (pdfText) pdfHits += 1;
+
+    const description = buildPdfBackedDescription({
+      introLines: [
+        `${THERAPIEZENTRUM_MEGGEN_COMPANY_NAME} — privates Therapiezentrum für Suchterkrankungen und psychische Gesundheit am Vierwaldstättersee, ${HQ_CITY} (${HQ_CANTON}), Schweiz.`,
+        `Stelle: ${it.title}.`,
+      ],
+      pdfText,
+      fallbackText: `Stellenausschreibung ${it.title} beim ${THERAPIEZENTRUM_MEGGEN_COMPANY_NAME}. Vollständige Angaben zu Profil und Bewerbung finden Sie im offiziellen PDF.`,
+      footerLines: [
+        `Quelle (PDF): ${it.pdfUrl}`,
+        `Karriereseite: ${THERAPIEZENTRUM_MEGGEN_CAREERS_URL}`,
+        `Sektor: Psychiatrie / Psychotherapie / Suchtmedizin`,
+      ],
+    });
+
+    const sourceLang = detectLang(`${it.title} ${pdfText}`, 'de');
+    const jobSlug = slugify(`${it.title} ${THERAPIEZENTRUM_MEGGEN_KEY} ${HQ_CITY}`);
+    const urlHash = createHash('sha1').update(it.pdfUrl).digest('hex').slice(0, 12);
+
+    jobs.push({
+      id: `${THERAPIEZENTRUM_MEGGEN_KEY}-${urlHash}`,
+      slug: jobSlug,
+      slugByLocale: { [sourceLang]: jobSlug },
+      company: THERAPIEZENTRUM_MEGGEN_COMPANY_NAME,
+      companyKey: THERAPIEZENTRUM_MEGGEN_KEY,
+      companyDomain: THERAPIEZENTRUM_MEGGEN_COMPANY_DOMAIN,
+      title: it.title,
+      titleByLocale: { [sourceLang]: it.title },
+      description,
+      descriptionByLocale: { [sourceLang]: description },
+      needsRetranslation: true,
+      location: HQ_CITY,
+      canton: HQ_CANTON,
+      url: it.pdfUrl,
+      source: `${THERAPIEZENTRUM_MEGGEN_COMPANY_NAME} Dedicated Parser (PDF)`,
+      sourceLang,
+      crawledAt: new Date().toISOString(),
+      addressLocality: HQ_CITY,
+      addressRegion: HQ_CANTON,
+      addressCountry: 'CH',
+      country: 'CH',
+      postalCode: HQ_POSTAL,
+      category: detectHealthcareCategory(it.title),
+      contract: 'full-time',
+      employmentType: detectHealthcareEmploymentType(it.title),
+      experienceLevel: detectHealthcareExperienceLevel(it.title),
+      sector: 'Sanità / Ospedali',
+      currency: 'CHF',
+      featured: false,
+      postedDate: todayIso,
+      applyUrl: THERAPIEZENTRUM_MEGGEN_CAREERS_URL,
+      requirements: [],
+      requirementsByLocale: { [sourceLang]: [] },
+    });
+  }
+
+  console.log(
+    `📋 Total ${THERAPIEZENTRUM_MEGGEN_COMPANY_NAME} jobs discovered: ${jobs.length} (${pdfHits}/${items.length} with PDF text)`,
+  );
+  return jobs;
+}

--- a/scripts/update-klinik-aadorf-jobs.mjs
+++ b/scripts/update-klinik-aadorf-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllKlinikAadorfJobs,
+  isKlinikAadorfJob,
+  isTrustedDomain,
+  KLINIK_AADORF_KEY,
+  KLINIK_AADORF_COMPANY_NAME,
+} from './lib/klinik-aadorf-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: KLINIK_AADORF_KEY,
+  companyLabel: KLINIK_AADORF_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllKlinikAadorfJobs,
+  isCompanyJob: isKlinikAadorfJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Klinik Aadorf crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-klinik-seeschau-jobs.mjs
+++ b/scripts/update-klinik-seeschau-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllKlinikSeeschauJobs,
+  isKlinikSeeschauJob,
+  isTrustedDomain,
+  KLINIK_SEESCHAU_KEY,
+  KLINIK_SEESCHAU_COMPANY_NAME,
+} from './lib/klinik-seeschau-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: KLINIK_SEESCHAU_KEY,
+  companyLabel: KLINIK_SEESCHAU_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllKlinikSeeschauJobs,
+  isCompanyJob: isKlinikSeeschauJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Klinik Seeschau crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-modellstation-somosa-jobs.mjs
+++ b/scripts/update-modellstation-somosa-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllModellstationSomosaJobs,
+  isModellstationSomosaJob,
+  isTrustedDomain,
+  MODELLSTATION_SOMOSA_KEY,
+  MODELLSTATION_SOMOSA_COMPANY_NAME,
+} from './lib/modellstation-somosa-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: MODELLSTATION_SOMOSA_KEY,
+  companyLabel: MODELLSTATION_SOMOSA_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllModellstationSomosaJobs,
+  isCompanyJob: isModellstationSomosaJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Modellstation SOMOSA crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-therapiezentrum-meggen-jobs.mjs
+++ b/scripts/update-therapiezentrum-meggen-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllTherapiezentrumMeggenJobs,
+  isTherapiezentrumMeggenJob,
+  isTrustedDomain,
+  THERAPIEZENTRUM_MEGGEN_KEY,
+  THERAPIEZENTRUM_MEGGEN_COMPANY_NAME,
+} from './lib/therapiezentrum-meggen-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: THERAPIEZENTRUM_MEGGEN_KEY,
+  companyLabel: THERAPIEZENTRUM_MEGGEN_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllTherapiezentrumMeggenJobs,
+  isCompanyJob: isTherapiezentrumMeggenJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Therapiezentrum Meggen crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds four dedicated crawlers for small Swiss clinics (no minimum-job threshold).

| Tenant                        | Canton | Pattern        | Smoke-test count |
|-------------------------------|--------|----------------|------------------|
| Klinik Aadorf                 | TG     | Dualoo portal  | 4 jobs           |
| Klinik Seeschau (Kreuzlingen) | TG     | Joomla SPB     | 4 jobs           |
| Modellstation SOMOSA          | ZH     | Contao detail  | 3 jobs           |
| Therapiezentrum Meggen        | LU     | Jimdo + PDF    | 1 job            |

All workflows set SKIP_BOILERPLATE_GUARD=1. needsRetranslation: true on
every discovered job. No edits to crawler-location-config.mjs,
known-company-slugs.json, or data/jobs*.json.
