### PR TITLE
fix(seo): strip markdown from card titles + parse long separator runs (round 2)

### DIFF
--- a/build-plugins/shared/jobCardHtml.ts
+++ b/build-plugins/shared/jobCardHtml.ts
@@ -25,6 +25,26 @@ import {
 
 export { resolveJobCardLogo, escHtml };
 
+/**
+ * Strip literal markdown markers from a job title before it lands in <h3>.
+ * The shared description parser only runs on body text — titles flow through
+ * `escHtml()` raw, so AI-translation leaks like `**Title**` survive into the
+ * card markup and trigger the 0-tolerance `audit-no-literal-markdown` gate.
+ * Mirrors the helper of the same name in build-plugins/jobsSeoPagesPlugin.ts
+ * (kept duplicated to avoid a circular import between the plugin and this
+ * shared file). Contract: `**X**` → `X`, separator runs (3+ of `_`/`=`/`~`) → space,
+ * orphan leading/trailing `*` removed, double-spaces collapsed. Idempotent.
+ */
+function stripLiteralMarkdownFromTitle(title: string): string {
+  if (!title) return title;
+  let t = String(title);
+  t = t.replace(/\*\*([^*\n]+?)\*\*/g, '$1');
+  t = t.replace(/[_=~]{3,}/g, ' ');
+  t = t.replace(/^\s*\*+\s*/, '').replace(/\s*\*+\s*$/, '');
+  t = t.replace(/[ \t]{2,}/g, ' ');
+  return t.trim();
+}
+
 export type JobCardLocale = 'it' | 'en' | 'de' | 'fr';
 
 /**
@@ -221,7 +241,9 @@ export function renderJobCardHtml(
 
   const titleSource =
     (job.titleByLocale && job.titleByLocale[locale]) || job.title || '';
-  const title = String(titleSource).replace(/\s+/g, ' ').trim();
+  const title = stripLiteralMarkdownFromTitle(
+    String(titleSource).replace(/\s+/g, ' ').trim(),
+  );
   const company = String(job.company || '').trim();
   const rawLocation = String(job.location || job.addressLocality || '').trim();
   const cantonStr = job.canton ? ` (${escHtml(String(job.canton))})` : '';

--- a/build-plugins/shared/jobDescription/parser.ts
+++ b/build-plugins/shared/jobDescription/parser.ts
@@ -146,6 +146,13 @@ function preprocess(raw: string): string {
   // paragraph break first so the subsequent SEPARATOR_LINE_RE filter drops
   // them. Audit: no-literal-markdown 0-tol (CLAUDE.md rule #1).
   s = s.replace(/[ \t]+[_=~]{3,}[ \t]+/g, '\n\n');
+  // PR #481 follow-up: above only catches separator runs with whitespace on
+  // BOTH sides. AMEOS / Hôpital Fribourgeois descriptions sometimes flatten
+  // to literal `text________________…________________text` (64+ chars, no
+  // surrounding whitespace) — those slip through and trip
+  // audit-no-literal-markdown. Any run of 6+ `_`/`=`/`~` is unambiguously a
+  // visual divider (no real identifier has that long a run), strip wholesale.
+  s = s.replace(/[_=~]{6,}/g, '\n\n');
 
   s = s.replace(/;\s*([A-ZÀ-ÖØ-Þ][^.;!?\n]{1,80}[:：])/g, '\n$1');
   s = s.replace(/([a-zà-öø-þ.0-9%])\s*;\s*([A-ZÀ-ÖØ-Þ][a-zà-öø-þ])/g, '$1\n- $2');


### PR DESCRIPTION
Round-1 (PR #481) shipped `stripLiteralMarkdownFromTitle` in
jobsSeoPagesPlugin.ts and applied it to `localizedTitle` (job detail H1)
and `relatedTitle` (related-jobs sidebar). Reduced offenders 27 → 4 in
run 26264463075. The 4 surviving leaks split into two paths:

1. **Company hub at /cerca-lavoro-ticino/azienda-regiospitex-limmattal/**
   listed each company job via `renderJobCardHtml` (shared), which
   extracts `job.titleByLocale[locale] || job.title` raw and emits it
   under `<h3>${escHtml(title)}</h3>`. AI-translated titles like
   `**Diplomierte Pflegefachperson HF / FH (40-100%)**` leaked into
   <main>. Fix: duplicate the small `stripLiteralMarkdownFromTitle`
   helper into build-plugins/shared/jobCardHtml.ts (no circular import
   risk — same regex contract, mirrored docstring) and apply on line 224
   right after the whitespace-collapse trim.

2. **3 AMEOS/HFR descriptions** carried literal
   `________________________________________________________________`
   (64+ underscores) flush with surrounding text — no whitespace on
   either side. The existing mid-line strip
   `/[ \t]+[_=~]{3,}[ \t]+/g` requires whitespace on BOTH sides so it
   skipped these. Added unconditional strip `/[_=~]{6,}/g` → `\n\n` in
   `preprocess()`. No real identifier has 6+ underscore/equal/tilde
   chars, so the threshold avoids touching legitimate tokens.

Both fixes preserve content semantics. Parser tests
(tests/job-description-parser.test.ts) still green (22/22).
