### PR TITLE
fix(workflows): remove orphan env: blocks from 5 failure reporters

### DIFF
--- a/.github/workflows/cathedral-noindex-flip.yml
+++ b/.github/workflows/cathedral-noindex-flip.yml
@@ -119,7 +119,6 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
-        env:
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: cathedral-noindex-flip — run ${{ github.run_number }}" \

--- a/.github/workflows/persist-job-stats.yml
+++ b/.github/workflows/persist-job-stats.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
-        env:
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Persist Job Stats — run ${{ github.run_number }}" \

--- a/.github/workflows/refresh-article-trending.yml
+++ b/.github/workflows/refresh-article-trending.yml
@@ -72,7 +72,6 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
-        env:
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Refresh Article Trending — run ${{ github.run_number }}" \

--- a/.github/workflows/refresh-bfs-stats.yml
+++ b/.github/workflows/refresh-bfs-stats.yml
@@ -112,7 +112,6 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
-        env:
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Refresh BFS Stats — run ${{ github.run_number }}" \

--- a/.github/workflows/refresh-job-popularity.yml
+++ b/.github/workflows/refresh-job-popularity.yml
@@ -69,7 +69,6 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
-        env:
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Refresh Job Popularity — run ${{ github.run_number }}" \


### PR DESCRIPTION
PR #433 (Linear→GH Issues migration) left empty `env:` lines behind
after stripping LINEAR_API_KEY. The bare `env:` with no children
triggers GitHub Actions parser error "Invalid workflow file ...
Unexpected value ''" and aborts the entire workflow run before any
step executes.

Affected workflows (all currently failing on main):
- cathedral-noindex-flip.yml
- persist-job-stats.yml
- refresh-article-trending.yml
- refresh-bfs-stats.yml
- refresh-job-popularity.yml
