### PR TITLE
feat(seo): add border municipality pages

### DIFF
--- a/build-plugins/borderMunicipalityPagesPlugin.ts
+++ b/build-plugins/borderMunicipalityPagesPlugin.ts
@@ -1,0 +1,826 @@
+/**
+ * Static pages for Italian border municipalities near Ticino.
+ *
+ * Emits one SEO page per municipality under:
+ *   /vivere-in-ticino/comuni-di-frontiera/{comune}/
+ *
+ * The pages turn the existing border-municipalities hub into a decision tool:
+ * local tax/rent facts, playful "cosa succede se..." scenarios, nearest
+ * crossing guidance, and links into the salary, border-wait, transport and
+ * tax-return surfaces.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+import { WriteCollector } from './batchWrite';
+import { BASE_URL, countHtmlBodyWords, MIN_INDEXABLE_WORDS } from './constants';
+import { buildSeoPageHtml } from './shared/seoPageShell';
+import { staticPagesFlushed } from './shared/buildSignals';
+import { MUNICIPALITIES, type Municipality } from '../data/municipalities';
+import { borderCrossings, type BorderCrossing } from '../data/borderCrossings';
+
+type Locale = 'it' | 'en' | 'de' | 'fr';
+type WaitSnapshot = {
+  updatedAt?: string;
+  perCrossing?: Record<string, {
+    waitTimeMinutes?: number;
+    approachMinutes?: number;
+    totalCrossingMinutes?: number;
+    status?: 'green' | 'yellow' | 'red' | string;
+    source?: string;
+    lastUpdate?: string;
+  }>;
+};
+
+const LOCALES: readonly Locale[] = ['it', 'en', 'de', 'fr'] as const;
+const TICINO_CORRIDOR_PROVINCES = new Set(['CO', 'VA']);
+const SITEMAP_NAME = 'sitemap-comuni-frontiera.xml';
+
+const MUNICIPALITY_BASE_PATH: Record<Locale, string> = {
+  it: '/vivere-in-ticino/comuni-di-frontiera',
+  en: '/en/living-in-ticino/border-municipalities',
+  de: '/de/leben-im-tessin/grenzgemeinden',
+  fr: '/fr/vivre-au-tessin/communes-frontiere',
+};
+
+const LOCALE_OG: Record<Locale, string> = {
+  it: 'it_IT',
+  en: 'en_US',
+  de: 'de_DE',
+  fr: 'fr_FR',
+};
+
+const HUB_PATH = '/vivere-in-ticino/comuni-di-frontiera/';
+const HUB_LABEL: Record<Locale, string> = {
+  it: 'Comuni di frontiera',
+  en: 'Border municipalities',
+  de: 'Grenzgemeinden',
+  fr: 'Communes frontalières',
+};
+const HOME_LABEL: Record<Locale, string> = {
+  it: 'Home',
+  en: 'Home',
+  de: 'Startseite',
+  fr: 'Accueil',
+};
+
+const METRIC_DETAIL = {
+  municipalDataset: {
+    it: 'dato geografico comunale',
+    en: 'municipality dataset',
+    de: 'Gemeindedatensatz',
+    fr: 'jeu de données communal',
+  },
+  localRate: {
+    it: 'aliquota comunale stimata',
+    en: 'estimated local rate',
+    de: 'geschätzter Gemeindesatz',
+    fr: 'taux communal estimé',
+  },
+  monthlyRent: {
+    it: 'bilocale mensile indicativo',
+    en: 'indicative monthly rent',
+    de: 'indikative Monatsmiete',
+    fr: 'loyer mensuel indicatif',
+  },
+} satisfies Record<string, Record<Locale, string>>;
+
+const ACTION_LINKS = [
+  {
+    href: '/calcola-stipendio/',
+    label: {
+      it: 'Calcola stipendio netto',
+      en: 'Calculate net salary',
+      de: 'Nettolohn berechnen',
+      fr: 'Calculer le salaire net',
+    },
+  },
+  {
+    href: '/guida-frontaliere/mappa-confine/',
+    label: {
+      it: 'Mappa valichi',
+      en: 'Border crossing map',
+      de: 'Grenzübergänge Karte',
+      fr: 'Carte des passages',
+    },
+  },
+  {
+    href: '/vivere-in-ticino/trasporti-frontalieri/',
+    label: {
+      it: 'Trasporti frontalieri',
+      en: 'Cross-border transport',
+      de: 'Grenzgänger Verkehr',
+      fr: 'Transports frontaliers',
+    },
+  },
+  {
+    href: '/tasse-e-pensione/dichiarazione-redditi/',
+    label: {
+      it: 'Dichiarazione redditi',
+      en: 'Italian tax return',
+      de: 'Italienische Steuererklärung',
+      fr: 'Déclaration fiscale italienne',
+    },
+  },
+] satisfies Array<{ href: string; label: Record<Locale, string> }>;
+
+const BUTTON_LABELS = {
+  borderWait: {
+    it: 'Vedi tempi dogana',
+    en: 'View border waits',
+    de: 'Wartezeiten ansehen',
+    fr: 'Voir les attentes',
+  },
+  compareAlternative: {
+    it: 'Confronta alternativa',
+    en: 'Compare alternative',
+    de: 'Alternative vergleichen',
+    fr: 'Comparer une alternative',
+  },
+} satisfies Record<string, Record<Locale, string>>;
+
+const WAIT_SOURCE_FALLBACK: Record<Locale, string> = {
+  it: 'dataset interno / storico dogane',
+  en: 'internal dataset / border history',
+  de: 'interner Datensatz / Grenzhistorie',
+  fr: 'jeu interne / historique des frontières',
+};
+
+const CANDIDATE_HUB_LINKS = [
+  'Como',
+  'Cernobbio',
+  'Maslianico',
+  'Bizzarone',
+  'Cantù',
+  'Campione d\'Italia',
+  'Varese',
+  'Clivio',
+  'Saltrio',
+  'Lavena Ponte Tresa',
+  'Porto Ceresio',
+  'Luino',
+];
+
+interface Copy {
+  updated: string;
+  role: string;
+  h1: (m: Municipality) => string;
+  title: (m: Municipality) => string;
+  desc: (m: Municipality, c: BorderCrossing) => string;
+  badgeFrontier: (m: Municipality) => string;
+  distance: string;
+  irpef: string;
+  rent: string;
+  population: string;
+  playTitle: string;
+  scenario1: string;
+  scenario2: string;
+  scenario3: string;
+  customsTitle: string;
+  currentWait: string;
+  morning: string;
+  evening: string;
+  hours: string;
+  traffic: string;
+  customs: string;
+  yes: string;
+  no: string;
+  webcam: string;
+  noWebcam: string;
+  source: string;
+  compareTitle: string;
+  faqTitle: string;
+  faq1: (m: Municipality) => string;
+  faq1a: (m: Municipality) => string;
+  faq2: (c: BorderCrossing) => string;
+  faq2a: (m: Municipality, c: BorderCrossing) => string;
+  faq3: string;
+  faq3a: string;
+  hubTitle: string;
+  hubText: string;
+}
+
+const COPY = {
+  it: {
+    updated: 'Aggiornato',
+    role: 'Comune di frontiera',
+    h1: (m: Municipality) => `${m.name}: vivere da frontaliere e lavorare in Ticino`,
+    title: (m: Municipality) => `${m.name} frontalieri Ticino: dogana, tasse e tempi`,
+    desc: (m: Municipality, c: BorderCrossing) => `${m.name} (${m.province}) per frontalieri: distanza dal confine, addizionale IRPEF, affitti stimati e dogana più vicina (${c.name}) con tempi medi.`,
+    badgeFrontier: (m: Municipality) => `Fascia ${m.fascia}`,
+    distance: 'Distanza confine',
+    irpef: 'Addizionale IRPEF',
+    rent: 'Affitto stimato',
+    population: 'Residenti',
+    playTitle: 'Cosa cambierebbe se...',
+    scenario1: '...scegliessi questo comune per il pendolarismo?',
+    scenario2: '...lavorassi a Lugano o Mendrisio?',
+    scenario3: '...volessi ottimizzare tasse e affitto?',
+    customsTitle: 'Dogana più vicina',
+    currentWait: 'Snapshot attuale',
+    morning: 'Mattina',
+    evening: 'Sera',
+    hours: 'Orari',
+    traffic: 'Traffico',
+    customs: 'Controllo doganale',
+    yes: 'presente',
+    no: 'non fisso',
+    webcam: 'webcam disponibile',
+    noWebcam: 'nessuna webcam diretta',
+    source: 'Fonte tempi',
+    compareTitle: 'Azioni utili da fare ora',
+    faqTitle: 'Domande frequenti',
+    faq1: (m: Municipality) => `${m.name} è un comune di frontiera per lavorare in Svizzera?`,
+    faq1a: (m: Municipality) => `${m.name} risulta nella fascia ${m.fascia} del dataset interno dei comuni di frontiera usato da Frontaliere Ticino. Verifica sempre il tuo caso fiscale con un consulente se stai cambiando residenza o status di frontaliere.`,
+    faq2: (c: BorderCrossing) => `Quale dogana conviene da qui?`,
+    faq2a: (m: Municipality, c: BorderCrossing) => `Per ${m.name} la dogana più vicina nel nostro calcolo geografico è ${c.name}. Nelle ore di punta conviene confrontarla con le alternative del corridoio prima di partire.`,
+    faq3: 'Questi dati sostituiscono un parere fiscale?',
+    faq3a: 'No. Servono a orientare la scelta abitativa e il pendolarismo. La tassazione dipende anche da data di assunzione, status vecchio/nuovo frontaliere, dichiarazione italiana, deduzioni e situazione familiare.',
+    hubTitle: 'Esplora i comuni più cercati',
+    hubText: 'Parti da un comune concreto: la scheda mostra cosa cambia su dogana, tempi, tasse locali e collegamenti utili.',
+  },
+  en: {
+    updated: 'Updated',
+    role: 'Border municipality',
+    h1: (m: Municipality) => `${m.name}: living in Italy and commuting to Ticino`,
+    title: (m: Municipality) => `${m.name} for Ticino commuters: border, tax and time`,
+    desc: (m: Municipality, c: BorderCrossing) => `${m.name} (${m.province}) for cross-border workers: border distance, local IRPEF surcharge, estimated rents and nearest crossing (${c.name}) with average waits.`,
+    badgeFrontier: (m: Municipality) => `Zone ${m.fascia}`,
+    distance: 'Border distance',
+    irpef: 'Local IRPEF',
+    rent: 'Estimated rent',
+    population: 'Residents',
+    playTitle: 'What would change if...',
+    scenario1: '...you chose this municipality for commuting?',
+    scenario2: '...you worked in Lugano or Mendrisio?',
+    scenario3: '...you wanted to balance tax and rent?',
+    customsTitle: 'Nearest border crossing',
+    currentWait: 'Current snapshot',
+    morning: 'Morning',
+    evening: 'Evening',
+    hours: 'Hours',
+    traffic: 'Traffic',
+    customs: 'Customs control',
+    yes: 'present',
+    no: 'not fixed',
+    webcam: 'webcam available',
+    noWebcam: 'no direct webcam',
+    source: 'Wait source',
+    compareTitle: 'Useful next steps',
+    faqTitle: 'FAQ',
+    faq1: (m: Municipality) => `Is ${m.name} a border municipality for Swiss work?`,
+    faq1a: (m: Municipality) => `${m.name} appears in zone ${m.fascia} in the internal border-municipality dataset used by Frontaliere Ticino. Always verify your individual tax status before moving.`,
+    faq2: (_c: BorderCrossing) => `Which border crossing should I use?`,
+    faq2a: (m: Municipality, c: BorderCrossing) => `For ${m.name}, the nearest crossing in our geographic calculation is ${c.name}. During peak hours, compare it with nearby alternatives before leaving.`,
+    faq3: 'Is this tax advice?',
+    faq3a: 'No. These pages help with orientation. Tax treatment depends on hiring date, old/new cross-border status, Italian filing, deductions and family situation.',
+    hubTitle: 'Explore popular municipalities',
+    hubText: 'Start from a concrete municipality: each profile shows border crossing, timing, local taxes and useful links.',
+  },
+  de: {
+    updated: 'Aktualisiert',
+    role: 'Grenzgemeinde',
+    h1: (m: Municipality) => `${m.name}: in Italien wohnen und ins Tessin pendeln`,
+    title: (m: Municipality) => `${m.name} für Tessin-Pendler: Grenze, Steuer und Zeit`,
+    desc: (m: Municipality, c: BorderCrossing) => `${m.name} (${m.province}) für Grenzgänger: Distanz zur Grenze, kommunaler IRPEF-Zuschlag, geschätzte Mieten und nächster Übergang (${c.name}).`,
+    badgeFrontier: (m: Municipality) => `Zone ${m.fascia}`,
+    distance: 'Grenzdistance',
+    irpef: 'IRPEF-Zuschlag',
+    rent: 'Mietschätzung',
+    population: 'Einwohner',
+    playTitle: 'Was würde sich ändern, wenn...',
+    scenario1: '...du diese Gemeinde fürs Pendeln wählst?',
+    scenario2: '...du in Lugano oder Mendrisio arbeitest?',
+    scenario3: '...du Steuern und Miete ausbalancieren willst?',
+    customsTitle: 'Nächster Grenzübergang',
+    currentWait: 'Aktuelle Momentaufnahme',
+    morning: 'Morgen',
+    evening: 'Abend',
+    hours: 'Öffnung',
+    traffic: 'Verkehr',
+    customs: 'Zollkontrolle',
+    yes: 'vorhanden',
+    no: 'nicht fix',
+    webcam: 'Webcam verfügbar',
+    noWebcam: 'keine direkte Webcam',
+    source: 'Quelle Wartezeit',
+    compareTitle: 'Nützliche nächste Schritte',
+    faqTitle: 'FAQ',
+    faq1: (m: Municipality) => `Ist ${m.name} eine Grenzgemeinde?`,
+    faq1a: (m: Municipality) => `${m.name} erscheint in Zone ${m.fascia} im internen Grenzgemeinden-Datensatz von Frontaliere Ticino. Prüfe deinen Steuerfall vor einem Umzug individuell.`,
+    faq2: (_c: BorderCrossing) => `Welcher Grenzübergang passt?`,
+    faq2a: (m: Municipality, c: BorderCrossing) => `Für ${m.name} ist ${c.name} der nächstgelegene Übergang in unserer geografischen Berechnung. Zu Spitzenzeiten lohnt sich der Vergleich mit Alternativen.`,
+    faq3: 'Ist das Steuerberatung?',
+    faq3a: 'Nein. Die Seite dient zur Orientierung. Die Besteuerung hängt von Einstellungsdatum, altem/neuem Grenzgängerstatus, italienischer Erklärung, Abzügen und Familie ab.',
+    hubTitle: 'Beliebte Gemeinden erkunden',
+    hubText: 'Starte bei einer konkreten Gemeinde: jede Karte zeigt Grenze, Zeiten, lokale Steuern und nützliche Links.',
+  },
+  fr: {
+    updated: 'Mis à jour',
+    role: 'Commune frontalière',
+    h1: (m: Municipality) => `${m.name}: vivre en Italie et travailler au Tessin`,
+    title: (m: Municipality) => `${m.name} frontaliers Tessin: douane, impôts et temps`,
+    desc: (m: Municipality, c: BorderCrossing) => `${m.name} (${m.province}) pour frontaliers: distance frontière, surtaxe IRPEF locale, loyers estimés et poste frontière le plus proche (${c.name}).`,
+    badgeFrontier: (m: Municipality) => `Zone ${m.fascia}`,
+    distance: 'Distance frontière',
+    irpef: 'IRPEF locale',
+    rent: 'Loyer estimé',
+    population: 'Habitants',
+    playTitle: 'Qu’est-ce qui changerait si...',
+    scenario1: '...vous choisissiez cette commune pour vos trajets?',
+    scenario2: '...vous travailliez à Lugano ou Mendrisio?',
+    scenario3: '...vous vouliez équilibrer impôts et loyer?',
+    customsTitle: 'Douane la plus proche',
+    currentWait: 'Instantané actuel',
+    morning: 'Matin',
+    evening: 'Soir',
+    hours: 'Horaires',
+    traffic: 'Trafic',
+    customs: 'Contrôle douanier',
+    yes: 'présent',
+    no: 'non fixe',
+    webcam: 'webcam disponible',
+    noWebcam: 'pas de webcam directe',
+    source: 'Source attente',
+    compareTitle: 'Prochaines actions utiles',
+    faqTitle: 'FAQ',
+    faq1: (m: Municipality) => `${m.name} est-elle une commune frontalière?`,
+    faq1a: (m: Municipality) => `${m.name} apparaît en zone ${m.fascia} dans le jeu de données interne des communes frontalières utilisé par Frontaliere Ticino. Vérifiez toujours votre cas fiscal avant un déménagement.`,
+    faq2: (_c: BorderCrossing) => `Quel poste frontière choisir?`,
+    faq2a: (m: Municipality, c: BorderCrossing) => `Pour ${m.name}, le poste le plus proche dans notre calcul géographique est ${c.name}. Aux heures de pointe, comparez avec les alternatives voisines.`,
+    faq3: 'Est-ce un conseil fiscal?',
+    faq3a: 'Non. Cette page sert d’orientation. Le traitement fiscal dépend de la date d’embauche, du statut ancien/nouveau frontalier, de la déclaration italienne, des déductions et de la famille.',
+    hubTitle: 'Explorer les communes populaires',
+    hubText: 'Partez d’une commune concrète: chaque fiche montre douane, temps, taxes locales et liens utiles.',
+  },
+} satisfies Record<Locale, Copy>;
+
+function esc(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function pathFor(locale: Locale, municipality: Municipality): string {
+  return `${MUNICIPALITY_BASE_PATH[locale]}/${slugify(municipality.name)}/`;
+}
+
+function haversineKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const earthKm = 6371;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * earthKm * Math.asin(Math.sqrt(h));
+}
+
+function crossingSlug(crossing: BorderCrossing): string {
+  if (crossing.name.startsWith('Gaggiolo')) return 'gaggiolo';
+  if (crossing.name.startsWith('San Pietro')) return 'san-pietro';
+  return slugify(crossing.name.replace(/\s*\([^)]*\)\s*/g, ' '));
+}
+
+function readWaitSnapshot(rootDir: string): WaitSnapshot {
+  try {
+    const raw = fs.readFileSync(path.resolve(rootDir, 'data', 'border-wait-current.json'), 'utf-8');
+    return JSON.parse(raw) as WaitSnapshot;
+  } catch {
+    return {};
+  }
+}
+
+function eligibleMunicipalities(): Municipality[] {
+  const limit = Number.parseInt(process.env.BORDER_MUNICIPALITY_PAGE_LIMIT ?? '', 10);
+  const all = MUNICIPALITIES
+    .filter((m) => TICINO_CORRIDOR_PROVINCES.has(m.province))
+    .sort((a, b) => a.province.localeCompare(b.province) || a.name.localeCompare(b.name));
+  return Number.isFinite(limit) && limit > 0 ? all.slice(0, limit) : all;
+}
+
+function nearestCrossings(municipality: Municipality): Array<{ crossing: BorderCrossing; slug: string; distanceKm: number }> {
+  return borderCrossings
+    .filter((crossing) => crossing.trafficLevel !== 'closed')
+    .map((crossing) => ({
+      crossing,
+      slug: crossingSlug(crossing),
+      distanceKm: haversineKm(municipality, crossing),
+    }))
+    .sort((a, b) => a.distanceKm - b.distanceKm);
+}
+
+function formatInt(n: number, locale: Locale): string {
+  const lang = locale === 'it' ? 'it-IT' : locale === 'de' ? 'de-DE' : locale === 'fr' ? 'fr-FR' : 'en-US';
+  return new Intl.NumberFormat(lang, { maximumFractionDigits: 0 }).format(n);
+}
+
+function formatDecimal(n: number, locale: Locale): string {
+  const lang = locale === 'it' ? 'it-IT' : locale === 'de' ? 'de-DE' : locale === 'fr' ? 'fr-FR' : 'en-US';
+  return new Intl.NumberFormat(lang, { maximumFractionDigits: 1 }).format(n);
+}
+
+function waitLabel(snapshot: WaitSnapshot, slug: string): string {
+  const current = snapshot.perCrossing?.[slug];
+  if (!current) return 'n.d.';
+  const total = current.totalCrossingMinutes ?? current.waitTimeMinutes;
+  return typeof total === 'number' ? `${Math.max(0, Math.round(total))} min` : 'n.d.';
+}
+
+function trafficTone(level: BorderCrossing['trafficLevel']): string {
+  if (level === 'high') return 'bg-warning-subtle text-warning border-warning-border';
+  if (level === 'medium') return 'bg-info-subtle text-info border-info-border';
+  return 'bg-success-subtle text-success border-success-border';
+}
+
+function estimateCommute(municipality: Municipality, crossingDistanceKm: number, crossing: BorderCrossing, snapshot: WaitSnapshot, slug: string): {
+  mendrisio: number;
+  lugano: number;
+  costMonthly: number;
+} {
+  const current = snapshot.perCrossing?.[slug]?.totalCrossingMinutes;
+  const wait = typeof current === 'number' ? current : Number.parseInt(crossing.avgWaitMorning, 10) || 8;
+  const toCrossing = crossingDistanceKm * 1.7;
+  const toMendrisio = crossing.province === 'CO' ? 12 : 10;
+  const toLugano = crossing.name.includes('Ponte Tresa') || crossing.name.includes('Fornasette') ? 18 : 28;
+  const dailyKm = Math.max(18, (municipality.distanceKm + toLugano / 2) * 2);
+  return {
+    mendrisio: Math.round(toCrossing + wait + toMendrisio),
+    lugano: Math.round(toCrossing + wait + toLugano),
+    costMonthly: Math.round(dailyKm * 22 * 0.22),
+  };
+}
+
+function renderScenarioBody(params: {
+  locale: Locale;
+  municipality: Municipality;
+  crossing: BorderCrossing;
+  crossingDistanceKm: number;
+  liveWait: string;
+  commute: ReturnType<typeof estimateCommute>;
+}): { commute: string; jobs: string; money: string } {
+  const { locale, municipality, crossing, crossingDistanceKm, liveWait, commute } = params;
+  const crossingKm = formatDecimal(crossingDistanceKm, locale);
+  const mendrisio = formatInt(commute.mendrisio, locale);
+  const lugano = formatInt(commute.lugano, locale);
+  const irpef = formatDecimal(municipality.irpefAddizionale, locale);
+  const rent = formatInt(municipality.avgRentMonthly, locale);
+  const carCost = formatInt(commute.costMonthly, locale);
+
+  if (locale === 'en') {
+    return {
+      commute: `From ${municipality.name}, the nearest crossing in the model is ${crossing.name}, about ${crossingKm} km as the crow flies from the municipal centre. With the current snapshot the crossing weighs around ${liveWait}; on ordinary days the declared historical wait is ${crossing.avgWaitMorning} in the morning and ${crossing.avgWaitEvening} in the evening.`,
+      jobs: `For a job in Sottoceneri, a prudent estimate is around ${mendrisio} minutes to Mendrisio and ${lugano} minutes to Lugano, including the approach to the crossing and the wait. These are orientation estimates: incidents, school traffic and weather can change the result a lot.`,
+      money: `The real game is adding net salary, housing and time. Here you have a local surcharge of ${irpef}%, indicative rent of EUR ${rent} and an estimated monthly car cost from EUR ${carCost}. Before moving, compare at least three municipalities in the same corridor.`,
+    };
+  }
+
+  if (locale === 'de') {
+    return {
+      commute: `Von ${municipality.name} ist ${crossing.name} der nächste Übergang im Modell, etwa ${crossingKm} km Luftlinie vom Gemeindezentrum entfernt. Mit der aktuellen Momentaufnahme zählt der Übergang rund ${liveWait}; an normalen Tagen liegt der historische Richtwert bei ${crossing.avgWaitMorning} am Morgen und ${crossing.avgWaitEvening} am Abend.`,
+      jobs: `Für eine Stelle im Sottoceneri ist eine vorsichtige Schätzung etwa ${mendrisio} Minuten nach Mendrisio und ${lugano} Minuten nach Lugano, inklusive Anfahrt zur Grenze und Wartezeit. Es sind Orientierungswerte: Unfälle, Schulverkehr und Wetter ändern das Ergebnis stark.`,
+      money: `Entscheidend ist die Summe aus Nettolohn, Wohnen und Zeit. Hier stehen kommunaler Zuschlag ${irpef}%, indikative Miete EUR ${rent} und geschätzte monatliche Autokosten ab EUR ${carCost}. Vergleiche vor einem Umzug mindestens drei Gemeinden desselben Korridors.`,
+    };
+  }
+
+  if (locale === 'fr') {
+    return {
+      commute: `Depuis ${municipality.name}, le passage le plus proche dans le modèle est ${crossing.name}, à environ ${crossingKm} km à vol d'oiseau du centre communal. Avec l'instantané actuel, le passage pèse environ ${liveWait}; les jours ordinaires, l'attente historique déclarée est ${crossing.avgWaitMorning} le matin et ${crossing.avgWaitEvening} le soir.`,
+      jobs: `Pour un emploi dans le Sottoceneri, une estimation prudente est d'environ ${mendrisio} minutes vers Mendrisio et ${lugano} minutes vers Lugano, avec l'approche de la douane et l'attente. Ce sont des repères: accidents, écoles et météo peuvent beaucoup changer le résultat.`,
+      money: `Le vrai jeu consiste à additionner net, logement et temps. Ici vous avez une surtaxe communale de ${irpef}%, un loyer indicatif de EUR ${rent} et un coût voiture mensuel estimé dès EUR ${carCost}. Avant de changer de résidence, comparez au moins trois communes du même corridor.`,
+    };
+  }
+
+  return {
+    commute: `Da ${municipality.name} la dogana più vicina nel modello è ${crossing.name}, a circa ${crossingKm} km in linea d'aria dal centro comunale. Con lo snapshot attuale il passaggio pesa circa ${liveWait}; nei giorni ordinari il dato storico dichiarato è ${crossing.avgWaitMorning} al mattino e ${crossing.avgWaitEvening} alla sera.`,
+    jobs: `Per un lavoro nel Sottoceneri, una stima prudente è circa ${mendrisio} minuti verso Mendrisio e ${lugano} minuti verso Lugano, includendo avvicinamento alla dogana e attesa. Sono stime orientative: incidenti, scuole e meteo cambiano molto il risultato.`,
+    money: `Il gioco vero è sommare netto, casa e tempo. Qui hai addizionale comunale ${irpef}%, affitto indicativo EUR ${rent} e costo auto mensile stimato da EUR ${carCost}. Prima di cambiare residenza, confronta almeno tre comuni dello stesso corridoio.`,
+  };
+}
+
+function summaryFor(locale: Locale, municipality: Municipality): string {
+  if (locale === 'en') {
+    return `${municipality.name} is useful for commuters who want an Italian base with daily travel to Ticino. Compare border crossing, fiscal zone, local tax, rent and peak-time waits together.`;
+  }
+  if (locale === 'de') {
+    return `${municipality.name} eignet sich für Pendler, die in Italien wohnen und täglich ins Tessin fahren. Vergleiche Grenzübergang, Steuerzone, kommunale Steuer, Miete und Wartezeiten gemeinsam.`;
+  }
+  if (locale === 'fr') {
+    return `${municipality.name} aide les frontaliers qui veulent vivre en Italie et se rendre chaque jour au Tessin. Comparez douane, zone fiscale, taxe locale, loyer et attentes aux heures de pointe.`;
+  }
+  return `${municipality.name} è adatto a chi vuole una base italiana con rientro quotidiano verso il Ticino. La scelta va letta insieme a dogana, fascia fiscale, addizionale comunale, costo dell'affitto e tempi di punta.`;
+}
+
+function buildAlternates(municipality: Municipality): string {
+  return LOCALES
+    .map((locale) => ` <link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathFor(locale, municipality)}">`)
+    .concat(` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathFor('it', municipality)}">`)
+    .join('\n');
+}
+
+function renderMetric(label: string, value: string, detail?: string): string {
+  return `<div class="rounded-md border border-edge bg-surface p-4">
+    <dt class="text-sm font-medium text-subtle">${esc(label)}</dt>
+    <dd class="mt-1 text-2xl font-bold text-heading">${esc(value)}</dd>
+    ${detail ? `<p class="mt-1 text-sm text-muted">${esc(detail)}</p>` : ''}
+  </div>`;
+}
+
+function renderPage(params: {
+  municipality: Municipality;
+  locale: Locale;
+  dateStamp: string;
+  distDir: string;
+  waitSnapshot: WaitSnapshot;
+}): { urlPath: string; html: string; wordCount: number } {
+  const { municipality, locale, dateStamp, distDir, waitSnapshot } = params;
+  const copy = COPY[locale];
+  const [primary, alternate] = nearestCrossings(municipality);
+  const crossing = primary.crossing;
+  const commute = estimateCommute(municipality, primary.distanceKm, crossing, waitSnapshot, primary.slug);
+  const canonicalPath = pathFor(locale, municipality);
+  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
+  const borderWaitUrl = `/traffico-dogane/${primary.slug}/oggi/`;
+  const altWaitUrl = alternate ? `/traffico-dogane/${alternate.slug}/oggi/` : '/traffico-dogane/';
+  const liveWait = waitLabel(waitSnapshot, primary.slug);
+  const hasWebcam = (crossing.webcams?.length ?? 0) > 0;
+  const scenarioBody = renderScenarioBody({
+    locale,
+    municipality,
+    crossing,
+    crossingDistanceKm: primary.distanceKm,
+    liveWait,
+    commute,
+  });
+  const aiSummary = summaryFor(locale, municipality);
+
+  const body = `<div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+    <nav class="mb-4 text-sm text-muted" aria-label="Breadcrumb">
+      <a class="text-link hover:text-link-hover" href="/">${esc(HOME_LABEL[locale])}</a>
+      <span class="mx-2">/</span>
+      <a class="text-link hover:text-link-hover" href="${pathFor(locale, municipality).replace(`${slugify(municipality.name)}/`, '')}">${esc(HUB_LABEL[locale])}</a>
+      <span class="mx-2">/</span>
+      <span>${esc(municipality.name)}</span>
+    </nav>
+
+    <header class="rounded-md border border-edge bg-surface p-5 sm:p-7" data-speakable>
+      <div class="flex flex-wrap items-center gap-2 text-sm">
+        <span class="rounded-full border border-info-border bg-info-subtle px-3 py-1 font-semibold text-info">${esc(copy.role)}</span>
+        <span class="rounded-full border border-edge bg-surface-raised px-3 py-1 text-subtle">${esc(copy.badgeFrontier(municipality))}</span>
+      </div>
+      <h1 class="mt-4 max-w-4xl text-3xl font-bold leading-tight text-heading sm:text-4xl">${esc(copy.h1(municipality))}</h1>
+      <p class="mt-3 max-w-3xl text-base leading-7 text-body">${esc(aiSummary)}</p>
+      <p class="mt-3 text-sm text-muted">${esc(copy.updated)}: <time datetime="${dateStamp}">${dateStamp}</time></p>
+    </header>
+
+    <dl class="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      ${renderMetric(copy.distance, `${formatDecimal(municipality.distanceKm, locale)} km`, METRIC_DETAIL.municipalDataset[locale])}
+      ${renderMetric(copy.irpef, `${formatDecimal(municipality.irpefAddizionale, locale)}%`, METRIC_DETAIL.localRate[locale])}
+      ${renderMetric(copy.rent, `EUR ${formatInt(municipality.avgRentMonthly, locale)}`, METRIC_DETAIL.monthlyRent[locale])}
+      ${renderMetric(copy.population, formatInt(municipality.population, locale), municipality.province)}
+    </dl>
+
+    <section class="mt-6 grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+      <div class="rounded-md border border-edge bg-surface p-5">
+        <h2 class="text-xl font-bold text-heading">${esc(copy.playTitle)}</h2>
+        <div class="mt-4 grid gap-3">
+          <article class="rounded-md border border-accent-border bg-accent-subtle p-4">
+            <h3 class="font-semibold text-heading">${esc(copy.scenario1)}</h3>
+            <p class="mt-2 text-sm leading-6 text-body">${esc(scenarioBody.commute)}</p>
+          </article>
+          <article class="rounded-md border border-info-border bg-info-subtle p-4">
+            <h3 class="font-semibold text-heading">${esc(copy.scenario2)}</h3>
+            <p class="mt-2 text-sm leading-6 text-body">${esc(scenarioBody.jobs)}</p>
+          </article>
+          <article class="rounded-md border border-success-border bg-success-subtle p-4">
+            <h3 class="font-semibold text-heading">${esc(copy.scenario3)}</h3>
+            <p class="mt-2 text-sm leading-6 text-body">${esc(scenarioBody.money)}</p>
+          </article>
+        </div>
+      </div>
+
+      <aside class="rounded-md border border-edge bg-surface p-5">
+        <h2 class="text-xl font-bold text-heading">${esc(copy.customsTitle)}</h2>
+        <div class="mt-4 rounded-md border ${trafficTone(crossing.trafficLevel)} p-4">
+          <p class="text-lg font-bold">${esc(crossing.name)}</p>
+          <p class="mt-1 text-sm">${esc(copy.currentWait)}: <strong>${esc(liveWait)}</strong></p>
+        </div>
+        <dl class="mt-4 grid grid-cols-2 gap-3 text-sm">
+          <div><dt class="font-medium text-subtle">${esc(copy.morning)}</dt><dd class="text-heading">${esc(crossing.avgWaitMorning)}</dd></div>
+          <div><dt class="font-medium text-subtle">${esc(copy.evening)}</dt><dd class="text-heading">${esc(crossing.avgWaitEvening)}</dd></div>
+          <div><dt class="font-medium text-subtle">${esc(copy.hours)}</dt><dd class="text-heading">${esc(crossing.hours)}</dd></div>
+          <div><dt class="font-medium text-subtle">${esc(copy.customs)}</dt><dd class="text-heading">${crossing.customsPresent ? esc(copy.yes) : esc(copy.no)}</dd></div>
+        </dl>
+        <p class="mt-4 text-sm leading-6 text-body">${hasWebcam ? esc(copy.webcam) : esc(copy.noWebcam)}. ${esc(copy.source)}: ${esc(waitSnapshot.perCrossing?.[primary.slug]?.source ?? WAIT_SOURCE_FALLBACK[locale])}.</p>
+        <div class="mt-4 flex flex-col gap-2">
+          <a class="inline-flex items-center justify-center rounded-md bg-accent-strong px-4 py-3 text-sm font-semibold text-on-accent hover:bg-accent-strong-hover" href="${borderWaitUrl}">${esc(BUTTON_LABELS.borderWait[locale])}</a>
+          <a class="inline-flex items-center justify-center rounded-md border border-edge bg-surface-raised px-4 py-3 text-sm font-semibold text-heading" href="${altWaitUrl}">${esc(BUTTON_LABELS.compareAlternative[locale])}</a>
+        </div>
+      </aside>
+    </section>
+
+    <section class="mt-6 rounded-md border border-edge bg-surface p-5">
+      <h2 class="text-xl font-bold text-heading">${esc(copy.compareTitle)}</h2>
+      <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        ${ACTION_LINKS.map((link) => `<a class="rounded-md border border-edge bg-surface-raised p-4 text-sm font-semibold text-heading hover:border-accent-border" href="${link.href}">${esc(link.label[locale])}</a>`).join('')}
+      </div>
+    </section>
+
+    <section class="mt-6 rounded-md border border-edge bg-surface p-5">
+      <h2 class="text-xl font-bold text-heading">${esc(copy.faqTitle)}</h2>
+      <div class="mt-4 divide-y divide-edge">
+        <details class="py-3" open><summary class="cursor-pointer font-semibold text-heading">${esc(copy.faq1(municipality))}</summary><p class="mt-2 text-sm leading-6 text-body">${esc(copy.faq1a(municipality))}</p></details>
+        <details class="py-3"><summary class="cursor-pointer font-semibold text-heading">${esc(copy.faq2(crossing))}</summary><p class="mt-2 text-sm leading-6 text-body">${esc(copy.faq2a(municipality, crossing))}</p></details>
+        <details class="py-3"><summary class="cursor-pointer font-semibold text-heading">${esc(copy.faq3)}</summary><p class="mt-2 text-sm leading-6 text-body">${esc(copy.faq3a)}</p></details>
+      </div>
+    </section>
+  </div>`;
+
+  const breadcrumbLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/` },
+      { '@type': 'ListItem', position: 2, name: HUB_LABEL[locale], item: `${BASE_URL}${MUNICIPALITY_BASE_PATH[locale]}/` },
+      { '@type': 'ListItem', position: 3, name: municipality.name, item: canonicalUrl },
+    ],
+  });
+
+  const placeLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'City',
+    name: municipality.name,
+    address: {
+      '@type': 'PostalAddress',
+      addressCountry: 'IT',
+      addressRegion: municipality.province,
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: municipality.lat,
+      longitude: municipality.lng,
+    },
+    subjectOf: {
+      '@type': 'WebPage',
+      name: copy.title(municipality),
+      url: canonicalUrl,
+    },
+  });
+
+  const faqLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      { '@type': 'Question', name: copy.faq1(municipality), acceptedAnswer: { '@type': 'Answer', text: copy.faq1a(municipality) } },
+      { '@type': 'Question', name: copy.faq2(crossing), acceptedAnswer: { '@type': 'Answer', text: copy.faq2a(municipality, crossing) } },
+      { '@type': 'Question', name: copy.faq3, acceptedAnswer: { '@type': 'Answer', text: copy.faq3a } },
+    ],
+  });
+
+  const wordCount = countHtmlBodyWords(body);
+  const html = buildSeoPageHtml({
+    locale,
+    title: copy.title(municipality),
+    description: copy.desc(municipality, crossing),
+    canonicalUrl,
+    hreflangHtml: buildAlternates(municipality),
+    robots: wordCount >= MIN_INDEXABLE_WORDS ? 'index,follow' : 'noindex,follow',
+    ogLocale: LOCALE_OG[locale],
+    bodyHtml: body,
+    jsonLdScripts: [breadcrumbLd, placeLd, faqLd],
+    hubChrome: { hubKey: 'vita', activeSubTab: 'municipalities' },
+    distDir,
+  });
+
+  return { urlPath: canonicalPath, html, wordCount };
+}
+
+function buildSitemap(entries: Array<{ municipality: Municipality; dateStamp: string }>): string {
+  const urls = entries.map(({ municipality, dateStamp }) => {
+    const alternates = LOCALES
+      .map((locale) => `    <xhtml:link rel="alternate" hreflang="${locale}" href="${BASE_URL}${pathFor(locale, municipality)}" />`)
+      .concat(`    <xhtml:link rel="alternate" hreflang="x-default" href="${BASE_URL}${pathFor('it', municipality)}" />`)
+      .join('\n');
+    return `  <url>\n    <loc>${BASE_URL}${pathFor('it', municipality)}</loc>\n${alternates}\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.55</priority>\n  </url>`;
+  }).join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">\n${urls}\n</urlset>\n`;
+}
+
+function patchSitemapIndex(distDir: string, dateStamp: string): void {
+  const sitemapPath = path.join(distDir, 'sitemap.xml');
+  if (!fs.existsSync(sitemapPath)) return;
+  let idx = fs.readFileSync(sitemapPath, 'utf-8');
+  if (!idx.includes(SITEMAP_NAME)) {
+    idx = idx.replace(
+      '</sitemapindex>',
+      `  <sitemap>\n    <loc>${BASE_URL}/${SITEMAP_NAME}</loc>\n    <lastmod>${dateStamp}</lastmod>\n  </sitemap>\n</sitemapindex>`,
+    );
+  } else {
+    idx = idx.replace(
+      new RegExp(`(<loc>${BASE_URL.replace(/\//g, '\\/')}/${SITEMAP_NAME}<\\/loc>\\s*<lastmod>)\\d{4}-\\d{2}-\\d{2}(<\\/lastmod>)`),
+      `$1${dateStamp}$2`,
+    );
+  }
+  fs.writeFileSync(sitemapPath, idx, 'utf-8');
+}
+
+function buildHubPatch(municipalities: Municipality[]): string {
+  const byName = new Map(municipalities.map((m) => [m.name, m]));
+  const links = CANDIDATE_HUB_LINKS
+    .map((name) => byName.get(name))
+    .filter((m): m is Municipality => Boolean(m))
+    .map((m) => {
+      const [nearest] = nearestCrossings(m);
+      return `<a class="rounded-md border border-edge bg-surface p-4 hover:border-accent-border" href="${pathFor('it', m)}">
+        <span class="block text-sm font-semibold text-heading">${esc(m.name)}</span>
+        <span class="mt-1 block text-xs text-muted">${esc(m.province)} · ${formatDecimal(m.distanceKm, 'it')} km · ${esc(nearest.crossing.name)}</span>
+      </a>`;
+    })
+    .join('');
+
+  return `<section data-border-municipality-links="1" class="my-8 rounded-md border border-edge bg-surface p-5">
+    <h2 class="text-2xl font-bold text-heading">${esc(COPY.it.hubTitle)}</h2>
+    <p class="mt-2 max-w-3xl text-sm leading-6 text-body">${esc(COPY.it.hubText)}</p>
+    <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">${links}</div>
+  </section>`;
+}
+
+function patchHubPage(distDir: string, municipalities: Municipality[]): void {
+  const file = path.join(distDir, 'vivere-in-ticino', 'comuni-di-frontiera', 'index.html');
+  if (!fs.existsSync(file)) return;
+  let html = fs.readFileSync(file, 'utf-8');
+  if (html.includes('data-border-municipality-links="1"')) return;
+  const patch = buildHubPatch(municipalities);
+  if (html.includes('<nav class="s-eazYqN">')) {
+    html = html.replace('<nav class="s-eazYqN">', `${patch}<nav class="s-eazYqN">`);
+  } else if (html.includes('</article>')) {
+    html = html.replace('</article>', `${patch}</article>`);
+  } else {
+    html = html.replace('</main>', `${patch}</main>`);
+  }
+  fs.writeFileSync(file, html, 'utf-8');
+}
+
+export function borderMunicipalityPagesPlugin(rootDir: string): Plugin {
+  return {
+    name: 'border-municipality-pages',
+    apply: 'build',
+    enforce: 'post',
+    async closeBundle() {
+      if (process.env.SKIP_BORDER_MUNICIPALITY_PAGES === '1') {
+        console.log('\x1b[36m[border-municipalities]\x1b[0m skipped (SKIP_BORDER_MUNICIPALITY_PAGES=1)');
+        return;
+      }
+
+      const distDir = path.resolve(rootDir, 'dist');
+      const dateStamp = new Date().toISOString().slice(0, 10);
+      const waitSnapshot = readWaitSnapshot(rootDir);
+      const municipalities = eligibleMunicipalities();
+      const collector = new WriteCollector({ distDir, pluginName: 'borderMunicipalityPagesPlugin' });
+      let pagesWritten = 0;
+      let thinPages = 0;
+
+      for (const municipality of municipalities) {
+        for (const locale of LOCALES) {
+          const rendered = renderPage({ municipality, locale, dateStamp, distDir, waitSnapshot });
+          if (rendered.wordCount < MIN_INDEXABLE_WORDS) thinPages++;
+          const indexPath = path.join(distDir, rendered.urlPath, 'index.html');
+          const flatPath = path.join(distDir, rendered.urlPath.replace(/\/+$/, '') + '.html');
+          collector.add(indexPath, rendered.html);
+          collector.add(flatPath, rendered.html);
+          pagesWritten++;
+        }
+      }
+
+      const sitemapXml = buildSitemap(municipalities.map((municipality) => ({ municipality, dateStamp })));
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(path.join(distDir, SITEMAP_NAME), sitemapXml, 'utf-8');
+
+      const t0 = Date.now();
+      const flushed = await collector.flush();
+      patchSitemapIndex(distDir, dateStamp);
+
+      if (process.env.BORDER_MUNICIPALITY_STANDALONE !== '1') {
+        await staticPagesFlushed;
+      }
+      patchHubPage(distDir, municipalities);
+
+      console.log(
+        `\x1b[36m[border-municipalities]\x1b[0m Generated ${pagesWritten} pages for ${municipalities.length} municipalities — flushed ${flushed} files in ${((Date.now() - t0) / 1000).toFixed(1)}s${thinPages ? ` (${thinPages} thin)` : ''}`,
+      );
+    },
+  };
+}

