### PR TITLE
feat(seo): strip bridge-page prose behind STRIP_BRIDGE_PAGE_PROSE flag

### DIFF
--- a/build-plugins/shared/bridgePageProse.ts
+++ b/build-plugins/shared/bridgePageProse.ts
@@ -44,6 +44,21 @@
  * Pure: identical (locale, bridgeKind) inputs produce identical HTML.
  */
 
+// Local feature flag: skip the prose entirely on bridge pages (slug rename
+// / legacy alias redirects). Default ON because bridges are pure redirect
+// vehicles — Google de-duplicates via canonical, and these pages add bulk
+// to the dist without SEO value. When stripped each bridge HTML carries
+// the marker below; scripts/audit-text-html-ratio.mjs already skips pages
+// matching this marker (mirrors STRIP_EXPIRED_JOB_PROSE in jobsSeoPagesPlugin).
+// Opt out with STRIP_BRIDGE_PAGE_PROSE=0 (re-enables the original prose
+// that was added to keep bridges above the 10 % text-html-ratio gate).
+//
+// Read lazily inside renderBridgePageProse() so unit tests can override via
+// vi.stubEnv() — module-load reads cannot be overridden by tests.
+const isStripBridgeProse = (): boolean =>
+  (process.env.STRIP_BRIDGE_PAGE_PROSE ?? '1') !== '0';
+const EJP_STRIPPED_MARKER = '<!--ejp-stripped-->';
+
 export type BridgeProseLocale = 'it' | 'en' | 'de' | 'fr';
 
 /**
@@ -284,6 +299,10 @@ const PROSE_CACHE = new Map<string, string>();
  * embedding it within its own `<main>`.
  */
 export function renderBridgePageProse(opts: BridgePageProseOpts): string {
+  // Default-on strip: bridges become near-empty (just the marker), and the
+  // text-html-ratio audit ignores them via the EJP_STRIPPED_MARKER match.
+  if (isStripBridgeProse()) return EJP_STRIPPED_MARKER;
+
   const { locale, bridgeKind } = opts;
   const cacheKey = `${locale}::${bridgeKind}`;
   const cached = PROSE_CACHE.get(cacheKey);

--- a/tests/seo/bridge-page-prose.test.ts
+++ b/tests/seo/bridge-page-prose.test.ts
@@ -34,13 +34,25 @@
  * gate on the bridge pages.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterAll, beforeAll, describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   renderBridgePageProse,
   __resetBridgeProseCache,
   type BridgePageKind,
   type BridgePageLocale,
 } from '../../build-plugins/shared/bridgePageProse';
+
+// The default behaviour of renderBridgePageProse is now to return only the
+// `<!--ejp-stripped-->` marker (STRIP_BRIDGE_PAGE_PROSE=1, default ON, dist
+// shrinkage). The original prose-content assertions below validate the
+// opt-out path, so each block opts out via vi.stubEnv before running and
+// restores afterwards.
+beforeAll(() => {
+  vi.stubEnv('STRIP_BRIDGE_PAGE_PROSE', '0');
+});
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 const LOCALES: BridgePageLocale[] = ['it', 'en', 'de', 'fr'];
 const KINDS: BridgePageKind[] = [
@@ -170,5 +182,31 @@ describe('bridgePageProse helper', () => {
         expect(a).toBe(b);
       }
     }
+  });
+});
+
+describe('bridgePageProse — STRIP_BRIDGE_PAGE_PROSE default-on behaviour', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('STRIP_BRIDGE_PAGE_PROSE', '1');
+    __resetBridgeProseCache();
+  });
+
+  it('returns only the audit-skip marker when flag is on (default)', () => {
+    for (const locale of LOCALES) {
+      for (const kind of KINDS) {
+        const html = renderBridgePageProse({ locale, bridgeKind: kind });
+        expect(html).toBe('<!--ejp-stripped-->');
+      }
+    }
+  });
+
+  it('absent env var also strips (default ON)', () => {
+    vi.unstubAllEnvs();
+    expect(process.env.STRIP_BRIDGE_PAGE_PROSE).toBeUndefined();
+    const html = renderBridgePageProse({ locale: 'it', bridgeKind: 'generic' });
+    expect(html).toBe('<!--ejp-stripped-->');
+    // Restore the outer beforeAll state so subsequent tests still see flag=0.
+    vi.stubEnv('STRIP_BRIDGE_PAGE_PROSE', '0');
   });
 });

--- a/tests/seo/expired-job-prose-marker.test.ts
+++ b/tests/seo/expired-job-prose-marker.test.ts
@@ -2,12 +2,15 @@
  * expired-job-prose-marker.test.ts
  *
  * Verifies that the text-html-ratio auditor skips pages carrying the
- * `<!--ejp-stripped-->` marker emitted by jobsSeoPagesPlugin when either
- * STRIP_EXPIRED_JOB_PROSE (default ON, soft-landing pages) or
- * STRIP_ACTIVE_JOB_PROSE (default OFF, opt-in for active job-detail) is set.
- * Those pages have their SEO prose deliberately removed to keep dist under
- * the 10 GB GitHub Pages limit; their low text/HTML ratio is by design, so
- * they must not be counted as offenders.
+ * `<!--ejp-stripped-->` marker emitted when prose is intentionally
+ * stripped via one of:
+ *   - STRIP_EXPIRED_JOB_PROSE (default ON, soft-landing job pages)
+ *   - STRIP_ACTIVE_JOB_PROSE  (default OFF, opt-in for active job-detail)
+ *   - STRIP_BRIDGE_PAGE_PROSE (default ON, slug-rename / legacy alias bridges)
+ *
+ * In all three cases the page's low text/HTML ratio is by design (dist
+ * shrinkage toward the 10 GB GitHub Pages cap), so it must not count as
+ * an offender against the Semrush gate.
  */
 
 import { describe, expect, it } from 'vitest';


### PR DESCRIPTION
Default ON. renderBridgePageProse() returns only the <!--ejp-stripped-->
marker so audit-text-html-ratio skips the (now near-empty) bridge HTML.
Bridges are pure redirect vehicles (slug renames / legacy aliases) —
Google de-duplicates via canonical, so the ~1.6-2.0 KB filler that was
added to keep them above the 10 % text-html-ratio gate has no SEO value.

Estimated dist savings: ~24-95 MB depending on how many tracking entries
carry previousSlugs bridges (4 locales each).

Flag is evaluated lazily so unit tests can opt out via vi.stubEnv('0')
to keep validating the original prose copy when flag is off. Opt out
with STRIP_BRIDGE_PAGE_PROSE=0 (re-enables the original prose).

Together with STRIP_EXPIRED_JOB_PROSE (default on) and the opt-in
STRIP_ACTIVE_JOB_PROSE this completes the dist-shrinkage pass toward
the 10 GB GitHub Pages cap.
