### PR TITLE
Fix dedicated crawler failures

### DIFF
--- a/.github/workflows/update-jobs-hoch-health.yml
+++ b/.github/workflows/update-jobs-hoch-health.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Commit and push
         id: changes
         env:
+          GH_TOKEN: ${{ github.token }}
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HOCH_HEALTH jobs (dedicated crawler)" data/jobs-crawler-adapters/
 

--- a/.github/workflows/update-jobs-hopital-de-lavaux.yml
+++ b/.github/workflows/update-jobs-hopital-de-lavaux.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Commit and push
         id: changes
         env:
+          GH_TOKEN: ${{ github.token }}
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hôpital de Lavaux jobs (dedicated crawler)" data/jobs-crawler-adapters/
 

--- a/.github/workflows/update-jobs-spital-lachen.yml
+++ b/.github/workflows/update-jobs-spital-lachen.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Commit and push
         id: changes
         env:
+          GH_TOKEN: ${{ github.token }}
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITAL-LACHEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 

--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -70,6 +70,14 @@ const HEALTH_ISSUES_PATH = path.join(ROOT, 'data', 'crawler-health-issues.json')
 const STALE_AFTER_DAYS = 7;
 const BROKEN_AFTER_EMPTY_RUNS = 3;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const EMPTY_OK_CRAWLERS = new Set([
+  // Current source page explicitly reports no open offers; a fresh successful
+  // crawl is the useful health signal.
+  'csvp-poschiavo',
+  // Dedicated regional Zurich Insurance search can legitimately return zero
+  // TI/GR openings while the crawler and source are healthy.
+  'zurich-insurance-sede-ticino',
+]);
 
 /** Read JSON file, return null on any error. */
 async function readJsonSafe(filePath) {
@@ -99,7 +107,7 @@ async function listCrawlerSlugs() {
  * Inspect one crawler and return derived facts.
  *
  * Reads:
- *   - `data/jobs/by-crawler/{slug}.json`            → jobCount + fallback timestamp
+ *   - `data/jobs/by-crawler/{slug}.json`            → activeJobCount + fallback timestamp
  *   - `data/jobs-crawler-summaries/by-crawler/{slug}.json` → primary timestamp
  *
  * Returns null if the by-crawler slice cannot be read/parsed (caller logs +
@@ -107,7 +115,7 @@ async function listCrawlerSlugs() {
  * `assembledAt`.
  *
  * Returns `{ slug, freshnessAt, freshnessSource, assembledAt, generatedAt,
- * jobCount }`:
+ * jobCount, activeJobCount }`:
  *   - `freshnessAt` is the timestamp the stale gate compares against
  *     (summary `generatedAt` when present, otherwise by-crawler `assembledAt`).
  *   - `freshnessSource` is `'summary' | 'by-crawler' | 'mtime' | 'none'`.
@@ -121,17 +129,17 @@ async function inspectCrawler(slug) {
   }
 
   // Tolerate any shape: array of jobs OR { jobs: [...] } OR { entries: [...] }.
-  let jobCount = 0;
+  let activeJobCount = 0;
   if (Array.isArray(data)) {
-    jobCount = data.length;
+    activeJobCount = data.length;
   } else if (data && Array.isArray(data.jobs)) {
-    jobCount = data.jobs.length;
+    activeJobCount = data.jobs.length;
   } else if (data && Array.isArray(data.entries)) {
-    jobCount = data.entries.length;
+    activeJobCount = data.entries.length;
   } else if (data && typeof data === 'object') {
     // Best-effort: count any array property at the top level.
     for (const v of Object.values(data)) {
-      if (Array.isArray(v) && v.length > jobCount) jobCount = v.length;
+      if (Array.isArray(v) && v.length > activeJobCount) activeJobCount = v.length;
     }
   }
 
@@ -160,6 +168,15 @@ async function inspectCrawler(slug) {
     summary && typeof summary === 'object' && typeof summary.generatedAt === 'string'
       ? summary.generatedAt
       : null;
+  const summaryTotal =
+    summary && typeof summary === 'object' && Number.isFinite(Number(summary.total))
+      ? Number(summary.total)
+      : null;
+  // For crawler health, count what the crawler found, not what later
+  // housekeeping kept in the active slice. URL cleanup has its own failure
+  // surface; otherwise a cleanup false positive is mislabeled as a parser
+  // returning zero jobs.
+  const jobCount = summaryTotal ?? activeJobCount;
 
   let freshnessAt;
   let freshnessSource;
@@ -186,6 +203,7 @@ async function inspectCrawler(slug) {
     assembledAt,
     generatedAt,
     jobCount,
+    activeJobCount,
   };
 }
 
@@ -206,8 +224,9 @@ function nextCrawlerState(prev, observation, nowIso, nowMs) {
   const hadPriorState = Boolean(prev);
   const lastObservedJobs = observation.jobCount;
 
+  const emptyOk = EMPTY_OK_CRAWLERS.has(observation.slug);
   const consecutiveEmptyRuns =
-    lastObservedJobs > 0 ? 0 : (previous.consecutiveEmptyRuns ?? 0) + 1;
+    lastObservedJobs > 0 || emptyOk ? 0 : (previous.consecutiveEmptyRuns ?? 0) + 1;
 
   const lastNonZeroJobs =
     lastObservedJobs > 0 ? lastObservedJobs : (previous.lastNonZeroJobs ?? 0);
@@ -241,10 +260,12 @@ function nextCrawlerState(prev, observation, nowIso, nowMs) {
 
   let status = 'healthy';
   let reason = null;
-
   if (freshnessAgeDays > STALE_AFTER_DAYS) {
     status = 'stale';
     reason = `crawler not run in ${Math.round(freshnessAgeDays)} days (freshnessAt=${freshnessAt ?? 'unknown'}, source=${freshnessSource})`;
+  } else if (lastObservedJobs === 0 && emptyOk) {
+    status = 'healthy';
+    reason = null;
   } else if (consecutiveEmptyRuns >= BROKEN_AFTER_EMPTY_RUNS) {
     status = 'broken';
     reason = `${consecutiveEmptyRuns} consecutive runs returned 0 jobs`;

--- a/scripts/cleanup-jobs.mjs
+++ b/scripts/cleanup-jobs.mjs
@@ -393,9 +393,20 @@ async function main() {
         console.log(`🧹 Slice housekeeping: checking ${kept.length} jobs (concurrency=${MAX_CONCURRENCY}, timeout=${TIMEOUT_MS}ms)`);
         const checks = await validateJobUrls(kept.map((j) => ({ id: j.id, url: j.url })), { concurrency: MAX_CONCURRENCY, timeoutMs: TIMEOUT_MS });
         const checkById = new Map(checks.map((c) => [c.id, c]));
+        const fallbackCandidates = kept
+          .filter((job) => {
+            const c = checkById.get(job.id);
+            return c?.valid === false && job.applyUrl && job.applyUrl !== job.url;
+          })
+          .map((job) => ({ id: job.id, url: job.applyUrl }));
+        const fallbackById = fallbackCandidates.length > 0
+          ? new Map((await validateJobUrls(fallbackCandidates, { concurrency: MAX_CONCURRENCY, timeoutMs: TIMEOUT_MS })).map((c) => [c.id, c]))
+          : new Map();
         kept = kept.filter((job) => {
           const c = checkById.get(job.id);
           if (c && c.valid === false) {
+            const fallback = fallbackById.get(job.id);
+            if (fallback && fallback.valid !== false) return true;
             if (isFreshProtected(job) && !c.definitive) return true;
             urlRemoved.push({ id: job.id, reason: c.reason });
             return false;
@@ -647,9 +658,23 @@ async function main() {
     );
 
     const checkById = new Map(checks.map((c) => [c.id, c]));
+    const fallbackCandidates = afterAgePrune
+      .filter((job) => {
+        const c = checkById.get(job.id);
+        return c?.valid === false && job.applyUrl && job.applyUrl !== job.url;
+      })
+      .map((job) => ({ id: job.id, url: job.applyUrl }));
+    const fallbackById = fallbackCandidates.length > 0
+      ? new Map((await validateJobUrls(fallbackCandidates, { concurrency: MAX_CONCURRENCY, timeoutMs: TIMEOUT_MS })).map((c) => [c.id, c]))
+      : new Map();
     for (const job of afterAgePrune) {
       const c = checkById.get(job.id);
       if (c && c.valid === false) {
+        const fallback = fallbackById.get(job.id);
+        if (fallback && fallback.valid !== false) {
+          kept.push(job);
+          continue;
+        }
         // Definitive signals (HTTP 404/410, explicit closure phrases, portal-specific)
         // bypass fresh protection — the job is unambiguously gone.
         if (isFreshProtected(job) && !c.definitive) {

--- a/scripts/lib/ats-clients/successfactors-client.mjs
+++ b/scripts/lib/ats-clients/successfactors-client.mjs
@@ -190,6 +190,10 @@ export function detectSuccessFactorsKind(url) {
   if (host === 'careers.oerlikon.com') return 'html-jobreq';
   // HOCH Health Ostschweiz (KSSG group) — SF Career Site Builder
   if (host === 'jobs.h-och.ch') return 'html-jobreq';
+  // Nestlé global careers moved from Workday to SuccessFactors Career Site Builder.
+  if (host === 'jobdetails.nestle.com' && (/\/(?:search|job)\b/i.test(path) || path === '/')) {
+    return 'html-jobreq';
+  }
 
   return null;
 }
@@ -619,22 +623,33 @@ export async function* fetchSuccessFactorsJobs(careerUrl, options = {}) {
     // jobs2web-style search is server-rendered (Heineken, Mobiliar via sitemap).
     // SBB v2 detail pages have JSON-LD. The listing index for jobreqcareer
     // is a SPA — we accept a single page and parse what we can.
-    const res = await fetchOnce(careerUrl, {
-      timeoutMs,
-      userAgent,
-      accept: 'text/html,application/xhtml+xml',
-    });
-    const html = await res.text();
-    const ldJob = extractJsonLdJobPosting(html);
-    if (ldJob) {
-      const job = extractSuccessFactorsJobIdentity(ldJob, { company });
-      if (matchesLocation(job.location)) yield job;
-      return;
-    }
-    const rows = parseJobs2WebSearchRows(html, careerUrl);
-    for (const row of rows) {
-      const job = extractSuccessFactorsJobIdentity(row, { company });
-      if (matchesLocation(job.location)) yield job;
+    const seenJobIds = new Set();
+    for (let page = 0; page < maxPages; page++) {
+      const pageUrl = buildJobs2WebPageUrl(careerUrl, page);
+      const res = await fetchOnce(pageUrl, {
+        timeoutMs,
+        userAgent,
+        accept: 'text/html,application/xhtml+xml',
+      });
+      const html = await res.text();
+      const ldJob = extractJsonLdJobPosting(html);
+      if (ldJob) {
+        const job = extractSuccessFactorsJobIdentity(ldJob, { company });
+        if (matchesLocation(job.location)) yield job;
+        return;
+      }
+      const rows = parseJobs2WebSearchRows(html, pageUrl);
+      if (rows.length === 0) return;
+      for (const row of rows) {
+        const job = extractSuccessFactorsJobIdentity(row, { company });
+        if (job.jobReqId && seenJobIds.has(job.jobReqId)) continue;
+        if (job.jobReqId) seenJobIds.add(job.jobReqId);
+        if (matchesLocation(job.location)) {
+          yield job;
+        }
+      }
+      if (rows.length < 10) return;
+      if (page < maxPages - 1 && minDelayMs > 0) await sleep(minDelayMs);
     }
     return;
   }
@@ -649,6 +664,17 @@ function extractTenantFromHost(url) {
     return m ? m[1] : host;
   } catch {
     return '';
+  }
+}
+
+function buildJobs2WebPageUrl(url, page) {
+  if (page <= 0) return url;
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set('startrow', String(page * 10));
+    return parsed.toString();
+  } catch {
+    return url;
   }
 }
 

--- a/scripts/lib/benteler-job-parser.mjs
+++ b/scripts/lib/benteler-job-parser.mjs
@@ -47,6 +47,26 @@ function normalizeSpace(s = '') {
   return String(s || '').replace(/\s+/g, ' ').trim();
 }
 
+function isLikelyJobLink({ title = '', href = '' } = {}) {
+  const text = normalizeSpace(title);
+  const lowerText = text.toLowerCase();
+  const lowerHref = String(href || '').toLowerCase();
+
+  if (!text || text.length < 5) return false;
+  if (/^(more|apply now|click here to apply|faqs? and job offers)$/i.test(text)) return false;
+  if (/\b(opens in new window|job offers|faq|privacy|impressum|login|register|contact|about)\b/i.test(text)) {
+    return false;
+  }
+  if (/login|register|contact|about|impressum|datenschutz|privacy|faq/i.test(lowerHref)) return false;
+
+  return (
+    /\/job\//i.test(lowerHref) ||
+    /\/jobs\//i.test(lowerHref) ||
+    /jobid=|job_id=|jobreqid=|requisition|stellenangebot|karriere/i.test(lowerHref) ||
+    /\b(engineer|manager|specialist|technician|operator|mechanic|quality|logistics|praktik|intern|fach|leiter|mitarbeiter)\b/i.test(lowerText)
+  );
+}
+
 /* ── Company Matchers ──────────────────────────────────────── */
 
 /**
@@ -177,12 +197,12 @@ function parseCareerPageHtml(html = '') {
         const href = link.getAttribute('href') || '';
         const title = normalizeSpace(link.textContent || '');
 
-        if (!title || title.length < 5) continue;
-        if (seen.has(title.toLowerCase())) continue;
-        if (/login|register|contact|about|impressum|datenschutz/i.test(href)) continue;
-
-        seen.add(title.toLowerCase());
         const fullUrl = href.startsWith('http') ? href : `https://career.benteler.com${href.startsWith('/') ? '' : '/'}${href}`;
+        if (!isTrustedDomain(fullUrl)) continue;
+        if (!isLikelyJobLink({ title, href: fullUrl })) continue;
+        if (seen.has(fullUrl.toLowerCase())) continue;
+
+        seen.add(fullUrl.toLowerCase());
 
         // Check if this looks like a Swiss job
         const parent = link.closest('li, tr, div, article') || link.parentElement;
@@ -317,3 +337,8 @@ export async function fetchAllBentelerJobs() {
   console.log(`\n📋 Total Benteler jobs discovered: ${jobs.length}`);
   return jobs;
 }
+
+export const __internals = {
+  isLikelyJobLink,
+  parseCareerPageHtml,
+};

--- a/scripts/lib/engadin-tourismus-job-parser.mjs
+++ b/scripts/lib/engadin-tourismus-job-parser.mjs
@@ -25,6 +25,11 @@ export const ENGADIN_TOURISMUS_COMPANY_DOMAIN = 'engadintourismus.ch';
 
 export const MIN_DESC_LENGTH = 100;
 
+function createDocument(html = '') {
+  const sanitized = String(html || '').replace(/<style\b[\s\S]*?<\/style>/gi, '');
+  return new JSDOM(sanitized).window.document;
+}
+
 /* ── Job identification ───────────────────────────────────── */
 
 export function isEngadinTourismusJob(job = {}) {
@@ -55,7 +60,7 @@ export function isTrustedDomain(rawUrl = '') {
  */
 function parseListingPage(html = '') {
   if (!html) return [];
-  const { document } = new JSDOM(html).window;
+  const document = createDocument(html);
   const jobs = [];
   const seen = new Set();
 
@@ -100,7 +105,7 @@ function parseListingPage(html = '') {
 function parseDetailPage(html = '') {
   if (!html) return '';
 
-  const { document } = new JSDOM(html).window;
+  const document = createDocument(html);
 
   const BODY_SELECTORS = [
     '.frame-type-text',
@@ -232,3 +237,9 @@ export async function fetchAllEngadinTourismusJobs() {
   console.log(`  Total Engadin Tourismus jobs discovered: ${jobs.length}`);
   return jobs;
 }
+
+export const __internals = {
+  createDocument,
+  parseListingPage,
+  parseDetailPage,
+};

--- a/scripts/lib/git-commit-data.sh
+++ b/scripts/lib/git-commit-data.sh
@@ -630,6 +630,27 @@ abort_if_conflict_markers_staged() {
 git config user.name  "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
+# ── 2b. Keep Git auth explicit across retry/rebase paths ───────────────────
+# actions/checkout normally persists an HTTP extraheader, but the crawler
+# commit loop does several fetch/pull/push retries after long-running jobs. Make
+# the token source explicit so retries do not depend on checkout's implicit
+# credential state.
+CHECKOUT_GIT_EXTRAHEADER="$(git config --local --get http.https://github.com/.extraheader 2>/dev/null || true)"
+ensure_git_auth() {
+  local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  local encoded
+
+  if [ -n "$token" ]; then
+    encoded="$(printf 'x-access-token:%s' "$token" | base64 | tr -d '\n')"
+    git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${encoded}"
+    return 0
+  fi
+
+  if [ -n "$CHECKOUT_GIT_EXTRAHEADER" ]; then
+    git config --local http.https://github.com/.extraheader "$CHECKOUT_GIT_EXTRAHEADER"
+  fi
+}
+
 # ── 3+4 loop: Sync, align, commit, push (with retry on race conditions) ────
 MAX_PUSH_ATTEMPTS=8
 push_attempt=0
@@ -637,6 +658,7 @@ push_attempt=0
 while true; do
 
 # ── 3. Sync with remote (stash → rebase → pop → merge if needed) ──────────
+ensure_git_auth
 git fetch origin main
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
@@ -651,9 +673,11 @@ if [ "$LOCAL" != "$REMOTE" ]; then
   # Stash local changes so rebase can proceed cleanly
   git stash --include-untracked
 
+  ensure_git_auth
   if ! git pull --rebase origin main; then
     git rebase --abort 2>/dev/null || true
     echo "⚠️ Fast-rebase failed — pulling with merge..."
+    ensure_git_auth
     git pull --no-rebase origin main || true
   fi
 
@@ -754,6 +778,7 @@ abort_if_conflict_markers_staged "pre-commit"
 git commit -m "$COMMIT_MSG"
 
 # Last-moment rebase: fetch latest remote right before push to minimise race window
+ensure_git_auth
 git fetch origin main
 if ! git rebase origin/main 2>/dev/null; then
   echo "⚠️ Last-moment rebase conflict — resolving with 3-way JSON merge..."
@@ -764,6 +789,7 @@ if ! git rebase origin/main 2>/dev/null; then
 
   # Re-pull with merge strategy to get remote changes
   git stash --include-untracked 2>/dev/null || true
+  ensure_git_auth
   git pull --no-rebase origin main || true
 
   restore_stashed_changes_with_safe_merge \
@@ -793,6 +819,7 @@ fi
 
 # Push — if rejected, undo commit and re-run sync from step 3
 push_attempt=$((push_attempt + 1))
+ensure_git_auth
 if git push origin main; then
   echo "✅ Pushed successfully"
 

--- a/scripts/lib/leukerbad-clinic-job-parser.mjs
+++ b/scripts/lib/leukerbad-clinic-job-parser.mjs
@@ -217,10 +217,12 @@ function buildJob(doc) {
       ? langPrefix
       : detectLang(description || title, 'fr');
 
-  // Build canonical URL. The Nuxt site exposes jobs at /{lang}/page/jobs/{uid}/
-  // We use the German page when source is de, otherwise fr.
+  // Build canonical URL. Leukerbad's Nuxt/Prismic site renders individual
+  // job documents only inside the listing page; /{lang}/page/jobs/{uid}/
+  // returns 404. Keep the source URL on the live language-specific listing so
+  // URL housekeeping does not expire valid Prismic jobs.
   const sitePath = sourceLang === 'de' ? 'de' : 'fr';
-  const publicUrl = `https://leukerbadclinic.ch/${sitePath}/page/jobs/${doc.uid || ''}/`;
+  const publicUrl = `https://leukerbadclinic.ch/${sitePath}/page/jobs/`;
   const urlForHash = `${PRISMIC_REPO}:${doc.id || doc.uid || title}`;
   const urlHash = createHash('sha1').update(urlForHash).digest('hex').slice(0, 12);
 

--- a/scripts/lib/nestle-job-parser.mjs
+++ b/scripts/lib/nestle-job-parser.mjs
@@ -15,13 +15,9 @@ import { detectLang } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 import {
-  buildWorkdayApiBase,
-  fetchWorkdayJobs,
-  fetchWorkdayJobDescriptionText,
-  parseWorkdayPostedDate,
-  extractWorkdayJobIdentity,
-  WorkdayAuthError,
-} from './ats-clients/workday-client.mjs';
+  fetchSuccessFactorsJobs,
+  SuccessFactorsAuthError,
+} from './ats-clients/successfactors-client.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 
@@ -29,10 +25,9 @@ export const NESTLE_KEY = 'nestle';
 export const NESTLE_COMPANY_NAME = 'Nestlé';
 export const NESTLE_COMPANY_DOMAIN = 'nestle.com';
 
-const WORKDAY_TENANT_HOST = 'nestle.wd3.myworkdayjobs.com';
-const WORKDAY_SITE_PATH = 'Nestle_External_Careers';
-const WORKDAY_PUBLIC_BASE = `https://${WORKDAY_TENANT_HOST}/en/${WORKDAY_SITE_PATH}`;
-const CAREER_URL = WORKDAY_PUBLIC_BASE;
+const SUCCESSFACTORS_HOST = 'jobdetails.nestle.com';
+const SUCCESSFACTORS_SEARCH_URL = `https://${SUCCESSFACTORS_HOST}/search/?createNewAlert=false&q=&locationsearch=Switzerland&optionsFacetsDD_country=CH&locale=en_US`;
+const CAREER_URL = SUCCESSFACTORS_SEARCH_URL;
 
 /* ── Helpers ───────────────────────────────────────────────── */
 
@@ -42,6 +37,14 @@ function normalize(value = '') {
 
 function normalizeSpace(s = '') {
   return String(s || '').replace(/\s+/g, ' ').trim();
+}
+
+function isSwissLocation(location = '') {
+  return /(?:^|,\s*)CH(?:\s|$)/i.test(String(location || ''));
+}
+
+function wordCount(text = '') {
+  return String(text || '').split(/\s+/).filter(Boolean).length;
 }
 
 /* ── Company Matchers ──────────────────────────────────────── */
@@ -66,7 +69,7 @@ export function isNestleJob(job) {
     company.includes('nestle') ||
     url.includes('nestle.com') ||
     url.includes('nestle.ch') ||
-    url.includes(WORKDAY_TENANT_HOST)
+    url.includes(SUCCESSFACTORS_HOST)
   );
 }
 
@@ -81,8 +84,7 @@ export function isTrustedDomain(rawUrl = '') {
       host.endsWith('.nestle.com') ||
       host === 'nestle.ch' ||
       host.endsWith('.nestle.ch') ||
-      host === WORKDAY_TENANT_HOST ||
-      host.endsWith('.myworkdayjobs.com')
+      host === SUCCESSFACTORS_HOST
     );
   } catch {
     return false;
@@ -123,45 +125,61 @@ function detectEmploymentType(text = '') {
   return 'OTHER';
 }
 
-/* ── Workday fetcher ──────────────────────────────────────────
- * Tenant: nestle.wd3.myworkdayjobs.com / site: Nestle_External_Careers
- * Switzerland location filter ID is the common Workday value
- * `187134fccb084a0ea9b4b95f23890dbe` on most tenants — verify on the first
- * dispatch run by inspecting the network tab on the live site (XHR
- * /wday/cxs/.../jobs payload `appliedFacets.locationCountry`). Adjust if
- * the tenant uses a different ID.
+/* ── SuccessFactors fetcher ───────────────────────────────────
+ * Nestlé's global careers site moved from Workday to SAP SuccessFactors
+ * (`jobdetails.nestle.com`). The search page is server-rendered and paginated
+ * with `startrow`, so the shared SuccessFactors jobs2web parser can discover
+ * the Swiss listing rows without browser automation.
  */
-const WORKDAY_API_BASE = buildWorkdayApiBase(WORKDAY_TENANT_HOST, WORKDAY_SITE_PATH);
-const SWISS_LOCATION_IDS = ['187134fccb084a0ea9b4b95f23890dbe'];
-
 async function fetchJobListings() {
   const out = [];
   try {
-    for await (const posting of fetchWorkdayJobs(WORKDAY_API_BASE, {
-      locationFilters: SWISS_LOCATION_IDS,
-      maxPages: 25,
+    for await (const posting of fetchSuccessFactorsJobs(SUCCESSFACTORS_SEARCH_URL, {
+      company: NESTLE_COMPANY_NAME,
+      maxPages: 10,
+      minDelayMs: 750,
     })) {
-      const id = extractWorkdayJobIdentity(posting, {
-        apiBase: WORKDAY_API_BASE,
-        company: NESTLE_COMPANY_NAME,
-      });
       out.push({
-        title: id.title,
-        location: id.location,
-        url: id.applyUrl,
-        postedAt: id.postedAt || (posting.postedOn ? parseWorkdayPostedDate(posting.postedOn) : null),
-        externalPath: id.externalPath,
-        jobReqId: id.jobReqId,
+        title: posting.title,
+        location: posting.location,
+        url: posting.applyUrl,
+        postedAt: posting.postedAt,
+        jobReqId: posting.jobReqId,
       });
     }
   } catch (err) {
-    if (err instanceof WorkdayAuthError) {
-      console.error(`❌ Workday anti-bot block: ${err.message}`);
+    if (err instanceof SuccessFactorsAuthError) {
+      console.error(`❌ SuccessFactors anti-bot block: ${err.message}`);
       return [];
     }
     throw err;
   }
-  return out;
+  return out.filter((job) => isSwissLocation(job.location));
+}
+
+async function fetchJobDescriptionText(listingUrl) {
+  if (!listingUrl) return '';
+  try {
+    const res = await fetch(listingUrl, {
+      headers: {
+        Accept: 'text/html,application/xhtml+xml',
+        'User-Agent': 'FrontaliereTicino-Bot/1.0 (+https://frontaliereticino.ch/)',
+      },
+      redirect: 'follow',
+    });
+    if (!res.ok) return '';
+    const html = await res.text();
+    const match = html.match(/<span[^>]*class="[^"]*jobdescription[^"]*"[^>]*>([\s\S]*?)<\/span>/i);
+    if (!match) return '';
+    return stripHtml(match[1])
+      .replace(/[ \t]+/g, ' ')
+      .replace(/[ \t]*\n[ \t]*/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+      .slice(0, 4000);
+  } catch {
+    return '';
+  }
 }
 
 /**
@@ -194,12 +212,7 @@ export async function fetchAllNestleJobs() {
     const canton = inferSwissTargetCanton(location) || 'VD';
     const publicUrl = listing.url || CAREER_URL;
 
-    // Workday listing endpoint NEVER returns the job body — see workday-client.mjs.
-    const detailDescription = await fetchWorkdayJobDescriptionText(
-      WORKDAY_API_BASE,
-      listing.externalPath,
-      stripHtml,
-    );
+    const detailDescription = await fetchJobDescriptionText(publicUrl);
     await new Promise((r) => setTimeout(r, 400));
 
     const fallbackDescription = [
@@ -209,16 +222,18 @@ export async function fetchAllNestleJobs() {
       `• Location: ${location}${canton ? `, ${canton} canton` : ''}, Switzerland`,
       '• Employer: Nestlé — world\'s largest food and beverage company',
       '• Apply on: Nestlé careers portal',
+      '',
+      'This listing is part of Nestlé’s official Swiss careers feed. Review the role requirements, team context, contract details, and application instructions directly on the Nestlé job page before applying. The position is kept in this dataset only while the official careers portal keeps the requisition active.',
     ].join('\n');
-    const descriptionText = detailDescription.length >= 100 ? detailDescription : fallbackDescription;
+    const descriptionText = wordCount(detailDescription) >= 50 ? detailDescription : fallbackDescription;
 
     const sourceLang = detectLang(descriptionText || title, 'en');
     const jobSlug = slugify(`${title} nestle ch`);
-    const urlHash = createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
+    const stableId = listing.jobReqId || createHash('sha1').update(publicUrl).digest('hex').slice(0, 12);
 
     const job = {
       // ── Required fields ──
-      id: `nestle-${urlHash}`,
+      id: `nestle-${stableId}`,
       slug: jobSlug,
       slugByLocale: { [sourceLang]: jobSlug },
       company: NESTLE_COMPANY_NAME,
@@ -246,7 +261,7 @@ export async function fetchAllNestleJobs() {
       sector: 'Food / Beverage',
       currency: 'CHF',
       featured: false,
-      postedDate: listing.postedDate || new Date().toISOString().split('T')[0],
+      postedDate: listing.postedAt || new Date().toISOString().split('T')[0],
       applyUrl: publicUrl,
       requirements: [],
       requirementsByLocale: { [sourceLang]: [] },

--- a/scripts/lib/pdag-job-parser.mjs
+++ b/scripts/lib/pdag-job-parser.mjs
@@ -27,6 +27,7 @@ const parser = createUmantisListingParser({
   defaultPostalCode: '5210',
   publicCareerUrl: 'https://www.pdag.ch/de/karriere.html',
   defaultSourceLang: 'de',
+  canonicalUrlMode: 'application',
 });
 
 export const fetchAllPdagJobs = parser.fetchAllJobs;

--- a/scripts/lib/ubs-job-parser.mjs
+++ b/scripts/lib/ubs-job-parser.mjs
@@ -173,6 +173,17 @@ function inferCanton(city = '', region = '') {
   return inferAnyCanton(city) || inferAnyCanton(region) || '';
 }
 
+function extractRequestVerificationToken(html = '') {
+  const source = String(html || '');
+  const inputMatch = source.match(/<input\b[^>]*name=(["'])__RequestVerificationToken\1[^>]*>/i);
+  const input = inputMatch?.[0] || '';
+  const valueMatch = input.match(/\bvalue=(["'])([^"']+)\1/i);
+  if (valueMatch?.[2]) return valueMatch[2];
+
+  const looseMatch = source.match(/__RequestVerificationToken[\s\S]{0,300}?\bvalue=(["'])([^"']+)\1/i);
+  return looseMatch?.[2] || '';
+}
+
 /* ── Company Matchers ──────────────────────────────────────── */
 
 /**
@@ -282,12 +293,12 @@ async function bootstrapSession() {
 
     // Extract RFT from HTML
     const html = await res.text();
-    const rftMatch = html.match(/__RequestVerificationToken[^>]*value="([^"]+)"/);
-    if (!rftMatch) {
+    const rft = extractRequestVerificationToken(html);
+    if (!rft) {
       throw new Error('Could not extract CSRF token (RFT) from Taleo page');
     }
 
-    return { cookies: cookieStr, rft: rftMatch[1] };
+    return { cookies: cookieStr, rft };
   } catch (err) {
     clearTimeout(timer);
     throw err;
@@ -516,3 +527,7 @@ export async function fetchAllUbsJobs() {
   console.log(`\n📋 Total UBS Swiss jobs: ${jobs.length}`);
   return jobs;
 }
+
+export const __internals = {
+  extractRequestVerificationToken,
+};

--- a/scripts/lib/umantis-listing-common.mjs
+++ b/scripts/lib/umantis-listing-common.mjs
@@ -423,6 +423,12 @@ async function fetchUmantisDetail(detailUrl, title = '') {
  * @param {string} config.defaultPostalCode  Fallback postal code
  * @param {string} [config.publicCareerUrl]  Public career site URL (corporate site)
  * @param {string} [config.defaultSourceLang='de']
+ * @param {'detail'|'application'} [config.canonicalUrlMode='detail'] Which
+ *                                           Umantis URL should become job.url.
+ *                                           Some tenants redirect Description/*
+ *                                           pages to a generic career center
+ *                                           while Application/* remains the
+ *                                           stable live job endpoint.
  */
 export function createUmantisListingParser(config) {
   const {
@@ -437,6 +443,7 @@ export function createUmantisListingParser(config) {
     defaultPostalCode,
     publicCareerUrl,
     defaultSourceLang = 'de',
+    canonicalUrlMode = 'detail',
   } = config;
 
   const customBaseUrl = rawCustomBaseUrl
@@ -507,6 +514,7 @@ export function createUmantisListingParser(config) {
       const title = entry.title;
       const detailUrl = `${BASE_URL}/Vacancies/${entry.id}/Description/${langCode}`;
       const applyUrl = `${BASE_URL}/Vacancies/${entry.id}/Application/CheckLogin/${langCode}`;
+      const jobUrl = canonicalUrlMode === 'application' ? applyUrl : detailUrl;
 
       // Fetch detail page for rich description content. Pass the title so the
       // detail-validity check can reject content that doesn't belong to this
@@ -576,7 +584,7 @@ export function createUmantisListingParser(config) {
         needsRetranslation: true,
         location,
         canton,
-        url: detailUrl,
+        url: jobUrl,
         source: customBaseUrl
           ? `${companyName} Dedicated Parser (Umantis listing @ ${customBaseHost || customBaseUrl})`
           : `${companyName} Dedicated Parser (Umantis listing tenant ${tenantId})`,

--- a/scripts/update-cambiavalute-jobs.mjs
+++ b/scripts/update-cambiavalute-jobs.mjs
@@ -163,8 +163,24 @@ async function fetchListingPage(url, timeoutMs, userAgent) {
   }
 }
 
+async function fetchListingPageWithRetry(url, timeoutMs, userAgent, attempts = 3) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fetchListingPage(url, timeoutMs, userAgent);
+    } catch (err) {
+      lastError = err;
+      if (attempt >= attempts) break;
+      const delayMs = attempt * 1500;
+      console.warn(`⚠️ Listing fetch attempt ${attempt}/${attempts} failed: ${err?.message || err}. Retrying in ${delayMs}ms...`);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}
+
 async function fetchCambiavalute() {
-  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 12000;
+  const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 25000;
   const userAgent =
     process.env.JOBS_CRAWLER_USER_AGENT ||
     'Mozilla/5.0 (compatible; FrontaliereTicinoBot/1.0; +https://frontaliereticino.ch/)';
@@ -173,7 +189,7 @@ async function fetchCambiavalute() {
 
   let html = '';
   try {
-    html = await fetchListingPage(CAMBIAVALUTE_LISTING_URL, timeoutMs, userAgent);
+    html = await fetchListingPageWithRetry(CAMBIAVALUTE_LISTING_URL, timeoutMs, userAgent);
   } catch (err) {
     console.error(`❌ Failed to fetch listing page: ${err?.message || err}`);
     throw err;

--- a/scripts/update-tarchini-group-jobs.mjs
+++ b/scripts/update-tarchini-group-jobs.mjs
@@ -361,6 +361,10 @@ async function main() {
     removedJobs: diff.removedJobs.slice(0, 30),
     unchangedJobs: (diff.unchangedJobs || []).slice(0, 30),
   });
+  if (process.env.CRAWLER_SLICE_ONLY === '1' || process.env.GITHUB_ACTIONS === 'true') {
+    console.log('📦 Slice-only run: skipping global dataset assembly (deploy assembles slices).');
+    return;
+  }
   await assembleJobsDataset();
 }
 

--- a/tests/benteler-crawler.test.ts
+++ b/tests/benteler-crawler.test.ts
@@ -4,6 +4,7 @@ import {
   BENTELER_COMPANY_NAME,
   isBentelerJob,
   isTrustedDomain,
+  __internals,
 } from '../scripts/lib/benteler-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -12,6 +13,22 @@ describe('Benteler crawler parser', () => {
   it('exports valid company key and name', () => {
     expect(BENTELER_KEY).toBe('benteler');
     expect(BENTELER_COMPANY_NAME).toBe('Benteler');
+  });
+
+  describe('HTML fallback filtering', () => {
+    it('rejects navigation and apply action links before they become fake jobs', () => {
+      const html = `
+        <a href="/go/jobs">FAQs and Job Offers</a>
+        <a href="https://career.benteler.com/go/job/foo">More(Opens in new window)</a>
+        <a href="https://career.benteler.com/job/Manno-Quality-Engineer-123">Quality Engineer Manno</a>
+      `;
+
+      const jobs = __internals.parseCareerPageHtml(html);
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].title).toBe('Quality Engineer Manno');
+      expect(jobs[0].url).toContain('/job/Manno-Quality-Engineer-123');
+    });
   });
 
   // ── isCompanyJob ──

--- a/tests/cleanup-jobs-archive-dedup-losers.test.ts
+++ b/tests/cleanup-jobs-archive-dedup-losers.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -43,6 +44,7 @@ interface CleanupSliceJob {
   postalCode?: string;
   streetAddress?: string;
   addressLocality?: string;
+  applyUrl?: string;
 }
 
 interface ExpiredEntry {
@@ -62,6 +64,32 @@ async function runCleanupSlice(slicePath: string, expiredDir: string): Promise<R
         JOBS_SLICE_FILE: slicePath,
         JOBS_SKIP_LOCALE_HARDENING: '1',
         JOBS_SKIP_URL_VALIDATION: '1',
+        JOBS_EXPIRED_SLICES_DIR: expiredDir,
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', rejectRun);
+    child.on('close', (code) => {
+      resolveRun({ code, stdout, stderr });
+    });
+  });
+}
+
+async function runCleanupSliceWithUrlValidation(slicePath: string, expiredDir: string): Promise<RunResult> {
+  return await new Promise<RunResult>((resolveRun, rejectRun) => {
+    const child = spawn(process.execPath, [SCRIPT_PATH], {
+      env: {
+        ...process.env,
+        JOBS_SLICE_FILE: slicePath,
+        JOBS_SKIP_LOCALE_HARDENING: '1',
         JOBS_EXPIRED_SLICES_DIR: expiredDir,
       },
     });
@@ -113,6 +141,53 @@ function buildJob(overrides: Partial<CleanupSliceJob> & Pick<CleanupSliceJob, 'i
 }
 
 describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', () => {
+  it('keeps a job when the canonical URL is dead but applyUrl is live', async () => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/apply') {
+        res.writeHead(200, { 'content-type': 'text/html' });
+        res.end('<html><body>Application form</body></html>');
+        return;
+      }
+      res.writeHead(404, { 'content-type': 'text/html' });
+      res.end('<html><body>Not found</body></html>');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('test server did not bind to a port');
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      const dir = makeTempDir();
+      const slicePath = path.join(dir, 'apply-url-fallback.json');
+      const expiredDir = path.join(dir, 'expired');
+      const crawlerKey = `apply-url-fallback-${Date.now()}`;
+      const jobs: CleanupSliceJob[] = [
+        buildJob({
+          id: 'job-apply-url-001',
+          slug: 'nurse-live-apply',
+          title: 'Nurse With Live Apply URL',
+          crawledAt: new Date().toISOString(),
+          url: `${baseUrl}/dead-detail`,
+          applyUrl: `${baseUrl}/apply`,
+        }),
+      ];
+
+      fs.writeFileSync(slicePath, JSON.stringify({ crawlerKey, jobs }, null, 2), 'utf-8');
+
+      const result = await runCleanupSliceWithUrlValidation(slicePath, expiredDir);
+      const output = result.stdout + result.stderr;
+      expect(result.code, output).toBe(0);
+
+      const sliceParsed = JSON.parse(fs.readFileSync(slicePath, 'utf-8'));
+      const keptJobs: CleanupSliceJob[] = Array.isArray(sliceParsed?.jobs) ? sliceParsed.jobs : sliceParsed;
+      expect(keptJobs).toHaveLength(1);
+      expect(keptJobs[0].id).toBe('job-apply-url-001');
+      expect(output).toContain('Slice clean');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it('moves losers to expired/by-crawler with disambiguated slugs and previousSlugs[]', async () => {
     const dir = makeTempDir();
     const slicePath = path.join(dir, 'archive-slice-test.json');

--- a/tests/engadin-tourismus-crawler.test.ts
+++ b/tests/engadin-tourismus-crawler.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { __internals } from '../scripts/lib/engadin-tourismus-job-parser.mjs';
+
+describe('Engadin Tourismus crawler parser', () => {
+  it('strips malformed style blocks before JSDOM parsing', () => {
+    const html = `
+      <style>@media (min-width: 1px) { :is(.broken { color: red; }</style>
+      <a class="more" title="Lehrstelle Kauffrau/Kaufmann EFZ" href="/ueber-uns/jobs/jobs/lehrstelle-kauffrau-kaufmann-efz">Mehr lesen</a>
+    `;
+
+    const listings = __internals.parseListingPage(html);
+
+    expect(listings).toEqual([
+      {
+        title: 'Lehrstelle Kauffrau/Kaufmann EFZ',
+        url: 'https://www.engadintourismus.ch/ueber-uns/jobs/jobs/lehrstelle-kauffrau-kaufmann-efz',
+      },
+    ]);
+  });
+});

--- a/tests/git-commit-data-auth.test.ts
+++ b/tests/git-commit-data-auth.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const GIT_COMMIT_DATA = readFileSync(resolve(ROOT, 'scripts/lib/git-commit-data.sh'), 'utf-8');
+
+const DEDICATED_WORKFLOWS = [
+  '.github/workflows/update-jobs-spital-lachen.yml',
+  '.github/workflows/update-jobs-hopital-de-lavaux.yml',
+  '.github/workflows/update-jobs-hoch-health.yml',
+] as const;
+
+describe('git-commit-data.sh GitHub auth hardening', () => {
+  it('prefers workflow/checkout auth over stale Remote Config GITHUB_PAT values', () => {
+    expect(GIT_COMMIT_DATA).toContain('local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"');
+    expect(GIT_COMMIT_DATA).toContain('CHECKOUT_GIT_EXTRAHEADER=');
+    expect(GIT_COMMIT_DATA).not.toContain('GITHUB_PAT:-');
+    expect(GIT_COMMIT_DATA).toContain('git config --local http.https://github.com/.extraheader');
+  });
+
+  it('refreshes git auth before every network operation in the retry loop', () => {
+    const networkOps = [...GIT_COMMIT_DATA.matchAll(/^\s*git (fetch|pull|push)\b/gm)];
+    expect(networkOps.length).toBeGreaterThan(0);
+
+    for (const match of networkOps) {
+      const before = GIT_COMMIT_DATA.slice(Math.max(0, match.index - 160), match.index);
+      expect(before, `missing ensure_git_auth before: ${match[0]}`).toMatch(/ensure_git_auth\s*$/m);
+    }
+  });
+});
+
+describe('dedicated crawler workflows using git-commit-data.sh', () => {
+  it('pass github.token explicitly to the commit step for affected workflows', () => {
+    for (const workflowPath of DEDICATED_WORKFLOWS) {
+      const workflow = readFileSync(resolve(ROOT, workflowPath), 'utf-8');
+      expect(workflow).toMatch(/- name: Commit and push[\s\S]*?env:\n[\s\S]*?GH_TOKEN: \$\{\{ github\.token \}\}/);
+    }
+  });
+});

--- a/tests/nestle-crawler.test.ts
+++ b/tests/nestle-crawler.test.ts
@@ -6,6 +6,7 @@ import {
   isTrustedDomain,
 } from '../scripts/lib/nestle-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
+import { detectSuccessFactorsKind } from '../scripts/lib/ats-clients/successfactors-client.mjs';
 
 describe('Nestlé crawler parser', () => {
   // ── Constants ──
@@ -26,6 +27,10 @@ describe('Nestlé crawler parser', () => {
 
     it('matches by URL domain', () => {
       expect(isNestleJob({ url: 'https://nestle.ch/jobs/123' })).toBe(true);
+    });
+
+    it('matches by current SuccessFactors URL domain', () => {
+      expect(isNestleJob({ url: 'https://jobdetails.nestle.com/job/Orbe-Test/123/' })).toBe(true);
     });
 
     it('rejects unrelated jobs', () => {
@@ -49,6 +54,10 @@ describe('Nestlé crawler parser', () => {
       expect(isTrustedDomain('https://careers.nestle.ch/job/456')).toBe(true);
     });
 
+    it('trusts current SuccessFactors job details host', () => {
+      expect(isTrustedDomain('https://jobdetails.nestle.com/job/Orbe-Test/123/')).toBe(true);
+    });
+
     it('rejects other domains', () => {
       expect(isTrustedDomain('https://example.com/jobs')).toBe(false);
     });
@@ -56,6 +65,16 @@ describe('Nestlé crawler parser', () => {
     it('handles invalid URLs', () => {
       expect(isTrustedDomain('')).toBe(false);
       expect(isTrustedDomain('not-a-url')).toBe(false);
+    });
+  });
+
+  describe('SuccessFactors routing', () => {
+    it('classifies Nestlé jobdetails search as a jobs2web SuccessFactors page', () => {
+      expect(detectSuccessFactorsKind('https://jobdetails.nestle.com/search/?q=&locationsearch=Switzerland')).toBe('html-jobreq');
+    });
+
+    it('classifies Nestlé jobdetails detail pages as SuccessFactors pages', () => {
+      expect(detectSuccessFactorsKind('https://jobdetails.nestle.com/job/Orbe-R%26D-Specialist/1377556533/')).toBe('html-jobreq');
     });
   });
 

--- a/tests/scripts/check-crawler-health.test.ts
+++ b/tests/scripts/check-crawler-health.test.ts
@@ -135,6 +135,35 @@ describe('nextCrawlerState', () => {
     expect(reason).toMatch(/3 consecutive runs returned 0 jobs/);
   });
 
+  it('does not flag explicitly empty-ok crawlers when a fresh run finds zero jobs', () => {
+    const prev = {
+      lastSuccessfulRunAt: '2026-05-10T00:00:00.000Z',
+      lastNonZeroJobs: 1,
+      consecutiveEmptyRuns: 4,
+      lastFailureReason: '4 consecutive runs returned 0 jobs',
+      status: 'broken',
+      _lastObservedAt: new Date(NOW_MS - DAY_MS).toISOString(),
+      _lastObservedJobs: 0,
+      _lastObservedAssembledAt: new Date(NOW_MS - DAY_MS).toISOString(),
+    };
+    const { status, state, reason } = nextCrawlerState(
+      prev,
+      {
+        slug: 'csvp-poschiavo',
+        jobCount: 0,
+        freshnessAt: new Date(NOW_MS - 2 * 60 * 60 * 1000).toISOString(),
+        freshnessSource: 'summary',
+        generatedAt: new Date(NOW_MS - 2 * 60 * 60 * 1000).toISOString(),
+        assembledAt: new Date(NOW_MS - 2 * 60 * 60 * 1000).toISOString(),
+      },
+      NOW_ISO,
+      NOW_MS,
+    );
+    expect(status).toBe('healthy');
+    expect(reason).toBeNull();
+    expect(state.consecutiveEmptyRuns).toBe(0);
+  });
+
   it('flags stale when slice assembledAt is older than 7 days (regardless of empty streak)', () => {
     // heineken-ch fixture: slice from 8d ago.
     const { status, state, reason } = nextCrawlerState(

--- a/tests/scripts/git-commit-data-auth.test.ts
+++ b/tests/scripts/git-commit-data-auth.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = resolve('scripts/lib/git-commit-data.sh');
+
+describe('scripts/lib/git-commit-data.sh authentication', () => {
+  it('configures GitHub auth before fetch/push operations without stale Remote Config PATs', () => {
+    const source = readFileSync(SCRIPT, 'utf8');
+    const configureIndex = source.indexOf('ensure_git_auth()');
+    const callIndex = source.indexOf('ensure_git_auth', configureIndex + 1);
+    const fetchIndex = source.indexOf('git fetch origin main');
+    const pushIndex = source.indexOf('git push origin main');
+
+    expect(configureIndex).toBeGreaterThan(-1);
+    expect(source).toContain('GH_TOKEN:-${GITHUB_TOKEN:-}');
+    expect(source).toContain('CHECKOUT_GIT_EXTRAHEADER=');
+    expect(source).not.toContain('GITHUB_PAT:-');
+    expect(source).toContain('git config --local http.https://github.com/.extraheader');
+    expect(callIndex).toBeGreaterThan(configureIndex);
+    expect(callIndex).toBeLessThan(fetchIndex);
+    expect(callIndex).toBeLessThan(pushIndex);
+  });
+});

--- a/tests/successfactors-client.test.ts
+++ b/tests/successfactors-client.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  detectSuccessFactorsKind,
+  fetchSuccessFactorsJobs,
+} from '../scripts/lib/ats-clients/successfactors-client.mjs';
+
+function searchPage(jobId: string, title: string, location = 'Orbe, CH') {
+  return `
+    <table>
+      <tr>
+        <td class="colTitle"><a href="/job/Orbe-${jobId}/${jobId}/">${title}</a></td>
+        <td class="colFacility"></td>
+        <td class="colLocation"><span class="jobLocation">${location}</span></td>
+        <td class="colDate"><span class="jobDate">May 23, 2026</span></td>
+      </tr>
+    </table>
+  `;
+}
+
+function fullSearchPage(startId: number) {
+  return Array.from({ length: 10 }, (_, index) =>
+    searchPage(String(startId + index), `Role ${startId + index}`),
+  ).join('\n');
+}
+
+describe('SuccessFactors client', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('classifies Nestlé jobdetails pages as jobs2web SuccessFactors pages', () => {
+    expect(detectSuccessFactorsKind('https://jobdetails.nestle.com/search/?q=&locationsearch=Switzerland')).toBe('html-jobreq');
+    expect(detectSuccessFactorsKind('https://jobdetails.nestle.com/job/Orbe-Test/123/')).toBe('html-jobreq');
+  });
+
+  it('paginates server-rendered jobs2web search pages with startrow', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(fullSearchPage(1001), { status: 200 }))
+      .mockResolvedValueOnce(new Response(searchPage('1011', 'Second Page Role'), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const jobs = [];
+    for await (const job of fetchSuccessFactorsJobs(
+      'https://jobdetails.nestle.com/search/?q=&locationsearch=Switzerland',
+      { maxPages: 2, minDelayMs: 0, company: 'Nestlé' },
+    )) {
+      jobs.push(job);
+    }
+
+    expect(jobs.map((job) => job.jobReqId)).toEqual([
+      '1001', '1002', '1003', '1004', '1005',
+      '1006', '1007', '1008', '1009', '1010',
+      '1011',
+    ]);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://jobdetails.nestle.com/search/?q=&locationsearch=Switzerland', expect.any(Object));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://jobdetails.nestle.com/search/?q=&locationsearch=Switzerland&startrow=10', expect.any(Object));
+  });
+});

--- a/tests/tarchini-group-crawler.test.ts
+++ b/tests/tarchini-group-crawler.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const SCRIPT = readFileSync(resolve(ROOT, 'scripts/update-tarchini-group-jobs.mjs'), 'utf-8');
+
+describe('Tarchini Group dedicated crawler', () => {
+  it('skips global assembly in GitHub Actions slice runs', () => {
+    expect(SCRIPT).toContain("process.env.GITHUB_ACTIONS === 'true'");
+    expect(SCRIPT).toContain('Slice-only run: skipping global dataset assembly');
+    expect(SCRIPT.indexOf('Slice-only run: skipping global dataset assembly')).toBeLessThan(
+      SCRIPT.indexOf('await assembleJobsDataset();'),
+    );
+  });
+});

--- a/tests/ubs-crawler.test.ts
+++ b/tests/ubs-crawler.test.ts
@@ -4,6 +4,7 @@ import {
   UBS_COMPANY_NAME,
   isUbsJob,
   isTrustedDomain,
+  __internals,
 } from '../scripts/lib/ubs-job-parser.mjs';
 import { slugify } from '../scripts/lib/crawler-template.mjs';
 
@@ -12,6 +13,20 @@ describe('UBS crawler parser', () => {
   it('exports valid company key and name', () => {
     expect(UBS_KEY).toBe('ubs');
     expect(UBS_COMPANY_NAME).toBe('UBS');
+  });
+
+  describe('Taleo token parsing', () => {
+    it('extracts the RFT token from the current hidden input shape', () => {
+      const html = `<input name="__RequestVerificationToken" type="hidden" value="abc-123" />`;
+
+      expect(__internals.extractRequestVerificationToken(html)).toBe('abc-123');
+    });
+
+    it('handles attributes before the token name', () => {
+      const html = `<input type='hidden' value='token-456' name='__RequestVerificationToken'>`;
+
+      expect(__internals.extractRequestVerificationToken(html)).toBe('token-456');
+    });
   });
 
   // ── isCompanyJob ──


### PR DESCRIPTION
Move Nestle to the current SuccessFactors source, harden shared dedicated crawler commit auth, and make crawler health use crawl summaries instead of post-cleanup active slices. Also fixes parser regressions for Benteler, Engadin Tourismus, UBS, CambiaValute, Tarchini, PDAG, Leukerbad, and Umantis listing cleanup.

Fixes #508 #509 #510 #512 #516 #517 #518 #519 #520 #521 #522 #523 #524 #525 #526 #527 #528 #529 #530 #531 #532 #533 #492 #491 #452 #360 #359 #358 #357
