### PR TITLE
fix(job-detail): salary line in static block + article self-start + translator markdown balancer (P2+P3+P4)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2377,13 +2377,22 @@ ${hreflangHtml}
  return fmt[locale as 'it'|'en'|'de'|'fr'](days);
  })();
  const contractText = String(job.contract || 'other');
+ const salaryLabel: Record<'it'|'en'|'de'|'fr', string> = {
+ it: 'Salario', en: 'Salary', de: 'Lohn', fr: 'Salaire',
+ };
+ // Salary line — only when we actually have a number; the "non indicato"
+ // fallback is meaningless as a money signal so we suppress it instead of
+ // rendering a tile that adds zero information.
+ const salaryLineHtml = Number.isFinite(salaryMin)
+ ? `<div class="mab-salary"><span class="mab-salary-label">${esc(salaryLabel[locale as 'it'|'en'|'de'|'fr'])}</span><span class="mab-salary-value">${esc(salaryText)}</span></div>`
+ : '';
  return `<section class="mobile-action-block" aria-label="${esc(localeCopy[locale].quickDetails)}">
  <a href="${referralUrl(job.url || canonicalUrl, job)}" rel="noopener noreferrer" class="mab-cta">${esc(localeCopy[locale].applyNow)}</a>
  <dl class="mab-grid">
  <div class="mab-tile"><dt>${esc(localeCopy[locale].location)}</dt><dd>${esc(addressLocality)}</dd></div>
  <div class="mab-tile"><dt>${esc(localeCopy[locale].contract)}</dt><dd>${esc(contractText)}</dd></div>
  <div class="mab-tile"><dt>${esc(publishedLabel[locale as 'it'|'en'|'de'|'fr'])}</dt><dd>${esc(daysAgo)}</dd></div>
- </dl>
+ </dl>${salaryLineHtml}
  </section>`;
  })()}
  <section class="section">

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -6491,7 +6491,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  {authPendingNoticeJsx}
 
  <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-6">
- <article className="lg:col-span-8 space-y-4 sm:space-y-5">
+ <article className="lg:col-span-8 lg:self-start space-y-4 sm:space-y-5">
  <header className="rounded-3xl border border-edge bg-gradient-to-br from-info-subtle via-surface to-success-subtle p-4 sm:p-6">
  <div className="flex items-start gap-3 sm:gap-4">
  <a

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -196,6 +196,29 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
   color: var(--color-strong);
   line-height: 1.2;
 }
+.mobile-action-block .mab-salary {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--color-success-subtle);
+  border: 1px solid var(--color-success-border);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.mobile-action-block .mab-salary-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-success);
+  font-weight: 700;
+}
+.mobile-action-block .mab-salary-value {
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--color-strong);
+}
 @media (min-width: 1024px) {
   .mobile-action-block { display: none; }
 }

