### PR TITLE
fix(spa): bridge orphan-flicker on refresh of cross-canton job URLs

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -5828,6 +5828,18 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (robotsMeta?.getAttribute('content')?.includes('noindex')) {
  robotsMeta.remove();
  }
+ // Bridge-in-flight guard: if the slug-map knows this slug points to a real
+ // job (different canton, slug-rename alias, or cross-locale), the bridge
+ // fallback effect above is still merging it into `jobs`. Show a skeleton
+ // instead of flashing JobOrphanView ("Questo annuncio non è più disponibile")
+ // for the few hundred ms between hydration and bridge resolve — the
+ // pre-rendered static body shows the real content during that window, so
+ // any flip to Orphan is a visible regression.
+ const bridgeTargetForRender = bridgeTargetSlug || initialJobSlug;
+ const bridgeMeta = getJobMetaForSlug(bridgeTargetForRender);
+ if (bridgeMeta?.id && bridgeFetchAttempted !== bridgeTargetForRender) {
+ return <SkeletonJobDetail />;
+ }
  // Expired: slug found in expired-jobs.json — show metadata + sign-in + related
  if (expiredJobLoading) return <SkeletonJobDetail />;
  if (expiredJob) {

--- a/services/router.ts
+++ b/services/router.ts
@@ -1644,11 +1644,41 @@ export async function ensureJobSlugMapLoaded(): Promise<void> {
 // The JobBoard component will trigger loading via registerJobSlugMap().
 // This saves ~800ms of main-thread blocking on initial page load.
 if (typeof window !== 'undefined') {
+ // Job-detail URLs (e.g. /cerca-lavoro-ticino/<slug>/) need the slug map
+ // eagerly to resolve cross-canton bridges before render. Without it, the
+ // SPA flashes JobOrphanView ("Questo annuncio non è più disponibile") for
+ // the few hundred ms between hydration and bridge fetch — see
+ // JobBoard.tsx bridge-in-flight guard. Detect via path shape: any segment
+ // matching a known job-board slug prefix followed by another non-empty
+ // segment is a candidate detail page.
+ const isJobDetailUrl = (): boolean => {
+ try {
+ const segments = window.location.pathname.split('/').filter(Boolean);
+ if (segments.length < 2) return false;
+ // Strip optional locale prefix
+ const start = ['en', 'de', 'fr'].includes(segments[0]) ? 1 : 0;
+ const candidate = segments[start];
+ if (!candidate) return false;
+ // Match "cerca-lavoro-*" (IT), "find-jobs-*" (EN), "jobs-in-*" (DE),
+ // "trouver-emploi-*" (FR) — see SLUG_TABLES and getJobBoardSlug.
+ if (!/^(cerca-lavoro|find-jobs|jobs-in|trouver-emploi)/.test(candidate)) return false;
+ // Must have at least one more segment (the job slug or city/sector)
+ return segments.length > start + 1;
+ } catch {
+ return false;
+ }
+ };
+ if (isJobDetailUrl()) {
+ // Eager: kick the fetch right away. Cheap parallel work; the network is
+ // mostly idle while the JS bundle parses.
+ ensureJobSlugMapLoaded().catch(() => { /* non-critical — JobBoard will register later */ });
+ } else {
  // Use requestIdleCallback (or setTimeout fallback) so it doesn't block LCP
  const deferLoad = typeof requestIdleCallback === 'function' ? requestIdleCallback : (cb: () => void) => setTimeout(cb, 4000);
  deferLoad(() => {
  ensureJobSlugMapLoaded().catch(() => { /* non-critical — JobBoard will register later */ });
  });
+ }
 }
 
 // ── Lazy-loaded blog data (code-split into routerBlogData.ts) ──

--- a/tests/bridge-orphan-flicker-guard.test.ts
+++ b/tests/bridge-orphan-flicker-guard.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(__dirname, '..');
+
+/**
+ * Regression: cross-canton bridge URLs (e.g. `/cerca-lavoro-ticino/<slug>/`
+ * pointing to a job whose canonical canton is SZ/AI/…) used to FLASH
+ * `JobOrphanView` ("Questo annuncio non è più disponibile") in the window
+ * between SPA hydration and the bridge fallback fetch resolving — even
+ * though the pre-rendered static body had the full job content.
+ *
+ * Reproduced on prod 2026-05-22 with
+ *   /cerca-lavoro-ticino/responsabile-pulizie-manutenzione-60-100-spital-schwyz-schwyz/
+ * (canonical canton SZ). First load showed the detail (static paint),
+ * refresh flipped to Orphan because hydration outran the slug-map fetch.
+ *
+ * Fix is two-fold:
+ *   1. JobBoard.tsx render branch: if the slug-map knows the job
+ *      (getJobMetaForSlug returns an id) and the bridge fallback effect
+ *      has not yet attempted for the current targetSlug, render a skeleton
+ *      instead of Orphan.
+ *   2. router.ts module init: for job-detail URLs, fire
+ *      ensureJobSlugMapLoaded() eagerly instead of in requestIdleCallback,
+ *      so the slug-map is in memory by the time the render guard runs.
+ */
+describe('Bridge orphan-flicker guard (2026-05-22 regression)', () => {
+  const jobBoardSrc = fs.readFileSync(
+    path.resolve(root, 'components/community/JobBoard.tsx'),
+    'utf-8',
+  );
+  const routerSrc = fs.readFileSync(
+    path.resolve(root, 'services/router.ts'),
+    'utf-8',
+  );
+
+  describe('JobBoard render guard', () => {
+    it('looks up bridge meta via getJobMetaForSlug before rendering JobOrphanView', () => {
+      // The guard must consult the slug map BEFORE the Orphan render branch.
+      expect(jobBoardSrc).toMatch(/const bridgeTargetForRender = bridgeTargetSlug \|\| initialJobSlug;/);
+      expect(jobBoardSrc).toMatch(/const bridgeMeta = getJobMetaForSlug\(bridgeTargetForRender\);/);
+    });
+
+    it('returns SkeletonJobDetail when the bridge fetch has not yet attempted for the current slug', () => {
+      // Pattern: if slug-map knows this slug (bridgeMeta.id present) AND
+      // bridgeFetchAttempted !== bridgeTargetForRender, render skeleton.
+      expect(jobBoardSrc).toMatch(
+        /if \(bridgeMeta\?\.id && bridgeFetchAttempted !== bridgeTargetForRender\) \{[\s\S]{0,200}return <SkeletonJobDetail \/>;[\s\S]{0,40}\}/,
+      );
+    });
+
+    it('places the guard above the JobOrphanView fallback', () => {
+      // Source order matters: guard must precede the Orphan return.
+      const guardIdx = jobBoardSrc.indexOf('bridgeFetchAttempted !== bridgeTargetForRender');
+      const orphanIdx = jobBoardSrc.indexOf('<JobOrphanView');
+      expect(guardIdx).toBeGreaterThan(0);
+      expect(orphanIdx).toBeGreaterThan(0);
+      expect(guardIdx).toBeLessThan(orphanIdx);
+    });
+  });
+
+  describe('router eager slug-map preload', () => {
+    it('defines an isJobDetailUrl predicate that matches cerca-lavoro / find-jobs / jobs-in / trouver-emploi prefixes', () => {
+      expect(routerSrc).toContain('const isJobDetailUrl');
+      // Must cover all four locale job-board prefixes.
+      expect(routerSrc).toMatch(/cerca-lavoro\|find-jobs\|jobs-in\|trouver-emploi/);
+    });
+
+    it('strips optional locale prefix (en / de / fr) before matching', () => {
+      expect(routerSrc).toMatch(/\['en', 'de', 'fr'\]\.includes\(segments\[0\]\)/);
+    });
+
+    it('requires at least two segments after locale stripping (board + job-slug-or-city)', () => {
+      // A bare /cerca-lavoro-ticino/ is the LISTING, not a detail page.
+      expect(routerSrc).toMatch(/segments\.length > start \+ 1/);
+    });
+
+    it('fires ensureJobSlugMapLoaded eagerly (NOT through requestIdleCallback) when on a job-detail URL', () => {
+      // Locate the eager branch and confirm it does not wrap in deferLoad.
+      const eagerBranch = routerSrc.match(
+        /if \(isJobDetailUrl\(\)\) \{[\s\S]{0,400}\} else \{/,
+      );
+      expect(eagerBranch).not.toBeNull();
+      expect(eagerBranch![0]).toContain('ensureJobSlugMapLoaded()');
+      expect(eagerBranch![0]).not.toContain('requestIdleCallback');
+      expect(eagerBranch![0]).not.toContain('deferLoad');
+    });
+
+    it('keeps the requestIdleCallback path for non-job-detail URLs (LCP-preserving default)', () => {
+      // The else branch must still defer to keep the original LCP win on
+      // calc/landing/blog pages. This is the regression boundary: don't
+      // accidentally eager-load on every page.
+      expect(routerSrc).toMatch(
+        /\} else \{[\s\S]{0,400}deferLoad\([\s\S]{0,200}ensureJobSlugMapLoaded/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Symptom (2026-05-22, reported on
/cerca-lavoro-ticino/responsabile-pulizie-manutenzione-60-100-spital-schwyz-schwyz/):
first paint shows the full job detail (pre-rendered static body), refresh
flips to "Questo annuncio non è più disponibile". The job lives in canton
SZ; the TI URL is a cross-canton bridge.

Root cause: JobBoard's render branch returned <JobOrphanView/> whenever
selectedJob was null, without waiting for the cross-canton bridge fallback
effect to attempt its slim-index merge. On refresh the HTTP cache made
hydration outrun the requestIdleCallback-scheduled slug-map fetch, so the
guard at line 5824 fired with bridgeMeta still unresolved.

Fix 1 (JobBoard.tsx): before falling through to JobOrphanView, look up
the target slug in the slug map via getJobMetaForSlug. If a job id exists
and bridgeFetchAttempted has not yet recorded this targetSlug, render
SkeletonJobDetail instead — the bridge effect is still in flight.

Fix 2 (router.ts): on module init, detect job-detail URLs (cerca-lavoro-/
find-jobs-/jobs-in-/trouver-emploi- followed by a job-slug segment) and
fire ensureJobSlugMapLoaded eagerly instead of through requestIdleCallback,
so the slug map is in memory by the time the guard runs. Other pages keep
the LCP-preserving idle defer.

Regression test (tests/bridge-orphan-flicker-guard.test.ts) source-greps
both fixes plus the predicate covering all 4 locale prefixes, mirroring
the existing tests/bridge-canton-aware.test.ts style.
