### PR TITLE
fix(seo): strip literal markdown from job titles before <main> render

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -376,6 +376,41 @@ export function composeJobPageH1(jobTitle: string, company: string): string {
  return cleanCompany ? `${jobTitle} — ${cleanCompany}` : jobTitle;
 }
 
+/**
+ * Strip literal markdown bold/separator tokens that leak from AI-translated
+ * crawler titles. The shared description parser only runs on body text — job
+ * titles flow through `esc()` (HTML-escape only) into <h1>, related-jobs
+ * sidebar, and aria-labels. When a crawler/translation leaves `**Title**`
+ * intact, the literal asterisks render in <main>, blowing the 0-tolerance
+ * `audit-no-literal-markdown` gate (PR #480 incident — 27 job-detail pages
+ * with `**Diplomierte Pflegefachperson HF / FH (40-100%)**` leaked from
+ * `titleByLocale`/`title`).
+ *
+ * Contract:
+ *  - `**X**` → `X` (single pair). Repeats for chained bold runs.
+ *  - `_X_`   → `X` (only when both delimiters touch the title's edges or
+ *               whitespace, to avoid mangling identifiers like `HFR_M_42`).
+ *  - `===…`, `___…`, `~~~…` separator runs (3+ chars) → stripped wholesale.
+ *  - Single leading/trailing `*` chars (orphan asterisks from unbalanced
+ *    bold runs that survived odd-count stripping in parseInline) → removed.
+ *  - Collapses any double-spaces left over from stripping.
+ *
+ * Idempotent (running twice produces the same output).
+ */
+export function stripLiteralMarkdownFromTitle(title: string): string {
+ if (!title) return title;
+ let t = String(title);
+ // Bold pairs — non-greedy body, no newline (titles are single-line).
+ t = t.replace(/\*\*([^*\n]+?)\*\*/g, '$1');
+ // Separator runs (3+ of `_`, `=`, `~`) — drop.
+ t = t.replace(/[_=~]{3,}/g, ' ');
+ // Orphan leading/trailing single `*` and double `**` (unbalanced survivors).
+ t = t.replace(/^\s*\*+\s*/, '').replace(/\s*\*+\s*$/, '');
+ // Collapse any double-spaces created by the strips.
+ t = t.replace(/[ \t]{2,}/g, ' ');
+ return t.trim();
+}
+
 // ─── Human-readable disambiguator cascade ─────────────────────────────────
 //
 // When two job postings share the same `<title>` base (job-title + company
@@ -1957,7 +1992,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // The page itself is still emitted with its own URL (breadcrumbs,
  // JobPosting, etc. describe THIS page) so existing backlinks resolve.
  const effectiveCanonicalUrl = resolveCanonicalUrl(perLocaleSlug[locale], canonicalUrl);
- const localizedTitle = String(job?.titleByLocale?.[locale] || job.title || '');
+ const localizedTitle = stripLiteralMarkdownFromTitle(String(job?.titleByLocale?.[locale] || job.title || ''));
  const jobLocation = String(job.location || '').trim();
  const dc = CANTON_DISPLAY[String(job.canton || DEFAULT_CANTON)] || String(job.canton || DEFAULT_CANTON);
  // City-aware title: always includes location when available, then truncates
@@ -2098,7 +2133,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  .map((r: any) => {
  const rp = `${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}/${localizedSlug(r, locale)}`.replace(/\/+/g, '/');
  const href = `${BASE_URL}${withSlash(rp)}`;
- const relatedTitle = String(r?.titleByLocale?.[locale] || r.title || '');
+ const relatedTitle = stripLiteralMarkdownFromTitle(String(r?.titleByLocale?.[locale] || r.title || ''));
  const rLogo = companyLogo(r);
  const rSalary = (() => {
  if (!r.salaryMin) return '';


### PR DESCRIPTION
audit-no-literal-markdown flagged 27 job-detail pages in run 26260198244
with literal `**Diplomierte Pflegefachperson HF / FH (40–100%)**` (and
similar Swiss-German bold-title leaks) inside <main>. Sample paths:
  - dist/cerca-lavoro-ticino/tecnico-di-sala-operatoria-m-f-d-80-100-kantonsspital-uri-altdorf/
  - dist/cerca-lavoro-ticino/professionnel-in-dipl-specialiste-des-soins-infirmiers-hf-fh-spital-limmattal-schlieren/
  - 25 more

Root cause: the shared description parser (`build-plugins/shared/jobDescription/parser.ts`)
only runs on body text. Job titles (`titleByLocale` / `title`) flow through
`esc()` (HTML-escape only) into:
  - `<h1>` (line 2347 via composeJobPageH1(localizedTitle))
  - related-jobs sidebar `.rjt` div + aria-label (line 2116 via relatedTitle)

When an AI-translation pass leaves `**Title**` markers intact in the
crawler title, `esc()` preserves the asterisks. The 0-tolerance audit
gate (CLAUDE.md rule #1 — no threshold-lowering) blocks deploy.

Fix: new `stripLiteralMarkdownFromTitle()` helper applied at the two
emission points (lines 1960 + 2101). Strips:
  - `**X**` → `X` (idempotent over chained bold runs)
  - `___`/`===`/`~~~` separator runs (3+ chars) → space
  - Orphan leading/trailing `*`/`**` (unbalanced bold survivors)
  - Collapses double-spaces created by the strips

Localised to titles (not body) so it doesn't reformat description prose
already handled by parseInline. Same semantic content, cleaner shape.
