### PR TITLE
revert(seo): disable attribute-quote removal — breaks ~14 dist audits

### DIFF
--- a/build-plugins/shared/htmlMinify.ts
+++ b/build-plugins/shared/htmlMinify.ts
@@ -24,13 +24,13 @@
 //      `<a>foo</a>bar`).
 //   4. Strip leading whitespace at the start of each line and trailing
 //      whitespace before `\n`. Output uses LF endings.
-//   5. Drop optional attribute quotes per the HTML5 spec — `attr="val"`
-//      → `attr=val` when `val` contains no whitespace/quotes/=/</>/backtick
-//      AND doesn't end in `/` (would collide with `/>` self-close marker).
-//      Added 2026-05-21 to bake in the 91% of dist-shrink savings at
-//      build time instead of at post-build (post-deploy run #26250403558
-//      attributed 91.2% of all dist-shrink saving to removeAttributeQuotes).
-//   6. Restore masked blocks verbatim.
+//   5. Restore masked blocks verbatim.
+//
+// Reverted 2026-05-22: PR #478 added attribute-quote removal as Step 5
+// here. ~14 dist-walking audits had quote-strict regex baselines; the
+// upstream change broke validate-dist with 438k+ false-positive
+// regressions in run #26255102850. See the ATTR_UNQUOTE_RX comment
+// further down for the re-enable checklist.
 //
 // Output is DOM-equivalent + content-equivalent to the input. The
 // text-html-ratio gate IMPROVES (HTML byte count drops by ~9-10 %, text
@@ -79,27 +79,22 @@ const NL_INDENT_RX = /\n[ \t]+/g;        // leading whitespace per line
 const TRAILING_WS_RX = /[ \t]+\n/g;      // trailing whitespace per line
 const CRLF_RX = /\r\n/g;                 // normalize CRLF → LF
 
-// Step 5: HTML5 unquoted attribute eligibility. The HTML5 spec says
-// `attr="value"` may be written as `attr=value` IFF the value contains
-// none of: whitespace, `"`, `'`, `=`, `<`, `>`, backtick. We also reject
-// values ending in `/` so `<link href="https://x/">` doesn't become
-// `<link href=https://x/>` which the parser splits at the `/` into the
-// void-element self-close marker (the actual breakage was caught when
-// PR #473 first enabled removeAttributeQuotes at the dist layer — see
-// tests/seo/dist-shrink.test.ts "canonical/hreflang/robots regexes").
+// Step 5 (REMOVED 2026-05-22) — was: HTML5 unquoted-attribute eligibility.
+// PR #478 added an attribute-quote-removal step here. While correct per
+// HTML5 spec, ~14 dist-walking audits (footer-root-presence,
+// spa-bundle-injection, h1-title-duplicates, sitemap-canonicals,
+// title-length, salary-landing-template, content-duplicates,
+// no-literal-markdown, …) carry quote-strict regexes baked into their
+// baseline snapshots. Removing quotes upstream caused 438k+ false-
+// positive audit regressions in run #26255102850.
 //
