### PR TITLE
Profile SEO plugins by default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ on:
         type: boolean
         default: false
       profile_jobs_seo:
-        description: 'Enable jobsSeoPagesPlugin per-category profiler (counts + total/avg/p50/p99 timings per emission category). Pair with profile_sequential for clean numbers.'
+        description: 'Compatibility no-op: jobsSeoPagesPlugin per-category profiling is now enabled by default whenever BUILD_PROFILE=1.'
         required: false
         type: boolean
         default: false
@@ -50,7 +50,7 @@ on:
         type: boolean
         default: false
       profile_weekly_employers:
-        description: 'Enable weeklyEmployersPlugin per-category profiler (counts + total/avg/p50/p99 timings per phase: cleanup, load-jobs, render-current-week, render-company-city-page, flush, etc.). Pair with profile_sequential for clean numbers.'
+        description: 'Compatibility no-op: weeklyEmployersPlugin per-category profiling is now enabled by default whenever BUILD_PROFILE=1.'
         required: false
         type: boolean
         default: false
@@ -447,22 +447,18 @@ jobs:
           # Everything else (push, cron, bare dispatch, profile dispatch)
           # gets sequential.
           SEQUENTIAL_PROFILE: ${{ github.event.inputs.parallel_plugins == 'true' && '' || '1' }}
-          # Opt-in jobsSeoPagesPlugin per-category profiler. Emits a sorted
-          # table at end of the plugin's closeBundle showing count + total +
-          # avg + p50 + p99 + min + max (ms) for each emission category
-          # (active-job, expired-soft-landing, previous-slug-bridge, etc.).
+          # jobsSeoPagesPlugin per-category profiler. Default-on when
+          # BUILD_PROFILE=1; set JOBS_SEO_PROFILE=0 locally to opt out. The
+          # workflow_dispatch input remains as a compatibility force-on flag.
           JOBS_SEO_PROFILE: ${{ github.event.inputs.profile_jobs_seo == 'true' && '1' || '' }}
           # Investigation-only before/after timing for the active-job related
           # pool change. When enabled, jobsSeoPagesPlugin computes the legacy
           # validJobs.filter(...) pool alongside the pre-indexed pool, records
           # both profiler rows, and fails if the ordered pools diverge.
           JOBS_SEO_PROFILE_COMPARE_RELATED: ${{ github.event.inputs.profile_related_compare == 'true' && '1' || '' }}
-          # Opt-in weeklyEmployersPlugin per-category profiler. Emits a sorted
-          # table at end of the plugin's closeBundle showing count + total +
-          # avg + p50 + p99 + min + max (ms) for each phase (cleanup,
-          # load-jobs, load-snapshots, generate-pages, render-current-week,
-          # render-archive-week, companycity-pass1-stats,
-          # render-company-city-page, process-page, flush, sitemap-write).
+          # weeklyEmployersPlugin per-category profiler. Default-on when
+          # BUILD_PROFILE=1; set WEEKLY_EMPLOYERS_PROFILE=0 locally to opt out.
+          # The workflow_dispatch input remains as a compatibility force-on flag.
           WEEKLY_EMPLOYERS_PROFILE: ${{ github.event.inputs.profile_weekly_employers == 'true' && '1' || '' }}
           # Disable the plugin-internal save/restore for related-search-clusters
           # since the GH Actions cache wrapper around .cache/related-search-clusters/
@@ -555,6 +551,20 @@ jobs:
                   }' \
                 | sort -t'|' -k3 -nr
             fi
+            for marker in jobs-seo-profile weekly-employers-profile related-search-profile; do
+              if grep -qE "^\[$marker\]" /tmp/build.log; then
+                echo ""
+                case "$marker" in
+                  jobs-seo-profile) echo "## jobsSeoPagesPlugin internal profile" ;;
+                  weekly-employers-profile) echo "## weeklyEmployersPlugin internal profile" ;;
+                  related-search-profile) echo "## relatedSearchClustersPlugin internal profile" ;;
+                esac
+                echo ""
+                echo '```text'
+                grep -E "^\[$marker\]" /tmp/build.log | sed -E "s/^\[$marker\] //"
+                echo '```'
+              fi
+            done
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: SPA fallback (GitHub Pages serves 404.html for unknown paths)

