### PR TITLE
feat(seo): add STRIP_ACTIVE_JOB_PROSE flag for active job-detail pages

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -580,6 +580,12 @@ export function pickJobDisambiguator(
 // expired-job HTML carries the marker below; audits use the same marker to
 // skip text-html-ratio and other content-quality gates on these pages.
 const STRIP_EXPIRED_JOB_PROSE = (process.env.STRIP_EXPIRED_JOB_PROSE ?? '1') !== '0';
+// Same idea for ACTIVE job-detail pages (h4 variant: ~2.4 KB/locale of
+// "Informazioni per frontalieri" + "Domande frequenti"). Default OFF — those
+// pages are the SEO primary surface and their text-html-ratio depends on the
+// prose, so opt-in only (set STRIP_ACTIVE_JOB_PROSE=1). When on, the same
+// marker is emitted and audits skip the page just like for expired pages.
+const STRIP_ACTIVE_JOB_PROSE = process.env.STRIP_ACTIVE_JOB_PROSE === '1';
 const EJP_STRIPPED_MARKER = '<!--ejp-stripped-->';
 
 export function jobsSeoPagesPlugin(rootDir: string): Plugin {
@@ -2659,6 +2665,10 @@ ${hreflangHtml}
  }
  return `<section class="section"><h4>${esc(heading[locale] || heading.it)}</h4><div class="pillrow">${links.join('')}</div></section>`;
  })();
+ // STRIP_ACTIVE_JOB_PROSE: when on, drop the two prose sections and emit the
+ // audit-skip marker so text-html-ratio (and other content gates) ignore the
+ // page. hubLinks (internal-linking chips) stays — it's UI, not filler prose.
+ if (STRIP_ACTIVE_JOB_PROSE) return EJP_STRIPPED_MARKER + hubLinks;
  return (frontalierInfo[locale] || '') + (faqSection[locale] || '') + hubLinks;
  })()}
  <nav class="fn">

--- a/tests/seo/expired-job-prose-marker.test.ts
+++ b/tests/seo/expired-job-prose-marker.test.ts
@@ -2,15 +2,16 @@
  * expired-job-prose-marker.test.ts
  *
  * Verifies that the text-html-ratio auditor skips pages carrying the
- * `<!--ejp-stripped-->` marker emitted by jobsSeoPagesPlugin when the
- * STRIP_EXPIRED_JOB_PROSE flag is on (default). Those pages have their
- * SEO prose deliberately removed to keep dist under the 10 GB GitHub
- * Pages limit; their low text/HTML ratio is by design, so they must
- * not be counted as offenders.
+ * `<!--ejp-stripped-->` marker emitted by jobsSeoPagesPlugin when either
+ * STRIP_EXPIRED_JOB_PROSE (default ON, soft-landing pages) or
+ * STRIP_ACTIVE_JOB_PROSE (default OFF, opt-in for active job-detail) is set.
+ * Those pages have their SEO prose deliberately removed to keep dist under
+ * the 10 GB GitHub Pages limit; their low text/HTML ratio is by design, so
+ * they must not be counted as offenders.
  */
 
 import { describe, expect, it } from 'vitest';
-// @ts-expect-error: importing from an .mjs script with no .d.ts
+// @ts-ignore: importing from an .mjs script with no .d.ts (works at runtime via vitest)
 import { createAuditor } from '../../scripts/audit-text-html-ratio.mjs';
 
 const STRIPPED_PAGE = `<!doctype html><html><head>


### PR DESCRIPTION
Adds a sibling flag to STRIP_EXPIRED_JOB_PROSE that drops the compact h4
"Informazioni per frontalieri" + "Domande frequenti" prose (~2.4 KB/locale)
from active job-detail pages and emits the same <!--ejp-stripped--> marker
so the text-html-ratio audit skips them.

Default OFF — opt-in only. Active job pages are the primary SEO surface
(target for "{job title} {city}" long-tail), so the prose is generally
worth keeping. With ~22,163 active jobs × 4 locales × ~2.4 KB the
theoretical savings are ~213 MB if enabled, vs the ~495 MB already
shaved off the expired-job pages.

Use STRIP_ACTIVE_JOB_PROSE=1 alongside STRIP_EXPIRED_JOB_PROSE if you
need to push dist further under the 10 GB GitHub Pages cap; verify
text-html-ratio first via audit-replay on the artifact.
