### PR TITLE
fix(seo): restore canton-landing CTA marker after style→class extraction

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -8293,7 +8293,7 @@ ${alternates}
        `<nav class="s-ZVaIKh"><a class="s-t_pXue" href="${BASE_URL}/">${esc(homeLabel[entry.locale])}</a> &rarr; <span aria-current="page">${esc(display)}</span></nav>`,
        `<header class="s-TYF4UK"><h1 class="s-Wb8ho2">${esc(display)}</h1><p class="s-b7cYUf">${esc(labels.lede)}</p></header>`,
        tileGrid,
-       `<p class="s-ziawP1"><a class="s-yy370N" href="${legacyJobBoardHref}">${esc(labels.ctaLabel)}</a></p>`,
+       `<p class="s-ziawP1"><a class="s-yy370N" data-primary-cta href="${legacyJobBoardHref}">${esc(labels.ctaLabel)}</a></p>`,
        subPageNav,
        cantonListSection,
        listingGrid,

--- a/tests/seo/cathedral-canton-landing-order.test.ts
+++ b/tests/seo/cathedral-canton-landing-order.test.ts
@@ -55,10 +55,12 @@ describe('canton landing mobile-first element order (CLAUDE.md #17)', () => {
 
       const h1 = html.indexOf('<h1');
       const tiles = html.indexOf('data-stat-tile-grid');
-      // Primary CTA = the inline-styled anchor with the accent background.
-      // Match the exact P4 style fragment so we don't pick up the prose's
-      // inline body links by accident.
-      const cta = html.search(/<a [^>]*style="[^"]*background:var\(--color-accent\)[^"]*"/);
+      // Primary CTA = the anchor explicitly marked with `data-primary-cta`
+      // in build-plugins/jobsSeoPagesPlugin.ts. Stable marker independent of
+      // CSS implementation: PR #454 extracted inline styles to content-hashed
+      // classes, so the previous `style="...background:var(--color-accent)..."`
+      // selector no longer matched.
+      const cta = html.search(/<a [^>]*\bdata-primary-cta\b/);
       const listing = html.indexOf('data-listing-grid');
       // Prose anchor — first user-facing H2 of the buildCantonContextProse
       // section. The four locales use different lead-words so we search


### PR DESCRIPTION
PR #454 extracted inline `style=` attributes to content-hashed CSS classes
(60-90 MB dist savings), but tests/seo/cathedral-canton-landing-order.test.ts
still searched for the old inline `style="...background:var(--color-accent)..."`
selector to locate the primary CTA. The CTA is still emitted in the correct
mobile-first slot — H1 → tiles → CTA → listings → prose — only the proxy used
to find it broke. validate-dist's gate:seo-source has been red on zurigo /
ginevra / vaud since the codemod merged (run 26209582640).

Add a stable `data-primary-cta` attribute on the canton-landing CTA anchor in
build-plugins/jobsSeoPagesPlugin.ts and update the test selector to match it.
The data attribute is implementation-agnostic — survives future style-extraction
or class-rename refactors — and the test continues to enforce CLAUDE.md #17
mobile-first element order.
