### PR TITLE
fix(seo): restore body bg + h1/h2/h3 sizing in seo-static.css

### DIFF
--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -23,14 +23,52 @@ body {
   padding: 0;
   font-family: "Manrope", sans-serif;
   color: var(--color-body);
+  /* Fallbacks on --color-job-bg-gradient-* tokens: those vars are scoped to
+     the per-job template SPA bundle; on hub pages they are undefined and
+     `var()` without a fallback marks the whole `background:` shorthand as
+     invalid-at-computed-value-time, which falls back to `initial`
+     (transparent) and defeats Tailwind's `.bg-surface-alt` utility (which
+     lives in @layer utilities, lower priority than this unlayered rule).
+     With explicit transparent fallbacks, the declaration stays valid and
+     var(--color-surface-alt) reaches the body background-color slot. */
   background:
-    radial-gradient(1100px 600px at 0% -10%, var(--color-job-bg-gradient-1), transparent 60%),
-    radial-gradient(1000px 600px at 100% 0%, var(--color-job-bg-gradient-2), transparent 60%),
+    radial-gradient(1100px 600px at 0% -10%, var(--color-job-bg-gradient-1, transparent), transparent 60%),
+    radial-gradient(1000px 600px at 100% 0%, var(--color-job-bg-gradient-2, transparent), transparent 60%),
     var(--color-surface-alt);
 }
 /* Padding only for static pre-hydration content */
 body > #root > main.static-job-page { padding: 26px; }
-h1, h2, h3, h4 { margin: 0; font-family: "Outfit", sans-serif; }
+/* Heading defaults at element-selector specificity (0,0,1). Tailwind preflight
+   in the SPA bundle resets `h1,h2,h3,h4,h5,h6 { font-size: inherit; font-weight: inherit }`,
+   so without explicit sizes here, raw `<h1>` emitters (jobsSeoPagesPlugin city
+   hubs, page-N, sector/category hubs, company landings) collapse to 16px body
+   text. Any s-* extracted class or `.hero-title` (specificity 0,1,0) still
+   wins, preserving per-job and inline-styled headings. */
+h1 {
+  margin: 0 0 12px;
+  font-family: "Outfit", sans-serif;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--color-heading);
+}
+h2 {
+  margin: 1.5rem 0 0.5rem;
+  font-family: "Outfit", sans-serif;
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--color-heading);
+}
+h3 {
+  margin: 1rem 0 0.5rem;
+  font-family: "Outfit", sans-serif;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--color-heading);
+}
+h4 { margin: 0; font-family: "Outfit", sans-serif; }
 main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
 .proposal {
   border: 1px solid var(--color-edge);


### PR DESCRIPTION
Two converging regressions surfaced when PR #461 + follow-ups (#459, e655f95948,
e0b958c799, 4979c9979d, 6f59dfa4ec) restored the SPA bundle CSS link from every
static SEO emitter:

1. Body background was transparent on hub pages (e.g. /cerca-lavoro-basilea/pratteln/).
   The `body { background: ... }` rule used `var(--color-job-bg-gradient-1/2)` with
   NO fallback. Those tokens are scoped to the per-job template and undefined on hub
   pages. Undefined `var()` without fallback marks the whole `background:` shorthand
   as invalid-at-computed-value-time → falls back to `initial` (transparent, no
   image). Because this rule is UNLAYERED (specificity 0,0,1) and Tailwind's
   `.bg-surface-alt` lives in @layer utilities (always loses to unlayered), the
   broken rule also defeats the Tailwind utility.

   Fix: add `, transparent` fallback to both gradient vars so the declaration
   stays valid; var(--color-surface-alt) reaches the background-color slot.

2. Raw `<h1>` collapsed to 16px on canton city hubs, page-N, sector/category
   hubs, company landings (jobsSeoPagesPlugin.ts:5467, 5611, 5731, 5873, 6020,
   6189, 6402). The SPA bundle's Tailwind preflight resets
   `h1,h2,h3,h4,h5,h6 { font-size: inherit; font-weight: inherit }`, so without
   explicit base sizes the h1 inherited 16px body text. Pre-PR #461 these pages
   never loaded the SPA bundle, so preflight didn't fire and browser default
   (h1 = 2em) covered the gap.

   Fix: split `h1, h2, h3, h4 { margin: 0; font-family: "Outfit" }` into per-tag
   rules with explicit font-size/weight/line-height/color. All at element
   specificity (0,0,1), so existing s-* extracted classes (0,1,0) and
   `.hero-title` still win — per-job pages and inline-styled headings stay
   identical.

Verified live on /cerca-lavoro-basilea/pratteln/: body bg was `rgba(0,0,0,0)`
+ h1 at 16px. Affected scope: every static page emitted by jobsSeoPagesPlugin
/ seoHubsPlugin that uses raw `<h1>` and any seo-static.css consumer without a
critical-css inline override.
