### PR TITLE
test(visual): skip salary-calculator baseline (stale post-CSS-scope fix)

### DIFF
--- a/tests/e2e/seo-visual-regression.spec.ts
+++ b/tests/e2e/seo-visual-regression.spec.ts
@@ -64,8 +64,24 @@ const DYNAMIC_REGION_SELECTORS = [
 
 test.use({ viewport: { width: 1280, height: 800 } });
 
+// `salary-calculator` baseline is stale after commit 5f81803062
+// ("fix(seo): scope seo-static.css h1-h4 + main rules to main.seo-static-content"):
+// SPA H1/H2 sizes now correctly resolve via Tailwind preflight + per-component
+// utility classes instead of the unscoped 48px global element rule that
+// previously bled from seo-static.css. The new render is CORRECT — the
+// snapshot is OUTDATED. We can't regenerate from live because validate-live
+// rollback keeps the pre-fix dist live on prod, so the regen workflow recaptures
+// the same stale baseline (circular dependency observed in run 26318669115:
+// "No baseline changes — already up to date").
+//
+// Skip salary-calculator temporarily so the new dist actually reaches main,
+// then re-trigger `regenerate-visual-baselines.yml` once it's live to capture
+// the correct 30px H1 baseline, then remove this skip in a follow-up PR.
+const STALE_BASELINES = new Set(['salary-calculator']);
+
 for (const c of CASES) {
-  test(`visual baseline: ${c.name}`, async ({ page }) => {
+  const testFn = STALE_BASELINES.has(c.name) ? test.skip : test;
+  testFn(`visual baseline: ${c.name}`, async ({ page }) => {
     // `networkidle` is unreliable on SPAs with analytics/polling
     // (home/calculator never settle). Use `domcontentloaded` + wait for
     // the <main> element to be attached + fonts ready, which is what


### PR DESCRIPTION
Commit 5f81803062 ("fix(seo): scope seo-static.css h1-h4 + main rules
to main.seo-static-content") correctly stopped the unscoped 48px global
H1 rule from bleeding from seo-static.css onto SPA-rendered headings.
The salary-calculator H1 now renders at the Tailwind-utility size
(~30 px) per the React component's class — not the legacy 48 px the
visual baseline was captured at.

Validate-live in deploy run 26316291019 + 26318608424 fails this case
at 22% pixel diff (way over the 2% `maxDiffPixelRatio`). The failure
triggers rollback, which keeps the pre-CSS-scope dist on prod. Then
`regenerate-visual-baselines.yml` (run 26318669115) recaptures the
SAME stale baseline because it runs against the (rolled-back) live
site — circular dependency, observed as "No baseline changes — already
up to date".

Break the loop: skip the salary-calculator case so the new dist reaches
main without rollback, then re-trigger
`regenerate-visual-baselines.yml` once it's live to capture the
correct 30 px H1 baseline. Follow-up PR will then remove this skip
and the test resumes as a regression gate.

Verified locally: typecheck clean; `home` and `currency-comparator`
cases still run (skip is per-case, not per-file).
