### PR TITLE
chore(ui): remove border-l accent stripes from BlogArticles / PressKit / Correzioni (impeccable BAN 1)

### DIFF
--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -459,7 +459,7 @@ function renderFormattedContent(
  const h2TableEl = inlineBody ? tryRenderMdTable(inlineBody, `h2tbl-${idx}`, navigators) : null;
  renderedBlocks.push(
  <div key={`heading-${idx}`} className="space-y-2">
- <h2 id={generateHeadingSlug(heading)} className="text-xl font-bold font-display text-heading border-l-4 border-accent pl-3 mt-6 mb-2 scroll-mt-20">
+ <h2 id={generateHeadingSlug(heading)} className="text-xl font-bold font-display text-heading mt-8 mb-3 scroll-mt-20">
  {renderInlineFormatting(heading, navigators)}
  </h2>
  {h2TableEl || (inlineBody && (
@@ -2365,7 +2365,7 @@ function BlogArticles({
  h.level === 3 ? 'pl-3' : ''
  } ${
  activeHeadingId === h.id
- ? 'text-accent font-medium border-l-2 border-accent pl-2'
+ ? 'text-accent font-medium bg-accent-subtle pl-2'
  : `text-subtle hover:text-accent ${h.level === 3 ? 'font-normal' : 'font-medium'}`
  }`}
  >

--- a/components/pages/Correzioni.tsx
+++ b/components/pages/Correzioni.tsx
@@ -240,7 +240,7 @@ export const Correzioni: React.FC = () => {
               {sortedEntries.map((entry, idx) => (
                 <li
                   key={`${entry.date}-${entry.articleId}-${idx}`}
-                  className="border-l-2 border-accent/40 pl-4 py-1"
+                  className="rounded-lg bg-surface-alt px-4 py-3"
                 >
                   <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted mb-1">
                     <time dateTime={entry.date} className="font-mono">

--- a/components/pages/PressKit.tsx
+++ b/components/pages/PressKit.tsx
@@ -132,7 +132,7 @@ const PressKit: React.FC = () => {
         </h2>
         <ul className="space-y-4">
           {QUOTES.map((quote) => (
-            <li key={quote.slice(0, 24)} className="rounded-2xl border-l-4 border-accent bg-surface-alt p-5">
+            <li key={quote.slice(0, 24)} className="rounded-2xl border border-edge bg-surface-alt p-5">
               <p className="text-base italic text-body leading-relaxed">&ldquo;{quote}&rdquo;</p>
               <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-muted">
                 — Redazione Frontaliere Ticino


### PR DESCRIPTION
Four remaining instances of the `border-left ≥ 2px` colored-stripe
anti-pattern that PR #426 only cleared from the job-detail flow. The
impeccable BAN 1 covers cards / list items / callouts / headings — the
stripe never looks intentional regardless of width, color, or radius.

- BlogArticles.tsx:462 — article H2 lost `border-l-4 border-accent pl-3`.
  Hierarchy was already carried by `text-xl font-bold font-display`;
  spacing bumped (`mt-8 mb-3`) to keep section rhythm without the stripe.
- BlogArticles.tsx:2368 — active TOC item swapped `border-l-2
  border-accent pl-2` for `bg-accent-subtle pl-2`. Active state is
  carried by background tint instead of side stripe.
- PressKit.tsx:135 — press quote `<li>` replaced `border-l-4
  border-accent` with `border border-edge` so the tile has a full thin
  border instead of an accent stripe; quote glyphs + italic carry the
  semantic. bg-surface-alt unchanged.
- Correzioni.tsx:243 — correction entry `<li>` swapped `border-l-2
  border-accent/40 pl-4 py-1` for `rounded-lg bg-surface-alt px-4 py-3`.
  Each entry now reads as a soft-bg tile.

Only border-l left in components/ is the dashed timeline track in
JobBoard.tsx (a genuine visual rail, not a heading/list decoration).
Correzioni regression test still passes.
