### PR TITLE
test: accept unquoted HTML attrs

### DIFF
--- a/tests/border-wait-hydration.test.ts
+++ b/tests/border-wait-hydration.test.ts
@@ -109,8 +109,8 @@ describe('border-wait pages — hydration injection', () => {
 
   it('marks the leaf page status card with `data-bw-crossing` for the slug', () => {
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
-    expect(html).toContain('data-bw-crossing="chiasso-brogeda"');
-    expect(html).toContain('data-bw-field="waitTimeMinutes"');
+    expect(html).toMatch(/\bdata-bw-crossing=["']?chiasso-brogeda["']?/);
+    expect(html).toMatch(/\bdata-bw-field=["']?waitTimeMinutes["']?/);
     expect(html).toContain('data-bw-live-badge');
   });
 
@@ -118,10 +118,10 @@ describe('border-wait pages — hydration injection', () => {
     const html = pages[buildRootHubPath('it')];
     expect(html).toBeDefined();
     // At least the two crossings in our fixture must appear.
-    expect(html).toContain('data-bw-crossing="chiasso-brogeda"');
-    expect(html).toContain('data-bw-crossing="gaggiolo"');
+    expect(html).toMatch(/\bdata-bw-crossing=["']?chiasso-brogeda["']?/);
+    expect(html).toMatch(/\bdata-bw-crossing=["']?gaggiolo["']?/);
     // Every row must carry a wait-minutes field marker.
-    expect(html).toContain('data-bw-field="waitTimeMinutes"');
+    expect(html).toMatch(/\bdata-bw-field=["']?waitTimeMinutes["']?/);
     // Hub also gets the snapshot/live badge in the header.
     expect(html).toContain('data-bw-live-badge');
     // External hydration tag (NOT the inline IIFE — keeps text-to-HTML gate green).
@@ -132,7 +132,7 @@ describe('border-wait pages — hydration injection', () => {
     const html = pages[buildRegionalHubPath('en', 'ticino-como')];
     expect(html).toBeDefined();
     expect(html).toContain('<script src="/border-wait-hydrate.js"');
-    expect(html).toContain('data-bw-crossing="chiasso-brogeda"');
+    expect(html).toMatch(/\bdata-bw-crossing=["']?chiasso-brogeda["']?/);
   });
 
   it('preserves the pre-rendered minute value in the HTML', () => {

--- a/tests/border-wait-og-webcam.test.ts
+++ b/tests/border-wait-og-webcam.test.ts
@@ -32,6 +32,7 @@ import {
   type BorderWaitCurrent,
 } from '../build-plugins/borderWaitPagesPlugin';
 import { buildOggiPath } from '../build-plugins/borderWaitData';
+import { htmlTagWithAttrs } from './utils/htmlAttr';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -323,12 +324,13 @@ describe('generateBorderWaitPages — per-page og:image from webcam snapshot', (
           : undefined,
     });
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
-    expect(html).toContain(
-      '<meta property="og:image" content="https://frontaliereticino.ch/og/border-wait/chiasso-brogeda.jpg">',
-    );
-    expect(html).toContain('<meta property="og:image:width" content="640">');
-    expect(html).toContain('<meta property="og:image:height" content="360">');
-    expect(html).toMatch(/<meta property="og:image:alt" content="Webcam live — Chiasso Brogeda">/);
+    expect(html).toMatch(htmlTagWithAttrs('meta', {
+      property: 'og:image',
+      content: 'https://frontaliereticino.ch/og/border-wait/chiasso-brogeda.jpg',
+    }));
+    expect(html).toMatch(htmlTagWithAttrs('meta', { property: 'og:image:width', content: '640' }));
+    expect(html).toMatch(htmlTagWithAttrs('meta', { property: 'og:image:height', content: '360' }));
+    expect(html).toMatch(htmlTagWithAttrs('meta', { property: 'og:image:alt', content: 'Webcam live — Chiasso Brogeda' }));
   });
 
   it('falls back to site default og-image.png (1200×630) when resolver returns undefined', () => {
@@ -338,9 +340,9 @@ describe('generateBorderWaitPages — per-page og:image from webcam snapshot', (
       ogImageUrlResolver: () => undefined,
     });
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
-    expect(html).toContain('<meta property="og:image" content="https://frontaliereticino.ch/og-image.png">');
-    expect(html).toContain('<meta property="og:image:width" content="1200">');
-    expect(html).toContain('<meta property="og:image:height" content="630">');
+    expect(html).toMatch(htmlTagWithAttrs('meta', { property: 'og:image', content: 'https://frontaliereticino.ch/og-image.png' }));
+    expect(html).toMatch(htmlTagWithAttrs('meta', { property: 'og:image:width', content: '1200' }));
+    expect(html).toMatch(htmlTagWithAttrs('meta', { property: 'og:image:height', content: '630' }));
   });
 
   it('localises og:image:alt for EN / DE / FR when a snapshot is present', () => {
@@ -372,7 +374,7 @@ describe('generateBorderWaitPages — per-page og:image from webcam snapshot', (
           : undefined,
     });
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
-    const count = (html.match(/<meta property="og:image" /g) ?? []).length;
+    const count = (html.match(new RegExp(htmlTagWithAttrs('meta', { property: 'og:image' } as Record<string, string>).source, 'g')) ?? []).length;
     expect(count).toBe(1);
   });
 
@@ -386,8 +388,9 @@ describe('generateBorderWaitPages — per-page og:image from webcam snapshot', (
           : undefined,
     });
     const noSnapshotPage = pages[buildOggiPath('it', 'drezzo-pedrinate')];
-    expect(noSnapshotPage).toContain(
-      '<meta property="og:image" content="https://frontaliereticino.ch/og-image.png">',
-    );
+    expect(noSnapshotPage).toMatch(htmlTagWithAttrs('meta', {
+      property: 'og:image',
+      content: 'https://frontaliereticino.ch/og-image.png',
+    }));
   });
 });

--- a/tests/border-wait-pages.test.ts
+++ b/tests/border-wait-pages.test.ts
@@ -191,9 +191,9 @@ describe('borderWaitPagesPlugin — page generation', () => {
   it('leaf pages have a self-referencing canonical and 4 hreflang alternates', () => {
     const path = buildOggiPath('it', 'chiasso-brogeda');
     const html = pages[path];
-    expect(html).toContain(`<link rel="canonical" href="https://frontaliereticino.ch${path}">`);
+    expect(html).toMatch(new RegExp(`<link\\s+rel=["']?canonical["']?\\s+href=["']?https://frontaliereticino\\.ch${path}["']?>`));
     for (const loc of BORDER_WAIT_LOCALES) {
-      expect(html).toContain(`hreflang="${loc}"`);
+      expect(html).toMatch(new RegExp(`\\bhreflang=["']?${loc}["']?`));
     }
   });
 
@@ -214,12 +214,12 @@ describe('borderWaitPagesPlugin — page generation', () => {
   it('Brogeda leaf page renders the webcam <figure> + attribution + loading="lazy"', () => {
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
     expect(html).toContain('<figure');
-    expect(html).toContain('loading="lazy"');
-    expect(html).toContain('rel="nofollow noopener"');
+    expect(html).toMatch(/\bloading=["']?lazy["']?/);
+    expect(html).toMatch(/\brel=["']?nofollow noopener["']?/);
     expect(html).toContain('data-webcam-refresh=');
     expect(html).toContain('data-webcam-base-url=');
-    expect(html).toContain('width="640"');
-    expect(html).toContain('height="360"');
+    expect(html).toMatch(/\bwidth=["']?640["']?/);
+    expect(html).toMatch(/\bheight=["']?360["']?/);
   });
 
   it('a crossing WITHOUT configured webcams renders graceful fallback notice (no <figure>)', () => {

--- a/tests/border-wait-webcam.test.ts
+++ b/tests/border-wait-webcam.test.ts
@@ -90,15 +90,15 @@ describe('webcam rendering — conditional display', () => {
 describe('webcam rendering — attribution + accessibility', () => {
   it('webcam figcaption carries rel="nofollow noopener" + target="_blank"', () => {
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
-    expect(html).toContain('rel="nofollow noopener"');
-    expect(html).toContain('target="_blank"');
+    expect(html).toMatch(/\brel=["']?nofollow noopener["']?/);
+    expect(html).toMatch(/\btarget=["']?_blank["']?/);
   });
 
   it('every webcam <img> has explicit width + height + loading="lazy"', () => {
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
-    expect(html).toMatch(/<img[^>]+loading="lazy"/);
-    expect(html).toMatch(/<img[^>]+width="640"/);
-    expect(html).toMatch(/<img[^>]+height="360"/);
+    expect(html).toMatch(/<img[^>]+\bloading=["']?lazy["']?/);
+    expect(html).toMatch(/<img[^>]+\bwidth=["']?640["']?/);
+    expect(html).toMatch(/<img[^>]+\bheight=["']?360["']?/);
   });
 
   it('webcam <img> has alt text mentioning the label + update time', () => {
@@ -112,7 +112,7 @@ describe('webcam rendering — attribution + accessibility', () => {
 
   it('webcam <img> uses referrerpolicy=no-referrer to bypass ti.ch hotlink 403', () => {
     const html = pages[buildOggiPath('it', 'chiasso-brogeda')];
-    expect(html).toContain('referrerpolicy="no-referrer"');
+    expect(html).toMatch(/\breferrerpolicy=["']?no-referrer["']?/);
   });
 
   it('webcam <img> onerror swaps to an inline SVG placeholder (not hide)', () => {

--- a/tests/fuel-daily-italian-cities.test.ts
+++ b/tests/fuel-daily-italian-cities.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { generateFuelItalianCityPages } from '../build-plugins/fuelDailyPagesPlugin';
+import { htmlAttr, htmlTagWithAttrs, htmlTagWithClass } from './utils/htmlAttr';
 
 const DATASET = {
   generatedAt: '2026-04-20T06:00:00.000Z',
@@ -132,16 +133,19 @@ describe('generateFuelItalianCityPages() — content quality', () => {
 
   it('every page has a self-referencing canonical', () => {
     for (const [path, html] of Object.entries(pages)) {
-      expect(html).toContain(`<link rel="canonical" href="https://frontaliereticino.ch${path}">`);
+      expect(html).toMatch(htmlTagWithAttrs('link', {
+        rel: 'canonical',
+        href: `https://frontaliereticino.ch${path}`,
+      }));
     }
   });
 
   it('every page has hreflang alternates for all 4 locales', () => {
     for (const html of Object.values(pages)) {
-      expect(html).toContain('hreflang="it"');
-      expect(html).toContain('hreflang="en"');
-      expect(html).toContain('hreflang="de"');
-      expect(html).toContain('hreflang="fr"');
+      expect(html).toMatch(htmlAttr('hreflang', 'it'));
+      expect(html).toMatch(htmlAttr('hreflang', 'en'));
+      expect(html).toMatch(htmlAttr('hreflang', 'de'));
+      expect(html).toMatch(htmlAttr('hreflang', 'fr'));
     }
   });
 
@@ -193,8 +197,8 @@ describe('generateFuelItalianCityPages() — content quality', () => {
     const comoPage = pages['/prezzi-benzina/italia/como/oggi/'];
     expect(comoPage).toContain('bg-surface-alt');
     // Empty `#root` so React hydration cannot replace static SEO content.
-    expect(comoPage).toMatch(/<div id="root"><\/div>/);
-    expect(comoPage).toContain('<main class="seo-static-content">');
+    expect(comoPage).toMatch(/<div\b[^>]*\bid=["']?root["']?(?=[\s>])[^>]*><\/div>/);
+    expect(comoPage).toMatch(htmlTagWithClass('main', 'seo-static-content'));
   });
 
   it('does not leak any dark: color prefix classes', () => {
@@ -205,7 +209,7 @@ describe('generateFuelItalianCityPages() — content quality', () => {
 
   it('emits a related-links nav block (fuel_italian_city type)', () => {
     const comoPage = pages['/prezzi-benzina/italia/como/oggi/'];
-    expect(comoPage).toMatch(/<nav[^>]*id="seoRelatedLinks"/);
+    expect(comoPage).toMatch(htmlTagWithAttrs('nav', { id: 'seoRelatedLinks' }));
   });
 });
 

--- a/tests/fuel-daily-pages.test.ts
+++ b/tests/fuel-daily-pages.test.ts
@@ -27,6 +27,7 @@ import {
   generateFuelArchivePages,
   generateFuelDailyPages,
 } from '../build-plugins/fuelDailyPagesPlugin';
+import { htmlAttr, htmlTagWithAttrs } from './utils/htmlAttr';
 
 // Minimal dataset sufficient for the renderer (nearby Swiss stations in each
 // target zone + enough copy seeds to clear the 250-word gate).
@@ -168,16 +169,19 @@ describe('fuel-daily page generation — content quality', () => {
 
   it('every page sets self-referencing canonical', () => {
     for (const [path, html] of Object.entries(pages)) {
-      expect(html).toContain(`<link rel="canonical" href="https://frontaliereticino.ch${path}">`);
+      expect(html).toMatch(htmlTagWithAttrs('link', {
+        rel: 'canonical',
+        href: `https://frontaliereticino.ch${path}`,
+      }));
     }
   });
 
   it('every page has hreflang alternates for all 4 locales', () => {
     for (const html of Object.values(pages)) {
-      expect(html).toContain('hreflang="it"');
-      expect(html).toContain('hreflang="en"');
-      expect(html).toContain('hreflang="de"');
-      expect(html).toContain('hreflang="fr"');
+      expect(html).toMatch(htmlAttr('hreflang', 'it'));
+      expect(html).toMatch(htmlAttr('hreflang', 'en'));
+      expect(html).toMatch(htmlAttr('hreflang', 'de'));
+      expect(html).toMatch(htmlAttr('hreflang', 'fr'));
     }
   });
 

--- a/tests/fuel-daily-stations.test.ts
+++ b/tests/fuel-daily-stations.test.ts
@@ -38,6 +38,7 @@ import {
   generateFuelStationPages,
   generateFuelItalianCityPages,
 } from '../build-plugins/fuelDailyPagesPlugin';
+import { htmlAttr, htmlTagWithAttrs, htmlTagWithClass } from './utils/htmlAttr';
 
 // Minimal dataset mimicking the real fuel-prices.json shape.
 // Covers 4 Ticino zones + 2 stations outside Ticino (Valais / Grisons) to
@@ -398,16 +399,19 @@ describe('generateFuelStationPages() — Ticino only', () => {
 
   it('every page has a self-referencing canonical', () => {
     for (const [path, html] of Object.entries(pages)) {
-      expect(html).toContain(`<link rel="canonical" href="https://frontaliereticino.ch${path}">`);
+      expect(html).toMatch(htmlTagWithAttrs('link', {
+        rel: 'canonical',
+        href: `https://frontaliereticino.ch${path}`,
+      }));
     }
   });
 
   it('every page has hreflang alternates for all 4 locales', () => {
     for (const html of Object.values(pages)) {
-      expect(html).toContain('hreflang="it"');
-      expect(html).toContain('hreflang="en"');
-      expect(html).toContain('hreflang="de"');
-      expect(html).toContain('hreflang="fr"');
+      expect(html).toMatch(htmlAttr('hreflang', 'it'));
+      expect(html).toMatch(htmlAttr('hreflang', 'en'));
+      expect(html).toMatch(htmlAttr('hreflang', 'de'));
+      expect(html).toMatch(htmlAttr('hreflang', 'fr'));
     }
   });
 
@@ -480,9 +484,9 @@ describe('generateFuelStationPages() — Ticino only', () => {
     expect(sample).toContain('bg-surface-alt');
     // #root is left EMPTY on SEO pages so React's hydration cannot visually
     // replace the static SEO content (bait-and-switch fix).
-    expect(sample).toMatch(/<div id="root"><\/div>/);
+    expect(sample).toMatch(/<div\b[^>]*\bid=["']?root["']?(?=[\s>])[^>]*><\/div>/);
     // SEO content lives in a sibling `<main class="seo-static-content">`.
-    expect(sample).toContain('<main class="seo-static-content">');
+    expect(sample).toMatch(htmlTagWithClass('main', 'seo-static-content'));
   });
 
   it('does not leak any dark: color prefix classes', () => {
@@ -509,6 +513,6 @@ describe('generateFuelStationPages() — sibling links', () => {
 
   it('page includes a related-links nav block', () => {
     const sample = pages['/prezzi-diesel/chiasso/stazioni/eni-via-compolongo/'];
-    expect(sample).toMatch(/<nav[^>]*id="seoRelatedLinks"/);
+    expect(sample).toMatch(htmlTagWithAttrs('nav', { id: 'seoRelatedLinks' }));
   });
 });

--- a/tests/fuel-italian-station-redesign.test.ts
+++ b/tests/fuel-italian-station-redesign.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { generateFuelItalianStationPages } from '../build-plugins/fuelDailyPagesPlugin';
+import { htmlAttr } from './utils/htmlAttr';
 
 const TODAY = new Date('2026-05-18T06:00:00Z');
 
@@ -93,27 +94,31 @@ function render() {
   });
 }
 
+function indexOfMatch(html: string, pattern: RegExp): number {
+  return html.search(pattern);
+}
+
 describe('IT per-station page — hero', () => {
   it('emits an above-the-fold hero card with brand name, EUR price, and fuel label', () => {
     const pages = render();
     const path = '/prezzi-benzina/italia/como/stazioni/carrefour-via-cristoforo-colombo/';
     expect(pages[path]).toBeDefined();
     const html = pages[path];
-    expect(html).toContain('aria-label="Carrefour Como"');
+    expect(html).toMatch(htmlAttr('aria-label', 'Carrefour Como'));
     // Class-extract migration (2026-05-20): the hero-price font-size:clamp(...)
     // rule moved from inline `style=` to a content-hashed class in seo-static.css.
-    expect(html).toMatch(/(font-size:clamp\(2\.2rem,6vw,3rem\);font-weight:800|class="s-[A-Za-z0-9_-]+")[^>]*>1,650</);
+    expect(html).toMatch(/(font-size:clamp\(2\.2rem,6vw,3rem\);font-weight:800|class=["']?s-[A-Za-z0-9_-]+["']?)[^>]*>1,650</);
     expect(html).toContain('EUR/litro · Benzina');
   });
 
   it('places hero BEFORE long prose (mobile-first ordering)', () => {
     const pages = render();
     const html = pages['/prezzi-benzina/italia/como/stazioni/carrefour-via-cristoforo-colombo/'];
-    const idxHero = html.indexOf('aria-label="Carrefour Como"');
+    const idxHero = indexOfMatch(html, htmlAttr('aria-label', 'Carrefour Como'));
     const idxAdvice = html.indexOf('data-station-advice');
-    const idxLocation = html.indexOf('aria-labelledby="stationLocation"');
-    const idxInfo = html.indexOf('aria-labelledby="itStationInfo"');
-    const idxContext = html.indexOf('aria-labelledby="itStationContext"');
+    const idxLocation = indexOfMatch(html, htmlAttr('aria-labelledby', 'stationLocation'));
+    const idxInfo = indexOfMatch(html, htmlAttr('aria-labelledby', 'itStationInfo'));
+    const idxContext = indexOfMatch(html, htmlAttr('aria-labelledby', 'itStationContext'));
     expect(idxHero).toBeGreaterThan(0);
     expect(idxAdvice).toBeGreaterThan(idxHero);
     expect(idxLocation).toBeGreaterThan(idxAdvice);
@@ -127,7 +132,7 @@ describe('IT per-station page — hero', () => {
     expect(html).toContain('<path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/>'); // trophy
     expect(html).toContain('<polygon points="3 11 22 2 13 21 11 13 3 11"/>'); // navigation
     expect(html).toContain('<path d="M3 3v18h18"/>'); // bar-chart
-    const heroChunk = html.slice(html.indexOf('aria-label="Carrefour Como"'), html.indexOf('data-station-advice'));
+    const heroChunk = html.slice(indexOfMatch(html, htmlAttr('aria-label', 'Carrefour Como')), html.indexOf('data-station-advice'));
     expect(heroChunk).not.toMatch(/🏆|📍|🚗|📊|📌|🧭/);
   });
 
@@ -137,7 +142,7 @@ describe('IT per-station page — hero', () => {
     expect(html).toContain('1° su 3 a Como');
     const rankIdx = html.indexOf('1° su 3 a Como');
     const window = html.slice(Math.max(0, rankIdx - 1200), rankIdx);
-    expect(window).toMatch(/href="https:\/\/frontaliereticino\.ch\/prezzi-benzina\/italia\/como\/oggi\/"/);
+    expect(window).toMatch(htmlAttr('href', 'https://frontaliereticino.ch/prezzi-benzina/italia/como/oggi/'));
   });
 });
 
@@ -145,14 +150,14 @@ describe('IT per-station page — brand logo', () => {
   it('uses /images/brands/{slug}.svg when a real logo exists (Carrefour)', () => {
     const pages = render();
     const html = pages['/prezzi-benzina/italia/como/stazioni/carrefour-via-cristoforo-colombo/'];
-    expect(html).toContain('src="/images/brands/carrefour.svg"');
-    expect(html).toContain('alt="Carrefour"');
+    expect(html).toMatch(htmlAttr('src', '/images/brands/carrefour.svg'));
+    expect(html).toMatch(htmlAttr('alt', 'Carrefour'));
   });
 
   it('falls back to monogram chip when no brand SVG is on disk', () => {
     const pages = render();
     const html = pages['/prezzi-benzina/italia/como/stazioni/indiebrand-via-roma/'];
-    expect(html).not.toContain('src="/images/brands/indiebrand.svg"');
+    expect(html).not.toMatch(htmlAttr('src', '/images/brands/indiebrand.svg'));
     // Monogram chip uses accent-subtle background + first letter I
     expect(html).toMatch(/border-radius:14px;background:var\(--color-accent-subtle\)[^>]*flex-shrink:0">I</);
   });
@@ -183,14 +188,14 @@ describe('IT per-station page — location card', () => {
     const pages = render();
     const html = pages['/prezzi-benzina/italia/como/stazioni/carrefour-via-cristoforo-colombo/'];
     expect(html).toContain('openstreetmap.org/export/embed.html');
-    expect(html).toContain('loading="lazy"');
+    expect(html).toMatch(htmlAttr('loading', 'lazy'));
     expect(html).toMatch(/marker=45\.810000%2C9\.083000/);
     expect(html).toContain('https://www.google.com/maps/search/?api=1&amp;query=45.810000,9.083000');
     expect(html).toContain('https://www.waze.com/ul?ll=45.810000%2C9.083000&amp;navigate=yes');
     // OSM text-fallback link
-    expect(html).toMatch(/href="https:\/\/www\.openstreetmap\.org\/\?mlat=45\.810000&amp;mlon=9\.083000/);
+    expect(html).toMatch(/href=["']?https:\/\/www\.openstreetmap\.org\/\?mlat=45\.810000&amp;mlon=9\.083000/);
     // aria-label external-link warning
-    expect(html).toMatch(/aria-label="Apri in Google Maps \(apre in una nuova scheda\)"/);
+    expect(html).toMatch(htmlAttr('aria-label', 'Apri in Google Maps (apre in una nuova scheda)'));
   });
 
   it('omits the location card when the station has no lat/lng', () => {
@@ -209,7 +214,7 @@ describe('IT per-station page — location card', () => {
     });
     const html = pages['/prezzi-benzina/italia/como/stazioni/nogeobrand-via-senza-coord/'];
     expect(html).toBeDefined();
-    expect(html).not.toContain('aria-labelledby="stationLocation"');
+    expect(html).not.toMatch(htmlAttr('aria-labelledby', 'stationLocation'));
     expect(html).not.toContain('openstreetmap.org/export');
   });
 });
@@ -228,7 +233,7 @@ describe('IT per-station page — last-updated timestamp on chart', () => {
       rootDir: process.cwd(),
     });
     const html = pages['/prezzi-benzina/italia/como/stazioni/carrefour-via-cristoforo-colombo/'];
-    expect(html).toContain('aria-labelledby="itStationTrend"');
+    expect(html).toMatch(htmlAttr('aria-labelledby', 'itStationTrend'));
     expect(html).toContain('Ultimo aggiornamento: 2026-05-18');
   });
 });

--- a/tests/fuel-station-redesign.test.ts
+++ b/tests/fuel-station-redesign.test.ts
@@ -12,6 +12,7 @@ import { generateFuelStationPages } from '../build-plugins/fuelDailyPagesPlugin'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import { buildStationSlug as _buildStationSlugJsRaw } from '../scripts/lib/fuel-station-slug.mjs';
 import { buildStationSlug as buildStationSlugTs } from '../build-plugins/fuelDailyData';
+import { htmlAttr } from './utils/htmlAttr';
 
 // `.mjs` has no `.d.ts` companion, so TS infers strict-required object props.
 // At runtime the JS twin accepts undefined/null/missing fields exactly like
@@ -97,17 +98,21 @@ function render() {
   });
 }
 
+function indexOfMatch(html: string, pattern: RegExp): number {
+  return html.search(pattern);
+}
+
 describe('Per-station page redesign — hero', () => {
   it('emits an above-the-fold hero card with brand name, price, and CHF/Diesel currency label', () => {
     const pages = render();
     const path = '/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/';
     expect(pages[path]).toBeDefined();
     const html = pages[path];
-    expect(html).toContain('aria-label="Migrol Chiasso"');
+    expect(html).toMatch(htmlAttr('aria-label', 'Migrol Chiasso'));
     // Class-extract migration (2026-05-20): the hero-price font-size:clamp(...) rule
     // moved from inline `style=` to a content-hashed class in seo-static.css. The
     // assertion accepts EITHER the legacy inline form or the new `class="s-..."` form.
-    expect(html).toMatch(/(font-size:clamp\(2\.2rem,6vw,3rem\);font-weight:800|class="s-[A-Za-z0-9_-]+")[^>]*>1,950</);
+    expect(html).toMatch(/(font-size:clamp\(2\.2rem,6vw,3rem\);font-weight:800|class=["']?s-[A-Za-z0-9_-]+["']?)[^>]*>1,950</);
     expect(html).toContain('CHF/litro · Diesel');
   });
 
@@ -115,10 +120,10 @@ describe('Per-station page redesign — hero', () => {
     const pages = render();
     const html = pages['/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/'];
     // Hero card aria-label format is "{brand} {city}"
-    const idxHero = html.indexOf('aria-label="Silo Chiasso"');
+    const idxHero = indexOfMatch(html, htmlAttr('aria-label', 'Silo Chiasso'));
     const idxAdvice = html.indexOf('data-station-advice');
-    const idxLocation = html.indexOf('aria-labelledby="stationLocation"');
-    const idxReview = html.indexOf('aria-labelledby="stationReview"');
+    const idxLocation = indexOfMatch(html, htmlAttr('aria-labelledby', 'stationLocation'));
+    const idxReview = indexOfMatch(html, htmlAttr('aria-labelledby', 'stationReview'));
     expect(idxHero).toBeGreaterThan(0);
     expect(idxAdvice).toBeGreaterThan(idxHero);
     expect(idxLocation).toBeGreaterThan(idxAdvice);
@@ -136,7 +141,7 @@ describe('Per-station page redesign — hero', () => {
     const rankIdx = html.indexOf('1° su 3 a Chiasso');
     // ~800 chars to clear the inline lucide SVG markup between href and rank label.
     const window = html.slice(Math.max(0, rankIdx - 1200), rankIdx);
-    expect(window).toMatch(/href="https:\/\/frontaliereticino\.ch\/prezzi-diesel\/chiasso\/oggi\/"/);
+    expect(window).toMatch(htmlAttr('href', 'https://frontaliereticino.ch/prezzi-diesel/chiasso/oggi/'));
   });
 
   it('uses lucide SVG icons (no emoji) for trophy/map-pin/navigation/bar-chart in the hero', () => {
@@ -149,7 +154,7 @@ describe('Per-station page redesign — hero', () => {
     // Lucide bar-chart-3 signature
     expect(html).toContain('<path d="M3 3v18h18"/>');
     // No raw emoji should remain in the hero area
-    const heroChunk = html.slice(html.indexOf('aria-label="Migrol'), html.indexOf('data-station-advice'));
+    const heroChunk = html.slice(indexOfMatch(html, htmlAttr('aria-label', 'Migrol Chiasso')), html.indexOf('data-station-advice'));
     expect(heroChunk).not.toMatch(/🏆|📍|🚗|📊|📌|🧭/);
   });
 });
@@ -158,15 +163,15 @@ describe('Per-station page redesign — brand logo', () => {
   it('uses /images/brands/{slug}.svg when a real logo exists for the brand', () => {
     const pages = render();
     const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
-    expect(html).toContain('src="/images/brands/migrol.svg"');
-    expect(html).toContain('alt="Migrol"');
+    expect(html).toMatch(htmlAttr('src', '/images/brands/migrol.svg'));
+    expect(html).toMatch(htmlAttr('alt', 'Migrol'));
   });
 
   it('falls back to a monogram chip when no brand SVG is on disk (Silo)', () => {
     const pages = render();
     const html = pages['/prezzi-diesel/chiasso/stazioni/silo-via-emilio-bossi/'];
     // Silo has no logo file — monogram chip with first letter "S"
-    expect(html).not.toContain('src="/images/brands/silo.svg"');
+    expect(html).not.toMatch(htmlAttr('src', '/images/brands/silo.svg'));
     expect(html).toMatch(/border-radius:14px;background:var\(--color-accent-subtle\)[^>]*flex-shrink:0">S</);
   });
 });
@@ -197,7 +202,7 @@ describe('Per-station page redesign — location card', () => {
     const pages = render();
     const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
     expect(html).toContain('<iframe');
-    expect(html).toContain('loading="lazy"');
+    expect(html).toMatch(htmlAttr('loading', 'lazy'));
     expect(html).toContain('openstreetmap.org/export/embed.html');
     expect(html).toMatch(/marker=45\.836000%2C9\.033000/);
     expect(html).toMatch(/bbox=9\.02700%2C45\.83000%2C9\.03900%2C45\.84200/);
@@ -231,7 +236,8 @@ describe('Per-station page redesign — location card', () => {
     } else {
       // Extract referenced s-* classes from html, then verify at least one
       // of them resolves to the expected grid rule in seo-static.css.
-      const classMatches = [...html.matchAll(/class="(?:[^"]* )?(s-[A-Za-z0-9_-]+)/g)].map(m => m[1]);
+      const classMatches = [...html.matchAll(/\bclass=(?:"(?:[^"]* )?(s-[A-Za-z0-9_-]+)"|'(?:[^']* )?(s-[A-Za-z0-9_-]+)'|(s-[A-Za-z0-9_-]+))/g)]
+        .map((m) => m[1] || m[2] || m[3]);
       const targetClass = classMatches.find((c) => {
         const rule = new RegExp(`\\.${c}\\s*\\{[^}]*grid-template-columns:repeat\\(auto-fit,minmax\\(320px,1fr\\)\\)`, 'm');
         return rule.test(cssRules);
@@ -245,13 +251,13 @@ describe('Per-station page redesign — location card', () => {
     const pages = render();
     const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
     // aria-label includes the "(apre in una nuova scheda)" suffix
-    expect(html).toMatch(/aria-label="Apri in Google Maps \(apre in una nuova scheda\)"/);
-    expect(html).toMatch(/aria-label="Apri in Waze \(apre in una nuova scheda\)"/);
-    expect(html).toMatch(/aria-label="Apri su OpenStreetMap \(apre in una nuova scheda\)"/);
+    expect(html).toMatch(htmlAttr('aria-label', 'Apri in Google Maps (apre in una nuova scheda)'));
+    expect(html).toMatch(htmlAttr('aria-label', 'Apri in Waze (apre in una nuova scheda)'));
+    expect(html).toMatch(htmlAttr('aria-label', 'Apri su OpenStreetMap (apre in una nuova scheda)'));
     // Visible ↗ marker (decorative, aria-hidden) appears next to each external CTA
-    expect(html).toMatch(/aria-hidden="true"[^>]*>↗/);
+    expect(html).toMatch(/aria-hidden=["']?true["']?[^>]*>↗/);
     // OSM text fallback link points to the full openstreetmap.org marker URL
-    expect(html).toMatch(/href="https:\/\/www\.openstreetmap\.org\/\?mlat=45\.836000&amp;mlon=9\.033000#map=17\/45\.836000\/9\.033000"/);
+    expect(html).toMatch(htmlAttr('href', 'https://www.openstreetmap.org/?mlat=45.836000&amp;mlon=9.033000#map=17/45.836000/9.033000'));
   });
 
   it('omits the location card entirely when the station has no lat/lng', () => {
@@ -271,7 +277,7 @@ describe('Per-station page redesign — location card', () => {
     });
     const html = pages['/prezzi-diesel/chiasso/stazioni/testbrand-via-test/'];
     expect(html).toBeDefined();
-    expect(html).not.toContain('aria-labelledby="stationLocation"');
+    expect(html).not.toMatch(htmlAttr('aria-labelledby', 'stationLocation'));
     expect(html).not.toContain('openstreetmap.org/export');
   });
 });
@@ -284,7 +290,7 @@ describe('Per-station page redesign — history chart', () => {
       history: [],
     });
     const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
-    expect(html).not.toContain('aria-labelledby="stationHistory"');
+    expect(html).not.toMatch(htmlAttr('aria-labelledby', 'stationHistory'));
   });
 
   it('falls back to the zone chart with disclaimer when station-level history is sparse', () => {
@@ -300,7 +306,7 @@ describe('Per-station page redesign — history chart', () => {
       history,
     });
     const html = pages['/prezzi-diesel/chiasso/stazioni/migrol-via-cantonale/'];
-    expect(html).toContain('aria-labelledby="stationHistory"');
+    expect(html).toMatch(htmlAttr('aria-labelledby', 'stationHistory'));
     expect(html).toContain('Andamento prezzo nella zona Chiasso');
     expect(html).toMatch(/non ancora disponibile/);
   });

--- a/tests/health-premiums-landing.test.ts
+++ b/tests/health-premiums-landing.test.ts
@@ -53,6 +53,7 @@ import {
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { htmlAttr, htmlTagWithAttrs } from './utils/htmlAttr';
 
 /**
  * Minimal but realistic dataset covering the 5 target cantons.
@@ -835,18 +836,19 @@ describe('generateHealthPremiumsPages — content quality', () => {
 
   it('every page has self-referencing canonical', () => {
     for (const [path, html] of Object.entries(generation.pages)) {
-      expect(html, path).toContain(
-        `<link rel="canonical" href="https://frontaliereticino.ch${path}">`,
-      );
+      expect(html, path).toMatch(htmlTagWithAttrs('link', {
+        rel: 'canonical',
+        href: `https://frontaliereticino.ch${path}`,
+      }));
     }
   });
 
   it('every page has hreflang alternates for all 4 locales', () => {
     for (const [path, html] of Object.entries(generation.pages)) {
-      expect(html, `${path} missing hreflang=it`).toContain('hreflang="it"');
-      expect(html, `${path} missing hreflang=en`).toContain('hreflang="en"');
-      expect(html, `${path} missing hreflang=de`).toContain('hreflang="de"');
-      expect(html, `${path} missing hreflang=fr`).toContain('hreflang="fr"');
+      expect(html, `${path} missing hreflang=it`).toMatch(htmlAttr('hreflang', 'it'));
+      expect(html, `${path} missing hreflang=en`).toMatch(htmlAttr('hreflang', 'en'));
+      expect(html, `${path} missing hreflang=de`).toMatch(htmlAttr('hreflang', 'de'));
+      expect(html, `${path} missing hreflang=fr`).toMatch(htmlAttr('hreflang', 'fr'));
     }
   });
 
@@ -1767,16 +1769,17 @@ describe('generateHealthPremiumsPages — full 26-canton coverage (B-cont-2)', (
 
   it('every page has self-referencing canonical', () => {
     for (const [path, html] of Object.entries(gen.pages)) {
-      expect(html, path).toContain(
-        `<link rel="canonical" href="https://frontaliereticino.ch${path}">`,
-      );
+      expect(html, path).toMatch(htmlTagWithAttrs('link', {
+        rel: 'canonical',
+        href: `https://frontaliereticino.ch${path}`,
+      }));
     }
   });
 
   it('every page has hreflang alternates for all 4 locales', () => {
     for (const [path, html] of Object.entries(gen.pages)) {
       for (const loc of HEALTH_PREMIUM_LOCALES) {
-        expect(html, `${path} missing hreflang=${loc}`).toContain(`hreflang="${loc}"`);
+        expect(html, `${path} missing hreflang=${loc}`).toMatch(htmlAttr('hreflang', loc));
       }
     }
   });

--- a/tests/job-market-sector.test.ts
+++ b/tests/job-market-sector.test.ts
@@ -29,6 +29,7 @@ import {
   type JobMarketSnapshotLocale,
 } from '../build-plugins/jobMarketSnapshotData';
 import { generateSectorSnapshotPages } from '../build-plugins/jobMarketSnapshotPlugin';
+import { htmlAttr, htmlTagWithAttrs } from './utils/htmlAttr';
 
 // ── Slug tables ───────────────────────────────────────────
 
@@ -202,19 +203,20 @@ describe('generateSectorSnapshotPages', () => {
 
   it('every sector page has self-referencing canonical', () => {
     for (const [path, html] of Object.entries(out.pages)) {
-      expect(html, `canonical missing on ${path}`).toContain(
-        `<link rel="canonical" href="https://frontaliereticino.ch${path}">`,
-      );
+      expect(html, `canonical missing on ${path}`).toMatch(htmlTagWithAttrs('link', {
+        rel: 'canonical',
+        href: `https://frontaliereticino.ch${path}`,
+      }));
     }
   });
 
   it('every sector page emits hreflang for all 4 locales + x-default', () => {
     for (const [path, html] of Object.entries(out.pages)) {
-      expect(html, `hreflang it missing on ${path}`).toContain('hreflang="it"');
-      expect(html).toContain('hreflang="en"');
-      expect(html).toContain('hreflang="de"');
-      expect(html).toContain('hreflang="fr"');
-      expect(html).toContain('hreflang="x-default"');
+      expect(html, `hreflang it missing on ${path}`).toMatch(htmlAttr('hreflang', 'it'));
+      expect(html).toMatch(htmlAttr('hreflang', 'en'));
+      expect(html).toMatch(htmlAttr('hreflang', 'de'));
+      expect(html).toMatch(htmlAttr('hreflang', 'fr'));
+      expect(html).toMatch(htmlAttr('hreflang', 'x-default'));
     }
   });
 
@@ -232,8 +234,8 @@ describe('generateSectorSnapshotPages', () => {
 
   it('every sector page is index,follow (not noindex)', () => {
     for (const [path, html] of Object.entries(out.pages)) {
-      expect(html).toContain('name="robots" content="index,follow"');
-      expect(html, `${path} is noindex`).not.toContain('name="robots" content="noindex');
+      expect(html).toMatch(htmlTagWithAttrs('meta', { name: 'robots', content: 'index,follow' }));
+      expect(html, `${path} is noindex`).not.toMatch(htmlTagWithAttrs('meta', { name: 'robots', content: 'noindex,follow' }));
     }
   });
 

--- a/tests/job-market-snapshot.test.ts
+++ b/tests/job-market-snapshot.test.ts
@@ -34,6 +34,7 @@ import {
   buildWeeklyTrendSeries,
   generateJobMarketSnapshotPages,
 } from '../build-plugins/jobMarketSnapshotPlugin';
+import { htmlAttr, htmlTagWithAttrs, htmlTagWithClass } from './utils/htmlAttr';
 
 // ── Fixtures ─────────────────────────────────────────────
 
@@ -343,17 +344,20 @@ describe('generateJobMarketSnapshotPages — normal mode (rich history)', () => 
 
   it('every page has self-referencing canonical', () => {
     for (const [path, html] of Object.entries(out.pages)) {
-      expect(html).toContain(`<link rel="canonical" href="https://frontaliereticino.ch${path}">`);
+      expect(html).toMatch(htmlTagWithAttrs('link', {
+        rel: 'canonical',
+        href: `https://frontaliereticino.ch${path}`,
+      }));
     }
   });
 
   it('every page has hreflang alternates for all 4 locales + x-default', () => {
     for (const [path, html] of Object.entries(out.pages)) {
-      expect(html, `missing hreflang on ${path}`).toContain('hreflang="it"');
-      expect(html).toContain('hreflang="en"');
-      expect(html).toContain('hreflang="de"');
-      expect(html).toContain('hreflang="fr"');
-      expect(html).toContain('hreflang="x-default"');
+      expect(html, `missing hreflang on ${path}`).toMatch(htmlAttr('hreflang', 'it'));
+      expect(html).toMatch(htmlAttr('hreflang', 'en'));
+      expect(html).toMatch(htmlAttr('hreflang', 'de'));
+      expect(html).toMatch(htmlAttr('hreflang', 'fr'));
+      expect(html).toMatch(htmlAttr('hreflang', 'x-default'));
     }
   });
 
@@ -384,7 +388,7 @@ describe('generateJobMarketSnapshotPages — normal mode (rich history)', () => 
     let noindexCount = 0;
     for (const [path, html] of Object.entries(out.pages)) {
       if (!/\/(settimana|week|woche|semaine)-\d/.test(path)) continue;
-      if (/meta name="robots" content="noindex/.test(html)) noindexCount++;
+      if (htmlTagWithAttrs('meta', { name: 'robots', content: 'noindex,follow' }).test(html)) noindexCount++;
     }
     // We have 14 complete weeks × 4 locales = 56 weekly pages; oldest 2 × 4 = 8 should be noindex
     expect(noindexCount).toBeGreaterThanOrEqual(4);
@@ -401,7 +405,7 @@ describe('generateJobMarketSnapshotPages — normal mode (rich history)', () => 
       // Every page links back to its own hub so the hub name must appear in the body.
       // SEO content is now emitted OUTSIDE `#root` (empty) inside a sibling
       // `<main class="seo-static-content">` — see seoPageShell.ts.
-      const bodyMatch = html.match(/<main class="seo-static-content">([\s\S]*?)<\/main>/);
+      const bodyMatch = html.match(new RegExp(`${htmlTagWithClass('main', 'seo-static-content').source}([\\s\\S]*?)<\\/main>`));
       const body = bodyMatch?.[1] ?? '';
       expect(body.length, `empty seo-static-content body on ${path}`).toBeGreaterThan(0);
     }

--- a/tests/regression/webcam-referrerpolicy.test.ts
+++ b/tests/regression/webcam-referrerpolicy.test.ts
@@ -54,7 +54,7 @@ describe('F8 webcam — referrerpolicy', () => {
   it('<img> carries referrerpolicy="no-referrer"', () => {
     // This attribute bypasses the ti.ch hotlink-protection check that
     // sends 403 when a Referer header is present.
-    expect(BROGEDA_IT).toContain('referrerpolicy="no-referrer"');
+    expect(BROGEDA_IT).toMatch(/\breferrerpolicy=["']?no-referrer["']?/);
   });
 
   it('every webcam <img> on this page has referrerpolicy="no-referrer"', () => {
@@ -64,8 +64,8 @@ describe('F8 webcam — referrerpolicy', () => {
     const webcamImgs = imgTags.filter((tag) => tag.includes('data-webcam-refresh'));
     expect(webcamImgs.length).toBeGreaterThanOrEqual(1);
     for (const img of webcamImgs) {
-      expect(img, `img missing referrerpolicy: ${img.slice(0, 100)}`).toContain(
-        'referrerpolicy="no-referrer"',
+      expect(img, `img missing referrerpolicy: ${img.slice(0, 100)}`).toMatch(
+        /\breferrerpolicy=["']?no-referrer["']?/,
       );
     }
   });
@@ -87,7 +87,11 @@ function htmlOrCssHas(html: string, declarations: ReadonlyArray<string>): boolea
     require('node:path').resolve(__dirname, '..', '..', 'public', 'assets', 'seo-static.css'),
     'utf-8',
   );
-  const classes = new Set([...html.matchAll(/class="(?:[^"]* )?(s-[A-Za-z0-9_-]+)/g)].map((m) => m[1]));
+  const classes = new Set(
+    [...html.matchAll(/\bclass=(?:"([^"]+)"|'([^']+)'|([^\s>]+))/g)]
+      .flatMap((m) => (m[1] || m[2] || m[3] || '').split(/\s+/))
+      .filter((c) => /^s-[A-Za-z0-9_-]+$/.test(c)),
+  );
   for (const c of classes) {
     const rule = cssRules.match(new RegExp(`\\.${c}\\s*\\{([^}]*)\\}`));
     if (!rule) continue;
@@ -139,7 +143,7 @@ describe('F8 webcam — multi-locale regression', () => {
       const html = pages[buildOggiPath(locale, 'chiasso-brogeda')];
       expect(typeof html).toBe('string');
       if (html.includes('data-webcam-refresh')) {
-        expect(html).toContain('referrerpolicy="no-referrer"');
+        expect(html).toMatch(/\breferrerpolicy=["']?no-referrer["']?/);
       }
     });
 

--- a/tests/utils/htmlAttr.ts
+++ b/tests/utils/htmlAttr.ts
@@ -1,0 +1,29 @@
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function attrSource(name: string, value: string): string {
+  const attr = escapeRegExp(name);
+  const expected = escapeRegExp(value);
+  return `\\b${attr}=(?:"${expected}"|'${expected}'|${expected})(?=[\\s>])`;
+}
+
+export function htmlAttr(name: string, value: string): RegExp {
+  return new RegExp(attrSource(name, value));
+}
+
+export function htmlTagWithAttrs(tagName: string, attrs: Record<string, string>): RegExp {
+  const tag = escapeRegExp(tagName);
+  const assertions = Object.entries(attrs)
+    .map(([name, value]) => `(?=[^>]*${attrSource(name, value)})`)
+    .join('');
+  return new RegExp(`<${tag}\\b${assertions}[^>]*>`);
+}
+
+export function htmlTagWithClass(tagName: string, className: string): RegExp {
+  const tag = escapeRegExp(tagName);
+  const klass = escapeRegExp(className);
+  return new RegExp(
+    `<${tag}\\b[^>]*\\bclass=(?:"[^"]*\\b${klass}\\b[^"]*"|'[^']*\\b${klass}\\b[^']*'|${klass})(?=[\\s>])[^>]*>`,
+  );
+}

--- a/tests/weekly-employers-company-city.test.ts
+++ b/tests/weekly-employers-company-city.test.ts
@@ -43,6 +43,7 @@ import {
   generateRelatedLinks,
   generateRelatedLinksBlock,
 } from '../build-plugins/shared/relatedLinks';
+import { htmlAttr, htmlTagWithAttrs } from './utils/htmlAttr';
 
 // ── Fixture helpers ─────────────────────────────────────────────
 
@@ -515,7 +516,10 @@ describe('renderCompanyCityPage', () => {
 
   it('emits canonical self-ref, ItemList JobPosting JSON-LD + FAQ', () => {
     const html = renderCompanyCityPage(fixture);
-    expect(html).toContain(`rel="canonical" href="https://frontaliereticino.ch${fixture.canonicalPath}"`);
+    expect(html).toMatch(htmlTagWithAttrs('link', {
+      rel: 'canonical',
+      href: `https://frontaliereticino.ch${fixture.canonicalPath}`,
+    }));
     expect(html).toContain('"@type":"ItemList"');
     expect(html).toContain('"@type":"JobPosting"');
     expect(html).toContain('"@type":"FAQPage"');
@@ -583,7 +587,7 @@ describe('renderCompanyCityPage', () => {
   it('links each listed job to the canonical detail path', () => {
     const html = renderCompanyCityPage(fixture);
     for (const job of fixture.stats.activeJobs) {
-      expect(html).toContain(`href="${job.detailPath}"`);
+      expect(html).toMatch(htmlAttr('href', job.detailPath));
     }
   });
 
@@ -623,9 +627,9 @@ describe('renderCompanyCityPage', () => {
   it('emits hreflang alternates across the 4 locales + x-default', () => {
     const html = renderCompanyCityPage(fixture);
     for (const alt of WEEKLY_EMPLOYERS_LOCALES) {
-      expect(html).toContain(`hreflang="${alt}"`);
+      expect(html).toMatch(htmlAttr('hreflang', alt));
     }
-    expect(html).toContain('hreflang="x-default"');
+    expect(html).toMatch(htmlAttr('hreflang', 'x-default'));
   });
 
   it('injects sibling links when siblings are provided', () => {

--- a/tests/weekly-employers.test.ts
+++ b/tests/weekly-employers.test.ts
@@ -46,6 +46,7 @@ import {
   type JobsSnapshot,
   type WeeklyCountableJob,
 } from '../build-plugins/weeklyEmployersPlugin';
+import { htmlAttr, htmlTagWithAttrs } from './utils/htmlAttr';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -405,7 +406,7 @@ describe('renderWeeklyEmployersPage', () => {
     const words = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().split(' ').filter(Boolean).length;
     expect(words).toBeGreaterThanOrEqual(300);
     expect(html).toContain('<title>');
-    expect(html).toContain('rel="canonical"');
+    expect(html).toMatch(htmlAttr('rel', 'canonical'));
     expect(html).toContain('application/ld+json');
     expect(html).toContain('"@type":"ItemList"');
     expect(html).toContain('"@type":"BreadcrumbList"');
@@ -505,11 +506,14 @@ describe('renderWeeklyEmployersPage', () => {
       today: new Date('2026-04-20T12:00:00Z'),
       indexable: true,
     });
-    expect(html).toContain(`rel="canonical" href="https://frontaliereticino.ch${path}"`);
+    expect(html).toMatch(htmlTagWithAttrs('link', {
+      rel: 'canonical',
+      href: `https://frontaliereticino.ch${path}`,
+    }));
     for (const alt of WEEKLY_EMPLOYERS_LOCALES) {
-      expect(html).toContain(`hreflang="${alt}"`);
+      expect(html).toMatch(htmlAttr('hreflang', alt));
     }
-    expect(html).toContain('hreflang="x-default"');
+    expect(html).toMatch(htmlAttr('hreflang', 'x-default'));
   });
 });
 


### PR DESCRIPTION
## Summary
- add shared HTML attribute test helpers that accept quoted or unquoted minified attributes
- update SEO/static HTML tests to assert semantic attributes instead of exact quote serialization

## Verification
- node scripts/assemble-jobs-dataset.mjs --stats
- node scripts/migrate-all-known-job-slugs-canton-aware.mjs
- npm test