### PR TITLE
fix(seo): blocking CSS for staticOverlay landings + full template for non-TI canton city hubs

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -5513,7 +5513,37 @@ ${alternates}
  if (locale === 'de') return `<p>Derzeit sind <strong>${cityJobs.length} Stellenangebote</strong> in ${esc(cityDisplay)} (Kanton ${esc(cDisplay)}) verfügbar. Die Anzeigen werden täglich von unserem automatischen Crawler aktualisiert. Für Grenzgänger mit G-Bewilligung erhebt der Kanton ${esc(cDisplay)} eine Quellensteuer auf das Bruttoeinkommen: nutzen Sie unseren <a href="${BASE_URL}/de/">kostenlosen Steuersimulator</a>.</p>`;
  return `<p>${cityJobs.length} <strong>offres d'emploi</strong> sont actuellement disponibles à ${esc(cityDisplay)} (Canton de ${esc(cDisplay)}). Les annonces sont mises à jour quotidiennement. Pour les frontaliers avec un permis G, le Canton de ${esc(cDisplay)} applique un impôt à la source sur le revenu brut : utilisez notre <a href="${BASE_URL}/fr/">simulateur fiscal gratuit</a>.</p>`;
  })();
- const bodyHtml = `<h1>${esc(cityHubSeo.h1)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul class="s-0WjlyL">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(backLabel)}</a></p>\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'city-landing', cantonEntityName: cityDisplay }))}`;
+ // SEO-landing template (CLAUDE.md rule #17) shared with TI city hubs:
+ // <header> eyebrow + H1 + lede → <section> stat tiles → <section> data
+ // area with heading + job list → long prose below. Mirrors the s-*
+ // classes used by the TI city hub renderer above (s-S_0cal, s-P0Hs0W,
+ // s-S6PRaY, s-CGuDZg, s-KZc0LQ, s-CqexyJ, s-YszcPD) so seo-static.css
+ // styles bind without per-page CSS. Before this template the body was
+ // a bare `<h1><p><p><ul>` which rendered visibly unstyled next to TI
+ // siblings.
+ const updatedDate = new Date().toISOString().slice(0, 10);
+ const updatedLabel = locale === 'it' ? 'Aggiornato'
+   : locale === 'en' ? 'Updated'
+   : locale === 'de' ? 'Aktualisiert'
+   : 'Mis à jour';
+ const jobCountLabel = locale === 'it' ? 'Offerte attive'
+   : locale === 'en' ? 'Open positions'
+   : locale === 'de' ? 'Offene Stellen'
+   : 'Offres actives';
+ const cantonTileLabel = locale === 'it' ? 'Cantone'
+   : locale === 'en' ? 'Canton'
+   : locale === 'de' ? 'Kanton'
+   : 'Canton';
+ const permitTileLabel = locale === 'it' ? 'Permesso'
+   : locale === 'en' ? 'Permit'
+   : locale === 'de' ? 'Bewilligung'
+   : 'Permis';
+ const listHeading = locale === 'it' ? `Offerte di lavoro a ${cityDisplay}`
+   : locale === 'en' ? `Job openings in ${cityDisplay}`
+   : locale === 'de' ? `Stellenangebote in ${cityDisplay}`
+   : `Offres d'emploi à ${cityDisplay}`;
+ const tilesHtml = `<section class="s-S6PRaY"><div class="s-CGuDZg"><div class="s-JFi4vt">${esc(jobCountLabel)}</div><div class="s-9UotdJ">${cityJobs.length}</div></div><div class="s-3kP_AL"><div class="s-z4q8yI">${esc(cantonTileLabel)}</div><div class="s-9UotdJ">${esc(canton)}</div></div><div class="s-3kP_AL"><div class="s-z4q8yI">${esc(permitTileLabel)}</div><div class="s-9UotdJ">G</div></div></section>`;
+ const bodyHtml = `<header class="s-S_0cal"><p class="s-zNiFzy">${esc(updatedLabel)} · ${updatedDate}</p><h1 class="s-P0Hs0W">${esc(cityHubSeo.h1)}</h1><p class="s-wU5Nrr">${esc(pageDesc)}</p>${intro}</header>${tilesHtml}<section class="s-KZc0LQ"><div class="s-r2QmTP"><h2 class="s-CqexyJ">${esc(listHeading)}</h2><a class="s-YszcPD" href="${sectionRootUrl}">${esc(backLabel)}</a></div><ul class="s-0WjlyL">${listHtml}</ul></section>${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cityDisplay, cantonDisplay: cDisplay, cantonSlot: 'city-landing', cantonEntityName: cityDisplay }))}`;
  // Use buildSeoPageHtml (NOT buildSimplePage) so the page emits
  // `<main class="seo-static-content">` OUTSIDE `<div id="root">` +
  // `<div id="footer-root"></div>`. The legacy path (buildSimplePage default