--- a/scripts/lib/free-translate.mjs
+++ b/scripts/lib/free-translate.mjs
@@ -830,6 +830,55 @@ function delay(ms) {
  * @param {string} options.targetLang - Target language (it/en/de/fr)
  * @returns {Promise<string>} Translated text or ''
  */
+/**
+ * Post-process a translator output to make sure `**bold**` markdown markers
+ * stay balanced. AI translators frequently re-flow paragraphs in a way that
+ * leaves orphan `**` (count parity broken) or empty `**…**` runs containing
+ * only whitespace/punctuation. Those artifacts then leak into the rendered
+ * job page as literal `**…**` strings, which is the bug we patched at the
+ * SSG+SPA parser layer in PR #426. This is the upstream root-cause guard:
+ * any translation result with odd `**` count gets its `**` stripped before
+ * we commit it to `descriptionByLocale`.
+ *
+ * Exported so the same balancer can be reused outside the cascade (tests,
+ * upstream sanitizers, retroactive cleanup scripts).
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+export function balanceMarkdownMarkers(s) {
+  if (typeof s !== 'string' || !s) return s;
+  let out = s;
+  // 1. Drop empty / whitespace-only / punctuation-only bolds (e.g. `** **`,
+  //    `**  **`, `** : **`, `** - **`).
+  out = out.replace(/\*\*\s*[\s:;,.\-–—]*\s*\*\*/g, ' ');
+  // 2. If `**` count is odd, the output is unrecoverable as bold structure —
+  //    strip every `**` so the renderer sees plain text instead of a half-
+  //    bold span.
+  const count = (out.match(/\*\*/g) || []).length;
+  if (count % 2 !== 0) {
+    out = out.replace(/\*\*/g, '');
+  }
+  // 3. Strip standalone separator-only lines (`______`, `======`) that some
+  //    translators emit as decoration.
+  out = out
+    .split('\n')
+    .filter((line) => !/^[\s_\-=*•·~]{3,}$/.test(line))
+    .join('\n');
+  // 4. Strip trailing inline separator runs that often hug a line end.
+  out = out
+    .split('\n')
+    .map((line) => line.replace(/\s+[_\-=~*]{3,}\s*$/g, '').trimEnd())
+    .join('\n');
+  // 5. Collapse 3+ consecutive newlines that step 3 may have created when
+  //    a separator line sat between two paragraph breaks (\n\nSEP\n\n →
+  //    \n\n\n after filter).
+  out = out.replace(/\n{3,}/g, '\n\n');
+  // 6. Collapse the consecutive double-spaces that step 1 may have left.
+  out = out.replace(/[ \t]{2,}/g, ' ');
+  return out.trim();
+}
+
 export async function freeTranslate({ text, sourceLang, targetLang }) {
   const clean = normalizeSpace(text);
   if (!clean) return '';
@@ -857,15 +906,15 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
 
   // Tier 1: DeepL Free API (best quality, if API key set)
   const t1 = await tryTier('deepl', () => translateWithDeepL(clean, sourceLang, targetLang));
-  if (t1) return t1;
+  if (t1) return balanceMarkdownMarkers(t1);
 
   // Tier 2: Azure Translator (F0 Free — 2M chars/month, near-DeepL quality)
   const t1b = await tryTier('azure', () => translateWithAzure(clean, sourceLang, targetLang));
-  if (t1b) return t1b;
+  if (t1b) return balanceMarkdownMarkers(t1b);
 
   // Tier 3: Google Cloud Translation (official API, 500K free/month, hard-capped 16K/day)
   const t2c = await tryTier('googleCloud', () => translateWithGoogleCloud(clean, sourceLang, targetLang));
-  if (t2c) return t2c;
+  if (t2c) return balanceMarkdownMarkers(t2c);
 
   // Tier 4: MyMemory (best EU language quality, 50K chars/day with email param)
   // Short text (≤5000 chars): single call. Long text: chunk at sentence boundaries.
@@ -891,45 +940,45 @@ export async function freeTranslate({ text, sourceLang, targetLang }) {
     if (joined && joined.toLowerCase() !== clean.toLowerCase()) return joined;
     return '';
   });
-  if (t2) return t2;
+  if (t2) return balanceMarkdownMarkers(t2);
 
   // Tier 4a: LibreTranslate self-hosted (CI service container — unlimited, no rate limits)
   const t3b = await tryTier('libreTranslateSelfHosted', () => translateWithLibreTranslateSelfHosted(clean, sourceLang, targetLang));
-  if (t3b) return t3b;
+  if (t3b) return balanceMarkdownMarkers(t3b);
 
   // Tier 4b: LibreTranslate public instances (raced in parallel — reliable from CI)
   const t4 = await tryTier('libreTranslate', () => translateWithLibreTranslate(clean, sourceLang, targetLang));
-  if (t4) return t4;
+  if (t4) return balanceMarkdownMarkers(t4);
 
   // Tier 5: Hugging Face OPUS-MT (Helsinki-NLP open-source, good for short text)
   const t5 = await tryTier('huggingFace', () => translateWithHuggingFace(clean, sourceLang, targetLang));
-  if (t5) return t5;
+  if (t5) return balanceMarkdownMarkers(t5);
 
   // Tier 6: Mozhi+DuckDuckGo (Bing via Mozhi proxy — works sometimes from CI)
   const t6b = await tryTier('mozhiDdg', () => translateWithMozhiEngine(clean, sourceLang, targetLang, 'duckduckgo'));
