### PR TITLE
fix(crawler): scrub mid-line separator runs at source (defense-in-depth for audit:no-literal-markdown)

### DIFF
--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -323,6 +323,17 @@ export function cleanCrawlerArtifacts(text) {
   // 1. Drop empty / whitespace-only bolds (e.g. "** **", "**  **", "** : **")
   s = s.replace(/\*\*\s*[\s:;,.\-–—]*\s*\*\*/g, ' ');
 
+  // 1b. Convert mid-line separator runs (6+ `_`/`=`/`~`) to paragraph breaks.
+  // AI-translation flattening occasionally collapses paragraph boundaries
+  // around visual dividers, producing patterns like
+  // `Ref.: HFR-M-251801 _______________________________________ Le Département…`
+  // on a single line. Step 2 below only catches WHOLE separator-only lines,
+  // step 3 only TRAILING runs — neither catches mid-line. Splitting here
+  // restores the original paragraph structure so the rest of the pipeline
+  // (and audit:no-literal-markdown, CLAUDE.md rule #1, 0-tolerance) stays
+  // clean even when the runtime parser is bypassed.
+  s = s.replace(/[_=~]{6,}/g, '\n\n');
+
   // 2. Strip standalone separator-only lines ("______", "===", "----")
   s = s
     .split('\n')

--- a/tests/scripts/clean-crawler-artifacts-separator.test.ts
+++ b/tests/scripts/clean-crawler-artifacts-separator.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression test for `cleanCrawlerArtifacts` mid-line separator scrub
+ * (scripts/lib/crawler-template.mjs step 1b).
+ *
+ * audit:no-literal-markdown (0-tolerance, CLAUDE.md rule #1) failed on
+ * HFR (Hôpital fribourgeois) job pages in runs #26264463075 and
+ * #26268380310 because AI-translation flattening produced patterns like
+ * `Ref.: HFR-M-251801 ____________ Le Département…` on a single line.
+ * Step 2 only catches whole separator-only lines; step 3 only trailing
+ * runs. This test pins down the mid-line case at the source so it can
+ * never leak past assemble-jobs-dataset.mjs regardless of which renderer
+ * downstream code uses.
+ */
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — .mjs without types
+import { cleanCrawlerArtifacts } from '../../scripts/lib/crawler-template.mjs';
+
+describe('cleanCrawlerArtifacts — mid-line separator runs', () => {
+  it('strips 60+ underscore run from HFR description', () => {
+    const input =
+      `Ref.: HFR-M-251801 ${'_'.repeat(63)} Le Département de médecine ` +
+      `interne et spécialités dispose d'un Service de référence.`;
+    const out: string = cleanCrawlerArtifacts(input);
+    expect(out).not.toMatch(/_{3,}/);
+    expect(out).toContain('Ref.: HFR-M-251801');
+    expect(out).toContain('Le Département');
+  });
+
+  it('strips 6+ equals / tilde runs', () => {
+    expect(cleanCrawlerArtifacts('a ============= b')).not.toMatch(/={3,}/);
+    expect(cleanCrawlerArtifacts('a ~~~~~~~~~~~~ b')).not.toMatch(/~{3,}/);
+  });
+
+  it('preserves short underscore tokens (snake_case, markdown bold tokens)', () => {
+    expect(cleanCrawlerArtifacts('snake_case identifier')).toContain('snake_case');
+    expect(cleanCrawlerArtifacts('a __b__ c')).toContain('__b__');
+  });
+
+  it('idempotent on already-clean text', () => {
+    const clean = 'Le Département de médecine interne.\n\nProfile recherché.';
+    expect(cleanCrawlerArtifacts(cleanCrawlerArtifacts(clean))).toBe(
+      cleanCrawlerArtifacts(clean),
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to PR #484. PR #484 fixed the two render gates
(splitIntoParagraphs + inlineTextToHtml) — this commit adds the
matching scrub at the source of truth, so data/jobs.json itself
never carries `[_=~]{6,}` runs regardless of which downstream
renderer consumes it.

Steps 2 and 3 of cleanCrawlerArtifacts already strip whole
separator-only lines and trailing runs, but mid-line separators
slip past — exactly the HFR pattern (`Ref.: HFR-M-251801
___________________________________________ Le Département…`)
that tripped audit:no-literal-markdown in runs #26264463075
and #26268380310. New step 1b converts any run of 6+ `_`/`=`/`~`
to a paragraph break BEFORE the existing line-level filters, so
step 2 then drops the resulting separator-only line.

Regression test pins the HFR pattern down at the source.
