### PR TITLE
fix(ci): wire GH_TOKEN into 420 failure-reporter steps + harden helper

### DIFF
--- a/.github/workflows/cathedral-noindex-flip.yml
+++ b/.github/workflows/cathedral-noindex-flip.yml
@@ -119,6 +119,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: cathedral-noindex-flip — run ${{ github.run_number }}" \

--- a/.github/workflows/deploy-cloud-functions.yml
+++ b/.github/workflows/deploy-cloud-functions.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: ${{ github.workflow }} — run ${{ github.run_number }}" \

--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: ${{ github.workflow }} — run ${{ github.run_number }}" \

--- a/.github/workflows/persist-job-stats.yml
+++ b/.github/workflows/persist-job-stats.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Persist Job Stats — run ${{ github.run_number }}" \

--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -130,6 +130,8 @@ jobs:
       - name: Read deploy metadata from Firestore
         id: deploy-meta
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DATA=$(node scripts/deploy-registry.mjs get \
             --run-id="${{ inputs.deploy_run_id }}" 2>/dev/null || echo '{}')

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -178,6 +178,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Validation Failure (live): post-deploy — run ${{ github.run_number }}" \

--- a/.github/workflows/refresh-article-trending.yml
+++ b/.github/workflows/refresh-article-trending.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Refresh Article Trending — run ${{ github.run_number }}" \

--- a/.github/workflows/refresh-job-popularity.yml
+++ b/.github/workflows/refresh-job-popularity.yml
@@ -69,6 +69,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Refresh Job Popularity — run ${{ github.run_number }}" \

--- a/.github/workflows/send-job-alerts.yml
+++ b/.github/workflows/send-job-alerts.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Report failure to Linear
         if: steps.send-alerts.outcome == 'failure'
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: ${{ github.workflow }} — run ${{ github.run_number }}" \

--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -231,6 +231,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Translation Pipeline Failure" \