--- a/.github/workflows/post-build-matrix-test.yml
+++ b/.github/workflows/post-build-matrix-test.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       profile_jobs_seo:
-        description: 'Enable jobsSeoPagesPlugin per-category profiler during the build step.'
+        description: 'Compatibility no-op: jobsSeoPagesPlugin per-category profiling is now enabled by default whenever BUILD_PROFILE=1.'
         required: false
         type: boolean
         default: false

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10605,7 +10605,8 @@ ${staticAnalyticsHtml}
  // canonical bridge URLs into sitemap-search-clusters.xml.
  resolveJobsSeoPagesFlushed();
 
- // Print profiler summary if JOBS_SEO_PROFILE=1 is set; no-op otherwise.
+ // Print profiler summary in normal profiled CI builds; local opt-out:
+ // JOBS_SEO_PROFILE=0.
  printJobsSeoProfile();
  if (PROFILE_RELATED_COMPARE) {
  console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m Related pool compare mismatches: ${relatedCompareMismatches}`);

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -80,6 +80,11 @@ import {
   type RawJob,
 } from './relatedSearchClustersData';
 import { jobsSeoPagesFlushed } from './shared/buildSignals';
+import {
+  startTimer as profileStart,
+  recordEmit as profileRecord,
+  printSummary as printRelatedSearchProfile,
+} from './shared/relatedSearchClustersProfiler';
 
 // ── Constants ───────────────────────────────────────────────────────────
 
@@ -1575,11 +1580,16 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       // Disable with RELATED_SEARCH_CLUSTERS_NO_CACHE=1 (e.g. during
       // local debugging when you want a clean re-emit).
       const cacheEnabled = process.env.RELATED_SEARCH_CLUSTERS_NO_CACHE !== '1';
+      const __tCacheKey = profileStart();
       const cacheKey = cacheEnabled ? computeCacheKey(rootDir) : '';
+      profileRecord('cache-key', __tCacheKey);
       if (cacheEnabled) {
+        const __tCacheRestore = profileStart();
         const restored = await tryRestoreFromCache(rootDir, distDir, cacheKey);
+        profileRecord('cache-restore-check', __tCacheRestore);
         if (restored) {
           // Re-run the cross-plugin patches against THIS build's dist.
+          const __tCacheHitPatch = profileStart();
           for (const { locale, url } of restored.hubs) {
             injectHubLinkIntoSectionLanding(distDir, locale, url, COPY[locale]);
           }
@@ -1591,21 +1601,30 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
               ).sort()
             : [];
           patchMasterSitemap(distDir, dateStamp, restoredShards);
+          profileRecord('cache-hit-patches', __tCacheHitPatch);
           console.log(
             `\x1b[36m[related-search-clusters]\x1b[0m cache HIT (key=${cacheKey}): ${restored.emittedCount} files restored in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
           );
+          printRelatedSearchProfile();
           return;
         }
         console.log(`\x1b[36m[related-search-clusters]\x1b[0m cache MISS (key=${cacheKey}): full emit`);
       }
 
+      const __tLoadCandidates = profileStart();
       const candidates = filterAndDedupeCandidates(loadCandidates(rootDir));
+      profileRecord('load-candidates', __tLoadCandidates);
       if (candidates.length === 0) {
         console.log('\x1b[36m[related-search-clusters]\x1b[0m 0 candidates after filtering — nothing to emit');
+        printRelatedSearchProfile();
         return;
       }
+      const __tLoadEnriched = profileStart();
       const enriched = loadEnriched(rootDir);
