### PR TITLE
revert(jobs): drop previousSlugs trim (Pass 3) — GSC sync lag makes cut unsafe

### DIFF
--- a/scripts/prune-known-slugs.mjs
+++ b/scripts/prune-known-slugs.mjs
@@ -3,7 +3,7 @@
  * prune-known-slugs.mjs
  *
  * Trim `data/all-known-job-slugs.json` to keep build artifacts under the
- * GitHub Pages size limit. Performs two passes:
+ * GitHub Pages size limit. Two passes:
  *
  * 1. ACTIVE/EXPIRED DEDUP (Task C from incident 2026-05-21):
  *    Remove tracking entries whose slug (or any locale slug variant)
@@ -21,31 +21,21 @@
  *
  * Idempotent. Re-runs without flag stay no-op when nothing exceeds cap.
  * Honors CLAUDE.md #1: cap is only EVER raised manually, never silently
- * lowered. Default cap was chosen to bring the artifact under 1.86 GiB.
+ * lowered.
+ *
+ * NOTE: a previous revision also trimmed per-job `previousSlugs` /
+ * `previousSlugsByLocale` arrays (PRs #469, #470). Reverted 2026-05-21
+ * because GSC sync lag (2-4 days reporting + ~24h sync) made the cut
+ * unsafe — a slug Google had just started ranking could be dropped
+ * before the impression showed up in our enrichment data. Preferred
+ * follow-up is to keep all bridges but emit a thinner HTML (1-2 KB
+ * canonical-only stub) for dark slugs, which preserves SEO equity
+ * without the per-page weight cost.
  *
  * Usage:
  *   node scripts/prune-known-slugs.mjs              # apply
  *   node scripts/prune-known-slugs.mjs --dry-run    # report only
  *   PRUNE_KNOWN_SLUGS_CAP=15000 node scripts/prune-known-slugs.mjs
- *   MAX_PREVIOUS_SLUGS_PER_JOB=3 node scripts/prune-known-slugs.mjs
- *
- * Pass 3 (previousSlugs traffic-aware trim):
- *   Each active job's `previousSlugs` + `previousSlugsByLocale[locale]` arrays
- *   feed jobsSeoPagesPlugin's full-content bridge emission — up to ~8 pages
- *   per old slug (4 locales × canton-aware + legacy-TI). 97 jobs had ≥10
- *   previousSlugs after the 2026-05-21 recovery, producing 32k extra pages.
- *
- *   Trim rule (user-stated, 2026-05-21):
- *     1. Keep ALL old slugs with GSC impressions > 0 (no upper limit).
- *        These are the slugs Google has actually indexed; dropping them
- *        loses real SEO equity.
- *     2. If NONE of a job's old slugs has impressions > 0 (entire history
- *        is "dark" — vendor-API churn, never indexed), fallback to the
- *        MOST RECENT N (`MAX_PREVIOUS_SLUGS_PER_JOB`, default 3).
- *
- *   GSC data sourced from `data/orphan-enriched-data.json` (1.7k entries
- *   today; refreshed by `sync-gsc-orphans.yml`). Slugs absent from the
- *   enrichment file are treated as 0 impressions (worst-case).
  */
 
 import fs from "node:fs";
@@ -56,7 +46,6 @@ const TRACKING_PATH = path.resolve("data/all-known-job-slugs.json");
 const ACTIVE_JOBS_PATH = path.resolve("data/jobs.json");
 const GSC_ENRICHED_PATH = path.resolve("data/orphan-enriched-data.json");
 const DEFAULT_CAP = 20_000;