@@ -5525,6 +5555,11 @@ ${alternates}
  // /cerca-lavoro-basilea/basel/ (and every other non-TI canton city hub).
  // The company-hub sibling at line ~6344 already received the same fix in
  // PR #376; this aligns per-canton city hubs to the same hydration-safe shell.
+ //
+ // hubChrome restores the job-board sub-nav (rendered as `confronti` fallback
+ // per HUB_FALLBACK in hubChrome.ts) above <main>, matching every other
+ // job-board staticOverlay landing (weeklyEmployers, orphanQueryLanding,
+ // career/profession landings).
  const html = buildSeoPageHtml({
  locale,
  title: pageTitle,
@@ -5534,6 +5569,7 @@ ${alternates}
  hreflangHtml: alternates,
  jsonLdScripts: [breadcrumbLd, collectionLd, itemListLd],
  bodyHtml,
+ hubChrome: { hubKey: 'job-board', activeSubTab: 'jobs' },
  distDir,
  // 0-job city pages exist as 404-rescue fallbacks (so the SPA-overlay
  // route doesn't render blank) but offer no city-specific signal to

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -4371,14 +4371,10 @@ ${hrefTags}
  }
 
  if (hasSpaBundle) {
- const useBlockingHomeCss = isHomeCriticalStaticPath(canonicalPath);
- const stylesheetMarkup = useBlockingHomeCss
- ? `<link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">`
- : `<link rel="preload" as="style" crossorigin href="/assets/${entryCss}" data-clarity-unmask="true">
- <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="print" onload="this.media='all'" data-clarity-unmask="true">
- <noscript><link rel="stylesheet" crossorigin href="/assets/${entryCss}" data-clarity-unmask="true"></noscript>
- <script>setTimeout(function(){var l=document.querySelector('link[media="print"][href*="/assets/"]');if(l){l.media='all';try{sessionStorage.setItem('_cssFallbackInfo',JSON.stringify({href:l.href,delayMs:3000,pagePath:location.pathname+location.search,ts:new Date().toISOString()}))}catch(e){}}},3000)</script>`;
-
+ // Hub-chrome detection moved above stylesheetMarkup so the blocking-CSS
+ // gate below can include every staticOverlay SEO-landing path, not just
+ // the 12 home/hub roots in HOME_CRITICAL_STATIC_PATHS.
+ //
  // BUG-1 / BUG-2 parity: SEMRUSH + editorial staticOverlay landings must
  // expose `<main class="seo-static-content">` as a SIBLING of `<div id="root">`
  // (so React's hydration into #root cannot visually replace it) and include
@@ -4388,6 +4384,28 @@ ${hrefTags}
  // so crawlers see the full editorial + FAQ content even when the SPA never
  // hydrates (noscript environments, AI crawlers, server-side snapshots).
  const hubChromeSpec = lookupStaticOverlayHubChrome(canonicalPath);
+
+ // FOUC fix (2026-05-21): the async-CSS pattern (`media="print"` +
+ // onload swap + 3s setTimeout fallback) defeats every `var(--color-*)`
+ // token reference until the swap fires. The SPA bundle CSS defines
+ // `:root,:host { --color-heading: ... }` etc. inside @layer theme,
+ // so while the stylesheet sits on media="print" the browser does NOT
+ // apply those rules to screen — inline styles like
+ // `background:var(--color-warning-subtle)` resolve to empty, tiles lose
+ // their colored backgrounds, headings collapse to default browser sizes,
+ // and the page renders visibly unstyled. Real-world repro:
+ // /calcola-stipendio/nuovi-frontalieri-oltre-20-km/ (every salary-hub
+ // long-tail), /prezzi-benzina-svizzera/oggi/ (fuel-daily), etc.
+ // Every staticOverlay SEO landing renders the SSG body as primary content
+ // (App.tsx skips React <main>) — there's nothing to defer for, so we
+ // load the bundle CSS synchronously like home + hub roots already do.
+ const useBlockingHomeCss = isHomeCriticalStaticPath(canonicalPath) || hubChromeSpec !== null;
+ const stylesheetMarkup = useBlockingHomeCss
+ ? `<link rel="stylesheet" href="/assets/${entryCss}" crossorigin data-clarity-unmask="true">`
+ : `<link rel="preload" as="style" crossorigin href="/assets/${entryCss}" data-clarity-unmask="true">
+ <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="print" onload="this.media='all'" data-clarity-unmask="true">
+ <noscript><link rel="stylesheet" crossorigin href="/assets/${entryCss}" data-clarity-unmask="true"></noscript>
+ <script>setTimeout(function(){var l=document.querySelector('link[media="print"][href*="/assets/"]');if(l){l.media='all';try{sessionStorage.setItem('_cssFallbackInfo',JSON.stringify({href:l.href,delayMs:3000,pagePath:location.pathname+location.search,ts:new Date().toISOString()}))}catch(e){}}},3000)</script>`;
  // Hub sub-nav is hoisted OUT of <main> so it renders as a sibling (matching
  // the SPA DOM shape) — otherwise the max-width / padding of
  // `main.seo-static-content` squishes the sub-nav at wide viewports.


### PR DESCRIPTION
Two regressions surfaced on /calcola-stipendio/nuovi-frontalieri-oltre-20-km/
and /cerca-lavoro-basilea/pratteln/ — both staticOverlay routes where the SSG
body is what end users see.

P1 — Blocking CSS for staticOverlay SEO landings (staticPagesPlugin.ts)

The bundle CSS was being loaded async via `media="print" onload="this.media='all'"`
+ 3s setTimeout fallback for every path NOT in HOME_CRITICAL_STATIC_PATHS
(home + 4 hub roots). Until the swap fires the browser does not apply rules
to screen, so `:root,:host { --color-heading: ... }` (defined in @layer theme
of the SPA bundle) is unavailable — every `var(--color-*)` reference in the
inline styles emitted by buildSalaryLandingBody / renderSalaryLandingShell
resolves to empty, tiles lose their colored backgrounds, headings collapse
to default browser sizes, and the page renders visibly unstyled.

Fix: include every hubChrome-driven staticOverlay landing in the blocking
gate (`isHomeCriticalStaticPath(canonicalPath) || hubChromeSpec !== null`).
Hub-chrome detection moved up two blocks so the OR works in the same scope.
Covers /calcola-stipendio/* long-tail (calculator hub), guida-frontaliere
LAMal/tassa-salute, vita-in-ticino FoxTown/ponti/vacanze, etc.

P2 — Full SEO-landing template for non-TI canton city hubs (jobsSeoPagesPlugin.ts)

The Phase 3.1 emitter (PR #463) for /cerca-lavoro-{cantonSlug}/{citySlug}/
shipped a bare body — `<h1>${h1}</h1><p>${desc}</p>...<ul>${cards}</ul>` —
missing every element required by the SEO-landing template (CLAUDE.md
rule #17): no eyebrow, no styled <header>, no stat tile grid, no data-area
heading. The buildSeoPageHtml call also passed no hubChrome so the job-board
sub-nav was absent above <main>. Result: Pratteln/Basel/etc. rendered as
plain HTML next to the rich TI sibling /cerca-lavoro-ticino/lugano/.

Fix: wrap the body in the same s-* extracted classes the TI city hub uses
(s-S_0cal, s-P0Hs0W, s-S6PRaY, s-CGuDZg, s-KZc0LQ, s-CqexyJ, s-YszcPD) and
pass `hubChrome: { hubKey: 'job-board', activeSubTab: 'jobs' }` to render
the confronti-fallback sub-nav above <main>. 4-locale strings inlined.
Stays under the 195 KB CITY_HUB_HARD_BUDGET_BYTES guard.

Tests: jobs-seo-pages-plugin, static-pages-blog-skip, router, app-lite-shell
all green (485 tests).
