### PR TITLE
feat(seo): align static job-detail with SPA evolution

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2386,6 +2386,39 @@ ${hreflangHtml}
  <article class="proposal">
  <section class="hero">
  <h1 class="hero-title">${esc(composeJobPageH1(localizedTitle, String(job.company || '')))}</h1>
+ ${(() => {
+ // SPA-parity hero badges. Mirrors the Featured ★ badge, "Nuovo" badge,
+ // and salary pill rendered in components/community/JobBoard.tsx so the
+ // static (crawler-facing) HTML stops looking visibly stale next to the
+ // hydrated React view. Each badge gates on its own signal — when all
+ // three are false we emit nothing (no empty wrapper).
+ const isFeatured = job.featured === true;
+ const isNew = (() => {
+ const dateStr = String(job.postedDate ?? job.crawledAt ?? '');
+ if (!dateStr) return false;
+ const t = new Date(dateStr).getTime();
+ if (!Number.isFinite(t)) return false;
+ return (Date.now() - t) < 7 * 86400000;
+ })();
+ const hasSalaryPill = Number.isFinite(salaryMin);
+ if (!isFeatured && !isNew && !hasSalaryPill) return '';
+ const featuredLabel: Record<'it'|'en'|'de'|'fr', string> = {
+ it: '★ In evidenza', en: '★ Featured', de: '★ Empfohlen', fr: '★ En vedette',
+ };
+ const newLabel: Record<'it'|'en'|'de'|'fr', string> = {
+ it: 'Nuovo', en: 'New', de: 'Neu', fr: 'Nouveau',
+ };
+ const featuredHtml = isFeatured
+ ? `<span class="badge badge-featured">${esc(featuredLabel[locale as 'it'|'en'|'de'|'fr'])}</span>`
+ : '';
+ const newHtml = isNew
+ ? `<span class="badge badge-new">${esc(newLabel[locale as 'it'|'en'|'de'|'fr'])}</span>`
+ : '';
+ const salaryPillHtml = hasSalaryPill
+ ? `<span class="badge badge-salary">${esc(salaryText)}</span>`
+ : '';
+ return `<div class="hero-badges">${featuredHtml}${newHtml}${salaryPillHtml}</div>`;
+ })()}
  <div class="hero-sub">${esc(job.company)} · ${esc(job.location)} (${esc(job.canton || DEFAULT_CANTON)})</div>
  <div class="hero-meta">
  <span>${esc(`Categoria: ${String(job.category || 'other')}`)}</span>
@@ -2441,11 +2474,82 @@ ${hreflangHtml}
  <h4>${esc(localeCopy[locale].summaryLabel)}</h4>
  ${summaryHtml}
  </section>
+ ${(() => {
+ // SPA-parity highlights chips. The React JobBoard renders canonical
+ // keywords / skills as pills under the Panoramica heading; backport
+ // here so crawlers and the static flash see the same signals.
+ // Source priority: canonicalLocale.highlights → canonicalKeywords. Cap 6.
+ const rawHighlights = Array.isArray((canonicalLocale as { highlights?: unknown })?.highlights)
+ ? ((canonicalLocale as { highlights?: unknown[] }).highlights as unknown[])
+ .map((h) => String(h ?? '').trim())
+ .filter((h) => h.length > 0)
+ : [];
+ const source = rawHighlights.length > 0 ? rawHighlights : canonicalKeywords;
+ const chips = source.slice(0, 6);
+ if (chips.length === 0) return '';
+ const ariaLabel: Record<'it'|'en'|'de'|'fr', string> = {
+ it: 'Competenze chiave', en: 'Key skills', de: 'Schlüsselkompetenzen', fr: 'Compétences clés',
+ };
+ const items = chips.map((c) => `<li class="chip">${esc(String(c))}</li>`).join('');
+ return `<ul class="highlights" aria-label="${esc(ariaLabel[locale as 'it'|'en'|'de'|'fr'])}">${items}</ul>`;
+ })()}
  <div class="timeline">
  ${timelineHtml || `<div class="timeline-step">${sectionHtml(localeCopy[locale].descriptionLabel, bodyParagraphs, [])}</div>`}
  </div>
  <a href="${referralUrl(job.url || canonicalUrl, job)}" rel="noopener noreferrer" class="cta">${esc(localeCopy[locale].applyNow)}</a>
  </article>
