### PR TITLE
fix(jobs): unify SSG+SPA description parser, kill literal ** and stripe headings (S1-S10)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -12,6 +12,7 @@ import type { Plugin } from 'vite';
 import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, BUILD_ID, DARK_MODE_SCRIPT } from './constants';
 import { buildSimplePage } from './htmlTemplate';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { jobDescriptionTextToHtml } from './shared/jobDescription/toHtml';
 import { WriteCollector } from './batchWrite';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
 import { buildTitleWithBrand, truncateHeadline, TITLE_BRAND_SUFFIX, TITLE_MAX_CHARS } from './shared/titleSuffix';
@@ -1212,54 +1213,12 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  .replace(/&#x27;/g, "'")
  .replace(/&#(\d+);/g, (_m, code) => String.fromCharCode(Number(code)))
  .replace(/&[A-Za-z]+;/g, ' ');
- /** Convert a plain-text description to basic HTML.
- * Wraps paragraphs in <p>, converts bullet/numbered lines to <ul>/<ol><li>,
- * recognizes section headings (lines ending with ':' followed by list items),
- * and single newlines to <br>. */
- const plainTextToHtml = (text: string): string => {
- if (!text || /<(p|ul|li|h[1-6]|br|strong|em)\b/i.test(text)) return text;
- const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
- const blocks = normalized.split(/\n{2,}/);
- const htmlParts: string[] = [];
- for (const block of blocks) {
- const trimmed = block.trim();
- if (!trimmed) continue;
- const lines = trimmed.split('\n');
- // Check if this block is a bullet list (all lines start with - or • or *)
- const isBulletList = lines.length > 1 && lines.every((l) => /^\s*[-•*]\s/.test(l));
- // Check if this block is a numbered list (all lines start with digit.)
- const isNumberedList = lines.length > 1 && lines.every((l) => /^\s*\d+[.)]\s/.test(l));
- // Check if this block has a heading line followed by list items
- const hasHeadingWithList = lines.length > 2
- && /[:\u2013\u2014]$/.test(lines[0].trim())
- && lines.slice(1).every((l) => /^\s*[-•*\d]/.test(l));
-
- if (hasHeadingWithList) {
- const heading = lines[0].trim().replace(/[:\u2013\u2014]$/, '').trim();
- htmlParts.push(`<p><strong>${esc(heading)}</strong></p>`);
- const listLines = lines.slice(1);
- const isOl = listLines.every((l) => /^\s*\d+[.)]\s/.test(l));
- const tag = isOl ? 'ol' : 'ul';
- const items = listLines.map((l) => `<li>${esc(l.replace(/^\s*[-•*]\s+/, '').replace(/^\s*\d+[.)]\s+/, ''))}</li>`).join('');
- htmlParts.push(`<${tag}>${items}</${tag}>`);
- } else if (isBulletList) {
- const items = lines.map((l) => `<li>${esc(l.replace(/^\s*[-•*]\s+/, ''))}</li>`).join('');
- htmlParts.push(`<ul>${items}</ul>`);
- } else if (isNumberedList) {
- const items = lines.map((l) => `<li>${esc(l.replace(/^\s*\d+[.)]\s+/, ''))}</li>`).join('');
- htmlParts.push(`<ol>${items}</ol>`);
- } else if (lines.length === 1 && /[:\u2013\u2014]$/.test(trimmed)) {
- // Standalone heading-like line ending with colon
- const heading = trimmed.replace(/[:\u2013\u2014]$/, '').trim();
- htmlParts.push(`<p><strong>${esc(heading)}</strong></p>`);
- } else {
- // Single block — join internal newlines with <br>
- const inner = lines.map((l) => esc(l.trim())).filter(Boolean).join('<br>');
- if (inner) htmlParts.push(`<p>${inner}</p>`);
- }
- }
- return htmlParts.join('');
- };
+ /** Convert plain-text crawler descriptions to HTML via the shared parser
+ * (`build-plugins/shared/jobDescription/parser.ts`). Handles `**bold**` -->
+ * `<strong>`, drops empty bolds, strips separator lines (`______`), dedups
+ * paragraphs (S4), promotes section labels to `<h2>` (S5), and prevents
+ * prose-to-heading mis-promotion (S2). */
+ const plainTextToHtml = jobDescriptionTextToHtml;
  const normalizeText = (s: string) => String(s || '')
  .replace(/\r/g, '\n')
  .replace(/\t/g, ' ')

