### PR TITLE
fix(audits): quote-flex regex across all dist HTML walkers (post-#478)

### DIFF
--- a/scripts/audit-cannibalization.mjs
+++ b/scripts/audit-cannibalization.mjs
@@ -160,7 +160,8 @@ function extractTitle(html) {
 }
 
 function extractCanonical(html) {
- const m = html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/i);
+ // Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+ const m = html.match(/<link\s+rel=["']?canonical["']?\s+href=["']?([^"'\s>]+)["']?/i);
  return m ? m[1].trim() : '';
 }
 

--- a/scripts/audit-content-duplicates.mjs
+++ b/scripts/audit-content-duplicates.mjs
@@ -37,19 +37,21 @@ function canonicalizeDistPath(relPath) {
   return posix;
 }
 
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream. URL hrefs and
+// short single-token meta names/contents lose their quotes in dist/.
 function extractCanonical(html) {
   const headMatch = /<head\b[^>]*>([\s\S]*?)<\/head>/i.exec(html);
   const scope = headMatch ? headMatch[1] : html;
-  const m = /<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i.exec(scope);
+  const m = /<link[^>]+rel=["']?canonical["']?[^>]*href=["']?([^"'\s>]+)["']?/i.exec(scope);
   if (m) return m[1].trim();
-  const m2 = /<link[^>]+href=["']([^"']+)["'][^>]*rel=["']canonical["']/i.exec(scope);
+  const m2 = /<link[^>]+href=["']?([^"'\s>]+)["']?[^>]*rel=["']?canonical["']?/i.exec(scope);
   return m2 ? m2[1].trim() : null;
 }
 
 function hasNoindex(html) {
   const headMatch = /<head\b[^>]*>([\s\S]*?)<\/head>/i.exec(html);
   const scope = headMatch ? headMatch[1] : html;
-  const m = /<meta[^>]+name=["']robots["'][^>]*content=["']([^"']+)["']/i.exec(scope);
+  const m = /<meta[^>]+name=["']?robots["']?[^>]*content=["']?([^"'>]+?)["']?\s*\/?>/i.exec(scope);
   if (!m) return false;
   return /\bnoindex\b/i.test(m[1]);
 }

--- a/scripts/audit-dist-multi.mjs
+++ b/scripts/audit-dist-multi.mjs
@@ -87,9 +87,11 @@ const SD_INLANGUAGE_WHITELIST = new Set(TYPES_ACCEPT_IN_LANGUAGE_LIST);
 const SD_WEBAPP_TYPES = new Set(['WebApplication', 'SoftwareApplication']);
 const SD_UNIQUE_TYPES = ['FAQPage', 'HowTo', 'Article', 'NewsArticle', 'BlogPosting'];
 
-// ───── shared regexes (verbatim from the originals) ──────────────────────────
-const NOINDEX_RE = /<meta[^>]+name=["']robots["'][^>]+content=["'][^"']*noindex/i;
-const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
+// ───── shared regexes ────────────────────────────────────────────────────────
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream so dist HTML
+// has unquoted single-token attribute values (`name=robots`, `http-equiv=refresh`).
+const NOINDEX_RE = /<meta[^>]+name=["']?robots["']?[^>]+content=["']?[^"'>]*noindex/i;
+const META_REFRESH_RE = /<meta[^>]+http-equiv=["']?refresh["']?(?=[\s/>])/i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 const H1_RE = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i;
 const HEAD_RE = /<head\b[^>]*>([\s\S]*?)<\/head>/i;
@@ -209,13 +211,13 @@ function inferRootLocale(relPath) {
   return 'it';
 }
 
-/** From audit-content-duplicates.extractCanonical. */
+/** From audit-content-duplicates.extractCanonical. Quote-flexible (PR #478). */
 function extractCanonical(html) {
   const headMatch = HEAD_RE.exec(html);
   const scope = headMatch ? headMatch[1] : html;
-  const m = /<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i.exec(scope);
+  const m = /<link[^>]+rel=["']?canonical["']?[^>]*href=["']?([^"'\s>]+)["']?/i.exec(scope);
   if (m) return m[1].trim();
-  const m2 = /<link[^>]+href=["']([^"']+)["'][^>]*rel=["']canonical["']/i.exec(scope);
+  const m2 = /<link[^>]+href=["']?([^"'\s>]+)["']?[^>]*rel=["']?canonical["']?/i.exec(scope);
   return m2 ? m2[1].trim() : null;
 }
 
@@ -223,7 +225,7 @@ function extractCanonical(html) {
 function hasNoindexDup(html) {
   const headMatch = HEAD_RE.exec(html);
   const scope = headMatch ? headMatch[1] : html;
-  const m = /<meta[^>]+name=["']robots["'][^>]*content=["']([^"']+)["']/i.exec(scope);
+  const m = /<meta[^>]+name=["']?robots["']?[^>]*content=["']?([^"'>]+?)["']?\s*\/?>/i.exec(scope);
   if (!m) return false;
   return /\bnoindex\b/i.test(m[1]);
 }
@@ -472,10 +474,10 @@ class PageWeightAudit {
 
 // ───── audit-hreflang helpers (verbatim) ─────────────────────────────────────
 
-/** From audit-hreflang.extractAlternates. */
+/** From audit-hreflang.extractAlternates. Quote-flexible (PR #478). */
 function extractAlternates(html) {
   const map = new Map();
-  const regex = /<link\s+rel="alternate"[^>]*hreflang="([^"]+)"[^>]*href="([^"]+)"/gi;
+  const regex = /<link\s+rel=["']?alternate["']?[^>]*hreflang=["']?([^"'\s>]+)["']?[^>]*href=["']?([^"'\s>]+)["']?/gi;
   let match;
   while ((match = regex.exec(html)) !== null) {
     map.set(match[1], match[2]);

--- a/scripts/audit-footer-root-presence.mjs
+++ b/scripts/audit-footer-root-presence.mjs
@@ -37,12 +37,17 @@ import { fileURLToPath } from 'node:url';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { writeAuditReport } from './lib/auditReport.mjs';
 
+// Quote-flexible: PR #478 baked `removeAttributeQuotes` into the per-page
+// htmlMinify.ts pass, so single-token attribute values lose their quotes
+// in dist/ (`id="footer-root"` → `id=footer-root`, `id="root"` → `id=root`).
+// `class="..."` values are space-separated (Tailwind utility classes) so
+// quotes are preserved — those regexes stay quote-mandatory.
 const SEO_STATIC_RE = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b/i;
-const FOOTER_ROOT_RE = /<div\b[^>]*\bid=["']footer-root["']/i;
+const FOOTER_ROOT_RE = /<div\b[^>]*\bid=["']?footer-root["']?(?=[\s/>])/i;
 // Buggy legacy shell: `<div id="root">` immediately followed by `<main class="static-job-page">`.
 // Mirrors the regression check in tests/city-jobs-hub.test.ts:358.
 const STATIC_JOB_INSIDE_ROOT_RE =
-  /<div\b[^>]*\bid=["']root["'][^>]*>\s*<main\b[^>]*class=["'][^"']*\bstatic-job-page\b/i;
+  /<div\b[^>]*\bid=["']?root["']?(?=[\s/>])[^>]*>\s*<main\b[^>]*class=["'][^"']*\bstatic-job-page\b/i;
 
 /**
  * Factory that creates a fresh stateful Auditor closure.

--- a/scripts/audit-h1-title-duplicates.mjs
+++ b/scripts/audit-h1-title-duplicates.mjs
@@ -23,8 +23,9 @@ import { classifyFeature, inferLocale } from './audit-title-length.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
-const NOINDEX_RE = /<meta[^>]+name=["']robots["'][^>]+content=["'][^"']*noindex/i;
-const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+const NOINDEX_RE = /<meta[^>]+name=["']?robots["']?[^>]+content=["']?[^"'>]*noindex/i;
+const META_REFRESH_RE = /<meta[^>]+http-equiv=["']?refresh["']?(?=[\s/>])/i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 const H1_RE = /<h1[^>]*>([\s\S]*?)<\/h1>/i;
 

--- a/scripts/audit-hreflang.mjs
+++ b/scripts/audit-hreflang.mjs
@@ -68,10 +68,11 @@ function walkHtmlFiles(root) {
   return out;
 }
 
-/** Return a Map<hreflang, href> parsed from one HTML file's <head>. */
+/** Return a Map<hreflang, href> parsed from one HTML file's <head>.
+ *  Quote-flexible — PR #478 baked removeAttributeQuotes upstream. */
 function extractAlternates(html) {
   const map = new Map();
-  const regex = /<link\s+rel="alternate"[^>]*hreflang="([^"]+)"[^>]*href="([^"]+)"/gi;
+  const regex = /<link\s+rel=["']?alternate["']?[^>]*hreflang=["']?([^"'\s>]+)["']?[^>]*href=["']?([^"'\s>]+)["']?/gi;
   let match;
   while ((match = regex.exec(html)) !== null) {
     map.set(match[1], match[2]);

--- a/scripts/audit-no-literal-markdown.mjs
+++ b/scripts/audit-no-literal-markdown.mjs
@@ -27,6 +27,10 @@ import { join, relative } from 'node:path';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { writeAuditReport } from './lib/auditReport.mjs';
 
+// Quote-flexible only for single-token attrs (`id`, `rel`, `name`, etc).
+// `class="..."` values are space-separated Tailwind utility classes so
+// removeAttributeQuotes (PR #478) preserves the quotes — this regex stays
+// quote-mandatory.
 const SEO_STATIC_OPEN = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b[^>]*>/i;
 const MAIN_CLOSE = /<\/main>/i;
 

--- a/scripts/audit-salary-landing-template.mjs
+++ b/scripts/audit-salary-landing-template.mjs
@@ -63,7 +63,8 @@ const PLACEHOLDER_DIV_RE = /<div\s+style="[^"]*;height:38rem;margin-top:1\.5rem"
 // redirects (handled by legacyRedirectsPlugin / shell helpers), NOT
 // salary-landing templates. Same exclusion pattern used by
 // audit-content-duplicates.mjs.
-const CANONICAL_RE = /<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i;
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+const CANONICAL_RE = /<link[^>]+rel=["']?canonical["']?[^>]*href=["']?([^"'\s>]+)["']?/i;
 
 /**
  * @param {{ limit?: number }} [opts]

--- a/scripts/audit-sitemap-canonicals.mjs
+++ b/scripts/audit-sitemap-canonicals.mjs
@@ -162,12 +162,19 @@ function locToHtmlPath(loc) {
  */
 function extractCanonical(html) {
   // Find all <link …> tags, then pick whichever has rel="canonical".
+  // Quote-flexible — PR #478 baked removeAttributeQuotes upstream. URL hrefs
+  // that end in `/` keep their quotes (upstream-rejected to avoid `/>`
+  // collision), so the double/single quote branches still match canonical URLs;
+  // the third branch handles unquoted hrefs for completeness.
   const linkRe = /<link\b[^>]*>/gi;
   let m;
   while ((m = linkRe.exec(html)) !== null) {
     const tag = m[0];
     if (!/rel\s*=\s*["']?canonical["']?/i.test(tag)) continue;
-    const href = tag.match(/href\s*=\s*"([^"]+)"/i) || tag.match(/href\s*=\s*'([^']+)'/i);
+    const href =
+      tag.match(/href\s*=\s*"([^"]+)"/i) ||
+      tag.match(/href\s*=\s*'([^']+)'/i) ||
+      tag.match(/href\s*=\s*([^"'\s>]+)/i);
     if (href && href[1]) return decodeEntities(href[1].trim());
   }
   return null;

--- a/scripts/audit-spa-bundle-injection.mjs
+++ b/scripts/audit-spa-bundle-injection.mjs
@@ -75,9 +75,15 @@ if (!fs.existsSync(DIST)) {
  *   <script type="module" crossorigin [fetchpriority="high"] src="/assets/index-{hash}.js">
  * The hash is content-addressed so it changes between builds. We only require
  * `type="module"` somewhere in the same tag and `src="/assets/index-{hash}.js"`.
+ *
+ * Quote-flexible — PR #478 baked removeAttributeQuotes upstream in htmlMinify.ts.
+ * `type="module"` → `type=module` (single token, no special chars) and
+ * `src="/assets/index-abc.js"` → `src=/assets/index-abc.js` (HTML5 allows
+ * unquoted attr values containing `/`; the only trailing-slash case is rejected
+ * upstream to avoid `/>` self-close collision, and `.js` doesn't end in `/`).
  */
 const SPA_BUNDLE_RX =
-  /<script[^>]*type="module"[^>]*src="\/assets\/index-[A-Za-z0-9_-]+\.js"/;
+  /<script[^>]*type=["']?module["']?[^>]*src=["']?\/assets\/index-[A-Za-z0-9_-]+\.js["']?/;
 
 /**
  * Per-slug index.html files MAY legitimately not contain the SPA bundle when

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -23,8 +23,9 @@ import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
-const NOINDEX_RE = /<meta[^>]+name=["']robots["'][^>]+content=["'][^"']*noindex/i;
-const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+const NOINDEX_RE = /<meta[^>]+name=["']?robots["']?[^>]+content=["']?[^"'>]*noindex/i;
+const META_REFRESH_RE = /<meta[^>]+http-equiv=["']?refresh["']?(?=[\s/>])/i;
 
 // Single combined strip regex (was 8 sequential .replace() calls). Each
 // alternative captures one strip category: HTML comments, DOCTYPE, opaque

--- a/scripts/audit-title-length.mjs
+++ b/scripts/audit-title-length.mjs
@@ -36,8 +36,10 @@ import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
-const NOINDEX_RE = /<meta[^>]+name=["']robots["'][^>]+content=["'][^"']*noindex/i;
-const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream, so single-
+// token attribute values lose their quotes in dist/. See audit-footer-root-presence.mjs.
+const NOINDEX_RE = /<meta[^>]+name=["']?robots["']?[^>]+content=["']?[^"'>]*noindex/i;
+const META_REFRESH_RE = /<meta[^>]+http-equiv=["']?refresh["']?(?=[\s/>])/i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 
 function normalizeText(raw) {

--- a/scripts/audit-title-no-disambig-hash.mjs
+++ b/scripts/audit-title-no-disambig-hash.mjs
@@ -24,8 +24,9 @@ import { classifyFeature, inferLocale } from './audit-title-length.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
-const NOINDEX_RE = /<meta[^>]+name=["']robots["'][^>]+content=["'][^"']*noindex/i;
-const META_REFRESH_RE = /<meta[^>]+http-equiv=["']refresh["']/i;
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+const NOINDEX_RE = /<meta[^>]+name=["']?robots["']?[^>]+content=["']?[^"'>]*noindex/i;
+const META_REFRESH_RE = /<meta[^>]+http-equiv=["']?refresh["']?(?=[\s/>])/i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 // Matches " (#" + 8 hex chars + ")". Emitted by the title-disambig path.
 const HASH_RE = /\(#[0-9a-f]{8}\)/;

--- a/scripts/audit-title-uniqueness.mjs
+++ b/scripts/audit-title-uniqueness.mjs
@@ -132,11 +132,12 @@ function extractHeadTitle(head) {
  * into one indexed page via the canonical signal, so counting them as
  * duplicate <title> collisions is a false positive.
  */
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
 function extractCanonical(head) {
-  const m = /<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i.exec(head);
+  const m = /<link[^>]+rel=["']?canonical["']?[^>]*href=["']?([^"'\s>]+)["']?/i.exec(head);
   if (m) return m[1].trim();
   // Alternate attribute order: href before rel.
-  const m2 = /<link[^>]+href=["']([^"']+)["'][^>]*rel=["']canonical["']/i.exec(head);
+  const m2 = /<link[^>]+href=["']?([^"'\s>]+)["']?[^>]*rel=["']?canonical["']?/i.exec(head);
   return m2 ? m2[1].trim() : null;
 }
 
@@ -148,7 +149,8 @@ function extractCanonical(head) {
  * Caller must pass extractHead() output.
  */
 function hasNoindex(head) {
-  const m = /<meta[^>]+name=["']robots["'][^>]*content=["']([^"']+)["']/i.exec(head);
+  // Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+  const m = /<meta[^>]+name=["']?robots["']?[^>]*content=["']?([^"'>]+?)["']?\s*\/?>/i.exec(head);
   if (!m) return false;
   return /\bnoindex\b/i.test(m[1]);
 }

--- a/scripts/lib/audit-runner.mjs
+++ b/scripts/lib/audit-runner.mjs
@@ -90,8 +90,13 @@ export const DEFAULT_DIST = join(ROOT, 'dist');
 
 const RX_TITLE         = /<title[^>]*>([\s\S]*?)<\/title>/i;
 const RX_H1            = /<h1[^>]*>([\s\S]*?)<\/h1>/i;
-const RX_NOINDEX       = /<meta\s+name=["']robots["']\s+content=["'][^"']*\bnoindex\b/i;
-const RX_META_REFRESH  = /<meta\s+http-equiv=["']refresh["'][^>]*url=/i;
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream so single-token
+// attribute values lose their quotes in dist/. `name=robots`, `http-equiv=refresh`,
+// `name=author`, etc. — all now appear unquoted. The `application/ld+json` value
+// contains a `/` and `+`, so the upstream minifier keeps its quotes (HTML5 spec
+// rules out unquoted values containing those chars), and that regex stays as-is.
+const RX_NOINDEX       = /<meta\s+name=["']?robots["']?\s+content=["']?[^"'>]*\bnoindex\b/i;
+const RX_META_REFRESH  = /<meta\s+http-equiv=["']?refresh["']?[^>]*url=/i;
 const RX_JSONLD_SCRIPT = /<script\s+[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
 
 /**

--- a/scripts/validate-canonical.mjs
+++ b/scripts/validate-canonical.mjs
@@ -58,9 +58,10 @@ function findHtmlFile(url) {
   return null;
 }
 
-// Extract canonical URL from HTML content
+// Extract canonical URL from HTML content.
+// Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
 function extractCanonical(content) {
-  const match = content.match(/<link\s+rel="canonical"\s+href="([^"]+)"/);
+  const match = content.match(/<link\s+rel=["']?canonical["']?\s+href=["']?([^"'\s>]+)["']?/);
   return match ? match[1] : null;
 }
 

--- a/scripts/validate-content-quality.mjs
+++ b/scripts/validate-content-quality.mjs
@@ -87,7 +87,8 @@ function isIndividualJobPage(path) {
 }
 
 function hasNoindex(html) {
-  return /<meta[^>]*name=["']robots["'][^>]*content=["'][^"']*noindex/i.test(html);
+  // Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+  return /<meta[^>]*name=["']?robots["']?[^>]*content=["']?[^"'>]*noindex/i.test(html);
 }
 
 function main() {

--- a/scripts/validate-hreflang.mjs
+++ b/scripts/validate-hreflang.mjs
@@ -37,8 +37,9 @@ function sitemapPages() {
 }
 
 function extractAlternates(html) {
+ // Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
  const out = new Map();
- const regex = /<link\s+rel="alternate"[^>]*hreflang="([^"]+)"[^>]*href="([^"]+)"/gi;
+ const regex = /<link\s+rel=["']?alternate["']?[^>]*hreflang=["']?([^"'\s>]+)["']?[^>]*href=["']?([^"'\s>]+)["']?/gi;
  let match;
  while ((match = regex.exec(html)) !== null) out.set(match[1], match[2]);
  return out;

--- a/scripts/validate-internal-links.mjs
+++ b/scripts/validate-internal-links.mjs
@@ -31,8 +31,12 @@ function sitemapPages() {
 }
 
 function extractInternalLinks(html, pageUrl) {
+ // Quote-flexible — PR #478 baked removeAttributeQuotes upstream. <a href="...">
+ // becomes <a href=...> for URLs without spaces/quotes/=/<>/backtick AND that
+ // don't end in `/` (trailing-slash collision with `/>` self-close is rejected
+ // upstream, so trailing-`/` URLs keep their quotes — both forms appear in dist).
  const out = new Set();
- const regex = /<a\b[^>]*href="([^"]+)"/gi;
+ const regex = /<a\b[^>]*href=["']?([^"'\s>]+)["']?/gi;
  let match;
  while ((match = regex.exec(html)) !== null) {
   const raw = match[1].trim();

--- a/scripts/validate-jobs-rich-results-sample.mjs
+++ b/scripts/validate-jobs-rich-results-sample.mjs
@@ -191,7 +191,15 @@ function validateJobPosting(jobPosting, html, job, localeCode) {
 
   const expectedSlug = resolveSlugForLocale(job, localeCode);
   const canonicalNeedle = `/` + (localeCode === 'it' ? '' : `${localeCode}/`) + `${LOCALES.find((l) => l.code === localeCode).segment}/${expectedSlug}/`;
-  if (!html.includes(`<link rel="canonical" href="${BASE_URL}${canonicalNeedle}">`)) {
+  // Quote-flexible — PR #478 baked removeAttributeQuotes upstream. Canonical
+  // URLs ending in `/` keep their quotes (the upstream `/`-trailing rejection
+  // avoids `/>` self-close collision), so both `href="…/"` and `href=…/` are
+  // valid shapes in dist/.
+  const canonicalUrl = `${BASE_URL}${canonicalNeedle}`;
+  const canonicalRe = new RegExp(
+    `<link\\s+rel=["']?canonical["']?\\s+href=["']?${canonicalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']?`,
+  );
+  if (!canonicalRe.test(html)) {
     warnings.push('canonical:mismatch_or_missing');
   }
 

--- a/scripts/validate-sitemap-pages.mjs
+++ b/scripts/validate-sitemap-pages.mjs
@@ -150,10 +150,11 @@ function countWords(text) {
   return text.split(' ').filter(w => w.length > 0).length;
 }
 
-/** soft404 + content-quality both use this exact noindex regex shape. */
+/** soft404 + content-quality both use this exact noindex regex shape.
+ *  Quote-flexible — PR #478 baked removeAttributeQuotes upstream. */
 function hasNoindex(html) {
   // soft404 uses match(); content-quality uses test() — same intent, same outcome.
-  return /<meta[^>]*name=["']robots["'][^>]*content=["'][^"']*noindex/i.test(html);
+  return /<meta[^>]*name=["']?robots["']?[^>]*content=["']?[^"'>]*noindex/i.test(html);
 }
 
 function hasJobPostingSchema(html) {
@@ -281,7 +282,8 @@ function findHtmlFile_vc(url) {
 }
 
 function extractCanonical_vc(content) {
-  const match = content.match(/<link\s+rel="canonical"\s+href="([^"]+)"/);
+  // Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+  const match = content.match(/<link\s+rel=["']?canonical["']?\s+href=["']?([^"'\s>]+)["']?/);
   return match ? match[1] : null;
 }
 

--- a/scripts/validate-sitemap.mjs
+++ b/scripts/validate-sitemap.mjs
@@ -26,7 +26,8 @@ function collectIndexablePages(dir, out = []) {
   }
   const relPath = '/' + rel.replace(/\/index\.html$/, '');
   const html = readFileSync(full, 'utf-8');
-  if (/<meta[^>]*name=["']robots["'][^>]*content=["'][^"']*noindex/i.test(html)) continue;
+  // Quote-flexible — PR #478 baked removeAttributeQuotes upstream.
+  if (/<meta[^>]*name=["']?robots["']?[^>]*content=["']?[^"'>]*noindex/i.test(html)) continue;
   if (html.includes('__BRIDGE_TARGET_SLUG__')) continue;
   if (html.includes('<script>location.replace(')) continue;
   out.push(normalize(relPath));

--- a/scripts/validate-soft404.mjs
+++ b/scripts/validate-soft404.mjs
@@ -72,9 +72,10 @@ function extractVisibleText(html) {
     .trim();
 }
 
-/** Check if a page has noindex in its robots meta tag. */
+/** Check if a page has noindex in its robots meta tag.
+ *  Quote-flexible — PR #478 baked removeAttributeQuotes upstream. */
 function hasNoindex(html) {
-  const match = html.match(/<meta\s+name=["']robots["']\s+content=["']([^"']+)["']/i);
+  const match = html.match(/<meta\s+name=["']?robots["']?\s+content=["']?([^"'>]+?)["']?\s*\/?>/i);
   return match ? match[1].toLowerCase().includes('noindex') : false;
 }
 


### PR DESCRIPTION
PR #478 baked `removeAttributeQuotes` upstream in build-plugins/shared/htmlMinify.ts,
so every dist HTML file now has unquoted single-token attribute values:
`id="footer-root"` → `id=footer-root`, `name="robots"` → `name=robots`,
`rel="canonical"` → `rel=canonical`, `type="module"` → `type=module`, etc.

Run 26255102850's validate-dist failed on 4 audit suites with massive false
positives because their regexes still required quotes:

  - audit:all (footer-root-presence 174k, h1-title-duplicates 399k,
    title-length 3423, title-no-disambig-hash 1078, text-html-ratio 826,
    salary-landing-template 1834, content-duplicates 8957, no-literal-markdown 25)
  - validate:sitemap-pages
  - audit:spa-bundle-injection
  - audit:sitemap-canonicals

This commit updates every audit/validate script that walks dist/ HTML to use
quote-flexible regexes (`["']?text["']?` instead of `["']text["']`, and
`["']?([^"'\s>]+)["']?` for value captures). Same semantic check, just
tolerant of both the pre-minify and post-minify attribute shapes.

`class="..."` values are space-separated Tailwind utility classes so the
upstream minifier preserves their quotes — those regexes stay quote-mandatory.
`application/ld+json` contains `/` and `+` which HTML5 disallows in unquoted
attr values — quotes preserved upstream, regex unchanged.

Files updated (23):
  scripts/lib/audit-runner.mjs (shared RX_NOINDEX, RX_META_REFRESH)
  scripts/audit-footer-root-presence.mjs (id="footer-root", id="root")
  scripts/audit-{h1-title-duplicates,text-html-ratio,title-length,title-no-disambig-hash}.mjs (noindex)
  scripts/audit-{content-duplicates,dist-multi,salary-landing-template,title-uniqueness}.mjs (canonical+noindex)
  scripts/audit-{hreflang,cannibalization}.mjs (canonical/hreflang/href)
  scripts/audit-no-literal-markdown.mjs (comment-only; class= regex stays quoted)
  scripts/audit-sitemap-canonicals.mjs (3rd href branch for unquoted)
  scripts/audit-spa-bundle-injection.mjs (type=module + src=/assets/…)
  scripts/validate-{canonical,content-quality,hreflang,internal-links,sitemap,sitemap-pages,soft404}.mjs
  scripts/validate-jobs-rich-results-sample.mjs (literal includes → quote-flex regex)
