### PR TITLE
Fix build profiling guard and cluster indexing perf

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -497,6 +497,9 @@ jobs:
       - name: Verify critical dist pages before upload
         run: node scripts/validate-critical-dist-pages.mjs
 
+      - name: Verify build profile markers before upload
+        run: node scripts/validate-build-profile-markers.mjs /tmp/build.log
+
       - name: Build profile summary
         if: always()
         shell: bash

--- a/build-plugins/profilePlugin.ts
+++ b/build-plugins/profilePlugin.ts
@@ -5,10 +5,8 @@
  * `Build profile summary` step parses these stdout lines into a Markdown
  * table).
  *
- * Activation: only when `BUILD_PROFILE=1` is set in the environment. In
- * normal local builds the wrappers are no-ops — `withProfile()` returns the
- * input plugin unchanged, so there is zero runtime overhead and zero risk
- * of altering plugin behavior.
+ * Activation: on by default for every build so local and CI logs both expose
+ * plugin timing regressions. Set `BUILD_PROFILE=0` to opt out.
  *
  * Output format (one line per plugin per closeBundle invocation):
  *
@@ -31,7 +29,7 @@
 
 import type { Plugin } from 'vite';
 
-const PROFILE_ON = process.env.BUILD_PROFILE === '1';
+const PROFILE_ON = process.env.BUILD_PROFILE !== '0';
 // Force sequential closeBundle execution. Use only for one-off profiling runs:
 // it serializes every plugin so wall-clock per plugin reflects real work
 // instead of parallel-overlapped time. Slower than normal — opt-in via env.