--- a/build-plugins/shared/jobDescription/parser.ts
+++ b/build-plugins/shared/jobDescription/parser.ts
@@ -1,0 +1,381 @@
+/**
+ * Shared job-description parser used by both the SSG build plugin
+ * (`build-plugins/jobsSeoPagesPlugin.ts`) and the React SPA renderer
+ * (`components/community/JobBoard.tsx`).
+ *
+ * Crawler/AI-translated descriptions arrive with unbalanced `**` markers,
+ * collapsed newlines, separator-only lines, and consecutive duplicate
+ * paragraphs. This parser produces a stable AST so both render paths emit
+ * the same structure.
+ */
+
+export type Inline =
+  | { kind: 'text'; value: string }
+  | { kind: 'strong'; value: string }
+  | { kind: 'em'; value: string };
+
+export type Block =
+  | { kind: 'heading'; level: 2 | 3; children: Inline[] }
+  | { kind: 'paragraph'; children: Inline[] }
+  | { kind: 'list'; ordered: boolean; items: Inline[][] };
+
+function decodeNoiseEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#39;|&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&hellip;/g, '…')
+    .replace(/&mdash;/g, '—')
+    .replace(/&ndash;/g, '–')
+    .replace(/&#(\d+);/g, (_m, c) => {
+      const n = Number(c);
+      return n >= 32 && n < 0x10ffff ? String.fromCharCode(n) : ' ';
+    });
+}
+
+const SEPARATOR_LINE_RE = /^[\s_\-=*•·~]{3,}$/;
+
+const SECTION_LABELS = new Set(
+  [
+    'compiti',
+    'responsabilità',
+    'responsabilita',
+    'requisiti',
+    'profilo',
+    'profilo richiesto',
+    'profilo ricercato',
+    'cosa offriamo',
+    'cosa offre',
+    'la tua missione',
+    'le tue responsabilità',
+    'cosa farai',
+    'chi cerchiamo',
+    'chi sei',
+    'cosa cerchiamo',
+    'esperienza',
+    'formazione',
+    'competenze',
+    'lingue',
+    'benefit',
+    'candidatura',
+    'come candidarsi',
+    'tasks',
+    'duties',
+    'main duties',
+    'main duties and responsibilities',
+    'responsibilities',
+    'requirements',
+    'profile',
+    'we offer',
+    'what we offer',
+    'your mission',
+    'your responsibilities',
+    'about you',
+    'who you are',
+    'experience',
+    'education',
+    'skills',
+    'languages',
+    'benefits',
+    'how to apply',
+    'aufgaben',
+    'ihre aufgaben',
+    'anforderungen',
+    'profil',
+    'ihr profil',
+    'wir bieten',
+    'was wir bieten',
+    'erfahrung',
+    'ausbildung',
+    'kenntnisse',
+    'sprachen',
+    'vorteile',
+    'bewerbung',
+    'missions',
+    'vos missions',
+    'profil recherché',
+    'nous offrons',
+    'ce que nous offrons',
+    'expérience',
+    'formation',
+    'compétences',
+    'competences',
+    'langues',
+    'avantages',
+    'candidature',
+  ].map((s) => s.toLowerCase()),
+);
+
+function stripLabelDecoration(s: string): string {
+  let t = s.trim();
+  t = t.replace(/^\*+\s*/, '').replace(/\s*\*+$/, '');
+  t = t.replace(/[\s:：–—\-]+$/, '');
+  return t.trim();
+}
+
+function isSectionLabel(line: string): boolean {
+  const trimmed = line.trim();
+  const cleaned = stripLabelDecoration(trimmed).toLowerCase();
+  if (!cleaned) return false;
+  if (cleaned.length > 60) return false;
+  if (SECTION_LABELS.has(cleaned)) return true;
+  if (trimmed.length <= 64 && /[:：]\s*$/.test(trimmed)) {
+    const body = trimmed.replace(/[:：]\s*$/, '').trim();
+    if (
+      body.length >= 3 &&
+      body.length <= 60 &&
+      !/[.!?]/.test(body) &&
+      /^[A-ZÀ-ÖØ-Þ*]/.test(body)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function preprocess(raw: string): string {
+  let s = String(raw || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  s = s.replace(/ /g, ' ');
+  s = decodeNoiseEntities(s);
+
+  s = s.replace(/;\s*([A-ZÀ-ÖØ-Þ][^.;!?\n]{1,80}[:：])/g, '\n$1');
+  s = s.replace(/([a-zà-öø-þ.0-9%])\s*;\s*([A-ZÀ-ÖØ-Þ][a-zà-öø-þ])/g, '$1\n- $2');
+
+  s = s.replace(/([^\n])\s+([•·]\s)/g, '$1\n$2');
+
+  s = s.replace(
+    /(^|\n)([ \t]*)\*\*([^*\n]{2,60})\*\*([ \t]*[:：]?)(?=[ \t]*\n|$)/g,
+    '$1$2**$3**$4',
+  );
+
+  // "## Heading - item1 - item2 - item3" (≥3 inline dashes) → split into
+  // heading + bullet list. Real pattern seen in Amministrazione Cantonale
+  // (Ticino) job posts. Accepts both Capital and lowercase items.
+  s = s.replace(
+    /(^|\n)((?:#{2,4}\s+)?[^\n]+?)((?: - [^\n -][^\n]*){3,})(?=\n|$)/g,
+    (_match, prefix, heading, dashes) => {
+      const items = dashes
+        .split(/ - /)
+        .map((part: string) => part.trim())
+        .filter((part: string) => part.length > 0);
+      const cleanHeading = String(heading).trim();
+      return `${prefix}${cleanHeading}\n- ${items.join('\n- ')}`;
+    },
+  );
+
+  s = s
+    .split('\n')
+    .map((line) =>
+      // Strip trailing separator runs that hug the end of a real line
+      // (e.g. "Be part of something. ______" → "Be part of something.").
+      line.replace(/\s+[_\-=~*]{3,}\s*$/g, '').trimEnd(),
+    )
+    .filter((line) => !SEPARATOR_LINE_RE.test(line))
+    .join('\n');
+
+  s = s.replace(/\n{3,}/g, '\n\n');
+
+  return s.trim();
+}
+
+export function parseInline(text: string): Inline[] {
+  if (!text) return [];
+
+  let s = text.replace(/\*\*\s*[\s:;,.\-–—]*\s*\*\*/g, ' ');
+
+  const doubleStars = (s.match(/\*\*/g) || []).length;
+  if (doubleStars % 2 !== 0) {
+    s = s.replace(/\*\*/g, '');
+  }
+
+  const out: Inline[] = [];
+  const re = /\*\*([^*\n]+?)\*\*|\*([^*\n]+?)\*/g;
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(s)) !== null) {
+    if (m.index > lastIndex) {
+      out.push({ kind: 'text', value: s.slice(lastIndex, m.index) });
+    }
+    const inner = (m[1] ?? m[2] ?? '').trim();
+    if (!inner) {
+      // skip empty
+    } else if (m[1] !== undefined) {
+      out.push({ kind: 'strong', value: inner });
+    } else {
+      out.push({ kind: 'em', value: inner });
+    }
+    lastIndex = re.lastIndex;
+  }
+  if (lastIndex < s.length) {
+    out.push({ kind: 'text', value: s.slice(lastIndex) });
+  }
+
+  const collapsed: Inline[] = [];
+  for (const tok of out) {
+    if (tok.kind === 'text') {
+      const v = tok.value.replace(/[ \t]+/g, ' ');
+      if (!v.trim() && collapsed.length > 0) {
+        const last = collapsed[collapsed.length - 1];
+        if (last.kind === 'text') {
+          last.value = (last.value + ' ').replace(/  +/g, ' ');
+        } else {
+          collapsed.push({ kind: 'text', value: ' ' });
+        }
+        continue;
+      }
+      collapsed.push({ kind: 'text', value: v });
+    } else {
+      collapsed.push(tok);
+    }
+  }
+  while (collapsed.length > 0 && collapsed[0].kind === 'text' && !collapsed[0].value.trim()) {
+    collapsed.shift();
+  }
+  while (
+    collapsed.length > 0 &&
+    collapsed[collapsed.length - 1].kind === 'text' &&
+    !(collapsed[collapsed.length - 1] as { value: string }).value.trim()
+  ) {
+    collapsed.pop();
+  }
+
+  return collapsed;
+}
+
+function inlinesToText(inlines: Inline[]): string {
+  return inlines.map((t) => t.value).join('').trim();
+}
+
+function normalizeForDedup(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[\p{P}\p{S}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const BULLET_RE = /^\s*[-•*]\s+(.+)$/;
+const NUMBERED_RE = /^\s*\d+[.)]\s+(.+)$/;
+const MAX_HEADING_CHARS = 120;
+
+export function parseJobDescription(raw: string): Block[] {
+  const pre = preprocess(raw);
+  if (!pre) return [];
+
+  const lines = pre.split('\n');
+  const blocks: Block[] = [];
+
+  let i = 0;
+  const seenParagraphs = new Set<string>();
+
+  const pushParagraph = (text: string): void => {
+    const inlines = parseInline(text);
+    if (inlines.length === 0) return;
+    const plain = inlinesToText(inlines);
+    if (plain.length < 2) return;
+    const key = normalizeForDedup(plain);
+    if (seenParagraphs.has(key)) return;
+    seenParagraphs.add(key);
+    blocks.push({ kind: 'paragraph', children: inlines });
+  };
+
+  const pushHeading = (text: string, level: 2 | 3 = 2): void => {
+    const cleanText = stripLabelDecoration(text);
+    if (!cleanText) return;
+    if (cleanText.length > MAX_HEADING_CHARS) {
+      pushParagraph(text);
+      return;
+    }
+    const last = blocks[blocks.length - 1];
+    if (
+      last &&
+      last.kind === 'heading' &&
+      inlinesToText(last.children).toLowerCase() === cleanText.toLowerCase()
+    ) {
+      return;
+    }
+    blocks.push({
+      kind: 'heading',
+      level,
+      children: parseInline(cleanText),
+    });
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      i++;
+      continue;
+    }
+
+    const mdHeader = trimmed.match(/^(#{2,4})\s+(.+)$/);
+    if (mdHeader) {
+      const level = mdHeader[1].length === 2 ? 2 : 3;
+      pushHeading(mdHeader[2], level as 2 | 3);
+      i++;
+      continue;
+    }
+
+    if (isSectionLabel(trimmed)) {
+      pushHeading(trimmed, 2);
+      i++;
+      continue;
+    }
+
+    if (BULLET_RE.test(line)) {
+      const items: Inline[][] = [];
+      while (i < lines.length && BULLET_RE.test(lines[i])) {
+        const m = lines[i].match(BULLET_RE)!;
+        const inline = parseInline(m[1]);
+        if (inline.length > 0) items.push(inline);
+        i++;
+      }
+      if (items.length > 0) blocks.push({ kind: 'list', ordered: false, items });
+      continue;
+    }
+
+    if (NUMBERED_RE.test(line)) {
+      const items: Inline[][] = [];
+      while (i < lines.length && NUMBERED_RE.test(lines[i])) {
+        const m = lines[i].match(NUMBERED_RE)!;
+        const inline = parseInline(m[1]);
+        if (inline.length > 0) items.push(inline);
+        i++;
+      }
+      if (items.length > 0) blocks.push({ kind: 'list', ordered: true, items });
+      continue;
+    }
+
+    const buf: string[] = [trimmed];
+    i++;
+    while (i < lines.length) {
+      const next = lines[i];
+      const nextTrim = next.trim();
+      if (!nextTrim) break;
+      if (BULLET_RE.test(next) || NUMBERED_RE.test(next)) break;
+      if (/^#{2,4}\s+/.test(nextTrim)) break;
+      if (isSectionLabel(nextTrim)) break;
+      buf.push(nextTrim);
+      i++;
+    }
+    pushParagraph(buf.join(' '));
+  }
+
+  return blocks;
+}
+
+export function blocksToPlainText(blocks: Block[]): string {
+  const out: string[] = [];
+  for (const b of blocks) {
+    if (b.kind === 'heading') {
+      out.push(inlinesToText(b.children));
+    } else if (b.kind === 'paragraph') {
+      out.push(inlinesToText(b.children));
+    } else {
+      for (const item of b.items) out.push('• ' + inlinesToText(item));
+    }
+  }
+  return out.join('\n').trim();
+}

--- a/build-plugins/shared/jobDescription/toHtml.ts
+++ b/build-plugins/shared/jobDescription/toHtml.ts
@@ -1,0 +1,58 @@
+/**
+ * Serialize the job-description AST to HTML strings for the SSG build plugin
+ * (`build-plugins/jobsSeoPagesPlugin.ts`). The SPA renderer consumes the same
+ * AST via `components/community/JobDescriptionBlocks.tsx`.
+ */
+
+import type { Block, Inline } from './parser';
+import { parseJobDescription } from './parser';
+
+function esc(s: string): string {
+  return String(s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function inlineToHtml(tok: Inline): string {
+  switch (tok.kind) {
+    case 'strong':
+      return `<strong>${esc(tok.value)}</strong>`;
+    case 'em':
+      return `<em>${esc(tok.value)}</em>`;
+    default:
+      return esc(tok.value);
+  }
+}
+
+function inlinesToHtml(inlines: Inline[]): string {
+  return inlines.map(inlineToHtml).join('');
+}
+
+export function blocksToHtml(blocks: Block[]): string {
+  const parts: string[] = [];
+  for (const b of blocks) {
+    if (b.kind === 'heading') {
+      const tag = b.level === 2 ? 'h2' : 'h3';
+      parts.push(`<${tag}>${inlinesToHtml(b.children)}</${tag}>`);
+    } else if (b.kind === 'paragraph') {
+      parts.push(`<p>${inlinesToHtml(b.children)}</p>`);
+    } else {
+      const tag = b.ordered ? 'ol' : 'ul';
+      const items = b.items.map((i) => `<li>${inlinesToHtml(i)}</li>`).join('');
+      parts.push(`<${tag}>${items}</${tag}>`);
+    }
+  }
+  return parts.join('');
+}
+
+/** Drop-in replacement for the previous `plainTextToHtml()` helper in
+ * jobsSeoPagesPlugin.ts. Passes through HTML input untouched when it
+ * already contains structural tags. */
+export function jobDescriptionTextToHtml(text: string): string {
+  if (!text) return '';
+  if (/<(p|ul|ol|li|h[1-6]|br|strong|em)\b/i.test(text)) return text;
+  const blocks = parseJobDescription(text);
+  return blocksToHtml(blocks);
+}

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -93,6 +93,11 @@ import JobOrphanView from '@/components/community/JobOrphanView';
 import { AD_SLOTS } from '@/services/adsenseSlots';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { eagerAuth, getAuthEmail, promptOneTap, renderGoogleButton, isLinkedInSignInAvailable, signInWithLinkedIn, saveAuthJobContext } from '@/services/authService';
+import {
+ parseJobDescription,
+ type Block as JobDescBlock,
+ type Inline as JobDescInline,
+} from '@/build-plugins/shared/jobDescription/parser';
 import { useAuthGateHeadlineVariant } from '@/services/authGateExperiment';
 import {
  isMultiLocation,
@@ -748,164 +753,78 @@ function splitFlatTextIntoItems(text: string): string[] {
  return merged.length >= 2 ? merged : [text];
 }
 
-/** Parse crawled markdown-like job description into structured JSX blocks. */
+/** Render an Inline[] from the shared parser AST into React text/strong/em. */
+function renderInlines(inlines: JobDescInline[]): React.ReactNode {
+ return inlines.map((tok, i) => {
+ if (tok.kind === 'strong') return <strong key={i}>{tok.value}</strong>;
+ if (tok.kind === 'em') return <em key={i}>{tok.value}</em>;
+ return <React.Fragment key={i}>{tok.value}</React.Fragment>;
+ });
+}
+
+/** Render a Block[] from the shared parser AST as JSX. */
+function renderJobDescBlocks(blocks: JobDescBlock[]): React.ReactNode[] {
+ return blocks.map((block, i) => {
+ if (block.kind === 'heading') {
+ // S5: real H2 for sections, H3 for sub-sections. S3: no border-l stripe,
+ // hierarchy via type weight + spacing only.
+ if (block.level === 2) {
+ return (
+ <h2
+ key={`h2-${i}`}
+ className="text-base font-semibold font-display text-heading mt-6 mb-2 first:mt-0"
+ >
+ {renderInlines(block.children)}
+ </h2>
+ );
+ }
+ return (
+ <h3
+ key={`h3-${i}`}
+ className="text-sm font-semibold text-heading mt-4 mb-1 first:mt-0"
+ >
+ {renderInlines(block.children)}
+ </h3>
+ );
+ }
+ if (block.kind === 'paragraph') {
+ return (
+ <p key={`p-${i}`} className="text-sm leading-relaxed text-body">
+ {renderInlines(block.children)}
+ </p>
+ );
+ }
+ const ListTag = block.ordered ? 'ol' : 'ul';
+ const listClass = block.ordered
+ ? 'space-y-1.5 pl-5 list-decimal marker:text-accent'
+ : 'space-y-1.5 pl-4 list-disc marker:text-accent';
+ return (
+ <ListTag key={`list-${i}`} className={listClass}>
+ {block.items.map((item, j) => (
+ <li key={j} className="text-sm leading-relaxed text-body">
+ {renderInlines(item)}
+ </li>
+ ))}
+ </ListTag>
+ );
+ });
+}
+
+/** Parse crawled markdown-like job description into structured JSX blocks
+ * via the shared parser (`@/build-plugins/shared/jobDescription/parser`).
+ * The shared parser fixes S1 (literal `**`), S2 (mis-promotion of prose to
+ * heading), S4 (dedup), S8 (separator stripping). The render layer enforces
+ * S3 (no border-l stripe) and S5 (real H2 hierarchy). */
 export function renderFormattedDescription(raw: string): React.ReactNode {
  const text = String(raw || '').trim();
  if (!text) return null;
-
- // Pre-process: inject line breaks for descriptions that lack them
- const normalized = normalizeDescriptionBreaks(text);
-
- // Split into lines, preserving structure
- const lines = normalized.split(/\n/).map(l => l.trim());
- const blocks: React.ReactNode[] = [];
- let bulletBuffer: string[] = [];
- let keyIdx = 0;
-
- const flushBullets = () => {
- if (bulletBuffer.length === 0) return;
- blocks.push(
- <ul key={`ul-${keyIdx++}`} className="space-y-1.5 pl-4 list-disc marker:text-accent">
- {bulletBuffer.map((b, i) => (
- <li key={i} className="text-sm leading-relaxed text-body">{b}</li>
- ))}
- </ul>
- );
- bulletBuffer = [];
- };
-
- for (const line of lines) {
- if (!line) {
- // blank line — flush bullets, skip
- flushBullets();
- continue;
- }
-
- // Bare ## marker with no content (e.g. "##" or "## ") — skip silently
- if (/^#{1,3}\s*$/.test(line)) {
- flushBullets();
- continue;
- }
-
- // ## Section header
- const headerMatch = line.match(/^#{1,3}\s+(.+)/);
- if (headerMatch) {
- flushBullets();
- const headingFull = headerMatch[1].replace(/:$/, '').trim();
-
- // A) Heading contains inline dash-bullets (" - CapitalWord" × 3+) → heading + list
- const dashHits = [...headingFull.matchAll(/ - [A-ZÀ-ÖÙ-Ü]/g)];
- if (dashHits.length >= 3 && (dashHits[0].index ?? 0) > 5) {
- const splitAt = dashHits[0].index!;
- const title = headingFull.substring(0, splitAt).trim();
- const items = headingFull.substring(splitAt)
- .split(/ - /)
- .map(s => s.trim())
- .filter(s => s.length > 0);
- blocks.push(
- <h3 key={`h-${keyIdx++}`} className="text-sm font-bold text-heading border-l-3 border-accent pl-3 mt-4 mb-1 first:mt-0">
- {title}
- </h3>
- );
- if (items.length > 0) {
- blocks.push(
- <ul key={`ul-${keyIdx++}`} className="space-y-1.5 pl-4 list-disc marker:text-accent">
- {items.map((item, i) => (
- <li key={i} className="text-sm leading-relaxed text-body">{item}</li>
- ))}
- </ul>
- );
- }
- continue;
- }
-
- // A-bis) Italian infinitive pattern: lowercase items after dash (" - lowercase")
- const dashHitsLc = [...headingFull.matchAll(/ - [a-zà-öù-ü]/g)];
- if (dashHitsLc.length >= 3 && (dashHitsLc[0].index ?? 0) > 5) {
- const splitAt = dashHitsLc[0].index!;
- const title = headingFull.substring(0, splitAt).trim();
- const items = headingFull.substring(splitAt)
-   .split(/ - /)
-   .map(s => s.trim())
-   .filter(s => s.length > 0);
- blocks.push(
-   <h3 key={`h-${keyIdx++}`} className="text-sm font-bold text-heading border-l-3 border-accent pl-3 mt-4 mb-1 first:mt-0">
-     {title}
-   </h3>
- );
- if (items.length > 0) {
-   blocks.push(
-     <ul key={`ul-${keyIdx++}`} className="space-y-1.5 pl-4 list-disc marker:text-accent">
-       {items.map((item, i) => (
-         <li key={i} className="text-sm leading-relaxed text-body">{item}</li>
-       ))}
-     </ul>
-   );
- }
- continue;
- }
-
- // B) Oversized heading (>150 chars) → split at first sentence boundary → heading + paragraph
- if (headingFull.length > 150) {
- const splitMatch = headingFull.match(/^(.{10,150}?(?:\d+%|[.!?]))\s+([A-ZÀ-ÖÙ-Ü][\s\S]*)/);
- if (splitMatch) {
- blocks.push(
- <h3 key={`h-${keyIdx++}`} className="text-sm font-bold text-heading border-l-3 border-accent pl-3 mt-4 mb-1 first:mt-0">
- {splitMatch[1]}
- </h3>
- );
- blocks.push(
- <p key={`p-${keyIdx++}`} className="text-sm leading-relaxed text-body">{splitMatch[2]}</p>
- );
- continue;
- }
- }
-
- // Normal heading
- blocks.push(
- <h3 key={`h-${keyIdx++}`} className="text-sm font-bold text-heading border-l-3 border-accent pl-3 mt-4 mb-1 first:mt-0">
- {headingFull}
- </h3>
- );
- continue;
- }
-
- // Bullet: starts with - or • or * (optionally followed by space)
- const bulletMatch = line.match(/^[-•*]\s+(.+)/);
- if (bulletMatch) {
- bulletBuffer.push(bulletMatch[1]);
- continue;
- }
-
- // Section-like label ending with : (e.g."Compiti:""Requisiti:")
- if (/^[A-ZÀ-ÖÙ-Ü][^.!?]{2,60}:$/.test(line) && !line.includes(' - ')) {
- flushBullets();
- const heading = line.replace(/:$/, '').trim();
- blocks.push(
- <h3 key={`h-${keyIdx++}`} className="text-sm font-bold text-heading border-l-3 border-accent pl-3 mt-4 mb-1 first:mt-0">
- {heading}
- </h3>
- );
- continue;
- }
-
- // Regular paragraph
- flushBullets();
- blocks.push(
- <p key={`p-${keyIdx++}`} className="text-sm leading-relaxed text-body">{line}</p>
- );
- }
-
- flushBullets();
-
- // Fallback: if we got no blocks (e.g. text had no newlines), split via normalizeParagraphs
+ const blocks = parseJobDescription(text);
  if (blocks.length === 0) {
  return normalizeParagraphs(text).map((p, i) => (
  <p key={i} className="text-sm leading-relaxed text-body">{p}</p>
  ));
  }
-
- return blocks;
+ return renderJobDescBlocks(blocks);
 }
 
 const NOISY_REQUIREMENT_PATTERNS = [
@@ -6364,18 +6283,45 @@ const JobBoard: React.FC<JobBoardProps> = ({
  requirements: canonicalRequirements,
  aiKeywords: canonicalContent.keywords,
  }).filter((term) => sortedJobs.some((job) => indexedQueryMatch(job, term)));
+ // Dedup bullets globally across all timeline sections: when AI enrichment
+ // populates the same item into multiple sections (S4 visual duplication
+ // observed on the casale "Lavora con noi" page where the same filler line
+ // appeared as responsibility, benefit AND process step), keep the first
+ // occurrence and drop later duplicates. Match is whitespace/punctuation
+ // insensitive.
+ const timelineDedupKey = (s: string): string =>
+ String(s || '')
+ .toLowerCase()
+ .replace(/[\p{P}\p{S}]+/gu, ' ')
+ .replace(/\s+/g, ' ')
+ .trim();
+ const seenBullets = new Set<string>();
+ const dedupBullets = (items: string[]): string[] => {
+ const out: string[] = [];
+ for (const item of items) {
+ const key = timelineDedupKey(item);
+ if (!key || seenBullets.has(key)) continue;
+ seenBullets.add(key);
+ out.push(item);
+ }
+ return out;
+ };
+ const dedupResponsibilities = dedupBullets(canonicalContent.responsibilities);
+ const dedupRequirementsList = dedupBullets(canonicalRequirements);
+ const dedupBenefits = dedupBullets(canonicalContent.benefits);
+ const dedupProcess = dedupBullets(canonicalContent.process);
  const timelineSections = [
- ...(canonicalContent.responsibilities.length > 0
- ? [{ id: 'responsibilities', heading: canonicalCopy.responsibilities, paragraphs: [], bullets: canonicalContent.responsibilities }]
+ ...(dedupResponsibilities.length > 0
+ ? [{ id: 'responsibilities', heading: canonicalCopy.responsibilities, paragraphs: [], bullets: dedupResponsibilities }]
  : []),
- ...(canonicalRequirements.length > 0
- ? [{ id: 'requirements', heading: canonicalCopy.requirements, paragraphs: [], bullets: canonicalRequirements }]
+ ...(dedupRequirementsList.length > 0
+ ? [{ id: 'requirements', heading: canonicalCopy.requirements, paragraphs: [], bullets: dedupRequirementsList }]
  : []),
- ...(canonicalContent.benefits.length > 0
- ? [{ id: 'benefits', heading: canonicalCopy.benefits, paragraphs: [], bullets: canonicalContent.benefits }]
+ ...(dedupBenefits.length > 0
+ ? [{ id: 'benefits', heading: canonicalCopy.benefits, paragraphs: [], bullets: dedupBenefits }]
  : []),
- ...(canonicalContent.process.length > 0
- ? [{ id: 'process', heading: canonicalCopy.process, paragraphs: [], bullets: canonicalContent.process }]
+ ...(dedupProcess.length > 0
+ ? [{ id: 'process', heading: canonicalCopy.process, paragraphs: [], bullets: dedupProcess }]
  : []),
  ...canonicalContactSections,
  ...canonicalResidualSections,
@@ -6705,7 +6651,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  <div key={`${section.id}-${index}`} className="timeline-step relative">
  <span className="absolute -left-[23px] top-2 w-3 h-3 rounded-full bg-accent ring-2 ring-surface" />
  <section className="section rounded-2xl border border-edge bg-surface p-4 sm:p-5 space-y-2">
- <h4 className="text-sm font-bold text-heading border-l-4 border-accent pl-3">
+ <h4 className="text-base font-semibold text-heading mb-1">
  {section.heading}
  </h4>
  {section.paragraphs.length > 0 && section.paragraphs.map((line, i) => (

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     "audit:orphan-sitemap-pages:rebaseline": "node scripts/audit-orphan-pages-in-sitemaps.mjs --rebaseline",
     "data:related-search-candidates": "node scripts/audit-related-search-candidates.mjs",
     "audit:image-object-license": "node scripts/audit-image-object-license.mjs",
+    "audit:no-literal-markdown": "node scripts/audit-no-literal-markdown.mjs",
     "audit:faqpage-validity": "node scripts/audit-faqpage-validity.mjs",
     "audit:parser-quality": "node scripts/audit-parser-quality.mjs",
     "audit:parser-quality:rebaseline": "node scripts/audit-parser-quality.mjs --rebaseline",

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -45,7 +45,7 @@ import {
 } from './lib/crawler-summary-store.mjs';
 import { buildStableJobIdentity } from './lib/job-identity.mjs';
 import { hardenJobsWithStructuredSalary } from './lib/structured-salary.mjs';
-import { normalizeDescriptionBullets } from './lib/crawler-template.mjs';
+import { normalizeDescriptionBullets, cleanCrawlerArtifacts } from './lib/crawler-template.mjs';
 import { computeCrawlerQualityAggregate, computeJobQualityScore, buildStableId, cleanPreviousSlugsPerLocale, isLocationExplicitlyForeign } from './lib/dedicated-crawler-common.mjs';
 import { inferAnyCanton, isKnownSwissCity, isCantonOnlyLabel, findSwissCityInText } from './lib/target-swiss-locations.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
@@ -615,15 +615,20 @@ export function writeJobsCrawlerSlice(crawlerKey, jobs) {
   // Centralizing the bullet-recovery step here means every crawler benefits
   // without each parser having to remember to call it. Applied to both the
   // source description and every locale-specific translation. Idempotent.
+  // Apply both normalization passes: cleanCrawlerArtifacts (drops empty bolds,
+  // separator lines, dedups paragraphs) runs FIRST so the bullet-recovery step
+  // sees clean line boundaries. Both are idempotent.
   for (const job of hardened.jobs) {
     if (typeof job.description === 'string' && job.description) {
-      const normalized = normalizeDescriptionBullets(job.description);
+      let normalized = cleanCrawlerArtifacts(job.description);
+      normalized = normalizeDescriptionBullets(normalized);
       if (normalized !== job.description) job.description = normalized;
     }
     if (job.descriptionByLocale && typeof job.descriptionByLocale === 'object') {
       for (const [locale, text] of Object.entries(job.descriptionByLocale)) {
         if (typeof text !== 'string' || !text) continue;
-        const normalized = normalizeDescriptionBullets(text);
+        let normalized = cleanCrawlerArtifacts(text);
+        normalized = normalizeDescriptionBullets(normalized);
         if (normalized !== text) job.descriptionByLocale[locale] = normalized;
       }
     }

--- a/scripts/audit-all.mjs
+++ b/scripts/audit-all.mjs
@@ -41,6 +41,7 @@ import { factory as pageWeight } from './audit-page-weight.mjs';
 import { factory as contentDuplicates } from './audit-content-duplicates.mjs';
 import { factory as faqpageValidity } from './audit-faqpage-validity.mjs';
 import { factory as imageObjectLicense } from './audit-image-object-license.mjs';
+import { factory as noLiteralMarkdown } from './audit-no-literal-markdown.mjs';
 
 const REGISTRY = [
   { factory: footerRootPresence, name: 'footer-root-presence' },
@@ -54,6 +55,7 @@ const REGISTRY = [
   { factory: contentDuplicates, name: 'content-duplicates' },
   { factory: faqpageValidity, name: 'faqpage-validity' },
   { factory: imageObjectLicense, name: 'image-object-license' },
+  { factory: noLiteralMarkdown, name: 'no-literal-markdown' },
 ];
 
 // ─── CLI parsing ─────────────────────────────────────────────────────────────

--- a/scripts/audit-no-literal-markdown.mjs
+++ b/scripts/audit-no-literal-markdown.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * audit-no-literal-markdown
+ *
+ * Fails when raw `**...**` markdown bold tokens (or separator runs like
+ * `______`, `======`) leak into the visible body of a job detail page.
+ *
+ * Root cause history (2026-05-20): the AI translation pipeline mangled bold
+ * markers in `descriptionByLocale`, leaving unbalanced `**` runs that the
+ * SSG renderer (`jobsSeoPagesPlugin.ts plainTextToHtml`) and the SPA
+ * renderer (`components/community/JobBoard.tsx renderFormattedDescription`)
+ * passed through literally. The shared parser in
+ * `build-plugins/shared/jobDescription/parser.ts` now strips them; this
+ * audit pins that down as a deploy-blocking 0-tolerance gate.
+ *
+ * Scope: only `<main class="seo-static-content">` content inside
+ * `dist/cerca-lavoro-ticino/**` is scanned. Outside the main and non-job
+ * pages can legitimately contain `**` (e.g. legal text, code samples).
+ *
+ * Two execution modes:
+ *   1. Standalone:  `node scripts/audit-no-literal-markdown.mjs`
+ *   2. Unified runner: import { auditor } from this file, register it with
+ *                       scripts/audit-all.mjs.
+ */
+import { readFile, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { writeAuditReport } from './lib/auditReport.mjs';
+
+const SEO_STATIC_OPEN = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b[^>]*>/i;
+const MAIN_CLOSE = /<\/main>/i;
+
+// `\*\*[^*\n]{1,200}\*\*` — bold tokens with non-empty body
+const LITERAL_BOLD_RE = /\*\*[^*\n]{1,200}\*\*/g;
+// 3+ run of `_`, `=`, `~` as separator decoration
+const SEPARATOR_RUN_RE = /[_=~]{3,}/g;
+
+function extractMainBody(html) {
+  const openMatch = html.match(SEO_STATIC_OPEN);
+  if (!openMatch) return '';
+  const startIdx = openMatch.index + openMatch[0].length;
+  const closeIdx = html.slice(startIdx).search(MAIN_CLOSE);
+  if (closeIdx < 0) return html.slice(startIdx);
+  return html.slice(startIdx, startIdx + closeIdx);
+}
+
+function isJobDetailPage(absPath) {
+  const rel = relative(ROOT, absPath).replace(/^dist\//, '');
+  return rel.startsWith('cerca-lavoro-ticino/') && rel.endsWith('.html');
+}
+
+export function createAuditor(opts = {}) {
+  const limit = Math.max(1, opts.limit ?? 30);
+  const offenders = [];
+  let scanned = 0;
+
+  return {
+    name: 'no-literal-markdown',
+    collect(file, html) {
+      if (!html || !isJobDetailPage(file)) return;
+      scanned++;
+      const body = extractMainBody(html);
+      if (!body) return;
+
+      const bolds = body.match(LITERAL_BOLD_RE);
+      const seps = body.match(SEPARATOR_RUN_RE);
+      if ((bolds && bolds.length > 0) || (seps && seps.length > 0)) {
+        offenders.push({
+          path: relative(ROOT, file),
+          literalBoldSamples: (bolds || []).slice(0, 3),
+          separatorSamples: (seps || []).slice(0, 3),
+        });
+      }
+    },
+    report() {
+      const passed = offenders.length === 0;
+      const humanSummary = passed
+        ? `scanned ${scanned} job detail page(s) — no literal ** or separator runs in <main>`
+        : `${offenders.length} of ${scanned} job detail page(s) carry literal markdown in <main>`;
+      return {
+        passed,
+        offendersTotal: offenders.length,
+        offenders,
+        threshold: { metric: 'literalMarkdownOffenders', value: 0, comparator: '<=' },
+        extra: { scanned, limit },
+        humanSummary,
+      };
+    },
+  };
+}
+
+export const auditor = createAuditor();
+export { createAuditor as factory };
+
+async function standalone() {
+  const args = process.argv.slice(2);
+  const limit = (() => {
+    const a = args.find((s) => s.startsWith('--limit='));
+    return a ? Math.max(1, parseInt(a.split('=')[1], 10) || 30) : 30;
+  })();
+
+  const distStat = await stat(DEFAULT_DIST).catch(() => null);
+  if (!distStat || !distStat.isDirectory()) {
+    console.error(`audit-no-literal-markdown: dist/ not found at ${DEFAULT_DIST}. Run a build first.`);
+    process.exit(2);
+  }
+
+  const a = createAuditor({ limit });
+  const files = await walkHtmlFiles(DEFAULT_DIST);
+  for (const file of files) {
+    let html;
+    try { html = await readFile(file, 'utf8'); }
+    catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    a.collect(file, html);
+  }
+
+  const result = await a.report();
+  await writeAuditReport({
+    audit: a.name,
+    passed: result.passed,
+    threshold: result.threshold ?? null,
+    offenders: result.offenders ?? [],
+    extra: result.extra ?? {},
+  });
+
+  console.log(`audit-no-literal-markdown: ${result.humanSummary}`);
+  if (result.passed) {
+    console.log('PASS: no literal ** or separator runs leak into job detail bodies.');
+    process.exit(0);
+  }
+
+  console.error(`\nFAIL: ${result.offendersTotal} job detail page(s) leak literal markdown.`);
+  console.error(`First ${Math.min(limit, result.offenders.length)} offenders:`);
+  for (const o of result.offenders.slice(0, limit)) {
+    const tail = [
+      ...(o.literalBoldSamples || []).map((s) => `** ${s.slice(0, 60)}`),
+      ...(o.separatorSamples || []).map((s) => `sep ${s.slice(0, 16)}`),
+    ].slice(0, 3).join(' | ');
+    console.error(`  ${o.path} — ${tail}`);
+  }
+  console.error(`\nHow to fix`);
+  console.error(`----------`);
+  console.error(`Both SSG (build-plugins/jobsSeoPagesPlugin.ts) and SPA`);
+  console.error(`(components/community/JobBoard.tsx) must call into the shared parser at`);
+  console.error(`build-plugins/shared/jobDescription/parser.ts. Crawler-time normalization`);
+  console.error(`runs in scripts/lib/crawler-template.mjs#cleanCrawlerArtifacts via`);
+  console.error(`scripts/assemble-jobs-dataset.mjs.`);
+  process.exit(1);
+}
+
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  standalone().catch((err) => {
+    console.error('audit-no-literal-markdown: fatal', err);
+    process.exit(2);
+  });
+}

--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -301,6 +301,63 @@ export function normalizeDescriptionBullets(text) {
 }
 
 /**
+ * Idempotent clean-up of crawler artifacts in job descriptions. Runs at
+ * assemble-time (`scripts/assemble-jobs-dataset.mjs`) alongside
+ * `normalizeDescriptionBullets`. Defensive against malformed input from
+ * AI translation: drops empty `**...**` bolds, strips standalone separator
+ * lines (`______`, `=====`), strips trailing inline separator runs, and
+ * dedupes consecutive identical paragraphs.
+ *
+ * Mirrors the runtime parser in `build-plugins/shared/jobDescription/parser.ts`
+ * but operates on raw text BEFORE the renderer parses. Cleaning here keeps
+ * the assembled dataset (`data/jobs.json`) tidy without rewriting every
+ * by-crawler source file.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function cleanCrawlerArtifacts(text) {
+  if (!text || typeof text !== 'string') return text;
+  let s = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  // 1. Drop empty / whitespace-only bolds (e.g. "** **", "**  **", "** : **")
+  s = s.replace(/\*\*\s*[\s:;,.\-–—]*\s*\*\*/g, ' ');
+
+  // 2. Strip standalone separator-only lines ("______", "===", "----")
+  s = s
+    .split('\n')
+    .filter((line) => !/^[\s_\-=*•·~]{3,}$/.test(line))
+    .join('\n');
+
+  // 3. Strip trailing inline separator runs ("Be part of something. ______")
+  s = s
+    .split('\n')
+    .map((line) => line.replace(/\s+[_\-=~*]{3,}\s*$/g, '').trimEnd())
+    .join('\n');
+
+  // 4. Dedup consecutive identical paragraphs (Panoramica/Descrizione artifact)
+  const paragraphs = s.split(/\n{2,}/);
+  const out = [];
+  const norm = (p) =>
+    p
+      .toLowerCase()
+      .replace(/[\p{P}\p{S}]+/gu, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  const seen = new Set();
+  for (const p of paragraphs) {
+    const t = p.trim();
+    if (!t) continue;
+    const key = norm(t);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+
+  return out.join('\n\n');
+}
+
+/**
  * Strip HTML tags and decode common entities. Use for description fields.
  */
 export function stripHtml(html = '') {

--- a/tests/job-description-parser.test.ts
+++ b/tests/job-description-parser.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseJobDescription,
+  parseInline,
+  blocksToPlainText,
+  type Block,
+} from '@/build-plugins/shared/jobDescription/parser';
+import {
+  blocksToHtml,
+  jobDescriptionTextToHtml,
+} from '@/build-plugins/shared/jobDescription/toHtml';
+
+const html = (raw: string): string => blocksToHtml(parseJobDescription(raw));
+
+describe('parseJobDescription — markdown bold/em handling (S1)', () => {
+  it('converts well-formed **bold** to <strong>', () => {
+    expect(html('Hello **world**.')).toBe('<p>Hello <strong>world</strong>.</p>');
+  });
+
+  it('converts well-formed *em* to <em>', () => {
+    expect(html('Hello *world*.')).toBe('<p>Hello <em>world</em>.</p>');
+  });
+
+  it('drops empty bolds like ** **, **  **, **:**', () => {
+    expect(html('Foo ** ** bar **  ** baz ** : ** qux')).toBe('<p>Foo bar baz qux</p>');
+  });
+
+  it('strips all ** markers when count is odd (unbalanced)', () => {
+    expect(html('Hello **world this is unbalanced')).toBe('<p>Hello world this is unbalanced</p>');
+  });
+
+  it('never leaks literal ** into the rendered HTML — casale "Lavora con noi" sample', () => {
+    const raw =
+      "**Se è così - **entrate a far parte di un'organizzazione dinamica che offre percorsi di carriera diversificati e opportunità di crescita eccezionali** **\n• Offriamo un'ampia gamma di opportunità per sviluppare le vostre competenze** e **migliorare le vostre capacità personali e professionali**. Fai parte di qualcosa di significativo. ______";
+    const out = html(raw);
+    expect(out).not.toMatch(/\*\*/);
+    expect(out).not.toMatch(/_{3,}/);
+  });
+});
+
+describe('parseJobDescription — block structure', () => {
+  it('promotes recognized section labels to <h2> (S5)', () => {
+    expect(html('Main duties and Responsibilities:')).toBe('<h2>Main duties and Responsibilities</h2>');
+    expect(html('Profilo:')).toBe('<h2>Profilo</h2>');
+    expect(html('Wir bieten')).toBe('<h2>Wir bieten</h2>');
+    expect(html('We offer')).toBe('<h2>We offer</h2>');
+  });
+
+  it('parses bullet lists with -, •, *', () => {
+    const out = html('- one\n- two\n• three\n* four');
+    expect(out).toBe('<ul><li>one</li><li>two</li><li>three</li><li>four</li></ul>');
+  });
+
+  it('parses numbered lists', () => {
+    const out = html('1. first\n2. second\n3) third');
+    expect(out).toBe('<ol><li>first</li><li>second</li><li>third</li></ol>');
+  });
+
+  it('does NOT promote a long narrative paragraph (>120c) to a heading (S2)', () => {
+    const raw =
+      'This is a long narrative paragraph that goes on for more than one hundred and fifty characters explaining the company and its values and certainly is not a section heading at all because it has a regular flow of ideas.';
+    expect(html(raw)).toMatch(/^<p>/);
+    expect(html(raw)).not.toMatch(/<h[23]>/);
+  });
+
+  it('handles a real well-formed Casale "Expediter" sample', () => {
+    const raw =
+      'Casale SA is a leading firm.\n\n**Main duties and Responsibilities:**\n\n- Act as the main interface\n- Ensure material delivery\n\n**Education**\n\nDegree in Engineering';
+    expect(html(raw)).toBe(
+      '<p>Casale SA is a leading firm.</p>' +
+        '<h2>Main duties and Responsibilities</h2>' +
+        '<ul><li>Act as the main interface</li><li>Ensure material delivery</li></ul>' +
+        '<h2>Education</h2>' +
+        '<p>Degree in Engineering</p>',
+    );
+  });
+});
+
+describe('parseJobDescription — noise removal', () => {
+  it('strips separator-only lines like ______, ===, ---', () => {
+    expect(html('Para 1\n\n______\n\nPara 2\n\n----\n\nPara 3')).toBe(
+      '<p>Para 1</p><p>Para 2</p><p>Para 3</p>',
+    );
+  });
+
+  it('strips trailing inline separators on a line (S8)', () => {
+    expect(html('Be part of something. ______')).toBe('<p>Be part of something.</p>');
+    expect(html('Some text ----')).toBe('<p>Some text</p>');
+  });
+
+  it('deduplicates consecutive identical paragraphs (S4: Panoramica == Descrizione)', () => {
+    const raw = 'Same paragraph here.\n\nSame paragraph here.\n\nDifferent one.';
+    expect(html(raw)).toBe('<p>Same paragraph here.</p><p>Different one.</p>');
+  });
+
+  it('dedup is whitespace/punctuation insensitive', () => {
+    const raw = 'Hello world!\n\nhello,  WORLD.\n\nthird.';
+    expect(html(raw)).toBe('<p>Hello world!</p><p>third.</p>');
+  });
+
+  it('decodes &nbsp; and named dashes but preserves &amp;/&lt; for escape pass', () => {
+    expect(html('Hello&nbsp;world &mdash; foo & bar')).toBe('<p>Hello world — foo &amp; bar</p>');
+  });
+});
+
+describe('parseJobDescription — HTML safety', () => {
+  it('escapes HTML special chars in inline text', () => {
+    expect(html('<script>alert(1)</script>')).toBe('<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>');
+  });
+
+  it('escapes inside <strong> too', () => {
+    expect(html('**<b>raw</b>**')).toBe('<p><strong>&lt;b&gt;raw&lt;/b&gt;</strong></p>');
+  });
+
+  it('passes through input that already contains structural HTML untouched', () => {
+    const raw = '<p>Pre-rendered</p><ul><li>x</li></ul>';
+    expect(jobDescriptionTextToHtml(raw)).toBe(raw);
+  });
+});
+
+describe('parseInline — defensive', () => {
+  it('returns [] on empty input', () => {
+    expect(parseInline('')).toEqual([]);
+  });
+  it('returns single text token on plain string', () => {
+    expect(parseInline('hello')).toEqual([{ kind: 'text', value: 'hello' }]);
+  });
+});
+
+describe('parser — AST stability', () => {
+  it('blocksToPlainText round-trips the structure', () => {
+    const raw = '**Education**\n\n- A\n- B\n\nDegree in X';
+    const blocks: Block[] = parseJobDescription(raw);
+    const plain = blocksToPlainText(blocks);
+    expect(plain).toContain('Education');
+    expect(plain).toContain('• A');
+    expect(plain).toContain('• B');
+    expect(plain).toContain('Degree in X');
+  });
+});

--- a/tests/jobboard-italian-lowercase-list-parsing.test.ts
+++ b/tests/jobboard-italian-lowercase-list-parsing.test.ts
@@ -90,7 +90,7 @@ describe('renderFormattedDescription – Check A-bis (Italian lowercase inline d
    const input = '## Compiti - organizzare cose - collaborare con team - accompagnare persone - sviluppare progetti';
    const rendered = renderFormattedDescription(input);
 
-   const headings = collectByType(rendered, 'h3');
+   const headings = collectByType(rendered, 'h2');
    const lists = collectByType(rendered, 'ul');
 
    expect(headings.length).toBeGreaterThanOrEqual(1);
@@ -117,7 +117,7 @@ describe('renderFormattedDescription – Check A-bis (Italian lowercase inline d
    const input = '## Compiti - organizzare cose - collaborare con team - accompagnare persone';
    const rendered = renderFormattedDescription(input);
 
-   const headings = collectByType(rendered, 'h3');
+   const headings = collectByType(rendered, 'h2');
    for (const h of headings) {
      const text = flattenText(h);
      // No heading should contain the inline dash items

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -23,14 +23,15 @@ const ALLOWLIST = [
   'build-plugins/shared/cantonSection.ts',
 
   // ── jobsSeoPagesPlugin: sectionByLocale legacy preservation (TI default) ──
-  // Lines shifted +1 by the renderJobCardHtml import added for the canton-
-  // index card-layout swap (2026-05-18). Prior +3 shift from BFS-depth
-  // Explore navigator imports + Phase 8(g) imports is included.
-  'build-plugins/jobsSeoPagesPlugin.ts:785',
+  // Lines shifted +1 by the shared jobDescription parser import added at the
+  // top of the file (May 2026 — fix for literal `**` markdown leak).
+  // Prior shifts: +1 from renderJobCardHtml import for canton-index card
+  // swap (2026-05-18), +3 from BFS-depth Explore navigator + Phase 8(g).
   'build-plugins/jobsSeoPagesPlugin.ts:786',
   'build-plugins/jobsSeoPagesPlugin.ts:787',
   'build-plugins/jobsSeoPagesPlugin.ts:788',
-  'build-plugins/jobsSeoPagesPlugin.ts:793',          // jsdoc reference to the legacy slugs
+  'build-plugins/jobsSeoPagesPlugin.ts:789',
+  'build-plugins/jobsSeoPagesPlugin.ts:794',          // jsdoc reference to the legacy slugs
   // (`:7853` removed 2026-05-18 — the breadcrumb-bugfix comment no longer
   // quotes "cerca-lavoro-ticino" directly; rephrased to "TI legacy
   // job-board section name" so the literal-grep stops matching.)


### PR DESCRIPTION
Diagnosis (live page /cerca-lavoro-ticino/lavora-con-noi-casale-sa-lugano-ticino/):
- S1 literal `**Se è così -**` in body of both static HTML and hydrated SPA
- S2 prose paragraph mis-promoted to <h3> by SPA renderer
- S3 stripe heading anti-pattern (border-l-3 border-accent pl-3) on every section
- S4 Panoramica/Descrizione/Cosa-offre triple duplication of same filler
- S5 broken hierarchy (H1 → H3 → H3 → H2 in hydrated DOM)
- S8 visible `______` separator decorations passed through to body

Root cause:
- Two parallel description parsers (plainTextToHtml in jobsSeoPagesPlugin.ts,
  renderFormattedDescription in JobBoard.tsx) that never converted **bold**
  to <strong>, never stripped empty / unbalanced markers, never dedup'd.
- AI translation pipeline emits unbalanced ** (e.g. `**Se è così - **entrate`).

Fix (one shared AST, two render targets):
- build-plugins/shared/jobDescription/parser.ts — single source of truth.
  Inline: drops empty bolds (** **), strips all ** when count is odd
  (unbalanced), promotes section labels (Profilo:, Compiti:, Education,
  Wir bieten, etc.) to H2, refuses to make prose >120c a heading.
  Block: parses bullets / numbered lists, strips separator-only lines and
  inline trailing `______`, fuzzy-dedups consecutive identical paragraphs,
  splits `## Heading - item1 - item2 - item3` patterns into heading+list.
- build-plugins/shared/jobDescription/toHtml.ts — Block[] → escaped HTML.
  Used by SSG via thin wrapper jobDescriptionTextToHtml.
- jobsSeoPagesPlugin.ts: plainTextToHtml is now jobDescriptionTextToHtml (-46 lines).
- JobBoard.tsx: renderFormattedDescription consumes the same AST and emits
  React. Removed border-l-3/border-l-4 stripe on every job-detail H3/H4.
  Real <h2> for section headings, hierarchy H1→H2→H3.
- JobBoard.tsx: dedup bullets ACROSS timelineSections (responsibilities ↔
  requirements ↔ benefits ↔ process) so AI-enrichment overlap stops
  showing the same line 3× under different labels.

Ingest-time normalization (scripts/lib/crawler-template.mjs +
scripts/assemble-jobs-dataset.mjs): cleanCrawlerArtifacts runs before the
existing normalizeDescriptionBullets pass, on both job.description and
every descriptionByLocale entry. Idempotent.

Audit gate (deploy-blocking, zero-tolerance):
- scripts/audit-no-literal-markdown.mjs walks dist/cerca-lavoro-ticino/**
  and fails when `**...**` or `______`/`====` runs leak into
  <main class="seo-static-content">. Wired into audit-all.mjs.

Tests:
- tests/job-description-parser.test.ts: 21 cases covering S1, S2, S4, S5, S8
  + casale "Lavora con noi" patient input.
- jobboard-italian-lowercase-list-parsing.test.ts: ## heading split into
  heading+bullets preserved (now expects h2 not h3 per real hierarchy).
- cathedral-no-ti-hardcodes.test.ts: line-pinned allowlist drift +1 from
  new parser import.

Note: only static HTML AND hydrated SPA verified — both now emit clean
<strong>/<em>/<h2>/<h3>/<p>/<ul> without literal ** or separator runs.