+      profileRecord('load-enriched', __tLoadEnriched);
+      const __tLoadJobs = profileStart();
       const jobs = loadJobs(rootDir);
+      profileRecord('load-jobs', __tLoadJobs);
       console.log(`\x1b[36m[related-search-clusters]\x1b[0m ${candidates.length} candidates, ${Object.keys(enriched).length} enriched entries, ${jobs.length} jobs`);
 
       // Inverted token index: lazy posting lists per (locale, token), shared
@@ -1617,16 +1636,22 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       // down for the rest of closeBundle.
       const tokenIndex = new TokenIndex(jobs);
       const contexts: ClusterContext[] = [];
+      const __tContextBuild = profileStart();
       for (const cand of candidates) {
         const ctx = buildClusterContext(cand, tokenIndex, jobs);
         if (ctx) contexts.push(ctx);
       }
+      profileRecord('build-contexts', __tContextBuild);
       console.log(`\x1b[36m[related-search-clusters]\x1b[0m ${contexts.length} clusters survived match-≥${MIN_MATCHING_JOBS} filter`);
       tokenIndex.clear(); // GC haystacks + posting lists before the render/emit loop runs
 
-      if (contexts.length === 0) return;
+      if (contexts.length === 0) {
+        printRelatedSearchProfile();
+        return;
+      }
 
       // Group by (normalized keyword + city) for cross-locale hreflang lookup.
+      const __tGroupHreflang = profileStart();
       const byKeywordCity = new Map<string, Map<Locale, ClusterContext>>();
       for (const ctx of contexts) {
         const key = `${normalizeText(ctx.keyword)}|${normalizeText(ctx.city || '')}`;
@@ -1637,8 +1662,10 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         }
         inner.set(ctx.candidate.locale, ctx);
       }
+      profileRecord('group-hreflang', __tGroupHreflang);
 
       // Group by locale + city for related-link suggestions.
+      const __tGroupRelated = profileStart();
       const byLocale = new Map<Locale, ClusterContext[]>();
       const byLocaleCity = new Map<Locale, Map<string, ClusterContext[]>>();
       for (const ctx of contexts) {
@@ -1656,6 +1683,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           inner.set(ctx.city, cityArr);
         }
       }
+      profileRecord('group-related-links', __tGroupRelated);
 
       const collector = new WriteCollector({ distDir, pluginName: 'relatedSearchClustersPlugin' });
       const sitemapLocs: string[] = [];
@@ -1675,6 +1703,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       // renderClusterPage into a standalone module with explicit `.ts`
       // imports (deferred). For now we keep the sequential loop.
       for (const ctx of contexts) {
+        const __tRenderCluster = profileStart();
         const locale = ctx.candidate.locale;
         const altKey = `${normalizeText(ctx.keyword)}|${normalizeText(ctx.city || '')}`;
         const altMap = byKeywordCity.get(altKey);
@@ -1719,6 +1748,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         emittedFiles.push(path.relative(distDir, indexPath));
         emittedFiles.push(path.relative(distDir, flatPath));
         sitemapLocs.push(out.loc);
+        profileRecord('render-cluster-page', __tRenderCluster);
       }
 
       // ── Per-locale hub pages ──────────────────────────────────────────