-// `\b` on the leading boundary keeps us off attribute-name suffixes —
-// e.g. `data-id="foo"` ATTR matches `data-id`, not `id`. The pre-attr
-// char is captured (`\s` typically — the space between `<tag` and
-// `attr=`) so we can write it back unchanged.
-//
-// Attribute name pattern matches names with `-`, `_`, `:` (latter for
-// xlink:href / xml:lang etc.). Anything starting with a digit is
-// rejected (HTML5 disallows). The opening `<` of a tag is matched by
-// the `(?<=<[^<>]*?)` lookbehind to ensure we only rewrite attribute
-// quotes INSIDE a tag, never content text that looks like `="value"`.
-const ATTR_UNQUOTE_RX =
-  /(?<=<[a-zA-Z][^<>]*?\s)([a-zA-Z][a-zA-Z0-9:_-]*)="([^"'\s=<>`]+)"/g;
+// Re-enable order when picking this up again:
+//   1. Migrate every audit in scripts/audit-*.mjs + scripts/lib/audit-*.mjs
+//      to quote-flex regexes (the canonical pattern lives in
+//      tests/seo/dist-shrink.test.ts "canonical/hreflang/robots regexes").
+//   2. Re-run validate-dist on a non-baseline deploy to confirm zero
+//      regression counts attributable to quote removal.
+//   3. Re-add Step 5 + ATTR_UNQUOTE_RX + the per-tag call below.
 
 /**
  * Minify HTML produced by buildSimplePage / buildSeoPageHtml.
@@ -163,14 +158,8 @@ export function minifyHtml(html: string): string {
     masked = masked.replace(BLOCK_GAP_RX, '$1$2');
   } while (masked !== prev);
 
-  // --- Step 5: drop optional attribute quotes (HTML5 spec — see
-  // ATTR_UNQUOTE_RX comment above). Values ending in `/` are explicitly
-  // preserved with quotes because `attr=value/` clashes with the void-
-  // element self-close marker `/>`.
-  masked = masked.replace(ATTR_UNQUOTE_RX, (m, attr, val) => {
-    if (val.endsWith('/')) return m;
-    return `${attr}=${val}`;
-  });
+  // --- Step 5 (REMOVED 2026-05-22) — was attribute-quote removal.
+  // See ATTR_UNQUOTE_RX comment above for the re-enable checklist.
 
   // --- Step 6: restore masked blocks.
   if (safe.length > 0) {

--- a/build-plugins/shared/jobDescription/toHtml.ts
+++ b/build-plugins/shared/jobDescription/toHtml.ts
@@ -69,11 +69,43 @@ export function jobDescriptionTextToHtml(text: string): string {
  * Render a single line/paragraph string to safe inline HTML — HTML-escapes
  * the text while converting `**bold**` → `<strong>` and `*em*` → `<em>`.
  * Strips literal markdown so audit:no-literal-markdown stays at 0.
- * If the input already carries structural tags, pass it through untouched.
+ *
+ * If the input already carries structural tags (strong/em/a/span/br),
+ * we pass it through but FIRST sanitize attributes:
+ *   - `<span>` and `<br>` are stripped of ALL attributes (no semantic
+ *     attributes; the MS-Word-paste `<span style="font-family:"Times
+ *     New Roman", serif">` pattern breaks html-minifier-terser AND
+ *     silently malforms the rendered styles because inner double-
+ *     quotes close the outer style attribute early — caught
+ *     2026-05-21 by dist-shrink parse-error report on 28 Bachem
+ *     job pages, runs #26250403558 + #26255102850)
+ *   - `<a>` keeps ONLY `href` (drops class/style/target/etc that
+ *     external sources inject)
+ *   - `<strong>` / `<em>` are stripped of attributes (none have
+ *     semantic value in our context)
+ * The tag itself is preserved so visible text flow stays intact.
+ *
+ * Why regex (not a real HTML sanitizer): the input is malformed
+ * enough that DOMParser would re-balance tags and change the visible
+ * text flow. Each regex below targets one tag at a time so a broken
+ * span doesn't eat into adjacent elements.
  */
+function stripExternalHtmlAttributes(s: string): string {
+  return s
+    // <span ... >  →  <span>      (always drop everything between tag name and `>`)
+    .replace(/<(span|br|strong|em)(\s[^>]*)?(\/?)>/gi, '<$1$3>')
+    // <a ... href="X" ... > → <a href="X">    (keep ONLY href)
+    .replace(/<a\s[^>]*>/gi, (m) => {
+      const hrefMatch = m.match(/\bhref\s*=\s*["']?([^"'>\s]+)["']?/i);
+      return hrefMatch ? `<a href="${hrefMatch[1]}">` : '<a>';
+    });
+}
+
 export function inlineTextToHtml(text: string): string {
   if (!text) return '';
   const s = String(text);
-  if (/<(strong|em|a|span|br)\b/i.test(s)) return s;
+  if (/<(strong|em|a|span|br)\b/i.test(s)) {
+    return stripExternalHtmlAttributes(s);
+  }
   return inlinesToHtml(parseInline(s));
 }

--- a/scripts/dist-shrink.mjs
+++ b/scripts/dist-shrink.mjs
@@ -97,15 +97,25 @@ const RATIO_MIN_BYTES = Number(args.get('ratio-min-bytes') || 5 * 1024);
 //   - minifyCSS                : almost no inline CSS in our output (one
 //                                 sample saved 12 B total → not worth the
 //                                 CSS-AST parsing cost across 841k files)
