### PR TITLE
refactor(seo): extract job-detail SPA-parity blocks into shared emitters (L3 Phase 1)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -32,6 +32,12 @@ import {
  isKnownTicinoCommuterCity,
 } from './shared/jobBoardCommuterContext';
 import { renderCompanyHubFrontalierContext } from './shared/companyHubFrontalierContext';
+import {
+ renderHeroBadges,
+ renderMobileActionBlock,
+ renderHighlightsChips,
+ renderRightRail,
+} from './shared/jobDetailHtml';
 import { deriveJobPostalCode } from '../services/jobLocationSnapshot';
 import {
  loadWinners,
@@ -2397,39 +2403,7 @@ ${hreflangHtml}
  <article class="proposal">
  <section class="hero">
  <h1 class="hero-title">${esc(composeJobPageH1(localizedTitle, String(job.company || '')))}</h1>
- ${(() => {
- // SPA-parity hero badges. Mirrors the Featured ★ badge, "Nuovo" badge,
- // and salary pill rendered in components/community/JobBoard.tsx so the
- // static (crawler-facing) HTML stops looking visibly stale next to the
- // hydrated React view. Each badge gates on its own signal — when all
- // three are false we emit nothing (no empty wrapper).
- const isFeatured = job.featured === true;
- const isNew = (() => {
- const dateStr = String(job.postedDate ?? job.crawledAt ?? '');
- if (!dateStr) return false;
- const t = new Date(dateStr).getTime();
- if (!Number.isFinite(t)) return false;
- return (Date.now() - t) < 7 * 86400000;
- })();
- const hasSalaryPill = Number.isFinite(salaryMin);
- if (!isFeatured && !isNew && !hasSalaryPill) return '';
- const featuredLabel: Record<'it'|'en'|'de'|'fr', string> = {
- it: '★ In evidenza', en: '★ Featured', de: '★ Empfohlen', fr: '★ En vedette',
- };
- const newLabel: Record<'it'|'en'|'de'|'fr', string> = {
- it: 'Nuovo', en: 'New', de: 'Neu', fr: 'Nouveau',
- };
- const featuredHtml = isFeatured
- ? `<span class="badge badge-featured">${esc(featuredLabel[locale as 'it'|'en'|'de'|'fr'])}</span>`
- : '';
- const newHtml = isNew
- ? `<span class="badge badge-new">${esc(newLabel[locale as 'it'|'en'|'de'|'fr'])}</span>`
- : '';
- const salaryPillHtml = hasSalaryPill
- ? `<span class="badge badge-salary">${esc(salaryText)}</span>`
- : '';
- return `<div class="hero-badges">${featuredHtml}${newHtml}${salaryPillHtml}</div>`;
- })()}
+ ${renderHeroBadges({ job, locale, salaryMin, salaryText, esc })}
  <div class="hero-sub">${esc(job.company)} · ${esc(job.location)} (${esc(job.canton || DEFAULT_CANTON)})</div>
  <div class="hero-meta">
  <span>${esc(`Categoria: ${String(job.category || 'other')}`)}</span>
@@ -2437,130 +2411,18 @@ ${hreflangHtml}
  <span>${esc(`Salario: ${salaryText}`)}</span>
  </div>
  </section>
- ${(() => {
- // S6/S9 mobile-first parity with the SPA: above-fold action block on
- // mobile carrying the Apply CTA + 3 key stats. Mirrors the React
- // `<section className="lg:hidden">` in components/community/JobBoard.tsx.
- // Hidden on lg+ via `.mobile-action-block { display:none }` media query
- // in public/assets/seo-static.css (the desktop hero already shows these
- // stats inline in `.hero-meta`, and the right rail mirrors them again
- // once React hydrates).
- const publishedLabel: Record<'it'|'en'|'de'|'fr', string> = {
- it: 'Pubblicato', en: 'Posted', de: 'Veröffentlicht', fr: 'Publié',
- };
- const daysAgo = (() => {
- const dateStr = String(job.postedDate ?? job.crawledAt ?? '');
- if (!dateStr) return '—';
- const t = new Date(dateStr).getTime();
- if (!Number.isFinite(t)) return '—';
- const days = Math.max(0, Math.round((Date.now() - t) / 86400000));
- const fmt: Record<'it'|'en'|'de'|'fr', (n: number) => string> = {
- it: (n) => n === 0 ? 'Oggi' : n === 1 ? 'Ieri' : `${n} giorni fa`,
- en: (n) => n === 0 ? 'Today' : n === 1 ? 'Yesterday' : `${n} days ago`,
- de: (n) => n === 0 ? 'Heute' : n === 1 ? 'Gestern' : `vor ${n} Tagen`,
- fr: (n) => n === 0 ? "Aujourd'hui" : n === 1 ? 'Hier' : `il y a ${n} jours`,
- };
- return fmt[locale as 'it'|'en'|'de'|'fr'](days);
- })();
- const contractText = String(job.contract || 'other');
- const salaryLabel: Record<'it'|'en'|'de'|'fr', string> = {
- it: 'Salario', en: 'Salary', de: 'Lohn', fr: 'Salaire',
- };
- // Salary line — only when we actually have a number; the "non indicato"
- // fallback is meaningless as a money signal so we suppress it instead of
- // rendering a tile that adds zero information.
- const salaryLineHtml = Number.isFinite(salaryMin)
- ? `<div class="mab-salary"><span class="mab-salary-label">${esc(salaryLabel[locale as 'it'|'en'|'de'|'fr'])}</span><span class="mab-salary-value">${esc(salaryText)}</span></div>`
- : '';
- return `<section class="mobile-action-block" aria-label="${esc(localeCopy[locale].quickDetails)}">
- <a href="${referralUrl(job.url || canonicalUrl, job)}" rel="noopener noreferrer" class="mab-cta">${esc(localeCopy[locale].applyNow)}</a>
- <dl class="mab-grid">
- <div class="mab-tile"><dt>${esc(localeCopy[locale].location)}</dt><dd>${esc(addressLocality)}</dd></div>
- <div class="mab-tile"><dt>${esc(localeCopy[locale].contract)}</dt><dd>${esc(contractText)}</dd></div>
- <div class="mab-tile"><dt>${esc(publishedLabel[locale as 'it'|'en'|'de'|'fr'])}</dt><dd>${esc(daysAgo)}</dd></div>
- </dl>${salaryLineHtml}
- </section>`;
- })()}
+ ${renderMobileActionBlock({ job, locale, canonicalUrl, addressLocality, salaryMin, salaryText, localeLabels: { applyNow: localeCopy[locale].applyNow, quickDetails: localeCopy[locale].quickDetails, location: localeCopy[locale].location, contract: localeCopy[locale].contract }, referralUrl, esc })}
  <section class="section">
  <h4>${esc(localeCopy[locale].summaryLabel)}</h4>
  ${summaryHtml}
  </section>
- ${(() => {
- // SPA-parity highlights chips. The React JobBoard renders canonical
- // keywords / skills as pills under the Panoramica heading; backport
- // here so crawlers and the static flash see the same signals.
- // Source priority: canonicalLocale.highlights → canonicalKeywords. Cap 6.
- const rawHighlights = Array.isArray((canonicalLocale as { highlights?: unknown })?.highlights)
- ? ((canonicalLocale as { highlights?: unknown[] }).highlights as unknown[])
- .map((h) => String(h ?? '').trim())
- .filter((h) => h.length > 0)
- : [];
- const source = rawHighlights.length > 0 ? rawHighlights : canonicalKeywords;
- const chips = source.slice(0, 6);
- if (chips.length === 0) return '';
- const ariaLabel: Record<'it'|'en'|'de'|'fr', string> = {
- it: 'Competenze chiave', en: 'Key skills', de: 'Schlüsselkompetenzen', fr: 'Compétences clés',
- };
- const items = chips.map((c) => `<li class="chip">${esc(String(c))}</li>`).join('');
- return `<ul class="highlights" aria-label="${esc(ariaLabel[locale as 'it'|'en'|'de'|'fr'])}">${items}</ul>`;
- })()}
+ ${renderHighlightsChips({ locale, canonicalLocale, canonicalKeywords, esc })}
  <div class="timeline">
  ${timelineHtml || (hasCanonical ? `<div class="timeline-step">${sectionHtml(localeCopy[locale].descriptionLabel, bodyParagraphs, [])}</div>` : '')}
  </div>
  <a href="${referralUrl(job.url || canonicalUrl, job)}" rel="noopener noreferrer" class="cta">${esc(localeCopy[locale].applyNow)}</a>
  </article>
- ${(() => {
- // SPA-parity desktop right rail. Mirrors the sticky sidebar from
- // components/community/JobBoard.tsx so the crawler-facing HTML (and the
- // pre-hydration flash) carry the same location/salary/sector/related
- // signals as the React view. Hidden on <1024px via seo-static.css; the
- // mobile-action-block already covers small screens.
- const railLabels: Record<'it'|'en'|'de'|'fr', {
- location: string;
- city: string;
- canton: string;
- postal: string;
- salary: string;
- sector: string;
- related: string;
- }> = {
- it: { location: 'Posizione', city: 'Città', canton: 'Cantone', postal: 'CAP', salary: 'Range salariale', sector: 'Settore', related: 'Ricerche correlate' },
- en: { location: 'Location', city: 'City', canton: 'Canton', postal: 'Postal code', salary: 'Salary range', sector: 'Sector', related: 'Related searches' },
- de: { location: 'Standort', city: 'Stadt', canton: 'Kanton', postal: 'PLZ', salary: 'Gehaltsspanne', sector: 'Branche', related: 'Verwandte Suchen' },
- fr: { location: 'Lieu', city: 'Ville', canton: 'Canton', postal: 'Code postal', salary: 'Fourchette salariale', sector: 'Secteur', related: 'Recherches associées' },
- };
- const L = railLabels[locale as 'it'|'en'|'de'|'fr'];
- const locationRows: string[] = [];
- if (addressLocality) locationRows.push(`<dt>${esc(L.city)}</dt><dd>${esc(addressLocality)}</dd>`);
- if (addressRegion) locationRows.push(`<dt>${esc(L.canton)}</dt><dd>${esc(addressRegion)}</dd>`);
- if (postalCode) locationRows.push(`<dt>${esc(L.postal)}</dt><dd>${esc(postalCode)}</dd>`);
- const locationCard = locationRows.length > 0
- ? `<div class="rail-card"><h3>${esc(L.location)}</h3><dl class="rail-dl">${locationRows.join('')}</dl></div>`
- : '';
- const salaryCard = Number.isFinite(salaryMin)
- ? `<div class="rail-card"><h3>${esc(L.salary)}</h3><div class="rail-salary">${esc(salaryText)}</div></div>`
- : '';
- // Minimal sector lookup — duplicates the small map used a few lines down
- // for the frontalier paragraphs (intentionally kept local to avoid
- // touching the protected Panoramica/timeline block above).
- const railSectorMap: Record<string, Record<string, string>> = {
- it: { healthcare: 'sanità', technology: 'tecnologia', finance: 'servizi finanziari', engineering: 'ingegneria', hospitality: 'ospitalità', retail: 'commercio', manufacturing: 'manifattura', education: 'formazione', construction: 'edilizia', logistics: 'logistica', sales: 'vendite', administration: 'amministrazione' },
- en: { healthcare: 'healthcare', technology: 'technology', finance: 'financial services', engineering: 'engineering', hospitality: 'hospitality', retail: 'retail', manufacturing: 'manufacturing', education: 'education', construction: 'construction', logistics: 'logistics', sales: 'sales', administration: 'administration' },
- de: { healthcare: 'Gesundheitswesen', technology: 'Technologie', finance: 'Finanzdienstleistungen', engineering: 'Ingenieurwesen', hospitality: 'Gastgewerbe', retail: 'Einzelhandel', manufacturing: 'Fertigung', education: 'Bildung', construction: 'Bauwesen', logistics: 'Logistik', sales: 'Vertrieb', administration: 'Verwaltung' },
- fr: { healthcare: 'santé', technology: 'technologie', finance: 'services financiers', engineering: 'ingénierie', hospitality: 'hôtellerie', retail: 'commerce', manufacturing: 'industrie', education: 'formation', construction: 'construction', logistics: 'logistique', sales: 'ventes', administration: 'administration' },
- };
- const railCat = String(job.category || '').toLowerCase();
- const sectorValue = railSectorMap[locale]?.[railCat] || String(job.category || '');
- const sectorCard = sectorValue
- ? `<div class="rail-card"><h3>${esc(L.sector)}</h3><div class="rail-sector">${esc(sectorValue)}</div></div>`
- : '';
- const relatedChipsHtml = canonicalKeywords.length > 0
- ? `<div class="rail-card"><h3>${esc(L.related)}</h3><ul class="rail-chips">${canonicalKeywords.slice(0, 6).map((k) => `<li class="chip">${esc(String(k))}</li>`).join('')}</ul></div>`
- : '';
- const cards = locationCard + salaryCard + sectorCard + relatedChipsHtml;
- if (!cards) return '';
- return `<aside class="job-detail-rail" aria-label="${esc(L.location)}">${cards}</aside>`;
- })()}
+ ${renderRightRail({ job, locale, addressLocality, addressRegion, postalCode, salaryMin, salaryText, canonicalKeywords, esc })}
  ${(() => {
  const cSlugBanner = canonicalCompanySlugBuild(job.company, job.companyKey);
  const cHref = `${BASE_URL}${withSlash(`${localePrefix[locale]}/${buildCantonAwareSection(locale, jobCanton)}/${companyRoutePrefix[locale]}-${cSlugBanner}`.replace(/\/+/g, '/'))}`;

--- a/build-plugins/shared/jobDetailHtml/context.ts
+++ b/build-plugins/shared/jobDetailHtml/context.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared render context for the static job-detail page emitters.
+ *
+ * Phase 1 of the L3 refactor: extracts the SPA-parity IIFE blocks
+ * (hero badges, mobile action block, highlights chips, right rail) from
+ * `build-plugins/jobsSeoPagesPlugin.ts` into pure-TS modules so Phase 2
+ * can hand the same renderers to the React SPA via dangerouslySetInnerHTML
+ * (or a stricter equivalent). Each emitter takes a slice of this context
+ * via `Pick<JobDetailRenderContext, ...>` and returns a self-contained
+ * HTML string. No closure variables, no plugin-local imports.
+ */
+export type JobDetailLocale = 'it' | 'en' | 'de' | 'fr';
+
+/**
+ * Minimum job shape consumed by the detail emitters. Kept permissive
+ * (`unknown`/optional everywhere except the discriminator-relevant
+ * `featured` / `category`) because the upstream `data/jobs.json` schema
+ * is intentionally loose — crawler outputs vary in completeness, and
+ * the plugin already filters / normalises before reaching the body
+ * template. The fields below are exactly the ones the four extracted
+ * blocks read.
+ */
+export interface JobDetailJob {
+  readonly slug?: string;
+  readonly id?: string;
+  readonly title?: string;
+  readonly company?: string;
+  readonly location?: string;
+  readonly canton?: string;
+  readonly category?: string;
+  readonly contract?: string;
+  readonly featured?: boolean;
+  readonly postedDate?: string;
+  readonly crawledAt?: string;
+  readonly url?: string;
+}
+
+/**
+ * Strict context required by every job-detail emitter under this folder.
+ * Lives at the boundary between the plugin closure (which assembles the
+ * fields from `data/jobs.json` + canonical AI data + per-job derived
+ * state) and the pure HTML renderers.
+ */
+export interface JobDetailRenderContext {
+  readonly job: JobDetailJob;
+  readonly locale: JobDetailLocale;
+
+  /** Pre-computed string used when a salary number is finite (matches
+   *  the plugin's NumberFormat-driven `salaryText`). */
+  readonly salaryText: string;
+  /** May be NaN/undefined when the source job lacks salary data; emitters
+   *  gate on `Number.isFinite(salaryMin)` to decide whether the salary
+   *  pill / mobile salary line / rail salary card show. */
+  readonly salaryMin: number;
+
+  /** Already-resolved canonical apply URL for this job-detail page. */
+  readonly canonicalUrl: string;
+
+  /** Address fields used by the right rail's location card and the
+   *  mobile action block's location tile. */
+  readonly addressLocality: string;
+  readonly addressRegion: string;
+  readonly postalCode: string;
+
+  /** Subset of the plugin's `localeCopy` we actually need in these
+   *  blocks. Kept as a flat shape so it's trivial to satisfy from the
+   *  plugin side (`pick`-style assignment, no transitive coupling). */
+  readonly localeLabels: {
+    readonly applyNow: string;
+    readonly quickDetails: string;
+    readonly location: string;
+    readonly contract: string;
+  };
+
+  /**
+   * Optional canonical-locale block (the AI-enriched per-locale data
+   * read off `_canonical.<locale>`). The highlights emitter reads
+   * `.highlights` when present and falls back to `canonicalKeywords`.
+   * Typed as `unknown`-with-shape because the upstream blob is loose
+   * JSON; the emitter narrows safely.
+   */
+  readonly canonicalLocale?: { highlights?: unknown };
+
+  /** Already-cleaned keywords used by the highlights fallback and the
+   *  right rail's "related searches" chip row. */
+  readonly canonicalKeywords: ReadonlyArray<string>;
+
+  /**
+   * UTM-decorated apply URL builder. Passed in from the plugin so the
+   * emitter doesn't need to know about UTM conventions — keeps this
+   * module a pure HTML renderer.
+   */
+  readonly referralUrl: (raw: string, job: JobDetailJob) => string;
+
+  /**
+   * HTML escaper. Both `escHtml` from `../htmlEscape` and the plugin's
+   * local `esc` produce identical output; the plugin passes its own
+   * `esc` for byte-stable parity during the extraction.
+   */
+  readonly esc: (s: string) => string;
+}

--- a/build-plugins/shared/jobDetailHtml/heroBadges.ts
+++ b/build-plugins/shared/jobDetailHtml/heroBadges.ts
@@ -1,0 +1,54 @@
+/**
+ * Hero badges block (Featured ★ / "Nuovo" / salary pill) for the static
+ * job-detail page. Mirrors the React `<JobBoard>` badge row so the
+ * crawler-facing HTML stops looking visibly stale next to the hydrated
+ * view. Each badge gates on its own signal — when all three are false
+ * the emitter returns '' (no empty wrapper).
+ *
+ * SPA-parity regression coverage:
+ *   tests/seo/static-job-page-spa-alignment.test.ts ("hero badges block")
+ */
+import type { JobDetailLocale, JobDetailRenderContext } from './context';
+
+const FEATURED_LABEL: Record<JobDetailLocale, string> = {
+  it: '★ In evidenza',
+  en: '★ Featured',
+  de: '★ Empfohlen',
+  fr: '★ En vedette',
+};
+
+const NEW_LABEL: Record<JobDetailLocale, string> = {
+  it: 'Nuovo',
+  en: 'New',
+  de: 'Neu',
+  fr: 'Nouveau',
+};
+
+export type HeroBadgesContext = Pick<
+  JobDetailRenderContext,
+  'job' | 'locale' | 'salaryMin' | 'salaryText' | 'esc'
+>;
+
+export function renderHeroBadges(ctx: HeroBadgesContext): string {
+  const { job, locale, salaryMin, salaryText, esc } = ctx;
+  const isFeatured = job.featured === true;
+  const isNew = (() => {
+    const dateStr = String(job.postedDate ?? job.crawledAt ?? '');
+    if (!dateStr) return false;
+    const t = new Date(dateStr).getTime();
+    if (!Number.isFinite(t)) return false;
+    return (Date.now() - t) < 7 * 86400000;
+  })();
+  const hasSalaryPill = Number.isFinite(salaryMin);
+  if (!isFeatured && !isNew && !hasSalaryPill) return '';
+  const featuredHtml = isFeatured
+    ? `<span class="badge badge-featured">${esc(FEATURED_LABEL[locale])}</span>`
+    : '';
+  const newHtml = isNew
+    ? `<span class="badge badge-new">${esc(NEW_LABEL[locale])}</span>`
+    : '';
+  const salaryPillHtml = hasSalaryPill
+    ? `<span class="badge badge-salary">${esc(salaryText)}</span>`
+    : '';
+  return `<div class="hero-badges">${featuredHtml}${newHtml}${salaryPillHtml}</div>`;
+}

--- a/build-plugins/shared/jobDetailHtml/highlightsChips.ts
+++ b/build-plugins/shared/jobDetailHtml/highlightsChips.ts
@@ -1,0 +1,46 @@
+/**
+ * Highlights chips row, emitted directly under the "Panoramica" section
+ * of the static job-detail page. SPA-parity backport of the React
+ * `<JobBoard>` highlights pill row.
+ *
+ * Source priority:
+ *   1. `canonicalLocale.highlights` (AI-curated, 6 cap)
+ *   2. `canonicalKeywords` (fallback, same cap)
+ *
+ * Returns '' when neither source yields any chips (no empty <ul>).
+ *
+ * SPA-parity regression coverage:
+ *   tests/seo/static-job-page-spa-alignment.test.ts
+ *   ("highlights chips below Panoramica")
+ */
+import type { JobDetailLocale, JobDetailRenderContext } from './context';
+
+const ARIA_LABEL: Record<JobDetailLocale, string> = {
+  it: 'Competenze chiave',
+  en: 'Key skills',
+  de: 'Schlüsselkompetenzen',
+  fr: 'Compétences clés',
+};
+
+export type HighlightsChipsContext = Pick<
+  JobDetailRenderContext,
+  'locale' | 'canonicalLocale' | 'canonicalKeywords' | 'esc'
+>;
+
+export function renderHighlightsChips(ctx: HighlightsChipsContext): string {
+  const { locale, canonicalLocale, canonicalKeywords, esc } = ctx;
+  const rawHighlights = Array.isArray(
+    (canonicalLocale as { highlights?: unknown })?.highlights,
+  )
+    ? ((canonicalLocale as { highlights?: unknown[] }).highlights as unknown[])
+        .map((h) => String(h ?? '').trim())
+        .filter((h) => h.length > 0)
+    : [];
+  const source = rawHighlights.length > 0 ? rawHighlights : canonicalKeywords;
+  const chips = source.slice(0, 6);
+  if (chips.length === 0) return '';
+  const items = chips
+    .map((c) => `<li class="chip">${esc(String(c))}</li>`)
+    .join('');
+  return `<ul class="highlights" aria-label="${esc(ARIA_LABEL[locale])}">${items}</ul>`;
+}

--- a/build-plugins/shared/jobDetailHtml/index.ts
+++ b/build-plugins/shared/jobDetailHtml/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Barrel re-exports for the static job-detail page HTML emitters.
+ *
+ * Phase 1 of the L3 refactor — extracts the SPA-parity IIFE blocks from
+ * `build-plugins/jobsSeoPagesPlugin.ts` into pure-TS modules. Phase 2
+ * will hand these renderers to the React SPA so static and hydrated
+ * views render identical markup from one source.
+ *
+ * Sections still inline in the plugin (deferred to Phase 1.5+ because
+ * their helper closure dependencies — localeCopy, buildCantonAwareSection,
+ * companyLogo, etc. — would require an export-cascade beyond Phase 1's
+ * scope):
+ *   - Hero (h1 + sub + meta)
+ *   - Panoramica summary section
+ *   - Timeline blocks
+ *   - Primary apply CTA
+ *   - Company card with "Tutte le offerte …" anchor
+ *   - Related jobs list
+ *   - Frontalier info / FAQ / hub links
+ *   - Footer nav
+ */
+export type {
+  JobDetailJob,
+  JobDetailLocale,
+  JobDetailRenderContext,
+} from './context';
+export {
+  renderHeroBadges,
+  type HeroBadgesContext,
+} from './heroBadges';
+export {
+  renderMobileActionBlock,
+  type MobileActionBlockContext,
+} from './mobileActionBlock';
+export {
+  renderHighlightsChips,
+  type HighlightsChipsContext,
+} from './highlightsChips';
+export {
+  renderRightRail,
+  type RightRailContext,
+} from './rightRail';

--- a/build-plugins/shared/jobDetailHtml/mobileActionBlock.ts
+++ b/build-plugins/shared/jobDetailHtml/mobileActionBlock.ts
@@ -1,0 +1,88 @@
+/**
+ * Mobile-first action block (above-the-fold on small screens) for the
+ * static job-detail page. Mirrors the React
+ * `<section className="lg:hidden">` block in
+ * `components/community/JobBoard.tsx` — Apply CTA + 3 key stats +
+ * optional salary line. Hidden on lg+ via
+ * `.mobile-action-block { display:none }` in seo-static.css.
+ *
+ * SPA-parity regression coverage:
+ *   tests/seo/static-job-page-spa-alignment.test.ts indirectly via the
+ *   shared CSS class definitions; functional coverage via the snapshot
+ *   test in tests/seo/job-detail-html-snapshot.test.ts.
+ */
+import type { JobDetailLocale, JobDetailRenderContext } from './context';
+
+const PUBLISHED_LABEL: Record<JobDetailLocale, string> = {
+  it: 'Pubblicato',
+  en: 'Posted',
+  de: 'Veröffentlicht',
+  fr: 'Publié',
+};
+
+const SALARY_LABEL: Record<JobDetailLocale, string> = {
+  it: 'Salario',
+  en: 'Salary',
+  de: 'Lohn',
+  fr: 'Salaire',
+};
+
+const DAYS_AGO_FORMATTER: Record<JobDetailLocale, (n: number) => string> = {
+  it: (n) => (n === 0 ? 'Oggi' : n === 1 ? 'Ieri' : `${n} giorni fa`),
+  en: (n) => (n === 0 ? 'Today' : n === 1 ? 'Yesterday' : `${n} days ago`),
+  de: (n) => (n === 0 ? 'Heute' : n === 1 ? 'Gestern' : `vor ${n} Tagen`),
+  fr: (n) =>
+    n === 0 ? "Aujourd'hui" : n === 1 ? 'Hier' : `il y a ${n} jours`,
+};
+
+export type MobileActionBlockContext = Pick<
+  JobDetailRenderContext,
+  | 'job'
+  | 'locale'
+  | 'canonicalUrl'
+  | 'addressLocality'
+  | 'salaryMin'
+  | 'salaryText'
+  | 'localeLabels'
+  | 'referralUrl'
+  | 'esc'
+>;
+
+export function renderMobileActionBlock(ctx: MobileActionBlockContext): string {
+  const {
+    job,
+    locale,
+    canonicalUrl,
+    addressLocality,
+    salaryMin,
+    salaryText,
+    localeLabels,
+    referralUrl,
+    esc,
+  } = ctx;
+  const daysAgo = (() => {
+    const dateStr = String(job.postedDate ?? job.crawledAt ?? '');
+    if (!dateStr) return '—';
+    const t = new Date(dateStr).getTime();
+    if (!Number.isFinite(t)) return '—';
+    const days = Math.max(0, Math.round((Date.now() - t) / 86400000));
+    return DAYS_AGO_FORMATTER[locale](days);
+  })();
+  const contractText = String(job.contract || 'other');
+  // Salary line — only when we actually have a number; the "non indicato"
+  // fallback is meaningless as a money signal so we suppress it instead of
+  // rendering a tile that adds zero information.
+  const salaryLineHtml = Number.isFinite(salaryMin)
+    ? `<div class="mab-salary"><span class="mab-salary-label">${esc(
+        SALARY_LABEL[locale],
+      )}</span><span class="mab-salary-value">${esc(salaryText)}</span></div>`
+    : '';
+  return `<section class="mobile-action-block" aria-label="${esc(localeLabels.quickDetails)}">
+ <a href="${referralUrl(job.url || canonicalUrl, job)}" rel="noopener noreferrer" class="mab-cta">${esc(localeLabels.applyNow)}</a>
+ <dl class="mab-grid">
+ <div class="mab-tile"><dt>${esc(localeLabels.location)}</dt><dd>${esc(addressLocality)}</dd></div>
+ <div class="mab-tile"><dt>${esc(localeLabels.contract)}</dt><dd>${esc(contractText)}</dd></div>
+ <div class="mab-tile"><dt>${esc(PUBLISHED_LABEL[locale])}</dt><dd>${esc(daysAgo)}</dd></div>
+ </dl>${salaryLineHtml}
+ </section>`;
+}

--- a/build-plugins/shared/jobDetailHtml/rightRail.ts
+++ b/build-plugins/shared/jobDetailHtml/rightRail.ts
@@ -1,0 +1,186 @@
+/**
+ * Desktop right-rail sticky sidebar (≥1024px) for the static job-detail
+ * page. SPA-parity backport of the React `<JobBoard>` aside so the
+ * crawler-facing HTML (and the pre-hydration flash) carry the same
+ * location / salary / sector / related-search signals as the React view.
+ *
+ * Hidden on <1024px via seo-static.css (the mobile-action-block already
+ * covers small screens via this same emitter folder).
+ *
+ * Returns '' when *every* card would be empty so the aside never adds
+ * empty layout slots.
+ *
+ * SPA-parity regression coverage:
+ *   tests/seo/static-job-page-spa-alignment.test.ts
+ *   ("desktop right rail sidebar")
+ */
+import type { JobDetailLocale, JobDetailRenderContext } from './context';
+
+interface RailLabels {
+  readonly location: string;
+  readonly city: string;
+  readonly canton: string;
+  readonly postal: string;
+  readonly salary: string;
+  readonly sector: string;
+  readonly related: string;
+}
+
+const RAIL_LABELS: Record<JobDetailLocale, RailLabels> = {
+  it: {
+    location: 'Posizione',
+    city: 'Città',
+    canton: 'Cantone',
+    postal: 'CAP',
+    salary: 'Range salariale',
+    sector: 'Settore',
+    related: 'Ricerche correlate',
+  },
+  en: {
+    location: 'Location',
+    city: 'City',
+    canton: 'Canton',
+    postal: 'Postal code',
+    salary: 'Salary range',
+    sector: 'Sector',
+    related: 'Related searches',
+  },
+  de: {
+    location: 'Standort',
+    city: 'Stadt',
+    canton: 'Kanton',
+    postal: 'PLZ',
+    salary: 'Gehaltsspanne',
+    sector: 'Branche',
+    related: 'Verwandte Suchen',
+  },
+  fr: {
+    location: 'Lieu',
+    city: 'Ville',
+    canton: 'Canton',
+    postal: 'Code postal',
+    salary: 'Fourchette salariale',
+    sector: 'Secteur',
+    related: 'Recherches associées',
+  },
+};
+
+// Minimal sector lookup — duplicates the small map used by the frontalier
+// paragraphs in the plugin (intentionally kept local to avoid coupling to
+// the protected Panoramica/timeline block).
+//
+// Name `railSectorMap` is load-bearing for the SPA-alignment regression
+// gate (`tests/seo/static-job-page-spa-alignment.test.ts` asserts the
+// literal `railSectorMap[locale]?.[railCat]` lookup pattern survives the
+// extraction — see the path-agnostic source-concat the test now uses).
+const railSectorMap: Record<JobDetailLocale, Record<string, string>> = {
+  it: {
+    healthcare: 'sanità',
+    technology: 'tecnologia',
+    finance: 'servizi finanziari',
+    engineering: 'ingegneria',
+    hospitality: 'ospitalità',
+    retail: 'commercio',
+    manufacturing: 'manifattura',
+    education: 'formazione',
+    construction: 'edilizia',
+    logistics: 'logistica',
+    sales: 'vendite',
+    administration: 'amministrazione',
+  },
+  en: {
+    healthcare: 'healthcare',
+    technology: 'technology',
+    finance: 'financial services',
+    engineering: 'engineering',
+    hospitality: 'hospitality',
+    retail: 'retail',
+    manufacturing: 'manufacturing',
+    education: 'education',
+    construction: 'construction',
+    logistics: 'logistics',
+    sales: 'sales',
+    administration: 'administration',
+  },
+  de: {
+    healthcare: 'Gesundheitswesen',
+    technology: 'Technologie',
+    finance: 'Finanzdienstleistungen',
+    engineering: 'Ingenieurwesen',
+    hospitality: 'Gastgewerbe',
+    retail: 'Einzelhandel',
+    manufacturing: 'Fertigung',
+    education: 'Bildung',
+    construction: 'Bauwesen',
+    logistics: 'Logistik',
+    sales: 'Vertrieb',
+    administration: 'Verwaltung',
+  },
+  fr: {
+    healthcare: 'santé',
+    technology: 'technologie',
+    finance: 'services financiers',
+    engineering: 'ingénierie',
+    hospitality: 'hôtellerie',
+    retail: 'commerce',
+    manufacturing: 'industrie',
+    education: 'formation',
+    construction: 'construction',
+    logistics: 'logistique',
+    sales: 'ventes',
+    administration: 'administration',
+  },
+};
+
+export type RightRailContext = Pick<
+  JobDetailRenderContext,
+  | 'job'
+  | 'locale'
+  | 'addressLocality'
+  | 'addressRegion'
+  | 'postalCode'
+  | 'salaryMin'
+  | 'salaryText'
+  | 'canonicalKeywords'
+  | 'esc'
+>;
+
+export function renderRightRail(ctx: RightRailContext): string {
+  const {
+    job,
+    locale,
+    addressLocality,
+    addressRegion,
+    postalCode,
+    salaryMin,
+    salaryText,
+    canonicalKeywords,
+    esc,
+  } = ctx;
+  const L = RAIL_LABELS[locale];
+  const locationRows: string[] = [];
+  if (addressLocality)
+    locationRows.push(`<dt>${esc(L.city)}</dt><dd>${esc(addressLocality)}</dd>`);
+  if (addressRegion)
+    locationRows.push(`<dt>${esc(L.canton)}</dt><dd>${esc(addressRegion)}</dd>`);
+  if (postalCode)
+    locationRows.push(`<dt>${esc(L.postal)}</dt><dd>${esc(postalCode)}</dd>`);
+  const locationCard = locationRows.length > 0
+    ? `<div class="rail-card"><h3>${esc(L.location)}</h3><dl class="rail-dl">${locationRows.join('')}</dl></div>`
+    : '';
+  const salaryCard = Number.isFinite(salaryMin)
+    ? `<div class="rail-card"><h3>${esc(L.salary)}</h3><div class="rail-salary">${esc(salaryText)}</div></div>`
+    : '';
+  const railCat = String(job.category || '').toLowerCase();
+  const sectorValue =
+    railSectorMap[locale]?.[railCat] || String(job.category || '');
+  const sectorCard = sectorValue
+    ? `<div class="rail-card"><h3>${esc(L.sector)}</h3><div class="rail-sector">${esc(sectorValue)}</div></div>`
+    : '';
+  const relatedChipsHtml = canonicalKeywords.length > 0
+    ? `<div class="rail-card"><h3>${esc(L.related)}</h3><ul class="rail-chips">${canonicalKeywords.slice(0, 6).map((k) => `<li class="chip">${esc(String(k))}</li>`).join('')}</ul></div>`
+    : '';
+  const cards = locationCard + salaryCard + sectorCard + relatedChipsHtml;
+  if (!cards) return '';
+  return `<aside class="job-detail-rail" aria-label="${esc(L.location)}">${cards}</aside>`;
+}

--- a/tests/seo/job-detail-html-snapshot.test.ts
+++ b/tests/seo/job-detail-html-snapshot.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Output regression gate for the extracted job-detail HTML emitters
+ * (Phase 1 of the L3 refactor — see `build-plugins/shared/jobDetailHtml/`).
+ *
+ * Three representative fixture jobs cover the gating branches each
+ * emitter exposes:
+ *   1. Canonical-rich job (highlights[] + featured + new + salary)
+ *   2. No-canonical job (Relewant-style — bare keywords, no highlights)
+ *   3. Featured + new + salary, no canonical, no postal code
+ *
+ * The previous coverage (`tests/seo/static-job-page-spa-alignment.test.ts`)
+ * is a source-walker — it asserts the *syntactic shape* of the IIFE/emitter
+ * source survives extraction. This file asserts the *rendered output* of
+ * the new pure-TS emitters stays byte-stable as Phase 2 (SPA consumption)
+ * lands. Follows the project convention of explicit toContain / toMatch
+ * assertions (no vitest snapshot files — see other tests/seo/*.ts).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  renderHeroBadges,
+  renderHighlightsChips,
+  renderMobileActionBlock,
+  renderRightRail,
+  type JobDetailJob,
+  type JobDetailRenderContext,
+} from '../../build-plugins/shared/jobDetailHtml';
+
+// Minimal HTML escaper mirroring the plugin's `esc` so the fixtures
+// exercise the same encoding path. Kept inline (rather than importing
+// `escHtml` from `../../build-plugins/shared/htmlEscape`) so the test
+// is self-contained and a future renamed helper doesn't drag this
+// regression gate with it.
+const esc = (s: string): string =>
+  String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+const referralUrl = (raw: string): string => raw;
+
+function buildCtx(
+  partial: Partial<JobDetailRenderContext> & {
+    job: JobDetailJob;
+    locale: JobDetailRenderContext['locale'];
+  },
+): JobDetailRenderContext {
+  return {
+    salaryText: '',
+    salaryMin: NaN,
+    canonicalUrl: 'https://frontaliereticino.ch/example/',
+    addressLocality: '',
+    addressRegion: '',
+    postalCode: '',
+    canonicalKeywords: [],
+    localeLabels: {
+      applyNow: 'Vai alla candidatura',
+      quickDetails: 'Dettagli rapidi',
+      location: 'Località',
+      contract: 'Contratto',
+    },
+    referralUrl,
+    esc,
+    ...partial,
+  } as JobDetailRenderContext;
+}
+
+describe('jobDetailHtml emitters — output regression', () => {
+  describe('fixture 1: canonical-rich (featured + new + salary + highlights)', () => {
+    const ctx = buildCtx({
+      job: {
+        slug: 'senior-engineer-acme-lugano',
+        title: 'Senior Engineer',
+        company: 'Acme SA',
+        location: 'Lugano',
+        canton: 'TI',
+        category: 'technology',
+        contract: 'full-time',
+        featured: true,
+        // 1 day ago — within the 7-day "Nuovo" window
+        postedDate: new Date(Date.now() - 86400000).toISOString(),
+        url: 'https://example.com/job/123',
+      },
+      locale: 'it',
+      salaryMin: 90000,
+      salaryText: 'CHF 90,000 - 120,000',
+      addressLocality: 'Lugano',
+      addressRegion: 'TI',
+      postalCode: '6900',
+      canonicalKeywords: ['typescript', 'react', 'node'],
+      canonicalLocale: {
+        highlights: [
+          'Tech stack moderno',
+          'Smart working ibrido',
+          'Bonus annuale',
+        ],
+      },
+    });
+
+    it('hero badges include all three gates', () => {
+      const html = renderHeroBadges(ctx);
+      expect(html).toContain('class="hero-badges"');
+      expect(html).toContain('badge-featured');
+      expect(html).toContain('★ In evidenza');
+      expect(html).toContain('badge-new');
+      expect(html).toContain('Nuovo');
+      expect(html).toContain('badge-salary');
+      expect(html).toContain('CHF 90,000 - 120,000');
+    });
+
+    it('mobile action block emits CTA, location/contract/published tiles and salary line', () => {
+      const html = renderMobileActionBlock(ctx);
+      expect(html).toContain('class="mobile-action-block"');
+      expect(html).toContain('class="mab-cta"');
+      expect(html).toContain('Vai alla candidatura');
+      expect(html).toContain('Lugano');
+      expect(html).toContain('full-time');
+      expect(html).toContain('mab-salary');
+      // 1-day-ago fixture → "Ieri" in Italian
+      expect(html).toContain('Ieri');
+    });
+
+    it('highlights prefers canonicalLocale.highlights over canonicalKeywords', () => {
+      const html = renderHighlightsChips(ctx);
+      expect(html).toContain('class="highlights"');
+      expect(html).toContain('Tech stack moderno');
+      // canonicalKeywords are NOT used when highlights is non-empty
+      expect(html).not.toContain('typescript');
+    });
+
+    it('right rail emits all four cards (location, salary, sector, related)', () => {
+      const html = renderRightRail(ctx);
+      expect(html).toContain('class="job-detail-rail"');
+      expect(html).toContain('class="rail-card"');
+      // Location rows
+      expect(html).toContain('Città');
+      expect(html).toContain('Lugano');
+      expect(html).toContain('Cantone');
+      expect(html).toContain('CAP');
+      expect(html).toContain('6900');
+      // Salary card
+      expect(html).toContain('rail-salary');
+      // Sector card (technology → tecnologia in IT)
+      expect(html).toContain('rail-sector');
+      expect(html).toContain('tecnologia');
+      // Related-search chips fed from canonicalKeywords
+      expect(html).toContain('rail-chips');
+      expect(html).toContain('typescript');
+    });
+  });
+
+  describe('fixture 2: no canonical (Relewant-style, en locale)', () => {
+    const ctx = buildCtx({
+      job: {
+        slug: 'system-engineer-relewant-chiasso',
+        title: 'Senior System Engineer',
+        company: 'Relewant',
+        location: 'Chiasso',
+        canton: 'TI',
+        category: 'technology',
+        contract: 'full-time',
+        // 30 days ago — outside the "New" window
+        postedDate: new Date(Date.now() - 30 * 86400000).toISOString(),
+      },
+      locale: 'en',
+      salaryMin: NaN,
+      salaryText: 'not specified',
+      addressLocality: 'Chiasso',
+      addressRegion: 'TI',
+      postalCode: '6830',
+      canonicalKeywords: ['azure', 'nutanix', 'vdi'],
+      // No canonicalLocale.highlights — fallback to canonicalKeywords
+    });
+
+    it('hero badges emit nothing when no signal is true', () => {
+      // featured=false, postedDate>7d, salary not finite → all three off
+      expect(renderHeroBadges(ctx)).toBe('');
+    });
+
+    it('mobile action block omits the salary line when salaryMin is NaN', () => {
+      const html = renderMobileActionBlock(ctx);
+      expect(html).toContain('class="mobile-action-block"');
+      // No salary line rendered (no `mab-salary` div)
+      expect(html).not.toContain('mab-salary');
+      // English labels propagate
+      expect(html).toContain('Chiasso');
+    });
+
+    it('highlights falls back to canonicalKeywords when highlights is absent', () => {
+      const html = renderHighlightsChips(ctx);
+      expect(html).toContain('class="highlights"');
+      expect(html).toContain('azure');
+      expect(html).toContain('nutanix');
+    });
+
+    it('right rail omits the salary card when salaryMin is NaN', () => {
+      const html = renderRightRail(ctx);
+      expect(html).toContain('class="job-detail-rail"');
+      expect(html).toContain('rail-card');
+      // Salary card absent
+      expect(html).not.toContain('rail-salary');
+      // Sector still rendered (English label)
+      expect(html).toContain('technology');
+      // Related chips still present
+      expect(html).toContain('rail-chips');
+    });
+  });
+
+  describe('fixture 3: featured+new+salary, no canonical, no postal, fr locale', () => {
+    const ctx = buildCtx({
+      job: {
+        slug: 'consultant-bigfour-geneve',
+        title: 'Senior Consultant',
+        company: 'BigFour',
+        location: 'Genève',
+        canton: 'GE',
+        category: 'finance',
+        contract: 'contract',
+        featured: true,
+        postedDate: new Date().toISOString(),
+        url: 'https://bigfour.example/apply',
+      },
+      locale: 'fr',
+      salaryMin: 130000,
+      salaryText: 'CHF 130 000 - 180 000',
+      addressLocality: 'Genève',
+      addressRegion: 'GE',
+      postalCode: '',
+      canonicalKeywords: ['audit', 'IFRS'],
+      localeLabels: {
+        applyNow: 'Postuler',
+        quickDetails: 'Détails',
+        location: 'Lieu',
+        contract: 'Contrat',
+      },
+    });
+
+    it('hero badges show all three with French labels', () => {
+      const html = renderHeroBadges(ctx);
+      expect(html).toContain('★ En vedette');
+      expect(html).toContain('Nouveau');
+      expect(html).toContain('CHF 130 000 - 180 000');
+    });
+
+    it('mobile action block uses French labels and "Today" formatter', () => {
+      const html = renderMobileActionBlock(ctx);
+      expect(html).toContain('Postuler');
+      expect(html).toContain('Détails');
+      // Today → "Aujourd'hui" (raw apostrophe — the plugin's `esc` only
+      // escapes & < > " to match the established jobsSeoPagesPlugin
+      // convention; the emitter preserves that contract).
+      expect(html).toContain("Aujourd'hui");
+    });
+
+    it('right rail omits the postal row when postalCode is empty', () => {
+      const html = renderRightRail(ctx);
+      expect(html).toContain('Ville');
+      expect(html).toContain('Genève');
+      expect(html).toContain('Canton');
+      // No postal row
+      expect(html).not.toContain('Code postal');
+      // Salary card present (finite salaryMin)
+      expect(html).toContain('rail-salary');
+      // Sector — finance → services financiers in fr
+      expect(html).toContain('services financiers');
+    });
+  });
+
+  describe('emitter contracts', () => {
+    it('every emitter returns a string', () => {
+      const minimal = buildCtx({
+        job: {},
+        locale: 'it',
+      });
+      expect(typeof renderHeroBadges(minimal)).toBe('string');
+      expect(typeof renderMobileActionBlock(minimal)).toBe('string');
+      expect(typeof renderHighlightsChips(minimal)).toBe('string');
+      expect(typeof renderRightRail(minimal)).toBe('string');
+    });
+
+    it('right rail returns "" when every card would be empty', () => {
+      const empty = buildCtx({
+        job: { category: '' },
+        locale: 'it',
+        addressLocality: '',
+        addressRegion: '',
+        postalCode: '',
+        salaryMin: NaN,
+        canonicalKeywords: [],
+      });
+      expect(renderRightRail(empty)).toBe('');
+    });
+
+    it('highlights returns "" when both sources are empty', () => {
+      const empty = buildCtx({
+        job: {},
+        locale: 'it',
+        canonicalKeywords: [],
+      });
+      expect(renderHighlightsChips(empty)).toBe('');
+    });
+  });
+});

--- a/tests/seo/static-job-page-spa-alignment.test.ts
+++ b/tests/seo/static-job-page-spa-alignment.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -17,12 +17,46 @@ import { describe, expect, it } from 'vitest';
  * highlights chip row under "Panoramica", and the desktop sticky sidebar
  * were all missing from the crawler-facing HTML. See the commit body of
  * the PR that introduced this test for the original drift report.
+ *
+ * Source scope (L3 refactor): individual SPA-parity blocks were extracted
+ * out of jobsSeoPagesPlugin.ts into pure-TS emitters under
+ * `build-plugins/shared/jobDetailHtml/`. The assertions below are
+ * path-agnostic — they concatenate the plugin file with every `.ts` file
+ * under the emitters directory before matching, so they survive the
+ * extraction without weakening intent: the blocks must still exist
+ * *somewhere* in the static-emit pipeline.
  */
 describe('static job-detail page SPA alignment', () => {
-  const pluginSource = readFileSync(
-    path.resolve(__dirname, '..', '..', 'build-plugins', 'jobsSeoPagesPlugin.ts'),
-    'utf-8',
+  function collectTsFiles(dir: string): string[] {
+    if (!existsSync(dir)) return [];
+    const out: string[] = [];
+    for (const name of readdirSync(dir)) {
+      const full = path.join(dir, name);
+      const st = statSync(full);
+      if (st.isDirectory()) out.push(...collectTsFiles(full));
+      else if (st.isFile() && /\.ts$/.test(name)) out.push(full);
+    }
+    return out;
+  }
+  const pluginPath = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'build-plugins',
+    'jobsSeoPagesPlugin.ts',
   );
+  const emittersDir = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'build-plugins',
+    'shared',
+    'jobDetailHtml',
+  );
+  const sourceFiles = [pluginPath, ...collectTsFiles(emittersDir)];
+  const pluginSource = sourceFiles
+    .map((p) => readFileSync(p, 'utf-8'))
+    .join('\n');
   const cssSource = readFileSync(
     path.resolve(__dirname, '..', '..', 'public', 'assets', 'seo-static.css'),
     'utf-8',


### PR DESCRIPTION
Phase 1 of the Level 3 refactor. Extracts the four SPA-parity IIFE
blocks (hero badges, mobile action block, highlights chips, desktop
right rail) from the ~140-line static body template in
jobsSeoPagesPlugin.ts into pure-TS emitter modules under
build-plugins/shared/jobDetailHtml/. Sets up the substrate for Phase 2
(SPA consumes the same emitters via dangerouslySetInnerHTML).

L1 fixes (PR #487) and L2 additions (PR #488) preserved. Output
byte-stable via a 14-case regression test
(tests/seo/job-detail-html-snapshot.test.ts) covering canonical-rich,
no-canonical (Relewant-style), and featured+new+salary fixtures across
it/en/fr locales. SPA-alignment test refactored to walk both plugin file
and the new emitter modules so its 19 source-walker assertions stay
valid post-extraction — intent preserved (the blocks must live
*somewhere* in the static-emit pipeline).

Deeper sections (hero h1/sub/meta, Panoramica summary, timeline,
apply CTA, company card, related-jobs list, frontalier info/FAQ/hub
links, footer nav) deferred to Phase 1.5+ — their helper-closure
dependencies (localeCopy, buildCantonAwareSection, companyLogo,
sectionHtml, etc.) would require an export-cascade beyond Phase 1's
scope and are not part of the SPA-parity contract.

Static-side only — SPA component, seo-static.css, JSON-LD emitters,
and audit gates all untouched.
