### PR TITLE
fix(seo): static job body — no truncation, no duplicate, render markdown

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2080,13 +2080,20 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const canonicalProcess = cleanItems(canonicalLocale?.process, 8);
  const canonicalKeywords = cleanItems(canonicalLocale?.keywords, 8);
  const fallbackParagraphs = [cantonPracticalNote0(locale, dc), ...localeCopy[locale].practicalNotes.slice(1)];
+ // When _canonical is missing we ARE the only body content — keep the full
+ // paragraph set (capped at 10 to match `descriptionParagraphs`) so jobs
+ // with a real markdown description (headings + bullets + sede/contract
+ // footer) don't lose Nutanix/VDI/Sede/Tempo indeterminato signals.
+ // When canonical IS present, summary is a short lede so 3-4 paragraphs is
+ // plenty and we stay byte-budget friendly.
+ const hasCanonical = canonicalSummary.length > 0;
  const bodyParagraphs = (descriptionParagraphs.length >= 3
- ? descriptionParagraphs.slice(0, 3)
+ ? (hasCanonical ? descriptionParagraphs.slice(0, 3) : descriptionParagraphs.slice(0, 10))
  : [localizedDescription, ...fallbackParagraphs]
  )
  .filter((p) => p && p.length > 25)
- .slice(0, 4);
- const summaryParagraphs = canonicalSummary.length > 0 ? canonicalSummary : bodyParagraphs;
+ .slice(0, hasCanonical ? 4 : 10);
+ const summaryParagraphs = hasCanonical ? canonicalSummary : bodyParagraphs;
  const mergedRequirements = canonicalRequirements.length > 0 ? canonicalRequirements : requirements;
  const logoUrl = companyLogo(job);
  // Related jobs cross-link block — densifies BFS reachability so the
@@ -2157,16 +2164,20 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  return `<li class="rj"><a href="${href}" aria-label="${esc(relatedTitle)} — ${esc(r.company)}" class="rja">${rLogoImg}<div class="rjw"><div class="rjt">${esc(relatedTitle)}</div><div class="rjs">${esc(r.company)} · ${esc(r.location)}${r.canton ? ` (${esc(r.canton)})` : ''}</div>${rSalary ? `<div class="rjp">${esc(rSalary)}</div>` : ''}</div></a></li>`;
  })
  .join('');
- // Visible body paragraphs / bullets go through `inlineTextToHtml` so
- // literal markdown bold (`**foo**`) and italic markers from
- // AI-translated descriptions render as <strong>/<em> instead of leaking
- // as plain text. audit:no-literal-markdown is a 0-tolerance gate.
+ // Body paragraphs go through `jobDescriptionTextToHtml` (full block-level
+ // parser) so AI-untouched descriptions with `### Heading` / `**bold**` /
+ // `• bullet` markdown render as proper <h3>/<strong>/<ul>. `inlineTextToHtml`
+ // only handles inline markers so headings/lists would leak as literal text
+ // and trip audit:no-literal-markdown (0-tolerance, CLAUDE.md rule #1).
+ // The parser already emits its own block wrappers (<p>/<h3>/<ul>), so we
+ // do NOT add an outer <p>; canonical summary items (clean one-sentence
+ // strings) still render as a single <p> via the parser.
  const summaryHtml = summaryParagraphs
