### PR TITLE
feat: crawlers batch 21S — DNS-dead candidate re-discovery (5 hospital tenants)

### DIFF
--- a/.github/workflows/update-jobs-adus-klinik.yml
+++ b/.github/workflows/update-jobs-adus-klinik.yml
@@ -1,0 +1,102 @@
+name: Update ADUS Klinik Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-adus-klinik
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-adus-klinik-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated ADUS Klinik crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_ADUS_KLINIK_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-adus-klinik-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'adus-klinik'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/adus-klinik.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ADUS Klinik jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-rehaklinik-hasliberg.yml
+++ b/.github/workflows/update-jobs-rehaklinik-hasliberg.yml
@@ -1,0 +1,102 @@
+name: Update Rehaklinik Hasliberg Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-rehaklinik-hasliberg
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-rehaklinik-hasliberg-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated Rehaklinik Hasliberg crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_REHAKLINIK_HASLIBERG_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-rehaklinik-hasliberg-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'rehaklinik-hasliberg'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/rehaklinik-hasliberg.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Rehaklinik Hasliberg jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-salina-reha.yml
+++ b/.github/workflows/update-jobs-salina-reha.yml
@@ -1,0 +1,105 @@
+name: Update Salina Rehaklinik Rheinfelden Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-salina-reha
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-salina-reha-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated Salina Rehaklinik crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_SALINA_REHA_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-salina-reha-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'salina-reha'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/salina-reha.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Salina Rehaklinik Rheinfelden jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-sune-egge.yml
+++ b/.github/workflows/update-jobs-sune-egge.yml
@@ -1,0 +1,102 @@
+name: Update Fachspital Sune-Egge Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-sune-egge
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-sune-egge-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated Sune-Egge crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_SUNE_EGGE_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-sune-egge-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'sune-egge'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/sune-egge.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Fachspital Sune-Egge jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-jobs-villa-im-park.yml
+++ b/.github/workflows/update-jobs-villa-im-park.yml
@@ -1,0 +1,102 @@
+name: Update Privatklinik Villa im Park Jobs (Dedicated)
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict_localization:
+        description: 'Fail if any locale is missing/untranslated (1=yes, 0=no)'
+        required: false
+        default: '1'
+        type: string
+      timeout_ms:
+        description: 'Optional request timeout in ms (4000-15000)'
+        required: false
+        type: string
+      skip_ai_translation:
+        description: "Skip AI translation (1=yes, cache only)"
+        required: false
+        default: "0"
+        type: string
+
+concurrency:
+  group: jobs-crawler-villa-im-park
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
+
+jobs:
+  update-villa-im-park-jobs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare Firebase credentials (optional)
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+          else
+            echo "ℹ️ Firebase secrets not set — crawler will use file config only."
+            exit 0
+          fi
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Load secrets from Remote Config
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run dedicated Villa im Park crawler
+        env:
+          JOBS_CRAWLER_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '' }}
+          JOBS_CRAWLER_USE_FIRESTORE_CONFIG: '1'
+          JOBS_VILLA_IM_PARK_STRICT: ${{ github.event.inputs.strict_localization || '1' }}
+          CRAWLER_SLICE_ONLY: '1'
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+          SKIP_BOILERPLATE_GUARD: '1'
+        run: node scripts/update-villa-im-park-jobs.mjs
+
+      - name: Housekeeping — remove expired job listings (scoped)
+        env:
+          JOBS_HOUSEKEEPING_SCOPE: 'villa-im-park'
+          JOBS_SLICE_FILE: 'data/jobs/by-crawler/villa-im-park.json'
+        run: node scripts/cleanup-jobs.mjs
+        continue-on-error: true
+
+      - name: Commit and push
+        id: changes
+        env:
+          SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
+        run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Privatklinik Villa im Park jobs (dedicated crawler)" data/jobs-crawler-adapters/
+
+      - name: Report failure to Linear
+        if: failure()
+        continue-on-error: true
+        run: |
+          node scripts/lib/linear-issue-creator.mjs \
+            --title "Crawler Failure: ${{ github.workflow }}" \
+            --description "## Crawler fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** ${{ github.ref_name }}
+          **Trigger:** ${{ github.event_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/data/slug-registry.json
+++ b/data/slug-registry.json
@@ -81033,5 +81033,189 @@
     },
     "createdAt": "2026-05-20",
     "canton": "BE"
+  },
+  "id|jobalino.ch|53": {
+    "canonicalSlug": "assistenzarztin-assistenzarzt-psychosomatische-medizin-muskuloskelettale-rehabilitation",
+    "slugByLocale": {
+      "de": "assistenzarztin-assistenzarzt-psychosomatische-medizin-muskuloskelettale-rehabilitation"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "BE"
+  },
+  "id|jobalino.ch|04": {
+    "canonicalSlug": "pflegefachpersonal-fur-pflegepool-10-40-rehaklinik-hasliberg-hasliberg-hohfluh",
+    "slugByLocale": {
+      "de": "pflegefachpersonal-fur-pflegepool-10-40-rehaklinik-hasliberg-hasliberg-hohfluh"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "BE"
+  },
+  "id|jobalino.ch|94": {
+    "canonicalSlug": "facharztin-facharzt-psychiatrie-und-psychotherapie-mit-schwerpunkt-psychosomatische-und",
+    "slugByLocale": {
+      "de": "facharztin-facharzt-psychiatrie-und-psychotherapie-mit-schwerpunkt-psychosomatische-und"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "BE"
+  },
+  "id|jobalino.ch|0798": {
+    "canonicalSlug": "facharztin-facharzt-allgemeine-innere-medizin-mit-schwerpunkt-psychosomatische-und",
+    "slugByLocale": {
+      "de": "facharztin-facharzt-allgemeine-innere-medizin-mit-schwerpunkt-psychosomatische-und"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "BE"
+  },
+  "id|jobalino.ch|50": {
+    "canonicalSlug": "mitarbeiter-in-therapiekoordination-80-rehaklinik-hasliberg-hasliberg-hohfluh",
+    "slugByLocale": {
+      "de": "mitarbeiter-in-therapiekoordination-80-rehaklinik-hasliberg-hasliberg-hohfluh"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "BE"
+  },
+  "url|https://link.ostendis.com/publication/facharzt-fachaerztin-ambulant/zltjilsrep8my2zyizc3ca3su3flqwjdd1yiqkbphkwk4dxd7qffb76pmeuvvl8d": {
+    "canonicalSlug": "facharzt-facharztin-ambulant-60-100-salina-rheinfelden",
+    "slugByLocale": {
+      "de": "facharzt-facharztin-ambulant-60-100-salina-rheinfelden"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://link.ostendis.com/publication/fachfrau-mann-gesundheit-rehaklinik/8aqq0aguzneiegzipazxf0gpk3365pw3sk67howz1381b2isz5m0jpstx28mw6hh": {
+    "canonicalSlug": "fachfrau-mann-gesundheit-rehaklinik-salina-rheinfelden",
+    "slugByLocale": {
+      "de": "fachfrau-mann-gesundheit-rehaklinik-salina-rheinfelden"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://link.ostendis.com/publication/dipl-pflegefachperson-fachperson-gesundheit-pool-im-stundenlohn/mnm2zldquioi3p2vwvpjvoromzh705yx9lgvzswlhue6kp5kl777vfjkra5vn3sv": {
+    "canonicalSlug": "dipl-pflegefachperson-fachperson-gesundheit-pool-im-stundenlohn-salina-rheinfelden",
+    "slugByLocale": {
+      "de": "dipl-pflegefachperson-fachperson-gesundheit-pool-im-stundenlohn-salina-rheinfelden"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://link.ostendis.com/publication/psychotherapeut-in/busy2qktsvis75ecdf8xwhe1tpdb7bg3ejrbltowe83y40uy5nylbe38wthkei25": {
+    "canonicalSlug": "psychotherapeut-in-salina-rheinfelden",
+    "slugByLocale": {
+      "de": "psychotherapeut-in-salina-rheinfelden"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "id|adus-klinik.ch|7537525": {
+    "canonicalSlug": "dipl-expert-in-anasthesiepflege-50-60-adus-klinik-dielsdorf",
+    "slugByLocale": {
+      "de": "dipl-expert-in-anasthesiepflege-50-60-adus-klinik-dielsdorf"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "ZH"
+  },
+  "id|adus-klinik.ch|6277966": {
+    "canonicalSlug": "dipl-physiotherapeut-in-20-30-im-stundenlohn-adus-klinik-dielsdorf",
+    "slugByLocale": {
+      "de": "dipl-physiotherapeut-in-20-30-im-stundenlohn-adus-klinik-dielsdorf"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "ZH"
+  },
+  "id|personio.com|2616543": {
+    "canonicalSlug": "koch-kochin-50-100-sune-egge-zurich",
+    "slugByLocale": {
+      "de": "koch-kochin-50-100-sune-egge-zurich"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "ZH"
+  },
+  "id|personio.com|2610349": {
+    "canonicalSlug": "dipl-pflegefachfrau-mann-hf-80-100-sune-egge-zurich",
+    "slugByLocale": {
+      "de": "dipl-pflegefachfrau-mann-hf-80-100-sune-egge-zurich"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "ZH"
+  },
+  "id|personio.com|2610155": {
+    "canonicalSlug": "dipl-pflegefachfrau-mann-hf-60-100-tagdienst-sune-egge-zurich",
+    "slugByLocale": {
+      "de": "dipl-pflegefachfrau-mann-hf-60-100-tagdienst-sune-egge-zurich"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "ZH"
+  },
+  "id|personio.com|2609975": {
+    "canonicalSlug": "physiotherapeutin-physiotherapeuten-30-50-sune-egge-zurich",
+    "slugByLocale": {
+      "de": "physiotherapeutin-physiotherapeuten-30-50-sune-egge-zurich"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "ZH"
+  },
+  "id|personio.com|2595649": {
+    "canonicalSlug": "fachfrau-fachmann-gesundheit-fage-efz-60-100-fur-den-tagdienst-sune-egge-zurich",
+    "slugByLocale": {
+      "de": "fachfrau-fachmann-gesundheit-fage-efz-60-100-fur-den-tagdienst-sune-egge-zurich"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "ZH"
+  },
+  "url|https://jobs.smartrecruiters.com/swissmedicalnetwork1/744000119577477-dipl-pflegefachperson-chirurgie-60-100-?oga=true": {
+    "canonicalSlug": "dipl-pflegefachperson-chirurgie-60-100-villa-im-park-rothrist",
+    "slugByLocale": {
+      "de": "dipl-pflegefachperson-chirurgie-60-100-villa-im-park-rothrist"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://jobs.smartrecruiters.com/swissmedicalnetwork1/744000123906949-studium-zur-dipl-pflegefachperson-hf?oga=true": {
+    "canonicalSlug": "studium-zur-dipl-pflegefachperson-hf-villa-im-park-rothrist",
+    "slugByLocale": {
+      "de": "studium-zur-dipl-pflegefachperson-hf-villa-im-park-rothrist"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://jobs.smartrecruiters.com/swissmedicalnetwork1/744000124593045-lehrstelle-fachperson-gesundheit-fur-sommer-2027?oga=true": {
+    "canonicalSlug": "lehrstelle-fachperson-gesundheit-fur-sommer-2027-villa-im-park-rothrist",
+    "slugByLocale": {
+      "de": "lehrstelle-fachperson-gesundheit-fur-sommer-2027-villa-im-park-rothrist"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://jobs.smartrecruiters.com/swissmedicalnetwork1/744000125169842-dipl-experte-expertin-anasthesiepflege-nds-hf-60-90-?oga=true": {
+    "canonicalSlug": "dipl-experte-expertin-anasthesiepflege-nds-hf-60-90-villa-im-park-rothrist",
+    "slugByLocale": {
+      "de": "dipl-experte-expertin-anasthesiepflege-nds-hf-60-90-villa-im-park-rothrist"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://jobs.smartrecruiters.com/swissmedicalnetwork1/744000126082024-fachperson-gesundheit-fage-efz-fur-den-bereich-aufwachraum-tagesklinik?oga=true": {
+    "canonicalSlug": "fachperson-gesundheit-fage-efz-fur-den-bereich-aufwachraum-tagesklinik-villa-im-park",
+    "slugByLocale": {
+      "de": "fachperson-gesundheit-fage-efz-fur-den-bereich-aufwachraum-tagesklinik-villa-im-park"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://jobs.smartrecruiters.com/swissmedicalnetwork1/744000127007889-assistent-in-gesundheit-und-soziales-40-60-?oga=true": {
+    "canonicalSlug": "assistent-in-gesundheit-und-soziales-40-60-villa-im-park-rothrist",
+    "slugByLocale": {
+      "de": "assistent-in-gesundheit-und-soziales-40-60-villa-im-park-rothrist"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
+  },
+  "url|https://jobs.smartrecruiters.com/swissmedicalnetwork1/744000127191779-dipl-pflegefachperson-hf-fh-fur-den-bereich-aufwachraum-tagesklinik-46-60-?oga=true": {
+    "canonicalSlug": "dipl-pflegefachperson-hf-fh-fur-den-bereich-aufwachraum-tagesklinik-46-60-villa-im-park",
+    "slugByLocale": {
+      "de": "dipl-pflegefachperson-hf-fh-fur-den-bereich-aufwachraum-tagesklinik-46-60-villa-im-park"
+    },
+    "createdAt": "2026-05-20",
+    "canton": "AG"
   }
 }

--- a/scripts/lib/adus-klinik-job-parser.mjs
+++ b/scripts/lib/adus-klinik-job-parser.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * ADUS Klinik Dielsdorf — Teamtailor ATS via public RSS feed.
+ *
+ * Source:
+ *   - Career site: https://karriere.adus-klinik.ch/jobs
+ *   - RSS feed:    https://karriere.adus-klinik.ch/jobs.rss
+ *   - Detail:      https://karriere.adus-klinik.ch/jobs/{id}-{slug}
+ *
+ * The ADUS Klinik is a privately held Belegarztspital (consultant-physician
+ * hospital) in Dielsdorf (ZH, 8157), part of the Epiona Gruppe since 2025.
+ * Specialisation: elective orthopedic surgery (~2'000 ops/year). The
+ * Teamtailor career site serves a clean RSS feed with full JobPosting
+ * descriptions (HTML) plus `<tt:locations>` blocks carrying zip / city /
+ * canton — no JS rendering needed.
+ *
+ * Re-discovery note (2026-05-20): batch-21 originally probed
+ * `adus-medica.ch` (NXDOMAIN). The clinic actually lives at
+ * `adus-klinik.ch` (legal entity Adus-Medica AG); career site at
+ * `karriere.adus-klinik.ch`.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+
+export const ADUS_KLINIK_KEY = 'adus-klinik';
+export const ADUS_KLINIK_COMPANY_NAME = 'ADUS Klinik';
+export const ADUS_KLINIK_COMPANY_DOMAIN = 'adus-klinik.ch';
+
+const RSS_URL = 'https://karriere.adus-klinik.ch/jobs.rss';
+const CAREER_URL = 'https://karriere.adus-klinik.ch/jobs';
+const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
+  || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
+
+const DEFAULT_CITY = 'Dielsdorf';
+const DEFAULT_CANTON = 'ZH';
+const DEFAULT_POSTAL = '8157';
+
+function normalize(s = '') {
+  return String(s || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+function decodeEntities(s = '') {
+  return String(s || '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(Number.parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number.parseInt(n, 10)));
+}
+
+/* ── Company matchers ─────────────────────────────────────── */
+
+export function isAdusKlinikJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === ADUS_KLINIK_KEY ||
+    /^adus(-|$)/.test(key) ||
+    /adus-medica/.test(key) ||
+    company.includes('adus') ||
+    url.includes('adus-klinik.ch') ||
+    url.includes('karriere.adus-klinik.ch')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'adus-klinik.ch' || host.endsWith('.adus-klinik.ch')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/* ── Category / employment helpers ────────────────────────── */
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(pflege|fage|fa-?gesundheit|gesundheits|pfleger|krankenschwester|krankenpfleger|fachfrau|fachmann|efz|efa|anaesth|anästh)/.test(t)) return 'Sanità';
+  if (/\b(arzt|aerztin|ärztin|medizin|physiotherap|ergotherap|psychotherap|facharzt)/.test(t)) return 'Sanità';
+  if (/\b(therapeut|therapie|logoped)/.test(t)) return 'Sanità';
+  if (/\b(verwalt|admin|sekretär|empfang|bookkeep|buchhalt|hr|personal)/.test(t)) return 'Amministrazione';
+  if (/\b(it|edv|netzwerk|system|software)/.test(t)) return 'IT';
+  if (/\b(techni|haustech|handwerk)/.test(t)) return 'Tecnica';
+  if (/\b(lehrling|lernend|apprenti|praktik|intern)/.test(t)) return 'Formazione';
+  return 'Altro';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(lehrling|lernend|apprenti|praktik|intern|trainee|aushilfe)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|chef|leiter|leitend|head|director|responsab|expert)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(text = '') {
+  const t = normalize(text);
+  const pctMatch = t.match(/(\d{2,3})\s*[-–]\s*\d{2,3}\s*%/) || t.match(/(\d{2,3})\s*%/);
+  if (pctMatch) {
+    const pct = Number(pctMatch[1]);
+    if (pct >= 90) return 'FULL_TIME';
+    if (pct > 0) return 'PART_TIME';
+  }
+  if (/\b(part.?time|teilzeit)/.test(t)) return 'PART_TIME';
+  if (/\b(full.?time|vollzeit)/.test(t)) return 'FULL_TIME';
+  if (/\b(praktik|intern|stage|lehrling|lernend)/.test(t)) return 'INTERN';
+  if (/\b(stundenlohn|aushilfe|befristet)/.test(t)) return 'CONTRACTOR';
+  return 'OTHER';
+}
+
+/* ── RSS parsing ──────────────────────────────────────────── */
+
+function parseRssItems(xml = '') {
+  const items = [];
+  const itemRe = /<item[\s>]([\s\S]*?)<\/item>/gi;
+  let m;
+  while ((m = itemRe.exec(xml)) !== null) {
+    const block = m[1];
+    const get = (tag) => {
+      const re = new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, 'i');
+      const mm = block.match(re);
+      if (!mm) return '';
+      let v = mm[1].trim();
+      // strip CDATA
+      const cdata = v.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);
+      if (cdata) v = cdata[1];
+      return v;
+    };
+    const item = {
+      title: decodeEntities(get('title')),
+      description: decodeEntities(get('description')),
+      link: decodeEntities(get('link')),
+      pubDate: get('pubDate'),
+      guid: get('guid'),
+    };
+    // tt:location nested block
+    const locBlock = block.match(/<tt:locations>([\s\S]*?)<\/tt:locations>/i);
+    if (locBlock) {
+      const inner = locBlock[1];
+      item.locationName = decodeEntities((inner.match(/<tt:name>([\s\S]*?)<\/tt:name>/i) || [])[1] || '').trim();
+      item.locationCity = decodeEntities((inner.match(/<tt:city>([\s\S]*?)<\/tt:city>/i) || [])[1] || '').trim();
+      item.locationZip = decodeEntities((inner.match(/<tt:zip>([\s\S]*?)<\/tt:zip>/i) || [])[1] || '').trim();
+      item.locationCountry = decodeEntities((inner.match(/<tt:country>([\s\S]*?)<\/tt:country>/i) || [])[1] || '').trim();
+      item.locationAddress = decodeEntities((inner.match(/<tt:address>([\s\S]*?)<\/tt:address>/i) || [])[1] || '').trim();
+    }
+    items.push(item);
+  }
+  return items;
+}
+
+async function fetchText(url) {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT, Accept: 'application/rss+xml,application/xml,text/xml,*/*' },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+    return await res.text();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+/* ── ParsedJob builder ────────────────────────────────────── */
+
+function buildParsedJob(item) {
+  const title = normalizeSpace(item.title || '');
+  if (!title || title.length < 3) return null;
+
+  const descText = stripHtml(item.description || '');
+  const sourceLang = detectLang(descText || title, 'de');
+  const city = item.locationCity || DEFAULT_CITY;
+  const zip = (item.locationZip && /^\d{4}$/.test(item.locationZip)) ? item.locationZip : DEFAULT_POSTAL;
+  const country = item.locationCountry && /switzerland|schweiz|suisse|svizzera/i.test(item.locationCountry) ? 'CH' : 'CH';
+
+  // Country gate — skip non-CH listings
+  if (item.locationCountry && country !== 'CH') return null;
+
+  const publicUrl = item.link || '';
+  if (!publicUrl) return null;
+  const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+  const jobSlug = slugify(`${title} ${ADUS_KLINIK_KEY} ${city}`);
+
+  const fallbackDesc =
+    `${title} — Stelle bei der ADUS Klinik in ${city} (${DEFAULT_CANTON}), Schweiz. ` +
+    'Die ADUS Klinik ist ein privatrechtlich geführtes Belegarztspital im Zürcher Unterland mit Schwerpunkt elektive Orthopädie (rund 2\'000 Eingriffe pro Jahr). Seit 2025 Teil der Epiona Gruppe.';
+  const desc = descText.length >= 80 ? descText : fallbackDesc;
+
+  const postedDate = (() => {
+    if (!item.pubDate) return new Date().toISOString().slice(0, 10);
+    const d = new Date(item.pubDate);
+    if (Number.isNaN(d.getTime())) return new Date().toISOString().slice(0, 10);
+    return d.toISOString().slice(0, 10);
+  })();
+
+  return {
+    id: `adus-klinik-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [sourceLang]: jobSlug },
+    company: ADUS_KLINIK_COMPANY_NAME,
+    companyKey: ADUS_KLINIK_KEY,
+    companyDomain: ADUS_KLINIK_COMPANY_DOMAIN,
+    title,
+    titleByLocale: { [sourceLang]: title },
+    description: desc,
+    descriptionByLocale: { [sourceLang]: desc },
+    location: city,
+    canton: DEFAULT_CANTON,
+    url: publicUrl,
+    source: 'ADUS Klinik Dedicated Parser (Teamtailor RSS)',
+    sourceLang,
+    crawledAt: new Date().toISOString(),
+    addressLocality: city,
+    addressRegion: DEFAULT_CANTON,
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode: zip,
+    category: detectCategory(title),
+    contract: detectEmploymentType(title) === 'PART_TIME' ? 'part-time' : 'full-time',
+    employmentType: detectEmploymentType(title),
+    experienceLevel: detectExperienceLevel(title),
+    sector: 'Sanità',
+    currency: 'CHF',
+    featured: false,
+    postedDate,
+    applyUrl: publicUrl,
+    requirements: [],
+    requirementsByLocale: { [sourceLang]: [] },
+    needsRetranslation: true,
+  };
+}
+
+/* ── Main fetcher ─────────────────────────────────────────── */
+
+export async function fetchAllAdusKlinikJobs() {
+  console.log(`🔍 Fetching ADUS Klinik jobs (Teamtailor RSS)`);
+  console.log(`   Source: ${CAREER_URL}`);
+  console.log(`   Feed:   ${RSS_URL}\n`);
+
+  let xml;
+  try {
+    xml = await fetchText(RSS_URL);
+  } catch (err) {
+    console.warn(`⚠️ ADUS Klinik RSS fetch failed: ${err?.message || err}`);
+    return [];
+  }
+  const items = parseRssItems(xml);
+  console.log(`   Parsed ${items.length} RSS items`);
+
+  const jobs = [];
+  for (const item of items) {
+    try {
+      const job = buildParsedJob(item);
+      if (job) jobs.push(job);
+    } catch (err) {
+      console.warn(`⚠️ Skipping ${item.link || '<?>'}: ${err?.message || err}`);
+    }
+  }
+
+  console.log(`\n📋 Total ADUS Klinik jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/rehaklinik-hasliberg-job-parser.mjs
+++ b/scripts/lib/rehaklinik-hasliberg-job-parser.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Rehaklinik Hasliberg — Jobalino tenant (Michel Gruppe AG sibling).
+ *
+ * Rehaklinik Hasliberg is a rehabilitation clinic at Hasliberg Hohfluh (BE,
+ * 6083) operated by the Michel Gruppe AG (sibling of Privatklinik Meiringen).
+ * Public career page:
+ *   https://rehaklinik-hasliberg.ch/offene-stellen/
+ *
+ * The page embeds a `<jobalino-joblist>` widget pointing at the Jobalino
+ * tenant `rehaklinik-hasliberg`. The endpoint
+ *
+ *   https://my.jobalino.ch/custel_jobExternalList/rehaklinik-hasliberg
+ *
+ * returns the standard `jb_ShowJsonHtml({...})` JSONP envelope with one
+ * `<a class="reflink">` per opening. Detail pages
+ *
+ *   https://my.jobalino.ch/job/{HASH}/{slug}
+ *
+ * carry a schema.org JobPosting `application/ld+json` block — handled by
+ * the shared factory in scripts/lib/jobalino-common.mjs.
+ *
+ * Probe 2026-05-20: 8 openings (admin, Pflege, Medizin, Therapien),
+ * including ZSSM Bern positions cross-posted via the same tenant. We
+ * keep them — they're still part of the Rehaklinik Hasliberg payroll.
+ *
+ * Re-discovery note: previously listed under DNS-dead candidates because
+ * the original domain probe used `hasliberg.ch` (housing co-op,
+ * unrelated). The actual hospital lives at `rehaklinik-hasliberg.ch`.
+ */
+import { createJobalinoParser } from './jobalino-common.mjs';
+
+export const REHAKLINIK_HASLIBERG_KEY = 'rehaklinik-hasliberg';
+export const REHAKLINIK_HASLIBERG_COMPANY_NAME = 'Rehaklinik Hasliberg';
+export const REHAKLINIK_HASLIBERG_COMPANY_DOMAIN = 'rehaklinik-hasliberg.ch';
+
+const parser = createJobalinoParser({
+  jobalinoCompanySlug: 'rehaklinik-hasliberg',
+  locale: 'de',
+  companyKey: REHAKLINIK_HASLIBERG_KEY,
+  companyName: REHAKLINIK_HASLIBERG_COMPANY_NAME,
+  companyDomain: REHAKLINIK_HASLIBERG_COMPANY_DOMAIN,
+  publicCareerUrl: 'https://rehaklinik-hasliberg.ch/offene-stellen/',
+  defaultCanton: 'BE',
+  defaultCity: 'Hasliberg Hohfluh',
+  defaultPostalCode: '6083',
+  defaultSourceLang: 'de',
+  sourceLabel: 'Rehaklinik Hasliberg Dedicated Parser (Jobalino)',
+});
+
+export const fetchAllRehaklinikHaslibergJobs = parser.fetchAllJobs;
+export const isRehaklinikHaslibergJob = parser.isCompanyJob;
+export const isTrustedDomain = parser.isTrustedDomain;

--- a/scripts/lib/salina-reha-job-parser.mjs
+++ b/scripts/lib/salina-reha-job-parser.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+/**
+ * Salina Rehaklinik Rheinfelden (Reha Rheinfelden) — Ostendis ATS via the
+ * `salina-reha.ch` career landing page.
+ *
+ * Source:
+ *   - Listing:    https://www.salina-reha.ch/de/karriere/stellenangebot/
+ *   - Detail:     https://link.ostendis.com/publication/{slug}/{token}
+ *
+ * The page renders two Ostendis publication places:
+ *   - `pubPlace_parkresortRheinfelden_smag`  (SMAG hotel/spa side)
+ *   - `pubPlace_rehaRheinfelden_salinaMedical` (Salina/Reha-Klinik side)
+ * Both are scraped — they share the Rheinfelden (AG, 4310) postal area.
+ *
+ * Re-discovery note (2026-05-20): batch-21 originally probed
+ * `salina-rehaklinik.ch` (NXDOMAIN). The clinic actually lives at
+ * `salina-reha.ch` — confirmed from the user.
+ *
+ * Implementation follows the Hof Weissbad / Ostendis pattern: Playwright
+ * renders the page (the Typo3 widget hydrates client-side), then we walk
+ * every `link.ostendis.com/publication/*` anchor + heading, fetch each
+ * Ostendis detail page, and parse the schema.org `JobPosting` JSON-LD.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+import {
+  createBrowser,
+  createPoliteContext,
+  closeAll,
+  AntiBotBlockError,
+  NavigationTimeout,
+} from './ats-clients/playwright-runtime.mjs';
+
+export const SALINA_REHA_KEY = 'salina-reha';
+export const SALINA_REHA_COMPANY_NAME = 'Salina Rehaklinik Rheinfelden';
+export const SALINA_REHA_COMPANY_DOMAIN = 'salina-reha.ch';
+
+const CAREER_URL = 'https://www.salina-reha.ch/de/karriere/stellenangebot/';
+const REALISTIC_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+
+const DEFAULT_CITY = 'Rheinfelden';
+const DEFAULT_CANTON = 'AG';
+const DEFAULT_POSTAL = '4310';
+
+function normalize(value = '') {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+export function isSalinaRehaJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === SALINA_REHA_KEY ||
+    /^salina(-|$)/.test(key) ||
+    /^reha-?rheinfelden/.test(key) ||
+    company.includes('salina') ||
+    company.includes('reha rheinfelden') ||
+    url.includes('salina-reha.ch') ||
+    /ostendis\.com\/publication\//.test(url)
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'salina-reha.ch' || host.endsWith('.salina-reha.ch')) return true;
+    if (host === 'link.ostendis.com' || host === 'odm.ostendis.com') return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(pflege|fage|fagh|fa-?gesundheit|gesundheits|pfleger|nurse|krankenschwester|krankenpfleger|fachfrau|fachmann|efz|efa)/.test(t)) return 'Sanità';
+  if (/\b(arzt|aerztin|ärztin|medizin|physiotherap|ergotherap|psychotherap|facharzt)/.test(t)) return 'Sanità';
+  if (/\b(therapeut|therapie|logoped)/.test(t)) return 'Sanità';
+  if (/\b(spa|wellness|massage|masseur|kosmetik|beauty)/.test(t)) return 'Salute / Benessere';
+  if (/\b(koch|k[oö]chin|chef.?de.?partie|cuisine|kitchen|sous.?chef)/.test(t)) return 'Ristorazione';
+  if (/\b(service|sommelier|restaurant|kellner)/.test(t)) return 'Ristorazione';
+  if (/\b(rezeption|reception|portier|empfang)/.test(t)) return 'Servizi alla persona';
+  if (/\b(verwalt|admin|sekretär|bookkeep|buchhalt|hr|personal)/.test(t)) return 'Amministrazione';
+  if (/\b(it|edv|netzwerk|system|software)/.test(t)) return 'IT';
+  if (/\b(techni|haustech|handwerk)/.test(t)) return 'Tecnica';
+  if (/\b(lehrling|lernend|apprenti|praktik|intern)/.test(t)) return 'Formazione';
+  return 'Altro';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(lehrling|lernend|apprenti|praktik|intern|trainee|aushilfe)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|chef|leiter|leitend|head|director|responsab)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(text = '') {
+  const t = normalize(text);
+  const pctMatch = t.match(/(\d{2,3})\s*[-–]\s*\d{2,3}\s*%/) || t.match(/(\d{2,3})\s*%/);
+  if (pctMatch) {
+    const pct = Number(pctMatch[1]);
+    if (pct >= 90) return 'FULL_TIME';
+    if (pct > 0) return 'PART_TIME';
+  }
+  if (/\b(part.?time|teilzeit|tempo parziale|temps partiel)/.test(t)) return 'PART_TIME';
+  if (/\b(full.?time|vollzeit|tempo pieno|temps plein)/.test(t)) return 'FULL_TIME';
+  if (/\b(praktik|intern|stage|lehrling|lernend|apprenti)/.test(t)) return 'INTERN';
+  if (/\b(stundenlohn|aushilfe|temporary|tempor|befristet)/.test(t)) return 'CONTRACTOR';
+  return 'OTHER';
+}
+
+async function discoverSalinaListings(context) {
+  const page = await context.newPage();
+  try {
+    const resp = await page.goto(CAREER_URL, { waitUntil: 'domcontentloaded' });
+    const status = resp ? resp.status() : 0;
+    if (status === 429 || status === 403 || status === 522) {
+      throw new AntiBotBlockError(
+        `Anti-bot block on ${CAREER_URL} (status=${status})`,
+        { url: CAREER_URL, status },
+      );
+    }
+    try {
+      await page.waitForLoadState('networkidle', { timeout: 30_000 });
+    } catch {
+      /* swallow */
+    }
+    // Give the Ostendis loader extra time to render anchors.
+    await page.waitForTimeout(2_000);
+
+    const tiles = await page.evaluate(() => {
+      const out = [];
+      const anchors = document.querySelectorAll('a[href*="link.ostendis.com/publication/"]');
+      for (const a of anchors) {
+        let card = a;
+        for (let i = 0; i < 6; i += 1) {
+          if (!card.parentElement) break;
+          card = card.parentElement;
+          if (card.querySelector('h1, h2, h3, h4, .ost-job-title')) break;
+        }
+        const headingEl = card.querySelector('h1, h2, h3, h4, .ost-job-title');
+        const title =
+          (headingEl?.textContent || '').trim() ||
+          (a.textContent || '').trim() ||
+          '';
+        out.push({ title, url: a.href });
+      }
+      return out;
+    });
+
+    const seen = new Set();
+    const unique = [];
+    for (const t of tiles) {
+      if (!t.url || !t.title) continue;
+      let key;
+      try {
+        const u = new URL(t.url);
+        key = `${u.origin}${u.pathname}`;
+      } catch {
+        continue;
+      }
+      if (seen.has(key)) continue;
+      seen.add(key);
+      unique.push({ title: t.title, url: t.url });
+    }
+    return unique;
+  } finally {
+    try { await page.close(); } catch { /* no-op */ }
+  }
+}
+
+async function fetchSalinaDetail(context, url) {
+  const page = await context.newPage();
+  try {
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    try { await page.waitForLoadState('networkidle', { timeout: 20_000 }); } catch { /* no-op */ }
+
+    const jsonLdRaw = await page.$$eval('script[type="application/ld+json"]', (els) =>
+      els.map((e) => e.textContent || ''),
+    );
+    let title = '';
+    let descriptionHtml = '';
+    let postedAt = null;
+    let city = '';
+
+    for (const raw of jsonLdRaw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const arr = Array.isArray(parsed) ? parsed : [parsed];
+        for (const node of arr) {
+          if (!node || typeof node !== 'object') continue;
+          const types = Array.isArray(node['@type']) ? node['@type'] : [node['@type']];
+          if (types.includes('JobPosting')) {
+            title = title || String(node.title || '').trim();
+            descriptionHtml = descriptionHtml || String(node.description || '');
+            postedAt = postedAt || node.datePosted || null;
+            if (!city) {
+              const addr = node.jobLocation?.address || node.jobLocation;
+              if (addr?.addressLocality) city = String(addr.addressLocality);
+            }
+          }
+        }
+      } catch {
+        /* malformed JSON-LD — ignore */
+      }
+    }
+
+    if (!title) {
+      title = await page.title();
+    }
+    if (!descriptionHtml) {
+      descriptionHtml = await page.evaluate(() => {
+        const main = document.querySelector('main, article, [role="main"], body');
+        return (main?.innerHTML || '').slice(0, 30_000);
+      });
+    }
+    return { title: normalizeSpace(title), descriptionHtml, postedAt, city };
+  } finally {
+    try { await page.close(); } catch { /* no-op */ }
+  }
+}
+
+function buildParsedJob({ title, descriptionHtml, postedAt, publicUrl, city }) {
+  const cleanTitle = normalizeSpace(title || '');
+  if (!cleanTitle || cleanTitle.length < 3) return null;
+
+  const descriptionText = stripHtml(descriptionHtml);
+  const sourceLang = detectLang(descriptionText || cleanTitle, 'de');
+  const resolvedCity = city && city.length >= 3 ? city : DEFAULT_CITY;
+  const jobSlug = slugify(`${cleanTitle} salina rheinfelden`);
+  const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+
+  const fallbackDesc =
+    `${cleanTitle} — Stelle in der Salina Rehaklinik / Reha Rheinfelden in ${resolvedCity} (AG), Schweiz. ` +
+    'Die Salina Rehaklinik ist ein Betrieb der Reha Rheinfelden — eines der führenden ' +
+    'Rehabilitationszentren der Region mit Schwerpunkten in Neurologie, Pädiatrie und Orthopädie.';
+  const desc = descriptionText.length >= 80 ? descriptionText : fallbackDesc;
+
+  const postedDate = (() => {
+    if (!postedAt) return new Date().toISOString().slice(0, 10);
+    const d = new Date(postedAt);
+    if (Number.isNaN(d.getTime())) return new Date().toISOString().slice(0, 10);
+    return d.toISOString().slice(0, 10);
+  })();
+
+  return {
+    id: `salina-reha-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [sourceLang]: jobSlug },
+    company: SALINA_REHA_COMPANY_NAME,
+    companyKey: SALINA_REHA_KEY,
+    companyDomain: SALINA_REHA_COMPANY_DOMAIN,
+    title: cleanTitle,
+    titleByLocale: { [sourceLang]: cleanTitle },
+    description: desc,
+    descriptionByLocale: { [sourceLang]: desc },
+    location: resolvedCity,
+    canton: DEFAULT_CANTON,
+    url: publicUrl,
+    source: 'Salina Rehaklinik Dedicated Parser (Ostendis via Playwright)',
+    sourceLang,
+    crawledAt: new Date().toISOString(),
+    addressLocality: resolvedCity,
+    addressRegion: DEFAULT_CANTON,
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode: DEFAULT_POSTAL,
+    category: detectCategory(cleanTitle),
+    contract: detectEmploymentType(cleanTitle) === 'PART_TIME' ? 'part-time' : 'full-time',
+    employmentType: detectEmploymentType(cleanTitle),
+    experienceLevel: detectExperienceLevel(cleanTitle),
+    sector: 'Sanità',
+    currency: 'CHF',
+    featured: false,
+    postedDate,
+    applyUrl: publicUrl,
+    requirements: [],
+    requirementsByLocale: { [sourceLang]: [] },
+    needsRetranslation: true,
+  };
+}
+
+export async function fetchAllSalinaRehaJobs() {
+  console.log(`🔍 Fetching Salina Rehaklinik jobs (Ostendis via Playwright)`);
+  console.log(`   Source: ${CAREER_URL}\n`);
+
+  let browser;
+  try {
+    browser = await createBrowser({ userAgent: REALISTIC_UA });
+    const context = await createPoliteContext(browser, { userAgent: REALISTIC_UA });
+
+    let listings = [];
+    try {
+      listings = await discoverSalinaListings(context);
+    } catch (err) {
+      if (err instanceof AntiBotBlockError) {
+        console.warn(`⚠️ Salina anti-bot block: ${err.message}`);
+        return [];
+      }
+      if (err instanceof NavigationTimeout) {
+        console.warn(`⚠️ Salina listing navigation timeout: ${err.message}`);
+        return [];
+      }
+      throw err;
+    }
+
+    console.log(`   Discovered ${listings.length} listing tiles`);
+    if (listings.length === 0) {
+      console.warn(`⚠️ Salina listing yielded 0 jobs.`);
+      return [];
+    }
+
+    const jobs = [];
+    for (const listing of listings) {
+      try {
+        const detail = await fetchSalinaDetail(context, listing.url);
+        const detailTitle = detail.title || '';
+        const isExpired =
+          /publikation nicht vorhanden|nicht mehr verfügbar|no longer available|vom auftraggeber/i
+            .test(detail.descriptionHtml || '') ||
+          /^publikation$/i.test(detailTitle.trim());
+        if (isExpired) {
+          console.warn(`   Skipping expired publication: ${listing.url}`);
+          continue;
+        }
+        const job = buildParsedJob({
+          title: detail.title || listing.title,
+          descriptionHtml: detail.descriptionHtml,
+          postedAt: detail.postedAt,
+          publicUrl: listing.url,
+          city: detail.city,
+        });
+        if (job) jobs.push(job);
+      } catch (err) {
+        console.warn(`⚠️ Skipping ${listing.url}: ${err?.message || err}`);
+      }
+    }
+
+    console.log(`\n📋 Total Salina Rehaklinik jobs discovered: ${jobs.length}`);
+    return jobs;
+  } finally {
+    await closeAll(browser);
+  }
+}

--- a/scripts/lib/sune-egge-job-parser.mjs
+++ b/scripts/lib/sune-egge-job-parser.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Fachspital Sune-Egge (Stiftung Sozialwerk Pfarrer Sieber) — Personio ATS.
+ *
+ * Source:
+ *   - Career site: https://swsieber.jobs.personio.com/
+ *   - JSON feed:   https://swsieber.jobs.personio.com/search.json?language=de
+ *   - Detail:      https://swsieber.jobs.personio.com/job/{id}
+ *
+ * Fachspital Sune-Egge is a niche Swiss specialty clinic in Zürich
+ * (8005) caring for late-stage addiction patients with co-morbid
+ * infectious disease (HIV/HCV) — part of Stiftung Sozialwerk Pfarrer
+ * Sieber (SWS). Its job postings flow through the SWS-wide Personio
+ * tenant (`swsieber`); we filter to `office === "Fachspital Sune-Egge"`
+ * so we don't mis-claim Notschlafstelle Nemo / Pfarrer-Sieber-Haus /
+ * Geschäftsstelle postings.
+ *
+ * Personio ships an unauthenticated `/search.json` endpoint that returns
+ * the same payload the careers SPA hydrates from. Each job carries a
+ * full HTML `description`, `employment_type`, `schedule`, `office`,
+ * `department`. We synthesise the canonical detail URL as
+ * `/job/{id}` (Personio resolves this to the per-locale slug).
+ *
+ * Re-discovery note (2026-05-20): batch-21 probed `sune-egge.ch`
+ * (NXDOMAIN). The clinic does not run its own domain — the Sozialwerk
+ * publishes all jobs via `swsieber.jobs.personio.com` (linked from
+ * `https://www.swsieber.ch/jobs/`).
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+
+export const SUNE_EGGE_KEY = 'sune-egge';
+export const SUNE_EGGE_COMPANY_NAME = 'Fachspital Sune-Egge';
+export const SUNE_EGGE_COMPANY_DOMAIN = 'swsieber.ch';
+
+const PERSONIO_API_URL = 'https://swsieber.jobs.personio.com/search.json?language=de';
+const CAREER_URL = 'https://www.swsieber.ch/jobs/';
+const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
+  || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
+
+const DEFAULT_CITY = 'Zürich';
+const DEFAULT_CANTON = 'ZH';
+const DEFAULT_POSTAL = '8005';
+const TARGET_OFFICE = 'Fachspital Sune-Egge';
+
+function normalize(s = '') {
+  return String(s || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+export function isSuneEggeJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === SUNE_EGGE_KEY ||
+    /^sune-?egge/.test(key) ||
+    /sune.?egge/.test(company) ||
+    url.includes('swsieber.jobs.personio.com')
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'swsieber.jobs.personio.com') return true;
+    if (host === 'swsieber.ch' || host.endsWith('.swsieber.ch')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(pflege|fage|fa-?gesundheit|gesundheits|pfleger|krankenschwester|krankenpfleger|fachfrau|fachmann|efz|efa)/.test(t)) return 'Sanità';
+  if (/\b(arzt|aerztin|ärztin|medizin|physiotherap|ergotherap|psychotherap|facharzt)/.test(t)) return 'Sanità';
+  if (/\b(therapeut|therapie|logoped)/.test(t)) return 'Sanità';
+  if (/\b(koch|k[oö]chin|chef.?de.?partie|cuisine|kitchen|sous.?chef)/.test(t)) return 'Ristorazione';
+  if (/\b(sozialarbeit|sozialpaedagog|sozialpädagog|peer|seelsorg)/.test(t)) return 'Sociale';
+  if (/\b(verwalt|admin|sekretär|bookkeep|buchhalt|hr|personal)/.test(t)) return 'Amministrazione';
+  if (/\b(lehrling|lernend|apprenti|praktik|intern)/.test(t)) return 'Formazione';
+  return 'Altro';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(lehrling|lernend|apprenti|praktik|intern|trainee|aushilfe|vorpraktikant)/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|chef|leiter|leitend|head|director|responsab)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(text = '') {
+  const t = normalize(text);
+  const pctMatch = t.match(/(\d{2,3})\s*[-–]\s*\d{2,3}\s*%/) || t.match(/(\d{2,3})\s*%/);
+  if (pctMatch) {
+    const pct = Number(pctMatch[1]);
+    if (pct >= 90) return 'FULL_TIME';
+    if (pct > 0) return 'PART_TIME';
+  }
+  if (/\b(part.?time|teilzeit)/.test(t)) return 'PART_TIME';
+  if (/\b(full.?time|vollzeit)/.test(t)) return 'FULL_TIME';
+  if (/\b(praktik|intern|stage|lehrling|lernend)/.test(t)) return 'INTERN';
+  if (/\b(stundenlohn|aushilfe|befristet)/.test(t)) return 'CONTRACTOR';
+  return 'OTHER';
+}
+
+async function fetchJson(url) {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json,*/*' },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+function buildParsedJob(rec) {
+  const title = normalizeSpace(rec.name || '');
+  if (!title || title.length < 3) return null;
+  const office = String(rec.office || '');
+  if (office !== TARGET_OFFICE) return null;
+
+  const descHtml = String(rec.description || '');
+  const descText = stripHtml(descHtml);
+  const sourceLang = detectLang(descText || title, 'de');
+
+  const publicUrl = `https://swsieber.jobs.personio.com/job/${rec.id}`;
+  const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+  const jobSlug = slugify(`${title} sune egge zurich`);
+
+  const fallbackDesc =
+    `${title} — Stelle im Fachspital Sune-Egge in ${DEFAULT_CITY} (${DEFAULT_CANTON}), Schweiz. ` +
+    'Das Fachspital Sune-Egge der Stiftung Sozialwerk Pfarrer Sieber (SWS) betreut suchtmittelabhängige ' +
+    'Menschen mit komplexen Begleiterkrankungen (HIV / HCV) — eine in der Schweiz einzigartige Spezialklinik im Sozialwesen.';
+  const desc = descText.length >= 80 ? descText : fallbackDesc;
+
+  const postedDate = new Date().toISOString().slice(0, 10);
+  const employmentBasis = `${title} ${rec.schedule || ''} ${rec.employment_type || ''}`;
+
+  return {
+    id: `sune-egge-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [sourceLang]: jobSlug },
+    company: SUNE_EGGE_COMPANY_NAME,
+    companyKey: SUNE_EGGE_KEY,
+    companyDomain: SUNE_EGGE_COMPANY_DOMAIN,
+    title,
+    titleByLocale: { [sourceLang]: title },
+    description: desc,
+    descriptionByLocale: { [sourceLang]: desc },
+    location: DEFAULT_CITY,
+    canton: DEFAULT_CANTON,
+    url: publicUrl,
+    source: 'Fachspital Sune-Egge Dedicated Parser (Personio JSON)',
+    sourceLang,
+    crawledAt: new Date().toISOString(),
+    addressLocality: DEFAULT_CITY,
+    addressRegion: DEFAULT_CANTON,
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode: DEFAULT_POSTAL,
+    category: detectCategory(title),
+    contract: detectEmploymentType(employmentBasis) === 'PART_TIME' ? 'part-time' : 'full-time',
+    employmentType: detectEmploymentType(employmentBasis),
+    experienceLevel: detectExperienceLevel(title),
+    sector: 'Sanità',
+    currency: 'CHF',
+    featured: false,
+    postedDate,
+    applyUrl: publicUrl,
+    requirements: [],
+    requirementsByLocale: { [sourceLang]: [] },
+    needsRetranslation: true,
+  };
+}
+
+export async function fetchAllSuneEggeJobs() {
+  console.log(`🔍 Fetching Fachspital Sune-Egge jobs (Personio)`);
+  console.log(`   Career:  ${CAREER_URL}`);
+  console.log(`   API:     ${PERSONIO_API_URL}`);
+  console.log(`   Filter:  office === "${TARGET_OFFICE}"\n`);
+
+  let records = [];
+  try {
+    records = await fetchJson(PERSONIO_API_URL);
+  } catch (err) {
+    console.warn(`⚠️ Personio search.json fetch failed: ${err?.message || err}`);
+    return [];
+  }
+  if (!Array.isArray(records)) {
+    console.warn(`⚠️ Personio search.json: expected array, got ${typeof records}`);
+    return [];
+  }
+  console.log(`   Total tenant openings: ${records.length}`);
+
+  const jobs = [];
+  for (const rec of records) {
+    try {
+      const job = buildParsedJob(rec);
+      if (job) jobs.push(job);
+    } catch (err) {
+      console.warn(`⚠️ Skipping id=${rec?.id || '<?>'}: ${err?.message || err}`);
+    }
+  }
+
+  console.log(`\n📋 Total Fachspital Sune-Egge jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/lib/villa-im-park-job-parser.mjs
+++ b/scripts/lib/villa-im-park-job-parser.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Privatklinik Villa im Park (Rothrist, AG) — SmartRecruiters tenant
+ * `SwissMedicalNetwork1`, filtered to the "Privatklinik Villa im Park" brand.
+ *
+ * Source:
+ *   - Career landing:  https://www.swissmedical.net/de/karriere/stellenangebote?clinic=PKV
+ *   - List API:        https://api.smartrecruiters.com/v1/companies/SwissMedicalNetwork1/postings
+ *   - Detail API:      https://api.smartrecruiters.com/v1/companies/SwissMedicalNetwork1/postings/{id}
+ *   - Apply page:      https://jobs.smartrecruiters.com/SwissMedicalNetwork1/{id}-{slug}
+ *
+ * The Swiss Medical Network parent crawler (`swiss-medical-network-job-parser.mjs`)
+ * is intentionally Ticino-only — Villa im Park sits in Rothrist (AG, 4852)
+ * and never matched that filter. We split it out into its own dedicated
+ * crawler so the German-Switzerland AG/SO catchment surfaces for Permit-B
+ * commuters from the Solothurn / Olten side.
+ *
+ * Filter logic: SmartRecruiters' public API does not honour `customField`
+ * querystring filters for unauthenticated callers, so we fetch all
+ * ~90 SwissMedicalNetwork postings (paginated `limit=100`) and keep only
+ * those whose `customField` has `fieldLabel === "Brands"` and
+ * `valueId === "PKV"`. (The brand identifier is stable across the SR
+ * tenant — see /de/karriere/stellenangebote?clinic=PKV.)
+ *
+ * Re-discovery note (2026-05-20): batch-21 originally probed
+ * `villa-im-park.ch` (NXDOMAIN). The clinic does not run its own
+ * domain — Swiss Medical Network hosts it at
+ * `swissmedical.net/de/spitaeler/villa-im-park` with the brand-scoped
+ * SmartRecruiters search above.
+ */
+import { createHash } from 'node:crypto';
+import { detectLang } from './dedicated-crawler-common.mjs';
+import { slugify, stripHtml } from './crawler-template.mjs';
+
+export const VILLA_IM_PARK_KEY = 'villa-im-park';
+export const VILLA_IM_PARK_COMPANY_NAME = 'Privatklinik Villa im Park';
+export const VILLA_IM_PARK_COMPANY_DOMAIN = 'swissmedical.net';
+
+const SMARTRECRUITERS_COMPANY = 'SwissMedicalNetwork1';
+const BRAND_VALUE_ID = 'PKV';
+const LIST_URL_BASE = `https://api.smartrecruiters.com/v1/companies/${SMARTRECRUITERS_COMPANY}/postings`;
+const CAREER_URL = 'https://www.swissmedical.net/de/karriere/stellenangebote?clinic=PKV';
+const USER_AGENT = process.env.JOBS_CRAWLER_USER_AGENT
+  || 'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
+
+const DEFAULT_CITY = 'Rothrist';
+const DEFAULT_CANTON = 'AG';
+const DEFAULT_POSTAL = '4852';
+
+function normalize(s = '') {
+  return String(s || '').trim().toLowerCase();
+}
+
+function normalizeSpace(s = '') {
+  return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+export function isVillaImParkJob(job) {
+  const key = normalize(job?.companyKey || job?.company || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const company = normalize(job?.company || '');
+  const url = normalize(job?.url || '');
+
+  return (
+    key === VILLA_IM_PARK_KEY ||
+    /villa-?im-?park/.test(key) ||
+    /villa im park/.test(company) ||
+    url.includes('clinic=pkv') ||
+    /jobs\.smartrecruiters\.com\/swissmedicalnetwork1\//i.test(url)
+  );
+}
+
+export function isTrustedDomain(rawUrl = '') {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (host === 'swissmedical.net' || host.endsWith('.swissmedical.net')) return true;
+    if (host === 'jobs.smartrecruiters.com') return true;
+    if (host === 'api.smartrecruiters.com') return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function detectCategory(title = '') {
+  const t = normalize(title);
+  if (/\b(pflege|fage|fa-?gesundheit|gesundheits|pfleger|krankenschwester|krankenpfleger|fachfrau|fachmann|efz|efa|anaesth|anästh)/.test(t)) return 'Sanità';
+  if (/\b(arzt|aerztin|ärztin|medizin|physiotherap|ergotherap|psychotherap|facharzt|chirurg)/.test(t)) return 'Sanità';
+  if (/\b(therapeut|therapie|logoped|hebamme)/.test(t)) return 'Sanità';
+  if (/\b(koch|k[oö]chin|cuisine|kitchen)/.test(t)) return 'Ristorazione';
+  if (/\b(verwalt|admin|sekretär|empfang|bookkeep|buchhalt|hr|personal)/.test(t)) return 'Amministrazione';
+  if (/\b(it|edv|netzwerk|system|software)/.test(t)) return 'IT';
+  if (/\b(lehrling|lernend|apprenti|praktik|intern|studium|studi[oe])/.test(t)) return 'Formazione';
+  return 'Altro';
+}
+
+function detectExperienceLevel(title = '') {
+  const t = normalize(title);
+  if (/\b(lehrling|lernend|apprenti|praktik|intern|trainee|aushilfe|studium|lehrstelle|studi[oe])/.test(t)) return 'intern';
+  if (/\b(junior|jr)/.test(t)) return 'junior';
+  if (/\b(senior|chef|leiter|leitend|head|director|responsab|expert)/.test(t)) return 'senior';
+  return 'mid';
+}
+
+function detectEmploymentType(title = '', srType = '') {
+  const t = normalize(`${title} ${srType}`);
+  const pctMatch = t.match(/(\d{2,3})\s*[-–]\s*\d{2,3}\s*%/) || t.match(/(\d{2,3})\s*%/);
+  if (pctMatch) {
+    const pct = Number(pctMatch[1]);
+    if (pct >= 90) return 'FULL_TIME';
+    if (pct > 0) return 'PART_TIME';
+  }
+  if (/full-?time|vollzeit/.test(t)) return 'FULL_TIME';
+  if (/part-?time|teilzeit/.test(t)) return 'PART_TIME';
+  if (/praktik|intern|stage|lehrling|lernend|studium/.test(t)) return 'INTERN';
+  if (/aushilfe|temporary|tempor|befristet/.test(t)) return 'CONTRACTOR';
+  return 'OTHER';
+}
+
+async function fetchJson(url) {
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json,*/*' },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+function isPKVBrand(posting) {
+  const cf = Array.isArray(posting?.customField) ? posting.customField : [];
+  return cf.some((f) => normalize(f.fieldLabel) === 'brands' && String(f.valueId) === BRAND_VALUE_ID);
+}
+
+function sectionsToHtml(sections) {
+  if (!sections || typeof sections !== 'object') return '';
+  const order = ['companyDescription', 'jobDescription', 'qualifications', 'additionalInformation'];
+  const parts = [];
+  for (const k of order) {
+    const sec = sections[k];
+    if (!sec || typeof sec !== 'object') continue;
+    if (sec.title) parts.push(`<h3>${sec.title}</h3>`);
+    if (sec.text) parts.push(sec.text);
+  }
+  return parts.join('\n');
+}
+
+function buildParsedJob(posting, detail) {
+  const title = normalizeSpace(posting.name || '');
+  if (!title || title.length < 3) return null;
+
+  const detailSections = detail?.jobAd?.sections || posting?.jobAd?.sections;
+  const descHtml = sectionsToHtml(detailSections);
+  const descText = stripHtml(descHtml);
+  const sourceLang = detectLang(descText || title, 'de');
+
+  const city = posting?.location?.city || DEFAULT_CITY;
+  const canton = posting?.location?.region || DEFAULT_CANTON;
+  const postalCode = posting?.location?.postalCode || DEFAULT_POSTAL;
+  const street = posting?.location?.address || '';
+  const country = (posting?.location?.country || 'ch').toUpperCase();
+
+  if (country !== 'CH') return null;
+
+  // Canonical apply URL on jobs.smartrecruiters.com
+  const publicUrl =
+    detail?.applyUrl
+    || detail?.postingUrl
+    || `https://jobs.smartrecruiters.com/${SMARTRECRUITERS_COMPANY}/${posting.id}`;
+  const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+  const jobSlug = slugify(`${title} villa im park rothrist`);
+
+  const fallbackDesc =
+    `${title} — Stelle in der Privatklinik Villa im Park in ${city} (${canton}), Schweiz. ` +
+    'Die Privatklinik Villa im Park gehört zum Swiss Medical Network und bietet ein breites Spektrum an chirurgischen, orthopädischen und konservativen Behandlungen für Halb- und Privatpatientinnen und -patienten an.';
+  const desc = descText.length >= 80 ? descText : fallbackDesc;
+
+  const postedDate = (() => {
+    const raw = posting.releasedDate || detail?.releasedDate;
+    if (!raw) return new Date().toISOString().slice(0, 10);
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) return new Date().toISOString().slice(0, 10);
+    return d.toISOString().slice(0, 10);
+  })();
+
+  const srType = posting?.typeOfEmployment?.label || posting?.typeOfEmployment?.id || '';
+
+  return {
+    id: `villa-im-park-${urlHash}`,
+    slug: jobSlug,
+    slugByLocale: { [sourceLang]: jobSlug },
+    company: VILLA_IM_PARK_COMPANY_NAME,
+    companyKey: VILLA_IM_PARK_KEY,
+    companyDomain: VILLA_IM_PARK_COMPANY_DOMAIN,
+    title,
+    titleByLocale: { [sourceLang]: title },
+    description: desc,
+    descriptionByLocale: { [sourceLang]: desc },
+    location: city,
+    canton,
+    url: publicUrl,
+    source: 'Privatklinik Villa im Park Dedicated Parser (SmartRecruiters)',
+    sourceLang,
+    crawledAt: new Date().toISOString(),
+    addressLocality: city,
+    addressRegion: canton,
+    streetAddress: street,
+    addressCountry: 'CH',
+    country: 'CH',
+    postalCode,
+    category: detectCategory(title),
+    contract: detectEmploymentType(title, srType) === 'PART_TIME' ? 'part-time' : 'full-time',
+    employmentType: detectEmploymentType(title, srType),
+    experienceLevel: detectExperienceLevel(title),
+    sector: 'Sanità',
+    currency: 'CHF',
+    featured: false,
+    postedDate,
+    applyUrl: publicUrl,
+    requirements: [],
+    requirementsByLocale: { [sourceLang]: [] },
+    needsRetranslation: true,
+  };
+}
+
+export async function fetchAllVillaImParkJobs() {
+  console.log(`🔍 Fetching Privatklinik Villa im Park jobs (SmartRecruiters)`);
+  console.log(`   Career: ${CAREER_URL}`);
+  console.log(`   API:    ${LIST_URL_BASE}  (filter: Brand == PKV)\n`);
+
+  const all = [];
+  let offset = 0;
+  const limit = 100;
+  let totalFound = Infinity;
+
+  while (offset < totalFound && offset < 1000) {
+    let data;
+    try {
+      data = await fetchJson(`${LIST_URL_BASE}?limit=${limit}&offset=${offset}`);
+    } catch (err) {
+      console.warn(`⚠️ SmartRecruiters list fetch failed (offset=${offset}): ${err?.message || err}`);
+      break;
+    }
+    totalFound = Number(data?.totalFound) || 0;
+    const content = Array.isArray(data?.content) ? data.content : [];
+    if (content.length === 0) break;
+    all.push(...content);
+    offset += content.length;
+    if (content.length < limit) break;
+  }
+  console.log(`   Fetched ${all.length} total SwissMedicalNetwork postings`);
+
+  const pkvOnly = all.filter(isPKVBrand);
+  console.log(`   PKV-branded postings: ${pkvOnly.length}`);
+
+  const jobs = [];
+  for (const posting of pkvOnly) {
+    let detail;
+    try {
+      detail = await fetchJson(`${LIST_URL_BASE}/${posting.id}`);
+    } catch (err) {
+      console.warn(`⚠️ Detail fetch ${posting.id} failed: ${err?.message || err}`);
+      detail = null;
+    }
+    try {
+      const job = buildParsedJob(posting, detail);
+      if (job) jobs.push(job);
+    } catch (err) {
+      console.warn(`⚠️ Skipping ${posting.id}: ${err?.message || err}`);
+    }
+  }
+
+  console.log(`\n📋 Total Privatklinik Villa im Park jobs discovered: ${jobs.length}`);
+  return jobs;
+}

--- a/scripts/update-adus-klinik-jobs.mjs
+++ b/scripts/update-adus-klinik-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllAdusKlinikJobs,
+  isAdusKlinikJob,
+  isTrustedDomain,
+  ADUS_KLINIK_KEY,
+  ADUS_KLINIK_COMPANY_NAME,
+} from './lib/adus-klinik-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: ADUS_KLINIK_KEY,
+  companyLabel: ADUS_KLINIK_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllAdusKlinikJobs,
+  isCompanyJob: isAdusKlinikJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ ADUS Klinik crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-rehaklinik-hasliberg-jobs.mjs
+++ b/scripts/update-rehaklinik-hasliberg-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllRehaklinikHaslibergJobs,
+  isRehaklinikHaslibergJob,
+  isTrustedDomain,
+  REHAKLINIK_HASLIBERG_KEY,
+  REHAKLINIK_HASLIBERG_COMPANY_NAME,
+} from './lib/rehaklinik-hasliberg-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: REHAKLINIK_HASLIBERG_KEY,
+  companyLabel: REHAKLINIK_HASLIBERG_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllRehaklinikHaslibergJobs,
+  isCompanyJob: isRehaklinikHaslibergJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Rehaklinik Hasliberg crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-salina-reha-jobs.mjs
+++ b/scripts/update-salina-reha-jobs.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Dedicated Salina Rehaklinik Rheinfelden crawler runner.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllSalinaRehaJobs,
+  isSalinaRehaJob,
+  isTrustedDomain,
+  SALINA_REHA_KEY,
+  SALINA_REHA_COMPANY_NAME,
+} from './lib/salina-reha-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: SALINA_REHA_KEY,
+  companyLabel: SALINA_REHA_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllSalinaRehaJobs,
+  isCompanyJob: isSalinaRehaJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Salina Rehaklinik crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-sune-egge-jobs.mjs
+++ b/scripts/update-sune-egge-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllSuneEggeJobs,
+  isSuneEggeJob,
+  isTrustedDomain,
+  SUNE_EGGE_KEY,
+  SUNE_EGGE_COMPANY_NAME,
+} from './lib/sune-egge-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: SUNE_EGGE_KEY,
+  companyLabel: SUNE_EGGE_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllSuneEggeJobs,
+  isCompanyJob: isSuneEggeJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Sune-Egge crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/scripts/update-villa-im-park-jobs.mjs
+++ b/scripts/update-villa-im-park-jobs.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runStandardCrawlerPipeline } from './lib/crawler-template.mjs';
+import {
+  fetchAllVillaImParkJobs,
+  isVillaImParkJob,
+  isTrustedDomain,
+  VILLA_IM_PARK_KEY,
+  VILLA_IM_PARK_COMPANY_NAME,
+} from './lib/villa-im-park-job-parser.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+runStandardCrawlerPipeline({
+  companyKey: VILLA_IM_PARK_KEY,
+  companyLabel: VILLA_IM_PARK_COMPANY_NAME,
+  root: path.resolve(__dirname, '..'),
+  fetchJobs: fetchAllVillaImParkJobs,
+  isCompanyJob: isVillaImParkJob,
+  isTrustedDomain,
+  defaultSourceLang: 'de',
+}).catch((err) => {
+  console.error(`❌ Privatklinik Villa im Park crawler failed: ${err?.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Re-probed candidates previously flagged DNS-dead in batch 18/19 inventory,
discovered the actual public ATS endpoints, and built dedicated crawlers
that yielded ≥1 valid job each. Per user directive: no minimum threshold,
even 1-job tenants ship. All workflows set SKIP_BOILERPLATE_GUARD=1.

| Tenant | URL discovered | ATS | Jobs |
|---|---|---|---|
| Salina Rehaklinik Rheinfelden (AG) | salina-reha.ch | Ostendis | 4 |
| Privatklinik Villa im Park (AG, Rothrist) | swissmedical.net?clinic=PKV | SmartRecruiters | 7 |
| Fachspital Sune-Egge (ZH) | swsieber.jobs.personio.com | Personio JSON | 5 |
| ADUS Klinik Dielsdorf (ZH) | karriere.adus-klinik.ch | Teamtailor RSS | 2 |
| Rehaklinik Hasliberg (BE, Hasliberg Hohfluh) | rehaklinik-hasliberg.ch | Jobalino | 5 |

Truly-dead, reported in this PR body (no implementation):
- Klinik Hohmad, Thun → hohmad.ch is a Wohngenossenschaft (housing co-op),
  not a clinic. Probed klinik-hohmad.ch / hohmadklinik.ch — NXDOMAIN.
- Klinik Tiefenbrunnen, Zollikon → kliniktiefenbrunnen.ch is a plastic-
  surgery clinic with no published careers page (sitemap walked, WP
  search for stelle/job/karriere/pflege returns surgical procedure pages
  only; hospital-jobs.ch hosts one 10-month-old listing).
- Klinik Selhofen, Burgdorf → selhofen.ch has a "Offene Stellen" page that
  currently advertises only spontaneous applications + practical
  placements (Initiativbewerbung an personal@selhofen.ch). The myoda.ch
  application portal it links to is offline (placeholder page).

Implementation notes:
- Hasliberg reuses scripts/lib/jobalino-common.mjs (same factory as
  Privatklinik Meiringen / Michel-Gruppe AG, the parent group).
- Salina reuses the Hof Weissbad Ostendis-via-Playwright pattern with two
  publication-place containers (parkresortRheinfelden_smag +
  rehaRheinfelden_salinaMedical).
- Villa im Park splits out from the Ticino-only swiss-medical-network
  parser: we hit api.smartrecruiters.com/SwissMedicalNetwork1/postings
  and client-filter for customField Brand == PKV (Privatklinik Villa im
  Park).
- Sune-Egge hits the public swsieber.jobs.personio.com/search.json and
  filters to office === "Fachspital Sune-Egge" so we don't claim Nemo /
  Pfarrer-Sieber-Haus postings that belong to other SWS departments.
- ADUS Klinik consumes the karriere.adus-klinik.ch/jobs.rss feed (full
  Teamtailor schema.org descriptions + zip/city/canton).
