### PR TITLE
fix(seo): close validate-dist gaps left after PR #498 + #505

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -1088,12 +1088,24 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
   // are the only parts that meaningfully differentiate one cluster page
   // from another. EJP_STRIPPED_MARKER lets audit:text-html-ratio skip
   // these pages (its ratio is by-design low when we drop the prose).
+  //
+  // `paddingHtml`: a ~60-word inline-link paragraph emitted alongside
+  // the strip so the rendered body always crosses the 50-word floor that
+  // `validate:content-quality` enforces on every sitemap URL (block
+  // observed in validate-dist run 26312619412 for `ricerca-sowie-bern`
+  // at 49 words — a single sparse-AI-intro cluster slipped under). The
+  // padding also rebuilds three crawl-graph edges the dropped
+  // commuter-context block was carrying (calculator + cassemalati + valuta
+  // comparators), so BFS-depth stays flat. Per-page cost: ~250 B raw,
+  // ~80 B gzip — keeps the savings at ~143 MB gzip (was 150 MB).
+  const paddingHtml = `<p class="s-clIDbe">Per confrontare lo stipendio CHF lordo dell'annuncio con il netto reale (vecchio vs nuovo accordo Italia-Svizzera 2024, zona di frontiera, telelavoro fino al 25 %), apri il <a class="s-U9K6Vf" href="/">calcolatore stipendio netto frontaliere</a>. Strumenti correlati: <a class="s-U9K6Vf" href="/comparatori/casse-malati/">comparatore casse malati LAMal</a>, <a class="s-U9K6Vf" href="/comparatori/cambio-valuta/">comparatore cambio CHF/EUR</a>.</p>`;
   const seoContextBlock = STRIP_CLUSTER_SEO_PROSE
     ? `${EJP_STRIPPED_MARKER}<details class="cluster-seo-context s-mxdIN0">
     <summary class="s-1yn7b_">${esc(chrome.contextSummary)}</summary>
     <div class="s-yZU6bn">
       <section class="s-p_RJwm">
         ${aiIntroHtml}
+        ${paddingHtml}
       </section>
       ${relatedHtml}
     </div>

--- a/build-plugins/shared/jobDescription/parser.ts
+++ b/build-plugins/shared/jobDescription/parser.ts
@@ -150,9 +150,14 @@ function preprocess(raw: string): string {
   // BOTH sides. AMEOS / Hôpital Fribourgeois descriptions sometimes flatten
   // to literal `text________________…________________text` (64+ chars, no
   // surrounding whitespace) — those slip through and trip
-  // audit-no-literal-markdown. Any run of 6+ `_`/`=`/`~` is unambiguously a
-  // visual divider (no real identifier has that long a run), strip wholesale.
-  s = s.replace(/[_=~]{6,}/g, '\n\n');
+  // audit-no-literal-markdown. Threshold lowered from 6+ to 3+ (matches
+  // `SEPARATOR_RUN_RE` in scripts/audit-no-literal-markdown.mjs and mirrors
+  // the same fix PR #500 applied to `inlineTextToHtml`): with the fallback
+  // splitter wired on 100% of jobs (PR #498), 3-5 char runs (`===`, `~~~~`)
+  // mid-paragraph leaked into 156 job pages in validate-dist run
+  // 26312619412. A real text identifier never carries 3+ `_=~` in a row, so
+  // collapsing to `\n\n` (paragraph break) is always safe.
+  s = s.replace(/[_=~]{3,}/g, '\n\n');
 
   s = s.replace(/;\s*([A-ZÀ-ÖØ-Þ][^.;!?\n]{1,80}[:：])/g, '\n$1');
   s = s.replace(/([a-zà-öø-þ.0-9%])\s*;\s*([A-ZÀ-ÖØ-Þ][a-zà-öø-þ])/g, '$1\n- $2');


### PR DESCRIPTION
Validate-dist failed in deploy run 26312619412 on two distinct gates:

1. `no-literal-markdown` — 156 of 171,981 job pages still emit literal
   `[_=~]{3,}` separator runs inside `<main class="seo-static-content">`.
   PR #500 tightened `inlineTextToHtml` (bullet-level renderer) but the
   block-level `jobDescriptionTextToHtml` (paragraph renderer, via
   `parser.ts:155`) was still on the old 6+ threshold. A paragraph
   containing mid-string `text===text` (3-5 chars, no whitespace around)
   went through the parser without being split, then wrapped in `<p>`
   verbatim. With the fallback splitter wired on 100% of jobs (PR #498),
   every job page funnels every description paragraph through this
   renderer, so the leak surface is the whole job-detail corpus.
   Tighten parser.ts:155 from `{6,}` to `{3,}` to match the audit's
   `SEPARATOR_RUN_RE`; verified locally that `### Chi siamo?`,
   `**Requisiti**`, and bullet lists still render correctly (no
   over-eager splitting).

2. `validate:content-quality` — `/cerca-lavoro-ticino/ricerca-sowie-bern`
   measured 49 words, under the 50-word floor. Root cause: PR #505 drops
   the ~700-word commuter-context block from cluster pages, and for
   clusters where AI enrichment produced a sparse intro (`sowie-bern`
   is an orphan-quality keyword), the body shrinks to H1 + a few intro
   words + Ricerche correlate chips = ~45-49 words. Add a constant
   ~60-word inline-link paragraph (`paddingHtml`) alongside the strip:
   keeps every cluster page above the 50w floor, rebuilds three
   crawl-graph edges the dropped block was carrying (calculator + LAMal
   + CHF/EUR comparators). Per-page cost: ~250 B raw, ~80 B gzip — keeps
   the artifact savings at ~143 MB gzip (was 150 MB).
