### PR TITLE
fix(seo): strip 60+ char separator runs from job description body (audit:no-literal-markdown)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -1284,13 +1284,19 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  return s;
  };
  const splitIntoParagraphs = (s: string): string[] => {
- const viaBreaks = String(s || '')
+ // AI-translation flattening collapses paragraph breaks around visual
+ // dividers (e.g. HFR `Ref.: HFR-M-251801 ____________ Le Département`).
+ // Treat any run of 6+ `_`/`=`/`~` as an explicit paragraph break before
+ // splitting so the divider doesn't leak into a paragraph body and trip
+ // audit:no-literal-markdown (CLAUDE.md rule #1, 0-tolerance).
+ const normalized = String(s || '').replace(/[_=~]{6,}/g, '\n\n');
+ const viaBreaks = normalized
  .replace(/\r/g, '\n')
  .split(/\n{2,}/)
  .map((p) => p.trim())
  .filter((p) => p.length > 40);
  if (viaBreaks.length >= 2) return viaBreaks;
- return normalizeText(s)
+ return normalizeText(normalized)
  .split(/(?<=[.!?])\s+/)
  .map((p) => p.trim())
  .filter((p) => p.length > 40);

--- a/build-plugins/shared/jobDescription/toHtml.ts
+++ b/build-plugins/shared/jobDescription/toHtml.ts
@@ -103,7 +103,16 @@ function stripExternalHtmlAttributes(s: string): string {
 
 export function inlineTextToHtml(text: string): string {
   if (!text) return '';
-  const s = String(text);
+  // Strip separator runs (6+ `_`/`=`/`~`) that AI-translation flattening
+  // sometimes leaves mid-paragraph. The full parser preprocess catches
+  // these for block-level rendering, but `inlineTextToHtml` runs on
+  // already-split paragraphs (jobsSeoPagesPlugin#summaryHtml /
+  // sectionHtml) and must scrub them itself or they leak into
+  // `<main class="seo-static-content">` and trip
+  // audit:no-literal-markdown (0-tolerance, CLAUDE.md rule #1).
+  // Real example: HFR ("Hôpital fribourgeois") descriptions flatten
+  // bilingual DE/FR copy to `Ref.: HFR-M-251801 ____________ Le Département…`.
+  const s = String(text).replace(/[_=~]{6,}/g, ' ').replace(/ {2,}/g, ' ');
   if (/<(strong|em|a|span|br)\b/i.test(s)) {
     return stripExternalHtmlAttributes(s);
   }

--- a/tests/seo/inline-text-to-html-sanitize.test.ts
+++ b/tests/seo/inline-text-to-html-sanitize.test.ts
@@ -80,6 +80,31 @@ describe('inlineTextToHtml — passthrough HTML attribute sanitization', () => {
     expect(out).toBe('<span>a</span> <a href="/x">b</a> <br>');
   });
 
+  // Regression: HFR-style flattened bilingual descriptions where the
+  // original paragraph break became a 60+ underscore divider.
+  // audit:no-literal-markdown (0-tolerance) failed on 4 job pages in
+  // workflow run #26264463075 because `inlineTextToHtml` left these
+  // separator runs in the body of `<main class="seo-static-content">`.
+  // See build-plugins/shared/jobDescription/toHtml.ts.
+  describe('separator-run scrub (audit:no-literal-markdown 0-tol)', () => {
+    it('drops 6+ underscore runs (HFR pattern)', () => {
+      const sixtyThree = '_'.repeat(63);
+      const input = `Ref.: HFR-M-251801 ${sixtyThree} Le Département`;
+      const out = inlineTextToHtml(input);
+      expect(out).not.toMatch(/_{3,}/);
+      expect(out).toContain('Ref.: HFR-M-251801');
+      expect(out).toContain('Le Département');
+    });
+    it('drops 6+ equals/tilde runs', () => {
+      expect(inlineTextToHtml('a =========== b')).not.toMatch(/={3,}/);
+      expect(inlineTextToHtml('a ~~~~~~~~~~ b')).not.toMatch(/~{3,}/);
+    });
+    it('leaves short underscore tokens alone (real text, not dividers)', () => {
+      expect(inlineTextToHtml('snake_case identifier')).toContain('snake_case');
+      expect(inlineTextToHtml('a __b__ c')).toContain('__b__');
+    });
+  });
+
   it('Bachem real-world fixture', () => {
     const input =
       'Ihre Aufgaben:\n\n<span style="font-size:12.0pt;line-height:107%;font-family:"Times New Roman", serif;">' +


### PR DESCRIPTION
audit:no-literal-markdown failed deploy run #26264463075 with 4 of
169,328 job detail pages carrying literal `___...___` runs in
`<main class="seo-static-content">`. Source: HFR (Hôpital fribourgeois)
descriptions where AI-translation flattening collapsed the
DE/FR paragraph break around a visual divider, producing
`Ref.: HFR-M-251801 _______________________________________ Le Département…`
inline.

Two gates leaked:

- `splitIntoParagraphs` (jobsSeoPagesPlugin.ts) split on `\n{2,}` and
  sentence boundaries, so the divider survived into the paragraph body.
- `inlineTextToHtml` (toHtml.ts) only ran `parseInline` — block-level
  preprocess (which already strips `[_=~]{6,}`) never fires for
  already-split paragraphs.

Both now treat 6+ `_`/`=`/`~` runs as paragraph breaks / whitespace
before rendering. `parseJobDescription` (the third path) already
handles them. Regression covered by
tests/seo/inline-text-to-html-sanitize.test.ts.
