### PR TITLE
fix(seo): nuke orphan asterisks in highlight chip text

### DIFF
--- a/build-plugins/shared/jobDetailHtml/highlightsChips.ts
+++ b/build-plugins/shared/jobDetailHtml/highlightsChips.ts
@@ -41,6 +41,17 @@ function stripChipMarkdown(value: string): string {
   return String(value || '')
     .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
     .replace(/\*([^*\n]+?)\*/g, '$1')
+    // After the pair-strip above, orphan markers may remain at one end of
+    // the chip text (e.g. `**Mansioni` with no closing pair, or
+    // `Rennbahnklinik è leader…**` with no opening pair). These slip
+    // through the audit because two consecutive chips of the form
+    // `<li>FOO**</li><li>**BAR</li>` produce the cross-chip regex match
+    // `**</li><li class="chip">**` that audit:no-literal-markdown flags
+    // (13 such offenders seen in run 26318775434 — all
+    // Rennbahnklinik / Clienia / NSN Medical / PBL chip rows).
+    // Asterisks have no semantic role inside a chip label anyway, so
+    // nuke any remaining `*` run wholesale.
+    .replace(/\*+/g, '')
     .replace(/^#+\s*/, '')
     .replace(/[_=~]{3,}/g, ' ')
     .replace(/\s+/g, ' ')


### PR DESCRIPTION
PR #513 stripped balanced `**bold**` / `*em*` pairs from chip text,
but orphan markers (single `**` at one end with no closing pair) slip
through because the regex requires `**X**` matching. When two
consecutive chips have orphans of opposite parity, the rendered HTML
becomes `<li>FOO**</li><li>**BAR</li>` — and audit:no-literal-markdown
flags the cross-chip regex match `**</li><li class="chip">**` (13
such offenders in validate-dist run 26318775434, down from 166 pre-#513,
all Rennbahnklinik / Clienia / NSN Medical / PBL chip rows where the
AI-translated description's bold markers landed on chunk boundaries).

Add `.replace(/\*+/g, '')` after the paired-strip so any remaining
`*` runs are nuked wholesale. Asterisks have no semantic role inside
a chip label — they wouldn't render as bold anyway because chips
escape via esc() — so the only outcomes are visible asterisks or
literal-markdown leak.

Verified locally: tests/seo/static-job-page-spa-alignment.test.ts (19
tests) remain green; typecheck clean.