-  if (t6b) return t6b;
+  if (t6b) return balanceMarkdownMarkers(t6b);
 
   // ── LOCAL/DEV TIERS (blocked from GitHub Actions IPs, work locally) ───────
 
   // Tier 6: Lingva (Google Translate proxy — works locally, blocked in CI)
   const t6 = await tryTier('lingva', () => translateWithLingva(clean, sourceLang, targetLang));
-  if (t6) return t6;
+  if (t6) return balanceMarkdownMarkers(t6);
 
   // Tier 7: Mozhi+Google (Google via Mozhi — works locally, blocked in CI)
   const t7 = await tryTier('mozhiGoogle', () => translateWithMozhiEngine(clean, sourceLang, targetLang, 'google'));
-  if (t7) return t7;
+  if (t7) return balanceMarkdownMarkers(t7);
 
   // Tier 8: Google Translate (unofficial direct endpoint — often blocked)
   const t8 = await tryTier('google', () => translateWithGoogle(clean, sourceLang, targetLang));
-  if (t8) return t8;
+  if (t8) return balanceMarkdownMarkers(t8);
 
   // Tier 9: Mozhi+DeepL (DeepL engine returns empty via proxy — broken since 2026-03)
   const t9 = await tryTier('mozhiDeepL', () => translateWithMozhiEngine(clean, sourceLang, targetLang, 'deepl'));
-  if (t9) return t9;
+  if (t9) return balanceMarkdownMarkers(t9);
 
   // Tier 10: Mozhi+Yandex (slow last resort)
   const t10 = await tryTier('mozhiYandex', () => translateWithMozhiEngine(clean, sourceLang, targetLang, 'yandex'));
-  if (t10) return t10;
+  if (t10) return balanceMarkdownMarkers(t10);
 
   _cascadeStats.failures++;
   return '';

--- a/tests/free-translate-markdown-balancer.test.ts
+++ b/tests/free-translate-markdown-balancer.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { balanceMarkdownMarkers } from '@/scripts/lib/free-translate.mjs';
+
+/**
+ * Upstream root-cause guard for the literal-`**` bug we patched at render
+ * time in PR #426. Translator outputs with unbalanced bold markers now get
+ * sanitized before reaching `descriptionByLocale[lang]`, so the artifact
+ * cannot propagate to the dataset and the rendered job page.
+ *
+ * The render-side parser (`build-plugins/shared/jobDescription/parser.ts`)
+ * is the second line of defence — this test pins the FIRST line: at the
+ * translator boundary the JSON we commit must never contain orphan `**`.
+ */
+describe('balanceMarkdownMarkers — translator-time defence', () => {
+ it('returns input untouched when `**` count is even and bolds are non-empty', () => {
+ const raw = 'Posizione **Senior Engineer** in **Lugano** con esperienza.';
+ expect(balanceMarkdownMarkers(raw)).toBe(raw);
+ });
+
+ it('strips ALL `**` when count is odd (the orphan-bold case)', () => {
+ const raw = 'Se è così **entrate a far parte di un\'organizzazione **dinamica** e crescere';
+ const out = balanceMarkdownMarkers(raw);
+ expect(out).not.toMatch(/\*\*/);
+ });
+
+ it('strips empty / whitespace-only / punctuation-only bolds (S1 casale repro)', () => {
+ const raw = 'Compiti ** ** **  ** **:** Operativo.';
+ expect(balanceMarkdownMarkers(raw)).toBe('Compiti Operativo.');
+ });
+
+ it('handles the exact casale "Lavora con noi" Italian artifact: drops empty pair, keeps balanced one', () => {
+ const raw =
+ "**Se è così - **entrate a far parte di un'organizzazione dinamica che offre percorsi di carriera diversificati e opportunità di crescita eccezionali** **";
+ const out = balanceMarkdownMarkers(raw);
+ // After empty-pair strip the remaining `**Se è così - **` is balanced (2
+ // markers, non-empty content) and survives — the render-side parser will
+ // convert it to <strong>. The trailing empty `** **` gets dropped here.
+ const markerCount = (out.match(/\*\*/g) || []).length;
+ expect(markerCount % 2).toBe(0);
+ expect(out).not.toMatch(/\*\*\s*\*\*/); // no empty pair survived
+ expect(out).toContain('Se è così');
+ expect(out).toContain('crescita eccezionali');
+ });
+
+ it('strips standalone separator-only lines (`______`, `=====`, `----`)', () => {
+ const raw = 'Para 1\n\n______\n\nPara 2\n\n=====\n\nPara 3';
+ expect(balanceMarkdownMarkers(raw)).toBe('Para 1\n\nPara 2\n\nPara 3');
+ });
+
+ it('strips trailing inline separator runs at end of a line', () => {
+ expect(balanceMarkdownMarkers('Be part of something. ______')).toBe('Be part of something.');
+ expect(balanceMarkdownMarkers('Some text ----')).toBe('Some text');
+ });
+
+ it('returns empty / null / non-string inputs unchanged (defensive)', () => {
+ expect(balanceMarkdownMarkers('')).toBe('');
+ expect(balanceMarkdownMarkers(null as unknown as string)).toBe(null);
+ expect(balanceMarkdownMarkers(undefined as unknown as string)).toBe(undefined);
+ });
+
+ it('preserves single `*emphasis*` markers untouched', () => {
+ const raw = 'Pacchetto *interessante* con benefit *aggiuntivi*';
+ expect(balanceMarkdownMarkers(raw)).toBe(raw);
+ });
+
+ it('idempotent: balancing twice equals balancing once', () => {
+ const raw =
+ "**Profilo:** orientato al cliente. ** ** Esperienza richiesta. ______";
+ const once = balanceMarkdownMarkers(raw);
+ const twice = balanceMarkdownMarkers(once);
+ expect(twice).toBe(once);
+ });
+});