@@ -1732,6 +1762,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         const totalPages = Math.max(1, Math.ceil(items.length / HUB_PAGE_SIZE));
 
         for (let page = 1; page <= totalPages; page++) {
+          const __tRenderHub = profileStart();
           const slice = items.slice((page - 1) * HUB_PAGE_SIZE, page * HUB_PAGE_SIZE);
           const out = renderHubPage({
             locale,
@@ -1748,15 +1779,22 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           emittedFiles.push(path.relative(distDir, indexPath));
           emittedFiles.push(path.relative(distDir, flatPath));
           sitemapLocs.push(out.loc);
+          profileRecord('render-hub-page', __tRenderHub);
         }
 
+        const __tHubInject = profileStart();
         const hubUrl = `${BASE_URL}${buildHubPath(locale, 1)}`;
         cachedHubs.push({ locale, url: hubUrl });
         injectHubLinkIntoSectionLanding(distDir, locale, hubUrl, COPY[locale]);
+        profileRecord('inject-hub-link', __tHubInject);
       }
 
+      const __tFlush = profileStart();
       const written = await collector.flush();
+      profileRecord('collector-flush', __tFlush);
+      const __tSitemap = profileStart();
       const sitemapShards = await writeSitemap(distDir, sitemapLocs, dateStamp);
+      profileRecord('sitemap-write', __tSitemap);
       for (const shard of sitemapShards) emittedFiles.push(shard);
 
       // Capture stats before releasing the maps that hold them.
@@ -1778,7 +1816,9 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       // every build (cache-hit and miss alike) inside the cache fast path.
       if (cacheEnabled) {
         try {
+          const __tCacheSave = profileStart();
           const cached = saveToCache(rootDir, distDir, cacheKey, emittedFiles, cachedHubs, sitemapLocs);
+          profileRecord('cache-save', __tCacheSave);
           console.log(`\x1b[36m[related-search-clusters]\x1b[0m saved ${cached} files to cache (${cacheKey})`);
         } catch (err) {
           console.warn('\x1b[33m[related-search-clusters]\x1b[0m cache save failed:', err);
@@ -1788,6 +1828,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       console.log(
         `\x1b[36m[related-search-clusters]\x1b[0m emitted ${ctxCount} cluster pages + ${hubCount} hubs (${written} files) in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
       );
+      printRelatedSearchProfile();
     },
   };
 }

--- a/build-plugins/shared/jobsSeoProfiler.ts
+++ b/build-plugins/shared/jobsSeoProfiler.ts
@@ -1,9 +1,9 @@
 /**
  * jobsSeoProfiler — per-category instrumentation for jobsSeoPagesPlugin.
  *
- * Activated only when `JOBS_SEO_PROFILE=1`. When disabled, every entry point
- * is a no-op so production builds carry zero measurable overhead (the env
- * check is read once at module load).
+ * Activated by default whenever `BUILD_PROFILE=1` is set, which is the normal
+ * CI build path. Set `JOBS_SEO_PROFILE=0` to opt out, or `JOBS_SEO_PROFILE=1`
+ * to force this table on in a one-off local/profile run.
  *
  * Categories the plugin emits:
  *   - active-job                 → /cerca-lavoro-{loc}/<slug>/index.html
@@ -47,7 +47,8 @@
  *   ...
  */
 
-const ENABLED = process.env.JOBS_SEO_PROFILE === '1';
+const ENABLED = process.env.JOBS_SEO_PROFILE === '1'
+  || (process.env.JOBS_SEO_PROFILE !== '0' && process.env.BUILD_PROFILE === '1');
 
 type CategoryStats = {
   count: number;

--- a/build-plugins/shared/relatedSearchClustersProfiler.ts
+++ b/build-plugins/shared/relatedSearchClustersProfiler.ts
@@ -1,0 +1,111 @@
+/**
+ * relatedSearchClustersProfiler — per-phase instrumentation for
+ * relatedSearchClustersPlugin.
+ *
+ * Activated by default whenever `BUILD_PROFILE=1` is set, which is the normal
+ * CI build path. Set `RELATED_SEARCH_CLUSTERS_PROFILE=0` to opt out, or
+ * `RELATED_SEARCH_CLUSTERS_PROFILE=1` to force this table on locally.
+ */
+
+const ENABLED = process.env.RELATED_SEARCH_CLUSTERS_PROFILE === '1'
+  || (process.env.RELATED_SEARCH_CLUSTERS_PROFILE !== '0' && process.env.BUILD_PROFILE === '1');
+
+type CategoryStats = {
+  count: number;
+  totalNs: bigint;
+  minNs: bigint;
+  maxNs: bigint;
+  samplesNs: number[];
+};
+
+const buckets = new Map<string, CategoryStats>();
+const SAMPLE_CAP = 10_000;
+
+export function startTimer(): bigint {
+  if (!ENABLED) return 0n;
+  return process.hrtime.bigint();
+}
+
+export function recordEmit(category: string, start: bigint): void {
+  if (!ENABLED || start === 0n) return;
+  const elapsed = process.hrtime.bigint() - start;
+  let b = buckets.get(category);
+  if (!b) {
+    b = {
+      count: 0,
+      totalNs: 0n,
+      minNs: elapsed,
+      maxNs: elapsed,
+      samplesNs: [],
+    };
+    buckets.set(category, b);
+  }
+  b.count++;
+  b.totalNs += elapsed;
+  if (elapsed < b.minNs) b.minNs = elapsed;
+  if (elapsed > b.maxNs) b.maxNs = elapsed;
+  const elapsedNum = Number(elapsed);
+  if (b.samplesNs.length < SAMPLE_CAP) {
+    b.samplesNs.push(elapsedNum);
+  } else {
+    const idx = Math.floor(Math.random() * b.count);
+    if (idx < SAMPLE_CAP) b.samplesNs[idx] = elapsedNum;
+  }
+}
+
+function nsToMs(ns: bigint | number): number {
+  const n = typeof ns === 'bigint' ? Number(ns) : ns;
+  return n / 1_000_000;
+}
+
+function percentile(sortedSamplesMs: number[], p: number): number {
+  if (sortedSamplesMs.length === 0) return 0;
+  const idx = Math.min(
+    sortedSamplesMs.length - 1,
+    Math.max(0, Math.floor((p / 100) * sortedSamplesMs.length)),
+  );
+  return sortedSamplesMs[idx];
+}
+
+export function printSummary(): void {
+  if (!ENABLED) return;
+  const rows = Array.from(buckets.entries()).map(([category, b]) => {
+    const sorted = b.samplesNs.slice().sort((a, b) => a - b);
+    const sortedMs = sorted.map((n) => n / 1_000_000);
+    return {
+      category,
+      count: b.count,
+      totalMs: nsToMs(b.totalNs),
+      avgMs: nsToMs(b.totalNs) / b.count,
+      p50Ms: percentile(sortedMs, 50),
+      p99Ms: percentile(sortedMs, 99),
+      minMs: nsToMs(b.minNs),
+      maxMs: nsToMs(b.maxNs),
+    };
+  });
+  rows.sort((a, b) => b.totalMs - a.totalMs);
+
+  const totalMsAll = rows.reduce((s, r) => s + r.totalMs, 0);
+  const totalCountAll = rows.reduce((s, r) => s + r.count, 0);
+
+  console.log(
+    `[related-search-profile] ${'category'.padEnd(28)} ${'count'.padStart(7)} ${'total_ms'.padStart(10)} ${'%'.padStart(5)} ${'avg_ms'.padStart(8)} ${'p50_ms'.padStart(8)} ${'p99_ms'.padStart(8)} ${'min_ms'.padStart(7)} ${'max_ms'.padStart(8)}`,
+  );
+  for (const r of rows) {
+    const pct = totalMsAll > 0 ? (r.totalMs / totalMsAll) * 100 : 0;
+    console.log(
+      `[related-search-profile] ${r.category.padEnd(28)} ${String(r.count).padStart(7)} ${r.totalMs.toFixed(1).padStart(10)} ${pct.toFixed(1).padStart(5)} ${r.avgMs.toFixed(2).padStart(8)} ${r.p50Ms.toFixed(2).padStart(8)} ${r.p99Ms.toFixed(2).padStart(8)} ${r.minMs.toFixed(2).padStart(7)} ${r.maxMs.toFixed(2).padStart(8)}`,
+    );
+  }
+  console.log(
+    `[related-search-profile] ${'TOTAL'.padEnd(28)} ${String(totalCountAll).padStart(7)} ${totalMsAll.toFixed(1).padStart(10)}`,
+  );
+}
+
+export function resetProfiler(): void {
+  buckets.clear();
+}
+
+export function isEnabled(): boolean {
+  return ENABLED;
+}

--- a/build-plugins/shared/weeklyEmployersProfiler.ts
+++ b/build-plugins/shared/weeklyEmployersProfiler.ts
@@ -2,9 +2,10 @@
  * weeklyEmployersProfiler — per-category instrumentation for
  * weeklyEmployersPlugin.
  *
- * Activated only when `WEEKLY_EMPLOYERS_PROFILE=1`. When disabled, every entry
- * point is a no-op so production builds carry zero measurable overhead (the
- * env check is read once at module load).
+ * Activated by default whenever `BUILD_PROFILE=1` is set, which is the normal
+ * CI build path. Set `WEEKLY_EMPLOYERS_PROFILE=0` to opt out, or
+ * `WEEKLY_EMPLOYERS_PROFILE=1` to force this table on in a one-off local/profile
+ * run.
  *
  * Categories the plugin times:
  *   - cleanup                    → wipe owned namespaces + sitemap files
@@ -43,7 +44,8 @@
  *   ...
  */
 
-const ENABLED = process.env.WEEKLY_EMPLOYERS_PROFILE === '1';
+const ENABLED = process.env.WEEKLY_EMPLOYERS_PROFILE === '1'
+  || (process.env.WEEKLY_EMPLOYERS_PROFILE !== '0' && process.env.BUILD_PROFILE === '1');
 
 type CategoryStats = {
   count: number;

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -4161,7 +4161,8 @@ ${urlEntries}
         console.warn('[weekly-employers] P2.S1 per-canton emit failed:', err);
       }
 
-      // Per-category profile summary (no-op unless WEEKLY_EMPLOYERS_PROFILE=1)
+      // Per-category profile summary in normal profiled CI builds; local opt-out:
+      // WEEKLY_EMPLOYERS_PROFILE=0.
       __weProfPrint();
     },
   };


### PR DESCRIPTION
## Summary
- enable jobsSeoPagesPlugin and weeklyEmployersPlugin profilers by default whenever BUILD_PROFILE=1, with env opt-outs
- add relatedSearchClustersPlugin phase profiling and attach all internal profile tables to the deploy summary
- keep legacy workflow inputs as compatibility force-on flags

## Verification
- ./node_modules/.bin/vitest run tests/jobs-seo-pages-plugin.test.ts tests/job-editorial-landing.test.ts tests/related-search-clusters.test.ts tests/build-plugins/companyHubFrontalierContext.test.ts --reporter=dot
- ./node_modules/.bin/tsx -e "import './build-plugins/relatedSearchClustersPlugin.ts'; import './build-plugins/shared/relatedSearchClustersProfiler.ts'; import './build-plugins/shared/jobsSeoProfiler.ts'; import './build-plugins/shared/weeklyEmployersProfiler.ts'; console.log('imports ok')"
- BUILD_PROFILE=1 profiler probe emitted [jobs-seo-profile], [weekly-employers-profile], and [related-search-profile]
- SKIP_RELATED_SEARCH_CLUSTERS=1 SKIP_WEEKLY_EMPLOYERS=1 SKIP_JOB_MARKET_SNAPSHOT=1 SKIP_HEALTH_PREMIUMS=1 SKIP_ORPHAN_LANDINGS=1 SKIP_BORDER_WAIT=1 BUILD_PROFILE=1 FAST_BUILD=1 NODE_OPTIONS='--max-old-space-size=8192' ./node_modules/.bin/vite build --minify esbuild

Note: ./node_modules/.bin/tsc --noEmit was blocked in this reused local dependency tree because knip is missing from node_modules, although package.json declares it.