- .map((p) => `<p>${inlineTextToHtml(p)}</p>`)
+ .map((p) => jobDescriptionTextToHtml(p))
  .join('');
  const isSubheadItem = (value: string) => /^(requisiti necessari|requisiti auspicati|required|preferred)$/i.test(normalizeText(value));
  const sectionHtml = (heading: string, paragraphs: string[], bullets: string[]) => {
- const paragraphsHtml = paragraphs.map((p) => `<p>${inlineTextToHtml(p)}</p>`).join('');
+ const paragraphsHtml = paragraphs.map((p) => jobDescriptionTextToHtml(p)).join('');
  const bulletsHtml = bullets.length > 0
  ? `<ul>${bullets.map((item) => `<li${isSubheadItem(item) ? ' class="subhead"' : ''}>${inlineTextToHtml(item)}</li>`).join('')}</ul>`
  : '';
@@ -2442,7 +2453,7 @@ ${hreflangHtml}
  ${summaryHtml}
  </section>
  <div class="timeline">
- ${timelineHtml || `<div class="timeline-step">${sectionHtml(localeCopy[locale].descriptionLabel, bodyParagraphs, [])}</div>`}
+ ${timelineHtml || (hasCanonical ? `<div class="timeline-step">${sectionHtml(localeCopy[locale].descriptionLabel, bodyParagraphs, [])}</div>` : '')}
  </div>
  <a href="${referralUrl(job.url || canonicalUrl, job)}" rel="noopener noreferrer" class="cta">${esc(localeCopy[locale].applyNow)}</a>
  </article>

--- a/tests/seo/static-job-page-body.test.ts
+++ b/tests/seo/static-job-page-body.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression test for the no-canonical body fallback in
+ * `build-plugins/jobsSeoPagesPlugin.ts`.
+ *
+ * When a job has NOT yet been AI-structured (translate-pending-jobs.yml
+ * hasn't filled `_canonical`), the static job-detail page must still:
+ *   1. Render the FULL description (no 3-paragraph truncation that drops
+ *      Requisiti / Sede / contract footer).
+ *   2. NOT print the same paragraphs twice (Panoramica + timeline fallback).
+ *   3. NOT leak markdown — `### Chi siamo?` must become `<h3>Chi siamo?</h3>`,
+ *      `**bold**` must become `<strong>`, `•` bullets must become `<ul><li>`.
+ *
+ * Observed in production at
+ * /cerca-lavoro-ticino/senior-system-ingegnere-relewant-chiasso/ where the
+ * source `data/jobs/by-crawler/relewant.json` description is 2402 chars but
+ * the emitted static body printed ~1100 chars TWICE with literal `### ` text.
+ *
+ * The plugin emitter is too coupled to import in isolation, so this test
+ * exercises the seam where the bug lives: paragraph splitting + the
+ * `summaryParagraphs.map(jobDescriptionTextToHtml).join('')` pipeline.
+ * If the helpers are reorganized, update the test to follow them.
+ */
+import { describe, expect, it } from 'vitest';
+import { jobDescriptionTextToHtml } from '../../build-plugins/shared/jobDescription/toHtml';
+
+// Mirror of `splitIntoParagraphs` from jobsSeoPagesPlugin.ts (line ~1286).
+// Kept inline here so the test stays self-contained and explicitly pins
+// the contract: blank-line split with a 40-char floor and a sentence-split
+// fallback for prose without paragraph breaks.
+function splitIntoParagraphs(s: string): string[] {
+  const normalized = String(s || '').replace(/[_=~]{6,}/g, '\n\n');
+  const viaBreaks = normalized
+    .replace(/\r/g, '\n')
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 40);
+  if (viaBreaks.length >= 2) return viaBreaks;
+  return normalized
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(/(?<=[.!?])\s+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 40);
+}
+
+// Real description from the Relewant senior-system-engineer-chiasso job,
+// trimmed to a representative slice. Contains:
+//   - ### Heading (must become <h3>)
+//   - **bold** (must become <strong>)
+//   - • bullets (must become <ul><li>)
+//   - Multiple paragraphs (must NOT be truncated to 3 in the no-canonical path)
+const RELEWANT_FIXTURE = `### Chi siamo?
+Relewant è una società di consulenza specializzata in ambito informatico con sede a Chiasso, in Svizzera.
+Con noi, potrai mettere a frutto il tuo potenziale in un team coeso e vincente.
+
+### La nostra Mission
+Il nostro successo nasce dalle qualità delle persone che fanno parte del gruppo.
+Competenza, professionalità e voglia di stare al passo in un mercato tecnologico in continua evoluzione ci contraddistinguono.
+
+### Chi stiamo cercando?
+Siamo alla ricerca di un Senior System Engineer altamente qualificato per il team IT ed Infrastrutture.
+
+#### Requisiti
+• Esperienza consolidata in ambienti Microsoft Azure e Modern work.
+• Esperienza con architetture hybrid cloud e con scenari di migrazione verso il cloud.
+• Conoscenza operativa preferenziale dei sistemi di iperconvergenza come Nutanix.
+• Confidenza con piattaforme VDI in ambienti enterprise.
+
+**Esperienza richiesta:** 4-5 anni
+**Settore:** Tecnologia
+**Sede:** Chiasso, TI, Svizzera
+**Tipo:** Tempo indeterminato`;
+
+describe('static job page body — no-canonical fallback', () => {
+  // Replicates the post-fix pipeline:
+  //   const hasCanonical = canonicalSummary.length > 0;            // false here
+  //   bodyParagraphs = descriptionParagraphs.slice(0, 10);         // no 3-cap
+  //   summaryParagraphs = bodyParagraphs;
+  //   summaryHtml = summaryParagraphs.map(jobDescriptionTextToHtml).join('')
+  function renderBody(description: string): string {
+    const descriptionParagraphs = splitIntoParagraphs(description).slice(0, 10);
+    const bodyParagraphs = descriptionParagraphs
+      .slice(0, 10)
+      .filter((p) => p && p.length > 25)
+      .slice(0, 10);
+    const summaryParagraphs = bodyParagraphs;
+    return summaryParagraphs.map((p) => jobDescriptionTextToHtml(p)).join('');
+  }
+
+  it('does NOT truncate the description to 3 paragraphs (Bug 1)', () => {
+    const html = renderBody(RELEWANT_FIXTURE);
+    // Nutanix and VDI live in the Requisiti block — paragraph 4 of 5.
+    // The pre-fix `.slice(0, 3)` dropped them entirely.
+    expect(html).toContain('Nutanix');
+    expect(html).toContain('VDI');
+    // Sede and contract type live in the trailing **bold** footer block.
+    expect(html).toContain('Chiasso');
+    expect(html).toContain('Tempo indeterminato');
+  });
+
+  it('renders markdown headings as <h3>, not literal "### text" (Bug 3)', () => {
+    const html = renderBody(RELEWANT_FIXTURE);
+    // Literal markdown must NOT appear in the body.
+    expect(html).not.toContain('### Chi siamo');
+    expect(html).not.toContain('### La nostra Mission');
+    expect(html).not.toContain('### Chi stiamo cercando');
+    // Headings should be promoted to real <h3>/<h4> tags.
+    expect(html).toMatch(/<h[34]>\s*Chi siamo\??/);
+    expect(html).toMatch(/<h[34]>\s*La nostra Mission/);
+  });
+
+  it('renders **bold** as <strong>, not literal asterisks (Bug 3)', () => {
+    const html = renderBody(RELEWANT_FIXTURE);
+    expect(html).not.toMatch(/\*\*Esperienza richiesta/);
+    expect(html).not.toMatch(/\*\*Sede/);
+    expect(html).toMatch(/<strong>[^<]*Esperienza richiesta[^<]*<\/strong>/);
+    expect(html).toMatch(/<strong>[^<]*Sede[^<]*<\/strong>/);
+  });
+
+  it('renders • bullets as a <ul><li> list (Bug 3)', () => {
+    const html = renderBody(RELEWANT_FIXTURE);
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>');
+    // The bullet character itself should NOT survive as visible text.
+    expect(html).not.toMatch(/<li>\s*•/);
+  });
+
+  it('does not print the body content twice (Bug 2 sanity check)', () => {
+    // The fix removes the timeline-step fallback when there is no canonical
+    // data, so the body is rendered exactly once via summaryHtml.
+    // This test asserts the post-fix summaryHtml itself does not duplicate
+    // — the "Chi siamo?" heading appears exactly once.
+    const html = renderBody(RELEWANT_FIXTURE);
+    const matches = html.match(/Chi siamo/g) || [];
+    expect(matches.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Three bugs in the no-canonical fallback path of build-plugins/jobsSeoPagesPlugin.ts
hit jobs that translate-pending-jobs.yml hasn't AI-structured yet:

- Truncation: bodyParagraphs hard-capped at slice(0,3)/slice(0,4) drops
  Requisiti + Sede + contract-type footer on real markdown descriptions.
  Branch on hasCanonical: keep up to 10 paragraphs in the fallback path,
  retain the old short cap when a canonical summary lede exists.
- Duplication: when canonicalSummary is empty, summaryParagraphs ===
  bodyParagraphs, so Panoramica section + timeline fallback both
  rendered the same paragraphs. Skip the timeline fallback in that case.
- Markdown leak: summaryHtml / sectionHtml wrapped each paragraph in
  <p>${inlineTextToHtml(p)}</p>, so a paragraph containing "### Chi siamo?"
  printed the hashes literally. Route through jobDescriptionTextToHtml,
  which produces <h3>/<strong>/<ul> and tolerates already-structured input.

Verified against
/cerca-lavoro-ticino/senior-system-ingegnere-relewant-chiasso/.
