### PR TITLE
Reduce job page font payload

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2497,10 +2497,6 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  <meta property="og:image:height" content="630">
  <meta property="og:image:type" content="${perLocaleSlug.it ? 'image/webp' : 'image/png'}">
  <link rel="canonical" href="${effectiveCanonicalUrl}">
- <link rel="preconnect" href="https://fonts.googleapis.com">
- <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
- <link rel="preload" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" as="style" crossorigin>
- <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" media="print" onload="this.media='all'" crossorigin data-clarity-unmask="true"><noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Outfit:wght@700;800&display=swap" crossorigin data-clarity-unmask="true"></noscript>
  ${SEO_STATIC_CSS_LINK}
 ${hreflangHtml}
  <script type="application/ld+json">${jobLd}</script>

--- a/tests/jobs-seo-pages-plugin.test.ts
+++ b/tests/jobs-seo-pages-plugin.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { JOB_SEO_LOCALES, pickSearchLandingFallbackJobs } from '../build-plugins/jobsSeoPagesPlugin';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('jobsSeoPagesPlugin search landing fallback', () => {
   it('falls back to the first locale with matching jobs instead of assuming italian exists', () => {
@@ -27,5 +32,14 @@ describe('jobsSeoPagesPlugin search landing fallback', () => {
 
     expect(fallback).toEqual([{ slug: 'ricerca-infermiere' }]);
     expect(JOB_SEO_LOCALES).toEqual(['it', 'en', 'de', 'fr']);
+  });
+});
+
+describe('jobsSeoPagesPlugin static payload budget', () => {
+  it('does not inline the remote Google Fonts loader on every job detail page', () => {
+    const source = readFileSync(resolve(__dirname, '../build-plugins/jobsSeoPagesPlugin.ts'), 'utf8');
+
+    expect(source).not.toContain('fonts.googleapis.com/css2?family=Manrope');
+    expect(source).not.toContain('fonts.gstatic.com');
   });
 });


### PR DESCRIPTION
## Summary
- remove the repeated Google Fonts loader from generated job detail static HTML
- add a regression test so the job SEO plugin does not reintroduce the remote font block

## Why
The old Pages artifact is 10,995,722,240 bytes as a tar, about 258 MB over the 10 GiB GitHub Pages limit. The repeated job-page font block is about 689 bytes per HTML page; removing it from the high-volume job detail template should save hundreds of MB without removing pages, content, JSON-LD, sitemap coverage, or quality gates.

## Verification
- npx vitest run tests/jobs-seo-pages-plugin.test.ts
- npm run validate:third-party-secrets
- git diff --check
- GitNexus detect changes: risk 0.00, no affected flows/test gaps