--- a/.github/workflows/update-jobs-a-plus-plus-group.yml
+++ b/.github/workflows/update-jobs-a-plus-plus-group.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-aarreha-schinznach.yml
+++ b/.github/workflows/update-jobs-aarreha-schinznach.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-abb.yml
+++ b/.github/workflows/update-jobs-abb.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-abbott.yml
+++ b/.github/workflows/update-jobs-abbott.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-adullam.yml
+++ b/.github/workflows/update-jobs-adullam.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-adus-klinik.yml
+++ b/.github/workflows/update-jobs-adus-klinik.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-afry.yml
+++ b/.github/workflows/update-jobs-afry.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-agie-charmilles.yml
+++ b/.github/workflows/update-jobs-agie-charmilles.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-agroscope.yml
+++ b/.github/workflows/update-jobs-agroscope.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ail.yml
+++ b/.github/workflows/update-jobs-ail.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-air-zermatt.yml
+++ b/.github/workflows/update-jobs-air-zermatt.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-alcon.yml
+++ b/.github/workflows/update-jobs-alcon.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-aldi-suisse.yml
+++ b/.github/workflows/update-jobs-aldi-suisse.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-allianz.yml
+++ b/.github/workflows/update-jobs-allianz.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-alpiq.yml
+++ b/.github/workflows/update-jobs-alpiq.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-alprose.yml
+++ b/.github/workflows/update-jobs-alprose.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-alten.yml
+++ b/.github/workflows/update-jobs-alten.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-amag.yml
+++ b/.github/workflows/update-jobs-amag.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ameos-ch.yml
+++ b/.github/workflows/update-jobs-ameos-ch.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-apg-sga.yml
+++ b/.github/workflows/update-jobs-apg-sga.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ardentis.yml
+++ b/.github/workflows/update-jobs-ardentis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ariston.yml
+++ b/.github/workflows/update-jobs-ariston.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-arosa-lenzerheide.yml
+++ b/.github/workflows/update-jobs-arosa-lenzerheide.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-arsante-clinique-de-carouge.yml
+++ b/.github/workflows/update-jobs-arsante-clinique-de-carouge.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-artificialy.yml
+++ b/.github/workflows/update-jobs-artificialy.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-artisa.yml
+++ b/.github/workflows/update-jobs-artisa.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-arxada.yml
+++ b/.github/workflows/update-jobs-arxada.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-asana-spital.yml
+++ b/.github/workflows/update-jobs-asana-spital.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-avaloq.yml
+++ b/.github/workflows/update-jobs-avaloq.yml
@@ -85,6 +85,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-axa.yml
+++ b/.github/workflows/update-jobs-axa.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-axpo.yml
+++ b/.github/workflows/update-jobs-axpo.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bachem.yml
+++ b/.github/workflows/update-jobs-bachem.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bachtelen.yml
+++ b/.github/workflows/update-jobs-bachtelen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-badrutts-palace.yml
+++ b/.github/workflows/update-jobs-badrutts-palace.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-balgrist.yml
+++ b/.github/workflows/update-jobs-balgrist.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bally.yml
+++ b/.github/workflows/update-jobs-bally.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-banca-sempione.yml
+++ b/.github/workflows/update-jobs-banca-sempione.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bcvs.yml
+++ b/.github/workflows/update-jobs-bcvs.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-benteler.yml
+++ b/.github/workflows/update-jobs-benteler.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-berit-klinik.yml
+++ b/.github/workflows/update-jobs-berit-klinik.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-berner-klinik-montana.yml
+++ b/.github/workflows/update-jobs-berner-klinik-montana.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-berner-montage.yml
+++ b/.github/workflows/update-jobs-berner-montage.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bethesda-spital.yml
+++ b/.github/workflows/update-jobs-bethesda-spital.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bitfinex.yml
+++ b/.github/workflows/update-jobs-bitfinex.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bls.yml
+++ b/.github/workflows/update-jobs-bls.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bms-building.yml
+++ b/.github/workflows/update-jobs-bms-building.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-board.yml
+++ b/.github/workflows/update-jobs-board.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bobst.yml
+++ b/.github/workflows/update-jobs-bobst.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bosch.yml
+++ b/.github/workflows/update-jobs-bosch.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bps-suisse.yml
+++ b/.github/workflows/update-jobs-bps-suisse.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-bracco.yml
+++ b/.github/workflows/update-jobs-bracco.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-buergenstock-hotels.yml
+++ b/.github/workflows/update-jobs-buergenstock-hotels.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-burkhalter.yml
+++ b/.github/workflows/update-jobs-burkhalter.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cambiavalute.yml
+++ b/.github/workflows/update-jobs-cambiavalute.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-canton-ticino-osc.yml
+++ b/.github/workflows/update-jobs-canton-ticino-osc.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-canton-valais.yml
+++ b/.github/workflows/update-jobs-canton-valais.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-capri-holdings.yml
+++ b/.github/workflows/update-jobs-capri-holdings.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-caritas-schweiz.yml
+++ b/.github/workflows/update-jobs-caritas-schweiz.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-casale.yml
+++ b/.github/workflows/update-jobs-casale.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-caseificio-gottardo.yml
+++ b/.github/workflows/update-jobs-caseificio-gottardo.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cds-savognin.yml
+++ b/.github/workflows/update-jobs-cds-savognin.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cedes.yml
+++ b/.github/workflows/update-jobs-cedes.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-centiel.yml
+++ b/.github/workflows/update-jobs-centiel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cerbios-pharma.yml
+++ b/.github/workflows/update-jobs-cerbios-pharma.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cereneo.yml
+++ b/.github/workflows/update-jobs-cereneo.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-chicco-doro.yml
+++ b/.github/workflows/update-jobs-chicco-doro.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-citta-di-bellinzona.yml
+++ b/.github/workflows/update-jobs-citta-di-bellinzona.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-citta-di-locarno.yml
+++ b/.github/workflows/update-jobs-citta-di-locarno.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-citta-di-lugano.yml
+++ b/.github/workflows/update-jobs-citta-di-lugano.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-claraspital.yml
+++ b/.github/workflows/update-jobs-claraspital.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cler.yml
+++ b/.github/workflows/update-jobs-cler.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clienia-ag.yml
+++ b/.github/workflows/update-jobs-clienia-ag.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clinica-hildebrand.yml
+++ b/.github/workflows/update-jobs-clinica-hildebrand.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clinica-holistica-engiadina.yml
+++ b/.github/workflows/update-jobs-clinica-holistica-engiadina.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clinica-varini.yml
+++ b/.github/workflows/update-jobs-clinica-varini.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clinique-cic.yml
+++ b/.github/workflows/update-jobs-clinique-cic.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clinique-de-la-plaine.yml
+++ b/.github/workflows/update-jobs-clinique-de-la-plaine.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clinique-la-source.yml
+++ b/.github/workflows/update-jobs-clinique-la-source.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-clinique-le-noirmont.yml
+++ b/.github/workflows/update-jobs-clinique-le-noirmont.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cnp.yml
+++ b/.github/workflows/update-jobs-cnp.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-colin-cie.yml
+++ b/.github/workflows/update-jobs-colin-cie.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-concara.yml
+++ b/.github/workflows/update-jobs-concara.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-confederazione.yml
+++ b/.github/workflows/update-jobs-confederazione.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-constellium.yml
+++ b/.github/workflows/update-jobs-constellium.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-convit.yml
+++ b/.github/workflows/update-jobs-convit.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-coop.yml
+++ b/.github/workflows/update-jobs-coop.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-coopers.yml
+++ b/.github/workflows/update-jobs-coopers.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-corner.yml
+++ b/.github/workflows/update-jobs-corner.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-crr-suva-sion.yml
+++ b/.github/workflows/update-jobs-crr-suva-sion.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cs-bregaglia.yml
+++ b/.github/workflows/update-jobs-cs-bregaglia.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-csc-costruzioni.yml
+++ b/.github/workflows/update-jobs-csc-costruzioni.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-csd-engineers.yml
+++ b/.github/workflows/update-jobs-csd-engineers.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-cseb.yml
+++ b/.github/workflows/update-jobs-cseb.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-csl-behring.yml
+++ b/.github/workflows/update-jobs-csl-behring.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-csvm-mustair.yml
+++ b/.github/workflows/update-jobs-csvm-mustair.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-csvp-poschiavo.yml
+++ b/.github/workflows/update-jobs-csvp-poschiavo.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-daler-hopital.yml
+++ b/.github/workflows/update-jobs-daler-hopital.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-damiani.yml
+++ b/.github/workflows/update-jobs-damiani.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-davos-klosters-bergbahnen.yml
+++ b/.github/workflows/update-jobs-davos-klosters-bergbahnen.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-debiopharm.yml
+++ b/.github/workflows/update-jobs-debiopharm.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-decathlon.yml
+++ b/.github/workflows/update-jobs-decathlon.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-delvitech.yml
+++ b/.github/workflows/update-jobs-delvitech.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-denner.yml
+++ b/.github/workflows/update-jobs-denner.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-diakoniewerk-neumuenster.yml
+++ b/.github/workflows/update-jobs-diakoniewerk-neumuenster.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-dxt.yml
+++ b/.github/workflows/update-jobs-dxt.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-efg.yml
+++ b/.github/workflows/update-jobs-efg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ehc-vd.yml
+++ b/.github/workflows/update-jobs-ehc-vd.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ehnv.yml
+++ b/.github/workflows/update-jobs-ehnv.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-elettra-1938.yml
+++ b/.github/workflows/update-jobs-elettra-1938.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ems-chemie.yml
+++ b/.github/workflows/update-jobs-ems-chemie.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-engadin-tourismus.yml
+++ b/.github/workflows/update-jobs-engadin-tourismus.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-engelvoelkers.yml
+++ b/.github/workflows/update-jobs-engelvoelkers.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-entero.yml
+++ b/.github/workflows/update-jobs-entero.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-eoc.yml
+++ b/.github/workflows/update-jobs-eoc.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-epfl.yml
+++ b/.github/workflows/update-jobs-epfl.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-epi-stiftung.yml
+++ b/.github/workflows/update-jobs-epi-stiftung.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ergolz-klinik.yml
+++ b/.github/workflows/update-jobs-ergolz-klinik.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-eth-zurich.yml
+++ b/.github/workflows/update-jobs-eth-zurich.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fart.yml
+++ b/.github/workflows/update-jobs-fart.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-faulhaber.yml
+++ b/.github/workflows/update-jobs-faulhaber.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ferrovia-retica.yml
+++ b/.github/workflows/update-jobs-ferrovia-retica.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fhgr.yml
+++ b/.github/workflows/update-jobs-fhgr.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fielmann.yml
+++ b/.github/workflows/update-jobs-fielmann.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fincons.yml
+++ b/.github/workflows/update-jobs-fincons.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-flury-stiftung.yml
+++ b/.github/workflows/update-jobs-flury-stiftung.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fmi.yml
+++ b/.github/workflows/update-jobs-fmi.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fnz.yml
+++ b/.github/workflows/update-jobs-fnz.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fondation-domus.yml
+++ b/.github/workflows/update-jobs-fondation-domus.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-forel-klinik.yml
+++ b/.github/workflows/update-jobs-forel-klinik.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-franklin-university.yml
+++ b/.github/workflows/update-jobs-franklin-university.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fusalp.yml
+++ b/.github/workflows/update-jobs-fusalp.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-fust.yml
+++ b/.github/workflows/update-jobs-fust.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-galenica.yml
+++ b/.github/workflows/update-jobs-galenica.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-gemeinde-st-moritz.yml
+++ b/.github/workflows/update-jobs-gemeinde-st-moritz.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-gesundheitsnetz-kuesnacht.yml
+++ b/.github/workflows/update-jobs-gesundheitsnetz-kuesnacht.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-gesundheitszentrum-fricktal.yml
+++ b/.github/workflows/update-jobs-gesundheitszentrum-fricktal.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ghol.yml
+++ b/.github/workflows/update-jobs-ghol.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-giardino.yml
+++ b/.github/workflows/update-jobs-giardino.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-giorgio-armani.yml
+++ b/.github/workflows/update-jobs-giorgio-armani.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-givaudan.yml
+++ b/.github/workflows/update-jobs-givaudan.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-gkb.yml
+++ b/.github/workflows/update-jobs-gkb.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-goline.yml
+++ b/.github/workflows/update-jobs-goline.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-grace.yml
+++ b/.github/workflows/update-jobs-grace.yml
@@ -85,6 +85,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-groupe-mutuel.yml
+++ b/.github/workflows/update-jobs-groupe-mutuel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-guess.yml
+++ b/.github/workflows/update-jobs-guess.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-gz-dielsdorf.yml
+++ b/.github/workflows/update-jobs-gz-dielsdorf.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-gzo-wetzikon.yml
+++ b/.github/workflows/update-jobs-gzo-wetzikon.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-h-ju-hopital-du-jura.yml
+++ b/.github/workflows/update-jobs-h-ju-hopital-du-jura.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hamilton.yml
+++ b/.github/workflows/update-jobs-hamilton.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-has-healthcare.yml
+++ b/.github/workflows/update-jobs-has-healthcare.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-heineken-ch.yml
+++ b/.github/workflows/update-jobs-heineken-ch.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-helsinn.yml
+++ b/.github/workflows/update-jobs-helsinn.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hes-so-valais.yml
+++ b/.github/workflows/update-jobs-hes-so-valais.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hfr-hopital-fribourgeois.yml
+++ b/.github/workflows/update-jobs-hfr-hopital-fribourgeois.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hib.yml
+++ b/.github/workflows/update-jobs-hib.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hilcona.yml
+++ b/.github/workflows/update-jobs-hilcona.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hirslanden.yml
+++ b/.github/workflows/update-jobs-hirslanden.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hitachi-energy.yml
+++ b/.github/workflows/update-jobs-hitachi-energy.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hoch-health.yml
+++ b/.github/workflows/update-jobs-hoch-health.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hochgebirgsklinik-davos.yml
+++ b/.github/workflows/update-jobs-hochgebirgsklinik-davos.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hofweissbad.yml
+++ b/.github/workflows/update-jobs-hofweissbad.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-holcim.yml
+++ b/.github/workflows/update-jobs-holcim.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hopital-de-lavaux.yml
+++ b/.github/workflows/update-jobs-hopital-de-lavaux.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hopital-du-valais.yml
+++ b/.github/workflows/update-jobs-hopital-du-valais.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hopital-la-tour.yml
+++ b/.github/workflows/update-jobs-hopital-la-tour.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hoval.yml
+++ b/.github/workflows/update-jobs-hoval.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hrc.yml
+++ b/.github/workflows/update-jobs-hrc.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hug.yml
+++ b/.github/workflows/update-jobs-hug.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-hugo-boss.yml
+++ b/.github/workflows/update-jobs-hugo-boss.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-huntsman.yml
+++ b/.github/workflows/update-jobs-huntsman.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ibsa.yml
+++ b/.github/workflows/update-jobs-ibsa.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-igs-bern.yml
+++ b/.github/workflows/update-jobs-igs-bern.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ikea.yml
+++ b/.github/workflows/update-jobs-ikea.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-imad.yml
+++ b/.github/workflows/update-jobs-imad.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-imerys.yml
+++ b/.github/workflows/update-jobs-imerys.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-institution-lavigny.yml
+++ b/.github/workflows/update-jobs-institution-lavigny.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-integra-biosciences.yml
+++ b/.github/workflows/update-jobs-integra-biosciences.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-interdiscount.yml
+++ b/.github/workflows/update-jobs-interdiscount.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-interroll.yml
+++ b/.github/workflows/update-jobs-interroll.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ipw.yml
+++ b/.github/workflows/update-jobs-ipw.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ist.yml
+++ b/.github/workflows/update-jobs-ist.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-julius-baer.yml
+++ b/.github/workflows/update-jobs-julius-baer.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-jumbo.yml
+++ b/.github/workflows/update-jobs-jumbo.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-jysk.yml
+++ b/.github/workflows/update-jobs-jysk.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kanton-gr.yml
+++ b/.github/workflows/update-jobs-kanton-gr.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kantonsspital-uri.yml
+++ b/.github/workflows/update-jobs-kantonsspital-uri.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kempinski.yml
+++ b/.github/workflows/update-jobs-kempinski.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kispi-sg.yml
+++ b/.github/workflows/update-jobs-kispi-sg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kispi-zurich.yml
+++ b/.github/workflows/update-jobs-kispi-zurich.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kispi.yml
+++ b/.github/workflows/update-jobs-kispi.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-aadorf.yml
+++ b/.github/workflows/update-jobs-klinik-aadorf.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-adelheid.yml
+++ b/.github/workflows/update-jobs-klinik-adelheid.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-arlesheim.yml
+++ b/.github/workflows/update-jobs-klinik-arlesheim.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-barmelweid.yml
+++ b/.github/workflows/update-jobs-klinik-barmelweid.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-gut.yml
+++ b/.github/workflows/update-jobs-klinik-gut.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-im-hasel.yml
+++ b/.github/workflows/update-jobs-klinik-im-hasel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-lengg.yml
+++ b/.github/workflows/update-jobs-klinik-lengg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-schloss-mammern.yml
+++ b/.github/workflows/update-jobs-klinik-schloss-mammern.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-schoenberg.yml
+++ b/.github/workflows/update-jobs-klinik-schoenberg.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-schuetzen.yml
+++ b/.github/workflows/update-jobs-klinik-schuetzen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-seeschau.yml
+++ b/.github/workflows/update-jobs-klinik-seeschau.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-sgm.yml
+++ b/.github/workflows/update-jobs-klinik-sgm.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-siloah.yml
+++ b/.github/workflows/update-jobs-klinik-siloah.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-sonnenhalde.yml
+++ b/.github/workflows/update-jobs-klinik-sonnenhalde.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-susenberg.yml
+++ b/.github/workflows/update-jobs-klinik-susenberg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-klinik-wyssholzli.yml
+++ b/.github/workflows/update-jobs-klinik-wyssholzli.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kliniken-valens.yml
+++ b/.github/workflows/update-jobs-kliniken-valens.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-knowledge-lab.yml
+++ b/.github/workflows/update-jobs-knowledge-lab.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kone.yml
+++ b/.github/workflows/update-jobs-kone.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kronenhof.yml
+++ b/.github/workflows/update-jobs-kronenhof.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ksa.yml
+++ b/.github/workflows/update-jobs-ksa.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ksb.yml
+++ b/.github/workflows/update-jobs-ksb.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ksbl.yml
+++ b/.github/workflows/update-jobs-ksbl.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ksgl.yml
+++ b/.github/workflows/update-jobs-ksgl.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ksgr.yml
+++ b/.github/workflows/update-jobs-ksgr.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kssg.yml
+++ b/.github/workflows/update-jobs-kssg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ksw.yml
+++ b/.github/workflows/update-jobs-ksw.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kudelski-nagra.yml
+++ b/.github/workflows/update-jobs-kudelski-nagra.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kulm-hotel.yml
+++ b/.github/workflows/update-jobs-kulm-hotel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-kzu.yml
+++ b/.github/workflows/update-jobs-kzu.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-laderach.yml
+++ b/.github/workflows/update-jobs-laderach.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lafonte.yml
+++ b/.github/workflows/update-jobs-lafonte.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lastminute.yml
+++ b/.github/workflows/update-jobs-lastminute.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-leukerbad-clinic.yml
+++ b/.github/workflows/update-jobs-leukerbad-clinic.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lhm-luzerner-hohenklinik-montana.yml
+++ b/.github/workflows/update-jobs-lhm-luzerner-hohenklinik-montana.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lidl.yml
+++ b/.github/workflows/update-jobs-lidl.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lindenhofgruppe.yml
+++ b/.github/workflows/update-jobs-lindenhofgruppe.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-linnea.yml
+++ b/.github/workflows/update-jobs-linnea.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lis.yml
+++ b/.github/workflows/update-jobs-lis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-livingcircle.yml
+++ b/.github/workflows/update-jobs-livingcircle.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-localsearch.yml
+++ b/.github/workflows/update-jobs-localsearch.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-logitech.yml
+++ b/.github/workflows/update-jobs-logitech.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lombard-odier.yml
+++ b/.github/workflows/update-jobs-lombard-odier.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lombardi.yml
+++ b/.github/workflows/update-jobs-lombardi.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lonza.yml
+++ b/.github/workflows/update-jobs-lonza.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-luks.yml
+++ b/.github/workflows/update-jobs-luks.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lups.yml
+++ b/.github/workflows/update-jobs-lups.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-lwphr.yml
+++ b/.github/workflows/update-jobs-lwphr.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-mabetex.yml
+++ b/.github/workflows/update-jobs-mabetex.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-manor.yml
+++ b/.github/workflows/update-jobs-manor.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-marriott.yml
+++ b/.github/workflows/update-jobs-marriott.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-matterhorn-gotthard-bahn.yml
+++ b/.github/workflows/update-jobs-matterhorn-gotthard-bahn.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-medacta.yml
+++ b/.github/workflows/update-jobs-medacta.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-medartis.yml
+++ b/.github/workflows/update-jobs-medartis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-medics-labor.yml
+++ b/.github/workflows/update-jobs-medics-labor.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-medtronic.yml
+++ b/.github/workflows/update-jobs-medtronic.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-mendrisio.yml
+++ b/.github/workflows/update-jobs-mendrisio.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-merian-iselin.yml
+++ b/.github/workflows/update-jobs-merian-iselin.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-michel-gruppe.yml
+++ b/.github/workflows/update-jobs-michel-gruppe.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-migros-hq.yml
+++ b/.github/workflows/update-jobs-migros-hq.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-migros.yml
+++ b/.github/workflows/update-jobs-migros.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-mikron.yml
+++ b/.github/workflows/update-jobs-mikron.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-mkspamp.yml
+++ b/.github/workflows/update-jobs-mkspamp.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-mobiliar.yml
+++ b/.github/workflows/update-jobs-mobiliar.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-modellstation-somosa.yml
+++ b/.github/workflows/update-jobs-modellstation-somosa.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-moncucco.yml
+++ b/.github/workflows/update-jobs-moncucco.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-msc-cargo.yml
+++ b/.github/workflows/update-jobs-msc-cargo.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-mtic.yml
+++ b/.github/workflows/update-jobs-mtic.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-nant.yml
+++ b/.github/workflows/update-jobs-nant.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-nestle.yml
+++ b/.github/workflows/update-jobs-nestle.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-novartis.yml
+++ b/.github/workflows/update-jobs-novartis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-novelis.yml
+++ b/.github/workflows/update-jobs-novelis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-nsn-medical.yml
+++ b/.github/workflows/update-jobs-nsn-medical.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-octapharma.yml
+++ b/.github/workflows/update-jobs-octapharma.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-oerlikon.yml
+++ b/.github/workflows/update-jobs-oerlikon.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-omega.yml
+++ b/.github/workflows/update-jobs-omega.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ophtalmique.yml
+++ b/.github/workflows/update-jobs-ophtalmique.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-oscam-castelrotto.yml
+++ b/.github/workflows/update-jobs-oscam-castelrotto.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-oscam.yml
+++ b/.github/workflows/update-jobs-oscam.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-otis.yml
+++ b/.github/workflows/update-jobs-otis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pallas-kliniken.yml
+++ b/.github/workflows/update-jobs-pallas-kliniken.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-palliativklinik.yml
+++ b/.github/workflows/update-jobs-palliativklinik.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-paraplegie.yml
+++ b/.github/workflows/update-jobs-paraplegie.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pbl.yml
+++ b/.github/workflows/update-jobs-pbl.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pdag.yml
+++ b/.github/workflows/update-jobs-pdag.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pdgr.yml
+++ b/.github/workflows/update-jobs-pdgr.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pemsa.yml
+++ b/.github/workflows/update-jobs-pemsa.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pictet.yml
+++ b/.github/workflows/update-jobs-pictet.yml
@@ -96,6 +96,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pigna.yml
+++ b/.github/workflows/update-jobs-pigna.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pizzarotti.yml
+++ b/.github/workflows/update-jobs-pizzarotti.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pole-sante-pays-enhaut.yml
+++ b/.github/workflows/update-jobs-pole-sante-pays-enhaut.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-postch.yml
+++ b/.github/workflows/update-jobs-postch.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-postfinance.yml
+++ b/.github/workflows/update-jobs-postfinance.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-prada.yml
+++ b/.github/workflows/update-jobs-prada.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-privatklinik-hohenegg.yml
+++ b/.github/workflows/update-jobs-privatklinik-hohenegg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-privatklinik-meiringen.yml
+++ b/.github/workflows/update-jobs-privatklinik-meiringen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-privatklinik-wyss.yml
+++ b/.github/workflows/update-jobs-privatklinik-wyss.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-prosenectute-ti.yml
+++ b/.github/workflows/update-jobs-prosenectute-ti.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-psgn.yml
+++ b/.github/workflows/update-jobs-psgn.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-puk-zuerich.yml
+++ b/.github/workflows/update-jobs-puk-zuerich.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pwc.yml
+++ b/.github/workflows/update-jobs-pwc.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-pzm-muensingen.yml
+++ b/.github/workflows/update-jobs-pzm-muensingen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-raiffeisen-vc.yml
+++ b/.github/workflows/update-jobs-raiffeisen-vc.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rapelli.yml
+++ b/.github/workflows/update-jobs-rapelli.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-reboot-monkey.yml
+++ b/.github/workflows/update-jobs-reboot-monkey.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-reha-andeer.yml
+++ b/.github/workflows/update-jobs-reha-andeer.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-reha-bellikon.yml
+++ b/.github/workflows/update-jobs-reha-bellikon.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rehab-basel.yml
+++ b/.github/workflows/update-jobs-rehab-basel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rehaklinik-hasliberg.yml
+++ b/.github/workflows/update-jobs-rehaklinik-hasliberg.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-relewant.yml
+++ b/.github/workflows/update-jobs-relewant.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rennbahnklinik.yml
+++ b/.github/workflows/update-jobs-rennbahnklinik.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rfsm-fribourg.yml
+++ b/.github/workflows/update-jobs-rfsm-fribourg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rhne-reseau-hospitalier-neuchatelois.yml
+++ b/.github/workflows/update-jobs-rhne-reseau-hospitalier-neuchatelois.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-richemont.yml
+++ b/.github/workflows/update-jobs-richemont.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-riri.yml
+++ b/.github/workflows/update-jobs-riri.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rittmeyer.yml
+++ b/.github/workflows/update-jobs-rittmeyer.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-riveneuve.yml
+++ b/.github/workflows/update-jobs-riveneuve.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-roche.yml
+++ b/.github/workflows/update-jobs-roche.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rsbj.yml
+++ b/.github/workflows/update-jobs-rsbj.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-rss-surselva.yml
+++ b/.github/workflows/update-jobs-rss-surselva.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ruag.yml
+++ b/.github/workflows/update-jobs-ruag.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-salina-reha.yml
+++ b/.github/workflows/update-jobs-salina-reha.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sanatorium-kilchberg.yml
+++ b/.github/workflows/update-jobs-sanatorium-kilchberg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sbb.yml
+++ b/.github/workflows/update-jobs-sbb.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-schindler.yml
+++ b/.github/workflows/update-jobs-schindler.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-schulthess-klinik.yml
+++ b/.github/workflows/update-jobs-schulthess-klinik.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-senevita.yml
+++ b/.github/workflows/update-jobs-senevita.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-siegfried.yml
+++ b/.github/workflows/update-jobs-siegfried.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-siemens-healthineers.yml
+++ b/.github/workflows/update-jobs-siemens-healthineers.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sika.yml
+++ b/.github/workflows/update-jobs-sika.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sintetica.yml
+++ b/.github/workflows/update-jobs-sintetica.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-skyguide.yml
+++ b/.github/workflows/update-jobs-skyguide.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sobi.yml
+++ b/.github/workflows/update-jobs-sobi.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-soh-solothurner-spitaeler.yml
+++ b/.github/workflows/update-jobs-soh-solothurner-spitaeler.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-solina.yml
+++ b/.github/workflows/update-jobs-solina.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-solothurner-spitaeler.yml
+++ b/.github/workflows/update-jobs-solothurner-spitaeler.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-somedia.yml
+++ b/.github/workflows/update-jobs-somedia.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sonnweid.yml
+++ b/.github/workflows/update-jobs-sonnweid.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spitaeler-schaffhausen.yml
+++ b/.github/workflows/update-jobs-spitaeler-schaffhausen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-affoltern.yml
+++ b/.github/workflows/update-jobs-spital-affoltern.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-buelach.yml
+++ b/.github/workflows/update-jobs-spital-buelach.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-davos.yml
+++ b/.github/workflows/update-jobs-spital-davos.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-emmental.yml
+++ b/.github/workflows/update-jobs-spital-emmental.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-lachen.yml
+++ b/.github/workflows/update-jobs-spital-lachen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-limmattal.yml
+++ b/.github/workflows/update-jobs-spital-limmattal.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-muri.yml
+++ b/.github/workflows/update-jobs-spital-muri.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-schwyz.yml
+++ b/.github/workflows/update-jobs-spital-schwyz.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-sts.yml
+++ b/.github/workflows/update-jobs-spital-sts.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-thurgau.yml
+++ b/.github/workflows/update-jobs-spital-thurgau.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-thusis.yml
+++ b/.github/workflows/update-jobs-spital-thusis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-zofingen.yml
+++ b/.github/workflows/update-jobs-spital-zofingen.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spital-zollikerberg.yml
+++ b/.github/workflows/update-jobs-spital-zollikerberg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spitex-basel.yml
+++ b/.github/workflows/update-jobs-spitex-basel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spitex-ch.yml
+++ b/.github/workflows/update-jobs-spitex-ch.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spitex-zuerich.yml
+++ b/.github/workflows/update-jobs-spitex-zuerich.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-spz.yml
+++ b/.github/workflows/update-jobs-spz.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-srg-ssr.yml
+++ b/.github/workflows/update-jobs-srg-ssr.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sro.yml
+++ b/.github/workflows/update-jobs-sro.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-stadler-rail.yml
+++ b/.github/workflows/update-jobs-stadler-rail.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-stadt-chur.yml
+++ b/.github/workflows/update-jobs-stadt-chur.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-stadtspital-zuerich.yml
+++ b/.github/workflows/update-jobs-stadtspital-zuerich.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-stgag.yml
+++ b/.github/workflows/update-jobs-stgag.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-stiftung-diaconis.yml
+++ b/.github/workflows/update-jobs-stiftung-diaconis.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-stiftung-kind-autismus.yml
+++ b/.github/workflows/update-jobs-stiftung-kind-autismus.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-stryker.yml
+++ b/.github/workflows/update-jobs-stryker.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-suchtfachstelle-zuerich.yml
+++ b/.github/workflows/update-jobs-suchtfachstelle-zuerich.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-suchthilfe-region-basel.yml
+++ b/.github/workflows/update-jobs-suchthilfe-region-basel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-suedhang.yml
+++ b/.github/workflows/update-jobs-suedhang.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sulzer.yml
+++ b/.github/workflows/update-jobs-sulzer.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sune-egge.yml
+++ b/.github/workflows/update-jobs-sune-egge.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-sunrise.yml
+++ b/.github/workflows/update-jobs-sunrise.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-supsi.yml
+++ b/.github/workflows/update-jobs-supsi.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-svar-spitalverbund-ar.yml
+++ b/.github/workflows/update-jobs-svar-spitalverbund-ar.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-swatchgroup.yml
+++ b/.github/workflows/update-jobs-swatchgroup.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-swiss-life.yml
+++ b/.github/workflows/update-jobs-swiss-life.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-swiss-medical-network.yml
+++ b/.github/workflows/update-jobs-swiss-medical-network.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-swiss-re.yml
+++ b/.github/workflows/update-jobs-swiss-re.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-swisscom.yml
+++ b/.github/workflows/update-jobs-swisscom.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tally-weijl.yml
+++ b/.github/workflows/update-jobs-tally-weijl.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tarchini-group.yml
+++ b/.github/workflows/update-jobs-tarchini-group.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tecan.yml
+++ b/.github/workflows/update-jobs-tecan.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tertianum.yml
+++ b/.github/workflows/update-jobs-tertianum.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tether.yml
+++ b/.github/workflows/update-jobs-tether.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-therapiezentrum-meggen.yml
+++ b/.github/workflows/update-jobs-therapiezentrum-meggen.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-thurklinik.yml
+++ b/.github/workflows/update-jobs-thurklinik.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tich.yml
+++ b/.github/workflows/update-jobs-tich.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tinext.yml
+++ b/.github/workflows/update-jobs-tinext.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tpl-lugano.yml
+++ b/.github/workflows/update-jobs-tpl-lugano.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-transgourmet.yml
+++ b/.github/workflows/update-jobs-transgourmet.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-triaplus.yml
+++ b/.github/workflows/update-jobs-triaplus.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-trumpf.yml
+++ b/.github/workflows/update-jobs-trumpf.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tschuggen.yml
+++ b/.github/workflows/update-jobs-tschuggen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-tsmg.yml
+++ b/.github/workflows/update-jobs-tsmg.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ubp.yml
+++ b/.github/workflows/update-jobs-ubp.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ubs.yml
+++ b/.github/workflows/update-jobs-ubs.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-ukbb.yml
+++ b/.github/workflows/update-jobs-ukbb.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-unispital-basel.yml
+++ b/.github/workflows/update-jobs-unispital-basel.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-upd.yml
+++ b/.github/workflows/update-jobs-upd.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-uroviva.yml
+++ b/.github/workflows/update-jobs-uroviva.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-usi.yml
+++ b/.github/workflows/update-jobs-usi.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-usz.yml
+++ b/.github/workflows/update-jobs-usz.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-vaudoise.yml
+++ b/.github/workflows/update-jobs-vaudoise.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-vaxcyte.yml
+++ b/.github/workflows/update-jobs-vaxcyte.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-vf.yml
+++ b/.github/workflows/update-jobs-vf.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-villa-im-park.yml
+++ b/.github/workflows/update-jobs-villa-im-park.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-vir-biotechnology.yml
+++ b/.github/workflows/update-jobs-vir-biotechnology.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-vista.yml
+++ b/.github/workflows/update-jobs-vista.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-vitrea-gesundheit.yml
+++ b/.github/workflows/update-jobs-vitrea-gesundheit.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-viva-luzern.yml
+++ b/.github/workflows/update-jobs-viva-luzern.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-volg.yml
+++ b/.github/workflows/update-jobs-volg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-vtg.yml
+++ b/.github/workflows/update-jobs-vtg.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-wagerenhof.yml
+++ b/.github/workflows/update-jobs-wagerenhof.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-weisse-arena.yml
+++ b/.github/workflows/update-jobs-weisse-arena.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-wuerth-international.yml
+++ b/.github/workflows/update-jobs-wuerth-international.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-zambon.yml
+++ b/.github/workflows/update-jobs-zambon.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-zegna.yml
+++ b/.github/workflows/update-jobs-zegna.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-zermatt-bergbahnen.yml
+++ b/.github/workflows/update-jobs-zermatt-bergbahnen.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-zuger-kantonsspital.yml
+++ b/.github/workflows/update-jobs-zuger-kantonsspital.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-zurich.yml
+++ b/.github/workflows/update-jobs-zurich.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/.github/workflows/update-jobs-zurzach-care.yml
+++ b/.github/workflows/update-jobs-zurzach-care.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Crawler Failure: ${{ github.workflow }}" \

