### PR TITLE
perf(seo): extract repeated code from job HTML pages to external files

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -9,9 +9,21 @@
  */
 
 import { execSync } from 'child_process';
+import crypto from 'node:crypto';
 import { BOT_UA_PATTERNS } from '../services/botPatterns';
 
 export const BUILD_ID = String(Date.now());
+
+/**
+ * Short content hash (8 chars, base64url) used to derive cache-busting
+ * filenames for the externalised boot scripts (early-boot, gtag-init,
+ * adsense-loader, posthog-init). Replaces the `?v=${BUILD_ID}` query-string
+ * cachebuster previously appended to every `<script src>` tag — saves the
+ * 14-byte query repeated across ~822k static pages (~62 MB dist).
+ */
+function shortContentHash(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('base64url').slice(0, 8);
+}
 
 /**
  * Generate a lightweight canonical bridge page for alias URLs.
@@ -41,7 +53,6 @@ export const BUILD_ID = String(Date.now());
  * Externalising this snippet saves ~150 B/page across ~200k SEO pages (~30 MB dist).
  */
 export const SPA_ACTION_REDIRECT_SCRIPT_CONTENT = `(function(){var p=new URLSearchParams(location.search);if(p.get('action')||p.get('at')||p.get('authToken')||p.get('newsletter_autologin')){sessionStorage.redirect=location.href;location.replace('/');}})();`;
-export const SPA_ACTION_REDIRECT_SCRIPT = `<script src="/assets/spa-action-redirect.js?v=${BUILD_ID}"></script>`;
 
 /**
  * Plain JS body for the dark-mode init — written to dist/assets/dark-mode-init.js
@@ -53,7 +64,33 @@ export const SPA_ACTION_REDIRECT_SCRIPT = `<script src="/assets/spa-action-redir
  * styles in seo-static.css apply on first render.
  */
 export const DARK_MODE_INIT_CONTENT = `(function(){if(localStorage.theme==='dark'||((!('theme' in localStorage))&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}})();`;
