### PR TITLE
fix(build): use relative imports in canonicalFallback for vite.config eval

### DIFF
--- a/services/jobs/canonicalFallback.ts
+++ b/services/jobs/canonicalFallback.ts
@@ -6,8 +6,11 @@
 //
 // Keep this module pure: no React, no DOM, no Node-only APIs.
 
-import type { Locale } from '@/services/i18n';
-import { cleanCanonicalItems } from '@/services/relatedSearchClusters';
+// Use relative imports (not the `@/...` Vite alias): this module is
+// transitively required by build-plugins loaded during `vite.config.ts`
+// evaluation, where Node ESM resolves before Vite installs alias support.
+import type { Locale } from '../i18n';
+import { cleanCanonicalItems } from '../relatedSearchClusters';
 
 export type CanonicalLocaleContent = {
  summary: string[];


### PR DESCRIPTION
`services/jobs/canonicalFallback.ts` is transitively required by
`build-plugins/jobsSeoPagesPlugin.ts`, which is imported during
`vite.config.ts` evaluation. At that stage Node ESM resolves modules
before Vite installs its path-alias resolver, so the `@/services/...`
imports introduced in PR #498 caused:

  Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@/services'
  imported from ...vite.config.ts.timestamp-*.mjs

(seen in deploy run 26293840374). All other build-plugin-facing modules
under `services/` use relative imports for the same reason — switch
this module to match.

No behaviour change: typecheck still clean, all canonicalFallback tests
still green.