--- a/scripts/lib/github-issue-creator.mjs
+++ b/scripts/lib/github-issue-creator.mjs
@@ -164,7 +164,17 @@ export async function createGithubIssue({
     const m = url.match(/\/issues\/(\d+)/);
     return { number: m ? Number(m[1]) : null, title, url };
   } catch (err) {
+    // Why: this helper runs in `if: failure()` reporter steps. If posting to
+    // GH fails (missing GH_TOKEN, API outage, perms), we must NOT lose the
+    // diagnostics — dump them so the workflow log preserves the upstream
+    // error context. Callers should still treat this as best-effort (CLI
+    // mode exits 0 below).
     console.error(`[github-issue-creator] Failed to create issue: ${err.message}`);
+    console.error('[github-issue-creator] --- begin issue body fallback ---');
+    console.error(`Title: ${title}`);
+    if (workflow) console.error(`Workflow: ${workflow}`);
+    console.error(body);
+    console.error('[github-issue-creator] --- end issue body fallback ---');
     return null;
   }
 }
@@ -201,11 +211,15 @@ if (process.argv[1]?.endsWith('github-issue-creator.mjs')) {
       return many.length > 0 ? many : (single ? [single] : ['bug']);
     })(),
     workflow: get('--workflow'),
-  }).then((issue) => {
-    process.exit(issue ? 0 : 1);
+  }).then(() => {
+    // Why: this CLI is a best-effort reporter invoked from `if: failure()`
+    // steps after the real failure has already been recorded. Exiting non-zero
+    // here would add a second red step and risk hiding the upstream cause —
+    // the body fallback above keeps the diagnostics in the workflow log.
+    process.exit(0);
   }).catch((err) => {
     console.error(`[github-issue-creator] Error: ${err.message}`);
-    process.exit(1);
+    process.exit(0);
   });
 }
 

