### PR TITLE
fix(seo): link seo-static.css from every buildSimplePage emission

### DIFF
--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -7,7 +7,7 @@
  *
  * Phase 3 optimization: reduces string concatenation overhead for 55k+ pages.
  */
-import { FAVICON_LINKS, GTAG_SNIPPET, ADSENSE_SNIPPET, BASE_URL, SPA_ACTION_REDIRECT_SCRIPT } from './constants';
+import { FAVICON_LINKS, GTAG_SNIPPET, ADSENSE_SNIPPET, BASE_URL, SPA_ACTION_REDIRECT_SCRIPT, SEO_STATIC_CSS_LINK } from './constants';
 
 /**
  * Common <head> prefix: charset + viewport + favicon + security meta.
@@ -197,6 +197,15 @@ export function buildSimplePage(opts: SimplePageOpts): string {
  const extraHead = extraHeadHtml ? `\n${extraHeadHtml}` : '';
  const ldTags = jsonLdScripts.map(ld => ` <script type="application/ld+json">${ld}</script>`).join('\n');
  const cssLink = entryCss ? `\n <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : '';
+ // PR #454 extracted ~3 920 static inline `style=` attributes into content-
+ // hashed CSS classes (s-{6char}) appended to public/assets/seo-static.css.
+ // The hand-rolled HTML in jobsSeoPagesPlugin / seoHubsPlugin already inlines
+ // ${SEO_STATIC_CSS_LINK}, but every page going through buildSimplePage was
+ // missing the link → ~50 plugins emit class-only s-* anchors with no CSS
+ // file behind them. Visible regression on staticOverlay pages
+ // (weekly-employers, fuel-daily, health-premiums, border-wait, ...) whose
+ // static content is rendered to end users.
+ const seoStaticLink = `\n ${SEO_STATIC_CSS_LINK}`;
  const jsScript = entryJs ? `\n <script type="module" crossorigin src="/assets/${entryJs}"></script>` : '';
 
  // Body composition — three modes:
@@ -251,7 +260,7 @@ ${skipMainWrap ? bodyHtml : ` <main class="static-job-page">\n ${bodyHtml}\n </m
  <meta name="twitter:image" content="${esc(ogImage ?? `${BASE_URL}/og-image.png`)}">
  <link rel="canonical" href="${canonicalUrl}">
 ${hreflangHtml}${extraHead}
-${ldTags}${cssLink}
+${ldTags}${cssLink}${seoStaticLink}
  ${GTAG_SNIPPET}
  ${ADSENSE_SNIPPET}
  </head>


### PR DESCRIPTION
PR #454 extracted ~3 920 static inline `style=` attributes from build-plugins
into content-hashed CSS classes (`s-{6char}`) appended to
`public/assets/seo-static.css`. The hand-rolled HTML templates in
jobsSeoPagesPlugin and seoHubsPlugin (4 sites) already inline
`${SEO_STATIC_CSS_LINK}` in their `<head>`, but every page emitted via
`buildSimplePage()` (and therefore `buildSeoPageHtml()` — used by ~50 build
plugins) was missing the link. The extracted CSS classes had no stylesheet
behind them.

End-user impact varies by route:
  - SPA-hydrated pages (canton landings, sector hubs, …) — invisible: the
    SPA hides `<main class="seo-static-content">` via lite-shell, so the
    unstyled static content is not rendered.
  - `staticOverlay: true` pages (weekly-employers, fuel-daily, health-
    premiums, border-wait, jobs-observatory, cost-of-living, …) — visible
    regression: tiles render without card backgrounds, sections without
    framing, CTAs as plain text. Confirmed live at
    https://frontaliereticino.ch/aziende-che-assumono/ — 63 unstyled
    `s-*` classes in a 1 810 px static body.

Inject `SEO_STATIC_CSS_LINK` alongside the existing `cssLink` inside
`buildSimplePage()`. Hand-rolled emitters that already include the link by
hand stay untouched (they don't go through buildSimplePage) — no
double-loading. Verified by tsx-rendering a sample page: head now contains
both `index-{hash}.css` and `seo-static-{hash}.css`.