@@ -44,7 +42,7 @@ const timings = new Map<string, number>();
 
 /**
  * Wrap a Vite Plugin so its `closeBundle` hook is timed. Returns the input
- * plugin unchanged when `BUILD_PROFILE !== '1'` or when the plugin has no
+ * plugin unchanged when `BUILD_PROFILE=0` or when the plugin has no
  * `closeBundle` to wrap.
  */
 export function withProfile(plugin: Plugin): Plugin {

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -496,10 +496,11 @@ interface ClusterContext {
 
 // ── Inverted index for token → posting list of jobIdx ────────────────────
 // Lazy-builds posting lists per (locale, token) pair. Each posting list is
-// computed once with a full O(jobs) substring scan, then reused across every
-// candidate that contains the same token. Across the candidate corpus there
-// are ~13.6k unique (locale, token) pairs vs ~53k candidates × 1.9k jobs
-// for the naive nested scan — a measured ~4× ceiling on the inner loop.
+// computed once, then reused across every candidate that contains the same
+// token. A per-locale alphanumeric 2/3-gram index narrows each token to a
+// small candidate job set before the final `haystack.includes(token)` check.
+// This preserves exact substring semantics while avoiding ~30k locale-token
+// full-corpus scans on the current 180k-candidate corpus.
 //
 // Substring semantics are preserved exactly: each posting list contains
 // jobIdx for every job whose locale-specific haystack contains `token` as a
@@ -509,6 +510,7 @@ interface ClusterContext {
 class TokenIndex {
   private haystacksByLocale = new Map<Locale, string[]>();
   private postingsByLocale = new Map<Locale, Map<string, number[]>>();
+  private gramPostingsByLocale = new Map<Locale, Map<string, number[]>>();
   private readonly scratchScores: Uint16Array;
   private readonly touchedIdx: number[] = [];
   private readonly jobs: ReadonlyArray<RawJob>;
@@ -529,9 +531,10 @@ class TokenIndex {
     if (cached !== undefined) return cached;
 
     const haystacks = this.getHaystacks(locale);
+    const candidateJobs = this.candidateJobsForToken(locale, token);
     const list: number[] = [];
-    for (let i = 0; i < haystacks.length; i++) {
-      if (haystacks[i].includes(token)) list.push(i);
+    for (const idx of candidateJobs) {
+      if (haystacks[idx].includes(token)) list.push(idx);
     }
     perLocale.set(token, list);
     return list;
@@ -563,6 +566,7 @@ class TokenIndex {
   clear(): void {
     this.haystacksByLocale.clear();
     this.postingsByLocale.clear();
+    this.gramPostingsByLocale.clear();
     this.touchedIdx.length = 0;
   }
 
@@ -575,6 +579,62 @@ class TokenIndex {
     }
     this.haystacksByLocale.set(locale, arr);
     return arr;
+  }
+
+  private getGramPostings(locale: Locale): Map<string, number[]> {
+    const cached = this.gramPostingsByLocale.get(locale);
+    if (cached) return cached;
+
+    const haystacks = this.getHaystacks(locale);
+    const grams = new Map<string, number[]>();
+    const seenInJob = new Set<string>();
+
+    for (let jobIdx = 0; jobIdx < haystacks.length; jobIdx++) {
+      const haystack = haystacks[jobIdx];
+      seenInJob.clear();
+
+      for (const width of [2, 3]) {
+        if (haystack.length < width) continue;
+        for (let i = 0; i <= haystack.length - width; i++) {
+          const gram = haystack.slice(i, i + width);
+          if (!isSearchTokenGram(gram)) continue;
+          if (seenInJob.has(gram)) continue;
+          seenInJob.add(gram);
+
+          let list = grams.get(gram);
+          if (!list) {
+            list = [];
+            grams.set(gram, list);
+          }
+          list.push(jobIdx);
+        }
+      }
+    }
+
+    this.gramPostingsByLocale.set(locale, grams);
+    return grams;
+  }
+
+  private candidateJobsForToken(locale: Locale, token: string): readonly number[] {
+    const grams = this.getGramPostings(locale);
+    if (token.length <= 2) {
+      return grams.get(token) ?? [];
+    }
+
+    let rarest: readonly number[] | null = null;
+    const seenTokenGrams = new Set<string>();
+    for (let i = 0; i <= token.length - 3; i++) {
+      const gram = token.slice(i, i + 3);
+      if (seenTokenGrams.has(gram)) continue;
+      seenTokenGrams.add(gram);
+
+      const list = grams.get(gram) ?? [];
+      if (rarest === null || list.length < rarest.length) {
+        rarest = list;
+        if (rarest.length === 0) break;
+      }
+    }
+    return rarest ?? [];
   }
 
   private firstAndMatches(lists: ReadonlyArray<readonly number[]>, maxJobs: number): number[] {
@@ -625,6 +685,16 @@ class TokenIndex {
     for (const idx of touched) scores[idx] = 0;
     touched.length = 0;
   }
+}
+
+function isSearchTokenGram(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    const isDigit = code >= 48 && code <= 57;
+    const isLowerAscii = code >= 97 && code <= 122;
+    if (!isDigit && !isLowerAscii) return false;
+  }
+  return true;
 }
 
 function binaryIncludes(sorted: readonly number[], value: number): boolean {

--- a/build-plugins/shared/jobsSeoProfiler.ts
+++ b/build-plugins/shared/jobsSeoProfiler.ts
@@ -1,9 +1,9 @@
 /**
  * jobsSeoProfiler — per-category instrumentation for jobsSeoPagesPlugin.
  *
- * Activated by default whenever `BUILD_PROFILE=1` is set, which is the normal
- * CI build path. Set `JOBS_SEO_PROFILE=0` to opt out, or `JOBS_SEO_PROFILE=1`
- * to force this table on in a one-off local/profile run.
+ * Activated by default with build profiling. Set `JOBS_SEO_PROFILE=0` or
+ * `BUILD_PROFILE=0` to opt out, or `JOBS_SEO_PROFILE=1` to force this table
+ * on in a one-off local/profile run.
  *
  * Categories the plugin emits:
  *   - active-job                 → /cerca-lavoro-{loc}/<slug>/index.html
@@ -48,7 +48,7 @@
  */
 
 const ENABLED = process.env.JOBS_SEO_PROFILE === '1'
-  || (process.env.JOBS_SEO_PROFILE !== '0' && process.env.BUILD_PROFILE === '1');
+  || (process.env.JOBS_SEO_PROFILE !== '0' && process.env.BUILD_PROFILE !== '0');
 
 type CategoryStats = {
   count: number;

--- a/build-plugins/shared/relatedSearchClustersProfiler.ts
+++ b/build-plugins/shared/relatedSearchClustersProfiler.ts
@@ -2,13 +2,12 @@
  * relatedSearchClustersProfiler — per-phase instrumentation for
  * relatedSearchClustersPlugin.
  *
- * Activated by default whenever `BUILD_PROFILE=1` is set, which is the normal
- * CI build path. Set `RELATED_SEARCH_CLUSTERS_PROFILE=0` to opt out, or
- * `RELATED_SEARCH_CLUSTERS_PROFILE=1` to force this table on locally.
+ * Activated by default with build profiling. Set
+ * `RELATED_SEARCH_CLUSTERS_PROFILE=0` or `BUILD_PROFILE=0` to opt out.
  */
 
 const ENABLED = process.env.RELATED_SEARCH_CLUSTERS_PROFILE === '1'
-  || (process.env.RELATED_SEARCH_CLUSTERS_PROFILE !== '0' && process.env.BUILD_PROFILE === '1');
+  || (process.env.RELATED_SEARCH_CLUSTERS_PROFILE !== '0' && process.env.BUILD_PROFILE !== '0');
 
 type CategoryStats = {
   count: number;

--- a/build-plugins/shared/weeklyEmployersProfiler.ts
+++ b/build-plugins/shared/weeklyEmployersProfiler.ts
@@ -2,10 +2,9 @@
  * weeklyEmployersProfiler — per-category instrumentation for
  * weeklyEmployersPlugin.
  *
- * Activated by default whenever `BUILD_PROFILE=1` is set, which is the normal
- * CI build path. Set `WEEKLY_EMPLOYERS_PROFILE=0` to opt out, or
- * `WEEKLY_EMPLOYERS_PROFILE=1` to force this table on in a one-off local/profile
- * run.
+ * Activated by default with build profiling. Set `WEEKLY_EMPLOYERS_PROFILE=0`
+ * or `BUILD_PROFILE=0` to opt out, or `WEEKLY_EMPLOYERS_PROFILE=1` to force
+ * this table on in a one-off local/profile run.
  *
  * Categories the plugin times:
  *   - cleanup                    → wipe owned namespaces + sitemap files
@@ -45,7 +44,7 @@
  */
 
 const ENABLED = process.env.WEEKLY_EMPLOYERS_PROFILE === '1'
-  || (process.env.WEEKLY_EMPLOYERS_PROFILE !== '0' && process.env.BUILD_PROFILE === '1');
+  || (process.env.WEEKLY_EMPLOYERS_PROFILE !== '0' && process.env.BUILD_PROFILE !== '0');
 
 type CategoryStats = {
   count: number;

--- a/scripts/validate-build-profile-markers.mjs
+++ b/scripts/validate-build-profile-markers.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Deploy guardrail: a production build must not be considered successful when
+ * the late SEO plugins silently failed to run. This catches sequential
+ * closeBundle deadlocks where Vite exits after a partial plugin chain.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+
+const logPath = process.argv[2] || '/tmp/build.log';
+
+if (!existsSync(logPath)) {
+  console.error(`[validate-build-profile-markers] FAIL: build log not found at ${logPath}`);
+  process.exit(1);
+}
+
+const log = readFileSync(logPath, 'utf-8');
+
+const requiredMarkers = [
+  {
+    label: 'related-search closeBundle profile',
+    pattern: /\[profile\]\s+related-search-clusters\s+\d+(?:\.\d+)?s/,
+  },
+  {
+    label: 'related-search internal profile total',
+    pattern: /\[related-search-profile\]\s+TOTAL\s+\d+\s+\d+(?:\.\d+)?/,
+  },
+  {
+    label: 'post-walk coordinator profile',
+    pattern: /\[profile\]\s+post-walk-coordinator\s+\d+(?:\.\d+)?s/,
+  },
+  {
+    label: 'post-walk coordinator completion log',
+    pattern: /\[post-walk-coordinator\]\x1b\[0m scanned \d+ files in \d+(?:\.\d+)?s|\[post-walk-coordinator\] scanned \d+ files in \d+(?:\.\d+)?s/,
+  },
+  {
+    label: 'profile total',
+    pattern: /\[profile-total\] closeBundle phase total: \d+(?:\.\d+)?s across \d+ plugins/,
+  },
+];
+
+const missing = requiredMarkers.filter(({ pattern }) => !pattern.test(log));
+
+if (missing.length > 0) {
+  console.error('[validate-build-profile-markers] FAIL: required build profile markers missing:');
+  for (const marker of missing) console.error(`  - ${marker.label}`);
+  console.error(
+    '\nA deploy build without these markers is not a valid performance sample and may be missing static SEO output.',
+  );
+  process.exit(1);
+}
+
+console.log(`[validate-build-profile-markers] PASS: ${requiredMarkers.length} required build profile markers present`);

--- a/tests/build-plugin-order.test.ts
+++ b/tests/build-plugin-order.test.ts
@@ -7,32 +7,51 @@ import viteConfig from '../vite.config';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function isNamedPlugin(plugin: unknown): plugin is { name: string } {
+  return Boolean(plugin)
+    && typeof plugin === 'object'
+    && 'name' in plugin
+    && typeof (plugin as { name?: unknown }).name === 'string';
+}
+
 function pluginNames(): string[] {
   const resolved = typeof viteConfig === 'function'
     ? viteConfig({ command: 'build', mode: 'production' })
     : viteConfig;
   const plugins = Array.isArray(resolved.plugins) ? resolved.plugins.flat() : [];
-  return plugins.map((plugin) => plugin?.name).filter((name): name is string => Boolean(name));
+  return plugins.filter(isNamedPlugin).map((plugin) => plugin.name);
+}
+
+function expectPluginAfter(names: string[], consumer: string, producer: string): void {
+  const producerIdx = names.indexOf(producer);
+  const consumerIdx = names.indexOf(consumer);
+
+  expect(producerIdx, `${producer} must be registered`).toBeGreaterThanOrEqual(0);
+  expect(consumerIdx, `${consumer} must be registered`).toBeGreaterThanOrEqual(0);
+  expect(consumerIdx, `${consumer} waits for ${producer}; it must run later in sequential closeBundle`).toBeGreaterThan(producerIdx);
 }
 
 describe('build plugin ordering', () => {
-  it('runs border municipality pages after static pages in sequential closeBundle builds', () => {
+  it('keeps signal consumers after their producers in sequential closeBundle builds', () => {
     const names = pluginNames();
-    const staticIdx = names.indexOf('static-pages');
-    const borderIdx = names.indexOf('border-municipality-pages');
-    const relatedIdx = names.indexOf('related-search-clusters');
 
-    expect(staticIdx).toBeGreaterThanOrEqual(0);
-    expect(borderIdx).toBeGreaterThan(staticIdx);
-    expect(relatedIdx).toBeGreaterThan(borderIdx);
+    expectPluginAfter(names, 'border-municipality-pages', 'static-pages');
+    expectPluginAfter(names, 'profession-landings-links', 'static-pages');
+    expectPluginAfter(names, 'profession-landings-links', 'profession-landings');
+    expectPluginAfter(names, 'salary-hub-index-link', 'static-pages');
+    expectPluginAfter(names, 'salary-hub-index-link', 'salary-hub-seo');
+    expectPluginAfter(names, 'related-search-clusters', 'jobs-seo-pages');
+    expectPluginAfter(names, 'post-walk-coordinator', 'related-search-clusters');
   });
 
-  it('keeps the deploy critical-dist guard before artifact upload', () => {
+  it('keeps deploy output guards before artifact upload', () => {
     const workflow = fs.readFileSync(path.resolve(__dirname, '../.github/workflows/deploy.yml'), 'utf-8');
-    const guardIdx = workflow.indexOf('node scripts/validate-critical-dist-pages.mjs');
+    const criticalGuardIdx = workflow.indexOf('node scripts/validate-critical-dist-pages.mjs');
+    const profileGuardIdx = workflow.indexOf('node scripts/validate-build-profile-markers.mjs /tmp/build.log');
     const uploadIdx = workflow.indexOf('Upload Pages artifact');
 
-    expect(guardIdx).toBeGreaterThanOrEqual(0);
-    expect(uploadIdx).toBeGreaterThan(guardIdx);
+    expect(criticalGuardIdx).toBeGreaterThanOrEqual(0);
+    expect(profileGuardIdx).toBeGreaterThan(criticalGuardIdx);
+    expect(uploadIdx).toBeGreaterThan(profileGuardIdx);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,8 +99,8 @@ export default defineConfig(({ mode }) => {
  const env = loadEnv(mode, '.', '');
  // Build the unified plugin list, then wrap every entry in `withProfile()`
  // and append `profileSummaryPlugin()` last so it emits the total line
- // after every wrapped closeBundle has resolved. `withProfile` is a no-op
- // when BUILD_PROFILE !== '1' (zero overhead in normal local builds).
+ // after every wrapped closeBundle has resolved. Profiling is on by default;
+ // set BUILD_PROFILE=0 to opt out for local one-offs.
  const allPlugins: Plugin[] = [
  // ── Core plugins (always run, including FAST_BUILD) ──────────
  // `@vitejs/plugin-react` returns multiple plugins (one per React feature
@@ -314,7 +314,7 @@ export default defineConfig(({ mode }) => {
  // last hook in the chain.
  writeRegistryReportPlugin({ rootDir: __dirname }),
  // Emits `[profile-total] ...` after every wrapped plugin's closeBundle has
- // resolved. No-op when BUILD_PROFILE !== '1'.
+ // resolved. No-op when BUILD_PROFILE=0.
  profileSummaryPlugin(),
  ],
  define: {


### PR DESCRIPTION
## Summary
- keep build/plugin profilers enabled by default, with BUILD_PROFILE=0 opt-out
- fail deploy before artifact upload when late SEO profile markers are missing
- speed up related-search TokenIndex posting construction with an alphanumeric 2/3-gram prefilter while preserving final haystack.includes semantics
- extend plugin-order guardrails for signal producer/consumer ordering

## Evidence
- Root cause of the false-fast run: late plugin markers were absent, so it was not a valid perf sample.
- Benchmark on first 50k current candidates: current TokenIndex 122.8s vs n-gram prefilter 31.7s, same 1,481,787 total matches, 0 mismatches across 20k checked candidates.

## Verification
- npx vitest run tests/build-plugin-order.test.ts
- NODE_OPTIONS='--max-old-space-size=18432' npx tsc --noEmit --pretty false
- node scripts/validate-build-profile-markers.mjs /tmp/frontaliere-build-77745376323.log
- node scripts/validate-build-profile-markers.mjs /tmp/frontaliere-build-77765202745.log (expected fail)
- FAST_BUILD=1 NODE_OPTIONS='--max-old-space-size=18432' npx vite build --minify esbuild

Note: npm test was also run, but invalidated by a concurrent FAST_BUILD rewriting dist/ while dist-driven tests were reading it; failures were in dist/cathedral gates from that contaminated run, not in the touched code paths.