### PR TITLE
fix: sanitize tracked diagnostic URLs

### DIFF
--- a/data/recovery-2026-05-18/app-errors.json
+++ b/data/recovery-2026-05-18/app-errors.json
@@ -104,7 +104,7 @@
       "",
       13,
       2,
-      "https://frontaliereticino.ch/?action=dbaavez_afjfyfggfe&email=w.cbabggv@themaconsulting.ch&token=2c576ed2ddb9b2ea56fd0a70f06abc1076e1295ddcfbbfcc51668626881f5710"
+      "https://frontaliereticino.ch/?action=dbaavez_afjfyfggfe&email=x&token=x"
     ],
     [
       "Error",
@@ -491,7 +491,7 @@
     ],
     [
       "Non-Error promise rejection captured with value: Object Not Found Matching Id:1, MethodName:update, ParamCount:4",
-      "https://frontaliereticino.ch/?action=dbaavez_afjfyfggfe&email=w.cbabggv@themaconsulting.ch&token=2c576ed2ddb9b2ea56fd0a70f06abc1076e1295ddcfbbfcc51668626881f5710",
+      "https://frontaliereticino.ch/?action=dbaavez_afjfyfggfe&email=x&token=x",
       9
     ],
     [
@@ -746,7 +746,7 @@
     ],
     [
       "Non-Error promise rejection captured with value: Object Not Found Matching Id:1, MethodName:update, ParamCount:4",
-      "https://frontaliereticino.ch/?action=hafhcfdevcf&email=zvdby.zbeeb%40manpower.ch&token=6ccd61f1a3413faecfc6168ab70de64990c2fdc28fba254187d75a9935def24a&utm_medium=afjfyfggfe",
+      "https://frontaliereticino.ch/?action=hafhcfdevcf&email=x&token=x&utm_medium=afjfyfggfe",
       4
     ],
     [
@@ -781,7 +781,7 @@
     ],
     [
       "Importing a module script failed.",
-      "https://frontaliereticino.ch/en/?action=unsubscribe&email=cipollavanessa040404%40gmail.com&token=f68e054730765602df5a4988f8d41775983a05c0ae1a9c11484fd6b6c2659d77&ne=cipollavanessa040404%40gmail.com&ac=65e625755aaca0c620dcdeb85a9e1426b4a38ea99d120f35e4cbf1cfbec15ea5&utm_medium=newsletter#google_vignette",
+      "https://frontaliereticino.ch/en/?action=unsubscribe&email=x&token=x&ne=x&ac=x&utm_medium=newsletter#google_vignette",
       3
     ],
     [
@@ -871,7 +871,7 @@
     ],
     [
       "Failed to fetch",
-      "https://frontaliereticino.ch/cerca-lavoro-ticino/?action=confirm_newsletter&email=constantintipa%40yahoo.it&token=feeec51803ecc4354df2a4efb46bb3c39d85a88b2c00f6c9d8f49344d87b47dc",
+      "https://frontaliereticino.ch/cerca-lavoro-ticino/?action=confirm_newsletter&email=x&token=x",
       2
     ],
     [

--- a/scripts/diagnose-app-errors.mjs
+++ b/scripts/diagnose-app-errors.mjs
@@ -3,6 +3,7 @@
 // Groups by exception_message + source URL.
 // Output: data/recovery-2026-05-18/app-errors.{json,md}
 import { writeFileSync, mkdirSync } from 'node:fs';
+import { sanitizeTrackedDiagnosticValue } from './lib/sanitizeTrackedDiagnostics.mjs';
 
 const PROJECT_ID = '157802';
 const API_KEY = process.env.POSTHOG_PERSONAL_API_KEY;
@@ -58,8 +59,8 @@ const q3 = await HQL(`
 const out = {
   generated: new Date().toISOString(),
   window_days: 30,
-  top_exceptions: q1.results ?? q1,
-  by_url: q2.results ?? q2,
+  top_exceptions: sanitizeTrackedDiagnosticValue(q1.results ?? q1),
+  by_url: sanitizeTrackedDiagnosticValue(q2.results ?? q2),
   daily: q3.results ?? q3,
 };
 mkdirSync('data/recovery-2026-05-18', { recursive: true });

--- a/scripts/lib/sanitizeTrackedDiagnostics.mjs
+++ b/scripts/lib/sanitizeTrackedDiagnostics.mjs
@@ -1,0 +1,65 @@
+const SENSITIVE_QUERY_KEYS = new Set([
+  'ac',
+  'api_key',
+  'apikey',
+  'auth',
+  'client_secret',
+  'email',
+  'key',
+  'ne',
+  'secret',
+  'sig',
+  'signature',
+  'token',
+  'access_token',
+]);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+const OPAQUE_SECRET_RE = /^[a-f0-9]{32,}$/i;
+const REDACTED_QUERY_VALUE = 'x';
+
+export function sanitizeTrackedDiagnosticValue(value) {
+  if (typeof value === 'string') return sanitizeUrlLikeText(value);
+  if (Array.isArray(value)) return value.map((item) => sanitizeTrackedDiagnosticValue(item));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, sanitizeTrackedDiagnosticValue(item)])
+    );
+  }
+  return value;
+}
+
+export function sanitizeUrlLikeText(text) {
+  return text.replace(/https?:\/\/[^\s"'<>]+/g, (urlText) => sanitizeUrl(urlText));
+}
+
+function sanitizeUrl(urlText) {
+  try {
+    const url = new URL(urlText);
+    const sensitiveKeys = [];
+
+    for (const [key, value] of url.searchParams.entries()) {
+      if (isSensitiveQueryParam(key, value)) sensitiveKeys.push(key);
+    }
+
+    for (const key of sensitiveKeys) {
+      url.searchParams.set(key, REDACTED_QUERY_VALUE);
+    }
+
+    return url.toString();
+  } catch {
+    return urlText;
+  }
+}
+
+function isSensitiveQueryParam(key, value) {
+  const normalizedKey = key.toLowerCase().replace(/-/g, '_');
+  return (
+    SENSITIVE_QUERY_KEYS.has(normalizedKey) ||
+    normalizedKey.includes('token') ||
+    normalizedKey.includes('secret') ||
+    normalizedKey.includes('signature') ||
+    EMAIL_RE.test(value) ||
+    OPAQUE_SECRET_RE.test(value)
+  );
+}

--- a/tests/scripts/lib/sanitizeTrackedDiagnostics.test.ts
+++ b/tests/scripts/lib/sanitizeTrackedDiagnostics.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  sanitizeTrackedDiagnosticValue,
+  sanitizeUrlLikeText,
+} from '../../../scripts/lib/sanitizeTrackedDiagnostics.mjs';
+
+describe('sanitizeTrackedDiagnostics', () => {
+  it('redacts secret and personal query values in diagnostic URLs', () => {
+    const value = sanitizeUrlLikeText(
+      'https://frontaliereticino.ch/en/?action=unsubscribe&email=test@example.com&token=abcdef1234567890abcdef1234567890&ne=test@example.com&ac=65e625755aaca0c620dcdeb85a9e1426b4a38ea99d120f35e4cbf1cfbec15ea5&utm_medium=newsletter#google_vignette'
+    );
+
+    expect(value).toContain('action=unsubscribe');
+    expect(value).toContain('utm_medium=newsletter');
+    expect(value).toContain('email=x');
+    expect(value).toContain('token=x');
+    expect(value).toContain('ne=x');
+    expect(value).toContain('ac=x');
+    expect(value).not.toContain('test@example.com');
+    expect(value).not.toContain('abcdef1234567890abcdef1234567890');
+  });
+
+  it('recursively sanitizes nested PostHog result shapes', () => {
+    const value = sanitizeTrackedDiagnosticValue({
+      results: [
+        [
+          'Failed to fetch',
+          'https://frontaliereticino.ch/?action=confirm_newsletter&email=user@example.com&token=feeec51803ecc4354df2a4efb46bb3c39d85a88b2c00f6c9d8f49344d87b47dc',
+          2,
+        ],
+      ],
+    });
+
+    expect(value.results[0][1]).toContain('email=x');
+    expect(value.results[0][1]).toContain('token=x');
+    expect(value.results[0][1]).not.toContain('user@example.com');
+    expect(value.results[0][2]).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- redact email/token-like query values in the tracked PostHog app-error recovery dump
- sanitize future diagnose-app-errors output before writing JSON
- add unit coverage for recursive diagnostic URL sanitization

## Verification
- npx vitest run tests/scripts/lib/sanitizeTrackedDiagnostics.test.ts
- npm run validate:third-party-secrets
- git diff --cached --check
- GitNexus detect changes: risk 0.00, no test gaps