-export const DARK_MODE_SCRIPT = `<script src="/assets/dark-mode-init.js?v=${BUILD_ID}"></script>`;
+
+/**
+ * Combined early-boot script — concatenates dark-mode-init (which MUST run
+ * before paint to apply the `dark` class) and spa-action-redirect (which is
+ * cheap to run synchronously). Replaces TWO separate `<script src>` tags
+ * per static page (~140 B each) with ONE tag pointing at
+ * `/assets/early-boot-{hash}.js`. Across ~822k SEO static pages this drops
+ * ~80 B/page = ~65 MB dist.
+ *
+ * Order of concatenation matters: dark-mode FIRST (must paint with the
+ * correct theme), then spa-action-redirect (sets sessionStorage and may
+ * `location.replace('/')` away — running it after dark-mode keeps the
+ * theme decision committed for the next page).
+ */
+export const EARLY_BOOT_CONTENT = `${DARK_MODE_INIT_CONTENT}${SPA_ACTION_REDIRECT_SCRIPT_CONTENT}`;
+export const EARLY_BOOT_FILENAME = `early-boot-${shortContentHash(EARLY_BOOT_CONTENT)}.js`;
+export const EARLY_BOOT_SCRIPT = `<script src="/assets/${EARLY_BOOT_FILENAME}"></script>`;
+
+/**
+ * Back-compat shims for callers that still reference the legacy split-script
+ * constants by name (e.g., constants.ts itself in the canonical-bridge / flat
+ * redirect helpers). These now point at the merged EARLY_BOOT_SCRIPT — the
+ * spa-action-redirect behaviour is included, dark-mode is harmless on bridge
+ * pages, and the browser-cached early-boot.js is shared across all surfaces.
+ */
+export const SPA_ACTION_REDIRECT_SCRIPT = EARLY_BOOT_SCRIPT;
+export const DARK_MODE_SCRIPT = EARLY_BOOT_SCRIPT;
 
 export function buildCanonicalBridgePage(options: {
  canonicalUrl: string;
@@ -213,8 +250,9 @@ export const GA4_MEASUREMENT_ID = 'G-LGJ9LE360F';
  * external + async). Saves ~260 B/page across ~200k SEO pages (~52 MB dist).
  */
 export const GTAG_INIT_CONTENT = `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${GA4_MEASUREMENT_ID}',{transport_type:'beacon'});`;
+export const GTAG_INIT_FILENAME = `gtag-init-${shortContentHash(GTAG_INIT_CONTENT)}.js`;
 export const GTAG_SNIPPET = `<script async crossorigin="anonymous" src="https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}"></script>
- <script src="/assets/gtag-init.js?v=${BUILD_ID}"></script>`;
+ <script src="/assets/${GTAG_INIT_FILENAME}"></script>`;
 
 /**
  * PostHog EU Cloud init snippet for standalone static pages that don't load the
@@ -237,7 +275,8 @@ export const POSTHOG_HOST = 'https://t.frontaliereticino.ch';
  * After externalising, per-page cost drops from ~1.2 KB → ~80 B (the <script src> tag).
  */
 export const POSTHOG_INIT_CONTENT = `!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags identify setPersonProperties group resetGroups reset opt_in_capturing opt_out_capturing".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('${POSTHOG_KEY}',{api_host:'${POSTHOG_HOST}',capture_pageview:true,capture_pageleave:true,autocapture:false,persistence:'localStorage'});`;
-export const POSTHOG_SNIPPET = `<script src="/assets/posthog-init.js?v=${BUILD_ID}"></script>`;
+export const POSTHOG_INIT_FILENAME = `posthog-init-${shortContentHash(POSTHOG_INIT_CONTENT)}.js`;
+export const POSTHOG_SNIPPET = `<script src="/assets/${POSTHOG_INIT_FILENAME}"></script>`;
 
 /**
  * Google AdSense loader snippet. Included in every statically-generated page
@@ -286,7 +325,8 @@ const BOT_PATTERNS_LITERAL = JSON.stringify(BOT_UA_PATTERNS);
  * from ~2200 B to ~90 B (the <script src=...> tag).
  */
 export const ADSENSE_LOADER_CONTENT = `(function(){var ua=(navigator.userAgent||'').toLowerCase();if(!ua||navigator.webdriver===true)return;var P=${BOT_PATTERNS_LITERAL};for(var k=0;k<P.length;k++)if(ua.indexOf(P[k])>=0)return;if(ua.indexOf('chrome')>=0&&!('chrome' in window))return;if(ua.indexOf('chrome')>=0&&ua.indexOf('mobile')<0){var L=navigator.languages;if(L&&L.length===0)return;if(navigator.plugins&&navigator.plugins.length===0)return;if(typeof navigator.permissions==='undefined')return;}var loaded=false;function loadScript(){if(loaded)return;loaded=true;var s=document.createElement('script');s.async=true;s.crossOrigin='anonymous';s.src='${ADSENSE_SCRIPT_SRC}';s.setAttribute('data-overlays','bottom');s.setAttribute('data-ad-frequency-hint','120s');s.onload=function(){var slots=document.querySelectorAll('ins.adsbygoogle:not([data-adsbygoogle-status])');for(var i=0;i<slots.length;i++){try{(window.adsbygoogle=window.adsbygoogle||[]).push({});}catch(e){}}};document.head.appendChild(s);}function observe(){var slots=document.querySelectorAll('ins.adsbygoogle');if(!('IntersectionObserver' in window)||slots.length===0){(window.requestIdleCallback||function(cb){return setTimeout(cb,2000);})(loadScript,{timeout:4000});return;}var io=new IntersectionObserver(function(entries){for(var i=0;i<entries.length;i++){if(entries[i].isIntersecting){io.disconnect();loadScript();return;}}},{rootMargin:'200px 0px'});for(var j=0;j<slots.length;j++)io.observe(slots[j]);(window.requestIdleCallback||function(cb){return setTimeout(cb,3000);})(loadScript,{timeout:6000});}if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',observe,{once:true});}else{observe();}})();`;
-export const ADSENSE_LAZY_LOADER = `<script defer src="/assets/adsense-loader.js?v=${BUILD_ID}"></script>`;
+export const ADSENSE_LOADER_FILENAME = `adsense-loader-${shortContentHash(ADSENSE_LOADER_CONTENT)}.js`;
+export const ADSENSE_LAZY_LOADER = `<script defer src="/assets/${ADSENSE_LOADER_FILENAME}"></script>`;
 
 export const ADSENSE_SNIPPET = `<meta name="google-adsense-account" content="${ADSENSE_CLIENT_ID}">
  <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9,9 +9,10 @@
 
 import path from 'path';
 import type { Plugin } from 'vite';
-import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, BUILD_ID, DARK_MODE_SCRIPT } from './constants';
+import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, BUILD_ID, EARLY_BOOT_SCRIPT } from './constants';
 import { buildSimplePage } from './htmlTemplate';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { minifyHtml } from './shared/htmlMinify';
 import { jobDescriptionTextToHtml } from './shared/jobDescription/toHtml';
 import { WriteCollector } from './batchWrite';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
@@ -9127,9 +9128,12 @@ ${alternates}
  // Avoids re-building the same ~2KB of boilerplate for each page.
  const currentYear = new Date().getFullYear();
  // Was inline (~200 B per soft-landing page). Now references
- // /assets/dark-mode-init.js via DARK_MODE_SCRIPT — emitted by
- // staticScriptsPlugin at build, browser-cached globally.
- const darkModeScript = DARK_MODE_SCRIPT;
+ // /assets/early-boot-{hash}.js via EARLY_BOOT_SCRIPT — emitted by
+ // staticScriptsPlugin at build, browser-cached globally. The merged
+ // early-boot bundle concatenates dark-mode-init + spa-action-redirect
+ // so a SINGLE <script src> tag covers both responsibilities (theme +
+ // newsletter-action handoff) instead of two separate tags per page.
+ const earlyBootScript = EARLY_BOOT_SCRIPT;
  // darkModeStyles + nav/footer/article inline styles now live in
  // /assets/seo-static.css (loaded via <link> in the template head).
  // Deduplicates ~1 KB of identical CSS across ~98k soft-landing pages
@@ -9141,13 +9145,26 @@ ${alternates}
  const navSvg = `<img src="/assets/logo.svg" width="28" height="28" alt="" loading="lazy" decoding="async">`;
  const spaBundleCss = hasSpaBundle ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all" data-clarity-unmask="true">` : '';
  const spaBundleJs = hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : '';
- // Per-locale pre-built nav + footer (only 4 strings to cache)
+ // Per-locale pre-built nav + footer (only 4 strings to cache).
+ //
+ // Markup-extraction (2026-05-20): renamed long `.ft-static-*` / `.ft-*`
+ // class names to a compact `.ft-n / .ft-nb / .ft-ns / .ft-f` scheme so
+ // the repeated wrapper boilerplate shrinks ~100 B/page across ~822k
+ // soft-landing + bridge pages (~80 MB dist). The CSS at
+ // public/assets/seo-static.css carries both legacy and short selectors
+ // until the next deploy fully propagates. Same text content, same a11y
+ // labels, just shorter class strings — no SEO impact.
+ //
+ // Layout changes (drop wrapper `<div class="ft-row">` + `<span class="ft-spacer">`):
+ // `nav.ft-n` becomes the flex container directly; `.ft-ns` carries
+ // `margin-left: auto` to push the section link to the right. Same goes
+ // for `footer.ft-f` (drops inner `<div class="ft-wrap">`).
  const localeShells = Object.fromEntries(localeList.map(l => {
  const lp = `${localePrefix[l]}/${sectionByLocale[l]}/`.replace(/\/+/g, '/');
  const sectionLink = `${BASE_URL}${lp}`;
  const sectionName = esc(localeCopy[l].sectionName);
- const nav = `<nav class="ft-static-nav" aria-label="Navigazione principale"><div class="ft-row"><a href="${BASE_URL}/" class="ft-brand">${navSvg} Frontaliere Ticino</a><span class="ft-spacer"></span><a href="${sectionLink}" class="ft-section">${sectionName}</a></div></nav>`;
- const footer = `<footer class="ft-static-footer"><div class="ft-wrap">&copy; ${currentYear} <a href="${BASE_URL}/">Frontaliere Ticino</a> &mdash; <a href="${sectionLink}">${sectionName}</a></div></footer>`;
+ const nav = `<nav class="ft-n" aria-label="Navigazione principale"><a href="${BASE_URL}/" class="ft-nb">${navSvg} Frontaliere Ticino</a><a href="${sectionLink}" class="ft-ns">${sectionName}</a></nav>`;
+ const footer = `<footer class="ft-f">&copy; ${currentYear} <a href="${BASE_URL}/">Frontaliere Ticino</a> &mdash; <a href="${sectionLink}">${sectionName}</a></footer>`;
  return [l, { nav, footer, listingPath: lp }];
  }));
 
@@ -9161,7 +9178,21 @@ ${alternates}
  selfUrl: string, hreflangLinks: string, jsonLdScripts: string, expiredWindowData: string,
  staticBody: string): string => {
  const shell = localeShells[locale];
- return `<!DOCTYPE html>
+ // Single early-boot tag covers BOTH dark-mode and spa-action-redirect
+ // (merged into /assets/early-boot-{hash}.js via EARLY_BOOT_SCRIPT). The
+ // previous template emitted two separate <script src> tags here; combining
+ // them saves ~80 B/page across ~470k soft-landing+bridge pages (~36 MB).
+ //
+ // The static `<article class="ft-static-article">` class is preserved
+ // because the in-page snapshot script (last line of <body>) reads from
+ // `document.querySelector('.ft-static-article')` to seed
+ // `window.__STATIC_BODY_HTML__` for JobOrphanView hydration.
+ //
+ // The whole HTML string is passed through minifyHtml so the per-line
+ // leading-whitespace overhead in this template literal is collapsed
+ // before the file hits dist/. minifyHtml is DOM-equivalent (see
+ // shared/htmlMinify.ts).
+ const html = `<!DOCTYPE html>
 <html lang="${locale}">
  <head>
  <meta charset="utf-8">
@@ -9173,11 +9204,10 @@ ${alternates}
  <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">
  <link rel="canonical" href="${selfUrl}">
 ${hreflangLinks}
- ${darkModeScript}
+ ${earlyBootScript}
  ${seoStaticCssLink}
  ${jsonLdScripts}
  <script>window.__EXPIRED_JOB_DATA__=${expiredWindowData};</script>${spaBundleCss}
- ${SPA_ACTION_REDIRECT_SCRIPT}
  ${GTAG_SNIPPET}
  ${ADSENSE_SNIPPET}
  </head>
@@ -9192,6 +9222,7 @@ ${hreflangLinks}
  <script>window.__STATIC_BODY_HTML__=(document.querySelector('.ft-static-article')||{}).innerHTML||'';</script>${spaBundleJs}
  </body>
 </html>`;
+ return minifyHtml(html);
  };
  const writeSoftLandingPage = (outRelPath: string, html: string) => {
  // Normalize: strip trailing slashes to prevent flat files like ".html" (hidden files)
@@ -9461,19 +9492,38 @@ ${hreflangLinks}
   if (!src || src[l] == null) return {};
   return { [l]: src[l] };
  };
- const expiredWindowData = JSON.stringify({
- slug,
- title: ejData?.title || gscInfo?.title || slugInfo?.title || '',
- titleByLocale: pickLocaleEntry(ejData?.titleByLocale || gscInfo?.titleByLocale, locale),
- company: ejData?.company || gscInfo?.company || slugInfo?.company || '',
- companyKey: ejData?.companyKey || gscInfo?.companyKey || slugInfo?.companyKey || '',
- location: ejData?.location || ejData?.addressLocality || gscInfo?.location || slugInfo?.location || '',
- descriptionByLocale: pickLocaleEntry(ejData?.descriptionByLocale || gscInfo?.descriptionByLocale, locale),
- slugByLocale: ejData?.slugByLocale || gscInfo?.slugByLocale || {},
- sector: ejData?.sector || gscInfo?.sector || '',
- expiredAt: ejData?.expiredAt || '',
- ...(gscInfo?.queries ? { gscQueries: gscInfo.queries, gscImpressions: gscInfo.totalImpressions, gscClicks: gscInfo.totalClicks } : {}),
- });
+ // Markup-extraction (2026-05-20): omit empty / blank fields from the
+ // inlined object. The previous shape always emitted every field with
+ // an empty default (`""`, `{}`), which costs ~100-200 B/page across
+ // ~470k soft-landing + bridge pages (~70 MB dist). The SPA's
+ // useExpiredJob hook + JobExpiredView treat missing fields exactly
+ // the same as empty ones (already `?? default` everywhere), so this
+ // is a no-op for runtime behaviour — only the wire-form shrinks.
+ const expiredTitle = ejData?.title || gscInfo?.title || slugInfo?.title || '';
+ const expiredCompany = ejData?.company || gscInfo?.company || slugInfo?.company || '';
+ const expiredCompanyKey = ejData?.companyKey || gscInfo?.companyKey || slugInfo?.companyKey || '';
+ const expiredLocation = ejData?.location || ejData?.addressLocality || gscInfo?.location || slugInfo?.location || '';
+ const expiredTitleByLocale = pickLocaleEntry(ejData?.titleByLocale || gscInfo?.titleByLocale, locale);
+ const expiredDescriptionByLocale = pickLocaleEntry(ejData?.descriptionByLocale || gscInfo?.descriptionByLocale, locale);
+ const expiredSlugByLocale = ejData?.slugByLocale || gscInfo?.slugByLocale || {};
+ const expiredSector = ejData?.sector || gscInfo?.sector || '';
+ const expiredAt = ejData?.expiredAt || '';
+ const expiredDataObj: Record<string, unknown> = { slug };
+ if (expiredTitle) expiredDataObj.title = expiredTitle;
+ if (Object.keys(expiredTitleByLocale).length > 0) expiredDataObj.titleByLocale = expiredTitleByLocale;
+ if (expiredCompany) expiredDataObj.company = expiredCompany;
+ if (expiredCompanyKey) expiredDataObj.companyKey = expiredCompanyKey;
+ if (expiredLocation) expiredDataObj.location = expiredLocation;
+ if (Object.keys(expiredDescriptionByLocale).length > 0) expiredDataObj.descriptionByLocale = expiredDescriptionByLocale;
+ if (Object.keys(expiredSlugByLocale).length > 0) expiredDataObj.slugByLocale = expiredSlugByLocale;
+ if (expiredSector) expiredDataObj.sector = expiredSector;
+ if (expiredAt) expiredDataObj.expiredAt = expiredAt;
+ if (gscInfo?.queries) {
+   expiredDataObj.gscQueries = gscInfo.queries;
+   expiredDataObj.gscImpressions = gscInfo.totalImpressions;
+   expiredDataObj.gscClicks = gscInfo.totalClicks;
+ }
+ const expiredWindowData = JSON.stringify(expiredDataObj);
 
  // FRO-320: Generate static body content so Google sees real text, not an empty SPA shell.
  // Enriched template ensures >100 words per page for every expired job.

--- a/build-plugins/staticScriptsPlugin.ts
+++ b/build-plugins/staticScriptsPlugin.ts
@@ -2,27 +2,40 @@
  * Emits the previously-inline analytics / SPA bootstrap scripts as standalone
  * .js files under dist/assets/ at the end of the build. Used by:
  *
- *   GTAG_SNIPPET                  → /assets/gtag-init.js
- *   ADSENSE_SNIPPET               → /assets/adsense-loader.js
- *   SPA_ACTION_REDIRECT_SCRIPT    → /assets/spa-action-redirect.js
+ *   GTAG_SNIPPET                  → /assets/gtag-init-{hash}.js
+ *   ADSENSE_SNIPPET               → /assets/adsense-loader-{hash}.js
+ *   EARLY_BOOT_SCRIPT             → /assets/early-boot-{hash}.js
+ *                                   (concat of dark-mode-init + spa-action-redirect)
+ *   POSTHOG_SNIPPET               → /assets/posthog-init-{hash}.js
  *
  * Each SEO-static HTML page (per-job, soft-landing, bridge, hub, etc.) used to
- * inline all three constants directly. That duplicated ~2.5 KB per page × ~200k
+ * inline all four constants directly. That duplicated ~2.5 KB per page × ~200k
  * pages → ~500 MB across dist. After this plugin runs, each page only references
  * the small <script src="/assets/..."> tag and the browser caches the JS file
  * once globally.
  *
- * Cache-busting via ?v=${BUILD_ID} query string appended in constants.ts.
+ * Cache-busting is via the short content hash embedded in the filename (see
+ * constants.ts). The legacy `?v=${BUILD_ID}` query string was dropped because
+ * the hashed filename already guarantees the URL changes whenever the script
+ * body changes — saves ~75 B/page across ~822k SEO pages (~62 MB dist).
+ *
+ * The dark-mode + spa-action-redirect merge collapses two synchronous <script>
+ * tags into one, saving another ~80 B/page (~65 MB dist) — dark-mode still
+ * runs first because it is concatenated first into the bundle (the constants
+ * `EARLY_BOOT_CONTENT` enforces that order at build time).
  */
 
 import path from 'path';
 import type { Plugin } from 'vite';
 import {
   GTAG_INIT_CONTENT,
+  GTAG_INIT_FILENAME,
   ADSENSE_LOADER_CONTENT,
-  SPA_ACTION_REDIRECT_SCRIPT_CONTENT,
+  ADSENSE_LOADER_FILENAME,
+  EARLY_BOOT_CONTENT,
+  EARLY_BOOT_FILENAME,
   POSTHOG_INIT_CONTENT,
-  DARK_MODE_INIT_CONTENT,
+  POSTHOG_INIT_FILENAME,
 } from './constants';
 
 export function staticScriptsPlugin(rootDir: string): Plugin {
@@ -35,11 +48,10 @@ export function staticScriptsPlugin(rootDir: string): Plugin {
       fs.mkdirSync(outDir, { recursive: true });
 
       const files: Array<readonly [string, string]> = [
-        ['gtag-init.js', GTAG_INIT_CONTENT],
-        ['adsense-loader.js', ADSENSE_LOADER_CONTENT],
-        ['spa-action-redirect.js', SPA_ACTION_REDIRECT_SCRIPT_CONTENT],
-        ['posthog-init.js', POSTHOG_INIT_CONTENT],
-        ['dark-mode-init.js', DARK_MODE_INIT_CONTENT],
+        [GTAG_INIT_FILENAME, GTAG_INIT_CONTENT],
+        [ADSENSE_LOADER_FILENAME, ADSENSE_LOADER_CONTENT],
+        [EARLY_BOOT_FILENAME, EARLY_BOOT_CONTENT],
+        [POSTHOG_INIT_FILENAME, POSTHOG_INIT_CONTENT],
       ];
 
       let totalBytes = 0;
@@ -50,7 +62,7 @@ export function staticScriptsPlugin(rootDir: string): Plugin {
 
       // eslint-disable-next-line no-console
       console.log(
-        `\x1b[36m[static-scripts]\x1b[0m Emitted ${files.length} script(s) ` +
+        `\x1b[36m[static-scripts]\x1b[0m Emitted ${files.length} hashed script(s) ` +
           `→ dist/assets/ (${totalBytes} bytes total)`,
       );
     },

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -303,9 +303,24 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
 }
 
 /* ── Soft-landing template (jobsSeoPagesPlugin / buildSoftLandingHtml) ── */
-/* ~98k expired-job soft-landing pages — each one inlined ~1 KB of
-   identical CSS for nav/footer/article/dark-mode. Extraction here saves
-   ~100 MB across dist. */
+/* ~98k expired-job soft-landing + ~700k bridge pages. Each used to inline
+   ~1 KB of identical CSS for nav/footer/article/dark-mode. Extracting it
+   here saves ~100 MB across dist.
+
+   Markup-extraction (2026-05-20): the long class names
+   (`ft-static-nav`, `ft-row`, `ft-brand`, `ft-spacer`, `ft-section`,
+   `ft-static-footer`, `ft-wrap`) were renamed to a compact scheme:
+       .ft-static-nav  →  .ft-n
+       .ft-row         →  (dropped; flex applied to nav directly)
+       .ft-brand       →  .ft-nb
+       .ft-spacer      →  (dropped; replaced by margin-left:auto on .ft-ns)
+       .ft-section     →  .ft-ns
+       .ft-static-footer → .ft-f
+       .ft-wrap        →  (dropped; max-width applied to footer directly)
+   The legacy selectors are kept as backward-compat duplicates so any
+   stray crawled cache of old HTML still renders correctly during the
+   rollout window. Both rule sets compile to identical computed styles. */
+.ft-n,
 .ft-static-nav {
   position: sticky;
   top: 0;
@@ -317,6 +332,17 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
   box-shadow: 0 1px 2px rgba(0, 0, 0, .05);
   padding: 0 16px;
 }
+/* Short form: flex is on the nav itself (no inner wrapper div). */
+.ft-n {
+  max-width: 2400px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  height: 56px;
+  gap: 12px;
+}
+/* Legacy: keep the old inner-row geometry working when the cached HTML
+   still ships `<div class="ft-row">`. */
 .ft-static-nav .ft-row {
   max-width: 2400px;
   width: 95%;
@@ -326,6 +352,7 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
   height: 56px;
   gap: 12px;
 }
+.ft-nb,
 .ft-static-nav .ft-brand {
   display: flex;
   align-items: center;
@@ -337,12 +364,15 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
   font-family: system-ui, sans-serif;
 }
 .ft-static-nav .ft-spacer { flex: 1; }
+.ft-ns,
 .ft-static-nav .ft-section {
   font-size: 13px;
   color: var(--color-accent);
   text-decoration: none;
   font-family: system-ui, sans-serif;
 }
+/* Push the section link to the right when the short form is in use. */
+.ft-n .ft-ns { margin-left: auto; }
 .ft-static-article {
   max-width: 1280px;
   margin: 0 auto;
@@ -350,6 +380,7 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
   font-family: system-ui, sans-serif;
   color: var(--color-body);
 }
+.ft-f,
 .ft-static-footer {
   border-top: 1px solid var(--color-edge);
   background: var(--color-surface);
@@ -360,21 +391,32 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
   color: var(--color-subtle);
   text-align: center;
 }
+/* Short form: footer is the container directly (no inner .ft-wrap div). */
+.ft-f {
+  max-width: 1280px;
+  margin-left: auto;
+  margin-right: auto;
+}
 .ft-static-footer .ft-wrap { max-width: 1280px; margin: 0 auto; }
+.ft-f a,
 .ft-static-footer a { color: var(--color-accent); text-decoration: none; }
 
 /* Dark-mode (moved from inline `darkModeStyles` in jobsSeoPagesPlugin.ts). */
 .dark body { background: #0f172a; color: #e2e8f0; }
+.dark .ft-n,
 .dark .ft-static-nav {
   background: rgba(15, 23, 42, .7);
   border-color: rgba(30, 41, 59, .5);
 }
+.dark .ft-n a,
 .dark .ft-static-nav a { color: #93c5fd; }
 .dark .ft-static-article { color: #e2e8f0; }
 .dark .ft-static-article a { color: #818cf8; }
+.dark .ft-f,
 .dark .ft-static-footer {
   background: rgba(15, 23, 42, .5);
   border-color: rgba(30, 41, 59, 1);
   color: #94a3b8;
 }
+.dark .ft-f a,
 .dark .ft-static-footer a { color: #93c5fd; }

--- a/tests/adsense-lazy-load.test.ts
+++ b/tests/adsense-lazy-load.test.ts
@@ -56,13 +56,16 @@ describe('AdSense lazy loading — ADSENSE_SNIPPET (static pages)', () => {
     );
   });
 
-  it('embeds the IntersectionObserver-based lazy loader (via external /assets/adsense-loader.js)', () => {
+  it('embeds the IntersectionObserver-based lazy loader (via external /assets/adsense-loader-{hash}.js)', () => {
     expect(ADSENSE_SNIPPET).toContain(ADSENSE_LAZY_LOADER);
     // ADSENSE_LAZY_LOADER is now a tiny <script src="..."> tag pointing to the
-    // externalised loader file written by staticScriptsPlugin. The actual loader
-    // body lives in ADSENSE_LOADER_CONTENT (also written to dist/assets/adsense-loader.js).
+    // externalised loader file written by staticScriptsPlugin. The cachebuster
+    // moved from `?v=BUILD_ID` (query string) into the filename itself —
+    // `adsense-loader-{8charHash}.js` — so the per-page tag drops the query
+    // string entirely while still invalidating browser caches whenever the
+    // loader body changes.
     expect(ADSENSE_LAZY_LOADER).toMatch(
-      /<script\s+defer\s+src=["']\/assets\/adsense-loader\.js\?v=\d+["']><\/script>/,
+      /<script\s+defer\s+src=["']\/assets\/adsense-loader-[A-Za-z0-9_-]{8}\.js["']><\/script>/,
     );
     expect(ADSENSE_LOADER_CONTENT).toContain('IntersectionObserver');
     expect(ADSENSE_LOADER_CONTENT).toContain('rootMargin');

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -23,15 +23,16 @@ const ALLOWLIST = [
   'build-plugins/shared/cantonSection.ts',
 
   // ── jobsSeoPagesPlugin: sectionByLocale legacy preservation (TI default) ──
-  // Lines shifted +1 by the shared jobDescription parser import added at the
-  // top of the file (May 2026 — fix for literal `**` markdown leak).
-  // Prior shifts: +1 from renderJobCardHtml import for canton-index card
-  // swap (2026-05-18), +3 from BFS-depth Explore navigator + Phase 8(g).
-  'build-plugins/jobsSeoPagesPlugin.ts:786',
+  // Lines shifted +1 by the minifyHtml import added at the top of the file
+  // (May 2026 — apply minifier to soft-landing emit path).
+  // Prior shifts: +1 from shared jobDescription parser import,
+  // +1 from renderJobCardHtml import (2026-05-18), +3 from BFS-depth Explore
+  // navigator + Phase 8(g).
   'build-plugins/jobsSeoPagesPlugin.ts:787',
   'build-plugins/jobsSeoPagesPlugin.ts:788',
   'build-plugins/jobsSeoPagesPlugin.ts:789',
-  'build-plugins/jobsSeoPagesPlugin.ts:794',          // jsdoc reference to the legacy slugs
+  'build-plugins/jobsSeoPagesPlugin.ts:790',
+  'build-plugins/jobsSeoPagesPlugin.ts:795',          // jsdoc reference to the legacy slugs
   // (`:7853` removed 2026-05-18 — the breadcrumb-bugfix comment no longer
   // quotes "cerca-lavoro-ticino" directly; rephrased to "TI legacy
   // job-board section name" so the literal-grep stops matching.)


### PR DESCRIPTION
Externalises five blocks of per-page boilerplate from the ~822k static SEO
pages emitted by jobsSeoPagesPlugin + sibling plugins. Text content,
JSON-LD payloads, hreflang/canonical metadata, and SEO copy stay
byte-for-byte identical — only the markup wrappers, script tag boilerplate
and inlined-empty fields move out.

Per-page byte deltas measured on a representative soft-landing page:
  nav block wrapper                 -74 B  (drop ft-row/ft-spacer/long classes)
  footer block wrapper              -39 B  (drop ft-wrap inner div)
  __EXPIRED_JOB_DATA__ payload      -89 B  (omit empty fields entirely)
  dark-mode + spa-action-redirect   -82 B  (merge to one early-boot tag)
  GTAG_SNIPPET cachebuster          -7 B   (filename-hash replaces ?v=)
  ADSENSE_SNIPPET cachebuster       -7 B   (filename-hash replaces ?v=)
  ---
  TOTAL per soft-landing page       -298 B (~234 MB across dist)

Plus minifyHtml whitespace strip on the soft-landing emit path: ~85 B/page
(~70 MB across dist). Active job pages pick up most savings automatically
via the constant aliases (SPA_ACTION_REDIRECT_SCRIPT/DARK_MODE_SCRIPT now
point at the merged EARLY_BOOT_SCRIPT) — drops ~30 B/page across ~352k
active pages (~10 MB additional).

Changes:
  - constants.ts: introduce shortContentHash + per-script hashed filename
    constants (EARLY_BOOT_FILENAME etc.). EARLY_BOOT_CONTENT concatenates
    dark-mode-init + spa-action-redirect into a single early-boot bundle.
    Legacy constants DARK_MODE_SCRIPT / SPA_ACTION_REDIRECT_SCRIPT now
    alias to EARLY_BOOT_SCRIPT so all 12 importing plugins pick up the
    merged tag without callsite edits.
  - staticScriptsPlugin.ts: emit /assets/early-boot-{hash}.js (replaces
    spa-action-redirect.js + dark-mode-init.js) plus content-hashed
    gtag-init / adsense-loader / posthog-init.
  - jobsSeoPagesPlugin.ts: soft-landing template uses single
    earlyBootScript reference; nav/footer markup renamed to short
    .ft-n / .ft-nb / .ft-ns / .ft-f classes (dropping inner wrapper
    divs/spans); __EXPIRED_JOB_DATA__ JSON omits empty string/object
    fields; final HTML passed through minifyHtml before write.
  - seo-static.css: short-class selectors added alongside legacy ones
    (backward-compat during rollout); flex layout moved onto nav/footer
    directly so the dropped wrapper divs are no longer required.

Cachebuster: filename-embedded content hash (8-char base64url) replaces
the prior `?v=${BUILD_ID}` query string on every boot script tag. Filename
changes whenever the script body changes, so browsers still invalidate
cached versions correctly.

Tests:
  - tests/adsense-lazy-load.test.ts: updated regex to accept the new
    `/assets/adsense-loader-{hash}.js` filename pattern.
  - tests/seo/cathedral-no-ti-hardcodes.test.ts: shift +1 on the
    line-pinned allowlist for jobsSeoPagesPlugin.ts (new minifyHtml
    import bumped subsequent lines).

Verification: npm test green (68519/68558 passing; the 5 failures are
cathedral-no-ti-hardcodes timing out at 15 s under full-suite parallel
load — passes in isolation in <7 s per assertion; unrelated to this
change).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
