### PR TITLE
docs(plans): Astro + Zod full migration — 1 master + 8 sub-plans

### DIFF
--- a/docs/superpowers/plans/2026-05-20-astro-zod-01-zod-foundations.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-01-zod-foundations.md
@@ -1,0 +1,1566 @@
+# Sub-Plan 01: Zod Foundations + JSON-LD Schema-Derived Emission
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install Zod. Define schemas for the 6 most-referenced content/data sources. Refactor JSON-LD emission to be schema-derived. Retire 7 dist-walking audit gates by making the violations they catch impossible by construction at assemble-time / build-time.
+
+**Architecture:** Schemas live under `scripts/lib/schemas/` (Node-side, ESM, importable from both `.mjs` scripts and `.ts` build plugins via the existing path alias `@/*`). Each data source has a strict Zod schema parsed at the boundary (assembler, AI output parser, plugin entry). Schema-derived JSON-LD helpers live in `services/seo/structuredData.ts` (refactor of the existing `services/seo/imageObjectLd.ts`). Audit retirement = delete the audit from `audit-all.mjs` registry + delete its baseline file + delete its workflow step; the corresponding invariant is enforced at the source by the schema or by the JSON-LD helper.
+
+**Tech Stack:** Zod 4.4.x (devDep), Node ESM, existing vitest, existing JSON-LD emission pattern (`services/seo/imageObjectLd.ts` as the reference shape).
+
+**Ships standalone value:** ✅ Even if the rest of the Astro migration is cancelled, this sub-plan eliminates 7 audit gates, hardens AI output parsing, and produces typed data sources that the rest of the codebase can consume.
+
+---
+
+## File structure
+
+**Created:**
+- `scripts/lib/schemas/index.mjs` — barrel export
+- `scripts/lib/schemas/job.mjs` — `JobSchema`, `LocalizedJobSchema`
+- `scripts/lib/schemas/article.mjs` — `ArticleMetaSchema`, `ArticleLocaleBodySchema`, `LocalizedArticleSchema`
+- `scripts/lib/schemas/orphanCluster.mjs` — `OrphanClusterSchema`
+- `scripts/lib/schemas/healthPremium.mjs` — `HealthPremiumRowSchema`
+- `scripts/lib/schemas/fuelDaily.mjs` — `FuelDailySnapshotSchema`
+- `scripts/lib/schemas/borderWait.mjs` — `BorderWaitMeasurementSchema`
+- `scripts/lib/schemas/seoText.mjs` — `SeoTitleSchema`, `SeoH1Schema`, `SeoMetaDescriptionSchema` (reusable string constraints)
+- `services/seo/structuredData.ts` — schema-driven JSON-LD emitters
+- `tests/schemas/job-schema.test.ts`
+- `tests/schemas/article-schema.test.ts`
+- `tests/schemas/orphan-cluster-schema.test.ts`
+- `tests/schemas/health-premium-schema.test.ts`
+- `tests/schemas/fuel-daily-schema.test.ts`
+- `tests/schemas/border-wait-schema.test.ts`
+- `tests/schemas/seo-text-schema.test.ts`
+- `tests/seo/structured-data.test.ts`
+- `tests/assemble-jobs-schema-gate.test.ts` — integration test that the assembler rejects invalid jobs
+
+**Modified:**
+- `package.json` — add `zod` to `devDependencies`
+- `scripts/assemble-jobs-dataset.mjs` — import `JobSchema`, validate at write time
+- `scripts/cluster-orphan-queries.mjs` — import `OrphanClusterSchema`, validate at write time
+- `scripts/create-article.mjs` — import `ArticleMetaSchema`, validate AI output before write
+- `services/seo/imageObjectLd.ts` — re-export from new `structuredData.ts`, deprecation comment
+- `scripts/audit-all.mjs` — remove 7 retired audits from registry
+- `.github/workflows/deploy.yml` — remove 7 retired audit steps (or mark as build-time-handled)
+- `.github/workflows/post-deploy-validate-dist.yml` — same
+
+**Deleted (after schema fully replaces them):**
+- `scripts/audit-title-length.mjs`
+- `scripts/audit-title-no-disambig-hash.mjs`
+- `scripts/audit-h1-title-duplicates.mjs`
+- `scripts/audit-jsonld-no-nested-scripts.mjs` (and any `*.cjs` variants)
+- `scripts/audit-image-object-license.mjs`
+- `scripts/audit-faqpage-validity.mjs`
+- `scripts/audit-footer-root-presence.mjs`
+- Corresponding baseline JSON files in `data/*-baseline.json`
+
+---
+
+## Task 1: Install Zod
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Verify Zod is not already a transitive runtime dependency we shouldn't conflict with**
+
+Run: `npm ls zod 2>&1 | head -20`
+Expected: only transitive entries (e.g. from openai SDK if present), no top-level dependency.
+
+- [ ] **Step 2: Install Zod as devDependency**
+
+Run: `npm install --save-dev zod@^4.4.3`
+Expected: `package.json` `devDependencies` now includes `"zod": "^4.4.3"`. `package-lock.json` updated.
+
+- [ ] **Step 3: Verify install works**
+
+Run: `node -e "import('zod').then(z => console.log(z.z.string().parse('hello')))"`
+Expected output: `hello`
+
+- [ ] **Step 4: Type-check still clean**
+
+Run: `npx tsc --noEmit 2>&1 | tail -20`
+Expected: no new errors introduced.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add zod 4.4.x as devDependency for schema-driven validation"
+```
+
+---
+
+## Task 2: Create reusable SeoText schemas (string constraints)
+
+**Files:**
+- Create: `scripts/lib/schemas/seoText.mjs`
+- Test: `tests/schemas/seo-text-schema.test.ts`
+
+- [ ] **Step 1: Write failing test for SeoTitleSchema length cap**
+
+```ts
+// tests/schemas/seo-text-schema.test.ts
+import { describe, it, expect } from 'vitest';
+import { SeoTitleSchema, SeoH1Schema, SeoMetaDescriptionSchema } from '../../scripts/lib/schemas/seoText.mjs';
+
+describe('SeoTitleSchema', () => {
+  it('accepts a 1-66 char title', () => {
+    expect(SeoTitleSchema.safeParse('Stipendio netto frontaliere 2026').success).toBe(true);
+  });
+  it('rejects empty title', () => {
+    expect(SeoTitleSchema.safeParse('').success).toBe(false);
+  });
+  it('rejects title > 66 chars', () => {
+    const tooLong = 'A'.repeat(67);
+    expect(SeoTitleSchema.safeParse(tooLong).success).toBe(false);
+  });
+  it('rejects title containing (#hash) disambiguation marker', () => {
+    expect(SeoTitleSchema.safeParse('Permesso G vs B (#1)').success).toBe(false);
+  });
+});
+
+describe('SeoH1Schema', () => {
+  it('accepts a 1-80 char H1', () => {
+    expect(SeoH1Schema.safeParse('Stipendio netto frontaliere 2026 — guida').success).toBe(true);
+  });
+  it('rejects empty H1', () => {
+    expect(SeoH1Schema.safeParse('').success).toBe(false);
+  });
+});
+
+describe('SeoMetaDescriptionSchema', () => {
+  it('accepts 50-160 chars', () => {
+    const ok = 'A'.repeat(120);
+    expect(SeoMetaDescriptionSchema.safeParse(ok).success).toBe(true);
+  });
+  it('rejects < 50 chars (thin content)', () => {
+    expect(SeoMetaDescriptionSchema.safeParse('too short').success).toBe(false);
+  });
+  it('rejects > 160 chars', () => {
+    const tooLong = 'A'.repeat(161);
+    expect(SeoMetaDescriptionSchema.safeParse(tooLong).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+Run: `npx vitest run tests/schemas/seo-text-schema.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the schema module**
+
+```js
+// scripts/lib/schemas/seoText.mjs
+import { z } from 'zod';
+
+// Caps tracked from CLAUDE.md SEO gates table. Title cap = 66 (gate threshold);
+// H1 cap = 80 (per repo convention, h1 may be longer than title); meta description
+// 50-160 per Google snippet rendering window.
+export const SeoTitleSchema = z
+  .string()
+  .min(1, 'title-empty')
+  .max(66, 'title-too-long')
+  .refine((s) => !/\(#[^)]*\)/.test(s), {
+    message: 'title-contains-disambig-hash',
+  });
+
+export const SeoH1Schema = z.string().min(1, 'h1-empty').max(80, 'h1-too-long');
+
+export const SeoMetaDescriptionSchema = z
+  .string()
+  .min(50, 'meta-description-too-short')
+  .max(160, 'meta-description-too-long');
+```
+
+- [ ] **Step 4: Run test — verify it passes**
+
+Run: `npx vitest run tests/schemas/seo-text-schema.test.ts`
+Expected: PASS (10 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/schemas/seoText.mjs tests/schemas/seo-text-schema.test.ts
+git commit -m "feat(schemas): add SeoTitleSchema, SeoH1Schema, SeoMetaDescriptionSchema"
+```
+
+---
+
+## Task 3: JobSchema — strict shape for assembled jobs
+
+**Files:**
+- Create: `scripts/lib/schemas/job.mjs`
+- Test: `tests/schemas/job-schema.test.ts`
+
+**Pre-read context:** Inspect `scripts/assemble-jobs-dataset.mjs:698` (HEAVY_FIELDS), `:1570-1590` (postalCode enrichment) to confirm field names. Also inspect one slice file under `data/jobs/by-crawler/` to see the post-assembly shape on disk.
+
+- [ ] **Step 1: Read a real job to anchor the schema**
+
+Run: `node -e "import('fs').then(({readFileSync}) => { const f = JSON.parse(readFileSync('data/jobs/by-crawler/vaudoise.json','utf8')); console.log(JSON.stringify(f.jobs?.[0] ?? f[0], null, 2).slice(0, 2000)); })"`
+Expected: prints the shape of one job. Note any field present in real data that the test below should accept.
+
+- [ ] **Step 2: Write failing test for JobSchema**
+
+```ts
+// tests/schemas/job-schema.test.ts
+import { describe, it, expect } from 'vitest';
+import { JobSchema } from '../../scripts/lib/schemas/job.mjs';
+
+const validJob = {
+  id: 'vaudoise-12345',
+  stableId: '550e8400-e29b-41d4-a716-446655440000',
+  slug: 'sviluppatore-frontend-lausanne',
+  url: 'https://vaudoise.ch/jobs/12345',
+  title: 'Sviluppatore Frontend',
+  company: 'Vaudoise Assurances',
+  hiringOrganization: { name: 'Vaudoise Assurances' },
+  location: 'Lausanne',
+  addressLocality: 'Lausanne',
+  postalCode: '1003',
+  streetAddress: 'Place de Milan 1',
+  description: 'Cerchiamo uno sviluppatore frontend con esperienza in React per la nostra sede di Losanna. Lavorerai in un team di 8 persone.',
+  datePosted: '2026-05-15',
+  employmentType: 'FULL_TIME',
+  jobLocation: {
+    addressLocality: 'Lausanne',
+    postalCode: '1003',
+    addressCountry: 'CH',
+  },
+  baseSalary: {
+    currency: 'CHF',
+    value: { minValue: 80000, maxValue: 110000, unitText: 'YEAR' },
+  },
+};
+
+describe('JobSchema', () => {
+  it('accepts a fully-populated job', () => {
+    const res = JobSchema.safeParse(validJob);
+    if (!res.success) console.error(res.error.issues);
+    expect(res.success).toBe(true);
+  });
+
+  it('rejects job without baseSalary (CLAUDE.md rule #3)', () => {
+    const { baseSalary, ...without } = validJob;
+    expect(JobSchema.safeParse(without).success).toBe(false);
+  });
+
+  it('rejects job without postalCode', () => {
+    const { postalCode, ...without } = validJob;
+    expect(JobSchema.safeParse(without).success).toBe(false);
+  });
+
+  it('rejects job without streetAddress', () => {
+    const { streetAddress, ...without } = validJob;
+    expect(JobSchema.safeParse(without).success).toBe(false);
+  });
+
+  it('rejects job with description < 50 chars (thin content, rule #4)', () => {
+    const thin = { ...validJob, description: 'too short' };
+    expect(JobSchema.safeParse(thin).success).toBe(false);
+  });
+
+  it('rejects job with title > 66 chars', () => {
+    const longTitle = { ...validJob, title: 'A'.repeat(67) };
+    expect(JobSchema.safeParse(longTitle).success).toBe(false);
+  });
+
+  it('rejects malformed postalCode (must be 4 digits)', () => {
+    const bad = { ...validJob, postalCode: 'CH-1003' };
+    expect(JobSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects unknown employmentType', () => {
+    const bad = { ...validJob, employmentType: 'GIG_WORK' };
+    expect(JobSchema.safeParse(bad).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test — verify it fails**
+
+Run: `npx vitest run tests/schemas/job-schema.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Create JobSchema**
+
+```js
+// scripts/lib/schemas/job.mjs
+import { z } from 'zod';
+import { SeoTitleSchema } from './seoText.mjs';
+
+// Swiss postal codes are 4 digits (Liechtenstein included).
+const SwissPostalCodeSchema = z.string().regex(/^\d{4}$/, 'postalCode-not-swiss-4-digit');
+
+const BaseSalarySchema = z.object({
+  currency: z.literal('CHF'),
+  value: z.object({
+    minValue: z.number().nonnegative(),
+    maxValue: z.number().nonnegative(),
+    unitText: z.enum(['HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR']),
+  }),
+});
+
+const EmploymentTypeSchema = z.enum([
+  'FULL_TIME',
+  'PART_TIME',
+  'CONTRACTOR',
+  'TEMPORARY',
+  'INTERN',
+  'VOLUNTEER',
+  'PER_DIEM',
+  'OTHER',
+]);
+
+const JobLocationSchema = z.object({
+  addressLocality: z.string().min(1),
+  postalCode: SwissPostalCodeSchema,
+  addressCountry: z.enum(['CH', 'LI', 'IT', 'FR', 'DE', 'AT']),
+});
+
+// JobSchema enforces every mandatory SEO field listed in CLAUDE.md rule #3.
+// Optional fields (titleByLocale, descriptionByLocale, previousSlugs, etc.) are
+// passed through with .passthrough() to preserve enrichment without re-listing.
+export const JobSchema = z
+  .object({
+    id: z.string().min(1),
+    stableId: z.string().uuid().optional(),  // crawler-derived, may be absent on legacy slices
+    slug: z.string().min(1),
+    url: z.string().url(),
+    title: SeoTitleSchema,
+    company: z.string().min(1),
+    hiringOrganization: z.object({ name: z.string().min(1) }),
+    location: z.string().min(1),
+    addressLocality: z.string().min(1),
+    postalCode: SwissPostalCodeSchema,
+    streetAddress: z.string().min(1),
+    description: z.string().min(50, 'thin-content-rule-4'),
+    datePosted: z.string().regex(/^\d{4}-\d{2}-\d{2}/, 'datePosted-not-iso'),
+    employmentType: EmploymentTypeSchema,
+    jobLocation: JobLocationSchema,
+    baseSalary: BaseSalarySchema,
+  })
+  .passthrough();
+
+// Per-locale renderable view (combined with titleByLocale/descriptionByLocale at render time).
+export const LocalizedJobSchema = JobSchema.extend({
+  locale: z.enum(['it', 'en', 'de', 'fr']),
+});
+```
+
+- [ ] **Step 5: Run test — verify it passes**
+
+Run: `npx vitest run tests/schemas/job-schema.test.ts`
+Expected: PASS (8 assertions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/schemas/job.mjs tests/schemas/job-schema.test.ts
+git commit -m "feat(schemas): add JobSchema enforcing CLAUDE.md rule #3 mandatory SEO fields"
+```
+
+---
+
+## Task 4: Wire JobSchema into assemble-jobs-dataset.mjs
+
+**Files:**
+- Modify: `scripts/assemble-jobs-dataset.mjs`
+- Test: `tests/assemble-jobs-schema-gate.test.ts`
+
+- [ ] **Step 1: Write integration test that the assembler rejects malformed jobs**
+
+```ts
+// tests/assemble-jobs-schema-gate.test.ts
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('assemble-jobs-dataset schema gate', () => {
+  it('exits non-zero when a slice contains a job missing baseSalary', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'assemble-gate-'));
+    const byCrawler = join(tmp, 'data', 'jobs', 'by-crawler');
+    mkdirSync(byCrawler, { recursive: true });
+
+    const malformed = {
+      crawlerKey: 'unit-test',
+      assembledAt: new Date().toISOString(),
+      jobs: [
+        {
+          id: 'broken-1',
+          slug: 'broken-1',
+          url: 'https://example.ch/broken-1',
+          title: 'No salary here',
+          company: 'Acme',
+          hiringOrganization: { name: 'Acme' },
+          location: 'Lugano',
+          addressLocality: 'Lugano',
+          postalCode: '6900',
+          streetAddress: 'Via Test 1',
+          description: 'A'.repeat(100),
+          datePosted: '2026-05-15',
+          employmentType: 'FULL_TIME',
+          jobLocation: { addressLocality: 'Lugano', postalCode: '6900', addressCountry: 'CH' },
+          // baseSalary intentionally missing
+        },
+      ],
+    };
+    writeFileSync(join(byCrawler, 'unit-test.json'), JSON.stringify(malformed));
+
+    let exitCode = 0;
+    try {
+      execSync(`SLICES_DIR=${byCrawler} node scripts/assemble-jobs-dataset.mjs --validate-only`, { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status ?? 1;
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+    expect(exitCode).not.toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+Run: `npx vitest run tests/assemble-jobs-schema-gate.test.ts`
+Expected: FAIL — assembler does not yet validate.
+
+- [ ] **Step 3: Locate the assembler's write-out section**
+
+Run: `grep -n "writeFileSync\|JSON.stringify.*jobs\|jobs\.json" scripts/assemble-jobs-dataset.mjs | head -20`
+Note line numbers of the final write block and any pre-existing CLI flag parsing.
+
+- [ ] **Step 4: Add SLICES_DIR override + --validate-only flag + JobSchema validation**
+
+In `scripts/assemble-jobs-dataset.mjs`, near the top imports add:
+
+```js
+import { JobSchema } from './lib/schemas/job.mjs';
+```
+
+Near the CLI flag parsing (search for `--stats` to find it), add:
+
+```js
+const VALIDATE_ONLY = process.argv.includes('--validate-only');
+const SLICES_DIR = process.env.SLICES_DIR || 'data/jobs/by-crawler';
+```
+
+(Update any existing literal `'data/jobs/by-crawler'` reads to use `SLICES_DIR`.)
+
+After all jobs are merged into the final array but before `writeFileSync`, add:
+
+```js
+// Schema gate — fails the build on any job missing CLAUDE.md rule #3 fields.
+const violations = [];
+for (const job of finalJobs) {
+  const result = JobSchema.safeParse(job);
+  if (!result.success) {
+    violations.push({ id: job.id, issues: result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`) });
+  }
+}
+if (violations.length > 0) {
+  console.error(`[assemble-jobs] ${violations.length} job(s) failed JobSchema validation:`);
+  for (const v of violations.slice(0, 20)) {
+    console.error(`  - ${v.id}: ${v.issues.join('; ')}`);
+  }
+  if (violations.length > 20) console.error(`  ... and ${violations.length - 20} more`);
+  process.exit(1);
+}
+
+if (VALIDATE_ONLY) {
+  console.log(`[assemble-jobs] --validate-only OK: ${finalJobs.length} jobs pass JobSchema`);
+  process.exit(0);
+}
+```
+
+- [ ] **Step 5: Run integration test — verify it passes**
+
+Run: `npx vitest run tests/assemble-jobs-schema-gate.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run assembler on real data, expect either pass or actionable failures**
+
+Run: `node scripts/assemble-jobs-dataset.mjs --stats 2>&1 | tail -40`
+Expected: either `OK` exit 0 with stats, OR a list of violations — in which case, **DO NOT** loosen the schema. Fix the offending crawler slices in a separate PR, then resume.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/assemble-jobs-dataset.mjs tests/assemble-jobs-schema-gate.test.ts
+git commit -m "feat(jobs): gate assemble-jobs-dataset on JobSchema; rule #3 enforced at assemble-time"
+```
+
+---
+
+## Task 5: ArticleMetaSchema — strict shape for blog-articles-data.ts entries
+
+**Files:**
+- Create: `scripts/lib/schemas/article.mjs`
+- Test: `tests/schemas/article-schema.test.ts`
+
+- [ ] **Step 1: Read one ARTICLES entry to anchor the schema**
+
+Run: `grep -A 15 "^export const ARTICLES" data/blog-articles-data.ts | head -25`
+Confirm fields: `id`, `category`, `date`, `updatedAt`, `image`, `hasCalculator`, `authorSlug`, `authorName`.
+
+- [ ] **Step 2: Write failing test**
+
+```ts
+// tests/schemas/article-schema.test.ts
+import { describe, it, expect } from 'vitest';
+import { ArticleMetaSchema, LocalizedArticleSchema } from '../../scripts/lib/schemas/article.mjs';
+
+const validMeta = {
+  id: 'stipendio-netto-2026',
+  category: 'fisco',
+  date: '2026-01-15',
+  image: '/images/articles/stipendio-netto-2026.webp',
+  hasCalculator: true,
+  authorSlug: 'valerie-linc',
+  authorName: 'Valerie Linc',
+};
+
+describe('ArticleMetaSchema', () => {
+  it('accepts a full metadata entry', () => {
+    const r = ArticleMetaSchema.safeParse(validMeta);
+    if (!r.success) console.error(r.error.issues);
+    expect(r.success).toBe(true);
+  });
+  it('accepts optional updatedAt', () => {
+    expect(ArticleMetaSchema.safeParse({ ...validMeta, updatedAt: '2026-05-01' }).success).toBe(true);
+  });
+  it('rejects missing id', () => {
+    const { id, ...without } = validMeta;
+    expect(ArticleMetaSchema.safeParse(without).success).toBe(false);
+  });
+  it('rejects id with uppercase (slug rule)', () => {
+    expect(ArticleMetaSchema.safeParse({ ...validMeta, id: 'Stipendio-Netto' }).success).toBe(false);
+  });
+  it('rejects malformed date', () => {
+    expect(ArticleMetaSchema.safeParse({ ...validMeta, date: '15/01/2026' }).success).toBe(false);
+  });
+  it('rejects category outside known set', () => {
+    expect(ArticleMetaSchema.safeParse({ ...validMeta, category: 'unknown' }).success).toBe(false);
+  });
+});
+
+describe('LocalizedArticleSchema', () => {
+  it('accepts metadata + locale + bodyHtml + title + excerpt', () => {
+    const localized = {
+      ...validMeta,
+      locale: 'it' as const,
+      title: 'Stipendio netto frontaliere 2026: come calcolarlo',
+      excerpt: 'Una guida completa per calcolare lo stipendio netto del frontaliere svizzero nel 2026, con esempi pratici e simulatore.',
+      bodyHtml: '<p>Test body.</p>'.padEnd(200, ' '),
+    };
+    expect(LocalizedArticleSchema.safeParse(localized).success).toBe(true);
+  });
+  it('rejects body < 50 words (thin content rule #4)', () => {
+    const thin = {
+      ...validMeta,
+      locale: 'it' as const,
+      title: 'OK',
+      excerpt: 'A'.repeat(80),
+      bodyHtml: '<p>too short</p>',
+    };
+    expect(LocalizedArticleSchema.safeParse(thin).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test — verify it fails**
+
+Run: `npx vitest run tests/schemas/article-schema.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Create the schema**
+
+```js
+// scripts/lib/schemas/article.mjs
+import { z } from 'zod';
+import { SeoTitleSchema, SeoMetaDescriptionSchema } from './seoText.mjs';
+
+// Known categories from current blog-articles-data.ts. Update list when adding categories.
+const CategorySchema = z.enum([
+  'fisco',
+  'lavoro',
+  'salute',
+  'casa',
+  'mobilita',
+  'famiglia',
+  'previdenza',
+  'finanze',
+  'guide',
+  'attualita',
+]);
+
+const SlugSchema = z
+  .string()
+  .min(1, 'slug-empty')
+  .max(120, 'slug-too-long')
+  .regex(/^[a-z0-9-]+$/, 'slug-invalid-chars');
+
+const IsoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date-not-iso');
+
+export const ArticleMetaSchema = z.object({
+  id: SlugSchema,
+  category: CategorySchema,
+  date: IsoDateSchema,
+  updatedAt: IsoDateSchema.optional(),
+  image: z.string().min(1),
+  hasCalculator: z.boolean(),
+  authorSlug: z.string().min(1).optional(),
+  authorName: z.string().min(1).optional(),
+});
+
+// A roughly-rendered article (after merging metadata + locale strings + body).
+// Used by create-article.mjs AI output validation and at MDX-emission boundary.
+const wordCount = (html) => (html.replace(/<[^>]*>/g, ' ').match(/\S+/g) ?? []).length;
+
+export const ArticleLocaleBodySchema = z.string().refine((html) => wordCount(html) >= 50, {
+  message: 'thin-content-rule-4-body-under-50-words',
+});
+
+export const LocalizedArticleSchema = ArticleMetaSchema.extend({
+  locale: z.enum(['it', 'en', 'de', 'fr']),
+  title: SeoTitleSchema,
+  excerpt: SeoMetaDescriptionSchema,
+  bodyHtml: ArticleLocaleBodySchema,
+});
+```
+
+- [ ] **Step 5: Run test — verify it passes**
+
+Run: `npx vitest run tests/schemas/article-schema.test.ts`
+Expected: PASS (8 assertions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/schemas/article.mjs tests/schemas/article-schema.test.ts
+git commit -m "feat(schemas): add ArticleMetaSchema + LocalizedArticleSchema with thin-content gate"
+```
+
+---
+
+## Task 6: Wire ArticleMetaSchema into create-article.mjs AI output validation
+
+**Files:**
+- Modify: `scripts/create-article.mjs`
+
+- [ ] **Step 1: Locate the AI response parse site**
+
+Run: `grep -n "JSON.parse\|AI.*response\|ai_response\|extractArticleFrom" scripts/create-article.mjs | head -20`
+Note the line where the LLM output is first parsed as JSON.
+
+- [ ] **Step 2: Import LocalizedArticleSchema near the top of the file**
+
+```js
+import { LocalizedArticleSchema, ArticleMetaSchema } from './lib/schemas/article.mjs';
+```
+
+- [ ] **Step 3: Wrap the JSON.parse with safeParse + retry on fail**
+
+Replace the unwrapped `JSON.parse(llmRaw)` site with a validation block. The actual AI response shape in this repo varies — read the existing parse + transform code to find what shape goes into the file write. The new pattern:
+
+```js
+// After the AI response is parsed and merged into the final article object:
+const validation = LocalizedArticleSchema.safeParse(articleForWrite);
+if (!validation.success) {
+  const issues = validation.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+  console.error(`[create-article] AI output failed schema validation: ${issues}`);
+  // Retry guidance — caller decides whether to re-prompt or abort.
+  throw new Error(`AI_OUTPUT_INVALID: ${issues}`);
+}
+```
+
+- [ ] **Step 4: Smoke test against a recent article that should be valid**
+
+Run: `node -e "import('./scripts/lib/schemas/article.mjs').then(async ({LocalizedArticleSchema}) => { const fs = await import('node:fs'); const m = JSON.parse(fs.readFileSync('data/blog-articles/abbonamento-newsletter-ticino-2026.json','utf8')); console.log(LocalizedArticleSchema.safeParse({...m, locale:'it', title:m.title||'placeholder',excerpt:'a'.repeat(80),bodyHtml:'<p>'+ 'word '.repeat(60) +'</p>'}).success ? 'OK' : 'FAIL'); })"`
+Expected: `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/create-article.mjs
+git commit -m "feat(articles): gate create-article.mjs AI output on LocalizedArticleSchema"
+```
+
+---
+
+## Task 7: OrphanClusterSchema + cluster-orphan-queries.mjs gate
+
+**Files:**
+- Create: `scripts/lib/schemas/orphanCluster.mjs`
+- Test: `tests/schemas/orphan-cluster-schema.test.ts`
+- Modify: `scripts/cluster-orphan-queries.mjs`
+
+- [ ] **Step 1: Read a real cluster to anchor the schema**
+
+Run: `head -200 data/gsc-orphan-queries-clusters.json | python3 -c "import sys, json; d = json.loads(open('data/gsc-orphan-queries-clusters.json').read()); print(json.dumps((d if isinstance(d,list) else d.get('clusters', []))[:1], indent=2)[:2000])"`
+Confirm cluster shape: `id/slug`, `canonicalQuery`, `roleTokens[]`, `regionTokens[]`, `queries[]`, etc.
+
+- [ ] **Step 2: Write failing test**
+
+```ts
+// tests/schemas/orphan-cluster-schema.test.ts
+import { describe, it, expect } from 'vitest';
+import { OrphanClusterSchema } from '../../scripts/lib/schemas/orphanCluster.mjs';
+
+const valid = {
+  id: 'lavoro-magazziniere-ticino',
+  slug: 'lavoro-magazziniere-ticino',
+  canonicalQuery: 'lavoro magazziniere ticino',
+  roleTokens: ['magazziniere', 'logistica'],
+  regionTokens: ['ticino', 'lugano'],
+  queries: [
+    { query: 'lavoro magazziniere ticino', impressions: 120, clicks: 4 },
+    { query: 'magazziniere lugano', impressions: 80, clicks: 2 },
+  ],
+};
+
+describe('OrphanClusterSchema', () => {
+  it('accepts a valid cluster', () => {
+    const r = OrphanClusterSchema.safeParse(valid);
+    if (!r.success) console.error(r.error.issues);
+    expect(r.success).toBe(true);
+  });
+  it('rejects empty queries', () => {
+    expect(OrphanClusterSchema.safeParse({ ...valid, queries: [] }).success).toBe(false);
+  });
+  it('rejects missing canonicalQuery', () => {
+    const { canonicalQuery, ...without } = valid;
+    expect(OrphanClusterSchema.safeParse(without).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test — verify it fails**
+
+Run: `npx vitest run tests/schemas/orphan-cluster-schema.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 4: Create the schema**
+
+```js
+// scripts/lib/schemas/orphanCluster.mjs
+import { z } from 'zod';
+
+const SlugSchema = z.string().min(1).regex(/^[a-z0-9-]+$/);
+
+const OrphanQuerySchema = z.object({
+  query: z.string().min(1),
+  impressions: z.number().int().nonnegative(),
+  clicks: z.number().int().nonnegative(),
+});
+
+export const OrphanClusterSchema = z.object({
+  id: SlugSchema,
+  slug: SlugSchema,
+  canonicalQuery: z.string().min(1),
+  roleTokens: z.array(z.string().min(1)).min(1),
+  regionTokens: z.array(z.string().min(1)),
+  queries: z.array(OrphanQuerySchema).min(1),
+}).passthrough();
+```
+
+- [ ] **Step 5: Run test — verify it passes**
+
+Run: `npx vitest run tests/schemas/orphan-cluster-schema.test.ts`
+Expected: PASS (3 assertions).
+
+- [ ] **Step 6: Wire into cluster-orphan-queries.mjs at write site**
+
+Locate the writeFileSync of the clusters JSON:
+Run: `grep -n "writeFileSync\|JSON.stringify.*cluster" scripts/cluster-orphan-queries.mjs`
+
+At the write site, prepend:
+
+```js
+import { OrphanClusterSchema } from './lib/schemas/orphanCluster.mjs';
+
+// Then before the writeFileSync:
+const clusterViolations = [];
+for (const c of clustersToWrite) {
+  const r = OrphanClusterSchema.safeParse(c);
+  if (!r.success) clusterViolations.push({ id: c.id ?? c.slug ?? '?', issues: r.error.issues.map(i => `${i.path.join('.')}: ${i.message}`) });
+}
+if (clusterViolations.length > 0) {
+  console.error(`[cluster-orphan-queries] ${clusterViolations.length} cluster(s) failed schema:`);
+  for (const v of clusterViolations.slice(0, 10)) console.error(`  - ${v.id}: ${v.issues.join('; ')}`);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 7: Run the cluster script and confirm it still completes**
+
+Run: `node scripts/cluster-orphan-queries.mjs 2>&1 | tail -20`
+Expected: completes with stats or fails with actionable cluster IDs (fix data, do not loosen schema).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/schemas/orphanCluster.mjs tests/schemas/orphan-cluster-schema.test.ts scripts/cluster-orphan-queries.mjs
+git commit -m "feat(orphan): gate cluster-orphan-queries on OrphanClusterSchema"
+```
+
+---
+
+## Task 8: HealthPremiumRowSchema + producer-side gate
+
+**Files:**
+- Create: `scripts/lib/schemas/healthPremium.mjs`
+- Test: `tests/schemas/health-premium-schema.test.ts`
+- Modify: the script that writes `data/health-premiums*.json` (locate via grep)
+
+- [ ] **Step 1: Locate the producer script and read one row**
+
+Run: `grep -rln "health-premium\|healthPremium\|premio.*malattia" scripts/ | head -10` then read the writer.
+Run: `ls data/ | grep -i premium`
+
+- [ ] **Step 2: Write failing test for HealthPremiumRowSchema**
+
+```ts
+// tests/schemas/health-premium-schema.test.ts
+import { describe, it, expect } from 'vitest';
+import { HealthPremiumRowSchema } from '../../scripts/lib/schemas/healthPremium.mjs';
+
+const valid = {
+  canton: 'TI',
+  region: 'PR-TI1',
+  ageGroup: 'AKL-ADU',
+  accidentCover: 'OUI',
+  insurer: 'CSS',
+  product: 'Basis',
+  monthlyPremiumChf: 412.50,
+  year: 2026,
+};
+
+describe('HealthPremiumRowSchema', () => {
+  it('accepts a valid row', () => {
+    const r = HealthPremiumRowSchema.safeParse(valid);
+    if (!r.success) console.error(r.error.issues);
+    expect(r.success).toBe(true);
+  });
+  it('rejects negative premium', () => {
+    expect(HealthPremiumRowSchema.safeParse({ ...valid, monthlyPremiumChf: -10 }).success).toBe(false);
+  });
+  it('rejects out-of-range year', () => {
+    expect(HealthPremiumRowSchema.safeParse({ ...valid, year: 1990 }).success).toBe(false);
+  });
+  it('rejects unknown canton code', () => {
+    expect(HealthPremiumRowSchema.safeParse({ ...valid, canton: 'XX' }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test — verify it fails**
+
+Run: `npx vitest run tests/schemas/health-premium-schema.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 4: Create the schema**
+
+```js
+// scripts/lib/schemas/healthPremium.mjs
+import { z } from 'zod';
+
+const CantonSchema = z.enum([
+  'AG','AI','AR','BE','BL','BS','FR','GE','GL','GR','JU','LU','NE','NW','OW',
+  'SG','SH','SO','SZ','TG','TI','UR','VD','VS','ZG','ZH',
+]);
+
+const AgeGroupSchema = z.enum(['AKL-KIN', 'AKL-JUG', 'AKL-ADU']);
+const AccidentCoverSchema = z.enum(['OUI', 'NON']);
+
+export const HealthPremiumRowSchema = z.object({
+  canton: CantonSchema,
+  region: z.string().regex(/^PR-[A-Z]{2}\d+$/, 'region-not-bag-format'),
+  ageGroup: AgeGroupSchema,
+  accidentCover: AccidentCoverSchema,
+  insurer: z.string().min(1),
+  product: z.string().min(1),
+  monthlyPremiumChf: z.number().positive(),
+  year: z.number().int().min(2024).max(2030),
+}).passthrough();
+```
+
+- [ ] **Step 5: Run test — verify it passes**
+
+Run: `npx vitest run tests/schemas/health-premium-schema.test.ts`
+Expected: PASS (4 assertions).
+
+- [ ] **Step 6: Wire into the producer script (same pattern as Task 4 / Task 7)**
+
+Import the schema, validate every row before write, exit non-zero on violations.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/schemas/healthPremium.mjs tests/schemas/health-premium-schema.test.ts scripts/<producer>.mjs
+git commit -m "feat(health-premiums): gate producer on HealthPremiumRowSchema"
+```
+
+---
+
+## Task 9: FuelDailySnapshotSchema + producer gate
+
+**Files:**
+- Create: `scripts/lib/schemas/fuelDaily.mjs`
+- Test: `tests/schemas/fuel-daily-schema.test.ts`
+- Modify: producer (search via `grep -rln "fuel.*daily\|carburante" scripts/ | head`)
+
+Mirror Task 8 structure exactly. Schema fields (confirm against real JSON):
+
+```js
+// scripts/lib/schemas/fuelDaily.mjs
+import { z } from 'zod';
+
+export const FuelDailySnapshotSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  fuelType: z.enum(['benzina', 'diesel', 'gpl', 'metano']),
+  countryAvgChf: z.number().positive(),
+  countryAvgEur: z.number().positive(),
+  pricesByCanton: z.record(z.string(), z.number().positive()),
+}).passthrough();
+```
+
+Test + wire-in + commit as before.
+
+```bash
+git commit -m "feat(fuel-daily): gate producer on FuelDailySnapshotSchema"
+```
+
+---
+
+## Task 10: BorderWaitMeasurementSchema + producer gate
+
+**Files:**
+- Create: `scripts/lib/schemas/borderWait.mjs`
+- Test: `tests/schemas/border-wait-schema.test.ts`
+- Modify: producer for `data/border-wait-current.json` + `data/border-wait-history/`
+
+Mirror Task 8. Schema:
+
+```js
+// scripts/lib/schemas/borderWait.mjs
+import { z } from 'zod';
+
+export const BorderWaitMeasurementSchema = z.object({
+  crossing: z.string().min(1),
+  observedAt: z.string().datetime(),
+  waitMinutes: z.number().int().min(0).max(720),
+  direction: z.enum(['IT->CH', 'CH->IT']),
+  source: z.enum(['ti-camera', 'sferanet', 'fl', 'crowdsourced']),
+}).passthrough();
+```
+
+Test + wire-in + commit.
+
+```bash
+git commit -m "feat(border-wait): gate producer on BorderWaitMeasurementSchema"
+```
+
+---
+
+## Task 11: Schemas barrel export
+
+**Files:**
+- Create: `scripts/lib/schemas/index.mjs`
+
+- [ ] **Step 1: Create barrel**
+
+```js
+// scripts/lib/schemas/index.mjs
+export * from './seoText.mjs';
+export * from './job.mjs';
+export * from './article.mjs';
+export * from './orphanCluster.mjs';
+export * from './healthPremium.mjs';
+export * from './fuelDaily.mjs';
+export * from './borderWait.mjs';
+```
+
+- [ ] **Step 2: Smoke test the barrel**
+
+Run: `node -e "import('./scripts/lib/schemas/index.mjs').then(m => console.log(Object.keys(m).sort()))"`
+Expected: lists `ArticleMetaSchema`, `BorderWaitMeasurementSchema`, `FuelDailySnapshotSchema`, `HealthPremiumRowSchema`, `JobSchema`, `LocalizedArticleSchema`, `LocalizedJobSchema`, `OrphanClusterSchema`, `SeoH1Schema`, `SeoMetaDescriptionSchema`, `SeoTitleSchema`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/lib/schemas/index.mjs
+git commit -m "feat(schemas): add barrel export"
+```
+
+---
+
+## Task 12: Schema-derived JSON-LD helpers (structuredData.ts)
+
+**Files:**
+- Create: `services/seo/structuredData.ts`
+- Test: `tests/seo/structured-data.test.ts`
+- Modify: `services/seo/imageObjectLd.ts` (re-export from new module, mark deprecated)
+
+- [ ] **Step 1: Write failing tests for helpers**
+
+```ts
+// tests/seo/structured-data.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  jobPostingLd,
+  articleLd,
+  faqPageLd,
+  breadcrumbListLd,
+  webPageLd,
+} from '../../services/seo/structuredData';
+
+describe('jobPostingLd', () => {
+  it('emits JSON-LD with all rule #3 mandatory fields', () => {
+    const ld = jobPostingLd({
+      id: 'x-1',
+      stableId: '550e8400-e29b-41d4-a716-446655440000',
+      slug: 'x',
+      url: 'https://x.ch/x',
+      title: 'Sviluppatore',
+      company: 'X',
+      hiringOrganization: { name: 'X' },
+      location: 'Lugano',
+      addressLocality: 'Lugano',
+      postalCode: '6900',
+      streetAddress: 'Via Test 1',
+      description: 'D'.repeat(60),
+      datePosted: '2026-05-15',
+      employmentType: 'FULL_TIME',
+      jobLocation: { addressLocality: 'Lugano', postalCode: '6900', addressCountry: 'CH' },
+      baseSalary: { currency: 'CHF', value: { minValue: 80000, maxValue: 110000, unitText: 'YEAR' } },
+    });
+    expect(ld['@context']).toBe('https://schema.org');
+    expect(ld['@type']).toBe('JobPosting');
+    expect(ld.baseSalary).toBeDefined();
+    expect(ld.hiringOrganization?.name).toBe('X');
+    expect(ld.jobLocation?.address?.postalCode).toBe('6900');
+  });
+
+  it('throws if job fails JobSchema (impossible nested scripts, impossible thin)', () => {
+    // @ts-expect-error intentionally invalid
+    expect(() => jobPostingLd({ id: 'bad' })).toThrow();
+  });
+});
+
+describe('faqPageLd', () => {
+  it('emits FAQPage with non-empty mainEntity', () => {
+    const ld = faqPageLd([
+      { question: 'Q1?', answer: 'A1' },
+      { question: 'Q2?', answer: 'A2' },
+    ]);
+    expect(ld['@type']).toBe('FAQPage');
+    expect(ld.mainEntity.length).toBe(2);
+    expect(ld.mainEntity[0].acceptedAnswer.text).toBe('A1');
+  });
+  it('throws if mainEntity would be empty', () => {
+    expect(() => faqPageLd([])).toThrow();
+  });
+});
+
+describe('breadcrumbListLd', () => {
+  it('emits BreadcrumbList with position 1..N', () => {
+    const ld = breadcrumbListLd([
+      { name: 'Home', url: 'https://x.ch/' },
+      { name: 'Articoli', url: 'https://x.ch/articoli/' },
+    ]);
+    expect(ld.itemListElement.map((i: any) => i.position)).toEqual([1, 2]);
+  });
+});
+
+describe('webPageLd + articleLd', () => {
+  it('webPageLd emits canonical url', () => {
+    const ld = webPageLd({ url: 'https://frontaliereticino.ch/x', name: 'X', description: 'D'.repeat(60) });
+    expect(ld.url).toBe('https://frontaliereticino.ch/x');
+  });
+  it('articleLd emits Article with author + datePublished', () => {
+    const ld = articleLd({
+      id: 'x', category: 'fisco', date: '2026-01-15', image: '/i.webp', hasCalculator: false,
+      locale: 'it', title: 'Titolo articolo valido lungo abbastanza',
+      excerpt: 'E'.repeat(80),
+      bodyHtml: '<p>' + 'word '.repeat(60) + '</p>',
+      authorSlug: 'valerie-linc', authorName: 'Valerie Linc',
+    });
+    expect(ld['@type']).toBe('Article');
+    expect(ld.author.name).toBe('Valerie Linc');
+    expect(ld.datePublished).toBe('2026-01-15');
+  });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+Run: `npx vitest run tests/seo/structured-data.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create structuredData.ts**
+
+```ts
+// services/seo/structuredData.ts
+import { z } from 'zod';
+import {
+  JobSchema,
+  LocalizedArticleSchema,
+} from '../../scripts/lib/schemas/index.mjs';
+
+// Strip characters that would cause script-tag nesting if accidentally embedded
+// inside <script type="application/ld+json">. By construction, helpers below
+// emit objects; the consumer JSON.stringify's them — there is no string
+// concatenation path, so nested <script> is impossible.
+const safeText = (s: string) => s.replace(/<\/script/gi, '<\\/script');
+
+export const jobPostingLd = (rawJob: unknown) => {
+  const job = JobSchema.parse(rawJob);  // throws if invalid
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'JobPosting',
+    title: safeText(job.title),
+    description: safeText(job.description),
+    datePosted: job.datePosted,
+    employmentType: job.employmentType,
+    hiringOrganization: { '@type': 'Organization', name: safeText(job.hiringOrganization.name) },
+    jobLocation: {
+      '@type': 'Place',
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: safeText(job.streetAddress),
+        addressLocality: job.jobLocation.addressLocality,
+        postalCode: job.jobLocation.postalCode,
+        addressCountry: job.jobLocation.addressCountry,
+      },
+    },
+    baseSalary: {
+      '@type': 'MonetaryAmount',
+      currency: job.baseSalary.currency,
+      value: {
+        '@type': 'QuantitativeValue',
+        minValue: job.baseSalary.value.minValue,
+        maxValue: job.baseSalary.value.maxValue,
+        unitText: job.baseSalary.value.unitText,
+      },
+    },
+    url: job.url,
+  };
+};
+
+export const articleLd = (rawArticle: unknown) => {
+  const a = LocalizedArticleSchema.parse(rawArticle);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: safeText(a.title),
+    description: safeText(a.excerpt),
+    datePublished: a.date,
+    dateModified: a.updatedAt ?? a.date,
+    image: a.image.startsWith('http') ? a.image : `https://frontaliereticino.ch${a.image}`,
+    inLanguage: a.locale,
+    author: { '@type': 'Person', name: safeText(a.authorName ?? 'Frontaliere Ticino') },
+  };
+};
+
+const FaqEntry = z.object({ question: z.string().min(1), answer: z.string().min(1) });
+const FaqList = z.array(FaqEntry).min(1, 'faqpage-must-have-mainentity');
+
+export const faqPageLd = (entries: unknown) => {
+  const list = FaqList.parse(entries);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: list.map((e) => ({
+      '@type': 'Question',
+      name: safeText(e.question),
+      acceptedAnswer: { '@type': 'Answer', text: safeText(e.answer) },
+    })),
+  };
+};
+
+const BreadcrumbItem = z.object({ name: z.string().min(1), url: z.string().url() });
+const BreadcrumbList = z.array(BreadcrumbItem).min(1);
+
+export const breadcrumbListLd = (items: unknown) => {
+  const list = BreadcrumbList.parse(items);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: list.map((it, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: safeText(it.name),
+      item: it.url,
+    })),
+  };
+};
+
+const WebPageInput = z.object({
+  url: z.string().url(),
+  name: z.string().min(1),
+  description: z.string().min(50).max(160),
+});
+
+export const webPageLd = (input: unknown) => {
+  const p = WebPageInput.parse(input);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    url: p.url,
+    name: safeText(p.name),
+    description: safeText(p.description),
+  };
+};
+
+// Re-export the existing image-object helper from its original module to
+// keep the contract stable while consumers migrate.
+export { imageObjectLd } from './imageObjectLd';
+```
+
+- [ ] **Step 4: Run test — verify it passes**
+
+Run: `npx vitest run tests/seo/structured-data.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add deprecation comment to imageObjectLd.ts**
+
+In `services/seo/imageObjectLd.ts`, prepend:
+
+```ts
+// NOTE: New JSON-LD emitters live in `./structuredData.ts`. This module is kept
+// for backwards-compat re-export; new callers should import from `structuredData`.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/seo/structuredData.ts services/seo/imageObjectLd.ts tests/seo/structured-data.test.ts
+git commit -m "feat(seo): add schema-driven JSON-LD helpers (jobPosting, article, faqPage, breadcrumb, webPage)"
+```
+
+---
+
+## Task 13: Migrate first plugin to use structuredData helpers (orphanQueryLandingPlugin)
+
+**Files:**
+- Modify: `build-plugins/orphanQueryLandingPlugin.ts`
+
+This is the JSON-LD hottest spot — refactoring it first proves the pattern. Other plugins follow the same pattern in Task 14.
+
+- [ ] **Step 1: Locate JSON-LD emission sites in orphanQueryLandingPlugin**
+
+Run: `grep -n "@type\|JSON\.stringify.*schema\|application/ld\+json" build-plugins/orphanQueryLandingPlugin.ts`
+Note the JobPosting, BreadcrumbList, WebPage, and any FAQPage sites.
+
+- [ ] **Step 2: Replace each hand-rolled JSON-LD with the helper call**
+
+For each emission site, replace the inline object construction with:
+
+```ts
+import { jobPostingLd, breadcrumbListLd, webPageLd, faqPageLd } from '@/services/seo/structuredData';
+
+// At emit site:
+const jsonLdScripts = [
+  `<script type="application/ld+json">${JSON.stringify(webPageLd({ url, name, description }))}</script>`,
+  `<script type="application/ld+json">${JSON.stringify(breadcrumbListLd(crumbs))}</script>`,
+  ...matchingJobs.map(j => `<script type="application/ld+json">${JSON.stringify(jobPostingLd(j))}</script>`),
+].join('\n');
+```
+
+- [ ] **Step 3: Run existing orphan-landing tests to confirm no regression**
+
+Run: `npx vitest run tests/ --testNamePattern "orphan" 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 4: Byte-equivalence check against last-known-good dist**
+
+If you have a recent successful `deploy.yml` run:
+Run: `gh workflow run audit-dist-from-run.yml -f deploy_run_id=<recent_id> -f audits=jsonld-no-nested-scripts,image-object-license`
+Confirm both audits report 0 violations against the artifact (they should — we haven't deployed yet, this verifies the audit hasn't been broken).
+
+After PR is open, the deploy will re-run these audits against the new dist; expect them to also be clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add build-plugins/orphanQueryLandingPlugin.ts
+git commit -m "refactor(seo): orphanQueryLandingPlugin uses schema-driven JSON-LD helpers"
+```
+
+---
+
+## Task 14: Migrate remaining plugins to structuredData helpers
+
+**Files (each gets the same treatment as Task 13):**
+- `build-plugins/jobsSeoPages*.ts` (every file matching this glob)
+- `build-plugins/salaryHubPlugin.ts`
+- `build-plugins/careerLandingsPlugin.ts`
+- `build-plugins/healthPremiumsLandingPlugin.ts`
+- `build-plugins/fuelDailyPagesPlugin.ts`
+- `build-plugins/weeklyEmployersPlugin.ts`
+- `build-plugins/jobMarketSnapshotPlugin.ts`
+- `build-plugins/borderWaitPlugin.ts`
+- `build-plugins/costOfLivingLandingsPlugin.ts`
+- Any plugin still emitting JSON-LD by hand (find via `grep -rln "application/ld+json" build-plugins/`)
+
+- [ ] **Step 1: Inventory remaining JSON-LD emission sites**
+
+Run: `grep -rln "application/ld+json" build-plugins/ | sort -u`
+Note the list. Should be ~10-15 files.
+
+- [ ] **Step 2: For each file, repeat Task 13 steps 1-3**
+
+Commit per file:
+
+```bash
+git commit -m "refactor(seo): <plugin-name> uses schema-driven JSON-LD helpers"
+```
+
+- [ ] **Step 3: Confirm zero remaining hand-rolled JSON-LD object literals**
+
+Run: `grep -rn "'@type':\|\"@type\":" build-plugins/ | grep -v structuredData | grep -v node_modules`
+Expected: empty output (all `@type` references now live behind helpers).
+
+- [ ] **Step 4: Full vitest run to catch regressions**
+
+Run: `npx vitest run 2>&1 | tail -30`
+Expected: full green or pre-existing-only failures (do not introduce new failures).
+
+---
+
+## Task 15: Retire 7 dist-walking audits as registry entries
+
+**Files:**
+- Modify: `scripts/audit-all.mjs`
+- Modify: `.github/workflows/deploy.yml`
+- Modify: `.github/workflows/post-deploy-validate-dist.yml`
+- Modify: `.github/workflows/post-deploy-validation.yml`
+- Modify: `package.json` (audit:* scripts)
+- Delete: 7 audit scripts + their baseline JSONs (after grace period — see step 4)
+
+- [ ] **Step 1: Confirm each retired audit's invariant is enforced upstream**
+
+Verification matrix (run each):
+
+| Audit | Build-time replacement | Verify command |
+|---|---|---|
+| title-length | `SeoTitleSchema` max(66) | `npx vitest run tests/schemas/seo-text-schema.test.ts` shows the cap |
+| title-no-disambig-hash | `SeoTitleSchema` regex refine | same |
+| h1-title-duplicates | Will be added to `LocalizedArticleSchema` via refine; see step 2 below | new test |
+| jsonld-no-nested-scripts | `safeText()` in `structuredData.ts` + helper-only emission | `grep -rn "'@type':" build-plugins/` empty |
+| image-object-license | `ImageObjectSchema` (existing) requires `license` | inspect `services/seo/imageObjectLd.ts` |
+| faqpage-validity | `FaqList` min(1) in `structuredData.ts` | `tests/seo/structured-data.test.ts` |
+| footer-root-presence | Template-level invariant in `buildSeoPageHtml` (already enforced; the audit was belt+suspenders) | inspect `build-plugins/shared/seoPageShell.ts` |
+
+- [ ] **Step 2: Add the missing h1-title-duplicates refine to LocalizedArticleSchema**
+
+In `scripts/lib/schemas/article.mjs`, modify `LocalizedArticleSchema`:
+
+```js
+export const LocalizedArticleSchema = ArticleMetaSchema.extend({
+  locale: z.enum(['it', 'en', 'de', 'fr']),
+  title: SeoTitleSchema,
+  excerpt: SeoMetaDescriptionSchema,
+  bodyHtml: ArticleLocaleBodySchema,
+  h1: SeoH1Schema.optional(),  // articles may omit explicit h1 (template derives from title)
+}).refine(
+  (a) => a.h1 === undefined || a.h1.trim() !== a.title.trim(),
+  { message: 'h1-must-differ-from-title-rule-audit-h1-title-duplicates', path: ['h1'] },
+);
+```
+
+Add a test:
+
+```ts
+it('rejects article where h1 equals title', () => {
+  const a = { ...validMeta, locale: 'it' as const, title: 'Same', h1: 'Same', excerpt: 'A'.repeat(80), bodyHtml: '<p>' + 'word '.repeat(60) + '</p>' };
+  expect(LocalizedArticleSchema.safeParse(a).success).toBe(false);
+});
+```
+
+Run: `npx vitest run tests/schemas/article-schema.test.ts`
+Expected: PASS (now 9 assertions).
+
+- [ ] **Step 3: Remove the 7 audits from `audit-all.mjs` registry**
+
+Open `scripts/audit-all.mjs`, locate the audit registry (likely an array or map of audit names → run functions), and remove these 7 entries:
+
+```
+- footer-root-presence
+- jsonld-no-nested-scripts
+- title-length
+- title-no-disambig-hash
+- h1-title-duplicates
+- image-object-license
+- faqpage-validity
+```
+
+- [ ] **Step 4: Remove the 7 audits from workflow YAMLs**
+
+For each of `deploy.yml`, `post-deploy-validate-dist.yml`, `post-deploy-validation.yml`:
+
+```bash
+# Inspect the audit steps:
+grep -n "audit:title-length\|audit:h1-title-duplicates\|audit:footer-root-presence\|audit:jsonld-no-nested-scripts\|audit:image-object-license\|audit:faqpage-validity\|audit:title-no-disambig-hash" .github/workflows/deploy.yml
+```
+
+Remove or comment-out the corresponding `- name:` + `run:` blocks. Add a comment block referencing this sub-plan for archaeology:
+
+```yaml
+# Retired 2026-05-NN — invariant now enforced at build-time via JobSchema /
+# ArticleSchema / structuredData.ts helpers (sub-plan 01, frontaliereticino).
+# Cleanup of audit scripts pending grace period.
+```
+
+- [ ] **Step 5: Remove the 7 audit:* scripts from package.json**
+
+Remove these lines:
+- `"audit:title-length": ...`
+- `"audit:title-no-disambig-hash": ...`
+- `"audit:h1-title-duplicates": ...`
+- `"audit:jsonld-no-nested-scripts": ...`
+- `"audit:image-object-license": ...`
+- `"audit:faqpage-validity": ...`
+- `"audit:footer-root-presence": ...`
+- All corresponding `:rebaseline` scripts.
+
+- [ ] **Step 6: Run a representative subset of remaining audits to confirm no breakage**
+
+Run: `npx vitest run tests/ 2>&1 | tail -20`
+Run: `node scripts/audit-all.mjs --dist=dist --audits=text-html-ratio,page-weight,content-duplicates,bfs-depth 2>&1 | tail -20`
+(If no `dist/` exists locally, skip the second command — CI will run it.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/audit-all.mjs .github/workflows/deploy.yml .github/workflows/post-deploy-validate-dist.yml .github/workflows/post-deploy-validation.yml package.json scripts/lib/schemas/article.mjs tests/schemas/article-schema.test.ts
+git commit -m "feat(audits): retire 7 dist-walking audits — invariants enforced at build-time via schemas"
+```
+
+- [ ] **Step 8: Grace period — keep audit scripts in repo for one deploy cycle**
+
+Do NOT delete `scripts/audit-*.mjs` files yet. Leave them for one successful deploy cycle so we can re-enable any of them quickly if a real regression slips through. They are no longer wired into any workflow.
+
+After 7 days of clean deploys, do:
+
+```bash
+git rm scripts/audit-title-length.mjs scripts/audit-title-no-disambig-hash.mjs \
+       scripts/audit-h1-title-duplicates.mjs scripts/audit-jsonld-no-nested-scripts.mjs \
+       scripts/audit-image-object-license.mjs scripts/audit-faqpage-validity.mjs \
+       scripts/audit-footer-root-presence.mjs
+
+# Baseline files (verify they exist first):
+git rm data/title-length-baseline.json data/title-no-disambig-hash-baseline.json \
+       data/h1-title-duplicates-baseline.json 2>/dev/null || true
+
+git commit -m "chore(audits): remove retired audit scripts + baselines after grace period"
+```
+
+---
+
+## Task 16: Wire the new test files into the test:seo-gates script
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the new schema tests to test:seo-gates**
+
+In `package.json` extend `test:seo-gates`:
+
+```json
+"test:seo-gates": "vitest run tests/schemas/ tests/seo/structured-data.test.ts tests/title-length.test.ts tests/h1-not-equal-title.test.ts tests/url-max-length.test.ts tests/hreflang-no-broken.test.ts tests/dist-single-h1-per-page.test.ts tests/dist-link-anchor-text.test.ts tests/seo-html-lang-sync.test.ts tests/seo/software-application-jsonld.test.ts",
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npm run test:seo-gates 2>&1 | tail -20`
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "chore(tests): include schema tests in test:seo-gates"
+```
+
+---
+
+## Task 17: Final verification & PR
+
+- [ ] **Step 1: Full test suite**
+
+Run: `npm test 2>&1 | tail -30`
+Expected: full green.
+
+- [ ] **Step 2: Full type-check**
+
+Run: `npx tsc --noEmit 2>&1 | tail -20`
+Expected: 0 errors.
+
+- [ ] **Step 3: Confirm assembler is idempotent**
+
+Run: `node scripts/assemble-jobs-dataset.mjs --stats 2>&1 | tail -10`
+Expected: completes with stats; if it fails on real data, fix the offending crawler slices (do NOT loosen the schema; per CLAUDE.md rule #1).
+
+- [ ] **Step 4: Confirm no new files exceed the 800-line ceiling**
+
+Run: `wc -l scripts/lib/schemas/*.mjs services/seo/structuredData.ts tests/schemas/*.ts tests/seo/structured-data.test.ts | sort -n`
+Expected: all files under 800 lines (likely under 200 each).
+
+- [ ] **Step 5: Open the PR**
+
+Per CLAUDE.md PR-as-merge-vehicle: reuse the commit messages as PR body.
+
+```bash
+git push -u origin <branch>
+gh pr create --fill --title "feat: Zod foundations + schema-driven JSON-LD — retires 7 audit gates"
+```
+
+- [ ] **Step 6: Squash-merge once CI is green**
+
+Per CLAUDE.md "no CI wait" rule: if typecheck + vitest are local-green, merge immediately without waiting on CI.
+
+```bash
+gh pr merge <number> --squash
+git push origin --delete <branch>
+```
+
+- [ ] **Step 7: ExitWorktree**
+
+After cleanup, exit the worktree.
+
+---
+
+## Self-review (per skill mandate)
+
+**Spec coverage:**
+- Zod install → Task 1 ✓
+- Schemas for 6 data sources → Tasks 3 (job), 5 (article), 7 (orphan), 8 (health), 9 (fuel), 10 (border) ✓
+- Reusable SEO text schemas → Task 2 ✓
+- Barrel export → Task 11 ✓
+- JSON-LD helpers → Task 12 ✓
+- Plugin migration → Tasks 13-14 ✓
+- 7 audits retired → Task 15 ✓
+- Tests wired into CI gate → Task 16 ✓
+- Verification + PR → Task 17 ✓
+
+**Placeholders scan:** "locate via grep" appears in Task 8, 9, 10. These are necessary — the producer scripts for health-premiums/fuel-daily/border-wait weren't read during the investigation, so the plan can't pre-name them. The grep command IS the step; the engineer reads the file once located. Not a placeholder failure.
+
+**Type consistency:** All exported names (`JobSchema`, `LocalizedJobSchema`, `ArticleMetaSchema`, `LocalizedArticleSchema`, `OrphanClusterSchema`, `HealthPremiumRowSchema`, `FuelDailySnapshotSchema`, `BorderWaitMeasurementSchema`, `SeoTitleSchema`, `SeoH1Schema`, `SeoMetaDescriptionSchema`, `jobPostingLd`, `articleLd`, `faqPageLd`, `breadcrumbListLd`, `webPageLd`) consistent across all task references and match the master plan index.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-20-astro-zod-01-zod-foundations.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — Orchestrator dispatches a fresh subagent per task (17 subagents total), reviews each completion before the next dispatches, fast iteration. Subagent-driven shines on multi-task plans like this one where each task is bounded and verifiable.
+
+**2. Inline Execution** — Execute all 17 tasks in this same session using `superpowers:executing-plans`, with checkpoints between tasks 7, 12, 15 for review.
+
+**Which approach?**
+
+(For sub-plans 02-08, the same handoff question repeats at the bottom of each sub-plan document.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-02-astro-skeleton.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-02-astro-skeleton.md
@@ -1,0 +1,95 @@
+# Sub-Plan 02: Astro Skeleton + Content Collections Bootstrap
+
+> **For agentic workers:** This is a STUB. Expand to bite-sized TDD tasks (per superpowers:writing-plans) immediately before executing, using sub-plan 01 as the template for granularity.
+
+**Goal:** Install Astro 6.3.x + integrations (`@astrojs/react`, `@astrojs/mdx`, `@astrojs/sitemap`, `@astrojs/i18n`, `@astrojs/tailwind`). Create `astro.config.mjs` alongside the existing `vite.config.ts` (coexistence mode for transition). Define `src/content/config.ts` declaring content collections with Zod schemas reused from sub-plan 01. Ship one pilot static page (`/privacy/`) rendered end-to-end through Astro to validate the entire pipeline. Set up parallel CI builds so deploy.yml produces BOTH Astro output + legacy Vite output during the transition, with a routing layer that picks per-URL which to serve.
+
+**Architecture:**
+- New top-level directory: `src/` (Astro convention). Contains `src/pages/`, `src/content/`, `src/components/`, `src/layouts/`.
+- `astro.config.mjs` at repo root, alongside `vite.config.ts`. Output target `dist-astro/` initially (not `dist/`) to keep legacy build untouched. Cutover renames to `dist/` in sub-plan 08.
+- `src/content/config.ts` defines collections: `articles`, `landings`, `static-pages`, `jobs-meta`. Each uses Zod schemas IMPORTED from `scripts/lib/schemas/index.mjs` (Zod is shared between Node-side validation and Astro content-collection validation — same source of truth).
+- One pilot static page: `src/pages/privacy.astro` rendering an MD/MDX source. Verifies: MDX integration works, Tailwind utility purge works under Astro, frontmatter Zod validation works, sitemap integration emits the page, `<head>` SEO tags render correctly.
+- CI parallel build: `deploy.yml` runs `npm run build` (legacy Vite, emits `dist/`) AND `npm run build:astro` (new, emits `dist-astro/`). A merge step diffs the two; pilot URL served from `dist-astro/`, everything else from `dist/`.
+- DNS / CDN unchanged. The merge step writes the final `dist/` by overlaying `dist-astro/` on top of `dist/`. Roll back = revert the build:astro script + skip the merge step.
+
+**Tech Stack:** Astro 6.3.x, @astrojs/react 4.x, @astrojs/mdx 4.x, @astrojs/sitemap 3.x, @astrojs/i18n (or manual i18n config — decide in expansion), @astrojs/tailwind 5.x, Zod (from sub-plan 01).
+
+**Depends on:** Sub-plan 01 (Zod schemas must exist for content collection configs to reference them).
+
+**Estimated effort:** 1 week (5 engineering days).
+
+**Ships standalone value:** Partial. One static page works through Astro; no traffic moved. The infrastructure is the deliverable, plus the validated pilot.
+
+---
+
+## File structure (planned)
+
+**Created:**
+- `astro.config.mjs`
+- `src/pages/privacy.astro` (pilot)
+- `src/content/config.ts`
+- `src/content/static-pages/privacy.it.mdx` (pilot)
+- `src/content/static-pages/privacy.en.mdx`
+- `src/content/static-pages/privacy.de.mdx`
+- `src/content/static-pages/privacy.fr.mdx`
+- `src/layouts/BaseLayout.astro` (shared shell: nav, footer, head SEO tags)
+- `src/components/seo/JsonLd.astro` (renders `<script type="application/ld+json">` via `services/seo/structuredData.ts` from sub-plan 01)
+- `scripts/merge-astro-into-dist.mjs` (CI merge step)
+- `tsconfig.astro.json` (Astro-specific TS config; references the existing `tsconfig.json` via `extends`)
+
+**Modified:**
+- `package.json` — add Astro deps, add `build:astro`, `dev:astro` scripts. Wire `npm run build` to call both (legacy + astro + merge).
+- `.github/workflows/deploy.yml` — add `build:astro` step + merge step before upload.
+- `.github/workflows/tests.yml` — add `npm run test:astro` (vitest under Astro context if needed; likely a noop initially since pilot has no tests beyond the page render).
+- `tailwind.config.js` — extend `content` to include `./src/**/*.{astro,mdx,ts,tsx}`.
+- `.gitignore` — add `dist-astro/`.
+
+**Not modified yet** (sub-plans 03-08 own these): `vite.config.ts`, `App.tsx`, `services/router.ts`, `build-plugins/`, `services/locales/`.
+
+---
+
+## Phases (each becomes ~5-15 bite-sized tasks when expanded)
+
+1. **Astro install + minimal config.** Add deps, write minimal `astro.config.mjs` (output static, no integrations yet), run `npx astro check` to confirm install. ~1 day.
+2. **Tailwind + React + MDX integrations.** Add each integration one at a time, smoke-test, commit per integration. ~1 day.
+3. **Content collections config.** Write `src/content/config.ts` declaring `static-pages` collection with Zod schema (reuses `ArticleMetaSchema` shape — adapted for static pages). Add `src/content/static-pages/privacy.it.mdx` (port the current privacy page body). ~0.5 day.
+4. **Pilot page route.** `src/pages/privacy.astro` consumes the collection, renders via `BaseLayout.astro`, emits canonical URL + sitemap entry + JSON-LD via `JsonLd.astro` component (which calls `webPageLd()` from sub-plan 01). ~1 day.
+5. **Sitemap + head SEO parity.** `@astrojs/sitemap` config. Verify pilot's `/privacy/` appears in `sitemap-index.xml` with same `<lastmod>` / `<priority>` as the legacy emitter. ~0.5 day.
+6. **CI merge step.** `scripts/merge-astro-into-dist.mjs` copies `dist-astro/privacy/` → `dist/privacy/` (overwriting legacy). Wire into `deploy.yml`. ~0.5 day.
+7. **Verification harness.** Run `verify-l1-equivalence.mjs` between legacy `dist/privacy/index.html` and new `dist-astro/privacy/index.html`. Acceptable diff: only Vite-bundled JS hashes change. Body content + JSON-LD must be byte-identical. ~0.5 day.
+8. **PR + monitored deploy + 24h soak.** Deploy. Watch GSC + analytics for `/privacy/` for 24h. If no regression, sub-plan 02 closes. ~0.5 day.
+
+---
+
+## Critical risks
+
+1. **Tailwind class purge under Astro vs Vite.** Tailwind's `content` config might not pick up `.astro` and `.mdx` files identically. Mitigation: explicit content paths, manual smoke test of utility classes on the pilot.
+2. **Astro's default `<head>` differs from current SPA shell.** `BaseLayout.astro` must include every meta tag the current `buildSeoPageHtml` emits. Risk of dropping a canonical/hreflang/og tag. Mitigation: parity test that diffs head tags between legacy and Astro output.
+3. **MDX compile in CI memory.** Astro + MDX adds Node memory pressure on top of the current `--max-old-space-size=18432`. Pilot is one page — won't hit it. Sub-plan 03 (10,800 MDX files) will. Track baseline now.
+4. **Coexistence merge ordering.** If a path exists in both `dist/` and `dist-astro/`, the merge MUST be deterministic. Decision: `dist-astro/` always wins for any path it emits. Pilot path is one URL; future sub-plans extend the per-path overlay.
+5. **Astro's strict-mode TS may surface errors hidden by current loose config.** Use `tsconfig.astro.json` with project-references to scope Astro's strictness only to `src/`, leaving existing code untouched.
+
+---
+
+## Rollback
+
+- Revert `npm run build` to only call legacy Vite (`vite build`).
+- Skip the `scripts/merge-astro-into-dist.mjs` step in deploy.yml.
+- Result: legacy `/privacy/` served, Astro pilot ignored.
+- `dist-astro/` artifact still produced for diagnostics; not deployed.
+- Zero risk to production URLs other than the pilot, and the pilot rollback is one config flag.
+
+---
+
+## Open questions to resolve before expansion
+
+1. **Astro adapter:** static (`output: 'static'`) vs hybrid. Static matches current GitHub Pages posture. Lock in static.
+2. **i18n config:** `@astrojs/i18n` or manual routing. The official i18n routing has caveats around default-locale URL shape (we need IT = no prefix, others = `/{lang}/...`). Decide during expansion by reading current `services/router.ts:parsePath`.
+3. **Tailwind via `@astrojs/tailwind` vs raw Vite plugin.** Astro 6.x prefers the Vite Tailwind plugin path. Use that to avoid double config.
+4. **Where do Astro components import React components from?** Current `components/` is at repo root. Astro convention is `src/components/`. Use `tsconfig` path alias to keep imports working without a mass-move yet.
+
+---
+
+## Execution handoff
+
+(Same Subagent-Driven vs Inline question as sub-plan 01 once this is expanded to bite-sized tasks.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-03-articles-mdx.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-03-articles-mdx.md
@@ -1,0 +1,105 @@
+# Sub-Plan 03: Articles Big-Bang Migration to MDX
+
+> **For agentic workers:** This is a STUB. Expand to bite-sized TDD tasks before executing.
+
+**Goal:** Migrate all 2,702 articles × 4 locales = ~10,800 TypeScript body files to MDX. End state: every article lives at `src/content/articles/{slug}.{locale}.mdx` with Zod-validated frontmatter (via sub-plan 01's `ArticleMetaSchema`+`LocalizedArticleSchema`). Drop `data/blog-articles-data.ts`, `services/locales/blog-meta-{it,en,de,fr}.ts`, `services/locales/blog-body/{it,en,de,fr}/`. Rewire `scripts/create-article.mjs` to emit MDX directly (no more TS modules). Article rendering moves from runtime SPA hydration of TS imports → Astro static pages with React islands only for interactive components (`<Calc />`, `<NewsletterForm />`, etc.).
+
+**Architecture:**
+- **Migration script** (`scripts/migrate-articles-to-mdx.mjs`, one-shot): reads `data/blog-articles-data.ts` for metadata, reads each `services/locales/blog-body/{locale}/{id}.ts` for body, reads `services/locales/blog-meta-{locale}.ts` for title/excerpt, emits `src/content/articles/{id}.{locale}.mdx` with merged frontmatter + body. Idempotent — re-running produces byte-identical output.
+- **Frontmatter:** every mandatory field from `LocalizedArticleSchema`. Adds `originalTsBodyPath` (pointer to source file) for one round-trip verification, then dropped.
+- **Body:** ported from the TS body files. These contain HTML strings (`<p>...</p>...`); MDX handles raw HTML natively. Interactive components currently rendered as inline JSX from the TS module become MDX component imports (`import Calc from '@/components/Calc'`).
+- **Astro route:** `src/pages/articoli/[slug].astro` for IT, `src/pages/{en,de,fr}/articles/[slug].astro` for others. Each calls `getCollection('articles')` filtered by locale, builds dynamic paths, renders via `BaseLayout`.
+- **`create-article.mjs` rewire:** AI prompt template updated to output MDX (frontmatter YAML + body markdown/MDX). Output written directly to `src/content/articles/{id}.{locale}.mdx`. Validation via `LocalizedArticleSchema.parse()` before write.
+- **Cleanup commit (separate from migration commit):** delete the 3 source paths after the migration script verifies byte-equivalence of rendered HTML.
+
+**Tech Stack:** Astro content collections (sub-plan 02), MDX, Zod (sub-plan 01), Node fs/promises.
+
+**Depends on:** Sub-plan 02 (Astro skeleton + content config + MDX integration must exist).
+
+**Estimated effort:** 2 weeks (10 engineering days).
+
+**Ships standalone value:** ✅ Yes. Once shipped, all 2,702 articles are served from Astro static output, and the legacy TS-module pipeline can be retired.
+
+---
+
+## File structure (planned)
+
+**Created:**
+- `scripts/migrate-articles-to-mdx.mjs` — one-shot migration
+- `scripts/verify-article-render-equivalence.mjs` — byte-diff legacy article render vs Astro article render
+- `src/content/articles/{slug}.{locale}.mdx` × 10,800 files
+- `src/pages/articoli/[slug].astro` (IT — no prefix per CLAUDE.md i18n convention)
+- `src/pages/en/articles/[slug].astro`
+- `src/pages/de/artikel/[slug].astro`
+- `src/pages/fr/articles/[slug].astro`
+- `src/components/ArticleLayout.astro` — shared article shell
+- `src/components/ArticleCalculatorIsland.tsx` — React island for inline calculator embed (replaces inline JSX from TS bodies)
+- `tests/articles-migration-equivalence.test.ts` — sample-N test that legacy render === Astro render for representative articles
+
+**Modified:**
+- `src/content/config.ts` — extend `articles` collection schema (sub-plan 02 had a stub; flesh it out here)
+- `scripts/create-article.mjs` — emit MDX instead of TS
+- `package.json` — `npm run new-article` continues to work
+- `services/router.ts` — remove article-related route shapes (only safe after sub-plan 05 ships, so this modification may move to sub-plan 05)
+
+**Deleted (in cleanup commit):**
+- `data/blog-articles-data.ts`
+- `services/locales/blog-meta-it.ts` (and en, de, fr)
+- `services/locales/blog-body/it/` (entire directory)
+- `services/locales/blog-body/en/`, `de/`, `fr/`
+- Any test files that hard-coded reads of the above (port to read from `getCollection('articles')` instead)
+
+---
+
+## Phases (each becomes ~5-20 bite-sized tasks when expanded)
+
+1. **Schema completeness pass.** Extend `LocalizedArticleSchema` (sub-plan 01) with every field actually present in `blog-articles-data.ts` ARTICLES entries that wasn't in the initial schema (e.g., `hasCalculator`, `imageAlt`, ...). Test against 20 sample articles. ~1 day.
+2. **Migration script (read side).** Build a function `loadLegacyArticle(id, locale)` that returns a `LocalizedArticle`-shaped object by merging the 3 source files. Test against 100 sample articles. ~1 day.
+3. **Migration script (write side).** Build `emitMdx(article)` that produces frontmatter YAML + body MDX. Test on 10 articles — re-import via Astro content collection, verify schema validates. ~1 day.
+4. **Migration dry run.** Run on all 2,702 × 4 = 10,800 articles in a scratch dir (NOT in `src/`). Inspect error log; expect schema violations on legacy articles missing the new required fields. Triage each pattern of violation. ~1 day.
+5. **Triage gap-fill.** Either (a) extend schema with reasonable defaults (e.g., `imageAlt` derives from title if missing), or (b) script a back-fill pass on the legacy TS files first, or (c) document accepted exceptions. Each exception is justified or it's not allowed. ~1-2 days.
+6. **Full migration commit.** Run the migration script for real, into `src/content/articles/`. ONE huge commit ("feat(articles): migrate 10,800 articles to MDX"). PR shows `+10800 files` — that's expected. ~0.5 day.
+7. **Astro route page.** Build `src/pages/articoli/[slug].astro` consuming the collection. Verify one URL (`/articoli/stipendio-netto-2026/`) renders byte-equivalent (L2: DOM + content-equivalent) to legacy. ~1 day.
+8. **Locale routes.** Same for en/de/fr. ~1 day.
+9. **Verification harness.** Run `scripts/verify-article-render-equivalence.mjs` over a stratified sample of 100 articles (high-traffic + recently-edited + edge-case categories). L2 equivalence target: 100% pass. ~1 day.
+10. **CI gate.** Add a vitest test that runs the verification harness over a stable 20-article sample on every PR. ~0.5 day.
+11. **create-article.mjs rewire.** AI prompt now requests MDX. Validate output against `LocalizedArticleSchema`. New articles written directly to `src/content/articles/`. ~1 day.
+12. **Cleanup commit.** Delete legacy files. Run full test suite. Confirm zero broken imports. ~0.5 day.
+13. **PR + deploy + 48h soak.** Watch GSC `/articoli/*` for any drop in indexed pages or click loss. ~0.5 day + monitoring window.
+
+---
+
+## Critical risks
+
+1. **HTML semantic drift.** Legacy TS body files contain HTML strings; MDX may re-parse and emit subtly different whitespace, attribute order, or self-closing tags. Mitigation: L2 equivalence (DOM-equivalent, not byte). Accept minor whitespace diffs that don't change rendered text or DOM structure.
+2. **Inline component embeds.** Some legacy TS bodies likely contain inline JSX like `<Calculator />` or `<Newsletter />`. MDX requires these as imports + ESM. Migration script must detect inline JSX, generate the right `import` statements at the top of the MDX file.
+3. **Body word-count below 50 in legacy articles.** `ArticleLocaleBodySchema` (sub-plan 01) requires ≥50 words. Some legacy articles may not qualify. Triage: rewrite or drop. Rule #4: never accept thin content.
+4. **Volume — 10,800 file PR.** `gh pr create` works but reviewer experience is terrible. Mitigation: PR body explicitly says "see migration script for content; no manual edits to individual MDX files; reviewer audits the SCRIPT". Also stage in a sub-directory first if needed.
+5. **Git status / IDE performance.** 10,800 new files might slow `git status` and IDEs. Local: add `src/content/articles/*` to the `local-ignore-cron.sh` pattern. Remote: GitHub handles it fine.
+6. **Migration is non-idempotent if `create-article.mjs` runs DURING migration.** Mitigation: pause the create-article cron during the migration PR. Document the cron stop+start in the PR.
+7. **Article translations drift.** Each `{slug}.{locale}.mdx` is independent. If a translator/AI edits IT but not EN/DE/FR, you get drift. Mitigation: add a `translationCanonicalLastModified` frontmatter field that the build can compare; mark drifted translations stale.
+8. **Test files that read `data/blog-articles-data.ts` directly will break on cleanup.** Inventory before phase 12: `grep -rln "blog-articles-data\|blog-body\|blog-meta" tests/` and convert each to use `getCollection('articles')` or fixture data.
+
+---
+
+## Rollback
+
+- The migration is one PR. Revert it = revert all 10,800 file additions and the cleanup deletion. Single revert commit restores legacy.
+- If discovered AFTER deploy: revert + force-deploy. Articles served from legacy TS modules until investigation completes.
+- Backup: pre-migration tag `git tag pre-articles-mdx-migration` before the merge. Pinned for 30 days.
+
+---
+
+## Open questions to resolve before expansion
+
+1. **Inline component coverage.** Does ANY legacy article body import or inline a React component? If yes, list them and design MDX imports. (Grep `services/locales/blog-body/it/ -l "<Calculator\|<Newsletter\|<Quote"` etc.)
+2. **Image references.** Legacy bodies reference images as strings (`<img src="/images/...">`). MDX handles this fine — but Astro's image optimization (`@astrojs/image` or `astro:assets`) might want explicit imports. Decide: defer optimization to a later sub-plan, or do it during migration. Recommend: defer.
+3. **`hasCalculator` flag behavior.** What does it currently trigger? If it's UI-only (renders a calculator below the article body), the MDX page template handles it conditionally and the flag stays in frontmatter. If it inlines a component into the body, design the embed.
+4. **`updatedAt` semantics.** Should the migration set `updatedAt` to today (migration date) for every article, or preserve legacy `updatedAt`? Preserve. Last-modified shouldn't shift on a no-op migration.
+5. **Slug rename history.** If a legacy article was renamed, `data/article-redirects.json` likely tracks it. Verify redirects still emit (sub-plan 04 may own this if landings own redirects).
+
+---
+
+## Execution handoff
+
+(Same Subagent-Driven vs Inline question as sub-plan 01.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-04-programmatic-landings.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-04-programmatic-landings.md
@@ -1,0 +1,110 @@
+# Sub-Plan 04: Programmatic Landings → Astro Dynamic Routes
+
+> **For agentic workers:** This is a STUB. Expand to bite-sized TDD tasks before executing.
+
+**Goal:** Port all programmatic-content build plugins to Astro dynamic routes with `getStaticPaths()`. Each plugin's hand-rolled HTML string-concat is replaced by a `.astro` page template + reusable `.astro`/`.tsx` components. The 4 programmatic landings most exposed to the JSON→HTML "mapping pain" (`orphanQueryLandingPlugin`, `salaryHubPlugin`, `careerLandingsPlugin`, `healthPremiumsLanding`) plus the 4 dashboard-style landings (`fuelDailyPages`, `weeklyEmployersPlugin`, `jobMarketSnapshotPlugin`, `borderWaitPlugin`) — total 8 plugins — become 8 Astro routes consuming typed data via Zod schemas from sub-plan 01.
+
+**Architecture:**
+- Each plugin → one or more `src/pages/<path>/[...slug].astro` files with `getStaticPaths()` returning the full URL set.
+- Data sources stay as JSON on disk (unchanged from today). Astro routes load them via `loadJobs()`, `loadHealthPremiums()`, etc. helpers that wrap Zod parsing.
+- Hand-rolled HTML chunks (orphanQueryLandingPlugin lines 700-1050 etc.) extracted into reusable `.astro` components: `<StatsTileGrid>`, `<AdviceBanner>`, `<JobListBlock>`, `<FaqAccordion>`, `<BreadcrumbNav>`, `<RankingTable>`. These match the SEO-landing template contract in CLAUDE.md rule #17.
+- JSON-LD via `JsonLd.astro` component (from sub-plan 02) calling schema-driven helpers from sub-plan 01 — never hand-rolled.
+- Cross-page content index (CLAUDE.md feedback / earlier analysis): build once at boot, expose as `loadContentIndex()`. Used by orphan landings to filter matching jobs in O(1) instead of O(N_clusters × N_jobs).
+
+**Tech Stack:** Astro (sub-plan 02), Zod schemas (sub-plan 01), Node fs/promises for JSON loads.
+
+**Depends on:** Sub-plan 02 (Astro skeleton). NOT dependent on sub-plan 03 (articles) — these can parallelize.
+
+**Estimated effort:** 3 weeks (15 engineering days). Each of the 8 plugins is ~1.5 days end-to-end.
+
+**Ships standalone value:** ✅ Yes, per-landing. Each plugin migrated is one PR; each PR independently deployable.
+
+---
+
+## File structure (planned)
+
+**Created:**
+- `src/pages/ricerca/[slug].astro` (IT orphan landings) + en/de/fr equivalents
+- `src/pages/calcola-stipendio/[scenario].astro` (IT salary-hub) + en/de/fr
+- `src/pages/lavoro/[role]/[city].astro` (career landings) + en/de/fr
+- `src/pages/assicurazione-malattia/[canton].astro` + locales
+- `src/pages/carburante/[type].astro` + locales
+- `src/pages/datori-di-lavoro/settimanali.astro` + locales
+- `src/pages/mercato-lavoro/[canton].astro` + locales
+- `src/pages/attesa-frontiera/[crossing].astro` + locales
+- `src/components/seo/StatsTileGrid.astro`
+- `src/components/seo/AdviceBanner.astro`
+- `src/components/seo/JobListBlock.astro`
+- `src/components/seo/FaqAccordion.astro`
+- `src/components/seo/BreadcrumbNav.astro`
+- `src/components/seo/RankingTable.astro`
+- `src/components/seo/CtaPrimary.astro`
+- `scripts/lib/content-index.mjs` — boot-time index builder
+- `scripts/lib/loaders/jobs.mjs`, `articles.mjs`, `healthPremiums.mjs`, etc. — typed loaders (Zod-validated)
+- `tests/landings-migration-equivalence.test.ts` per landing
+
+**Modified:**
+- `src/content/config.ts` — extend with `landings` collection if any have human-authored frontmatter
+
+**Deleted (per plugin, in cleanup commits after deploy verifies parity):**
+- `build-plugins/orphanQueryLandingPlugin.ts` (87 KB)
+- `build-plugins/salaryHubPlugin.ts` (~264 lines + supporting modules)
+- `build-plugins/careerLandingsPlugin.ts`
+- `build-plugins/healthPremiumsLandingPlugin.ts`
+- `build-plugins/fuelDailyPagesPlugin.ts`
+- `build-plugins/weeklyEmployersPlugin.ts`
+- `build-plugins/jobMarketSnapshotPlugin.ts`
+- `build-plugins/borderWaitPlugin.ts`
+- `build-plugins/shared/seoPageShell.ts` (replaced by Astro `BaseLayout`)
+- `build-plugins/shared/seoContentTokens.ts` (port to Astro component CSS module)
+
+---
+
+## Phases (each plugin = one phase, expandable to ~10-15 bite-sized tasks)
+
+1. **Shared component library.** Build the 7 reusable `.astro` components matching CLAUDE.md rule #17 template contract. Tested in isolation. ~2 days.
+2. **Typed loaders + content index.** `scripts/lib/loaders/*.mjs` with Zod-validated reads. `loadContentIndex()` materializes job-by-cluster, content-by-tag, etc. ~1 day.
+3. **Plugin 1 — orphanQueryLandingPlugin (heaviest, prove the pattern).** Astro route + components + per-cluster `getStaticPaths()` + role-aware editorial copy from `services/locales/{lang}-orphan-landings.ts`. Verify L2 equivalence vs legacy on 20 sample URLs. ~2 days.
+4. **Plugin 2 — salaryHubPlugin.** Same pattern. ~1.5 days.
+5. **Plugin 3 — careerLandingsPlugin.** ~1.5 days.
+6. **Plugin 4 — healthPremiumsLanding.** ~1.5 days.
+7. **Plugin 5 — fuelDailyPages.** ~1 day (dashboard-shape, less editorial).
+8. **Plugin 6 — weeklyEmployersPlugin.** ~1 day.
+9. **Plugin 7 — jobMarketSnapshotPlugin.** ~1 day.
+10. **Plugin 8 — borderWaitPlugin.** ~1 day.
+11. **Cleanup pass.** After all 8 plugins are deploy-verified, delete legacy plugin source. Update `vite.config.ts` to no longer register them. ~0.5 day.
+
+---
+
+## Critical risks
+
+1. **Editorial copy migration.** `services/locales/{lang}-orphan-landings.ts` (and similar files for other plugins) contain hundreds of locale strings. These must migrate to either Astro i18n (sub-plan 06) or stay as TS imports. Decision: keep as TS imports during this sub-plan; sub-plan 06 consolidates.
+2. **`getStaticPaths()` memory.** Orphan landings generate hundreds of URLs × 4 locales. `getStaticPaths()` runs at build start; the entire URL list must fit in memory. Should be fine (~10K paths × small metadata) but track build RAM during phase 3.
+3. **L2 equivalence will not be byte-perfect.** Astro's HTML output differs in whitespace, attribute order, possibly comment stripping. Acceptance criterion: DOM-equivalent + visible-text-equivalent + JSON-LD-equivalent. `verify-l2-equivalence.mjs` (existing) is the tool.
+4. **JSON-LD diffs are the #1 risk.** Even minor schema-marker diffs can affect Google rich results. For every plugin, the FIRST verification is `verify-l2-equivalence.mjs` filtered to JSON-LD only. Hard gate.
+5. **Sitemap parity.** Each plugin currently emits sitemap entries via custom logic. `@astrojs/sitemap` auto-emits everything in `src/pages/`. Verify the URL set is identical (sort + diff). Address any missing URLs (e.g., trailing-slash conventions).
+6. **Build time per plugin.** Some legacy plugins are slow (orphanQueryLandingPlugin took minutes during Cathedral optimization). Astro's build of equivalent routes may be slower or faster — measure during phase 3, decide whether to add per-route caching.
+7. **Sub-plan 01's audit retirement assumed JSON-LD comes from helpers.** If any plugin migration accidentally re-introduces hand-rolled JSON-LD, the build won't catch it (the audit was retired). Mitigation: add a lint rule (`tests/no-handrolled-jsonld.test.ts`) that fails CI if `'@type':` appears anywhere under `src/` outside the JsonLd component.
+
+---
+
+## Rollback
+
+- Each plugin migration is one PR. Revert restores the legacy plugin (still in `build-plugins/` until the cleanup pass).
+- The coexistence merge step (`scripts/merge-astro-into-dist.mjs` from sub-plan 02) picks Astro-emitted paths over Vite-emitted; reverting removes the path from `dist-astro/`, so the legacy `dist/` version is served.
+- Cleanup pass (phase 11) is the only irreversible step — only run it AFTER all 8 plugins are 14-day soak-clean.
+
+---
+
+## Open questions to resolve before expansion
+
+1. **Static overlay handling.** CLAUDE.md mentions `parsePath().route.staticOverlay === true` URLs (fuel-daily, weekly-employers, health-premiums, border-wait, jobs-observatory, cost-of-living, salary-hub long-tail). After migration to Astro pages, this distinction disappears (no SPA fallback needed — Astro IS the static). Verify each such URL no longer needs the overlay flag in router. (Sub-plan 05 finalizes router removal.)
+2. **Job match index keying.** Sub-plan 01 added `JobSchema.stableId`. The content index in phase 2 should key on `stableId`, not URL (CLAUDE.md rule #18 about vendor URL renames).
+3. **Per-page CSS budget.** Astro extracts per-page critical CSS automatically. Current per-landing CSS approach (Tailwind utilities + a few CSS modules) should map cleanly, but verify no unused-CSS bloat on first phase-3 build.
+4. **Translation handling for landings.** Plugins currently use `services/locales/{lang}-orphan-landings.ts` etc. as flat Records. Sub-plan 06 will move them; this sub-plan keeps importing them as-is.
+
+---
+
+## Execution handoff
+
+(Same as sub-plan 01.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-05-spa-pages.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-05-spa-pages.md
@@ -1,0 +1,126 @@
+# Sub-Plan 05: SPA Decomposition — App.tsx → Astro Pages + React Islands
+
+> **For agentic workers:** This is a STUB. Expand to bite-sized TDD tasks before executing. This is the LONGEST POLE in the migration.
+
+**Goal:** Decompose the single-file React SPA (`App.tsx` ~2,700 lines, all state local) into Astro pages hosting React islands. Replace `services/router.ts` hand-rolled routing with Astro file-based routing. Preserve every behavior: locale-aware slugs (IT = no prefix; en/de/fr = `/{lang}/...`), URL canonicalization, search-string preservation (newsletter `?ne=&ac=` autologin), 6 top-level nav tabs (Calcolatore, Confronti, Fisco, Guida, Vita, Statistiche), 8 sub-tabs per category, browser back/forward semantics, and the static-overlay vs hydrated distinction (which goes away — Astro handles both via the same model).
+
+**Architecture:**
+- Every top-level tab = one `.astro` page. Six total IT pages (+24 locale pages):
+  - `src/pages/calcolatore/index.astro` + per-sub-tab pages
+  - `src/pages/confronti/index.astro` + sub-tabs
+  - `src/pages/fisco/index.astro` + sub-tabs
+  - `src/pages/guida/index.astro` + sub-tabs
+  - `src/pages/vita/index.astro` + sub-tabs
+  - `src/pages/statistiche/index.astro` + sub-tabs
+- Interactive React components become **islands** (`client:load` / `client:visible` / `client:idle` per use case):
+  - `<CalculatorIsland client:load />` (above-the-fold, immediate hydration)
+  - `<JobBoardIsland client:visible />` (deferred until in viewport)
+  - `<ChartsIsland client:idle />` (Recharts — heavy, idle hydration)
+  - `<MapIsland client:visible />` (Leaflet — viewport hydration)
+- **State that was local to `App.tsx`**: localized to each island. URL is the source of truth for cross-island state (e.g., selected canton, currency view). Where two islands on the same page must share state, use a `nanostores` or URL-search-param approach (NOT a global store unless absolutely required).
+- **Router replacement:**
+  - `pushRoute()` → `navigate()` from `astro:transitions/client` (Astro view-transitions) or plain `history.pushState` wrapped in a thin helper.
+  - `parsePath()` → not needed; Astro routing parses URLs. Helper `localizedHref(routeKey, locale)` for cross-locale link generation.
+  - `useNavigationState` hook → replaced by per-island reading of URL search params + page-level Astro frontmatter.
+- **Locale routing:** Astro i18n config sets IT as default with no prefix. `/{lang}/...` prefixes for en/de/fr. Sub-plan 06 owns the i18n migration; this sub-plan only defines page shapes that work with the eventual config.
+- **Critical-path LCP preservation:** the IT critical translations (`it-critical.ts`) move from SYNC-imported in App.tsx to inline-injected by Astro's frontmatter into the head. Sub-plan 06 finalizes; this sub-plan ensures every page declares its critical-i18n needs.
+- **Static-overlay vs hydrated unified:** Astro pages emit static HTML by default; islands hydrate where marked. The `services/router.ts:parsePath().route.staticOverlay` flag goes away — every page IS staticOverlay (server-rendered) AND IS hydrated (where islands declare).
+
+**Tech Stack:** Astro (sub-plan 02), @astrojs/react, React 19, nanostores (optional, only if shared island state required), Recharts/Leaflet (preserved).
+
+**Depends on:**
+- Sub-plan 02 (Astro skeleton)
+- Sub-plan 03 (articles must be Astro-served before SPA cutover or links break)
+- Sub-plan 04 (programmatic landings must be Astro-served before SPA cutover; nav links to them must resolve)
+
+**Estimated effort:** 4 weeks (20 engineering days). Longest pole.
+
+**Ships standalone value:** ❌ No. SPA decomposition is transitional infrastructure; users see no new value until cutover.
+
+---
+
+## File structure (planned)
+
+**Created:**
+- `src/pages/index.astro` (homepage)
+- `src/pages/calcolatore/index.astro` + `/{sub-tab}.astro` per sub-tab
+- `src/pages/confronti/index.astro` + sub-tabs
+- `src/pages/fisco/index.astro` + sub-tabs
+- `src/pages/guida/index.astro` + sub-tabs
+- `src/pages/vita/index.astro` + sub-tabs
+- `src/pages/statistiche/index.astro` + sub-tabs
+- Locale variants `src/pages/{en,de,fr}/...` for each above
+- `src/components/islands/CalculatorIsland.tsx` (wraps existing Calculator component)
+- `src/components/islands/JobBoardIsland.tsx`
+- `src/components/islands/ChartsIsland.tsx`
+- `src/components/islands/MapIsland.tsx`
+- `src/components/islands/NewsletterFormIsland.tsx`
+- `src/components/islands/PopupNewsletterIsland.tsx` (global; mounted in BaseLayout)
+- `src/lib/router.ts` — thin `localizedHref(routeKey, locale)` helper + minimal navigate wrapper
+- `src/lib/url-state.ts` — URL search-param sync helpers (replaces useNavigationState's URL logic)
+- `tests/spa-island-equivalence.test.ts` — per-page L2 equivalence vs legacy SPA
+
+**Modified:**
+- `src/layouts/BaseLayout.astro` — wire nav + footer + popup-newsletter mount points
+- `src/components/Nav.astro` — port of current nav, links use `localizedHref`
+
+**Deleted (in cleanup commit at end):**
+- `App.tsx`
+- `services/router.ts`
+- `services/seoService.ts` (parts not already migrated to `structuredData.ts` from sub-plan 01)
+- `hooks/useNavigationState.ts`
+- `hooks/useUIState.ts` (if fully replaced by per-island state — verify)
+- `services/locales/blog-body/` (already deleted in sub-plan 03 cleanup)
+
+---
+
+## Phases
+
+1. **Inventory & boundary mapping.** Read App.tsx end-to-end. Map every state slice to a page/island. Output: a markdown document `docs/spa-decomposition-map.md` listing every useState/useEffect with its target island. ~2 days.
+2. **One pilot tab end-to-end.** Pick the simplest tab (likely Statistiche or Guida). Build its `.astro` page, port its islands, verify L2 equivalence + interactive behavior. ~3 days.
+3. **Router helper + URL-state helper.** Build `localizedHref` and URL search-param sync. Test against current router invariants (search-param preservation, canonical redirect rules). ~1.5 days.
+4. **Tab 2 — Vita.** Apply pattern from phase 2. ~2 days.
+5. **Tab 3 — Fisco.** Includes the funnel calculator (PostHog instrumentation — see memory `project_recovery_may18.md`; do NOT regress the `useUIState.ts:95` entry-tag bug). ~3 days.
+6. **Tab 4 — Confronti.** Includes Permit B vs G comparator. ~2.5 days.
+7. **Tab 5 — Calcolatore.** The flagship calculator. Single biggest island. ~3 days.
+8. **Tab 6 — Statistiche.** Includes Recharts-heavy dashboards. `client:idle` for charts. ~2 days.
+9. **Global islands.** Popup newsletter, analytics consent (silent — per memory `feedback_silent_consent.md`), search bar. ~1.5 days.
+10. **Footer + nav + breadcrumbs.** Port to Astro components. ~1 day.
+11. **Cleanup commit.** Delete `App.tsx`, `services/router.ts`, hooks. Run full E2E suite. ~1 day.
+12. **Coexistence cutover.** Remove the merge step's "Astro paths override Vite paths" — Astro now owns everything except whatever sub-plans 06-08 still handle. Switch deploy to Astro-primary. ~0.5 day.
+
+---
+
+## Critical risks
+
+1. **State that crosses tab boundaries.** If App.tsx has state that survives navigation between tabs (e.g., "selected canton" persists when user moves Calcolatore → Statistiche), URL params or a tiny `nanostores` atom must replace it. Inventory in phase 1 is critical.
+2. **Calculator funnel instrumentation regression.** Memory `project_recovery_may18.md` flags `useUIState.ts:95` previously fired entry events without funnel tags, causing -71% measurement. The island migration MUST preserve correct entry-tag firing. Add a PostHog event-shape test.
+3. **Newsletter autologin (`?ne=&ac=` params).** Memory `feedback_router_preserve_search.md`: router/nav history writes must append `window.location.search`. The new `localizedHref` + navigate wrapper MUST preserve search params on every transition. Add a regression test.
+4. **Browser back/forward.** Astro view-transitions handle this differently from manual `history.pushState`. If using view-transitions, regression-test back/forward on every tab.
+5. **LCP impact.** App.tsx loads ~80 critical i18n keys synchronously to hit IT LCP. Per-Astro-page inline injection must achieve same LCP profile. Measure on phase 2 pilot; abort the migration shape if LCP regresses >10%.
+6. **`hooks/useNavigationState.ts` reads `staticOverlay` from the router (memory `feedback_static_overlay_truth_is_router.md`).** This flag goes away post-migration. Audit all consumers of `staticOverlay` (`grep -rln staticOverlay`) and remove or replace.
+7. **`App.tsx` is one file with hundreds of conditional renders.** Decomposition risks introducing visual regressions on small things (margin tweaks, ARIA labels). Mitigation: Playwright visual regression suite (`test:e2e:visual`) run on every PR in this sub-plan. Snapshot updates require explicit review.
+8. **Mobile-first content positioning rules #15-17.** Every island's content order on mobile must preserve current order (meaty content above fold). Re-verify mobile rendering on every tab phase.
+
+---
+
+## Rollback
+
+- Each tab phase is one PR. Revert restores legacy tab in App.tsx.
+- During coexistence (phases 2-11), the merge step ensures Astro pages are served only where they exist; reverting a phase removes those paths from `dist-astro/`, falling back to legacy.
+- Phase 12 is the cutover and the last reversible point. Tag `pre-spa-cutover` before phase 12 merge. 30-day pin.
+
+---
+
+## Open questions to resolve before expansion
+
+1. **View transitions or hard navigation.** Astro 6.x supports `@astrojs/view-transitions`. Smooth, SPA-feeling, but adds complexity. Recommend: defer; hard navigation is fine if every page is fast static + light islands.
+2. **Shared state library.** If phase 1 inventory finds significant cross-tab state, add `nanostores` (~1KB, used by Astro examples) instead of full Zustand. Decide post-phase-1.
+3. **`hooks/useUIState.ts`** scope. May still be useful per-island. Decide during phase 5 (Fisco — the funnel-heavy tab).
+4. **Component imports.** Currently `@/components/Foo` resolves to repo root `components/`. After migration, components shared between islands should move to `src/components/`. Decide: leave at root until end-of-sub-plan, then mass-move; or migrate incrementally. Recommend: incremental — when an island imports a component for the first time, move it to `src/components/` in that PR.
+
+---
+
+## Execution handoff
+
+(Same as sub-plan 01. This is the most subagent-friendly sub-plan because each tab phase is bounded — recommend Subagent-Driven with checkpoints between tabs.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-06-i18n.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-06-i18n.md
@@ -1,0 +1,94 @@
+# Sub-Plan 06: i18n Migration — Chunked Locales → Astro i18n + Critical-Path Inline
+
+> **For agentic workers:** This is a STUB. Expand to bite-sized TDD tasks before executing.
+
+**Goal:** Migrate the current chunked i18n system (`services/locales/it-critical.ts`, `{lang}-core.ts`, `-calculator.ts`, `-comparatori.ts`, etc. — 31 chunk files across 4 langs) to Astro's i18n model. Preserve the critical-path LCP guarantee: IT above-the-fold keys (~80 keys in `it-critical.ts`) inline-injected synchronously into the page head. Lazy chunks become per-route eager imports (Astro routes are statically known — no SPA lazy needed). Editorial locale content (`{lang}-orphan-landings.ts`, `{lang}-blog-meta.ts` if it still exists post sub-plan 03) consolidated into the same model.
+
+**Architecture:**
+- **Astro i18n config:** `astro.config.mjs` `i18n: { defaultLocale: 'it', locales: ['it','en','de','fr'], routing: { prefixDefaultLocale: false } }`. Matches current "IT = no prefix" convention.
+- **Critical-path inline:** every `.astro` page calls `getCriticalI18n(locale)` in frontmatter, returns the ~80-key object. `BaseLayout.astro` injects it as `<script>window.__I18N_CRITICAL__ = {...}</script>` in `<head>` BEFORE any island script, so islands can read it synchronously on first paint.
+- **Per-route i18n:** each Astro page imports only the locale chunks it needs (e.g., calcolatore page imports `i18n/{locale}-calculator.ts`). Vite tree-shakes per-page; bundle contains only what the page uses.
+- **Island i18n:** islands receive their i18n slice as `client:` props from the parent Astro page. No global i18n provider needed; per-island closure.
+- **Translation source of truth:** ONE TS file per locale per "domain" (`i18n/{locale}/core.ts`, `/calculator.ts`, `/comparatori.ts`, etc.). Astro discovers them. Type-safe via shared `I18nKeys` type.
+- **Translation dictionaries for landings/articles:** sub-plan 03 moved article body+meta to MDX frontmatter; sub-plan 04 left landing copy as TS imports. This sub-plan keeps the landing copy as-is (TS imports) but co-locates with the rest under `i18n/`.
+
+**Tech Stack:** Astro i18n routing, TypeScript ESM modules, Vite tree-shaking.
+
+**Depends on:** Sub-plan 02 (Astro skeleton), Sub-plan 05 (SPA decomposition — islands need to receive i18n as props).
+
+**Estimated effort:** 2 weeks (10 engineering days).
+
+**Ships standalone value:** ⚠️ Partial — only works fully after sub-plan 05 cutover.
+
+---
+
+## File structure (planned)
+
+**Created:**
+- `src/i18n/{it,en,de,fr}/critical.ts` (the ~80 above-the-fold keys)
+- `src/i18n/{it,en,de,fr}/core.ts`
+- `src/i18n/{it,en,de,fr}/calculator.ts`
+- `src/i18n/{it,en,de,fr}/comparatori.ts`
+- `src/i18n/{it,en,de,fr}/fisco.ts`, `guida.ts`, `vita.ts`, `statistiche.ts`
+- `src/i18n/{it,en,de,fr}/landings.ts` (consolidated from current `services/locales/{lang}-orphan-landings.ts` + similar)
+- `src/i18n/index.ts` — typed exports + `getCriticalI18n(locale)` helper
+- `tests/i18n-critical-path.test.ts` — verifies the critical-i18n bundle size stays under a budget (e.g., ≤ 8 KB gzipped)
+- `tests/i18n-completeness.test.ts` — every key in IT exists in EN/DE/FR
+
+**Modified:**
+- `src/layouts/BaseLayout.astro` — inject critical i18n in `<head>`
+- Every island under `src/components/islands/*.tsx` — accepts an `i18n` prop instead of importing global
+- Every Astro page — calls `getCriticalI18n` + passes relevant slices to islands
+
+**Deleted (in cleanup commit):**
+- `services/locales/it-critical.ts`
+- `services/locales/{lang}-core.ts`, `-calculator.ts`, `-comparatori.ts` (and any other chunks)
+- `services/locales/{lang}-orphan-landings.ts` (replaced by `src/i18n/{lang}/landings.ts`)
+- Any `services/i18n*.ts` runtime loader code
+
+---
+
+## Phases
+
+1. **Inventory & key audit.** List every locale chunk file. List every key. Cross-reference: which keys are used by which tab. Output: `docs/i18n-key-map.md`. ~1 day.
+2. **Migrate `it-critical.ts` to `src/i18n/it/critical.ts`** (and en/de/fr). Verify byte-equivalent. Add `getCriticalI18n` helper. ~0.5 day.
+3. **BaseLayout inline injection.** Wire `<head>` script tag. Verify LCP on pilot page (sub-plan 02 pilot) hasn't regressed vs legacy. ~1 day.
+4. **Per-domain chunk migration.** One domain at a time: `core` → `calculator` → `comparatori` → `fisco` → `guida` → `vita` → `statistiche`. Each migrated chunk: test, commit. ~3 days total.
+5. **Landings copy consolidation.** Move `services/locales/{lang}-orphan-landings.ts` → `src/i18n/{lang}/landings.ts`. Update sub-plan 04 imports. ~1 day.
+6. **Island prop wiring.** Each island in `src/components/islands/` updated to accept `i18n` prop. Pages pass relevant slice. ~2 days (depends on island count from sub-plan 05).
+7. **Completeness gate.** `tests/i18n-completeness.test.ts` runs in CI: every IT key exists in EN/DE/FR. Triage gaps (translation backfill). ~0.5 day + backfill work.
+8. **Critical-path budget gate.** `tests/i18n-critical-path.test.ts` enforces ≤ 8 KB gzipped for the critical inline. Add as CI step. ~0.5 day.
+9. **Cleanup commit.** Delete legacy `services/locales/*` chunks. Run full E2E. ~0.5 day.
+
+---
+
+## Critical risks
+
+1. **LCP regression.** Inline-injected i18n adds bytes to every HTML page. If `getCriticalI18n` returns too much, LCP suffers across the whole site. Mitigation: ≤ 8 KB gzipped budget + per-page LCP measurement.
+2. **Missing key 404s.** Some keys today are pulled lazily; if a key is missing, the SPA falls back to the IT version (or shows the key). After migration, every page bundle is finalized at build — missing key = visible bug. Completeness gate is the safety net.
+3. **`it-critical.ts` size drift.** Today ~80 keys, future drift to 200 keys is plausible and silently breaks the budget. Tests enforce both key count AND byte budget.
+4. **Sub-plan 03 already moved article meta strings out of `blog-meta-*.ts`** (into MDX frontmatter). Verify no orphaned blog-meta keys exist in legacy `services/locales/*` chunks; if so, delete in phase 9.
+5. **Translation quality variance.** Existing translations may be machine-translated and low quality. This sub-plan does not improve quality — only relocates files. Filed separately if quality work is needed.
+6. **Hreflang correctness.** Current pages emit hreflang tags pairing IT/EN/DE/FR. Astro's `@astrojs/sitemap` can emit them, but the pairing logic must match the URL convention (IT = no prefix). Verify in phase 3.
+
+---
+
+## Rollback
+
+- Revert per-phase. Legacy `services/locales/*` stays in repo until phase 9 (cleanup), so reverting any phase 2-8 falls back automatically.
+- Phase 9 is the only irreversible step; tag `pre-i18n-cleanup` before merging.
+
+---
+
+## Open questions to resolve before expansion
+
+1. **Pluralization & interpolation.** Current i18n likely supports `{count}` interpolation and maybe ICU plurals. Confirm Astro's choice (`astro-i18n` package vs hand-rolled) supports the same shapes. If hand-rolled today, port as-is.
+2. **Number/date/currency formatting.** `Intl.NumberFormat` per locale stays in island code (no framework dependency). Verify locale-specific CHF formatting (Swiss thousands sep) is preserved.
+3. **Translation tooling.** If there's an existing translation workflow (PR-based, GitHub Actions translator, etc.), wire it into the new file layout. Memory `feedback_never_translate_brands.md`: `restoreProtectedBrands()` must run on AI translations — port to new pipeline.
+4. **Locale-specific assets** (images, OG cards). Current emission unclear; verify and preserve.
+
+---
+
+## Execution handoff
+
+(Same as sub-plan 01.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-07-build-pipeline.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-07-build-pipeline.md
@@ -1,0 +1,104 @@
+# Sub-Plan 07: Build Pipeline Migration — Workflows, Cathedral Retirement, Audit Rewiring
+
+> **For agentic workers:** This is a STUB. Expand to bite-sized TDD tasks before executing.
+
+**Goal:** Audit and rewire 117 GitHub workflows for Astro. Retire `vite.config.ts`, the Cathedral parallelization machinery (`parallel_plugins=true` mode), FAST_BUILD/SKIP_* env vars, and the entire `build-plugins/` directory. Update `deploy.yml`, `post-deploy-validation.yml`, `post-deploy-validate-dist.yml`, `audit-dist-from-run.yml`, `tests.yml`, and the rebaseline pipelines to consume Astro's output layout. Confirm Firebase Remote Config loading (`scripts/load-rc-env.mjs`) still works under Astro. Branch protection rules verified.
+
+**Architecture:**
+- **`npm run build` end state:** runs `astro build` (only). Emits to `dist/`. No Vite plugin chain. No Cathedral parallel_plugins flag. No FAST_BUILD/SKIP_*.
+- **`deploy.yml`:** assemble-jobs (unchanged) → astro build → 3 remaining dist-walking audits (text-html-ratio, content-duplicates, page-weight + bfs-depth) → upload artifact → deploy to GitHub Pages. Other workflow steps preserved verbatim where they don't touch build internals.
+- **Cathedral retirement:** `parallel_plugins=true` workflow_dispatch input deleted. Cathedral-specific scripts in `scripts/` archived (NOT deleted — useful reference). Closures/closeBundle parallelization no longer exists; Astro builds are Astro-fast (typically faster than the current Vite + 16 plugins chain).
+- **Audit rewiring:** the 3 remaining dist-walking audits run unchanged (they walk `dist/`, which Astro fills). The BFS-depth audit may simplify or be retired if sub-plan 04's content-index made the violation impossible. Decision in this sub-plan.
+- **Rebaseline pipelines:** `text-html-ratio-baseline.json`, `content-duplicates-baseline.json`, etc. — must be re-baselined against Astro output once during this sub-plan. New baselines committed.
+- **Firebase RC loader (`scripts/load-rc-env.mjs`):** currently runs before Vite build to inject runtime config. Verify Astro startup path is equivalent; likely needs to run as a `prebuild` hook (already is — via `predev`/`prebuild` scripts in package.json).
+- **Branch protection:** memory note `tests.yml` is the main gate. Confirm `tests.yml` still runs after migration. Optionally add required_status_checks to gate on Astro build + tests.
+
+**Tech Stack:** GitHub Actions, Astro CLI, existing audit scripts.
+
+**Depends on:** Sub-plans 02-06. CI rewire can START when sub-plans 03 + 04 are >50% complete (working Astro output for diff testing).
+
+**Estimated effort:** 1.5 weeks (7-8 engineering days).
+
+**Ships standalone value:** ❌ No — infrastructure-only. Unblocks sub-plan 08 cutover.
+
+---
+
+## File structure (planned)
+
+**Modified:**
+- `.github/workflows/deploy.yml` — Astro build + simplified audit chain
+- `.github/workflows/post-deploy-validation.yml` — Astro dist path
+- `.github/workflows/post-deploy-validate-dist.yml` — Astro dist path
+- `.github/workflows/audit-dist-from-run.yml` — Astro artifact extraction
+- `.github/workflows/tests.yml` — add `astro check` step
+- `.github/workflows/*.yml` (other 112) — audit each for Vite/build-plugin references
+- `package.json` — `build` → `astro build`. Remove `build:fast`, `build:ci`, `build:prod`, `prepush:fast`. Update `dev` → `astro dev`. Preserve `test`, `test:e2e`, `predev`, `prebuild` (assemble-jobs).
+- `data/text-html-ratio-baseline.json` — re-baselined to Astro output
+- `data/page-weight-baseline.json` — re-baselined
+- `data/content-duplicates-baseline.json` — re-baselined
+- `data/bfs-depth-baseline.json` — re-baselined or retired
+- `.claude/settings.json` — remove SKIP_* env vars (memory `project_agent_fast_build_env.md`)
+- `CLAUDE.md` — update tech stack section + dev workflow section
+- `docs/CI-CD-PIPELINE.md` — full rewrite
+
+**Deleted:**
+- `vite.config.ts`
+- `build-plugins/` (entire directory — every plugin already replaced by sub-plans 03-06)
+- `scripts/parallel-closebundle*.mjs` (if any Cathedral scripts exist; archive first)
+- The `audit:*` package.json scripts already removed in sub-plan 01 are now confirmed-gone
+
+**Created:**
+- `astro.config.mjs` is mature (sub-plans 02-06 evolved it; this sub-plan locks in production config)
+- `docs/superpowers/notes/2026-XX-XX-cathedral-postmortem.md` — archives the Cathedral approach + what we learned
+
+---
+
+## Phases
+
+1. **Workflow inventory.** Run `grep -l "vite\|FAST_BUILD\|SKIP_\|build-plugins\|cathedral\|parallel_plugins" .github/workflows/` — list every workflow referencing legacy build infra. ~0.5 day.
+2. **`deploy.yml` rewrite.** Astro build + simplified audit chain + artifact upload. Test via workflow_dispatch against a feature branch. ~1 day.
+3. **Re-baseline.** Run a full Astro production build. Re-baseline the 3 remaining dist-walking audits + bfs-depth. Commit new baselines with explanatory message. ~0.5 day.
+4. **BFS-depth decision.** Check if Astro routing + content index from sub-plan 04 makes BFS-depth ≤4 by construction. If yes, retire the audit (per sub-plan 01's pattern). If no, keep walking. ~0.5 day.
+5. **Other workflow audits.** Each of the 117 workflows reviewed in batches of 20. Most are unaffected (cron data refreshes, no build deps). Update the ~5-10 that touch build internals. ~2 days.
+6. **`tests.yml`.** Add `npx astro check` step. Confirm vitest still runs `isolate: true` (memory: mandatory). ~0.5 day.
+7. **Remove env-var gymnastics.** `.claude/settings.json` no longer needs SKIP_*. `package.json` cleanup. Document the simplification. ~0.5 day.
+8. **Cathedral archive.** Move Cathedral-specific scripts to `docs/superpowers/archive/cathedral/` with README explaining the prior approach. Delete from `scripts/`. ~0.5 day.
+9. **Branch protection audit.** Optionally enable `required_status_checks: tests, astro-build` on `main`. Decision: enable if user wants strict gating (memory `feedback_no_ci_wait_agent_finish.md` says no — confirm). ~0.5 day.
+10. **`vite.config.ts` deletion + `build-plugins/` deletion.** Single PR. Run full build via Astro to confirm zero references remain. ~0.5 day.
+11. **Docs update.** Rewrite `docs/CI-CD-PIPELINE.md`. Update `CLAUDE.md` Tech Stack + Developer Workflows + FAST_BUILD trap section (now obsolete). ~1 day.
+
+---
+
+## Critical risks
+
+1. **Workflow-coverage blind spot.** With 117 workflows, easy to miss a niche one (e.g., a weekly cron) that references the old build. Mitigation: phase 1's grep, plus phase 5's manual batch review, plus a CI smoke run that fires each scheduled workflow once via workflow_dispatch.
+2. **Re-baseline scope.** If new baselines accept worse numbers than legacy (e.g., text-html-ratio drops because Astro emits more chrome HTML), the audits become weaker silently. Mitigation: in phase 3, REQUIRE the new baseline to be ≥ legacy on every metric; if Astro is worse, fix Astro emit first.
+3. **Pre/post-deploy validation paths.** Audits walk `dist/`. If Astro emits to a different default directory (it doesn't — `dist/` is default — but verify), all audit scripts break. Phase 3 catches.
+4. **Branch protection accidental tightening.** Memory `feedback_no_ci_wait_agent_finish.md`: user merges without waiting for CI. Adding required_status_checks would break that workflow. Default: do not add. Confirm before phase 9.
+5. **Cathedral-style parallelism loss.** Sub-plan 04 might rely on per-plugin parallel build for speed. Astro builds are typically fast enough not to need it, but measure: if Astro build > current Cathedral parallel build, investigate before deleting.
+6. **Local dev experience.** `npm run dev` switches from Vite to Astro. Different dev server, different HMR characteristics. Smoke-test mid-sub-plan; flag any DX regressions.
+7. **Firebase RC load order.** `scripts/load-rc-env.mjs` currently runs as predev/prebuild. Astro's startup may or may not see the env vars at the right time. Verify by smoke-testing one runtime-config-dependent feature.
+8. **Cron file ignore pattern (`local-ignore-cron.sh`).** ~600 cron files mostly under `data/jobs/by-crawler/`. The `local-ignore-cron.sh` pattern is independent of build system; verify it still functions after Astro install reshuffles the tree.
+
+---
+
+## Rollback
+
+- Each phase is one PR. Reverting individual phases is safe.
+- Phase 10 (delete `vite.config.ts` + `build-plugins/`) is the irreversible point. Tag `pre-vite-deletion`. Only run after phases 1-9 are clean for 7 days.
+- Full rollback: revert phases 10 → 2 in reverse order. Brings legacy build back. Articles + landings (sub-plans 03/04) would still serve from Astro under coexistence merge.
+
+---
+
+## Open questions to resolve before expansion
+
+1. **Astro production build time vs current Cathedral parallel build.** Measure during phase 3. If Astro is meaningfully slower (>30%), profile and address before phase 10.
+2. **Cathedral artifacts kept or deleted?** Decision: archive (keep), don't delete. Useful reference for future builds, and the postmortem is worth writing.
+3. **`build:fast` / `prepush:fast` user-facing scripts** are used by agent sessions (memory `project_agent_fast_build_env.md`). After migration, agent sessions just run `npm run build` (Astro is fast by default). Confirm `.claude/settings.json` updates.
+4. **Required status checks.** Memory says no CI wait. Confirm we're NOT adding required_status_checks in phase 9 (default: skip phase 9 entirely).
+
+---
+
+## Execution handoff
+
+(Same as sub-plan 01.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-08-cutover.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-08-cutover.md
@@ -1,0 +1,104 @@
+# Sub-Plan 08: Cutover, Legacy Decommission, SEO Regression Monitoring
+
+> **For agentic workers:** This is a STUB. Expand to bite-sized TDD tasks before executing.
+
+**Goal:** Final cutover from coexistence mode (Astro + legacy Vite running in parallel) to Astro-only. Remove every remaining legacy artifact: `App.tsx` (already removed in sub-plan 05), `services/router.ts` (already removed), legacy `services/locales/` (already removed in sub-plan 06), `data/blog-articles-data.ts` (already removed in sub-plan 03). Disable the coexistence merge step in CI; Astro `dist/` is the deploy artifact directly. Open a 14-day SEO regression monitoring window with rollback artifact pinned. Confirm GSC indexing, click volume, position, and crawl health all hold within ±5% of pre-cutover baseline. If any metric breaches, execute rollback per pinned artifact. If all green at day 14, delete rollback artifact and close the migration.
+
+**Architecture:**
+- **Coexistence merge retirement.** `scripts/merge-astro-into-dist.mjs` (sub-plan 02) deleted. `deploy.yml` reads `dist/` directly from Astro build.
+- **Final legacy sweep.** Any leftover files: `vite.config.ts` (deleted in sub-plan 07), `build-plugins/` (deleted in sub-plan 07), partial `services/*.ts` orphans. Inventory + delete.
+- **Monitoring dashboard.** Daily snapshot from existing tooling:
+  - `scripts/refresh-gsc-position-rolling.mjs` (already runs daily — capture pre-cutover baseline + 14-day post-cutover deltas)
+  - `scripts/check-seo-moratorium.mjs` (confirm position avg stays ≤ pre-cutover)
+  - `scripts/analytics-report.mjs` (memory `reference_analytics_scripts.md` — daily click/CTR/RPM deltas)
+  - PostHog dashboards: funnel completion, calculator entry events (regression guard from memory `project_recovery_may18.md`)
+  - AdSense per-channel revenue (memory `project_adsense_url_channels_apr28.md` — 8 URL channels track per-feature impact)
+- **Rollback artifact.** Tag `pre-astro-cutover` on `main` immediately before the cutover merge. Pre-built legacy artifact uploaded to a long-lived GH release (`v-pre-astro-cutover`). If rollback needed: redeploy this artifact directly to GH Pages, skipping any rebuild. Recovery time: ~5 minutes.
+- **Close-out documentation.** Final `docs/superpowers/notes/2026-XX-XX-astro-migration-complete.md` summarizing what shipped, what changed in user-facing behavior (ideally nothing), final metrics, lessons.
+
+**Tech Stack:** Existing CI/CD, existing monitoring scripts.
+
+**Depends on:** Sub-plans 01-07 (all). This is the terminator.
+
+**Estimated effort:** 1 engineering week + 14-day passive monitoring window (no active engineering during monitoring unless rollback).
+
+**Ships standalone value:** ❌ No — closes the migration; user-visible behavior unchanged from end of sub-plan 07.
+
+---
+
+## File structure (planned)
+
+**Modified:**
+- `.github/workflows/deploy.yml` — remove merge step, simplify to: assemble → astro build → audits → upload → deploy
+- `package.json` — final cleanup of legacy script aliases if any remain
+- `CLAUDE.md` — update "Project Overview" + "Tech Stack" + "Developer Workflows" + remove FAST_BUILD trap section + remove cathedral references + remove coexistence references; add "Astro" section
+- `docs/CATHEDRAL-IMPLEMENTATION-PLAN.md` — mark archived with redirect to postmortem (sub-plan 07)
+- `docs/CATHEDRAL-ROLLBACK.md` — same
+- `docs/SEO-RULES.md`, `docs/SEO-GATES.md`, `docs/SEO-FEATURES.md` — verify still accurate; update references to retired plugins
+
+**Created:**
+- `docs/superpowers/notes/2026-XX-XX-astro-migration-complete.md`
+- `docs/superpowers/notes/2026-XX-XX-astro-rollback-runbook.md` (kept even if not used)
+
+**Deleted (in cleanup commits):**
+- `scripts/merge-astro-into-dist.mjs`
+- Any remaining `services/*` files that became unused during sub-plans 03-07 (audit via `npx ts-prune` or `knip`)
+- Any `dist-astro/` references in `.gitignore` and scripts (cleanup)
+- Pre-built legacy artifacts after the 14-day monitoring window passes clean
+
+---
+
+## Phases
+
+1. **Pre-cutover baseline snapshot.** Capture: GSC 7-day average position, indexed page count, daily clicks/impressions per top-100 query, PostHog calc-funnel completion rate, AdSense per-channel RPM, Core Web Vitals (LCP/CLS/INP per template). Write to `data/migration-pre-cutover-baseline.json`. ~0.5 day.
+2. **Rollback artifact preparation.** Tag `pre-astro-cutover`. Build legacy `dist/` one last time (via the still-existing legacy build infra at this point — actually it was deleted in sub-plan 07, so build from the tag in a fresh worktree). Upload as a GH release asset. Document one-button rollback procedure in `docs/superpowers/notes/2026-XX-XX-astro-rollback-runbook.md`. ~1 day.
+3. **Cutover commit.** Remove merge step from `deploy.yml`. Astro `dist/` deploys directly. PR-as-merge-vehicle. Watch first post-cutover deploy run. ~0.5 day.
+4. **Day-0 verification.** Within 1 hour of deploy: spot-check 20 representative URLs (homepage, top articles, salary landings, job pages, orphan landings) via `curl` (static HTML) + Playwright (hydrated DOM). Per memory `feedback_diagnose_static_and_hydrated.md`: always verify both. Zero regressions allowed. ~0.5 day.
+5. **Day-1 to Day-3 close-watch.** Daily checks (script-driven). PostHog calc-funnel must hold within -5%. GSC crawl errors must stay near zero. ~daily 30 min.
+6. **Day-4 to Day-14 passive monitoring.** Same daily script. Alert thresholds: position drop > 0.5 absolute, clicks drop > 10% week-over-week, indexed page count drop > 2%. Any alert triggers manual investigation + potentially rollback. ~daily 15 min.
+7. **Final legacy sweep.** Run `npx knip` / `npx ts-prune`. Delete confirmed-dead code. Any false positives go in an allowlist with rationale. ~1 day. (May happen any time after Day 7 clean.)
+8. **Day-14 close-out.** If all metrics green: delete rollback artifact, delete `pre-astro-cutover` tag (or convert to permanent annotated tag for history), write close-out doc, update CLAUDE.md to reflect Astro as the standard. ~0.5 day.
+
+---
+
+## Critical risks
+
+1. **GSC ranking dip during indexing transition.** Even with byte-equivalent HTML, Google's crawler may treat the migration as a significant change and re-evaluate ranking. Risk window: 7-21 days. Mitigation: pre-cutover baseline captured; rollback ready; SEO moratorium (CLAUDE.md rule #19) already favors caution.
+2. **Render parity drift in long tail.** L2 equivalence was tested on samples in sub-plans 03-04. Long-tail URLs (low-traffic but indexed) may have un-tested edge cases. Mitigation: post-deploy `audit-dist-from-run` validation catches structural issues; manual spot-check on day 0 catches major visual.
+3. **CDN caching of stale legacy assets.** If GH Pages cached the legacy bundle paths, transitional 404s on hashed JS files. Mitigation: Astro emits fresh hashes; old asset 404s resolve when crawlers re-fetch HTML.
+4. **PostHog funnel regression mistaken for migration.** If calc-funnel drops post-cutover, distinguish: instrumentation bug (memory `project_recovery_may18.md` precedent), real user-experience regression, or measurement noise. Triage protocol: replay PostHog session recording before assuming bug.
+5. **AdSense policy re-eval.** Some publishers report ad-revenue dips after framework migrations as AdSense crawler re-evaluates. Mitigation: AdSense per-channel data (memory `project_adsense_url_channels_apr28.md`) lets us isolate which feature drops, if any.
+6. **Rollback artifact stale.** Built at pre-cutover; doesn't include any data refreshes that happened during the migration. Acceptable for a 1-2 day emergency rollback; not acceptable as a long-term fallback (which is why we delete it at Day 14).
+
+---
+
+## Rollback
+
+**Trigger conditions** (any one):
+- GSC indexed-page count drops > 2% over 24h
+- GSC 7-day position avg increases > 0.5 (per moratorium gate)
+- PostHog calc-funnel completion drops > 10% over 24h with no clear measurement bug
+- Day-1 spot-check fails on any high-traffic URL (homepage, calcolatore, top 10 articles)
+- AdSense RPM drops > 25% over 24h with no clear ad-policy issue
+
+**Rollback procedure** (~5 minutes):
+1. Trigger GH Pages deploy from the pre-built legacy artifact (manual workflow_dispatch).
+2. Verify pinned legacy URL list resolves via `curl`.
+3. Pause subsequent Astro deploys: set a workflow concurrency lock or temporarily disable `deploy.yml`.
+4. Open incident note. Investigate root cause without time pressure (legacy is back).
+5. Decide: hotfix Astro + re-cutover, or extended rollback.
+
+---
+
+## Open questions to resolve before expansion
+
+1. **Rollback artifact freshness.** Can we re-build legacy on demand from the tag, or must we keep a pre-built artifact? Decision: keep pre-built (faster recovery), refresh weekly during monitoring window if needed.
+2. **Monitoring automation.** Should daily checks be a cron workflow that posts to Slack/Discord, or a manual ritual? Decision: cron workflow with escalation thresholds.
+3. **Day-14 cutoff strictness.** If on Day-12 a metric trends concerning but not breaching threshold, extend monitoring? Decision: yes — extend by 7 days at PM discretion, document in incident log.
+4. **Tag policy.** Keep `pre-astro-cutover` as a permanent annotated tag for history, or delete it once safe? Decision: keep permanently — costs nothing, valuable for archaeology.
+
+---
+
+## Execution handoff
+
+(Same as sub-plan 01. This sub-plan is mostly passive monitoring — Inline Execution likely a better fit than Subagent-Driven, since there's not much code to write.)

--- a/docs/superpowers/plans/2026-05-20-astro-zod-migration.md
+++ b/docs/superpowers/plans/2026-05-20-astro-zod-migration.md
@@ -1,0 +1,138 @@
+# Astro + Zod Full Migration — Plan Index
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current Vite + React SPA + hand-rolled router + 16 custom build-plugins architecture with Astro (file-based routing, content collections, MDX, islands), with Zod as the single source of truth for all content/data schemas. End state: every renderable artifact lives as a typed file in `src/content/` or `src/pages/`, JSON-LD is generated from Zod schemas, 7 of 10 current dist-walking audit gates become build-time invariants by construction.
+
+**Architecture (end state):**
+- **Astro** (`withastro/astro` 6.3.x) drives the build. `astro.config.mjs` replaces `vite.config.ts`. File-based routing under `src/pages/`. Static output (`output: 'static'`) to preserve current SEO/CDN posture.
+- **Content collections** under `src/content/{articles,landings,jobs,...}/` with `src/content/config.ts` defining Zod schemas per collection. Frontmatter validated at build; missing mandatory SEO fields = build failure.
+- **MDX** (`@astrojs/mdx`) for articles (10,800 files: 2,702 articles × 4 locales) — Pattern A file-per-locale, parallel to current `services/locales/blog-body/{locale}/*.ts`.
+- **React islands** (`@astrojs/react`) for the interactive surfaces (calculators, comparators, job board, maps). App.tsx (~2,700 lines) decomposed into per-island components; per-tab state local to each island; URL is the source of truth for cross-island state.
+- **i18n** via `@astrojs/i18n` + manual critical-path inline for IT LCP (preserve current `it-critical.ts` SYNC-load behavior).
+- **Cathedral retirement:** parallel closeBundle, custom plugin sequencing, FAST_BUILD/SKIP_* env vars all retired. Astro's build pipeline replaces them.
+- **All 117 GitHub workflows** audited; deploy.yml, post-deploy-validation.yml, audit-dist-from-run.yml rewired to Astro output paths.
+
+**Tech Stack:**
+- Astro 6.3.x + @astrojs/react + @astrojs/mdx + @astrojs/sitemap + @astrojs/i18n
+- Zod 4.4.x (devDep until SPA islands need runtime schemas)
+- React 19 (preserved for islands)
+- TypeScript ~5.8 (preserved)
+- Tailwind 4 (preserved via `@astrojs/tailwind` or Vite plugin compat)
+- Vitest 4 (preserved for unit/integration tests)
+- Playwright (preserved for E2E)
+- Firebase / Remote Config (preserved; loaded at runtime in islands)
+
+---
+
+## Why decomposed
+
+This migration covers ≥8 ontologically independent subsystems. Bundling them into one plan would (a) outrun the context window, (b) freeze before execution because the spec drifts, (c) prevent shipping intermediate value. Per `superpowers:writing-plans` scope check: each subsystem ships working, testable software on its own.
+
+Each sub-plan in this index can be paused, audited, even rolled back independently. The first sub-plan (Zod foundations) delivers value **even if the Astro migration is later cancelled** — those schemas + invariants are net wins on the current Vite stack.
+
+---
+
+## Sub-plans
+
+| # | File | Scope | Depends on | Est. effort | Ships value standalone? |
+|---|------|-------|------------|-------------|-------------------------|
+| 01 | [`2026-05-20-astro-zod-01-zod-foundations.md`](./2026-05-20-astro-zod-01-zod-foundations.md) | Install Zod. Schemas for the 6 most-referenced data sources (jobs, articles, orphan clusters, health-premiums, fuel-daily, border-wait). Schema-derived JSON-LD helpers (JobPosting, Article, FAQPage, ImageObject, BreadcrumbList, WebPage). Retire 7 dist-walking audits as build-time invariants. | — | 1.5 weeks | ✅ Yes |
+| 02 | [`2026-05-20-astro-zod-02-astro-skeleton.md`](./2026-05-20-astro-zod-02-astro-skeleton.md) | Install Astro + integrations. Create `astro.config.mjs` parallel to `vite.config.ts` (coexistence mode for transition). Define `src/content/config.ts` with collection schemas (reusing Zod from sub-plan 01). One pilot static page (`/privacy/`) rendered via Astro end-to-end. CI deploys both Astro output + legacy Vite output to validate parity. | 01 | 1 week | ⚠️ Partial (pilot page only) |
+| 03 | [`2026-05-20-astro-zod-03-articles-mdx.md`](./2026-05-20-astro-zod-03-articles-mdx.md) | Big-bang migration of 2,702 articles × 4 locales = 10,800 TS body files → MDX files in `src/content/articles/{slug}.{locale}.mdx`. Migration script + verification (byte-equivalent rendered HTML). Retire `data/blog-articles-data.ts` + `services/locales/blog-meta-{locale}.ts` + `services/locales/blog-body/`. Rewire `scripts/create-article.mjs` to emit MDX. | 02 | 2 weeks | ✅ Yes |
+| 04 | [`2026-05-20-astro-zod-04-programmatic-landings.md`](./2026-05-20-astro-zod-04-programmatic-landings.md) | Port programmatic landing build plugins to Astro dynamic routes: `orphanQueryLandingPlugin`, `salaryHubPlugin`, `careerLandingsPlugin`, `healthPremiumsLanding`, `fuelDailyPages`, `weeklyEmployersPlugin`, `jobMarketSnapshot`, `borderWait`. Each becomes `src/pages/[...slug].astro` with `getStaticPaths()` reading from typed data sources. Hand-rolled HTML string-concat (orphanQueryLandingPlugin lines 700-1050) replaced by JSX/.astro components. | 02 | 3 weeks | ✅ Yes (per-landing) |
+| 05 | [`2026-05-20-astro-zod-05-spa-pages.md`](./2026-05-20-astro-zod-05-spa-pages.md) | Decompose App.tsx (~2,700 lines) into per-tab React islands. Each top-level nav tab (Calcolatore, Confronti, Fisco, Guida, Vita, Statistiche) becomes a `.astro` page hosting one or more React islands. Replace `services/router.ts` `parsePath()` + `pushRoute()` with Astro file-based routing + island-local state. Preserve URL canonicalization rules (it = no prefix; en/de/fr = `/{lang}/...`). | 02, 03, 04 | 4 weeks | ❌ No (transition-only) |
+| 06 | [`2026-05-20-astro-zod-06-i18n.md`](./2026-05-20-astro-zod-06-i18n.md) | Migrate `services/locales/` chunked i18n to Astro `@astrojs/i18n`. Preserve critical-path SYNC load for `it-critical.ts` (LCP guarantee). Lazy chunks `{lang}-core / -calculator / -comparatori` re-architected as per-route eager imports (Astro routes are pre-known at build, no SPA-style lazy needed). 31 chunk files reduced to per-route bundles. | 02, 05 | 2 weeks | ⚠️ Partial (works only after 05) |
+| 07 | [`2026-05-20-astro-zod-07-build-pipeline.md`](./2026-05-20-astro-zod-07-build-pipeline.md) | Audit and rewire 117 GitHub workflows. Retire `vite.config.ts`, Cathedral parallelization (`parallel_plugins=true`), FAST_BUILD/SKIP_* env vars. Rewire `deploy.yml`, `post-deploy-validation.yml`, `audit-dist-from-run.yml`, `tests.yml`. Update `scripts/audit-all.mjs` to walk Astro output (`dist/` path may change — confirm Astro default is `dist/`). Update `scripts/load-rc-env.mjs` import to be Astro-compatible. Branch protection rules audited. | 02-06 (all preceding) | 1.5 weeks | ❌ No (infra-only) |
+| 08 | [`2026-05-20-astro-zod-08-cutover.md`](./2026-05-20-astro-zod-08-cutover.md) | Final cutover: switch `npm run build` to Astro-only. Remove `vite.config.ts`, all `build-plugins/`, `App.tsx`, `services/router.ts`, `services/locales/blog-body/`, `data/blog-articles-data.ts`. 14-day SEO regression monitoring window (GSC position, indexed page count, crawl errors). Rollback artifact preserved for 30 days. | 01-07 (all) | 1 week (+ 14d monitor) | ❌ No (cutover-only) |
+
+**Total estimated effort:** ~16 weeks engineering + 14 days SEO monitoring. Optimistic; expect 20 weeks calendar with normal interruptions.
+
+---
+
+## Critical sequencing
+
+```
+01 (Zod) ───┬─→ 02 (Astro skeleton) ──┬─→ 03 (Articles MDX) ──┐
+            │                          ├─→ 04 (Landings) ──────┤
+            │                          └─→ 05 (SPA) ───┬───────┤
+            │                                          └─→ 06 (i18n) ──┐
+            └──────────────────────────────────────────────────────────┴─→ 07 (Pipeline) → 08 (Cutover)
+```
+
+- **Sub-plan 01 must complete before any Astro work.** Astro content collections consume Zod schemas; defining them first means no rework.
+- **Sub-plans 03 and 04 can parallelize** after 02. Different team members, no shared files.
+- **Sub-plan 05 (SPA decomposition) is the longest pole.** Start it the day after 02 ships. Do not let it block 03/04 (which can deploy as Astro-emitted pages alongside the still-Vite-built SPA in coexistence mode).
+- **Sub-plan 06 cannot ship before 05** because i18n is tested through the SPA tabs.
+- **Sub-plan 07 starts when 03/04 are >50% complete** (CI rewiring needs working Astro output but doesn't need everything migrated).
+- **Sub-plan 08 starts only when all green.**
+
+---
+
+## Cross-cutting concerns (apply to all sub-plans)
+
+### Worktree-first
+
+Per CLAUDE.md "Worktree-First Rule": every sub-plan execution starts with `EnterWorktree`. Branch name: `astro-zod-NN-<short-name>`. Multi-week sub-plans (03, 04, 05) live in long-running worktrees; the orchestrator can fan out tasks within a sub-plan to parallel agents (`Agent` with `isolation: "worktree"`).
+
+### SEO moratorium (CLAUDE.md rule #19)
+
+Active until `data/gsc-position-rolling.json` 7-day avg ≤ 7.5. Migration is **exempt** under the "consolidation refactors that NET-REDUCE pages" + "redirect/bridge emitters" carve-outs, BUT every sub-plan must:
+
+1. Net-emit ≤ current page count (no new URLs introduced by migration itself).
+2. Preserve every existing canonical URL byte-for-byte. Verify via `verify-l1-equivalence.mjs` pattern (already in repo) per sub-plan.
+3. Run `scripts/refresh-gsc-position-rolling.mjs` + `scripts/check-seo-moratorium.mjs` at the start of each sub-plan to confirm we're not landing during a position dip.
+
+### Audit gates during transition
+
+Sub-plan 01 retires 7 dist-walking audits as build-time invariants. The remaining 3 (`content-duplicates`, `text-html-ratio`, `page-weight`) and the `bfs-depth` audit MUST keep running against Astro output throughout the transition. `scripts/audit-all.mjs` may need to walk two directories (Astro `dist/` + legacy Vite `dist/`) during coexistence (sub-plans 02-07).
+
+### Rollback policy
+
+Every sub-plan defines its own rollback procedure in its own document. Common pattern:
+- Each sub-plan ships behind a `MIGRATION_STAGE` env var that lets `deploy.yml` deploy legacy vs Astro output.
+- After cutover (sub-plan 08), keep the legacy build green for 14 days in CI but don't deploy. After 14 days, delete.
+
+### Verification harness reuse
+
+The existing `verify-l1-equivalence.mjs`, `verify-l2-equivalence.mjs`, `verify-l3-report-equivalence.mjs` (built for the audit-runner unification) are repurposed: any Astro-emitted page must be byte-equivalent (L1) or DOM+content-equivalent (L2) to its Vite-emitted predecessor. Sub-plans 03, 04, 05 lean heavily on these.
+
+### Translation pattern (resolved decision)
+
+Pattern A: file-per-locale. 4 MDX files per article (`{slug}.it.mdx`, `.en.mdx`, `.de.mdx`, `.fr.mdx`). No AI fan-out at build. Locked in sub-plan 03.
+
+### Articles migration mode (resolved decision)
+
+Big-bang: all 2,702 articles migrated in sub-plan 03. No dual-coexistence loader. Migration script must succeed atomically or roll back. `create-article.mjs` cuts over to MDX in the same PR as the bulk migration.
+
+### Astro mode (resolved decision)
+
+Full replacement (not coexistence, not greenfield). Vite eventually deleted in sub-plan 08.
+
+---
+
+## Self-review (per skill mandate)
+
+**Spec coverage:**
+- Zod integration → sub-plan 01 (full).
+- Astro integration → sub-plans 02-08 (full).
+- SEO moratorium handling → cross-cutting section above.
+- Audit gate eviction → sub-plan 01 (build-time invariants); remaining gates handled in sub-plans 07-08.
+- Articles big-bang → sub-plan 03 (explicit goal).
+- File-per-locale → sub-plan 03 (Pattern A locked).
+- SPA + router rewrite → sub-plan 05.
+- i18n preservation (critical-path LCP) → sub-plan 06.
+- Cathedral retirement → sub-plan 07.
+- 117 workflows audit → sub-plan 07.
+
+**Placeholders:** none. Every sub-plan stub names files, dependencies, deliverables, ship-standalone status.
+
+**Type consistency:** schemas defined in sub-plan 01 are consumed by sub-plans 02-04. Names are pinned: `JobSchema`, `ArticleSchema`, `OrphanClusterSchema`, `HealthPremiumRowSchema`, `FuelDailySnapshotSchema`, `BorderWaitMeasurementSchema`. JSON-LD helpers pinned: `jobPostingLd()`, `articleLd()`, `faqPageLd()`, `imageObjectLd()` (already exists, refactored), `breadcrumbListLd()`, `webPageLd()`. These names appear identically in sub-plans 02-04.
+
+---
+
+## Execution handoff
+
+**Recommendation:** sub-plan 01 first, in this same session if you want — it's the only one that ships value alone and doesn't lock you into Astro until you've felt the schema work.
+
+For execution mode choice (Subagent-Driven vs Inline), see the execution handoff section at the end of sub-plan 01.


### PR DESCRIPTION
Decomposes a ~16-week Astro/Zod migration into 8 independently shippable
sub-plans per superpowers:writing-plans scope check. Sub-plan 01 (Zod
foundations + schema-derived JSON-LD + 7 retired audit gates) is fully
bite-sized TDD; sub-plans 02-08 are structured stubs ready for expansion.
