### PR TITLE
fix(article-gen): track validated JSON success

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -64,7 +64,7 @@ import { readFileSync, writeFileSync, mkdirSync, statSync, readdirSync, copyFile
 import { execSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import path from 'node:path';
-import { callLLM as _aiCallLLM, AI_MODELS, getStats as getAiStats, initScoreStore, flushScores, recordModelContentFailure } from './lib/ai-models.mjs';
+import { callLLM as _aiCallLLM, AI_MODELS, getStats as getAiStats, initScoreStore, flushScores, recordModelContentFailure, recordModelContentSuccess } from './lib/ai-models.mjs';
 import { AI_SEARCH_PROMPT_BLOCK_IT } from './lib/ai-search-template.mjs';
 import { tokenizeIt, jaccardSim, containmentSim, normalizeItWord } from './lib/it-text-similarity.mjs';
 import { DOMAIN_DUP_STOPLIST, filterDistinctive } from './lib/dup-stoplist.mjs';
@@ -2367,6 +2367,8 @@ async function callLLM(messages, opts = {}) {
         // MAX_CONSECUTIVE_CONTENT_FAILURES → model exhausted for this run).
         recordModelContentFailure(modelUsedRef.model);
         if (attempt < maxBody2Retries) continue;
+      } else {
+        recordModelContentSuccess(modelUsedRef.model);
       }
     }
     return result;

--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1222,8 +1222,17 @@ export function recordModelSuccess(modelId) {
   d.successes++;
   _modelDetails.set(modelId, d);
   _dirtyModels.add(modelId);
-  _consecutiveContentFailures.delete(modelId);
   _schedulePersist();
+}
+
+/**
+ * Clear downstream content-quality failures after a caller has parsed and
+ * validated the HTTP-200 payload. Plain transport success is not enough: weak
+ * models can return malformed JSON forever unless validation owns this reset.
+ */
+export function recordModelContentSuccess(modelId) {
+  if (!modelId) return;
+  _consecutiveContentFailures.delete(modelId);
 }
 
 /**
@@ -1357,10 +1366,13 @@ export function printRunSummary() {
 /** Reset exhausted models and scores (useful for long-running processes or tests) */
 export function resetState() {
   _exhaustedModels.clear();
+  _exhaustedLogged.clear();
   _providerCooldown.clear();
   _modelScores.clear();
   _modelDetails.clear();
   _dirtyModels.clear();
+  _consecutive429.clear();
+  _consecutiveContentFailures.clear();
   _mutationCount = 0;
   if (_persistTimer) { clearTimeout(_persistTimer); _persistTimer = null; }
   _stats.calls = 0;

--- a/tests/scripts/ai-models-content-failures.test.ts
+++ b/tests/scripts/ai-models-content-failures.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const aiModels = await import('../../scripts/lib/ai-models.mjs');
+
+describe('ai-models content-quality failure tracking', () => {
+  beforeEach(() => {
+    aiModels.resetState();
+  });
+
+  it('does not let HTTP success reset malformed-content streaks', () => {
+    aiModels.recordModelContentFailure('mistral/ministral-8b-latest');
+    aiModels.recordModelSuccess('mistral/ministral-8b-latest');
+    aiModels.recordModelContentFailure('mistral/ministral-8b-latest');
+
+    expect(aiModels.getStats().exhaustedModels).toContain('mistral/ministral-8b-latest');
+  });
+
+  it('resets the malformed-content streak only after validated content success', () => {
+    aiModels.recordModelContentFailure('mistral/ministral-8b-latest');
+    aiModels.recordModelContentSuccess('mistral/ministral-8b-latest');
+    aiModels.recordModelContentFailure('mistral/ministral-8b-latest');
+
+    expect(aiModels.getStats().exhaustedModels).not.toContain('mistral/ministral-8b-latest');
+  });
+});


### PR DESCRIPTION
## Summary
- keep malformed-content streaks until a payload is parsed and validated
- reset the streak only after create-article accepts required IT JSON fields
- add regression tests for HTTP success between malformed payloads

## Tests
- npx vitest run tests/scripts/ai-models-content-failures.test.ts
- npx vitest run tests/pre-spend-topic-gate.test.ts tests/create-article-gates.test.ts
- npm run test:articles
- git diff --check