### PR TITLE
fix(ci): reclaim ~25 GB of preinstalled SDKs in validate-dist + rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -996,6 +996,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # See post-deploy-validate-dist.yml: same OOM root cause on rollback —
+      # downloading the last-known-good github-pages artifact (~1.8 GB) on top
+      # of the failed run's leftovers blows the 14 GB partition. Reclaim
+      # preinstalled SDKs before any heavy I/O.
+      - name: Free disk space on runner
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
+            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
+          df -h /
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -37,6 +37,21 @@ jobs:
       - name: Checkout (same SHA as deploy — invariant in workflow_call)
         uses: actions/checkout@v5
 
+      # Reclaim ~25 GB of preinstalled SDKs we never use (dotnet, android,
+      # haskell, CodeQL, powershell). Run 26287421188 OOM'd the runner mid
+      # artifact-extract because the github-pages tarball (~1.8 GB) + dist
+      # extraction + node_modules + Playwright report leftovers crowded a
+      # 14 GB default partition. Best-effort: `|| true` keeps the build
+      # green if a path was already pruned by a future image refresh.
+      - name: Free disk space on runner
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
+            /usr/local/share/chromium /usr/local/lib/node_modules 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
+          df -h /
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
Run 26287421188 OOM'd both jobs ("No space left on device") mid github-pages
artifact extract. The 1.8 GB tarball + dist + node_modules + Playwright report
leftovers exceed the 14 GB default partition on ubuntu-latest. Prune dotnet,
android, haskell, CodeQL, powershell, chromium preinstalled toolchains right
after checkout — best-effort with || true so future image refreshes don't
break us.
