### PR TITLE
fix: restore static post-build pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -494,6 +494,9 @@ jobs:
           set -o pipefail
           npm run build:ci 2>&1 | tee /tmp/build.log
 
+      - name: Verify critical dist pages before upload
+        run: node scripts/validate-critical-dist-pages.mjs
+
       - name: Build profile summary
         if: always()
         shell: bash

--- a/scripts/validate-critical-dist-pages.mjs
+++ b/scripts/validate-critical-dist-pages.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Guardrail for deploy builds: fail before artifact upload when critical
+ * static SEO pages were not emitted into dist/.
+ */
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const distDir = path.join(root, 'dist');
+
+const requiredPages = [
+  'index.html',
+  '404.html',
+  'en/index.html',
+  'de/index.html',
+  'fr/index.html',
+  'calcola-stipendio/index.html',
+  'cerca-lavoro-ticino/index.html',
+  'glossario-frontaliere/index.html',
+  'guida-frontaliere/index.html',
+  'mappa-del-sito/index.html',
+  'privacy/index.html',
+  'sitemap.xml',
+];
+
+const missing = requiredPages.filter((rel) => !existsSync(path.join(distDir, rel)));
+
+if (missing.length > 0) {
+  console.error('[validate-critical-dist-pages] FAIL: critical dist pages are missing:');
+  for (const rel of missing) console.error(`  - dist/${rel}`);
+  console.error(
+    '\nThese pages are emitted by post-build SEO/static plugins. Do not upload a Pages artifact until the root cause is fixed.',
+  );
+  process.exit(1);
+}
+
+console.log(`[validate-critical-dist-pages] PASS: ${requiredPages.length} critical dist files present`);

--- a/tests/build-plugin-order.test.ts
+++ b/tests/build-plugin-order.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import viteConfig from '../vite.config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function pluginNames(): string[] {
+  const resolved = typeof viteConfig === 'function'
+    ? viteConfig({ command: 'build', mode: 'production' })
+    : viteConfig;
+  const plugins = Array.isArray(resolved.plugins) ? resolved.plugins.flat() : [];
+  return plugins.map((plugin) => plugin?.name).filter((name): name is string => Boolean(name));
+}
+
+describe('build plugin ordering', () => {
+  it('runs border municipality pages after static pages in sequential closeBundle builds', () => {
+    const names = pluginNames();
+    const staticIdx = names.indexOf('static-pages');
+    const borderIdx = names.indexOf('border-municipality-pages');
+    const relatedIdx = names.indexOf('related-search-clusters');
+
+    expect(staticIdx).toBeGreaterThanOrEqual(0);
+    expect(borderIdx).toBeGreaterThan(staticIdx);
+    expect(relatedIdx).toBeGreaterThan(borderIdx);
+  });
+
+  it('keeps the deploy critical-dist guard before artifact upload', () => {
+    const workflow = fs.readFileSync(path.resolve(__dirname, '../.github/workflows/deploy.yml'), 'utf-8');
+    const guardIdx = workflow.indexOf('node scripts/validate-critical-dist-pages.mjs');
+    const uploadIdx = workflow.indexOf('Upload Pages artifact');
+
+    expect(guardIdx).toBeGreaterThanOrEqual(0);
+    expect(uploadIdx).toBeGreaterThan(guardIdx);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -151,7 +151,6 @@ export default defineConfig(({ mode }) => {
  // callout linking to the annual report.
  annualReportPlugin(__dirname),
  borderWaitMapPlugin(__dirname),
- borderMunicipalityPagesPlugin(__dirname),
  nursingLandingsPlugin(__dirname),
  // AE-2 — 4 career quick-win landings × 4 locales = 16 HTML outputs. Uses
  // concorsi.ti.ch snapshot + SECO AVG registry for cited content.
@@ -188,6 +187,10 @@ export default defineConfig(({ mode }) => {
  // the link from each section landing to the cluster paginated hub is
  // never written, breaking the hub's inbound link graph.
  staticPagesPlugin(__dirname),
+ // Border-municipality pages patch the static hub after it has been flushed.
+ // Keep this after staticPagesPlugin: with sequential closeBundle hooks,
+ // running it earlier would wait on a signal that cannot be resolved yet.
+ borderMunicipalityPagesPlugin(__dirname),
  // Related-search cluster landings (B2). Self-gated by
  // SKIP_RELATED_SEARCH_CLUSTERS=1 (no outer wrapper needed); skipped in
  // typical agent sessions via .claude/settings.json env block.


### PR DESCRIPTION
## Summary
- run border municipality pages after static pages so sequential closeBundle builds do not wait before static-pages can flush
- add a pre-upload critical dist guard for locale/root SEO pages and sitemap
- add regression coverage for plugin order and deploy guard placement

## Verification
- npx vitest run tests/build-plugin-order.test.ts
- git diff --check
- node --check scripts/validate-critical-dist-pages.mjs
- synthetic dist run: node scripts/validate-critical-dist-pages.mjs
- GitNexus detect changes (risk 0.00)