### PR TITLE
fix(seo): inlineTextToHtml strips 3+ separator runs to match audit gate

### DIFF
--- a/build-plugins/shared/jobDescription/toHtml.ts
+++ b/build-plugins/shared/jobDescription/toHtml.ts
@@ -103,16 +103,21 @@ function stripExternalHtmlAttributes(s: string): string {
 
 export function inlineTextToHtml(text: string): string {
   if (!text) return '';
-  // Strip separator runs (6+ `_`/`=`/`~`) that AI-translation flattening
+  // Strip separator runs (3+ `_`/`=`/`~`) that AI-translation flattening
   // sometimes leaves mid-paragraph. The full parser preprocess catches
   // these for block-level rendering, but `inlineTextToHtml` runs on
   // already-split paragraphs (jobsSeoPagesPlugin#summaryHtml /
   // sectionHtml) and must scrub them itself or they leak into
   // `<main class="seo-static-content">` and trip
   // audit:no-literal-markdown (0-tolerance, CLAUDE.md rule #1).
-  // Real example: HFR ("Hôpital fribourgeois") descriptions flatten
-  // bilingual DE/FR copy to `Ref.: HFR-M-251801 ____________ Le Département…`.
-  const s = String(text).replace(/[_=~]{6,}/g, ' ').replace(/ {2,}/g, ' ');
+  // Threshold matches `SEPARATOR_RUN_RE` in scripts/audit-no-literal-markdown.mjs
+  // (`[_=~]{3,}`): the previous 6+ threshold left 3-5 char runs (e.g. `===`,
+  // `~~~~`) untouched, surfaced after PR #498 wired the fallback splitter on
+  // 100% of jobs and surfaced 149 offender pages in validate-dist run 26300359056.
+  // Real examples: HFR job ads flatten bilingual copy to
+  // `Ref.: HFR-M-251801 ____________ Le Département…`; Tether-style postings
+  // wrap section headers in `===== Cosa offriamo: =====`.
+  const s = String(text).replace(/[_=~]{3,}/g, ' ').replace(/ {2,}/g, ' ');
   if (/<(strong|em|a|span|br)\b/i.test(s)) {
     return stripExternalHtmlAttributes(s);
   }


### PR DESCRIPTION
The audit at `scripts/audit-no-literal-markdown.mjs` flags any
`[_=~]{3,}` run in `<main class="seo-static-content">` as a 0-tolerance
failure. `inlineTextToHtml` was only stripping `[_=~]{6,}`, leaving
3-5 char runs (`===`, `~~~~`) to leak verbatim into bullet `<li>` items.

Previously the leak was statistically rare — only descriptions with mid-
paragraph separator decoration hit it. PR #498 wired the fallback
splitter on 100% of jobs, dropping every section item through
`inlineTextToHtml`, which surfaced 149 offender pages in validate-dist
run 26300359056. Tighten the threshold to match the audit's exact
pattern; defense-in-depth for any future content source (cron crawl
updates, locale relocalisation) that introduces short separator runs.

Verified locally on a synthetic Tether-style description containing
`===== Cosa offriamo: =====` and `~~~~`: both runs now scrub to a
space, `**bold**` continues to convert via `parseInline` correctly.
Existing `static-job-page-body` and `canonical-fallback-shape` tests
remain green.
