### PR TITLE
fix(job-detail): mobile action block + collapse blocked ads + suppress shard 404 + font crossorigin (S6-S10)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2326,7 +2326,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  <link rel="preconnect" href="https://fonts.googleapis.com">
  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" as="style" crossorigin>
- <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" media="print" onload="this.media='all'" data-clarity-unmask="true"><noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" data-clarity-unmask="true"></noscript>
+ <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" media="print" onload="this.media='all'" crossorigin data-clarity-unmask="true"><noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" crossorigin data-clarity-unmask="true"></noscript>
  <link rel="stylesheet" href="/assets/seo-static.css?v=${BUILD_ID}">
 ${hreflangHtml}
  <script type="application/ld+json">${jobLd}</script>

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6588,6 +6588,44 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </div>
  </header>
 
+ {/* S6 — Mobile-only action block above the description. 75 % traffic is
+ * mobile (CLAUDE.md #15/#17); the user must see CTA + key stats + a
+ * money-signal BEFORE scrolling through the prose. Desktop keeps the
+ * sticky right rail so this block is hidden on lg+. */}
+ <section
+ aria-label={t('jobBoard.snapshotTitle')}
+ className="lg:hidden rounded-2xl border border-edge bg-surface p-4 space-y-3"
+ >
+ <button
+ onClick={() => handleApply(selectedJob)}
+ className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 min-h-[48px] text-base font-semibold font-display bg-accent hover:bg-accent-hover text-on-accent rounded-lg transition-colors"
+ >
+ <ArrowUpRight className="w-4 h-4" />
+ {t('jobBoard.apply')}
+ </button>
+ <dl className="grid grid-cols-3 gap-2 text-xs">
+ <div className="rounded-lg bg-surface-alt p-2 text-center">
+ <dt className="uppercase tracking-wide text-[10px] text-muted">{t('jobBoard.snapshot.location')}</dt>
+ <dd className="font-semibold font-display text-strong mt-0.5 leading-tight truncate">
+ {locationSnapshot?.locality || selectedJob.location}
+ </dd>
+ </div>
+ <div className="rounded-lg bg-surface-alt p-2 text-center">
+ <dt className="uppercase tracking-wide text-[10px] text-muted">{t('jobBoard.snapshot.contract')}</dt>
+ <dd className="font-semibold font-display text-strong mt-0.5 leading-tight">
+ {t(contractTranslationKey(selectedJob))}
+ </dd>
+ </div>
+ <div className="rounded-lg bg-surface-alt p-2 text-center">
+ <dt className="uppercase tracking-wide text-[10px] text-muted">{t('jobBoard.snapshot.published')}</dt>
+ <dd className="font-semibold font-display text-strong mt-0.5 leading-tight">
+ {daysSincePosted(selectedJob.postedDate)}
+ </dd>
+ </div>
+ </dl>
+ {salaryEstimateWidget}
+ </section>
+
  <section className="section rounded-2xl border border-edge bg-surface p-4 sm:p-5 space-y-3">
  <h4 className="text-base font-bold text-heading">{canonicalCopy.summary}</h4>
  {enrichmentLoading && canonicalSummary.length === 0 && !detailDescription ? (

--- a/components/shared/AdSenseBanner.tsx
+++ b/components/shared/AdSenseBanner.tsx
@@ -254,13 +254,19 @@ export default function AdSenseBanner({
  observer.observe(el, { attributes: true, attributeFilter: ['data-ad-status'] });
  statusObserverRef.current = observer;
 
+ // Collapse the placeholder when the ad doesn't fill quickly. Was 90s
+ // historically — Privacy Sandbox / Attestation / adblockers now block
+ // AdSense before it can report unfilled, leaving a 400px reservation
+ // on every blocked slot for 90s. Multiple slots × 400px = 800-1200px
+ // of visible dead-space below the fold on every page load (S7).
+ // 8s is plenty for genuine fills (real fills land <2s in practice).
  fillTimeoutRef.current = setTimeout(() => {
  const status = el.getAttribute('data-ad-status');
  if (status === 'filled') return;
  console.info(`[AdSense] fill timeout for slot=${adSlot} (status=${status}), collapsing`);
  cleanupAsyncWatchers();
  setState('collapsed');
- }, 90_000);
+ }, 8_000);
 
  return true;
  };

--- a/services/jobsService.ts
+++ b/services/jobsService.ts
@@ -61,6 +61,14 @@ export const AGGREGATE_CANTON_CODE = '_AGGREGATE_' as const;
 /** Default cantons fetched when callers don't specify (backward-compat = TI/GR/VS). */
 export const DEFAULT_AGGREGATE_CANTONS: readonly string[] = ['TI', 'GR', 'VS'] as const;
 
+/** Per-canton shards are not yet emitted to dist/ (planned future deploy).
+ * Until they ship, requesting them generates a noisy 404 in DevTools on every
+ * job-board mount even though the SPA gracefully falls back to the legacy
+ * locale-wide index. Gate the shard fetch behind this flag so we stop poking
+ * a path we know returns 404. Flip to `true` in the same PR that lands the
+ * shard pipeline. (S10a 2026-05-20) */
+export const CANTON_SHARDS_ENABLED = false;
+
 const SHARD_BASE_PATH = '/data/jobs-by-canton';
 const IDB_DB_NAME = 'frontaliere-jobs-cache';
 const IDB_DB_VERSION = 1;
@@ -241,6 +249,12 @@ async function revalidateWithEtag(
 export async function fetchJobsForCanton(cantonCode: string): Promise<Job[]> {
  if (typeof cantonCode !== 'string' || cantonCode.length === 0) {
   throw new Error('[jobsService] fetchJobsForCanton: cantonCode must be a non-empty string');
+ }
+
+ // Short-circuit when shards aren't deployed yet — saves the inevitable 404
+ // and lets the JobBoard caller hit its legacy-loader fallback immediately.
+ if (!CANTON_SHARDS_ENABLED) {
+  return [];
  }
 
  const db = await openCantonCacheDb();


### PR DESCRIPTION
Follow-up to PR #426. Addresses the four residual issues left out of the
parser-fix PR, all on the job detail flow.

S6 — Mobile action block above the description
  components/community/JobBoard.tsx now renders a `lg:hidden` <section>
  between the hero header and the description: full-width Apply CTA +
  3-tile grid (Sede / Contratto / Pubblicato) + Calcola netto widget.
  75 % of traffic is mobile (CLAUDE.md #15/#17) and the CTA was
  previously buried below 600 px of prose. Desktop unchanged (sticky
  right rail still owns these widgets, no duplication on lg+).

S7 — Dead-space under the fold (collapsed-ad timeout)
  components/shared/AdSenseBanner.tsx — collapse timeout reduced from
  90 s to 8 s. Privacy Sandbox / Attestation Reporting now block
  AdSense before it reports `unfilled`, so the 400 px placeholder on
  each of the 2-3 ad slots sat reserved for 90 s — 800-1200 px of
  visible whitespace below `Annunci correlati` on every load. Genuine
  fills resolve <2 s in practice, so 8 s is plenty.

S9 — Structured content above the fold for thin descriptions
  The new mobile block surfaces location/contract/published-days +
  Calcola netto (CHF range) regardless of description length. Pages
  with <50-word descriptions now have substantive visible signal
  above the fold instead of just H1+filler.

S10a — TI.json / shard 404 noise
  services/jobsService.ts — added `CANTON_SHARDS_ENABLED = false`
  guard. Per-canton shards `/data/jobs-by-canton/*.json` are not yet
  emitted to dist/, so every JobBoard mount triggered a red 404 in
  DevTools even though the SPA gracefully falls back to the legacy
  locale-wide index. Short-circuit before fetch. Flip the flag in the
  same PR that lands the shard pipeline.

S10b — Manrope/Outfit font preload credentials mismatch
  build-plugins/jobsSeoPagesPlugin.ts — `<link rel="stylesheet">` for
  Google Fonts CSS now sets `crossorigin` to match the existing
  `<link rel="preload" ... crossorigin>`, eliminating the
  "preload found but not used because the request credentials mode
  does not match" Chrome warning on every job page.

Verified on the casale lavora-con-noi sample (the page used as the
canonical S6-S10 repro since 2026-05-20).