-// Keeping these enabled costs ~50% of the per-file parse time for zero
-// bytes saved. They can be re-enabled if dist-shrink's `Per-rule
-// contribution` block starts attributing non-zero bytes to them again.
+//
+// Disabled 2026-05-22 due to audit incompatibility:
+//   - removeAttributeQuotes    : ~14 dist-walking audits carry quote-strict
+//                                 regexes baked into their baseline snapshots
+//                                 (footer-root-presence, spa-bundle-injection,
+//                                 h1-title-duplicates, sitemap-canonicals,
+//                                 title-length, salary-landing-template,
+//                                 content-duplicates, no-literal-markdown, …).
+//                                 Run #26255102850 surfaced 438k+ false-
+//                                 positive regressions. Re-enable once those
+//                                 audits migrate to the quote-flex pattern
+//                                 already used in tests/seo/dist-shrink.test.ts
+//                                 ("canonical/hreflang/robots regexes").
 const MINIFY_OPTS = {
   collapseWhitespace: true,
   conservativeCollapse: true,
   collapseInlineTagWhitespace: false,
   removeComments: false,
-  removeAttributeQuotes: true,           // 91.2% of measured saving — the lever
+  removeAttributeQuotes: false,          // reverted — audits depend on quoted attrs
   removeRedundantAttributes: false,
   removeEmptyAttributes: false,
   removeOptionalTags: false,             // SEO-risk: kept off

--- a/tests/seo/html-minify.test.ts
+++ b/tests/seo/html-minify.test.ts
@@ -168,10 +168,10 @@ describe('minifyHtml — real-world structure', () => {
 </html>`;
     const out = minifyHtml(input);
 
-    // Structural assertions. Attribute values may now be unquoted per
-    // HTML5 (Step 5 in minifyHtml — added 2026-05-21 to capture the
-    // dist-shrink-attributed quote-removal upstream), so we use
-    // quote-flexible matchers for those.
+    // Structural assertions. Quote-flexible matchers retained from the
+    // PR #478 quote-removal experiment so the test still passes if quote
+    // removal is re-enabled in the future (after the audit-quote-flex
+    // migration described in build-plugins/shared/htmlMinify.ts).
     expect(out).toContain('<!DOCTYPE html>');
     expect(out).toMatch(/<html\s+lang=["']?it["']?>/);
     expect(out).toContain('<title>Test · rif. stabio</title>');
@@ -197,10 +197,18 @@ describe('minifyHtml — real-world structure', () => {
   });
 });
 
-describe('minifyHtml — Step 5: drop optional attribute quotes (HTML5)', () => {
-  it('unquotes safe simple values', () => {
-    expect(minifyHtml('<div class="hero" id="main"></div>'))
-      .toContain('<div class=hero id=main>');
+describe('minifyHtml — Step 5 REMOVED 2026-05-22 (attribute-quote removal disabled)', () => {
+  // PR #478 added a Step 5 attribute-quote-removal pass here that
+  // broke ~14 dist-walking audits with quote-strict regexes
+  // (run #26255102850: 438k+ false-positive regressions). Reverted in
+  // round-2 source fixes. These tests now pin the QUOTED-FORM output
+  // so a future re-introduction would have to update them deliberately
+  // alongside the audit-quote-flex migration.
+
+  it('preserves attribute quotes on safe simple values', () => {
+    const out = minifyHtml('<div class="hero" id="main"></div>');
+    expect(out).toContain('class="hero"');
+    expect(out).toContain('id="main"');
   });
 
   it('preserves quotes when value has whitespace', () => {
@@ -208,23 +216,9 @@ describe('minifyHtml — Step 5: drop optional attribute quotes (HTML5)', () => 
     expect(out).toContain('class="hero big"');
   });
 
-  it('preserves quotes when value ends in `/` (void-element self-close clash)', () => {
+  it('preserves URL quotes (no premature self-close clash)', () => {
     const out = minifyHtml('<link rel="canonical" href="https://example.com/">');
-    // `href=https://example.com/` would let the parser read `>` as part
-    // of `/>` self-close — keep the quotes.
     expect(out).toContain('href="https://example.com/"');
-  });
-
-  it('unquotes URL values that do NOT end in `/`', () => {
-    const out = minifyHtml('<link rel="stylesheet" href="https://example.com/a.css">');
-    expect(out).toContain('href=https://example.com/a.css');
-  });
-
-  it('preserves quotes when value contains `=` (parse boundary)', () => {
-    const out = minifyHtml(
-      '<script src="https://example.com/?foo=bar"></script>',
-    );
-    expect(out).toContain('"https://example.com/?foo=bar"');
   });
 
   it('preserves quotes inside JSON-LD body (opaque)', () => {
@@ -234,21 +228,12 @@ describe('minifyHtml — Step 5: drop optional attribute quotes (HTML5)', () => 
     expect(out).toContain('{"@type":"Foo","key":"value"}');
   });
 
-  it('never strips quotes inside content text that looks like attrs', () => {
-    // `<p>foo="bar"</p>` must NOT become `<p>foo=bar</p>` — the regex
-    // is anchored to attribute position via lookbehind on the open-tag.
+  it('never touches content text that looks like attrs', () => {
     const out = minifyHtml('<p>foo="bar"</p>');
     expect(out).toContain('foo="bar"');
   });
 
-  it('handles multiple attributes on one tag', () => {
-    const out = minifyHtml('<a class="cta" href="/about" rel="noopener">x</a>');
-    expect(out).toContain('class=cta');
-    expect(out).toContain('href=/about');
-    expect(out).toContain('rel=noopener');
-  });
-
-  it('preserves canonical/hreflang/robots regex match (quote-flex contract)', () => {
+  it('preserves canonical/hreflang/robots — quote-flex matchers still work', () => {
     const out = minifyHtml(
       '<link rel="canonical" href="https://x.test/page">' +
       '<link rel="alternate" hreflang="en" href="https://x.test/en/page">' +

--- a/tests/seo/inline-text-to-html-sanitize.test.ts
+++ b/tests/seo/inline-text-to-html-sanitize.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for the inline-style-strip behavior in
+ * `build-plugins/shared/jobDescription/toHtml.ts:inlineTextToHtml`.
+ *
+ * Bachem (and similar) crawler imports contain MS-Word-paste HTML:
+ *
+ *   <span style="font-family:"Times New Roman", serif;">…</span>
+ *
+ * The inner double-quoted CSS string `"Times New Roman"` closes the
+ * outer `style="..."` attribute early; the rest of the styles leak
+ * into the HTML body as raw text. html-minifier-terser parse-errored
+ * on 28 such pages in runs #26250403558 + #26255102850. The fix
+ * strips ALL attributes from passthrough <span>/<br>/<strong>/<em>
+ * tags and keeps ONLY href on <a> — they have zero SEO value and
+ * break the minifier.
+ */
+import { describe, expect, it } from 'vitest';
+import { inlineTextToHtml } from '../../build-plugins/shared/jobDescription/toHtml';
+
+describe('inlineTextToHtml — passthrough HTML attribute sanitization', () => {
+  it('strips inline style="..." with inner double quotes (MS Word pattern)', () => {
+    const input =
+      '<span style="font-size:12.0pt;line-height:107%;font-family:"Times New Roman", serif;">x</span>';
+    const out = inlineTextToHtml(input);
+    expect(out).toContain('<span>');
+    expect(out).toContain('</span>');
+    expect(out).toContain('x');
+    expect(out).not.toMatch(/style=/);
+    expect(out).not.toMatch(/font-family/);
+  });
+
+  it('strips inline class="..." from <span>', () => {
+    const input = '<span class="cls">y</span>';
+    const out = inlineTextToHtml(input);
+    expect(out).toBe('<span>y</span>');
+  });
+
+  it('preserves plain text + markdown via parseInline path', () => {
+    expect(inlineTextToHtml('hello **world**')).toBe('hello <strong>world</strong>');
+  });
+
+  it('keeps href on <a>, drops class/style/target/rel', () => {
+    const input = '<a href="https://example.com/" class="link" style="color:red" target="_blank">x</a>';
+    const out = inlineTextToHtml(input);
+    expect(out).toBe('<a href="https://example.com/">x</a>');
+  });
+
+  it('handles single-quoted style attributes', () => {
+    const input = "<span style='color:red'>x</span>";
+    const out = inlineTextToHtml(input);
+    expect(out).toBe('<span>x</span>');
+  });
+
+  it('strips attributes from <br> (Word also paste-bombs these)', () => {
+    expect(inlineTextToHtml('a<br style="margin:0">b'))
+      .toBe('a<br>b');
+    // `<br />` (XHTML) and `<br>` (HTML5) are equivalent; we normalize
+    // to HTML5 to match the rest of the dist output.
+    expect(inlineTextToHtml('a<br />b')).toBe('a<br>b');
+  });
+
+  it('strips attributes from <strong>/<em>', () => {
+    expect(inlineTextToHtml('<strong style="x">y</strong>'))
+      .toBe('<strong>y</strong>');
+    expect(inlineTextToHtml('<em class="x">y</em>'))
+      .toBe('<em>y</em>');
+  });
+
+  it('handles <a> with no href (no crash)', () => {
+    expect(inlineTextToHtml('<a class="x">link</a>'))
+      .toBe('<a>link</a>');
+  });
+
+  it('multiple offenders in one string', () => {
+    const input =
+      '<span style="color:red">a</span> ' +
+      '<a href="/x" class="y">b</a> ' +
+      '<br style="margin:0">';
+    const out = inlineTextToHtml(input);
+    expect(out).toBe('<span>a</span> <a href="/x">b</a> <br>');
+  });
+
+  it('Bachem real-world fixture', () => {
+    const input =
+      'Ihre Aufgaben:\n\n<span style="font-size:12.0pt;line-height:107%;font-family:"Times New Roman", serif;">' +
+      'Compliance & Governance' +
+      '</span>';
+    const out = inlineTextToHtml(input);
+    expect(out).not.toMatch(/style=/);
+    expect(out).not.toMatch(/font-family/);
+    expect(out).toContain('Compliance');
+  });
+});


### PR DESCRIPTION
PR #478's source-side `removeAttributeQuotes` (in htmlMinify.ts Step 5)
+ the same option in dist-shrink.mjs caused validate-dist to surface
438k+ false-positive regressions in run #26255102850 across these
quote-strict baselines:

  audit:spa-bundle-injection    : 438k missing (baseline 10800)
  audit:footer-root-presence    : 174k missing
  audit:h1-title-duplicates     : 399k duplicates
  audit:text-html-ratio         : 826 offenders
  audit:salary-landing-template : 1834 of 1835
  audit:content-duplicates      : 8957 across locales
  audit:no-literal-markdown     : 25 (new)
  audit:title-length            : 3423 over threshold
  audit:title-no-disambig-hash  : 1078
  validate:sitemap-pages, audit:sitemap-canonicals, …

Root cause: each audit walks dist HTML with quote-strict regex like
`/id="footer-root"/` or `/type="module"/`. Their baselines were captured
when dist preserved attribute quotes. Once dist-shrink (PR #473) and
then htmlMinify Step 5 (PR #478) stripped optional quotes, every page
became a false-positive regression because the regex no longer matches.

Reverted (this PR):
- build-plugins/shared/htmlMinify.ts: drop Step 5 (ATTR_UNQUOTE_RX + the
  per-tag replace). The comments document the re-enable checklist —
  migrate every dist-walking audit to quote-flex regex FIRST.
- scripts/dist-shrink.mjs MINIFY_OPTS: removeAttributeQuotes false.
- tests/seo/html-minify.test.ts: re-pin QUOTED-FORM assertions; the
  quote-flex matchers from PR #478 are retained for the canonical/
  hreflang/robots cases so a future re-enable Just Works.

Kept (from this PR's earlier work):
- build-plugins/shared/jobDescription/toHtml.ts:inlineTextToHtml now
  strips ALL attributes from passthrough <span>/<br>/<strong>/<em>
  and keeps only `href` on <a>. Fixes 28 Bachem job-page parse errors
  caused by `<span style="font-family:"Times New Roman", ..."> — same
  inner-double-quote pattern as the tnum bug, but in imported HTML
  not our own templates.
- tests/seo/inline-text-to-html-sanitize.test.ts: 10 unit tests for the
  new sanitizer.

Tradeoff: lose ~91% of the dist-shrink HTML byte saving (172 MB → ~15
MB residual whitespace). The dist-shrink step now mostly serves as
JSON compaction (~16 MB) + boolean-attribute collapse + diagnostic
report. Validate-dist green again, deploys can succeed.

Next round target: make the 14 audit scripts quote-flex, THEN re-enable
attribute-quote removal upstream. The savings are worth recovering
but only after the audit contract is portable across quote styles.

SEO test suite: 562 passing, 22 skipped, 0 failing.
