### PR TITLE
fix(ci): migrate jobRecencyPagesPlugin TI hardcodes to inline cathedral-allow markers

### DIFF
--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -51,10 +51,10 @@ import { windowDaysForVariant } from './jobRecencyLanding';
 const LOCALES: ReadonlyArray<JobLandingLocale> = ['it', 'en', 'de', 'fr'];
 
 const SECTION_BY_LOCALE: Record<JobLandingLocale, string> = {
-  it: 'cerca-lavoro-ticino',
-  en: 'find-jobs-ticino',
-  de: 'jobs-im-tessin',
-  fr: 'trouver-emploi-tessin',
+  it: 'cerca-lavoro-ticino', // cathedral-allow: TI legacy section fallback (per-plugin SECTION_SLUG table)
+  en: 'find-jobs-ticino', // cathedral-allow: TI legacy section fallback (per-plugin SECTION_SLUG table)
+  de: 'jobs-im-tessin', // cathedral-allow: TI legacy section fallback (per-plugin SECTION_SLUG table)
+  fr: 'trouver-emploi-tessin', // cathedral-allow: TI legacy section fallback (per-plugin SECTION_SLUG table)
 };
 
 const LOCALE_PREFIX: Record<JobLandingLocale, string> = {

--- a/tests/seo/cathedral-no-ti-hardcodes.test.ts
+++ b/tests/seo/cathedral-no-ti-hardcodes.test.ts
@@ -72,10 +72,8 @@ const ALLOWLIST = [
   'build-plugins/jobOrphanBridgePlugin.ts:86',
   'build-plugins/jobOrphanBridgePlugin.ts:87',
   'build-plugins/jobOrphanBridgePlugin.ts:88',
-  'build-plugins/jobRecencyPagesPlugin.ts:53',
-  'build-plugins/jobRecencyPagesPlugin.ts:54',
-  'build-plugins/jobRecencyPagesPlugin.ts:55',
-  'build-plugins/jobRecencyPagesPlugin.ts:56',
+  // (jobRecencyPagesPlugin.ts: migrated to inline `cathedral-allow` markers on
+  // the 4 SECTION_BY_LOCALE entries, 2026-05-21 — drift-proof.)
   'build-plugins/jobSectorLanding.ts:103',
   'build-plugins/jobSectorLanding.ts:104',
   'build-plugins/jobSectorLanding.ts:105',


### PR DESCRIPTION
Commit 6f59dfa4ec added 2 lines at the top of jobRecencyPagesPlugin.ts,
shifting SECTION_BY_LOCALE down by 2. The line-pinned allowlist still
referenced lines 53-56, so the fr literal at the new line 57
('trouver-emploi-tessin') fell outside the allowlist and broke the
cathedral-no-ti-hardcodes audit on every PR/post-deploy run.

Migrate the 4 SECTION_BY_LOCALE entries to inline `// cathedral-allow:`
markers (drift-proof per PR #300's design) and drop the brittle
line-pinned entries from the legacy ALLOWLIST.
