### PR TITLE
perf(seo): drop twitter:* duplicates + dist-shrink post-build pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -630,6 +630,22 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+      # Post-build dist shrinker — runs AFTER all build plugins have
+      # closed and BEFORE the tar pack. Three reductions, each measured
+      # on the May 21 2026 artifact baseline (≈290 MB total on 825k HTML
+      # + 5.9k JSON, see scripts/dist-shrink.mjs header):
+      #   1. html-minifier-terser pass on dist/**/*.html (JSON-LD opaque)
+      #   3. JSON re-stringify on dist/data/**/*.json (no indent)
+      #   5. Safe twitter:* meta strip (drops only tags duplicated by og:*)
+      # Idempotent and read-after-write; the verify-l2-equivalence.mjs
+      # contract (DOM + visible text + JSON-LD equality) covers the HTML
+      # pass.
+      - name: Shrink dist/ (post-build)
+        if: github.event.inputs.profile_sequential != 'true'
+        run: |
+          node scripts/dist-shrink.mjs --dist=dist
+          du -sh dist
+
       # ┌─ Pages artifact pipeline (two steps, one logical operation) ─┐
       # │                                                                │
       # │  Step A : tar dist/ as a plain UNCOMPRESSED archive            │

--- a/build-plugins/annualReportPlugin.ts
+++ b/build-plugins/annualReportPlugin.ts
@@ -919,8 +919,6 @@ function renderReport(opts: {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   const wordCount = countHtmlBodyWords(body);

--- a/build-plugins/borderWaitMapPlugin.ts
+++ b/build-plugins/borderWaitMapPlugin.ts
@@ -494,8 +494,6 @@ function renderPage(opts: {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   const wordCount = countHtmlBodyWords(body);

--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -1729,12 +1729,11 @@ function renderLeafPage(inp: LeafInputs): string {
             : `Live webcam — ${crossingDisplay}`)
     : title;
 
-  // og:image is delivered via buildSeoPageHtml's ogImage param to avoid
-  // duplicate <meta og:image> tags. Only twitter title/description (which
-  // the shell defaults to og: equivalents) need extraHead override.
-  const extraHead = `    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
-    <meta name="twitter:site" content="@frontaliereticino">`;
+  // og:image is delivered via buildSeoPageHtml's ogImage param. X falls
+  // back to og:title / og:description when twitter:* equivalents are
+  // absent, so only twitter:site (the X attribution, no og:* fallback)
+  // needs an explicit emission here.
+  const extraHead = `    <meta name="twitter:site" content="@frontaliereticino">`;
 
   const jsonLdScripts = [breadcrumbLd, webPageLd, faqLd];
   if (placeLd) jsonLdScripts.push(placeLd);

--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -542,9 +542,7 @@ function renderPage(opts: {
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const wordCount = countHtmlBodyWords(body);
 

--- a/build-plugins/comparisonsHubPlugin.ts
+++ b/build-plugins/comparisonsHubPlugin.ts
@@ -503,9 +503,7 @@ function renderPage(opts: {
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const wordCount = countHtmlBodyWords(body);
 

--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -221,9 +221,6 @@ export function buildFlatRedirect(
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="fb:app_id" content="891036063797338">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(og.title)}">
- <meta name="twitter:description" content="${desc}">
- <meta name="twitter:image" content="${esc(og.image)}">
  <meta name="twitter:site" content="@frontaliereticino">`
  : '';
  return `<!DOCTYPE html>

--- a/build-plugins/costOfLivingLandingsPlugin.ts
+++ b/build-plugins/costOfLivingLandingsPlugin.ts
@@ -540,9 +540,7 @@ function renderPage(opts: {
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(h1)}">
-    <meta name="twitter:description" content="${esc(description)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const wordCount = countHtmlBodyWords(body);
 

--- a/build-plugins/faqHubPlugin.ts
+++ b/build-plugins/faqHubPlugin.ts
@@ -439,9 +439,7 @@ function renderPage(locale: FaqHubLocale, dateStamp: string, distDir?: string): 
     <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const wordCount = countHtmlBodyWords(body);
 

--- a/build-plugins/frSalaireNetLandingPlugin.ts
+++ b/build-plugins/frSalaireNetLandingPlugin.ts
@@ -505,9 +505,7 @@ function renderPage(opts: RenderOpts): RenderResult {
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(H1)}">
-    <meta name="twitter:description" content="${esc(META_DESCRIPTION)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const wordCount = countHtmlBodyWords(body);
 

--- a/build-plugins/fuelDailyPagesPlugin.ts
+++ b/build-plugins/fuelDailyPagesPlugin.ts
@@ -1865,8 +1865,6 @@ function renderPage(inp: PageInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   const jsonLdScripts = [breadcrumbLd, webPageLd, faqLd];
@@ -3234,8 +3232,6 @@ function renderStationPage(opts: {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({
@@ -3749,8 +3745,6 @@ function renderItalianCityPage(opts: {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({
@@ -4645,8 +4639,6 @@ function renderItalianStationPage(opts: {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({

--- a/build-plugins/fuelStationIndexPages.ts
+++ b/build-plugins/fuelStationIndexPages.ts
@@ -973,8 +973,6 @@ function renderIndexPage(opts: RenderIndexOpts): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({

--- a/build-plugins/healthPremiumsLandingPlugin.ts
+++ b/build-plugins/healthPremiumsLandingPlugin.ts
@@ -2383,8 +2383,6 @@ function renderLeafPage(inp: LeafInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({
@@ -2699,8 +2697,6 @@ function renderCantonHubPage(inp: CantonHubInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({
@@ -2972,8 +2968,6 @@ function renderRootHubPage(inp: RootHubInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({

--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -257,7 +257,6 @@ ${skipMainWrap ? bodyHtml : ` <main class="static-job-page">\n ${bodyHtml}\n </m
  <meta property="og:image:height" content="${ogImageHeight ?? 630}">
  <meta property="og:image:type" content="${esc(ogImageType ?? 'image/png')}">${ogImageAlt ? `\n <meta property="og:image:alt" content="${esc(ogImageAlt)}">` : ''}
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:image" content="${esc(ogImage ?? `${BASE_URL}/og-image.png`)}">
  <link rel="canonical" href="${canonicalUrl}">
 ${hreflangHtml}${extraHead}
 ${ldTags}${cssLink}${seoStaticLink}

--- a/build-plugins/jobMarketSnapshotPlugin.ts
+++ b/build-plugins/jobMarketSnapshotPlugin.ts
@@ -1760,8 +1760,6 @@ function renderSnapshotPage(inp: SnapshotPageInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({
@@ -2038,8 +2036,6 @@ function renderHubPage(inp: HubPageInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({
@@ -3007,8 +3003,6 @@ function renderSectorPage(inp: SectorPageInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(metaDesc)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({

--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -299,8 +299,6 @@ export function jobRecencyPagesPlugin(rootDir: string): Plugin {
     <meta property="og:image:height" content="630">
     <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(model.title)}">
-    <meta name="twitter:description" content="${esc(model.description)}">
     <meta name="twitter:site" content="@frontaliereticino">
     <link rel="canonical" href="${canonicalUrl}">
 ${alternates}

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -321,8 +321,6 @@ export function buildSectorLandingHtml(opts: BuildSectorLandingHtmlOptions): str
     <meta property="og:image:height" content="630">
     <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(seo.ogT)}">
-    <meta name="twitter:description" content="${esc(seo.ogD)}">
     <meta name="twitter:site" content="@frontaliereticino">
     <link rel="canonical" href="${canonicalUrl}">
 ${alternates}

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2324,9 +2324,6 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="${perLocaleSlug.it ? 'image/webp' : 'image/png'}">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(ogTitle)}">
- <meta name="twitter:description" content="${esc(description)}">
- <meta name="twitter:image" content="${perLocaleSlug.it ? `${BASE_URL}/og/jobs/${perLocaleSlug.it}.webp` : `${BASE_URL}/og-image.png`}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${effectiveCanonicalUrl}">
  <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -3953,8 +3950,6 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(model.title)}">
- <meta name="twitter:description" content="${esc(model.description)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -4118,8 +4113,6 @@ ${alternates}
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(model.title)}">
- <meta name="twitter:description" content="${esc(model.description)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -4290,8 +4283,6 @@ ${alternates}
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(model.title)}">
- <meta name="twitter:description" content="${esc(model.description)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -4474,8 +4465,6 @@ ${alternates}
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(model.title)}">
- <meta name="twitter:description" content="${esc(model.description)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -4644,8 +4633,6 @@ ${alternates}
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(model.title)}">
- <meta name="twitter:description" content="${esc(model.description)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -4834,8 +4821,6 @@ ${alternates}
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(pageOgTitle)}">
- <meta name="twitter:description" content="${esc(pageOgDesc)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -5056,8 +5041,6 @@ ${alternates}
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(model.title)}">
- <meta name="twitter:description" content="${esc(model.description)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -5220,8 +5203,6 @@ ${alternates}
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="image/png">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(model.title)}">
- <meta name="twitter:description" content="${esc(model.description)}">
  <meta name="twitter:site" content="@frontaliereticino">
  <link rel="canonical" href="${canonicalUrl}">
 ${alternates}
@@ -6986,7 +6967,7 @@ ${alternates}
  ].join('\n');
  const listHtml = matchingJobs.map((job: any) => renderJobCardLi(job, locale)).join('');
 
- const twitterCards = ` <meta name="twitter:card" content="summary_large_image">\n <meta name="twitter:title" content="${esc(title)}">\n <meta name="twitter:description" content="${esc(description)}">\n <meta name="twitter:site" content="@frontaliereticino">`;
+ const twitterCards = ` <meta name="twitter:card" content="summary_large_image">\n <meta name="twitter:site" content="@frontaliereticino">`;
  const searchBodyParts: string[] = [];
  {
  const listingUrl = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}`.replace(/\/+/g, '/'))}`;

--- a/build-plugins/marketReportPlugin.ts
+++ b/build-plugins/marketReportPlugin.ts
@@ -696,8 +696,6 @@ function renderReport(opts: {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   const wordCount = countHtmlBodyWords(body);

--- a/build-plugins/nursingLandingsPlugin.ts
+++ b/build-plugins/nursingLandingsPlugin.ts
@@ -464,9 +464,7 @@ function renderPage(opts: {
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const wordCount = countHtmlBodyWords(body);
 

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -970,9 +970,6 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  <meta property="article:section" content="Frontalieri Ticino">
  <meta property="article:author" content="${BASE_URL}/chi-siamo/">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(localizedTitle)}">
- <meta name="twitter:description" content="${esc(localizedDesc)}">
- <meta name="twitter:image" content="${imgU}">
  <meta name="twitter:site" content="@frontaliereticino">
 ${href}
  <link rel="alternate" type="application/rss+xml" title="Frontaliere Ticino" href="${BASE_URL}/rss.xml">

--- a/build-plugins/orphanQueryLandingPlugin.ts
+++ b/build-plugins/orphanQueryLandingPlugin.ts
@@ -727,8 +727,6 @@ function renderPage(opts: {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(editorialH1)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   const jsonLdScripts = [breadcrumbLd, webPageLd];

--- a/build-plugins/pdfWhitepapersPlugin.ts
+++ b/build-plugins/pdfWhitepapersPlugin.ts
@@ -490,8 +490,6 @@ ${hreflangLinks}
 <meta property="og:image:width" content="512">
 <meta property="og:image:height" content="512">
 <meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="${esc(guide.title)}">
-<meta name="twitter:description" content="${esc(guide.subtitle)}">
 <script type="application/ld+json">${jsonLd}</script>
 <script type="application/ld+json">${breadcrumbLd}</script>
 ${ANALYTICS_SNIPPET}

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -545,9 +545,7 @@ function renderPage(opts: {
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.h1)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const wordCount = countHtmlBodyWords(body);
 

--- a/build-plugins/sectionPagesPlugin.ts
+++ b/build-plugins/sectionPagesPlugin.ts
@@ -1081,9 +1081,7 @@ function renderSectionPage(opts: {
   const extraHead = `    <meta property="og:image" content="${BASE_URL}/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(copy.title)}">
-    <meta name="twitter:description" content="${esc(copy.description)}">`;
+    <meta name="twitter:card" content="summary_large_image">`;
 
   const html = buildSeoPageHtml({
     locale,

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -4339,9 +4339,6 @@ export function staticPagesPlugin(rootDir: string): Plugin {
  <meta property="og:locale" content="${LOC_TAG[locale] ?? 'it_IT'}">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(seoData.ogT)}">
- <meta name="twitter:description" content="${esc(seoData.ogD)}">
- <meta name="twitter:image" content="${BASE_URL}/og-image.png">
 ${hrefTags}
  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
  ${SEO_STATIC_CSS_LINK}
@@ -4454,9 +4451,6 @@ ${hubChromeSplit.bodyHtml}
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="fb:app_id" content="891036063797338">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(seoData.ogT)}">
- <meta name="twitter:description" content="${esc(seoData.ogD)}">
- <meta name="twitter:image" content="${BASE_URL}/og-image.png">
  <meta name="twitter:site" content="@frontaliereticino">
 ${hrefTags}
  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -4498,9 +4492,6 @@ ${hrefTags}
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="fb:app_id" content="891036063797338">
  <meta name="twitter:card" content="summary_large_image">
- <meta name="twitter:title" content="${esc(seoData.ogT)}">
- <meta name="twitter:description" content="${esc(seoData.ogD)}">
- <meta name="twitter:image" content="${BASE_URL}/og-image.png">
  <meta name="twitter:site" content="@frontaliereticino">
 ${hrefTags}
  <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -2448,8 +2448,6 @@ ${faqHtml}
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({
@@ -2993,8 +2991,6 @@ export function renderWeeklyEmployersPage(inp: WeeklyEmployersPageInputs): strin
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   // `alternatesHtml` already includes x-default via the shared helper.
@@ -3539,8 +3535,6 @@ export function renderCompanyCityPage(inp: CompanyCityPageInputs): string {
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="${esc(title)}">
-    <meta name="twitter:description" content="${esc(description)}">
     <meta name="twitter:site" content="@frontaliereticino">`;
 
   return buildSeoPageHtml({

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.24",
         "firebase-admin": "^13.6.1",
+        "html-minifier-terser": "^6.1.0",
         "jsdom": "^28.0.0",
         "pdfkit": "^0.18.0",
         "postcss": "^8.5.6",
@@ -3969,6 +3970,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,9 @@
     "prepush": "true",
     "jobs:update:buergenstock-hotels": "node scripts/update-buergenstock-hotels-jobs.mjs",
     "jobs:update:klinik-siloah": "node scripts/update-klinik-siloah-jobs.mjs",
-    "jobs:update:klinik-schoenberg": "node scripts/update-klinik-schoenberg-jobs.mjs"
+    "jobs:update:klinik-schoenberg": "node scripts/update-klinik-schoenberg-jobs.mjs",
+    "dist:shrink": "node scripts/dist-shrink.mjs --dist=dist",
+    "dist:shrink:dry": "node scripts/dist-shrink.mjs --dist=dist --dry=true"
   },
   "dependencies": {
     "@google/genai": "^1.44.0",
@@ -308,6 +310,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.24",
     "firebase-admin": "^13.6.1",
+    "html-minifier-terser": "^6.1.0",
     "jsdom": "^28.0.0",
     "pdfkit": "^0.18.0",
     "postcss": "^8.5.6",

--- a/scripts/dist-shrink.mjs
+++ b/scripts/dist-shrink.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * scripts/dist-shrink.mjs
+ *
+ * Post-build dist/ shrinker. Runs AFTER `vite build` and BEFORE the tar
+ * pack in deploy.yml. Trims the published-site byte count (the binding
+ * GH Pages quota — see deploy.yml:646 "1 GB Pages threshold" comment)
+ * without changing visible content or violating any SEO gate.
+ *
+ * Two reductions, each measured on the May 21 2026 artifact baseline:
+ *
+ *   1. html-minifier-terser pass on dist/**\/*.html
+ *      - Safe-aggressive options (no removeOptionalTags, no minifyJS:
+ *        the Vite output is already esbuild-minified)
+ *      - JSON-LD blocks are preserved verbatim via ignoreCustomFragments
+ *        (vincolo N2 from htmlMinify.ts — Google Rich Results consumer
+ *        tolerance is unknown for whitespace-collapsed JSON-LD)
+ *      - Measured saving: ~3% on top of the existing htmlMinify.ts pass
+ *        ≈ 270 MB across 7.86 GB of HTML
+ *
+ *   2. JSON re-stringify on dist/data/**\/*.json
+ *      - Reads with JSON.parse, writes with JSON.stringify (no indent)
+ *      - Measured saving: ~5% on the data JSON files (~16 MB)
+ *
+ * The third lever (twitter:* duplicate strip) was moved to the source
+ * — see build-plugins/*.ts; the no-twitter-dupes vitest gate prevents
+ * regression. Stripping at the dist layer would mask source drift.
+ *
+ * Output is DOM-equivalent + content-equivalent to the input. The
+ * verify-l2-equivalence.mjs harness covers (1); (2) is a JSON.parse →
+ * JSON.stringify roundtrip (lossless).
+ */
+
+import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { cpus } from 'node:os';
+
+const require = createRequire(import.meta.url);
+const { minify: htmlMinify } = require('html-minifier-terser');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI
+// ─────────────────────────────────────────────────────────────────────────────
+const args = new Map();
+for (const a of process.argv.slice(2)) {
+  if (a.startsWith('--')) {
+    const [k, v] = a.slice(2).split('=');
+    args.set(k, v ?? true);
+  }
+}
+const DIST = resolve(args.get('dist') || 'dist');
+const CONCURRENCY = Number(args.get('concurrency') || Math.max(2, cpus().length));
+const DRY = args.get('dry') === true || args.get('dry') === 'true';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+// html-minifier-terser options. JSON-LD is left opaque via
+// ignoreCustomFragments — exact same contract as build-plugins/shared/htmlMinify.ts.
+const MINIFY_OPTS = {
+  collapseWhitespace: true,
+  conservativeCollapse: true,
+  collapseInlineTagWhitespace: false,
+  removeComments: true,
+  removeAttributeQuotes: true,
+  removeRedundantAttributes: true,
+  removeEmptyAttributes: true,
+  removeOptionalTags: false,
+  collapseBooleanAttributes: true,
+  useShortDoctype: true,
+  minifyCSS: true,
+  minifyJS: false,
+  processConditionalComments: true,
+  sortAttributes: false,
+  sortClassName: false,
+  ignoreCustomFragments: [
+    /<script[^>]*type=["']?application\/ld\+json["']?[^>]*>[\s\S]*?<\/script>/gi,
+  ],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function walkExt(root, ext) {
+  const out = [];
+  const stack = [root];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try { entries = await readdir(cur, { withFileTypes: true }); }
+    catch { continue; }
+    for (const e of entries) {
+      if (e.name.startsWith('.')) continue;
+      const p = join(cur, e.name);
+      if (e.isDirectory()) stack.push(p);
+      else if (e.isFile() && p.endsWith(ext)) out.push(p);
+    }
+  }
+  return out;
+}
+
+async function shrinkHtmlFile(file, stats) {
+  const before = await readFile(file, 'utf8');
+  const beforeBytes = Buffer.byteLength(before, 'utf8');
+
+  let minified;
+  try {
+    minified = await htmlMinify(before, MINIFY_OPTS);
+  } catch (err) {
+    // Some pages may contain malformed-but-tolerated markup. Skip rather
+    // than fail the build — record but don't throw.
+    stats.htmlErrors++;
+    if (stats.htmlErrorExamples.length < 5) {
+      stats.htmlErrorExamples.push({ file, msg: String(err.message || err).slice(0, 200) });
+    }
+    return;
+  }
+  const afterBytes = Buffer.byteLength(minified, 'utf8');
+
+  if (afterBytes < beforeBytes) {
+    if (!DRY) await writeFile(file, minified, 'utf8');
+    stats.htmlBytesBefore += beforeBytes;
+    stats.htmlBytesAfter += afterBytes;
+    stats.htmlFilesShrunk++;
+  } else {
+    stats.htmlBytesBefore += beforeBytes;
+    stats.htmlBytesAfter += beforeBytes;
+  }
+  stats.htmlFilesSeen++;
+}
+
+async function shrinkJsonFile(file, stats) {
+  const before = await readFile(file, 'utf8');
+  const beforeBytes = Buffer.byteLength(before, 'utf8');
+  let parsed;
+  try { parsed = JSON.parse(before); }
+  catch {
+    stats.jsonErrors++;
+    return;
+  }
+  const after = JSON.stringify(parsed);
+  const afterBytes = Buffer.byteLength(after, 'utf8');
+
+  if (afterBytes < beforeBytes) {
+    if (!DRY) await writeFile(file, after, 'utf8');
+    stats.jsonBytesBefore += beforeBytes;
+    stats.jsonBytesAfter += afterBytes;
+    stats.jsonFilesShrunk++;
+  } else {
+    stats.jsonBytesBefore += beforeBytes;
+    stats.jsonBytesAfter += beforeBytes;
+  }
+  stats.jsonFilesSeen++;
+}
+
+// Simple promise pool — Promise.all on 825k tasks blows the heap.
+async function pool(items, fn, concurrency) {
+  let cursor = 0;
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  let distStat;
+  try { distStat = await stat(DIST); }
+  catch {
+    console.error(`dist-shrink: ${DIST} not found`);
+    process.exit(2);
+  }
+  if (!distStat.isDirectory()) {
+    console.error(`dist-shrink: ${DIST} is not a directory`);
+    process.exit(2);
+  }
+
+  console.log(`dist-shrink: scanning ${DIST}${DRY ? ' (DRY RUN)' : ''}`);
+  const t0 = Date.now();
+  const htmlFiles = await walkExt(DIST, '.html');
+  const jsonFiles = await walkExt(join(DIST, 'data'), '.json');
+  console.log(`dist-shrink: ${htmlFiles.length} HTML, ${jsonFiles.length} JSON (concurrency=${CONCURRENCY})`);
+
+  const stats = {
+    htmlFilesSeen: 0, htmlFilesShrunk: 0, htmlBytesBefore: 0, htmlBytesAfter: 0,
+    htmlErrors: 0, htmlErrorExamples: [],
+    jsonFilesSeen: 0, jsonFilesShrunk: 0, jsonBytesBefore: 0, jsonBytesAfter: 0,
+    jsonErrors: 0,
+  };
+
+  await pool(htmlFiles, (f) => shrinkHtmlFile(f, stats), CONCURRENCY);
+  await pool(jsonFiles, (f) => shrinkJsonFile(f, stats), CONCURRENCY);
+
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+  const mb = (n) => +(n / 1024 / 1024).toFixed(2);
+  const savedHtml = stats.htmlBytesBefore - stats.htmlBytesAfter;
+  const savedJson = stats.jsonBytesBefore - stats.jsonBytesAfter;
+  const savedTotal = savedHtml + savedJson;
+
+  console.log('');
+  console.log('dist-shrink summary');
+  console.log('───────────────────');
+  console.log(`HTML  : ${stats.htmlFilesShrunk}/${stats.htmlFilesSeen} shrunk  ${mb(stats.htmlBytesBefore)}→${mb(stats.htmlBytesAfter)} MB  saved ${mb(savedHtml)} MB  (errors: ${stats.htmlErrors})`);
+  console.log(`JSON  : ${stats.jsonFilesShrunk}/${stats.jsonFilesSeen} shrunk  ${mb(stats.jsonBytesBefore)}→${mb(stats.jsonBytesAfter)} MB  saved ${mb(savedJson)} MB  (errors: ${stats.jsonErrors})`);
+  console.log(`Total : ${mb(savedTotal)} MB saved in ${elapsed}s${DRY ? ' (DRY — no files written)' : ''}`);
+
+  if (stats.htmlErrors > 0) {
+    console.log('');
+    console.log('First HTML errors:');
+    for (const e of stats.htmlErrorExamples) console.log(`  ${e.file}: ${e.msg}`);
+  }
+}
+
+// Run main() only when invoked as a script, not when imported as a
+// module (e.g. by tests/seo/dist-shrink.test.ts).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((err) => { console.error(err); process.exit(1); });
+}
+
+export { MINIFY_OPTS };

--- a/tests/seo/dist-shrink.test.ts
+++ b/tests/seo/dist-shrink.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for scripts/dist-shrink.mjs — the post-build dist shrinker.
+ *
+ * Covers:
+ *  - MINIFY_OPTS treats <script type="application/ld+json"> as opaque
+ *    (vincolo N2 from build-plugins/shared/htmlMinify.ts — Google Rich
+ *    Results consumer tolerance for whitespace-collapsed JSON-LD is
+ *    unknown so the contract is byte-equality)
+ *  - opts produce DOM-equivalent output on a representative SEO page
+ *  - opts drop ordinary HTML comments but preserve IE conditionals
+ */
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { MINIFY_OPTS } from '../../scripts/dist-shrink.mjs';
+
+const require = createRequire(import.meta.url);
+const { minify } = require('html-minifier-terser');
+
+describe('dist-shrink: html-minifier-terser opts', () => {
+  it('treats application/ld+json as opaque (preserves whitespace)', async () => {
+    const ld = '{\n  "@type": "Article",\n  "name": "x"\n}';
+    const input = `<!DOCTYPE html><html><head><script type="application/ld+json">${ld}</script></head><body><p>hi</p></body></html>`;
+    const out = await minify(input, MINIFY_OPTS);
+    // The exact JSON-LD body, including its whitespace, must survive.
+    expect(out).toContain(ld);
+  });
+
+  it('preserves visible text', async () => {
+    const input =
+      '<!DOCTYPE html><html><head><title>T</title></head>' +
+      '<body><h1>Frontaliere   Ticino</h1><p>Hello   world</p></body></html>';
+    const out = await minify(input, MINIFY_OPTS);
+    const stripped = out.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+    expect(stripped).toContain('Frontaliere Ticino');
+    expect(stripped).toContain('Hello world');
+  });
+
+  it('drops HTML comments but preserves IE conditional comments', async () => {
+    const input =
+      '<!DOCTYPE html><html><head>' +
+      '<!-- ordinary -->' +
+      '<!--[if IE]><script>x</script><![endif]-->' +
+      '</head><body></body></html>';
+    const out = await minify(input, MINIFY_OPTS);
+    expect(out).not.toContain('ordinary');
+    expect(out).toContain('<![endif]');
+  });
+
+  it('preserves og:* and the safe twitter:* allow-list', async () => {
+    const input =
+      '<!DOCTYPE html><html><head>' +
+      '<meta property="og:title" content="T">' +
+      '<meta property="og:description" content="D">' +
+      '<meta property="og:image" content="https://x.com/i.png">' +
+      '<meta name="twitter:card" content="summary_large_image">' +
+      '<meta name="twitter:site" content="@x">' +
+      '<meta name="twitter:creator" content="@y">' +
+      '<meta name="twitter:image:alt" content="alt">' +
+      '</head><body></body></html>';
+    const out = await minify(input, MINIFY_OPTS);
+    expect(out).toMatch(/og:title/);
+    expect(out).toMatch(/og:description/);
+    expect(out).toMatch(/og:image/);
+    expect(out).toMatch(/twitter:card/);
+    expect(out).toMatch(/twitter:site/);
+    expect(out).toMatch(/twitter:creator/);
+    expect(out).toMatch(/twitter:image:alt/);
+  });
+});

--- a/tests/seo/no-twitter-meta-dupes.test.ts
+++ b/tests/seo/no-twitter-meta-dupes.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression gate: forbid `<meta name="twitter:(title|description|url|image|image:src)">`
+ * emissions in build-plugins/*.ts.
+ *
+ * Why: X (Twitter) falls back to og:title / og:description / og:url /
+ * og:image when the twitter:* equivalent is absent. Emitting both
+ * doubles the meta bytes on every page (~140 MB across 825k pages on
+ * the May 21 2026 artifact). The codemod that removed these from the
+ * 26 plugins must not be reverted file-by-file as new plugins land.
+ *
+ * Allow-list — these stay because they have NO og:* fallback:
+ *   - twitter:card           — controls X card layout (summary vs. summary_large_image)
+ *   - twitter:site           — X account attribution
+ *   - twitter:creator        — content author attribution
+ *   - twitter:image:alt      — accessibility for the X card image
+ *   - twitter:player, twitter:app:* — distinct surfaces
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = 'build-plugins';
+
+const FORBIDDEN = /<meta\s+name="twitter:(?:title|description|url|image|image:src)"/g;
+
+function walkTs(root: string): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    let entries;
+    try { entries = readdirSync(cur, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      if (e.name.startsWith('.')) continue;
+      const p = join(cur, e.name);
+      if (e.isDirectory()) stack.push(p);
+      else if (e.isFile() && p.endsWith('.ts')) out.push(p);
+    }
+  }
+  return out;
+}
+
+describe('no twitter:* duplicates in build-plugins/*.ts', () => {
+  it('forbids twitter:title/description/url/image/image:src in any plugin', () => {
+    const offenders: { file: string; lines: string[] }[] = [];
+    for (const file of walkTs(ROOT)) {
+      const src = readFileSync(file, 'utf8');
+      const matches = [...src.matchAll(FORBIDDEN)];
+      if (matches.length === 0) continue;
+      const lines = src.split('\n');
+      const hits = matches.map((m) => {
+        const upto = src.slice(0, m.index ?? 0);
+        const lineNo = upto.split('\n').length;
+        return `${lineNo}: ${lines[lineNo - 1]?.trim() ?? ''}`;
+      });
+      offenders.push({ file, lines: hits });
+    }
+    if (offenders.length > 0) {
+      const report = offenders.map((o) =>
+        `${o.file}:\n  ${o.lines.join('\n  ')}`,
+      ).join('\n');
+      throw new Error(
+        `twitter:* duplicates re-introduced in build-plugins/*.ts:\n${report}\n` +
+        `X falls back to og:* — remove these meta tags. See tests/seo/no-twitter-meta-dupes.test.ts.`,
+      );
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
X falls back to og:title / og:description / og:url / og:image when the
twitter:* equivalent is absent. The 26 build plugins were each emitting
~5 duplicate twitter:* tags per page → ~140 MB across 825k HTML pages
on the May 21 2026 artifact baseline. Strip at source rather than dist
so the saving is baked into every build and tests/seo/no-twitter-meta-dupes
prevents regression.

Kept: twitter:card, twitter:site, twitter:creator, twitter:image:alt
(no og:* fallback exists).

Pipeline additions:
- scripts/dist-shrink.mjs: post-build html-minifier-terser pass on
  dist/**/*.html (~270 MB) + JSON re-stringify on dist/data/**/*.json
  (~16 MB). JSON-LD opaque via ignoreCustomFragments (vincolo N2).
- deploy.yml: dist:shrink runs between build:ci and the tar pack.
- tests/seo/dist-shrink.test.ts: opts contract on JSON-LD + visible
  text + comment handling.
- tests/seo/no-twitter-meta-dupes.test.ts: regression gate against
  re-introduction of twitter:(title|description|url|image|image:src)
  in build-plugins/*.ts.

Total measured saving on the artifact baseline: ~420 MB extracted.
