### PR TITLE
fix(tests): make SEO regex gates quote-flexible (post-#473 dist-shrink)

### DIFF
--- a/tests/seo/brand-dedup.test.ts
+++ b/tests/seo/brand-dedup.test.ts
@@ -140,13 +140,16 @@ function readHtml(relPath: string): string | null {
   return fs.readFileSync(abs, 'utf-8');
 }
 
+// Quote-flexible regexes — see scripts/dist-shrink.mjs (PR #473) which strips
+// attribute quotes from dist/ HTML at minify time. DOM-equivalent but text-shape
+// changes: `rel="canonical"` → `rel=canonical`, `href="…"` → `href=…`.
 function extractCanonical(html: string): string | null {
-  const m = /<link\s+rel="canonical"\s+href="([^"]+)"/i.exec(html);
+  const m = /<link\s+rel=["']?canonical["']?\s+href=["']?([^"'\s>]+)["']?/i.exec(html);
   return m ? m[1] : null;
 }
 
 function extractRobots(html: string): string | null {
-  const m = /<meta\s+name="robots"\s+content="([^"]+)"/i.exec(html);
+  const m = /<meta\s+name=["']?robots["']?\s+content=["']?([^"'>]+?)["']?\s*\/?>/i.exec(html);
   return m ? m[1] : null;
 }
 

--- a/tests/seo/breadcrumb-coverage.test.ts
+++ b/tests/seo/breadcrumb-coverage.test.ts
@@ -43,7 +43,12 @@ const ALLOWED_MISSING: ReadonlySet<string> = new Set([
 ]);
 
 const BREADCRUMB_JSONLD_RE = /"@type"\s*:\s*"BreadcrumbList"/;
-const NOINDEX_RE = /<meta[^>]*\bname\s*=\s*["']robots["'][^>]*\bcontent\s*=\s*["'][^"']*noindex/i;
+// Quote-flexible: scripts/dist-shrink.mjs removes attribute quotes, so
+// `name="robots" content="noindex,follow"` becomes
+// `name=robots content="noindex,follow"` (commas force quotes, plain
+// `name=robots` does not). Match both shapes.
+const NOINDEX_RE =
+  /<meta[^>]*\bname\s*=\s*["']?robots["']?[^>]*\bcontent\s*=\s*["']?[^"'>]*noindex/i;
 // Canonical bridge pages (built via `buildCanonicalBridgePage` in
 // build-plugins/constants.ts) ship the signature hero string
 // "Questa URL legacy" (or its localised variant) + a `<link rel="canonical">`

--- a/tests/seo/cathedral-hreflang-cross-locale.test.ts
+++ b/tests/seo/cathedral-hreflang-cross-locale.test.ts
@@ -17,9 +17,16 @@ describe('hreflang round-trip non-TI canton (P3-B)', () => {
     const sample = slugs.find((s) => fs.existsSync(path.join(zhDir, s, 'index.html')));
     if (!sample) return;
     const html = fs.readFileSync(path.join(zhDir, sample, 'index.html'), 'utf8');
-    // The hreflang block must reference each non-IT locale's ZH section
-    expect(html, 'EN alt missing').toMatch(/hreflang="en"[^>]*href="[^"]*\/en\/find-jobs-zurich\//);
-    expect(html, 'DE alt missing').toMatch(/hreflang="de"[^>]*href="[^"]*\/de\/jobs-in-zurich\//);
-    expect(html, 'FR alt missing').toMatch(/hreflang="fr"[^>]*href="[^"]*\/fr\/trouver-emploi-zurich\//);
+    // Quote-flexible: scripts/dist-shrink.mjs strips attribute quotes.
+    // `hreflang="en" href="…"` is DOM-equivalent to `hreflang=en href=…`.
+    expect(html, 'EN alt missing').toMatch(
+      /hreflang=["']?en["']?[^>]*href=["']?[^"'\s>]*\/en\/find-jobs-zurich\//,
+    );
+    expect(html, 'DE alt missing').toMatch(
+      /hreflang=["']?de["']?[^>]*href=["']?[^"'\s>]*\/de\/jobs-in-zurich\//,
+    );
+    expect(html, 'FR alt missing').toMatch(
+      /hreflang=["']?fr["']?[^>]*href=["']?[^"'\s>]*\/fr\/trouver-emploi-zurich\//,
+    );
   });
 });

--- a/tests/seo/cathedral-sector-hubs.test.ts
+++ b/tests/seo/cathedral-sector-hubs.test.ts
@@ -44,10 +44,13 @@ describe('cathedral — per-canton sector hubs (Phase 3.2)', () => {
         const f = path.join(dir, slug, 'index.html');
         if (fs.existsSync(f)) {
           anyHub = true;
-          // Verify canonical points at itself (self-canonical for per-canton hub)
+          // Verify canonical points at itself (self-canonical for per-canton hub).
+          // Quote-flexible: dist-shrink (PR #473) strips attribute quotes.
           const html = fs.readFileSync(f, 'utf-8');
           expect(html, `${sec}/${slug} must self-canonicalize`).toMatch(
-            new RegExp(`<link rel="canonical" href="https://frontaliereticino\\.ch/${sec}/${slug}/"`),
+            new RegExp(
+              `<link\\s+rel=["']?canonical["']?\\s+href=["']?https://frontaliereticino\\.ch/${sec}/${slug}/["']?`,
+            ),
           );
           // Verify it embeds at least one job-card structure
           expect(html, `${sec}/${slug} must have a job listing grid`).toMatch(
@@ -69,7 +72,7 @@ describe('cathedral — per-canton sector hubs (Phase 3.2)', () => {
     if (!fs.existsSync(f)) return;
     const html = fs.readFileSync(f, 'utf-8');
     expect(html).toMatch(
-      /<link rel="canonical" href="https:\/\/frontaliereticino\.ch\/cerca-lavoro-ticino\/infermieri\/"/,
+      /<link\s+rel=["']?canonical["']?\s+href=["']?https:\/\/frontaliereticino\.ch\/cerca-lavoro-ticino\/infermieri\/["']?/,
     );
   });
 });
@@ -109,7 +112,7 @@ describe('cathedral — per-canton company hubs (Phase 3.3)', () => {
       const html = fs.readFileSync(f, 'utf-8');
       expect(html, 'per-canton company hub must self-canonicalize').toMatch(
         new RegExp(
-          `<link rel="canonical" href="https://frontaliereticino\\.ch/${anyCompanyHub.section}/${anyCompanyHub.entry}/"`,
+          `<link\\s+rel=["']?canonical["']?\\s+href=["']?https://frontaliereticino\\.ch/${anyCompanyHub.section}/${anyCompanyHub.entry}/["']?`,
         ),
       );
     }
@@ -133,7 +136,7 @@ describe('cathedral — per-canton company hubs (Phase 3.3)', () => {
     // company hub (BRAND_CANONICAL_MAP rerouting). Either way, never a
     // non-TI section.
     expect(html, 'TI legacy company hub canonical must stay under /cerca-lavoro-ticino/').toMatch(
-      /<link rel="canonical" href="https:\/\/frontaliereticino\.ch\/cerca-lavoro-ticino\/azienda-/,
+      /<link\s+rel=["']?canonical["']?\s+href=["']?https:\/\/frontaliereticino\.ch\/cerca-lavoro-ticino\/azienda-/,
     );
   });
 });

--- a/tests/seo/dist-shrink.test.ts
+++ b/tests/seo/dist-shrink.test.ts
@@ -46,6 +46,44 @@ describe('dist-shrink: html-minifier-terser opts', () => {
     expect(out).toContain('<![endif]');
   });
 
+  // Regression — PR #473 incident: `removeAttributeQuotes: true` rewrote
+  // `<link rel="canonical" href="https://x/">` to
+  // `<link rel=canonical href=https://x/>` in dist/, breaking the
+  // quoted-only SEO regex gates in tests/seo/{brand-dedup,
+  // breadcrumb-coverage, cathedral-hreflang-cross-locale,
+  // cathedral-sector-hubs, legacy-city-hub-hreflang}. Those tests have
+  // since been switched to quote-flexible regexes, but the contract is:
+  // the canonical SEO patterns below MUST match minifier output for both
+  // the plain quoted form (unminified) and the unquoted form (minified).
+  // This test pins both shapes so future minifier-opt changes can't
+  // silently defeat the SEO gates again.
+  it('canonical/hreflang/robots regexes (quote-flex) match before AND after minify', async () => {
+    const canonicalRe =
+      /<link\s+rel=["']?canonical["']?\s+href=["']?([^"'\s>]+)["']?/i;
+    const hreflangRe =
+      /<link\s+rel=["']?alternate["']?\s+hreflang=["']?en["']?\s+href=["']?([^"'\s>]+)["']?/i;
+    const noindexRe =
+      /<meta[^>]*\bname\s*=\s*["']?robots["']?[^>]*\bcontent\s*=\s*["']?[^"'>]*noindex/i;
+
+    const input =
+      '<!DOCTYPE html><html lang="it"><head>' +
+      '<link rel="canonical" href="https://frontaliereticino.ch/test/">' +
+      '<link rel="alternate" hreflang="en" href="https://frontaliereticino.ch/en/test/">' +
+      '<meta name="robots" content="noindex,follow">' +
+      '</head><body><h1>x</h1></body></html>';
+
+    // Quoted (pre-minify) shape matches.
+    expect(canonicalRe.exec(input)?.[1]).toBe('https://frontaliereticino.ch/test/');
+    expect(hreflangRe.exec(input)?.[1]).toBe('https://frontaliereticino.ch/en/test/');
+    expect(noindexRe.test(input)).toBe(true);
+
+    // Minified (post-shrink) shape ALSO matches — this is the contract.
+    const out = await minify(input, MINIFY_OPTS);
+    expect(canonicalRe.exec(out)?.[1]).toBe('https://frontaliereticino.ch/test/');
+    expect(hreflangRe.exec(out)?.[1]).toBe('https://frontaliereticino.ch/en/test/');
+    expect(noindexRe.test(out)).toBe(true);
+  });
+
   it('preserves all og:* meta tags', async () => {
     const input =
       '<!DOCTYPE html><html><head>' +

--- a/tests/seo/legacy-city-hub-hreflang.test.ts
+++ b/tests/seo/legacy-city-hub-hreflang.test.ts
@@ -64,8 +64,12 @@ const LEGACY_CITY_HUB_PATHS: ReadonlyArray<{
   },
 ];
 
-const HREFLANG_RE = /<link\s+rel="alternate"\s+hreflang=/i;
-const CANONICAL_RE = /<link\s+rel="canonical"\s+href="([^"]+)"/i;
+// Quote-flexible: scripts/dist-shrink.mjs runs html-minifier-terser with
+// removeAttributeQuotes=true on dist/, so `rel="canonical"` becomes
+// `rel=canonical` and `href="https://x/"` becomes `href=https://x/`.
+// The DOM is equivalent but a quoted-only regex breaks. See PR #473.
+const HREFLANG_RE = /<link\s+rel=["']?alternate["']?\s+hreflang=/i;
+const CANONICAL_RE = /<link\s+rel=["']?canonical["']?\s+href=["']?([^"'\s>]+)["']?/i;
 
 describeBuild('legacy city-hub duplicates — no hreflang on canonicalized pages', () => {
   for (const { description, legacyPath, canonicalPath } of LEGACY_CITY_HUB_PATHS) {


### PR DESCRIPTION
PR #473 turned on `removeAttributeQuotes: true` in scripts/dist-shrink.mjs,
which is DOM-equivalent but changes the on-disk shape of attributes in
dist/ HTML: `rel="canonical"` → `rel=canonical`,
`href="https://..."` → `href=https://...`. The five SEO regression
tests below used quoted-only regexes and started failing
gate:seo-source in validate-dist (run 26246169046):

  - tests/seo/brand-dedup.test.ts (extractCanonical, extractRobots)
  - tests/seo/breadcrumb-coverage.test.ts (NOINDEX_RE noindex detection)
  - tests/seo/cathedral-hreflang-cross-locale.test.ts (hreflang/href)
  - tests/seo/cathedral-sector-hubs.test.ts (canonical assertions x4)
  - tests/seo/legacy-city-hub-hreflang.test.ts (HREFLANG_RE, CANONICAL_RE)

Switched each regex to a quote-flexible form that matches both:

  1. plain quoted form (unminified input from build plugins)
  2. unquoted form (post-html-minifier-terser output in dist/)

Pattern: `rel=["']?canonical["']?\s+href=["']?([^"'\s>]+)["']?`. Semantic
validation is preserved — same canonical hrefs, same hreflang locales,
same noindex detection. Only the textual shape tolerance changes.

Added a regression assertion in tests/seo/dist-shrink.test.ts that pins
both shapes against the minifier output, so future opts changes can't
silently defeat the SEO gates again.
