### PR TITLE
fix(router): preserve slug map when slim payload lacks slugByLocale

### DIFF
--- a/services/router.ts
+++ b/services/router.ts
@@ -1577,6 +1577,14 @@ export function registerJobSlugMap(jobs: Array<{ id?: string; canton?: string; s
  }
  }
  }
+ // Skip overwrite when the new map is empty. The slim job-index payload
+ // (`/data/jobs-${locale}-index.json`) was size-trimmed to drop
+ // `slugByLocale`, so calling this with slim jobs produces an empty map
+ // and was wiping out the full map previously loaded from
+ // `/data/jobs-slug-map.json` — breaking cross-canton bridge resolution
+ // (e.g. /cerca-lavoro-ticino/<SZ-job-slug>/ rendered JobOrphanView even
+ // though the job is alive in another canton).
+ if (map.size === 0 && _jobSlugMap && _jobSlugMap.size > 0) return;
  _jobSlugMap = map;
 
  // Do NOT rewrite the browser URL when the slug belongs to a different

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
-import { buildPath, parsePath, pushRoute, replaceRoute, updatePathForLocale, registerJobSlugMap } from '@/services/router';
+import { buildPath, parsePath, pushRoute, replaceRoute, updatePathForLocale, registerJobSlugMap, getJobMetaForSlug } from '@/services/router';
 
 const SEO_LANDINGS = [
   'salary-60000',
@@ -848,5 +848,34 @@ describe('Router — SPA equivalent wins over static landing', () => {
     const { route } = parsePath('/fr/calculer-salaire/scenarios');
     expect(route.activeTab).toBe('calculator');
     expect(route.staticOverlay).toBe(true);
+  });
+});
+
+describe('Router — registerJobSlugMap protects against slim-payload wipe', () => {
+  it('does not overwrite a populated slug map when called with slim jobs that lack slugByLocale', () => {
+    const slug = 'responsabile-pulizie-manutenzione-60-100-spital-schwyz-schwyz';
+    registerJobSlugMap([
+      {
+        id: 'spital-schwyz-a273343ebd6e',
+        canton: 'SZ',
+        slug,
+        slugByLocale: {
+          it: slug,
+          de: 'stv-leitung-reinigung-unterhalt-60-100-spital-schwyz-schwyz',
+        },
+      },
+    ]);
+    expect(getJobMetaForSlug(slug)).toMatchObject({ canton: 'SZ', id: 'spital-schwyz-a273343ebd6e' });
+
+    // Second call mimics JobBoard.finalize() invoking registerJobSlugMap
+    // with the size-trimmed /data/jobs-${locale}-index.json payload, which
+    // carries `slug` + `previousSlugs` but no `slugByLocale`.
+    registerJobSlugMap([
+      { id: 'spital-schwyz-a273343ebd6e', canton: 'SZ', slug },
+    ]);
+
+    // Bridge resolution would break here if the empty payload wiped the
+    // full map loaded from /data/jobs-slug-map.json.
+    expect(getJobMetaForSlug(slug)).toMatchObject({ canton: 'SZ', id: 'spital-schwyz-a273343ebd6e' });
   });
 });


### PR DESCRIPTION
The slim job-index (`/data/jobs-${locale}-index.json`) was trimmed to
drop `slugByLocale`. `JobBoard.finalize()` calls `registerJobSlugMap`
with that payload, which iterated 5902 entries hitting
`if (!byLocale) continue` on every one and ended up storing an empty
Map — wiping out the full map loaded from `/data/jobs-slug-map.json`.

After the wipe, cross-canton bridge resolution (e.g.
`/cerca-lavoro-ticino/<SZ-job-slug>/`) fails: `getJobMetaForSlug`
returns undefined, the SPA bridge effect early-returns at the
`if (!meta?.canton || !meta?.id) return` guard, the locale-index
fallback fetch never fires, and JobOrphanView renders even though
the job is alive in another canton.

Fix: skip the assignment when the new map would be empty AND the
existing map has entries. This protects the canonical map against
size-trimmed slim payloads while still allowing legitimate clears.

Regression test in tests/router.test.ts asserts that calling
registerJobSlugMap a second time with a slug-only payload preserves
the cross-canton lookup result.