--- a/scripts/scaffold-crawler.mjs
+++ b/scripts/scaffold-crawler.mjs
@@ -799,6 +799,8 @@ ${playwrightTier ? `
       - name: Report failure to Linear
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \\
             --title "Crawler Failure: \${{ github.workflow }}" \\


### PR DESCRIPTION
The github-issue-creator.mjs helper runs in `if: failure()` steps to log
crawler failures as GH Issues, but the surrounding steps never exposed
GH_TOKEN — so every `gh issue create` call exits 1 with the GitHub CLI's
"set the GH_TOKEN environment variable" hint. Net effect: 4 crawler runs
yesterday (Engadin, Nestlé, Reboot Monkey, Tarchini) each ended with the
issue-creator step erroring AFTER the real crawler error, masking the
upstream diagnostic in workflow logs and dropping the issue trail.

Two fixes, defense in depth:

1. Workflow side — add `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to
   the `Report failure to Linear` step in every workflow that calls the
   helper (420 files). Scaffolder template updated so new crawlers
   inherit the wiring automatically.

2. Script side — when `gh issue create` fails (auth, outage, perms),
   dump the full title + body to stderr so the diagnostic survives in
   workflow logs, then exit 0 from CLI mode instead of 1. The step is
   already `continue-on-error: true` but the extra non-zero exit added
   a second red marker that hid the upstream cause; the body fallback
   keeps everything traceable even when posting fails.
