### PR TITLE
fix(seo): strip markdown markers from highlights chip text

### DIFF
--- a/build-plugins/shared/jobDetailHtml/highlightsChips.ts
+++ b/build-plugins/shared/jobDetailHtml/highlightsChips.ts
@@ -27,16 +27,38 @@ export type HighlightsChipsContext = Pick<
   'locale' | 'canonicalLocale' | 'canonicalKeywords' | 'esc'
 >;
 
+// Strip residual markdown markers (`**bold**`, `*em*`, leading `#+`, mid-string
+// `[_=~]{3,}` separator runs) before HTML-escaping into <li class="chip">. The
+// chip renderer feeds `canonicalLocale.highlights` / `canonicalKeywords` (often
+// produced by the fallback splitter at services/jobs/canonicalFallback.ts, which
+// preserves source `**bold**` markers verbatim) through `esc()` only — so
+// `**Flexible Arbeitszeiten**` survived as literal text and tripped
+// audit:no-literal-markdown (166 offenders in validate-dist run 26316291019,
+// pattern observed: Axpo benefit chips + Casale SA `** e **` + Fonte
+// `**luglio 2026**`). Markers don't render as bold inside chips anyway — they
+// just leak as visible asterisks — so unwrap to plain text.
+function stripChipMarkdown(value: string): string {
+  return String(value || '')
+    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+    .replace(/\*([^*\n]+?)\*/g, '$1')
+    .replace(/^#+\s*/, '')
+    .replace(/[_=~]{3,}/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 export function renderHighlightsChips(ctx: HighlightsChipsContext): string {
   const { locale, canonicalLocale, canonicalKeywords, esc } = ctx;
   const rawHighlights = Array.isArray(
     (canonicalLocale as { highlights?: unknown })?.highlights,
   )
     ? ((canonicalLocale as { highlights?: unknown[] }).highlights as unknown[])
-        .map((h) => String(h ?? '').trim())
+        .map((h) => stripChipMarkdown(String(h ?? '')))
         .filter((h) => h.length > 0)
     : [];
-  const source = rawHighlights.length > 0 ? rawHighlights : canonicalKeywords;
+  const source = rawHighlights.length > 0
+    ? rawHighlights
+    : canonicalKeywords.map((c) => stripChipMarkdown(String(c))).filter((c) => c.length > 0);
   const chips = source.slice(0, 6);
   if (chips.length === 0) return '';
   const items = chips


### PR DESCRIPTION
audit:no-literal-markdown failed in validate-dist run 26316291019 with
166 of 172,088 job pages carrying literal markdown — pattern observed
across the top offenders is consistently `**bold**` in highlights
chips (`<li class="chip">**Flexible Arbeitszeiten**</li>` on Axpo
benefit chips, `**luglio 2026**` on Fonte job hire-date chips,
`** e **` on Casale SA Italian "X e Y" titles).

Root cause: `renderHighlightsChips` at
build-plugins/shared/jobDetailHtml/highlightsChips.ts:43 wraps each
chip value through `esc()` only — HTML-escapes `<`/`&` but does
NOT touch markdown markers. `canonicalLocale.highlights` and
`canonicalKeywords` (the two chip sources) are fed by the fallback
splitter at services/jobs/canonicalFallback.ts which preserves source
`**` markers verbatim, so any AI-translated description carrying
markdown bold survives into the static chip row.

Add `stripChipMarkdown` helper that drops `**bold**` / `*em*` to
plain text (chips don't render as bold anyway — they'd just show
visible asterisks), strips leading `#+` headings, collapses
`[_=~]{3,}` separator runs to whitespace, and normalises spacing.
Apply to both chip sources before esc() so the output cannot trip
audit:no-literal-markdown again.

Verified locally: 27 existing tests (static-job-page-spa-alignment +
static-job-page-body + canonical-fallback-shape) remain green; typecheck
clean.
