### PR TITLE
fix(seo): differentiate combo city+company H1 from title to clear h1-title-duplicates

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -7115,24 +7115,29 @@ ${alternates}
  const comboKey = `${cityKey}-${compKey}`;
  const normCity = normalizeSearchTerm(cityKey);
  const normComp = normalizeSearchTerm(compKey);
+ // Title and heading use STRUCTURALLY DIFFERENT lead words so that when
+ // long company names (e.g. "EOC – Ente Ospedaliero Cantonale") push the
+ // titled+brand past TITLE_MAX_CHARS=66, buildTitleWithBrand drops the
+ // brand and the bare title would otherwise collide with the H1.
+ // audit:h1-title-duplicates is zero-tolerance — guard at source.
  generateComboPage(comboKey, {
  it: {
- title: `Lavoro ${compName} a ${cityName} | Frontaliere Ticino`,
+ title: `Offerte ${compName} a ${cityName} | Frontaliere Ticino`,
  description: (c) => `${c} offerte di lavoro ${compName} a ${cityName}. Scopri le posizioni aperte e candidati subito.`,
  heading: `Lavoro ${compName} a ${cityName}`,
  },
  en: {
- title: `${compName} jobs in ${cityName} | Frontaliere Ticino`,
+ title: `${compName} careers in ${cityName} | Frontaliere Ticino`,
  description: (c) => `${c} ${compName} job openings in ${cityName}. Browse available positions and apply today.`,
  heading: `${compName} jobs in ${cityName}`,
  },
  de: {
- title: `${compName} Jobs in ${cityName} | Frontaliere Ticino`,
+ title: `${compName} Stellenangebote in ${cityName} | Frontaliere Ticino`,
  description: (c) => `${c} offene Stellen bei ${compName} in ${cityName}. Entdecke aktuelle Positionen und bewirb dich direkt.`,
  heading: `${compName} Jobs in ${cityName}`,
  },
  fr: {
- title: `Emploi ${compName} à ${cityName} | Frontaliere Ticino`,
+ title: `Postes ${compName} à ${cityName} | Frontaliere Ticino`,
  description: (c) => `${c} offres d'emploi ${compName} à ${cityName}. Consultez les postes ouverts et postulez directement.`,
  heading: `Emploi ${compName} à ${cityName}`,
  },


### PR DESCRIPTION
Run 26143868872 validate-dist failed with 8 h1=title duplicate offenders on
the combo city+company landings for EOC – Ente Ospedaliero Cantonale across
Lugano + Bellinzona × 4 locales.

Root cause: combo block at jobsSeoPagesPlugin.ts:7110 used the same lead
word in both <title> and the H1 ("Lavoro X a Y" / "X jobs in Y"). For
short company names + brand suffix " | Frontaliere Ticino" the full title
fits within TITLE_MAX_CHARS=66 and audit sees title≠h1. For the long EOC
name the combined title (69+ chars) exceeds the cap, buildTitleWithBrand
drops the brand, and the bare title becomes byte-identical with the H1.

Fix: structurally distinct lead word per locale —
  IT  title  Offerte X a Y    | heading  Lavoro X a Y
  EN  title  X careers in Y   | heading  X jobs in Y
  DE  title  X Stellenangebote in Y | heading  X Jobs in Y
  FR  title  Postes X à Y     | heading  Emploi X à Y

Even after brand drop the bare title and H1 differ by lead noun, so the
audit:h1-title-duplicates ratchet (zero-tolerance per baseline) stays at 0.

Title-length audit unaffected: longest variant
"EOC – Ente Ospedaliero Cantonale Stellenangebote in Bellinzona" = 62 char
≤ 66 cap (brand drops for the long-EOC pages either way; no regression
for shorter company names where brand stays).