-const DEFAULT_MAX_PSL_PER_JOB = 3;
 
 function readJson(p, fallback) {
   try {
@@ -93,92 +82,10 @@ function collectGscPriority(orphanEnriched) {
   return priority;
 }
 
-function loadGscImpressions() {
-  // Per-slug aggregated GSC impressions. Sourced from
-  // data/orphan-enriched-data.json (refreshed by sync-gsc-orphans.yml).
-  // Returns Map<slug, impressions>. Slugs absent from the map are treated
-  // as 0 impressions (worst-case assumption when GSC data is missing).
-  const map = new Map();
-  let data;
-  try {
-    data = JSON.parse(fs.readFileSync(GSC_ENRICHED_PATH, "utf8"));
-  } catch {
-    return map;
-  }
-  const arr = Array.isArray(data) ? data : Object.values(data);
-  for (const entry of arr) {
-    if (!entry?.slug) continue;
-    const imp = Number(entry.totalImpressions) || 0;
-    // Multiple entries may share a slug (per-locale rows) — keep the max.
-    const prev = map.get(entry.slug) ?? 0;
-    if (imp > prev) map.set(entry.slug, imp);
-  }
-  return map;
-}
-
-function trimSlugArray(slugs, gscImp, fallbackCap) {
-  // Strategy (user-stated, 2026-05-21):
-  //   1. Keep ALL slugs with GSC impressions > 0.
-  //   2. If NONE has impressions > 0 (whole array is dark), keep the MOST
-  //      RECENT `fallbackCap` entries — most likely to still carry
-  //      indexing that hasn't surfaced in our GSC sync yet.
-  // A slug missing from `gscImp` is treated as 0 impressions.
-  const withTraffic = slugs.filter((s) => (gscImp.get(s) ?? 0) > 0);
-  if (withTraffic.length > 0) return withTraffic;
-  return slugs.slice(-fallbackCap);
-}
-
-function capJobPreviousSlugs(activeJobs, fallbackCap, gscImp) {
-  // Mutates active jobs in place. See `trimSlugArray` for the rule.
-  const arr = Array.isArray(activeJobs) ? activeJobs : (activeJobs?.jobs ?? []);
-  let flatTrimmed = 0;
-  let localeTrimmed = 0;
-  let jobsAffected = 0;
-  let jobsKeptByTraffic = 0;
-  let jobsFallbackTopN = 0;
-  for (const j of arr) {
-    if (!j || typeof j !== "object") continue;
-    let touched = false;
-    let trafficWin = false;
-    if (Array.isArray(j.previousSlugs) && j.previousSlugs.length > 0) {
-      const trimmed = trimSlugArray(j.previousSlugs, gscImp, fallbackCap);
-      if (trimmed.length !== j.previousSlugs.length) {
-        flatTrimmed += j.previousSlugs.length - trimmed.length;
-        j.previousSlugs = trimmed;
-        touched = true;
-      }
-      if (trimmed.some((s) => (gscImp.get(s) ?? 0) > 0)) trafficWin = true;
-    }
-    if (j.previousSlugsByLocale && typeof j.previousSlugsByLocale === "object") {
-      for (const locale of Object.keys(j.previousSlugsByLocale)) {
-        const v = j.previousSlugsByLocale[locale];
-        if (!Array.isArray(v) || v.length === 0) continue;
-        const trimmed = trimSlugArray(v, gscImp, fallbackCap);
-        if (trimmed.length !== v.length) {
-          localeTrimmed += v.length - trimmed.length;
-          j.previousSlugsByLocale[locale] = trimmed;
-          touched = true;
-        }
-        if (trimmed.some((s) => (gscImp.get(s) ?? 0) > 0)) trafficWin = true;
-      }
-    }
-    if (touched) {
-      jobsAffected++;
-      if (trafficWin) jobsKeptByTraffic++;
-      else jobsFallbackTopN++;
-    }
-  }
-  return { flatTrimmed, localeTrimmed, jobsAffected, jobsKeptByTraffic, jobsFallbackTopN };
-}
-
 function main() {
   const dryRun = process.argv.includes("--dry-run");
   const capFromEnv = Number(process.env.PRUNE_KNOWN_SLUGS_CAP);
   const cap = Number.isFinite(capFromEnv) && capFromEnv > 0 ? capFromEnv : DEFAULT_CAP;
-  const pslCapFromEnv = Number(process.env.MAX_PREVIOUS_SLUGS_PER_JOB);
-  const pslCap = Number.isFinite(pslCapFromEnv) && pslCapFromEnv > 0
-    ? pslCapFromEnv
-    : DEFAULT_MAX_PSL_PER_JOB;
 
   const tracking = readJson(TRACKING_PATH, null);
   if (!tracking || typeof tracking !== "object" || Array.isArray(tracking)) {
@@ -256,25 +163,11 @@ function main() {
 
   const finalCount = Object.keys(tracking).length;
 
-  // PASS 3: prune per-job previousSlugs / previousSlugsByLocale arrays.
-  // Traffic-aware: keep all slugs with GSC impressions > 0; fallback to
-  // most-recent `pslCap` per array when the entire history is dark.
-  // Mutates data/jobs.json in place (gitignored, regenerated by assemble
-  // each deploy — full history preserved in committed slice files).
-  const gscImp = loadGscImpressions();
-  const pslReport = capJobPreviousSlugs(activeJobs, pslCap, gscImp);
-
   console.log("prune-known-slugs:");
-  console.log(`  before:                          ${beforeCount}`);
-  console.log(`  active-dedup:                    -${dedupRemoved}`);
-  console.log(`  tail-cap (≤${cap}):              -${capRemoved}`);
-  console.log(`  after:                           ${finalCount}`);
-  console.log(`  GSC enrichment loaded:           ${gscImp.size} slugs`);
-  console.log(`  previousSlugs (keep-if-traffic, else top-${pslCap}):`);
-  console.log(`    jobs affected:                 ${pslReport.jobsAffected}`);
-  console.log(`      kept ≥1 by GSC traffic:      ${pslReport.jobsKeptByTraffic}`);
-  console.log(`      fallback to top-${pslCap} (all dark):  ${pslReport.jobsFallbackTopN}`);
-  console.log(`    entries removed:               -${pslReport.flatTrimmed} flat, -${pslReport.localeTrimmed} per-locale`);
+  console.log(`  before:           ${beforeCount}`);
+  console.log(`  active-dedup:     -${dedupRemoved}`);
+  console.log(`  tail-cap (≤${cap}):  -${capRemoved}`);
+  console.log(`  after:            ${finalCount}`);
   if (dedupRemoved > 0) {
     console.log(`  active-dedup samples (first 5): ${dedupSamples.slice(0, 5).join(", ")}`);
   }
@@ -283,20 +176,13 @@ function main() {
     console.log("(dry-run — no file written)");
     return;
   }
-
-  if (dedupRemoved !== 0 || capRemoved !== 0) {
-    fs.writeFileSync(TRACKING_PATH, JSON.stringify(tracking, null, 2) + "\n", "utf8");
-    console.log(`✅ wrote ${TRACKING_PATH}`);
-  } else {
-    console.log("ℹ️  tracking file unchanged.");
+  if (dedupRemoved === 0 && capRemoved === 0) {
+    console.log("✅ no changes — file untouched.");
+    return;
   }
 
-  if (pslReport.jobsAffected > 0) {
-    fs.writeFileSync(ACTIVE_JOBS_PATH, JSON.stringify(activeJobs, null, 2) + "\n", "utf8");
-    console.log(`✅ wrote ${ACTIVE_JOBS_PATH} (previousSlugs trimmed)`);
-  } else {
-    console.log("ℹ️  no jobs exceeded previousSlugs cap.");
-  }
+  fs.writeFileSync(TRACKING_PATH, JSON.stringify(tracking, null, 2) + "\n", "utf8");
+  console.log(`✅ wrote ${TRACKING_PATH}`);
 }
 
 main();


### PR DESCRIPTION
## Why revert PRs #469 + #470

User feedback (2026-05-21): GSC data has 2-4 days reporting delay + our `sync-gsc-orphans.yml` adds another ~24h. A slug Google just started ranking would show 0 impressions in our current snapshot. Pass 3 would drop it. We'd only realize after the URL has been dead for days.

Coverage compounds the risk: only **260 of 14 002 unique previousSlugs (1.9%)** have any GSC data in `orphan-enriched-data.json`. The remaining 98% fell into the recency-cap fallback — exactly the scenarios where our visibility is weakest.

## What survives

| Pass | Status | Why kept |
|---|---|---|
| 1 — active∩expired dedup | ✅ | Removes duplicates that get overwritten anyway during build. No SEO risk. |
| 2 — tail cap (≤20k) on `all-known-job-slugs.json` | ✅ | Ranked by GSC impressions DESC; dropped tail only produces soft-landing pages, worst case = 404 → SPA-shell search redirect, NOT a dead canonical chain |
| 3 — previousSlugs trim | ❌ REVERTED | GSC lag makes cuts unsafe |

## Follow-up (separate PR)

Keep ALL previousSlugs as bridges, but emit a lightweight HTML (~1-2 KB canonical-only stub) for those without GSC traffic. Same artifact-size savings as the cut, zero SEO equity loss.