--- a/services/router.ts
+++ b/services/router.ts
@@ -2290,6 +2290,21 @@ export function parsePath(pathname: string): ParseResult {
    }
  }
 
+ // Border-municipality static SEO pages — one page per Italian comune under
+ // the municipalities hub. The build emits the actual page body outside
+ // #root; staticOverlay keeps SPA navigation from replacing it with the
+ // generic "Comuni di Frontiera" sub-tab.
+ if (
+   /^\/vivere-in-ticino\/comuni-di-frontiera\/[a-z0-9-]+\/?$/.test(pathname) ||
+   /^\/en\/living-in-ticino\/border-municipalities\/[a-z0-9-]+\/?$/.test(pathname) ||
+   /^\/de\/leben-im-tessin\/grenzgemeinden\/[a-z0-9-]+\/?$/.test(pathname) ||
+   /^\/fr\/vivre-au-tessin\/communes-frontiere\/[a-z0-9-]+\/?$/.test(pathname)
+ ) {
+   const localeMatch = pathname.match(/^\/(en|de|fr)\//);
+   const targetLocale = (localeMatch ? localeMatch[1] : 'it') as Locale;
+   return { route: { activeTab: 'vita', vitaSubTab: 'municipalities', staticOverlay: true }, locale: targetLocale };
+ }
+
  // FR salary calculator landing — /fr/calculer-salaire/calcul-salaire-net-frontalier-suisse/.
  // Without staticOverlay the SPA's calculator tab parser treats the trailing
  // segment as an unknown sub-tab slug, falls back to the default calculator

--- a/tests/seo/static-overlay-coverage.test.ts
+++ b/tests/seo/static-overlay-coverage.test.ts
@@ -38,6 +38,12 @@ const cases: ReadonlyArray<{ url: string; tab: string }> = [
   { url: '/report/frontalieri-2026/', tab: 'stats' },
   { url: '/guida-frontaliere/mappa-live-valichi/', tab: 'guida' },
   { url: '/guida-frontaliere/guida-completa-calcolo-stipendio-frontaliere-2026/', tab: 'guida' },
+
+  // Border municipality profiles (borderMunicipalityPagesPlugin)
+  { url: '/vivere-in-ticino/comuni-di-frontiera/como/', tab: 'vita' },
+  { url: '/en/living-in-ticino/border-municipalities/como/', tab: 'vita' },
+  { url: '/de/leben-im-tessin/grenzgemeinden/como/', tab: 'vita' },
+  { url: '/fr/vivre-au-tessin/communes-frontiere/como/', tab: 'vita' },
 ];
 
 describe('static-overlay coverage — SEO shell URLs must be recognised by parsePath', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,6 +66,7 @@ import { borderWaitPagesPlugin } from './build-plugins/borderWaitPagesPlugin';
 import { marketReportPlugin } from './build-plugins/marketReportPlugin';
 import { annualReportPlugin } from './build-plugins/annualReportPlugin';
 import { borderWaitMapPlugin } from './build-plugins/borderWaitMapPlugin';
+import { borderMunicipalityPagesPlugin } from './build-plugins/borderMunicipalityPagesPlugin';
 import { nursingLandingsPlugin } from './build-plugins/nursingLandingsPlugin';
 import { careerLandingsPlugin } from './build-plugins/careerLandingsPlugin';
 import { professionLandingsPlugin } from './build-plugins/professionLandingsPlugin';
@@ -150,6 +151,7 @@ export default defineConfig(({ mode }) => {
  // callout linking to the annual report.
  annualReportPlugin(__dirname),
  borderWaitMapPlugin(__dirname),
+ borderMunicipalityPagesPlugin(__dirname),
  nursingLandingsPlugin(__dirname),
  // AE-2 — 4 career quick-win landings × 4 locales = 16 HTML outputs. Uses
  // concorsi.ti.ch snapshot + SECO AVG registry for cited content.


### PR DESCRIPTION
## Summary
- add static SEO profiles for Ticino-corridor border municipalities in 4 locales
- include nearest border crossing, wait snapshot, commute scenarios, FAQ JSON-LD, and sitemap coverage
- register staticOverlay routing and coverage tests

## Verification
- BORDER_MUNICIPALITY_STANDALONE=1 ./node_modules/.bin/tsx -e "import { borderMunicipalityPagesPlugin } from './build-plugins/borderMunicipalityPagesPlugin.ts'; (async () => { const plugin = borderMunicipalityPagesPlugin(process.cwd()); await plugin.closeBundle?.call({}); })().catch((e) => { console.error(e); process.exit(1); });"
- ./node_modules/.bin/vitest run tests/seo/static-overlay-coverage.test.ts --reporter=dot
- NODE_OPTIONS='--max-old-space-size=8192' FAST_BUILD=1 ./node_modules/.bin/vite build --minify esbuild
- Playwright mobile/desktop smoke on /vivere-in-ticino/comuni-di-frontiera/como/

Note: tsc --noEmit with default heap OOMed locally before completion.