### PR DESCRIPTION
Three follow-ups bundled.

P2 — Static mobile-action-block salary parity
  PR #428 surfaced location/contract/posted in the SPA above-fold block but
  the SSG equivalent (PR #431) only mirrored those three tiles, missing the
  salary signal. build-plugins/jobsSeoPagesPlugin.ts now appends a
  .mab-salary row after the 3-tile grid when salaryMin is finite — falls
  back silently when the job has no salary so we never render a tile that
  says "non indicato". Localized label (`Salario` / `Salary` / `Lohn` /
  `Salaire`). seo-static.css gets the matching .mab-salary{,-label,-value}
  rules in a success-tinted callout style.

P3 — Article column self-start on desktop
  components/community/JobBoard.tsx: <article class="lg:col-span-8"> →
  <article class="lg:col-span-8 lg:self-start">. The 12-column grid was
  stretching the article cell to match the (taller) sticky aside on jobs
  with short descriptions, leaving ~800-2000 px of empty whitespace below
  the article body before "Annunci correlati". lg:self-start pins the
  article to its natural content height; the aside still flows in its own
  column.

P4 — Translator-time `**` balancer (root-cause guard for S1)
  scripts/lib/free-translate.mjs exports new `balanceMarkdownMarkers()`.
  Applied to every tier return inside `freeTranslate()` (Tier 1..10). The
  balancer:
    - drops empty/whitespace-only/punctuation-only `**…**` pairs,
    - strips ALL `**` markers when the count is odd (unrecoverable orphan),
    - removes standalone separator-only lines (`______`, `=====`, `----`),
    - strips trailing inline separator runs at line ends,
    - collapses 3+ newlines and double-spaces left over by the strips.
  This is the upstream root cause of the literal-`**` bug we previously
  patched at render time in PR #426 — the AI translator (DeepL/MyMemory/
  LibreTranslate/etc.) often re-flows paragraphs into unbalanced markers,
  and every cascade tier output goes through balancer before reaching the
  consumer (relocalize-pending-jobs.mjs → descriptionByLocale). The
  render-side parser stays as a defence in depth.

  9 unit tests covering: balanced pairs untouched, odd-count stripping,
  empty-bold drop, casale "Lavora con noi" repro (post-balance still
  parseable by render-side parser), separator-line + trailing-separator
  strip, null/undefined defensiveness, italic markers preserved,
  idempotency.
