### PR TITLE
fix(seo): job-detail emitter — hoist <main> outside #root + add footer-root

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2339,8 +2339,8 @@ ${hreflangHtml}
  ${ADSENSE_SNIPPET}
  </head>
  <body>
- <div id="root">
- <main class="static-job-page">
+ <div id="root"></div>
+ <main class="seo-static-content static-job-page">
  <nav class="bn"><a href="${BASE_URL}${withSlash(`${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}`.replace(/\/+/g, '/'))}">&larr; ${esc(allJobsLinkLabel(locale, getCantonDisplayLabel(String(job.canton || DEFAULT_CANTON), locale)))}</a></nav>
  <article class="proposal">
  <section class="hero">
@@ -2645,7 +2645,7 @@ ${hreflangHtml}
  })()}
  </nav>
  </main>
- </div>${hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
+ <div id="footer-root"></div>${hasSpaBundle ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
  </body>
 </html>`;
  _qw(np.join(outDir, 'index.html'), html);


### PR DESCRIPTION
PR #427 extended audit-footer-root-presence to catch any dist HTML
matching `<div id="root"><main class="static-job-page">` (legacy
buildSimplePage shell that React wipes on hydrate). The job-detail
emitter in jobsSeoPagesPlugin.ts (172k pages on dist) was missed by
the cleanup PRs #376/#416/#420 and tripped the gate on every deploy
since 74af8a1101 landed (run 26150874538).

Convert the inline template to the hydration-safe shape:
  - `<div id="root">` now empty/self-closed; SPA hydrates with the
    JobBoard view inside.
  - `<main>` becomes a body-direct sibling carrying both
    `seo-static-content` (so App.tsx's useEffect hides it post-hydrate
    on non-staticOverlay routes — CLAUDE.md rule #14) and the
    pre-existing `static-job-page` class (preserves /assets/seo-static.css
    selectors).
  - `<div id="footer-root"></div>` emitted as the App.tsx portal target
    so the footer no longer renders above the static body.

No other plugin emitters change. Same JSON-LD, head, body content,
script tags — only the wrapper shell is reshaped.