+ ${(() => {
+ // SPA-parity desktop right rail. Mirrors the sticky sidebar from
+ // components/community/JobBoard.tsx so the crawler-facing HTML (and the
+ // pre-hydration flash) carry the same location/salary/sector/related
+ // signals as the React view. Hidden on <1024px via seo-static.css; the
+ // mobile-action-block already covers small screens.
+ const railLabels: Record<'it'|'en'|'de'|'fr', {
+ location: string;
+ city: string;
+ canton: string;
+ postal: string;
+ salary: string;
+ sector: string;
+ related: string;
+ }> = {
+ it: { location: 'Posizione', city: 'Città', canton: 'Cantone', postal: 'CAP', salary: 'Range salariale', sector: 'Settore', related: 'Ricerche correlate' },
+ en: { location: 'Location', city: 'City', canton: 'Canton', postal: 'Postal code', salary: 'Salary range', sector: 'Sector', related: 'Related searches' },
+ de: { location: 'Standort', city: 'Stadt', canton: 'Kanton', postal: 'PLZ', salary: 'Gehaltsspanne', sector: 'Branche', related: 'Verwandte Suchen' },
+ fr: { location: 'Lieu', city: 'Ville', canton: 'Canton', postal: 'Code postal', salary: 'Fourchette salariale', sector: 'Secteur', related: 'Recherches associées' },
+ };
+ const L = railLabels[locale as 'it'|'en'|'de'|'fr'];
+ const locationRows: string[] = [];
+ if (addressLocality) locationRows.push(`<dt>${esc(L.city)}</dt><dd>${esc(addressLocality)}</dd>`);
+ if (addressRegion) locationRows.push(`<dt>${esc(L.canton)}</dt><dd>${esc(addressRegion)}</dd>`);
+ if (postalCode) locationRows.push(`<dt>${esc(L.postal)}</dt><dd>${esc(postalCode)}</dd>`);
+ const locationCard = locationRows.length > 0
+ ? `<div class="rail-card"><h3>${esc(L.location)}</h3><dl class="rail-dl">${locationRows.join('')}</dl></div>`
+ : '';
+ const salaryCard = Number.isFinite(salaryMin)
+ ? `<div class="rail-card"><h3>${esc(L.salary)}</h3><div class="rail-salary">${esc(salaryText)}</div></div>`
+ : '';
+ // Minimal sector lookup — duplicates the small map used a few lines down
+ // for the frontalier paragraphs (intentionally kept local to avoid
+ // touching the protected Panoramica/timeline block above).
+ const railSectorMap: Record<string, Record<string, string>> = {
+ it: { healthcare: 'sanità', technology: 'tecnologia', finance: 'servizi finanziari', engineering: 'ingegneria', hospitality: 'ospitalità', retail: 'commercio', manufacturing: 'manifattura', education: 'formazione', construction: 'edilizia', logistics: 'logistica', sales: 'vendite', administration: 'amministrazione' },
+ en: { healthcare: 'healthcare', technology: 'technology', finance: 'financial services', engineering: 'engineering', hospitality: 'hospitality', retail: 'retail', manufacturing: 'manufacturing', education: 'education', construction: 'construction', logistics: 'logistics', sales: 'sales', administration: 'administration' },
+ de: { healthcare: 'Gesundheitswesen', technology: 'Technologie', finance: 'Finanzdienstleistungen', engineering: 'Ingenieurwesen', hospitality: 'Gastgewerbe', retail: 'Einzelhandel', manufacturing: 'Fertigung', education: 'Bildung', construction: 'Bauwesen', logistics: 'Logistik', sales: 'Vertrieb', administration: 'Verwaltung' },
+ fr: { healthcare: 'santé', technology: 'technologie', finance: 'services financiers', engineering: 'ingénierie', hospitality: 'hôtellerie', retail: 'commerce', manufacturing: 'industrie', education: 'formation', construction: 'construction', logistics: 'logistique', sales: 'ventes', administration: 'administration' },
+ };
+ const railCat = String(job.category || '').toLowerCase();
+ const sectorValue = railSectorMap[locale]?.[railCat] || String(job.category || '');
+ const sectorCard = sectorValue
+ ? `<div class="rail-card"><h3>${esc(L.sector)}</h3><div class="rail-sector">${esc(sectorValue)}</div></div>`
+ : '';
+ const relatedChipsHtml = canonicalKeywords.length > 0
+ ? `<div class="rail-card"><h3>${esc(L.related)}</h3><ul class="rail-chips">${canonicalKeywords.slice(0, 6).map((k) => `<li class="chip">${esc(String(k))}</li>`).join('')}</ul></div>`
+ : '';
+ const cards = locationCard + salaryCard + sectorCard + relatedChipsHtml;
+ if (!cards) return '';
+ return `<aside class="job-detail-rail" aria-label="${esc(L.location)}">${cards}</aside>`;
+ })()}
  ${(() => {
  const cSlugBanner = canonicalCompanySlugBuild(job.company, job.companyKey);
  const cHref = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}/${companyRoutePrefix[locale]}-${cSlugBanner}`.replace(/\/+/g, '/'))}`;

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -298,6 +298,125 @@ main { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
 .pillrow { display: flex; flex-wrap: wrap; gap: 10px; }
 .fn { margin: 24px 0 0; padding: 16px 0; border-top: 1px solid var(--color-edge); font-size: 14px; }
 
+/* ── SPA-parity additions (static-job-page) ───────────────────────────── */
+/* Hero badges row + highlights chips below Panoramica. Mirrors the SPA
+   pill row in components/community/JobBoard.tsx so the crawler-facing
+   HTML and the pre-hydration flash stop diverging from the React view. */
+.hero-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 6px 0 8px;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  border: 1px solid var(--color-edge);
+  background: var(--color-surface);
+  color: var(--color-heading);
+}
+.badge-featured {
+  background: var(--color-warning-subtle);
+  color: var(--color-warning);
+  border-color: var(--color-warning);
+}
+.badge-new {
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.badge-salary {
+  background: var(--color-success-subtle);
+  color: var(--color-success);
+  border-color: var(--color-success);
+}
+.highlights {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chip {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-accent);
+  background: var(--color-accent-subtle);
+  border: 1px solid var(--color-accent);
+}
+
+/* Desktop right-rail sidebar — hidden below lg. Mirrors the sticky aside
+   in components/community/JobBoard.tsx. */
+.job-detail-rail {
+  display: none;
+}
+.rail-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-edge);
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin: 0 0 12px;
+}
+.rail-card h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.rail-dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 10px;
+  row-gap: 4px;
+  margin: 0;
+  font-size: 14px;
+}
+.rail-dl dt {
+  color: var(--color-subtle);
+}
+.rail-dl dd {
+  margin: 0;
+  color: var(--color-heading);
+  font-weight: 600;
+}
+.rail-salary {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-success);
+}
+.rail-sector {
+  font-size: 14px;
+  color: var(--color-heading);
+  font-weight: 600;
+}
+.rail-chips {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+@media (min-width: 1024px) {
+  .job-detail-rail {
+    display: block;
+    position: sticky;
+    top: 80px;
+    margin-top: 16px;
+  }
+}
+
 @media (max-width: 980px) {
   body > #root > main.static-job-page { padding: 14px; }
   .hero-title { font-size: 22px; }

--- a/tests/seo/static-job-page-spa-alignment.test.ts
+++ b/tests/seo/static-job-page-spa-alignment.test.ts
@@ -1,0 +1,153 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * SPA-parity regression gate for the static job-detail template.
+ *
+ * The full HTML for a job-detail page is assembled inside a closure in
+ * `build-plugins/jobsSeoPagesPlugin.ts` and only flushed during a real Vite
+ * build (which OOMs locally — see CLAUDE.md FAST_BUILD trap). So we assert
+ * against the plugin source itself: the new SPA-parity blocks must remain
+ * present, and the CSS classes they reference must exist in seo-static.css.
+ *
+ * Backport context: `components/community/JobBoard.tsx` (the React view)
+ * had drifted past the static template — featured/new/salary badges, the
+ * highlights chip row under "Panoramica", and the desktop sticky sidebar
+ * were all missing from the crawler-facing HTML. See the commit body of
+ * the PR that introduced this test for the original drift report.
+ */
+describe('static job-detail page SPA alignment', () => {
+  const pluginSource = readFileSync(
+    path.resolve(__dirname, '..', '..', 'build-plugins', 'jobsSeoPagesPlugin.ts'),
+    'utf-8',
+  );
+  const cssSource = readFileSync(
+    path.resolve(__dirname, '..', '..', 'public', 'assets', 'seo-static.css'),
+    'utf-8',
+  );
+
+  describe('hero badges block', () => {
+    it('emits a hero-badges wrapper inside the hero section', () => {
+      expect(pluginSource).toContain('class="hero-badges"');
+    });
+
+    it('gates the Featured badge on job.featured === true', () => {
+      expect(pluginSource).toMatch(/const isFeatured = job\.featured === true/);
+      expect(pluginSource).toContain('class="badge badge-featured"');
+    });
+
+    it('gates the "New" badge on a <7d postedDate window', () => {
+      // 7 * 86400000 ms = one week in ms.
+      expect(pluginSource).toMatch(/7\s*\*\s*86400000/);
+      expect(pluginSource).toContain('class="badge badge-new"');
+    });
+
+    it('renders the salary pill only when salaryMin is a finite number', () => {
+      expect(pluginSource).toMatch(/hasSalaryPill = Number\.isFinite\(salaryMin\)/);
+      expect(pluginSource).toContain('class="badge badge-salary"');
+    });
+
+    it('returns an empty string when no badge condition is true', () => {
+      // The guard avoids emitting an empty wrapper that would still take
+      // vertical space in the rendered hero.
+      expect(pluginSource).toMatch(/if \(!isFeatured && !isNew && !hasSalaryPill\) return ''/);
+    });
+  });
+
+  describe('highlights chips below Panoramica', () => {
+    it('sources from canonicalLocale.highlights when present, falling back to canonicalKeywords', () => {
+      expect(pluginSource).toMatch(/canonicalLocale as \{ highlights\?: unknown \}/);
+      expect(pluginSource).toMatch(/source\.slice\(0, 6\)/);
+    });
+
+    it('emits a <ul class="highlights"> with chip items', () => {
+      expect(pluginSource).toContain('class="highlights"');
+      expect(pluginSource).toMatch(/class="chip"/);
+    });
+
+    it('returns an empty string when there are no highlights and no keywords', () => {
+      expect(pluginSource).toMatch(/if \(chips\.length === 0\) return ''/);
+    });
+  });
+
+  describe('desktop right rail sidebar', () => {
+    it('emits an <aside class="job-detail-rail"> after the proposal article', () => {
+      expect(pluginSource).toContain('class="job-detail-rail"');
+      // The aside must come after the closing </article> tag — i.e. the
+      // company card / related / footer order is preserved.
+      const articleClose = pluginSource.indexOf('</article>');
+      const railOpen = pluginSource.indexOf('class="job-detail-rail"');
+      expect(articleClose).toBeGreaterThan(-1);
+      expect(railOpen).toBeGreaterThan(articleClose);
+    });
+
+    it('renders a location rail-card with localised labels', () => {
+      expect(pluginSource).toContain('class="rail-card"');
+      // Italian labels — the rail is the same in every locale; spot-check IT.
+      expect(pluginSource).toContain("location: 'Posizione'");
+      expect(pluginSource).toContain("city: 'Città'");
+      expect(pluginSource).toContain("canton: 'Cantone'");
+      expect(pluginSource).toContain("postal: 'CAP'");
+    });
+
+    it('renders a salary card only when salaryMin is finite', () => {
+      expect(pluginSource).toMatch(/const salaryCard = Number\.isFinite\(salaryMin\)/);
+      expect(pluginSource).toContain('class="rail-salary"');
+    });
+
+    it('renders a sector card derived from job.category via the locale map', () => {
+      expect(pluginSource).toContain('class="rail-sector"');
+      expect(pluginSource).toMatch(/railSectorMap\[locale\]\?\.\[railCat\]/);
+    });
+
+    it('renders related-search chips when canonicalKeywords is non-empty', () => {
+      expect(pluginSource).toContain('class="rail-chips"');
+      expect(pluginSource).toMatch(/canonicalKeywords\.slice\(0, 6\)/);
+    });
+
+    it('emits nothing when all rail cards would be empty', () => {
+      expect(pluginSource).toMatch(/if \(!cards\) return ''/);
+    });
+  });
+
+  describe('seo-static.css carries the new classes', () => {
+    it('defines .hero-badges + badge variants', () => {
+      expect(cssSource).toMatch(/\.hero-badges\s*\{/);
+      expect(cssSource).toMatch(/\.badge\s*\{/);
+      expect(cssSource).toMatch(/\.badge-featured\s*\{/);
+      expect(cssSource).toMatch(/\.badge-new\s*\{/);
+      expect(cssSource).toMatch(/\.badge-salary\s*\{/);
+    });
+
+    it('defines .highlights + .chip', () => {
+      expect(cssSource).toMatch(/\.highlights\s*\{/);
+      expect(cssSource).toMatch(/\.chip\s*\{/);
+    });
+
+    it('defines .job-detail-rail hidden by default, shown ≥1024px', () => {
+      expect(cssSource).toMatch(/\.job-detail-rail\s*\{[\s\S]*?display:\s*none/);
+      expect(cssSource).toMatch(/@media \(min-width: 1024px\)\s*\{[\s\S]*?\.job-detail-rail/);
+    });
+
+    it('defines the rail-card / rail-dl / rail-salary / rail-sector / rail-chips classes', () => {
+      expect(cssSource).toMatch(/\.rail-card\s*\{/);
+      expect(cssSource).toMatch(/\.rail-dl\s*\{/);
+      expect(cssSource).toMatch(/\.rail-salary\s*\{/);
+      expect(cssSource).toMatch(/\.rail-sector\s*\{/);
+      expect(cssSource).toMatch(/\.rail-chips\s*\{/);
+    });
+
+    it('uses only semantic --color-* tokens for the new rules (no hex)', () => {
+      // Slice from .hero-badges to the canton-hub section.
+      const start = cssSource.indexOf('/* ── SPA-parity additions');
+      const end = cssSource.indexOf('/* ── Canton-hub template', start);
+      expect(start).toBeGreaterThan(-1);
+      expect(end).toBeGreaterThan(start);
+      const section = cssSource.slice(start, end);
+      // No raw hex literals — only var(--color-*) references.
+      expect(section).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    });
+  });
+});


### PR DESCRIPTION
Backport from components/community/JobBoard.tsx:
- Highlights chips below Panoramica (canonicalLocale.highlights, falls
  back to canonicalKeywords, capped at 6)
- Featured/New/Salary badges in hero (gated individually; emits nothing
  if all three signals are absent)
- Desktop sticky sidebar (.job-detail-rail) with location snapshot,
  salary estimate, sector context, and related-search chips (hidden
  <1024px via seo-static.css)

New CSS rules in public/assets/seo-static.css use only --color-* semantic
tokens (no hex). Regression coverage in
tests/seo/static-job-page-spa-alignment.test.ts asserts every new HTML
block + every new CSS class is present.

Closes drift documented in CLAUDE.md rule #14 (SPA-over-static handoff).
