### PR TITLE
Slim flat bridge social meta

### DIFF
--- a/build-plugins/flatHtmlRedirectPlugin.ts
+++ b/build-plugins/flatHtmlRedirectPlugin.ts
@@ -35,7 +35,7 @@ import fs from 'node:fs';
 import type { Plugin } from 'vite';
 
 /**
- * Extract og:* / twitter:* / description meta tags from the sibling index.html
+ * Extract only preview-critical meta tags from the sibling index.html
  * so the bridge can serve them to crawlers (Facebook, Twitter, LinkedIn, Slack…)
  * that don't follow the JS location.replace redirect. The bridge keeps
  * `noindex,follow` for Google — only social crawlers care about OG.
@@ -46,6 +46,9 @@ import type { Plugin } from 'vite';
  *
  * Defense-in-depth for deploy run #25033670793: even if a crawler hits the
  * no-slash URL, it now gets correct preview metadata instead of a blank bridge.
+ * Keep this list tight: flat bridges are high-volume noindex pages, so
+ * repeated non-essential OG tags quickly become hundreds of MB in the Pages
+ * artifact.
  *
  * Re-applied 2026-04-28 after confirming the text-html-ratio regression
  * was caused by the SPA-style job-card refactor (commit affb542cc), NOT by
@@ -67,10 +70,13 @@ function extractOgTags(indexHtml: string): string {
     }
     const property = String(attrs.property || '').toLowerCase();
     const name = String(attrs.name || '').toLowerCase();
-    const isOg = property.startsWith('og:');
-    const isTwitter = name.startsWith('twitter:');
+    const isOgPreview =
+      property === 'og:title' ||
+      property === 'og:description' ||
+      property === 'og:image' ||
+      property === 'og:image:alt';
     const isDescription = name === 'description';
-    if (isOg || isTwitter || isDescription) {
+    if (isOgPreview || isDescription) {
       tags.push(tag);
     }
   }

--- a/tests/flat-html-redirect.test.ts
+++ b/tests/flat-html-redirect.test.ts
@@ -97,6 +97,43 @@ describe('flatHtmlRedirectPlugin redirect bridge', () => {
     expect(bridge).not.toMatch(/http-equiv\s*=\s*["']refresh["']/i);
   });
 
+  it('keeps only preview-critical social meta on noindex bridge pages', async () => {
+    fixture = setupFixture(
+      '<!DOCTYPE html><html><head><title>Foo Bar</title>' +
+        '<meta name="description" content="Useful summary">' +
+        '<meta property="og:title" content="Share title">' +
+        '<meta property="og:description" content="Share description">' +
+        '<meta property="og:image" content="https://frontaliereticino.ch/og/foo.webp">' +
+        '<meta property="og:image:alt" content="Preview alt">' +
+        '<meta property="og:type" content="article">' +
+        '<meta property="og:site_name" content="Frontaliere Ticino">' +
+        '<meta property="og:locale" content="it_IT">' +
+        '<meta property="og:url" content="https://frontaliereticino.ch/foo/">' +
+        '<meta property="og:image:width" content="1200">' +
+        '<meta property="og:image:height" content="630">' +
+        '<meta property="og:image:type" content="image/webp">' +
+        '<meta name="twitter:title" content="Duplicate title">' +
+        '</head><body>canonical</body></html>',
+    );
+
+    await runPluginCloseBundle(fixture.tmpRoot);
+
+    const bridge = fs.readFileSync(fixture.flatFile, 'utf-8');
+    expect(bridge).toContain('<meta name="description" content="Useful summary">');
+    expect(bridge).toContain('<meta property="og:title" content="Share title">');
+    expect(bridge).toContain('<meta property="og:description" content="Share description">');
+    expect(bridge).toContain('<meta property="og:image" content="https://frontaliereticino.ch/og/foo.webp">');
+    expect(bridge).toContain('<meta property="og:image:alt" content="Preview alt">');
+    expect(bridge).not.toContain('og:type');
+    expect(bridge).not.toContain('og:site_name');
+    expect(bridge).not.toContain('og:locale');
+    expect(bridge).not.toContain('og:url');
+    expect(bridge).not.toContain('og:image:width');
+    expect(bridge).not.toContain('og:image:height');
+    expect(bridge).not.toContain('og:image:type');
+    expect(bridge).not.toContain('twitter:title');
+  });
+
   it('falls back to a per-URL string when the sibling has no parsable title', async () => {
     fixture = setupFixture('<!DOCTYPE html><html><head></head><body>no title here</body></html>');
 


### PR DESCRIPTION
## Summary
- keep only preview-critical meta tags on noindex flat bridge pages
- preserve description, og:title, og:description, og:image, and og:image:alt
- drop repeated non-essential OG/twitter metadata from bridge pages

## Why
The old Pages artifact contains 479,207 flat redirect bridge files. Streaming analysis measured ~144.8 MB of removable non-essential OG metadata there, or ~152.6 MB after tar block rounding, without removing pages or touching canonical indexed pages.

## Verification
- npx vitest run tests/flat-html-redirect.test.ts
- npm run validate:third-party-secrets
- git diff --check
- GitNexus detect changes: risk 0.00, no affected flows/test gaps