### PR TITLE
Fix deploy artifact bloat and validate-dist regressions

### DIFF
--- a/build-plugins/orphanQueryLandingPlugin.ts
+++ b/build-plugins/orphanQueryLandingPlugin.ts
@@ -43,6 +43,7 @@ import {
   MIN_INDEXABLE_WORDS,
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
+import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
 import {
   BREADCRUMB_LINK_STYLE,
   BREADCRUMB_STYLE,
@@ -82,6 +83,32 @@ import { adSlotHtml } from './lib/adSlotHtml';
 
 const MIN_MATCHING_JOBS = 3;
 const DEFAULT_MAX_LANDINGS = 500;
+
+export function buildOrphanLandingHubPath(locale: OrphanLandingLocale): string {
+  const prefix = ORPHAN_LANDING_LOCALE_PREFIX[locale];
+  const section = ORPHAN_LANDING_SECTION[locale];
+  return `${prefix}/${section}/`.replace(/\/+/g, '/');
+}
+
+export function buildOrphanLandingHubUrl(locale: OrphanLandingLocale): string {
+  return `${BASE_URL}${buildOrphanLandingHubPath(locale)}`;
+}
+
+export function renderOrphanLandingHubHreflang(
+  hasEntriesByLocale: Record<OrphanLandingLocale, boolean>,
+): string {
+  const availableLocales = ORPHAN_LANDING_LOCALES.filter((alt) => hasEntriesByLocale[alt]);
+  if (availableLocales.length === 0) return '';
+
+  const lines = availableLocales.map(
+    (alt) => `    <link rel="alternate" hreflang="${alt}" href="${buildOrphanLandingHubUrl(alt)}">`,
+  );
+  const xDefaultLocale = availableLocales.includes('it') ? 'it' : availableLocales[0];
+  lines.push(
+    `    <link rel="alternate" hreflang="x-default" href="${buildOrphanLandingHubUrl(xDefaultLocale)}">`,
+  );
+  return lines.join('\n');
+}
 
 /** Load and merge all jobs from main jobs.json + per-crawler slices. */
 function loadAllJobs(rootDir: string): OrphanCountableJob[] {
@@ -858,7 +885,7 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
         const indexPath = path.join(distDir, render.urlPath, 'index.html');
         const flatPath = path.join(distDir, render.urlPath.replace(/\/+$/, '') + '.html');
         collector.add(indexPath, render.html);
-        collector.add(flatPath, render.html);
+        collector.add(flatPath, buildFlatBridgeFromSibling(render.html, `${BASE_URL}${render.urlPath}`));
 
         routes.push({
           locale: cluster.locale,
@@ -927,10 +954,8 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
         if (list.length === 0) continue;
         const sorted = [...list].sort((a, b) => a.query.localeCompare(b.query, loc));
         const copy = HUB_COPY[loc];
-        const prefix = ORPHAN_LANDING_LOCALE_PREFIX[loc];
-        const section = ORPHAN_LANDING_SECTION[loc];
-        const hubPath = `${prefix}/${section}/`.replace(/\/+/g, '/');
-        const canonicalUrl = `${BASE_URL}${hubPath}`;
+        const hubPath = buildOrphanLandingHubPath(loc);
+        const canonicalUrl = buildOrphanLandingHubUrl(loc);
 
         const itemsHtml = sorted
           .map((it) => `<li class="s-q3nqK4"><a href="${esc(it.path)}" style="${LINK_ACCENT_STYLE};font-weight:600">${esc(cap(it.query))}</a></li>`)
@@ -964,15 +989,12 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
           },
         });
 
-        const hreflangHtml = ORPHAN_LANDING_LOCALES
-          .filter((alt) => indexableByLocale[alt].length > 0)
-          .map((alt) => {
-            const altPrefix = ORPHAN_LANDING_LOCALE_PREFIX[alt];
-            const altSection = ORPHAN_LANDING_SECTION[alt];
-            const altUrl = `${BASE_URL}${altPrefix}/${altSection}/`.replace(/\/+/g, '/');
-            return `    <link rel="alternate" hreflang="${alt}" href="${altUrl}">`;
-          })
-          .join('\n');
+        const hreflangHtml = renderOrphanLandingHubHreflang({
+          it: indexableByLocale.it.length > 0,
+          en: indexableByLocale.en.length > 0,
+          de: indexableByLocale.de.length > 0,
+          fr: indexableByLocale.fr.length > 0,
+        });
 
         // Locale-aware "how it works" + "who it's for" prose. Without it,
         // the hub renders as breadcrumb + h1 + intro + list — under 50 visible
@@ -1040,7 +1062,10 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
         });
 
         collector.add(path.join(distDir, hubPath, 'index.html'), hubHtml);
-        collector.add(path.join(distDir, hubPath.replace(/\/+$/, '') + '.html'), hubHtml);
+        collector.add(
+          path.join(distDir, hubPath.replace(/\/+$/, '') + '.html'),
+          buildFlatBridgeFromSibling(hubHtml, canonicalUrl),
+        );
 
         sitemapEntries.push(
           `  <url>\n    <loc>${canonicalUrl}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.7</priority>\n  </url>`,

--- a/build-plugins/salaryHubPlugin.ts
+++ b/build-plugins/salaryHubPlugin.ts
@@ -26,9 +26,16 @@ import { EVERGREEN_ARTICLES, generateArticleHtml } from './salaryHubArticles';
 import { calculateSimulation } from '../services/calculationService';
 import { buildScenarioIndexHtml, SCENARIO_INDEX_PATH } from './salaryHubIndex';
 import { resolveSalaryHubFlushed } from './shared/buildSignals';
+import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
 
 const LOCALES = ['it', 'en', 'de', 'fr'] as const;
 type Locale = (typeof LOCALES)[number];
+
+export const SALARY_HUB_SCENARIO_OWNERSHIP_PATTERN =
+  /\/(stipendio-netto|net-salary|nettogehalt|salaire-net)-\d+-chf(?:-[^/]+)*(\/index\.html|\.html)$/;
+
+export const SALARY_HUB_SCENARIO_INDEX_OWNERSHIP_PATTERN =
+  /\/(calcola-stipendio\/scenari|en\/calculate-salary\/scenarios|de\/gehalt-berechnen\/szenarien|fr\/calculer-salaire\/scenarios)(\/index\.html|\.html)$/;
 
 /**
  * Declare salaryHubPlugin as the canonical owner of every salary-scenario path
@@ -53,11 +60,17 @@ type Locale = (typeof LOCALES)[number];
  * module never accumulate stale entries.
  */
 declareSharedPath({
-  pattern:
-    /\/(stipendio-netto|net-salary|nettogehalt|salaire-net)-\d+-chf(\/index\.html|\.html)$/,
+  pattern: SALARY_HUB_SCENARIO_OWNERSHIP_PATTERN,
   winner: 'salaryHubPlugin',
   reason:
     'salaryHubPlugin emits ~500 pre-computed salary scenarios across 4 locales with full simulation data + AdSense slots. staticPagesPlugin reaches the same paths via its seoMap loop and would race-overwrite with a less-rich shell. Winner is salaryHubPlugin.',
+});
+
+declareSharedPath({
+  pattern: SALARY_HUB_SCENARIO_INDEX_OWNERSHIP_PATTERN,
+  winner: 'salaryHubPlugin',
+  reason:
+    'salaryHubPlugin emits the browseable scenario index for every locale. staticPagesPlugin can derive the same locale paths from sitemap alternates, but those fallback pages miss the salary landing shell.',
 });
 
 export function salaryHubPlugin(rootDir: string): Plugin {
@@ -114,7 +127,7 @@ export function salaryHubPlugin(rootDir: string): Plugin {
           // Write flat /calcola-stipendio/slug.html (for GitHub Pages compatibility)
           const flatSlug = urlPath.replace(/\/$/, '');
           const flatPath = path.join(distDir, `${flatSlug}.html`);
-          collector.add(flatPath, html);
+          collector.add(flatPath, buildFlatBridgeFromSibling(html, `${BASE_URL}${urlPath}`));
 
           // Sitemap entry
           const fullUrl = `${BASE_URL}${urlPath}`;
@@ -151,7 +164,10 @@ export function salaryHubPlugin(rootDir: string): Plugin {
           const urlPath = `${ARTICLE_PREFIX[locale]}/${article.slugs[locale]}/`;
 
           collector.add(path.join(distDir, urlPath, 'index.html'), html);
-          collector.add(path.join(distDir, `${urlPath.replace(/\/$/, '')}.html`), html);
+          collector.add(
+            path.join(distDir, `${urlPath.replace(/\/$/, '')}.html`),
+            buildFlatBridgeFromSibling(html, `${BASE_URL}${urlPath}`),
+          );
 
           const fullUrl = `${BASE_URL}${urlPath}`;
           sitemapEntries.push(
@@ -199,7 +215,10 @@ export function salaryHubPlugin(rootDir: string): Plugin {
         const indexPath = SCENARIO_INDEX_PATH[locale];
         collector.add(path.join(distDir, indexPath, 'index.html'), indexHtml);
         const flatSlug = indexPath.replace(/\/$/, '');
-        collector.add(path.join(distDir, `${flatSlug}.html`), indexHtml);
+        collector.add(
+          path.join(distDir, `${flatSlug}.html`),
+          buildFlatBridgeFromSibling(indexHtml, `${BASE_URL}${indexPath}`),
+        );
 
         const fullUrl = `${BASE_URL}${indexPath}`;
         sitemapEntries.push(

--- a/build-plugins/staticPagesPlugin.ts
+++ b/build-plugins/staticPagesPlugin.ts
@@ -33,6 +33,8 @@ import { getJobTodayLandingSlug, getJobNursesHubSlug, getJobPartTimeLandingSlug,
 import { SECTOR_HUB_KEYS, SECTOR_HUB_SLUG, jobMatchesSector as jobMatchesSectorImpl, type SectorHubKey } from './jobSectorLanding';
 import { MIN_JOBS_FOR_CANTON_PAGE } from './weeklyEmployersData';
 import { getCantonCities, normalizeCitySlug } from './shared/cantonCities';
+import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
+import { minifyHtml } from './shared/htmlMinify';
 
 // ── SPA shell <title> handling ────────────────────────────────────────
 // Universal rule: headline VERBATIM, brand suffix appended only when total
@@ -4319,7 +4321,7 @@ export function staticPagesPlugin(rootDir: string): Plugin {
 
  // Static-only pages: pure HTML for crawlers, no SPA bundle, no JS redirect
  if (isStaticOnly) {
- return `<!DOCTYPE html>
+ return minifyHtml(`<!DOCTYPE html>
 <html lang="${locale}">
  <head>
  <meta charset="utf-8">
@@ -4363,7 +4365,7 @@ ${hrefTags}
  <a href="/glossario-frontaliere/">Glossario</a>
  </nav>
  </body>
-</html>`;
+</html>`);
  }
 
  if (hasSpaBundle) {
@@ -4429,7 +4431,7 @@ ${hubChromeSplit.bodyHtml}
  : `<div id="root"><main id="main-content">${rootHtml}</main></div>
  <div id="footer-root"></div>`;
 
- return `<!DOCTYPE html>
+ return minifyHtml(`<!DOCTYPE html>
 <html lang="${locale}">
  <head>
  <meta charset="utf-8">
@@ -4464,7 +4466,7 @@ ${hrefTags}
  ${bodySection}
  <script type="module" crossorigin fetchpriority="high" src="/assets/${entryJs}"></script>
  </body>
-</html>`;
+</html>`);
  }
 
  // Fallback: redirect to SPA (only if bundles not found)
@@ -4543,10 +4545,10 @@ ${hrefTags}
  pageHtml = injectJobboardSeoContent(pageHtml, jbLocale);
  }
  _qw(filePath, pageHtml);
- // Also write flat .html — real content without redirect script
+ // Also write flat .html as a noindex bridge; the slash URL keeps the full content.
  if (url.path !== '/') {
  const flatFile = np.join(distDir, url.path + '.html');
- _qw(flatFile, pageHtml.replace(/\s*<script>location\.replace\([^<]*\)<\/script>/, ''));
+ _qw(flatFile, buildFlatBridgeFromSibling(pageHtml, `${BASE_URL}${withTrailingSlash(url.path)}`));
  }
  count++;
  } else {
@@ -4602,7 +4604,7 @@ ${hrefTags}
  const indexFile = np.join(distDir, url.path, 'index.html');
  if (!fs.existsSync(flatFile) && fs.existsSync(indexFile)) {
  const existingIndexHtml = fs.readFileSync(indexFile, 'utf-8');
- _qw(flatFile, existingIndexHtml.replace(/\s*<script>location\.replace\([^<]*\)<\/script>/, ''));
+ _qw(flatFile, buildFlatBridgeFromSibling(existingIndexHtml, `${BASE_URL}${withTrailingSlash(url.path)}`));
  }
  }
  skipped++;
@@ -4676,9 +4678,9 @@ ${hrefTags}
  locPageHtml = injectJobboardSeoContent(locPageHtml, locJbLocale);
  }
  _qw(locFile, locPageHtml);
- // Also write flat .html — real content without redirect script
+  // Also write flat .html as a noindex bridge; the slash URL keeps the full content.
  const flatLoc = np.join(distDir, locPath + '.html');
- _qw(flatLoc, locPageHtml.replace(/\s*<script>location\.replace\([^<]*\)<\/script>/, ''));
+ _qw(flatLoc, buildFlatBridgeFromSibling(locPageHtml, `${BASE_URL}${withTrailingSlash(locPath)}`));
  count++;
  }
  }

--- a/data/all-known-job-slugs.json
+++ b/data/all-known-job-slugs.json
@@ -12107,18 +12107,18 @@
     "fr": "/fr/trouver-emploi-tessin/sage-femme-obstetricien-ne-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offerta-o"
   },
   "heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni": {
-    "it": "/cerca-lavoro-ticino/tecnico-di-consegna-di-elettrodomestici-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-delivery-technician-for-electrical-appliances-fust-grigioni",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/technicien-de-livraison-d-appareils-electromenagers-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/tecnico-di-consegna-di-elettrodomestici-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-delivery-technician-for-electrical-appliances-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/technicien-de-livraison-d-appareils-electromenagers-fust-grigioni"
   },
   "heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj": {
     "source": "gsc-404-import",
     "importedAt": "2026-03-31",
-    "it": "/cerca-lavoro-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
-    "en": "/en/find-jobs-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
-    "fr": "/fr/trouver-emploi-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj"
+    "it": "/cerca-lavoro-grigioni/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
+    "en": "/en/find-jobs-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
+    "fr": "/fr/trouver-emploi-grisons/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj"
   },
   "history-teacher-international-school-of-ticino-lugano": {
     "it": "/cerca-lavoro-ticino/history-teacher-international-school-of-ticino-lugano",
@@ -12147,10 +12147,10 @@
   "home-appliance-installer-fust-grigioni": {
     "source": "gsc-404-import",
     "importedAt": "2026-03-31",
-    "it": "/cerca-lavoro-ticino/home-appliance-installer-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-appliance-installer-fust-grigioni",
-    "de": "/de/jobs-im-tessin/home-appliance-installer-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/home-appliance-installer-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/home-appliance-installer-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-appliance-installer-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/home-appliance-installer-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/home-appliance-installer-fust-grigioni"
   },
   "home-delivery-fitter-of-electrical-household-appliances-fust-grigioni": {
     "source": "gsc-404-import",
@@ -17373,10 +17373,10 @@
     "fr": "/fr/trouver-emploi-tessin/monteur-d-installations-electromenager-fust-grigioni"
   },
   "montatore-di-elettrodomestici-fust-grigioni": {
-    "it": "/cerca-lavoro-ticino/montatore-di-elettrodomestici-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-delivery-technician-for-electrical-appliances-fust-grigioni",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/technicien-de-livraison-a-domicile-d-appareils-electromenagers-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/montatore-di-elettrodomestici-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-delivery-technician-for-electrical-appliances-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/technicien-de-livraison-a-domicile-d-appareils-electromenagers-fust-grigioni"
   },
   "montatore-di-facciate-pemsa-locarno": {
     "it": "/cerca-lavoro-ticino/montatore-di-facciate-pemsa-locarno",
@@ -19337,10 +19337,10 @@
     "fr": "/fr/trouver-emploi-tessin/membre-de-l-equipe-de-controle-hubers-landhendl-gmbh-pfaffstatt"
   },
   "collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-geiser-ag-schlieren": {
-    "it": "/cerca-lavoro-ticino/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-geiser-ag-schlieren",
-    "en": "/en/find-jobs-ticino/technical-and-materials-team-member-geiser-ag-schlieren",
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "fr": "/fr/trouver-emploi-tessin/membre-du-team-technique-et-materiel-geiser-ag-schlieren"
+    "it": "/cerca-lavoro-zurigo/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-geiser-ag-schlieren",
+    "en": "/en/find-jobs-zurich/technical-and-materials-team-member-geiser-ag-schlieren",
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "fr": "/fr/trouver-emploi-zurich/membre-du-team-technique-et-materiel-geiser-ag-schlieren"
   },
   "collaboratore-trice-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht": {
     "it": "/cerca-lavoro-ticino/collaboratore-trice-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
@@ -26531,10 +26531,10 @@
     "fr": "/fr/trouver-emploi-tessin/mitarbeiter-steuerung-m-w-d-hilcona-ag-bell-food-group-landquart"
   },
   "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq": {
-    "it": "/cerca-lavoro-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
-    "en": "/en/find-jobs-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq"
+    "it": "/cerca-lavoro-zurigo/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
+    "en": "/en/find-jobs-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
+    "fr": "/fr/trouver-emploi-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq"
   },
   "mitarbeiter-verladung-versand-m-w-d-hilcona-ag-bell-food-group-landquart": {
     "it": "/cerca-lavoro-ticino/mitarbeiter-verladung-versand-m-w-d-hilcona-ag-bell-food-group-landquart",
@@ -33401,10 +33401,10 @@
     "fr": "/fr/trouver-emploi-tessin/assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-locarno"
   },
   "nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano": {
-    "en": "/en/find-jobs-ticino/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
-    "it": "/cerca-lavoro-ticino/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
-    "de": "/de/jobs-im-tessin/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
-    "fr": "/fr/trouver-emploi-tessin/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano"
+    "en": "/en/find-jobs-basel/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
+    "it": "/cerca-lavoro-basilea/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
+    "de": "/de/jobs-in-basel/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
+    "fr": "/fr/trouver-emploi-bale/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano"
   },
   "krankenpfleger-in-in-allgemeinpflege-derzeit-in-ausbildung-diplom-noch-zu-erwerben-eoc-ente-ospedaliero-cantonale-lugano": {
     "de": "/de/jobs-im-tessin/krankenpfleger-in-in-allgemeinpflege-derzeit-in-ausbildung-diplom-noch-zu-erwerben-eoc-ente-ospedaliero-cantonale-lugano",
@@ -33779,10 +33779,10 @@
     "fr": "/fr/trouver-emploi-tessin/medico-radiologo-eoc-ente-ospedaliero-cantonale-bellinzona-uil4ya"
   },
   "biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona": {
-    "en": "/en/find-jobs-ticino/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "it": "/cerca-lavoro-ticino/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "de": "/de/jobs-im-tessin/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "fr": "/fr/trouver-emploi-tessin/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona"
+    "en": "/en/find-jobs-aargau/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "it": "/cerca-lavoro-argovia/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "de": "/de/jobs-im-aargau/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "fr": "/fr/trouver-emploi-argovie/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona"
   },
   "100-medical-assistant-training-position-eoc-ente-ospedaliero-cantonale-bellinzona": {
     "en": "/en/find-jobs-ticino/100-medical-assistant-training-position-eoc-ente-ospedaliero-cantonale-bellinzona",
@@ -35537,10 +35537,10 @@
     "en": "/en/find-jobs-solothurn/chef-d-equipe-chef-d-equipe-genie-electrique-et-automatisation-bell-schweiz-ag-oensingen"
   },
   "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren": {
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
-    "it": "/cerca-lavoro-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
-    "en": "/en/find-jobs-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren"
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
+    "it": "/cerca-lavoro-zurigo/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
+    "en": "/en/find-jobs-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
+    "fr": "/fr/trouver-emploi-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren"
   },
   "membre-du-team-technique-et-materiel-geiser-ag-schlieren": {
     "fr": "/fr/trouver-emploi-tessin/membre-du-team-technique-et-materiel-geiser-ag-schlieren",
@@ -35549,16 +35549,16 @@
     "en": "/en/find-jobs-ticino/membre-du-team-technique-et-materiel-geiser-ag-schlieren"
   },
   "collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart": {
-    "it": "/cerca-lavoro-ticino/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
-    "en": "/en/find-jobs-ticino/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
-    "de": "/de/jobs-im-tessin/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
-    "fr": "/fr/trouver-emploi-tessin/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart"
+    "it": "/cerca-lavoro-zurigo/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
+    "en": "/en/find-jobs-zurich/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
+    "de": "/de/jobs-in-zurich/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
+    "fr": "/fr/trouver-emploi-zurich/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart"
   },
   "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren": {
-    "it": "/cerca-lavoro-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "en": "/en/find-jobs-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren"
+    "it": "/cerca-lavoro-zurigo/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "en": "/en/find-jobs-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "fr": "/fr/trouver-emploi-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren"
   },
   "bezirksleitung-im-aussendienst-food-service-m-w-d-duesseldorf-krefeld-aachen-hugli-nahrungsmittel-gmbh-radolfzell": {
     "de": "/de/jobs-im-tessin/bezirksleitung-im-aussendienst-food-service-m-w-d-duesseldorf-krefeld-aachen-hugli-nahrungsmittel-gmbh-radolfzell",
@@ -47093,10 +47093,10 @@
     "fr": "/fr/trouver-emploi-tessin/apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-7haru0"
   },
   "heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c": {
-    "it": "/cerca-lavoro-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
-    "en": "/en/find-jobs-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
-    "fr": "/fr/trouver-emploi-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c"
+    "it": "/cerca-lavoro-grigioni/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
+    "en": "/en/find-jobs-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
+    "fr": "/fr/trouver-emploi-grisons/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c"
   },
   "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
     "de": "/de/jobs-in-bern/einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra",
@@ -68711,16 +68711,16 @@
     "en": "/en/find-jobs-ticino/consultant-en-ventes-pour-l-electricite-et-le-multimedia-fust-chur-graubunden"
   },
   "home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni": {
-    "it": "/cerca-lavoro-ticino/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
-    "de": "/de/jobs-im-tessin/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni"
   },
   "fournisseurs-dans-les-appareils-electromenagers-fust-grigioni": {
-    "fr": "/fr/trouver-emploi-tessin/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
-    "it": "/cerca-lavoro-ticino/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
-    "de": "/de/jobs-im-tessin/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
-    "en": "/en/find-jobs-ticino/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni"
+    "fr": "/fr/trouver-emploi-grisons/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
+    "it": "/cerca-lavoro-grigioni/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni"
   },
   "assistente-contabile-50-giardino-group-champfer": {
     "it": "/cerca-lavoro-ticino/assistente-contabile-50-giardino-group-champfer",
@@ -75293,16 +75293,16 @@
     "fr": "/fr/trouver-emploi-tessin/capofila-dell-istruzione-denner-horw"
   },
   "head-of-branch-in-education-denner-horw": {
-    "en": "/en/find-jobs-ticino/head-of-branch-in-education-denner-horw",
-    "it": "/cerca-lavoro-ticino/head-of-branch-in-education-denner-horw",
-    "de": "/de/jobs-im-tessin/head-of-branch-in-education-denner-horw",
-    "fr": "/fr/trouver-emploi-tessin/head-of-branch-in-education-denner-horw"
+    "en": "/en/find-jobs-lucerne/head-of-branch-in-education-denner-horw",
+    "it": "/cerca-lavoro-lucerna/head-of-branch-in-education-denner-horw",
+    "de": "/de/jobs-in-luzern/head-of-branch-in-education-denner-horw",
+    "fr": "/fr/trouver-emploi-lucerne/head-of-branch-in-education-denner-horw"
   },
   "chef-de-division-en-education-denner-horw": {
-    "fr": "/fr/trouver-emploi-tessin/chef-de-division-en-education-denner-horw",
-    "it": "/cerca-lavoro-ticino/chef-de-division-en-education-denner-horw",
-    "en": "/en/find-jobs-ticino/chef-de-division-en-education-denner-horw",
-    "de": "/de/jobs-im-tessin/chef-de-division-en-education-denner-horw"
+    "fr": "/fr/trouver-emploi-lucerne/chef-de-division-en-education-denner-horw",
+    "it": "/cerca-lavoro-lucerna/chef-de-division-en-education-denner-horw",
+    "en": "/en/find-jobs-lucerne/chef-de-division-en-education-denner-horw",
+    "de": "/de/jobs-in-luzern/chef-de-division-en-education-denner-horw"
   },
   "mediatore-trice-interculturale-60-eoc-ente-ospedaliero-cantonale-mendrisio": {
     "it": "/cerca-lavoro-ticino/mediatore-trice-interculturale-60-eoc-ente-ospedaliero-cantonale-mendrisio",
@@ -81653,10 +81653,10 @@
     "de": "/de/jobs-im-tessin/associe-debut-de-carriere-en-fiscalite-d-entreprise-80-100-pwc-switzerland-luzern"
   },
   "manager-senior-manager-senior-cyber-security-architect-pwc-zurich": {
-    "it": "/cerca-lavoro-ticino/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
-    "en": "/en/find-jobs-ticino/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
-    "de": "/de/jobs-im-tessin/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
-    "fr": "/fr/trouver-emploi-tessin/manager-senior-manager-senior-cyber-security-architect-pwc-zurich"
+    "it": "/cerca-lavoro-ginevra/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
+    "en": "/en/find-jobs-geneva/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
+    "de": "/de/jobs-in-genf/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
+    "fr": "/fr/trouver-emploi-geneve/manager-senior-manager-senior-cyber-security-architect-pwc-zurich"
   },
   "director-of-basic-education-supsi-dti-direzione-supsi": {
     "en": "/en/find-jobs-ticino/director-of-basic-education-supsi-dti-direzione-supsi",
@@ -82043,16 +82043,16 @@
     "fr": "/fr/trouver-emploi-tessin/mitarbeiter-karriereeinstieg-steuerberatung-80-100-pwc-switzerland-luzern"
   },
   "manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich": {
-    "it": "/cerca-lavoro-ticino/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
-    "en": "/en/find-jobs-ticino/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
-    "de": "/de/jobs-im-tessin/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
-    "fr": "/fr/trouver-emploi-tessin/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich"
+    "it": "/cerca-lavoro-ginevra/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
+    "en": "/en/find-jobs-geneva/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
+    "de": "/de/jobs-in-genf/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
+    "fr": "/fr/trouver-emploi-geneve/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich"
   },
   "manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
-    "it": "/cerca-lavoro-ticino/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
-    "en": "/en/find-jobs-ticino/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
-    "de": "/de/jobs-im-tessin/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich"
+    "fr": "/fr/trouver-emploi-geneve/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
+    "it": "/cerca-lavoro-ginevra/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
+    "en": "/en/find-jobs-geneva/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
+    "de": "/de/jobs-in-genf/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich"
   },
   "installateurin-oder-elektroinstallateurin-zu-100-mit-klempnerfunktion-citta-di-mendrisio-mendrisio": {
     "de": "/de/jobs-im-tessin/installateurin-oder-elektroinstallateurin-zu-100-mit-klempnerfunktion-citta-di-mendrisio-mendrisio",
@@ -84089,10 +84089,10 @@
     "fr": "/fr/trouver-emploi-tessin/feldstratege-zukunftige-lebensmittelfabrik-epfl-lausanne"
   },
   "mechanical-engineer-epfl-sion": {
-    "it": "/cerca-lavoro-ticino/mechanical-engineer-epfl-sion",
-    "de": "/de/jobs-im-tessin/mechanical-engineer-epfl-sion",
-    "en": "/en/find-jobs-ticino/mechanical-engineer-epfl-sion",
-    "fr": "/fr/trouver-emploi-tessin/mechanical-engineer-epfl-sion"
+    "it": "/cerca-lavoro-vallese/mechanical-engineer-epfl-sion",
+    "de": "/de/jobs-im-wallis/mechanical-engineer-epfl-sion",
+    "en": "/en/find-jobs-valais/mechanical-engineer-epfl-sion",
+    "fr": "/fr/trouver-emploi-valais/mechanical-engineer-epfl-sion"
   },
   "chef-e-du-service-academique-epfl-lausanne": {
     "it": "/cerca-lavoro-ticino/chef-e-du-service-academique-epfl-lausanne",
@@ -84179,10 +84179,10 @@
     "de": "/de/jobs-im-tessin/global-product-specialiste-dry-type-transformers-mainstream-hitachi-energy-remote-zurich"
   },
   "fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich": {
-    "de": "/de/jobs-im-tessin/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
-    "it": "/cerca-lavoro-ticino/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
-    "en": "/en/find-jobs-ticino/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
-    "fr": "/fr/trouver-emploi-tessin/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich"
+    "de": "/de/jobs-in-zurich/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
+    "it": "/cerca-lavoro-zurigo/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
+    "en": "/en/find-jobs-zurich/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
+    "fr": "/fr/trouver-emploi-zurich/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich"
   },
   "lead-data-platform-architetto-hitachi-energy-krakow": {
     "it": "/cerca-lavoro-ticino/lead-data-platform-architetto-hitachi-energy-krakow",
@@ -84197,10 +84197,10 @@
     "de": "/de/jobs-im-tessin/lead-data-platform-architecte-hitachi-energy-krakow"
   },
   "lagerspezialist-80-100-w-m-d-hitachi-energy-zurich": {
-    "de": "/de/jobs-im-tessin/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
-    "it": "/cerca-lavoro-ticino/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
-    "en": "/en/find-jobs-ticino/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
-    "fr": "/fr/trouver-emploi-tessin/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich"
+    "de": "/de/jobs-in-zurich/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
+    "it": "/cerca-lavoro-zurigo/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
+    "en": "/en/find-jobs-zurich/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
+    "fr": "/fr/trouver-emploi-zurich/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich"
   },
   "gestionnaire-de-projet-d-installation-80-100-f-m-d-hitachi-energy-zurich": {
     "fr": "/fr/trouver-emploi-tessin/gestionnaire-de-projet-d-installation-80-100-f-m-d-hitachi-energy-zurich",
@@ -84545,16 +84545,16 @@
     "fr": "/fr/trouver-emploi-tessin/applikations-manager-in-kantonsspital-winterthur-ksw-winterthur"
   },
   "fachfrau-mann-gesundheit-lindenhofgruppe-bern": {
-    "it": "/cerca-lavoro-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
-    "en": "/en/find-jobs-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
-    "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-bern"
+    "it": "/cerca-lavoro-berna/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
+    "en": "/en/find-jobs-bern/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
+    "de": "/de/jobs-in-bern/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
+    "fr": "/fr/trouver-emploi-berne/fachfrau-mann-gesundheit-lindenhofgruppe-bern"
   },
   "fachfrau-mann-gesundheit-lindenhofgruppe-ch": {
-    "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
-    "en": "/en/find-jobs-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
-    "it": "/cerca-lavoro-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-ch"
+    "de": "/de/jobs-in-bern/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
+    "en": "/en/find-jobs-bern/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
+    "fr": "/fr/trouver-emploi-berne/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
+    "it": "/cerca-lavoro-berna/fachfrau-mann-gesundheit-lindenhofgruppe-ch"
   },
   "leiter-in-medizinische-codierung-lindenhofgruppe-ch": {
     "de": "/de/jobs-im-tessin/leiter-in-medizinische-codierung-lindenhofgruppe-ch",
@@ -86009,10 +86009,10 @@
     "it": "/cerca-lavoro-ticino/dipl-pflegefachmann-frau-palliativstation-stgag-ch"
   },
   "dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "oberarzt-arztin-neurologie-stgag-ch": {
     "it": "/cerca-lavoro-ticino/oberarzt-arztin-neurologie-stgag-ch",
@@ -87329,22 +87329,22 @@
     "fr": "/fr/trouver-emploi-tessin/medizinische-r-praxisassistent-in-onkologie-unispital-basel-ch"
   },
   "assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel": {
-    "it": "/cerca-lavoro-ticino/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
-    "en": "/en/find-jobs-ticino/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
-    "de": "/de/jobs-im-tessin/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel"
+    "it": "/cerca-lavoro-basilea/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
+    "en": "/en/find-jobs-basel/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
+    "de": "/de/jobs-in-basel/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
+    "fr": "/fr/trouver-emploi-bale/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel"
   },
   "assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel": {
-    "de": "/de/jobs-im-tessin/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
-    "it": "/cerca-lavoro-ticino/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
-    "en": "/en/find-jobs-ticino/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel"
+    "de": "/de/jobs-in-basel/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
+    "it": "/cerca-lavoro-basilea/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
+    "en": "/en/find-jobs-basel/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
+    "fr": "/fr/trouver-emploi-bale/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel"
   },
   "assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch": {
-    "en": "/en/find-jobs-ticino/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
-    "fr": "/fr/trouver-emploi-tessin/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
-    "it": "/cerca-lavoro-ticino/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
-    "de": "/de/jobs-im-tessin/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch"
+    "en": "/en/find-jobs-basel/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
+    "fr": "/fr/trouver-emploi-bale/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
+    "it": "/cerca-lavoro-basilea/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
+    "de": "/de/jobs-in-basel/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch"
   },
   "oberarztin-oberarzt-angiologie-unispital-basel-ch": {
     "it": "/cerca-lavoro-ticino/oberarztin-oberarzt-angiologie-unispital-basel-ch",
@@ -87359,10 +87359,10 @@
     "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-angiologie-universitatsspital-basel-basel"
   },
   "dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch"
+    "it": "/cerca-lavoro-basilea/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
+    "de": "/de/jobs-in-basel/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
+    "fr": "/fr/trouver-emploi-bale/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
+    "en": "/en/find-jobs-basel/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch"
   },
   "fachfrau-fachmann-hr-administration-unispital-basel-ch": {
     "it": "/cerca-lavoro-ticino/fachfrau-fachmann-hr-administration-unispital-basel-ch",
@@ -89405,16 +89405,16 @@
     "fr": "/fr/trouver-emploi-tessin/assicurazione-fornitore-e-consigliere-mortgage-presso-l-agenzia-generale-di-losanna-nord-vaudois-die-mobiliar-conseiller"
   },
   "collaboratore-compliance-office-commercial-clientele-postfinance-bulle": {
-    "it": "/cerca-lavoro-ticino/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
-    "en": "/en/find-jobs-ticino/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
-    "de": "/de/jobs-im-tessin/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
-    "fr": "/fr/trouver-emploi-tessin/collaboratore-compliance-office-commercial-clientele-postfinance-bulle"
+    "it": "/cerca-lavoro-friburgo/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
+    "en": "/en/find-jobs-fribourg/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
+    "de": "/de/jobs-in-freiburg/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
+    "fr": "/fr/trouver-emploi-fribourg/collaboratore-compliance-office-commercial-clientele-postfinance-bulle"
   },
   "consulente-clienti-privati-carouge-postfinance-carouge": {
-    "it": "/cerca-lavoro-ticino/consulente-clienti-privati-carouge-postfinance-carouge",
-    "en": "/en/find-jobs-ticino/consulente-clienti-privati-carouge-postfinance-carouge",
-    "de": "/de/jobs-im-tessin/consulente-clienti-privati-carouge-postfinance-carouge",
-    "fr": "/fr/trouver-emploi-tessin/consulente-clienti-privati-carouge-postfinance-carouge"
+    "it": "/cerca-lavoro-ginevra/consulente-clienti-privati-carouge-postfinance-carouge",
+    "en": "/en/find-jobs-geneva/consulente-clienti-privati-carouge-postfinance-carouge",
+    "de": "/de/jobs-in-genf/consulente-clienti-privati-carouge-postfinance-carouge",
+    "fr": "/fr/trouver-emploi-geneve/consulente-clienti-privati-carouge-postfinance-carouge"
   },
   "manager-in-rischio-regolatore-conformita-pwc-switzerland-geneve": {
     "it": "/cerca-lavoro-ticino/manager-in-rischio-regolatore-conformita-pwc-switzerland-geneve",
@@ -89447,10 +89447,10 @@
     "fr": "/fr/trouver-emploi-tessin/home-medico-50-100-regionalspital-surselva-ilanz"
   },
   "neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "interni-anno-di-pratica-strutturato-spj-cura-fh-ost-2026-spital-thurgau-stgag-kantonsspital-frauenfeld": {
     "it": "/cerca-lavoro-ticino/interni-anno-di-pratica-strutturato-spj-cura-fh-ost-2026-spital-thurgau-stgag-kantonsspital-frauenfeld",
@@ -90203,10 +90203,10 @@
     "en": "/en/find-jobs-ticino/destination-experience-manager-msc-group-geneva"
   },
   "destinations-experience-manager-msc-geneva": {
-    "en": "/en/find-jobs-ticino/destinations-experience-manager-msc-geneva",
-    "it": "/cerca-lavoro-ticino/destinations-experience-manager-msc-geneva",
-    "de": "/de/jobs-im-tessin/destinations-experience-manager-msc-geneva",
-    "fr": "/fr/trouver-emploi-tessin/destinations-experience-manager-msc-geneva"
+    "en": "/en/find-jobs-geneva/destinations-experience-manager-msc-geneva",
+    "it": "/cerca-lavoro-ginevra/destinations-experience-manager-msc-geneva",
+    "de": "/de/jobs-in-genf/destinations-experience-manager-msc-geneva",
+    "fr": "/fr/trouver-emploi-geneve/destinations-experience-manager-msc-geneva"
   },
   "corporate-communications-senior-manager-msc-geneva": {
     "en": "/en/find-jobs-ticino/corporate-communications-senior-manager-msc-geneva",
@@ -90305,10 +90305,10 @@
     "fr": "/fr/trouver-emploi-tessin/kulinarischer-betriebsleiter-msc-group-geneva"
   },
   "mobile-app-product-specialist-msc-geneva": {
-    "en": "/en/find-jobs-ticino/mobile-app-product-specialist-msc-geneva",
-    "it": "/cerca-lavoro-ticino/mobile-app-product-specialist-msc-geneva",
-    "de": "/de/jobs-im-tessin/mobile-app-product-specialist-msc-geneva",
-    "fr": "/fr/trouver-emploi-tessin/mobile-app-product-specialist-msc-geneva"
+    "en": "/en/find-jobs-geneva/mobile-app-product-specialist-msc-geneva",
+    "it": "/cerca-lavoro-ginevra/mobile-app-product-specialist-msc-geneva",
+    "de": "/de/jobs-in-genf/mobile-app-product-specialist-msc-geneva",
+    "fr": "/fr/trouver-emploi-geneve/mobile-app-product-specialist-msc-geneva"
   },
   "direttore-crm-msc-group-geneva": {
     "it": "/cerca-lavoro-ticino/direttore-crm-msc-group-geneva",
@@ -90893,16 +90893,16 @@
     "fr": "/fr/trouver-emploi-tessin/gruppe-eb-uni-beziehung-praktikant-richemont-bellevue"
   },
   "hr-business-partner-piaget-plan-les-ouates": {
-    "fr": "/fr/trouver-emploi-tessin/hr-business-partner-piaget-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/hr-business-partner-piaget-plan-les-ouates",
-    "en": "/en/find-jobs-ticino/hr-business-partner-piaget-plan-les-ouates",
-    "de": "/de/jobs-im-tessin/hr-business-partner-piaget-plan-les-ouates"
+    "fr": "/fr/trouver-emploi-geneve/hr-business-partner-piaget-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/hr-business-partner-piaget-plan-les-ouates",
+    "en": "/en/find-jobs-geneva/hr-business-partner-piaget-plan-les-ouates",
+    "de": "/de/jobs-in-genf/hr-business-partner-piaget-plan-les-ouates"
   },
   "hr-socio-de-negocios-piaget-plan-les-ouates": {
-    "en": "/en/find-jobs-ticino/hr-socio-de-negocios-piaget-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/hr-socio-de-negocios-piaget-plan-les-ouates",
-    "de": "/de/jobs-im-tessin/hr-socio-de-negocios-piaget-plan-les-ouates",
-    "fr": "/fr/trouver-emploi-tessin/hr-socio-de-negocios-piaget-plan-les-ouates"
+    "en": "/en/find-jobs-geneva/hr-socio-de-negocios-piaget-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/hr-socio-de-negocios-piaget-plan-les-ouates",
+    "de": "/de/jobs-in-genf/hr-socio-de-negocios-piaget-plan-les-ouates",
+    "fr": "/fr/trouver-emploi-geneve/hr-socio-de-negocios-piaget-plan-les-ouates"
   },
   "hr-intern-valfleurier-buttes": {
     "en": "/en/find-jobs-ticino/hr-intern-valfleurier-buttes",
@@ -91751,22 +91751,22 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-specialista-di-cura-forense-spital-thurgau-stgag-munsterlingen-7418fa"
   },
   "dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen": {
-    "it": "/cerca-lavoro-ticino/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
-    "en": "/en/find-jobs-ticino/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
-    "de": "/de/jobs-im-tessin/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen"
+    "it": "/cerca-lavoro-turgovia/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
+    "en": "/en/find-jobs-thurgau/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
+    "de": "/de/jobs-im-thurgau/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen"
   },
   "dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen": {
-    "en": "/en/find-jobs-ticino/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
-    "it": "/cerca-lavoro-ticino/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
-    "de": "/de/jobs-im-tessin/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen"
+    "en": "/en/find-jobs-thurgau/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
+    "it": "/cerca-lavoro-turgovia/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
+    "de": "/de/jobs-im-thurgau/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen"
   },
   "dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen": {
-    "fr": "/fr/trouver-emploi-tessin/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
-    "it": "/cerca-lavoro-ticino/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
-    "en": "/en/find-jobs-ticino/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
-    "de": "/de/jobs-im-tessin/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen"
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
+    "it": "/cerca-lavoro-turgovia/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
+    "en": "/en/find-jobs-thurgau/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
+    "de": "/de/jobs-im-thurgau/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen"
   },
   "medical-device-technology-medical-device-technology-efz-universitatsspital-basel-basel": {
     "en": "/en/find-jobs-ticino/medical-device-technology-medical-device-technology-efz-universitatsspital-basel-basel",
@@ -91829,22 +91829,22 @@
     "de": "/de/jobs-im-tessin/dipl-specialiste-des-soins-hf-fh-poste-de-plongee-universitatsspital-basel-basel"
   },
   "assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel": {
-    "it": "/cerca-lavoro-ticino/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
-    "en": "/en/find-jobs-ticino/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
-    "de": "/de/jobs-im-tessin/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel"
+    "it": "/cerca-lavoro-basilea/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
+    "en": "/en/find-jobs-basel/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
+    "de": "/de/jobs-in-basel/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
+    "fr": "/fr/trouver-emploi-bale/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel"
   },
   "assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel": {
-    "en": "/en/find-jobs-ticino/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
-    "it": "/cerca-lavoro-ticino/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
-    "de": "/de/jobs-im-tessin/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel"
+    "en": "/en/find-jobs-basel/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
+    "it": "/cerca-lavoro-basilea/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
+    "de": "/de/jobs-in-basel/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
+    "fr": "/fr/trouver-emploi-bale/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel"
   },
   "assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel": {
-    "fr": "/fr/trouver-emploi-tessin/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
-    "it": "/cerca-lavoro-ticino/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
-    "en": "/en/find-jobs-ticino/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
-    "de": "/de/jobs-im-tessin/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel"
+    "fr": "/fr/trouver-emploi-bale/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
+    "it": "/cerca-lavoro-basilea/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
+    "en": "/en/find-jobs-basel/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
+    "de": "/de/jobs-in-basel/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel"
   },
   "amministrazione-aziendale-universitatsspital-basel-basel": {
     "it": "/cerca-lavoro-ticino/amministrazione-aziendale-universitatsspital-basel-basel",
@@ -92303,10 +92303,10 @@
     "fr": "/fr/trouver-emploi-tessin/mechanical-ingegnere-epfl-sion"
   },
   "mechanical-ingenieur-epfl-sion": {
-    "fr": "/fr/trouver-emploi-tessin/mechanical-ingenieur-epfl-sion",
-    "it": "/cerca-lavoro-ticino/mechanical-ingenieur-epfl-sion",
-    "en": "/en/find-jobs-ticino/mechanical-ingenieur-epfl-sion",
-    "de": "/de/jobs-im-tessin/mechanical-ingenieur-epfl-sion"
+    "fr": "/fr/trouver-emploi-valais/mechanical-ingenieur-epfl-sion",
+    "it": "/cerca-lavoro-vallese/mechanical-ingenieur-epfl-sion",
+    "en": "/en/find-jobs-valais/mechanical-ingenieur-epfl-sion",
+    "de": "/de/jobs-im-wallis/mechanical-ingenieur-epfl-sion"
   },
   "head-of-academic-service-epfl-lausanne": {
     "en": "/en/find-jobs-ticino/head-of-academic-service-epfl-lausanne",
@@ -92951,10 +92951,10 @@
     "fr": "/fr/trouver-emploi-tessin/mobile-services-w-m-d-axpo-group-hagenbuch"
   },
   "gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
-    "it": "/cerca-lavoro-ticino/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
-    "en": "/en/find-jobs-ticino/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
-    "de": "/de/jobs-im-tessin/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich"
+    "fr": "/fr/trouver-emploi-zurich/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
+    "it": "/cerca-lavoro-zurigo/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
+    "en": "/en/find-jobs-zurich/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
+    "de": "/de/jobs-in-zurich/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich"
   },
   "fornitore-di-servizi-elettrici-per-manutenzione-e-piccoli-ordini-100-elektro-bau-ag-filiale-lenzburg-lenzburg": {
     "it": "/cerca-lavoro-ticino/fornitore-di-servizi-elettrici-per-manutenzione-e-piccoli-ordini-100-elektro-bau-ag-filiale-lenzburg-lenzburg",
@@ -93029,10 +93029,10 @@
     "de": "/de/jobs-im-tessin/gestionnaire-des-prestations-lindenhofgruppe-bern"
   },
   "associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug": {
-    "fr": "/fr/trouver-emploi-tessin/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
-    "it": "/cerca-lavoro-ticino/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
-    "en": "/en/find-jobs-ticino/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
-    "de": "/de/jobs-im-tessin/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug"
+    "fr": "/fr/trouver-emploi-zoug/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
+    "it": "/cerca-lavoro-zugo/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
+    "en": "/en/find-jobs-zug/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
+    "de": "/de/jobs-in-zug/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug"
   },
   "amministrazione-aziendale-universitatsspital-basel-basel-65d8a1": {
     "it": "/cerca-lavoro-ticino/amministrazione-aziendale-universitatsspital-basel-basel-65d8a1",
@@ -93737,16 +93737,16 @@
     "de": "/de/jobs-im-tessin/montres-de-luxe-omega-sales-associate-dallas-the-swatch-group-u-s-inc-75225-dallas-tx-texas-united-states-company-address-the-swatch-group-u-7uavyr"
   },
   "directeur-des-ventes-cartier-geneva": {
-    "fr": "/fr/trouver-emploi-tessin/directeur-des-ventes-cartier-geneva",
-    "it": "/cerca-lavoro-ticino/directeur-des-ventes-cartier-geneva",
-    "en": "/en/find-jobs-ticino/directeur-des-ventes-cartier-geneva",
-    "de": "/de/jobs-im-tessin/directeur-des-ventes-cartier-geneva"
+    "fr": "/fr/trouver-emploi-geneve/directeur-des-ventes-cartier-geneva",
+    "it": "/cerca-lavoro-ginevra/directeur-des-ventes-cartier-geneva",
+    "en": "/en/find-jobs-geneva/directeur-des-ventes-cartier-geneva",
+    "de": "/de/jobs-in-genf/directeur-des-ventes-cartier-geneva"
   },
   "associe-de-vente-temps-partiel-40-cartier-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/associe-de-vente-temps-partiel-40-cartier-zurich",
-    "it": "/cerca-lavoro-ticino/associe-de-vente-temps-partiel-40-cartier-zurich",
-    "en": "/en/find-jobs-ticino/associe-de-vente-temps-partiel-40-cartier-zurich",
-    "de": "/de/jobs-im-tessin/associe-de-vente-temps-partiel-40-cartier-zurich"
+    "fr": "/fr/trouver-emploi-zurich/associe-de-vente-temps-partiel-40-cartier-zurich",
+    "it": "/cerca-lavoro-zurigo/associe-de-vente-temps-partiel-40-cartier-zurich",
+    "en": "/en/find-jobs-zurich/associe-de-vente-temps-partiel-40-cartier-zurich",
+    "de": "/de/jobs-in-zurich/associe-de-vente-temps-partiel-40-cartier-zurich"
   },
   "interno-finanziario-vacheron-constantin-plan-les-ouates": {
     "it": "/cerca-lavoro-ticino/interno-finanziario-vacheron-constantin-plan-les-ouates",
@@ -94205,10 +94205,10 @@
     "fr": "/fr/trouver-emploi-tessin/intern-practice-integrated-bachelor-s-degree-pibs-industrial-engineering-40-m-f-d-hitachi-energy-wettingen-switzerland"
   },
   "au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland": {
-    "de": "/de/jobs-im-tessin/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
-    "it": "/cerca-lavoro-ticino/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
-    "en": "/en/find-jobs-ticino/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
-    "fr": "/fr/trouver-emploi-tessin/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland"
+    "de": "/de/jobs-in-zurich/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
+    "it": "/cerca-lavoro-zurigo/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
+    "en": "/en/find-jobs-zurich/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
+    "fr": "/fr/trouver-emploi-zurich/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland"
   },
   "debut-de-carriere-en-verification-banque-herbst-2026-pwc-switzerland-basel": {
     "fr": "/fr/trouver-emploi-tessin/debut-de-carriere-en-verification-banque-herbst-2026-pwc-switzerland-basel",
@@ -94247,10 +94247,10 @@
     "fr": "/fr/trouver-emploi-tessin/architecture-owner-telephony-and-cop-f-m-d-postfinance-bern"
   },
   "consulente-servizio-clienti-privato-losanna-postfinance-lausanne": {
-    "it": "/cerca-lavoro-ticino/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
-    "en": "/en/find-jobs-ticino/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
-    "de": "/de/jobs-im-tessin/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
-    "fr": "/fr/trouver-emploi-tessin/consulente-servizio-clienti-privato-losanna-postfinance-lausanne"
+    "it": "/cerca-lavoro-vaud/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
+    "en": "/en/find-jobs-vaud/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
+    "de": "/de/jobs-in-der-waadt/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
+    "fr": "/fr/trouver-emploi-vaud/consulente-servizio-clienti-privato-losanna-postfinance-lausanne"
   },
   "charge-e-de-contestations-postfinance-bern": {
     "fr": "/fr/trouver-emploi-tessin/charge-e-de-contestations-postfinance-bern",
@@ -94733,16 +94733,16 @@
     "fr": "/fr/trouver-emploi-tessin/gruppenprojektleiter-immobilien-masterdatenprojekte-richemont-bellevue"
   },
   "clienteling-data-project-manager-roger-dubuis-meyrin": {
-    "en": "/en/find-jobs-ticino/clienteling-data-project-manager-roger-dubuis-meyrin",
-    "it": "/cerca-lavoro-ticino/clienteling-data-project-manager-roger-dubuis-meyrin",
-    "de": "/de/jobs-im-tessin/clienteling-data-project-manager-roger-dubuis-meyrin",
-    "fr": "/fr/trouver-emploi-tessin/clienteling-data-project-manager-roger-dubuis-meyrin"
+    "en": "/en/find-jobs-geneva/clienteling-data-project-manager-roger-dubuis-meyrin",
+    "it": "/cerca-lavoro-ginevra/clienteling-data-project-manager-roger-dubuis-meyrin",
+    "de": "/de/jobs-in-genf/clienteling-data-project-manager-roger-dubuis-meyrin",
+    "fr": "/fr/trouver-emploi-geneve/clienteling-data-project-manager-roger-dubuis-meyrin"
   },
   "clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin": {
-    "fr": "/fr/trouver-emploi-tessin/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
-    "it": "/cerca-lavoro-ticino/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
-    "en": "/en/find-jobs-ticino/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
-    "de": "/de/jobs-im-tessin/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin"
+    "fr": "/fr/trouver-emploi-geneve/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
+    "it": "/cerca-lavoro-ginevra/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
+    "en": "/en/find-jobs-geneva/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
+    "de": "/de/jobs-in-genf/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin"
   },
   "ict-senior-system-engineer-safe-team-coach-80-100-w-m-d-ruag-ag-zurich-seebach": {
     "it": "/cerca-lavoro-ticino/ict-senior-system-engineer-safe-team-coach-80-100-w-m-d-ruag-ag-zurich-seebach",
@@ -94763,10 +94763,10 @@
     "fr": "/fr/trouver-emploi-tessin/med-praxisassistentin-oder-fachperson-gesundheit-f-u00fcr-die-fachbereiche-onkologie-h"
   },
   "med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60": {
-    "de": "/de/jobs-im-tessin/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
-    "it": "/cerca-lavoro-ticino/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
-    "en": "/en/find-jobs-ticino/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
-    "fr": "/fr/trouver-emploi-tessin/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60"
+    "de": "/de/jobs-in-zurich/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
+    "it": "/cerca-lavoro-zurigo/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
+    "en": "/en/find-jobs-zurich/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
+    "fr": "/fr/trouver-emploi-zurich/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60"
   },
   "fachfrau-mann-gesundheit-efz-f-u00fcr-eine-medizinische-oder-chirurgische-bettenstation": {
     "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-efz-f-u00fcr-eine-medizinische-oder-chirurgische-bettenstation",
@@ -95177,10 +95177,10 @@
     "de": "/de/jobs-im-tessin/marchandiser-et-formateur-visuel-cote-est-the-swatch-group-u-s-inc-10017-new-york-ny-new-york-united-states-company"
   },
   "clienting-data-project-manager-roger-dubuis-meyrin": {
-    "de": "/de/jobs-im-tessin/clienting-data-project-manager-roger-dubuis-meyrin",
-    "it": "/cerca-lavoro-ticino/clienting-data-project-manager-roger-dubuis-meyrin",
-    "en": "/en/find-jobs-ticino/clienting-data-project-manager-roger-dubuis-meyrin",
-    "fr": "/fr/trouver-emploi-tessin/clienting-data-project-manager-roger-dubuis-meyrin"
+    "de": "/de/jobs-in-genf/clienting-data-project-manager-roger-dubuis-meyrin",
+    "it": "/cerca-lavoro-ginevra/clienting-data-project-manager-roger-dubuis-meyrin",
+    "en": "/en/find-jobs-geneva/clienting-data-project-manager-roger-dubuis-meyrin",
+    "fr": "/fr/trouver-emploi-geneve/clienting-data-project-manager-roger-dubuis-meyrin"
   },
   "head-of-ai-machine-learning-services-m-w-100-w-m-d-ruag-ag-bern": {
     "it": "/cerca-lavoro-ticino/head-of-ai-machine-learning-services-m-w-100-w-m-d-ruag-ag-bern",
@@ -95807,22 +95807,22 @@
     "fr": "/fr/trouver-emploi-tessin/audizione-notturna-marriott-international-geneva"
   },
   "mobile-app-product-specialista-msc-group-geneva": {
-    "it": "/cerca-lavoro-ticino/mobile-app-product-specialista-msc-group-geneva",
-    "en": "/en/find-jobs-ticino/mobile-app-product-specialista-msc-group-geneva",
-    "de": "/de/jobs-im-tessin/mobile-app-product-specialista-msc-group-geneva",
-    "fr": "/fr/trouver-emploi-tessin/mobile-app-product-specialista-msc-group-geneva"
+    "it": "/cerca-lavoro-ginevra/mobile-app-product-specialista-msc-group-geneva",
+    "en": "/en/find-jobs-geneva/mobile-app-product-specialista-msc-group-geneva",
+    "de": "/de/jobs-in-genf/mobile-app-product-specialista-msc-group-geneva",
+    "fr": "/fr/trouver-emploi-geneve/mobile-app-product-specialista-msc-group-geneva"
   },
   "mobile-app-product-spezialist-msc-group-geneva": {
-    "de": "/de/jobs-im-tessin/mobile-app-product-spezialist-msc-group-geneva",
-    "it": "/cerca-lavoro-ticino/mobile-app-product-spezialist-msc-group-geneva",
-    "en": "/en/find-jobs-ticino/mobile-app-product-spezialist-msc-group-geneva",
-    "fr": "/fr/trouver-emploi-tessin/mobile-app-product-spezialist-msc-group-geneva"
+    "de": "/de/jobs-in-genf/mobile-app-product-spezialist-msc-group-geneva",
+    "it": "/cerca-lavoro-ginevra/mobile-app-product-spezialist-msc-group-geneva",
+    "en": "/en/find-jobs-geneva/mobile-app-product-spezialist-msc-group-geneva",
+    "fr": "/fr/trouver-emploi-geneve/mobile-app-product-spezialist-msc-group-geneva"
   },
   "mobile-app-product-specialiste-msc-group-geneva": {
-    "fr": "/fr/trouver-emploi-tessin/mobile-app-product-specialiste-msc-group-geneva",
-    "it": "/cerca-lavoro-ticino/mobile-app-product-specialiste-msc-group-geneva",
-    "en": "/en/find-jobs-ticino/mobile-app-product-specialiste-msc-group-geneva",
-    "de": "/de/jobs-im-tessin/mobile-app-product-specialiste-msc-group-geneva"
+    "fr": "/fr/trouver-emploi-geneve/mobile-app-product-specialiste-msc-group-geneva",
+    "it": "/cerca-lavoro-ginevra/mobile-app-product-specialiste-msc-group-geneva",
+    "en": "/en/find-jobs-geneva/mobile-app-product-specialiste-msc-group-geneva",
+    "de": "/de/jobs-in-genf/mobile-app-product-specialiste-msc-group-geneva"
   },
   "miu-miu-client-consulente-tirocinante-saint-tropez-h-f-prada-group-cannes": {
     "it": "/cerca-lavoro-ticino/miu-miu-client-consulente-tirocinante-saint-tropez-h-f-prada-group-cannes",
@@ -96275,10 +96275,10 @@
     "fr": "/fr/trouver-emploi-tessin/inizio-carriera-in-audit-asset-management-autunno-2026-pwc-switzerland-zurich"
   },
   "inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve": {
-    "it": "/cerca-lavoro-ticino/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "en": "/en/find-jobs-ticino/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "de": "/de/jobs-im-tessin/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "fr": "/fr/trouver-emploi-tessin/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve"
+    "it": "/cerca-lavoro-vaud/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "en": "/en/find-jobs-vaud/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "de": "/de/jobs-in-der-waadt/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "fr": "/fr/trouver-emploi-vaud/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve"
   },
   "associe-de-vente-tissot-the-swatch-group-u-s-inc-33180-aventura-fl-florida-united-states-company-address-the-swatch-group-u-7uaw28": {
     "fr": "/fr/trouver-emploi-tessin/associe-de-vente-tissot-the-swatch-group-u-s-inc-33180-aventura-fl-florida-united-states-company-address-the-swatch-group-u-7uaw28",
@@ -96839,10 +96839,10 @@
     "fr": "/fr/trouver-emploi-tessin/career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-basel"
   },
   "collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern": {
-    "it": "/cerca-lavoro-ticino/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
-    "en": "/en/find-jobs-ticino/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
-    "de": "/de/jobs-im-tessin/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
-    "fr": "/fr/trouver-emploi-tessin/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern"
+    "it": "/cerca-lavoro-lucerna/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
+    "en": "/en/find-jobs-lucerne/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
+    "de": "/de/jobs-in-luzern/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern"
   },
   "consulente-commerciale-in-christ-uhren-schmuck-ag-chur-w2vgxm": {
     "it": "/cerca-lavoro-ticino/consulente-commerciale-in-christ-uhren-schmuck-ag-chur-w2vgxm",
@@ -97181,10 +97181,10 @@
     "it": "/cerca-lavoro-ticino/facharztin-arzt-fur-radiologie-mit-schwerpunkt-muskuloskelettale-radiologie-oa-oder-oambf"
   },
   "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und": {
-    "de": "/de/jobs-im-tessin/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
-    "en": "/en/find-jobs-ticino/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
-    "fr": "/fr/trouver-emploi-tessin/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
-    "it": "/cerca-lavoro-ticino/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und"
+    "de": "/de/jobs-im-thurgau/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+    "en": "/en/find-jobs-thurgau/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+    "fr": "/fr/trouver-emploi-thurgovie/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+    "it": "/cerca-lavoro-turgovia/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und"
   },
   "dipl-expertin-experte-intensivpflege-nds-hf-mit-zusatzfunktion-implementierung-ficus": {
     "it": "/cerca-lavoro-ticino/dipl-expertin-experte-intensivpflege-nds-hf-mit-zusatzfunktion-implementierung-ficus",
@@ -98111,10 +98111,10 @@
     "de": "/de/jobs-im-tessin/health-safety-stagiaire-prada-group-montevarchi-health-safety-intern"
   },
   "ansprechpartner-fur-das-personal-piaget-plan-les-ouates": {
-    "de": "/de/jobs-im-tessin/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
-    "en": "/en/find-jobs-ticino/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
-    "fr": "/fr/trouver-emploi-tessin/ansprechpartner-fur-das-personal-piaget-plan-les-ouates"
+    "de": "/de/jobs-in-genf/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
+    "en": "/en/find-jobs-geneva/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
+    "fr": "/fr/trouver-emploi-geneve/ansprechpartner-fur-das-personal-piaget-plan-les-ouates"
   },
   "ai-forschung-ingenieur-pre-training-tether-operations-san-francisco-california": {
     "de": "/de/jobs-im-tessin/ai-forschung-ingenieur-pre-training-tether-operations-san-francisco-california",
@@ -98681,10 +98681,10 @@
     "fr": "/fr/trouver-emploi-tessin/infermiere-a-specializzato-a-in-cure-palliative-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "formazione-infermiere-a-dipl-sss-3-anni-regolare-settembre-2026-bfgs-spital-thurgau-stgag-kantonsspital-frauenfeld": {
     "it": "/cerca-lavoro-ticino/formazione-infermiere-a-dipl-sss-3-anni-regolare-settembre-2026-bfgs-spital-thurgau-stgag-kantonsspital-frauenfeld",
@@ -101453,16 +101453,16 @@
     "fr": "/fr/trouver-emploi-tessin/laboratoriumsleiter-fur-manner-lifestyle-kleidung-prada-group-montevarchi-responsabile-laboratorio-di-collezione"
   },
   "client-services-project-manager-europe-cis-richemont-geneva": {
-    "it": "/cerca-lavoro-ticino/client-services-project-manager-europe-cis-richemont-geneva",
-    "fr": "/fr/trouver-emploi-tessin/client-services-project-manager-europe-cis-richemont-geneva",
-    "de": "/de/jobs-im-tessin/client-services-project-manager-europe-cis-richemont-geneva",
-    "en": "/en/find-jobs-ticino/client-services-project-manager-europe-cis-richemont-geneva"
+    "it": "/cerca-lavoro-ginevra/client-services-project-manager-europe-cis-richemont-geneva",
+    "fr": "/fr/trouver-emploi-geneve/client-services-project-manager-europe-cis-richemont-geneva",
+    "de": "/de/jobs-in-genf/client-services-project-manager-europe-cis-richemont-geneva",
+    "en": "/en/find-jobs-geneva/client-services-project-manager-europe-cis-richemont-geneva"
   },
   "client-services-project-manager-europe-cis-van-cleef-arpels-geneva": {
-    "en": "/en/find-jobs-ticino/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
-    "it": "/cerca-lavoro-ticino/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
-    "de": "/de/jobs-im-tessin/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
-    "fr": "/fr/trouver-emploi-tessin/client-services-project-manager-europe-cis-van-cleef-arpels-geneva"
+    "en": "/en/find-jobs-geneva/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
+    "it": "/cerca-lavoro-ginevra/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
+    "de": "/de/jobs-in-genf/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
+    "fr": "/fr/trouver-emploi-geneve/client-services-project-manager-europe-cis-van-cleef-arpels-geneva"
   },
   "lehrstelle-come-commercio-donna-efz-da-agosto-2026-roche-basel": {
     "it": "/cerca-lavoro-ticino/lehrstelle-come-commercio-donna-efz-da-agosto-2026-roche-basel",
@@ -101675,10 +101675,10 @@
     "de": "/de/jobs-im-tessin/chef-de-service-d-angiologie-eoc-ente-ospedaliero-cantonale-lugano"
   },
   "direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva": {
-    "it": "/cerca-lavoro-ticino/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
-    "en": "/en/find-jobs-ticino/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
-    "de": "/de/jobs-im-tessin/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
-    "fr": "/fr/trouver-emploi-tessin/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva"
+    "it": "/cerca-lavoro-ginevra/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
+    "en": "/en/find-jobs-geneva/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
+    "de": "/de/jobs-in-genf/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
+    "fr": "/fr/trouver-emploi-geneve/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva"
   },
   "mobile-app-produktspezialist-msc-group-geneva": {
     "de": "/de/jobs-im-tessin/mobile-app-produktspezialist-msc-group-geneva",
@@ -101693,10 +101693,10 @@
     "fr": "/fr/trouver-emploi-tessin/auszubildende-verfahren-procadrans-la-chaux-de-fonds-142a0c"
   },
   "chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva": {
-    "fr": "/fr/trouver-emploi-tessin/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
-    "it": "/cerca-lavoro-ticino/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
-    "en": "/en/find-jobs-ticino/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
-    "de": "/de/jobs-im-tessin/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva"
+    "fr": "/fr/trouver-emploi-geneve/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
+    "it": "/cerca-lavoro-ginevra/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
+    "en": "/en/find-jobs-geneva/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
+    "de": "/de/jobs-in-genf/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva"
   },
   "client-services-projektmanager-europa-cis-van-cleef-arpels-geneva": {
     "de": "/de/jobs-im-tessin/client-services-projektmanager-europa-cis-van-cleef-arpels-geneva",
@@ -101849,10 +101849,10 @@
     "fr": "/fr/trouver-emploi-tessin/insegnamento-come-fornitore-di-logistica-consegna-mista-in-efz-distribution-lettere-e-pacchetti-die-schweizerische-post"
   },
   "advisor-ere-client-en-placement-losanna-postfinance-lausanne": {
-    "it": "/cerca-lavoro-ticino/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
-    "en": "/en/find-jobs-ticino/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
-    "de": "/de/jobs-im-tessin/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
-    "fr": "/fr/trouver-emploi-tessin/advisor-ere-client-en-placement-losanna-postfinance-lausanne"
+    "it": "/cerca-lavoro-vaud/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
+    "en": "/en/find-jobs-vaud/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
+    "de": "/de/jobs-in-der-waadt/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
+    "fr": "/fr/trouver-emploi-vaud/advisor-ere-client-en-placement-losanna-postfinance-lausanne"
   },
   "dr-venditrice-tore-casse-servizi-f-m-d-coop-genossenschaft-caslano": {
     "it": "/cerca-lavoro-ticino/dr-venditrice-tore-casse-servizi-f-m-d-coop-genossenschaft-caslano",
@@ -104705,46 +104705,46 @@
     "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-en-tant-que-responsable-adjoint-d-equipe-a-80-100-concara-domicil-spitex-bern"
   },
   "global-ot-partner-engage-csl-behring-bern": {
-    "it": "/cerca-lavoro-ticino/global-ot-partner-engage-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/global-ot-partner-enablement-csl-behring-ch",
-    "de": "/de/jobs-im-tessin/globaler-ot-partner-engage-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/global-ot-partner-enablement-csl-behring-ch"
+    "it": "/cerca-lavoro-berna/global-ot-partner-engage-csl-behring-bern",
+    "en": "/en/find-jobs-bern/global-ot-partner-enablement-csl-behring-ch",
+    "de": "/de/jobs-in-bern/globaler-ot-partner-engage-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/global-ot-partner-enablement-csl-behring-ch"
   },
   "global-ot-partner-enablement-csl-behring-ch": {
-    "en": "/en/find-jobs-ticino/global-ot-partner-enablement-csl-behring-ch",
-    "fr": "/fr/trouver-emploi-tessin/global-ot-partner-enablement-csl-behring-ch",
-    "it": "/cerca-lavoro-ticino/global-ot-partner-enablement-csl-behring-ch",
-    "de": "/de/jobs-im-tessin/global-ot-partner-enablement-csl-behring-ch"
+    "en": "/en/find-jobs-bern/global-ot-partner-enablement-csl-behring-ch",
+    "fr": "/fr/trouver-emploi-berne/global-ot-partner-enablement-csl-behring-ch",
+    "it": "/cerca-lavoro-berna/global-ot-partner-enablement-csl-behring-ch",
+    "de": "/de/jobs-in-bern/global-ot-partner-enablement-csl-behring-ch"
   },
   "globaler-ot-partner-engage-csl-behring-bern": {
-    "de": "/de/jobs-im-tessin/globaler-ot-partner-engage-csl-behring-bern",
-    "it": "/cerca-lavoro-ticino/globaler-ot-partner-engage-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/globaler-ot-partner-engage-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/globaler-ot-partner-engage-csl-behring-bern"
+    "de": "/de/jobs-in-bern/globaler-ot-partner-engage-csl-behring-bern",
+    "it": "/cerca-lavoro-berna/globaler-ot-partner-engage-csl-behring-bern",
+    "en": "/en/find-jobs-bern/globaler-ot-partner-engage-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/globaler-ot-partner-engage-csl-behring-bern"
   },
   "direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern": {
-    "it": "/cerca-lavoro-ticino/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern"
+    "it": "/cerca-lavoro-berna/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
+    "en": "/en/find-jobs-bern/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
+    "de": "/de/jobs-in-bern/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern"
   },
   "directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern": {
-    "fr": "/fr/trouver-emploi-tessin/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
-    "it": "/cerca-lavoro-ticino/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern"
+    "fr": "/fr/trouver-emploi-berne/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
+    "it": "/cerca-lavoro-berna/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
+    "en": "/en/find-jobs-bern/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
+    "de": "/de/jobs-in-bern/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern"
   },
   "esperto-senior-ehs-gestione-del-rischio-e-sicurezza-tecnica-f-m-d-csl-behring-bern": {
-    "it": "/cerca-lavoro-ticino/esperto-senior-ehs-gestione-del-rischio-e-sicurezza-tecnica-f-m-d-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
-    "de": "/de/jobs-im-tessin/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
-    "fr": "/fr/trouver-emploi-tessin/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
+    "it": "/cerca-lavoro-berna/esperto-senior-ehs-gestione-del-rischio-e-sicurezza-tecnica-f-m-d-csl-behring-bern",
+    "en": "/en/find-jobs-bern/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
+    "de": "/de/jobs-in-bern/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
+    "fr": "/fr/trouver-emploi-berne/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
   },
   "expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern": {
-    "fr": "/fr/trouver-emploi-tessin/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
-    "it": "/cerca-lavoro-ticino/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
+    "fr": "/fr/trouver-emploi-berne/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
+    "it": "/cerca-lavoro-berna/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
+    "en": "/en/find-jobs-bern/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
+    "de": "/de/jobs-in-bern/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
   },
   "esperto-senior-ehs-f-m-d-csl-behring-bern": {
     "it": "/cerca-lavoro-ticino/esperto-senior-ehs-f-m-d-csl-behring-bern",
@@ -104753,22 +104753,22 @@
     "fr": "/fr/trouver-emploi-tessin/senior-ehs-expert-f-m-d-csl-behring-ch"
   },
   "manutenzione-ecosystem-lead-rimozione-csl-behring-bern": {
-    "it": "/cerca-lavoro-ticino/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/manutenzione-ecosystem-lead-rimozione-csl-behring-bern"
+    "it": "/cerca-lavoro-berna/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
+    "en": "/en/find-jobs-bern/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
+    "de": "/de/jobs-in-bern/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/manutenzione-ecosystem-lead-rimozione-csl-behring-bern"
   },
   "maintenance-ecosystem-lead-remote-csl-behring-ch": {
-    "en": "/en/find-jobs-ticino/maintenance-ecosystem-lead-remote-csl-behring-ch",
-    "it": "/cerca-lavoro-ticino/maintenance-ecosystem-lead-remote-csl-behring-ch",
-    "de": "/de/jobs-im-tessin/maintenance-ecosystem-lead-remote-csl-behring-ch",
-    "fr": "/fr/trouver-emploi-tessin/maintenance-ecosystem-lead-remote-csl-behring-ch"
+    "en": "/en/find-jobs-bern/maintenance-ecosystem-lead-remote-csl-behring-ch",
+    "it": "/cerca-lavoro-berna/maintenance-ecosystem-lead-remote-csl-behring-ch",
+    "de": "/de/jobs-in-bern/maintenance-ecosystem-lead-remote-csl-behring-ch",
+    "fr": "/fr/trouver-emploi-berne/maintenance-ecosystem-lead-remote-csl-behring-ch"
   },
   "fuhrender-wartungssystem-manager-remote-csl-behring-bern": {
-    "de": "/de/jobs-im-tessin/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
-    "it": "/cerca-lavoro-ticino/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/fuhrender-wartungssystem-manager-remote-csl-behring-bern"
+    "de": "/de/jobs-in-bern/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
+    "it": "/cerca-lavoro-berna/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
+    "en": "/en/find-jobs-bern/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/fuhrender-wartungssystem-manager-remote-csl-behring-bern"
   },
   "direttore-associato-affidabilita-e-miglioramento-del-prodotto-csl-behring-bern": {
     "it": "/cerca-lavoro-ticino/direttore-associato-affidabilita-e-miglioramento-del-prodotto-csl-behring-bern",
@@ -104963,10 +104963,10 @@
     "fr": "/fr/trouver-emploi-tessin/graduated-physiotherapist-eoc-ente-ospedaliero-cantonale-novaggio-224f42"
   },
   "gestionnaire-de-la-philanthropie-80-100-epfl-lausanne": {
-    "fr": "/fr/trouver-emploi-tessin/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
-    "it": "/cerca-lavoro-ticino/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
-    "en": "/en/find-jobs-ticino/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
-    "de": "/de/jobs-im-tessin/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne"
+    "fr": "/fr/trouver-emploi-vaud/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
+    "it": "/cerca-lavoro-vaud/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
+    "en": "/en/find-jobs-vaud/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
+    "de": "/de/jobs-in-der-waadt/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne"
   },
   "health-and-natural-sciences-vocational-maturity-practical-training-in-nursing-gesundheitsnetz-kusnacht-ag-kusnacht": {
     "en": "/en/find-jobs-ticino/health-and-natural-sciences-vocational-maturity-practical-training-in-nursing-gesundheitsnetz-kusnacht-ag-kusnacht",
@@ -104981,22 +104981,22 @@
     "fr": "/fr/trouver-emploi-tessin/initiative-r-abteilungsleiter-in-betreuung-und-pflege-gesundheitsnetz-kuesnacht-kusnacht"
   },
   "aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle": {
-    "it": "/cerca-lavoro-ticino/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "en": "/en/find-jobs-ticino/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "de": "/de/jobs-im-tessin/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "fr": "/fr/trouver-emploi-tessin/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle"
+    "it": "/cerca-lavoro-vaud/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "en": "/en/find-jobs-vaud/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "de": "/de/jobs-in-der-waadt/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "fr": "/fr/trouver-emploi-vaud/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle"
   },
   "aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle": {
-    "fr": "/fr/trouver-emploi-tessin/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "it": "/cerca-lavoro-ticino/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "en": "/en/find-jobs-ticino/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "de": "/de/jobs-im-tessin/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle"
+    "fr": "/fr/trouver-emploi-vaud/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "it": "/cerca-lavoro-vaud/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "en": "/en/find-jobs-vaud/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "de": "/de/jobs-in-der-waadt/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle"
   },
   "care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle": {
-    "en": "/en/find-jobs-ticino/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "it": "/cerca-lavoro-ticino/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "de": "/de/jobs-im-tessin/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "fr": "/fr/trouver-emploi-tessin/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle"
+    "en": "/en/find-jobs-vaud/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "it": "/cerca-lavoro-vaud/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "de": "/de/jobs-in-der-waadt/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "fr": "/fr/trouver-emploi-vaud/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle"
   },
   "apprentice-fachfrau-mann-hotellerie-hauswirtschaft-cfc-m-w-d-from-august-2027-grand-hotel-des-bains-kempinski-st-moritz": {
     "it": "/cerca-lavoro-ticino/apprentice-fachfrau-mann-hotellerie-hauswirtschaft-cfc-m-w-d-from-august-2027-grand-hotel-des-bains-kempinski-st-moritz",
@@ -105047,10 +105047,10 @@
     "fr": "/fr/trouver-emploi-tessin/apprentice-koch-efz-f-m-d-from-august-2027-grand-hotel-des-bains-kempinski-st-moritz-st-moritz"
   },
   "fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf": {
-    "it": "/cerca-lavoro-ticino/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "en": "/en/find-jobs-ticino/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "de": "/de/jobs-im-tessin/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf"
+    "it": "/cerca-lavoro-zurigo/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "en": "/en/find-jobs-zurich/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "de": "/de/jobs-in-zurich/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "fr": "/fr/trouver-emploi-zurich/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf"
   },
   "healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf": {
     "en": "/en/find-jobs-ticino/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf",
@@ -105059,10 +105059,10 @@
     "fr": "/fr/trouver-emploi-tessin/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf"
   },
   "fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf": {
-    "de": "/de/jobs-im-tessin/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
-    "it": "/cerca-lavoro-ticino/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
-    "en": "/en/find-jobs-ticino/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf"
+    "de": "/de/jobs-in-zurich/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
+    "it": "/cerca-lavoro-zurigo/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
+    "en": "/en/find-jobs-zurich/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
+    "fr": "/fr/trouver-emploi-zurich/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf"
   },
   "candidatura-spontanea-gesundheitszentrum-dielsdorf-dielsdorf-regensdorf": {
     "it": "/cerca-lavoro-ticino/candidatura-spontanea-gesundheitszentrum-dielsdorf-dielsdorf-regensdorf",
@@ -107741,10 +107741,10 @@
     "fr": "/fr/trouver-emploi-tessin/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich"
   },
   "fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg": {
-    "de": "/de/jobs-im-tessin/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
-    "it": "/cerca-lavoro-ticino/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
-    "en": "/en/find-jobs-ticino/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg"
+    "de": "/de/jobs-in-zurich/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
+    "it": "/cerca-lavoro-zurigo/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
+    "en": "/en/find-jobs-zurich/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
+    "fr": "/fr/trouver-emploi-zurich/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg"
   },
   "dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich": {
     "it": "/cerca-lavoro-ticino/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich",
@@ -107753,10 +107753,10 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich"
   },
   "dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich": {
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich"
+    "en": "/en/find-jobs-zurich/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich"
   },
   "diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich": {
     "fr": "/fr/trouver-emploi-tessin/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich",
@@ -107783,16 +107783,16 @@
     "fr": "/fr/trouver-emploi-tessin/healthcare-educator-in-a-klinik-lengg-zurich"
   },
   "berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich": {
-    "de": "/de/jobs-im-tessin/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich"
+    "de": "/de/jobs-in-zurich/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich"
   },
   "formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich"
+    "fr": "/fr/trouver-emploi-zurich/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich"
   },
   "medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich": {
     "it": "/cerca-lavoro-ticino/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich",
@@ -107807,10 +107807,10 @@
     "fr": "/fr/trouver-emploi-tessin/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich": {
-    "de": "/de/jobs-im-tessin/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich"
+    "de": "/de/jobs-in-zurich/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich": {
     "fr": "/fr/trouver-emploi-tessin/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich",
@@ -107825,10 +107825,10 @@
     "fr": "/fr/trouver-emploi-tessin/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich"
   },
   "oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich": {
-    "de": "/de/jobs-im-tessin/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich"
+    "de": "/de/jobs-in-zurich/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich": {
     "fr": "/fr/trouver-emploi-tessin/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich",
@@ -109169,10 +109169,10 @@
     "fr": "/fr/trouver-emploi-tessin/nursing-intern-80-100-luzerner-kantonsspital-luks-wolhusen"
   },
   "fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern": {
-    "de": "/de/jobs-im-tessin/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
-    "it": "/cerca-lavoro-ticino/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
-    "en": "/en/find-jobs-ticino/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern"
+    "de": "/de/jobs-in-luzern/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
+    "en": "/en/find-jobs-lucerne/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern"
   },
   "healthcare-specialist-visceral-and-vascular-surgery-80-100-luzerner-kantonsspital-luks-luzern": {
     "en": "/en/find-jobs-ticino/healthcare-specialist-visceral-and-vascular-surgery-80-100-luzerner-kantonsspital-luks-luzern",
@@ -109205,10 +109205,10 @@
     "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-fur-radiologie-interventional-radiology-fellowship-100-befristet-auf-2-jahre-luzerner-kantonsspital"
   },
   "facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet": {
-    "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
-    "it": "/cerca-lavoro-ticino/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
-    "en": "/en/find-jobs-ticino/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
-    "de": "/de/jobs-im-tessin/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet"
+    "fr": "/fr/trouver-emploi-lucerne/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
+    "it": "/cerca-lavoro-lucerna/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
+    "en": "/en/find-jobs-lucerne/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
+    "de": "/de/jobs-in-luzern/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet"
   },
   "facharztin-facharzt-radiology-fellowship-abdominal-radiology-100-befristet-auf-1-jahr-luzerner-kantonsspital-luks-luzern": {
     "de": "/de/jobs-im-tessin/facharztin-facharzt-radiology-fellowship-abdominal-radiology-100-befristet-auf-1-jahr-luzerner-kantonsspital-luks-luzern",
@@ -109217,10 +109217,10 @@
     "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-radiology-fellowship-abdominal-radiology-100-befristet-auf-1-jahr-luzerner-kantonsspital-luks-luzern"
   },
   "facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr": {
-    "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
-    "it": "/cerca-lavoro-ticino/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
-    "en": "/en/find-jobs-ticino/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
-    "de": "/de/jobs-im-tessin/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr"
+    "fr": "/fr/trouver-emploi-lucerne/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
+    "it": "/cerca-lavoro-lucerna/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
+    "en": "/en/find-jobs-lucerne/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
+    "de": "/de/jobs-in-luzern/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr"
   },
   "insegnante-di-cura-in-ambito-operatorio-50-luzerner-kantonsspital-luks-luzern": {
     "it": "/cerca-lavoro-ticino/insegnante-di-cura-in-ambito-operatorio-50-luzerner-kantonsspital-luks-luzern",
@@ -109229,10 +109229,10 @@
     "fr": "/fr/trouver-emploi-tessin/insegnante-di-cura-in-ambito-operatorio-50-luzerner-kantonsspital-luks-luzern"
   },
   "lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern": {
-    "de": "/de/jobs-im-tessin/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
-    "it": "/cerca-lavoro-ticino/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
-    "en": "/en/find-jobs-ticino/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern"
+    "de": "/de/jobs-in-luzern/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
+    "en": "/en/find-jobs-lucerne/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern"
   },
   "educateur-en-soins-pratiques-en-chirurgie-50-luzerner-kantonsspital-luks-luzern": {
     "fr": "/fr/trouver-emploi-tessin/educateur-en-soins-pratiques-en-chirurgie-50-luzerner-kantonsspital-luks-luzern",
@@ -109247,10 +109247,10 @@
     "fr": "/fr/trouver-emploi-tessin/consulente-specializzato-in-diabete-70-80-luzerner-kantonsspital-luks-sursee"
   },
   "diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee": {
-    "de": "/de/jobs-im-tessin/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
-    "it": "/cerca-lavoro-ticino/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
-    "en": "/en/find-jobs-ticino/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
-    "fr": "/fr/trouver-emploi-tessin/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee"
+    "de": "/de/jobs-in-luzern/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
+    "it": "/cerca-lavoro-lucerna/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
+    "en": "/en/find-jobs-lucerne/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
+    "fr": "/fr/trouver-emploi-lucerne/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee"
   },
   "diabetes-specialist-advisor-70-80-luzerner-kantonsspital-luks-sursee": {
     "en": "/en/find-jobs-ticino/diabetes-specialist-advisor-70-80-luzerner-kantonsspital-luks-sursee",
@@ -109271,10 +109271,10 @@
     "fr": "/fr/trouver-emploi-tessin/addetta-o-alle-pulizie-50-80-a-tempo-determinato-fino-al-31-08-2026-luzerner-kantonsspital-luks-luzern"
   },
   "mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern": {
-    "de": "/de/jobs-im-tessin/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
-    "it": "/cerca-lavoro-ticino/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
-    "en": "/en/find-jobs-ticino/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern"
+    "de": "/de/jobs-in-luzern/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
+    "en": "/en/find-jobs-lucerne/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern"
   },
   "cleaning-staff-50-80-fixed-term-until-31-08-2026-luzerner-kantonsspital-luks-luzern": {
     "en": "/en/find-jobs-ticino/cleaning-staff-50-80-fixed-term-until-31-08-2026-luzerner-kantonsspital-luks-luzern",
@@ -109289,10 +109289,10 @@
     "de": "/de/jobs-im-tessin/employe-e-de-nettoyage-50-80-en-contrat-temporaire-jusqu-au-31-08-2026-luzerner-kantonsspital-luks-luzern"
   },
   "medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern": {
-    "de": "/de/jobs-im-tessin/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
-    "it": "/cerca-lavoro-ticino/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
-    "en": "/en/find-jobs-ticino/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern"
+    "de": "/de/jobs-in-luzern/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
+    "en": "/en/find-jobs-lucerne/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern"
   },
   "healthcare-professional-for-health-hub-50-100-luzerner-kantonsspital-luks-luzern": {
     "en": "/en/find-jobs-ticino/healthcare-professional-for-health-hub-50-100-luzerner-kantonsspital-luks-luzern",
@@ -109313,10 +109313,10 @@
     "fr": "/fr/trouver-emploi-tessin/capo-della-fisioterapia-possibilita-di-lavoro-condiviso-100-luzerner-kantonsspital-luks-stans"
   },
   "leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2": {
-    "it": "/cerca-lavoro-ticino/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
-    "en": "/en/find-jobs-ticino/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
-    "de": "/de/jobs-im-tessin/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
-    "fr": "/fr/trouver-emploi-tessin/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2"
+    "it": "/cerca-lavoro-nidvaldo/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
+    "en": "/en/find-jobs-nidwalden/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
+    "de": "/de/jobs-in-nidwalden/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
+    "fr": "/fr/trouver-emploi-nidwald/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2"
   },
   "infermiere-a-interdisciplinare-reparto-madre-bambino-100-luzerner-kantonsspital-luks-sursee": {
     "it": "/cerca-lavoro-ticino/infermiere-a-interdisciplinare-reparto-madre-bambino-100-luzerner-kantonsspital-luks-sursee",
@@ -109343,16 +109343,16 @@
     "fr": "/fr/trouver-emploi-tessin/capo-it-sicurezza-80-100-luzerner-kantonsspital-luks-luzern"
   },
   "leiterin-leiter-it-security-80-100-luks-luzern": {
-    "de": "/de/jobs-im-tessin/leiterin-leiter-it-security-80-100-luks-luzern",
-    "it": "/cerca-lavoro-ticino/leiterin-leiter-it-security-80-100-luks-luzern",
-    "en": "/en/find-jobs-ticino/leiterin-leiter-it-security-80-100-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/leiterin-leiter-it-security-80-100-luks-luzern"
+    "de": "/de/jobs-in-luzern/leiterin-leiter-it-security-80-100-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/leiterin-leiter-it-security-80-100-luks-luzern",
+    "en": "/en/find-jobs-lucerne/leiterin-leiter-it-security-80-100-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/leiterin-leiter-it-security-80-100-luks-luzern"
   },
   "head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern": {
-    "en": "/en/find-jobs-ticino/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
-    "it": "/cerca-lavoro-ticino/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
-    "de": "/de/jobs-im-tessin/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern"
+    "en": "/en/find-jobs-lucerne/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
+    "de": "/de/jobs-in-luzern/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern"
   },
   "impiego-di-servizio-civile-come-assistente-alla-cura-al-100-luzerner-psychiatrie-lups-luzern-16": {
     "it": "/cerca-lavoro-ticino/impiego-di-servizio-civile-come-assistente-alla-cura-al-100-luzerner-psychiatrie-lups-luzern-16",
@@ -109751,28 +109751,28 @@
     "de": "/de/jobs-im-tessin/collaborateur-trice-kuche-allrounder-in-80-100-michel-gruppe-ag-hasliberg-hohfluh"
   },
   "kv-apprendistato-cfc-2027-agenzia-generale-bern-west-die-mobiliar-bern": {
-    "it": "/cerca-lavoro-ticino/kv-apprendistato-cfc-2027-agenzia-generale-bern-west-die-mobiliar-bern",
-    "de": "/de/jobs-im-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "en": "/en/find-jobs-ticino/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "fr": "/fr/trouver-emploi-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
+    "it": "/cerca-lavoro-berna/kv-apprendistato-cfc-2027-agenzia-generale-bern-west-die-mobiliar-bern",
+    "de": "/de/jobs-in-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "en": "/en/find-jobs-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "fr": "/fr/trouver-emploi-berne/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
   },
   "kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch": {
-    "de": "/de/jobs-im-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "it": "/cerca-lavoro-ticino/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "en": "/en/find-jobs-ticino/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "fr": "/fr/trouver-emploi-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
+    "de": "/de/jobs-in-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "it": "/cerca-lavoro-berna/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "en": "/en/find-jobs-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "fr": "/fr/trouver-emploi-berne/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
   },
   "kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern": {
-    "en": "/en/find-jobs-ticino/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
-    "it": "/cerca-lavoro-ticino/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
-    "de": "/de/jobs-im-tessin/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
-    "fr": "/fr/trouver-emploi-tessin/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern"
+    "en": "/en/find-jobs-bern/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
+    "it": "/cerca-lavoro-berna/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
+    "de": "/de/jobs-in-bern/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
+    "fr": "/fr/trouver-emploi-berne/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern"
   },
   "apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern": {
-    "fr": "/fr/trouver-emploi-tessin/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
-    "it": "/cerca-lavoro-ticino/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
-    "en": "/en/find-jobs-ticino/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
-    "de": "/de/jobs-im-tessin/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern"
+    "fr": "/fr/trouver-emploi-berne/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
+    "it": "/cerca-lavoro-berna/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
+    "en": "/en/find-jobs-bern/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
+    "de": "/de/jobs-in-bern/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern"
   },
   "koch-w-m-d-kita-mikado-80-mobiliar-ch": {
     "it": "/cerca-lavoro-ticino/koch-w-m-d-kita-mikado-80-mobiliar-ch",
@@ -111371,10 +111371,10 @@
     "de": "/de/jobs-im-tessin/infirmier-ere-hf-fh-sanatorium-kilchberg-kilchberg"
   },
   "gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur": {
-    "it": "/cerca-lavoro-ticino/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
-    "en": "/en/find-jobs-ticino/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
-    "de": "/de/jobs-im-tessin/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
-    "fr": "/fr/trouver-emploi-tessin/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur"
+    "it": "/cerca-lavoro-lucerna/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
+    "en": "/en/find-jobs-lucerne/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
+    "de": "/de/jobs-in-luzern/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
+    "fr": "/fr/trouver-emploi-lucerne/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur"
   },
   "aufzugsmonteur-in-m-w-d-80-100-schindler-wettswil": {
     "it": "/cerca-lavoro-ticino/aufzugsmonteur-in-m-w-d-80-100-schindler-wettswil",
@@ -113585,10 +113585,10 @@
     "fr": "/fr/trouver-emploi-tessin/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten"
   },
   "nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten": {
-    "de": "/de/jobs-im-tessin/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
-    "it": "/cerca-lavoro-ticino/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
-    "en": "/en/find-jobs-ticino/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
-    "fr": "/fr/trouver-emploi-tessin/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten"
+    "de": "/de/jobs-in-solothurn/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
+    "it": "/cerca-lavoro-soletta/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
+    "en": "/en/find-jobs-solothurn/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
+    "fr": "/fr/trouver-emploi-soleure/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten"
   },
   "formation-postgrade-hf-en-soins-intensifs-h-f-solothurner-spitaler-ag-soh-olten": {
     "fr": "/fr/trouver-emploi-tessin/formation-postgrade-hf-en-soins-intensifs-h-f-solothurner-spitaler-ag-soh-olten",
@@ -114965,10 +114965,10 @@
     "fr": "/fr/trouver-emploi-tessin/civilian-service-technician-spitaler-schaffhausen-schaffhausen"
   },
   "dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen"
+    "it": "/cerca-lavoro-sciaffusa/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
+    "en": "/en/find-jobs-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
+    "de": "/de/jobs-in-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
+    "fr": "/fr/trouver-emploi-schaffhouse/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen"
   },
   "dipl-ing-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen": {
     "de": "/de/jobs-im-tessin/dipl-ing-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
@@ -114977,10 +114977,10 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-ing-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen"
   },
   "dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen"
+    "it": "/cerca-lavoro-sciaffusa/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
+    "en": "/en/find-jobs-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
+    "de": "/de/jobs-in-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
+    "fr": "/fr/trouver-emploi-schaffhouse/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen"
   },
   "accompagnatore-a-della-ripresa-peer-in-day-hospital-spitaler-schaffhausen-schaffhausen": {
     "it": "/cerca-lavoro-ticino/accompagnatore-a-della-ripresa-peer-in-day-hospital-spitaler-schaffhausen-schaffhausen",
@@ -115013,16 +115013,16 @@
     "fr": "/fr/trouver-emploi-tessin/interdisciplinary-emergency-center-manager-spitaler-schaffhausen-schaffhausen"
   },
   "intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am": {
-    "en": "/en/find-jobs-ticino/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
-    "it": "/cerca-lavoro-ticino/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
-    "de": "/de/jobs-im-tessin/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
-    "fr": "/fr/trouver-emploi-tessin/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am"
+    "en": "/en/find-jobs-zurich/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
+    "it": "/cerca-lavoro-zurigo/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
+    "de": "/de/jobs-in-zurich/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
+    "fr": "/fr/trouver-emploi-zurich/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am"
   },
   "abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach": {
-    "de": "/de/jobs-im-tessin/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
-    "it": "/cerca-lavoro-ticino/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
-    "en": "/en/find-jobs-ticino/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
-    "fr": "/fr/trouver-emploi-tessin/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach"
+    "de": "/de/jobs-in-zurich/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
+    "it": "/cerca-lavoro-zurigo/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
+    "en": "/en/find-jobs-zurich/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
+    "fr": "/fr/trouver-emploi-zurich/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach"
   },
   "head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach": {
     "en": "/en/find-jobs-ticino/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach",
@@ -115403,16 +115403,16 @@
     "it": "/cerca-lavoro-ticino/co-teamleitung-pflege-80-100-spitex-ch-thalwil"
   },
   "infermiere-dipl-hf-50-80-formatore-per-hf-fh-spitex-aare-selzach": {
-    "it": "/cerca-lavoro-ticino/infermiere-dipl-hf-50-80-formatore-per-hf-fh-spitex-aare-selzach",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "en": "/en/find-jobs-ticino/registered-nurse-hf-50-80-trainer-for-hf-fh-spitex-aare-selzach",
-    "fr": "/fr/trouver-emploi-tessin/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach"
+    "it": "/cerca-lavoro-soletta/infermiere-dipl-hf-50-80-formatore-per-hf-fh-spitex-aare-selzach",
+    "de": "/de/jobs-in-solothurn/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "en": "/en/find-jobs-solothurn/registered-nurse-hf-50-80-trainer-for-hf-fh-spitex-aare-selzach",
+    "fr": "/fr/trouver-emploi-soleure/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach"
   },
   "dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach": {
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach"
+    "de": "/de/jobs-in-solothurn/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "it": "/cerca-lavoro-soletta/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "en": "/en/find-jobs-solothurn/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "fr": "/fr/trouver-emploi-soleure/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach"
   },
   "infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach",
@@ -115421,10 +115421,10 @@
     "de": "/de/jobs-im-tessin/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach"
   },
   "infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen": {
-    "fr": "/fr/trouver-emploi-tessin/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
-    "it": "/cerca-lavoro-ticino/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
-    "en": "/en/find-jobs-ticino/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
-    "de": "/de/jobs-im-tessin/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen"
+    "fr": "/fr/trouver-emploi-soleure/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
+    "it": "/cerca-lavoro-soletta/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
+    "en": "/en/find-jobs-solothurn/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
+    "de": "/de/jobs-in-solothurn/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen"
   },
   "infermiere-infermiera-professionale-efz-60-90-spitex-region-bulach-bulach": {
     "it": "/cerca-lavoro-ticino/infermiere-infermiera-professionale-efz-60-90-spitex-region-bulach-bulach",
@@ -115541,28 +115541,28 @@
     "fr": "/fr/trouver-emploi-tessin/administration-internship-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil": {
-    "it": "/cerca-lavoro-ticino/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "en": "/en/find-jobs-ticino/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "de": "/de/jobs-im-tessin/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "fr": "/fr/trouver-emploi-tessin/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil"
+    "it": "/cerca-lavoro-lucerna/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "en": "/en/find-jobs-lucerne/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "de": "/de/jobs-in-luzern/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "fr": "/fr/trouver-emploi-lucerne/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil": {
-    "en": "/en/find-jobs-ticino/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "it": "/cerca-lavoro-ticino/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "de": "/de/jobs-im-tessin/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "fr": "/fr/trouver-emploi-tessin/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil"
+    "en": "/en/find-jobs-lucerne/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "it": "/cerca-lavoro-lucerna/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "de": "/de/jobs-in-luzern/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "fr": "/fr/trouver-emploi-lucerne/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "mitarbeiter-in-gastronomie-spz-nottwil": {
-    "de": "/de/jobs-im-tessin/mitarbeiter-in-gastronomie-spz-nottwil",
-    "it": "/cerca-lavoro-ticino/mitarbeiter-in-gastronomie-spz-nottwil",
-    "en": "/en/find-jobs-ticino/mitarbeiter-in-gastronomie-spz-nottwil",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-in-gastronomie-spz-nottwil"
+    "de": "/de/jobs-in-luzern/mitarbeiter-in-gastronomie-spz-nottwil",
+    "it": "/cerca-lavoro-lucerna/mitarbeiter-in-gastronomie-spz-nottwil",
+    "en": "/en/find-jobs-lucerne/mitarbeiter-in-gastronomie-spz-nottwil",
+    "fr": "/fr/trouver-emploi-lucerne/mitarbeiter-in-gastronomie-spz-nottwil"
   },
   "employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil": {
-    "fr": "/fr/trouver-emploi-tessin/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "it": "/cerca-lavoro-ticino/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "en": "/en/find-jobs-ticino/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "de": "/de/jobs-im-tessin/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil"
+    "fr": "/fr/trouver-emploi-lucerne/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "it": "/cerca-lavoro-lucerna/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "en": "/en/find-jobs-lucerne/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "de": "/de/jobs-in-luzern/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "medico-capo-ginecologia-60-100-sro-ag-spital-region-oberaargau-divers": {
     "it": "/cerca-lavoro-ticino/medico-capo-ginecologia-60-100-sro-ag-spital-region-oberaargau-divers",
@@ -115595,16 +115595,16 @@
     "fr": "/fr/trouver-emploi-tessin/infermiere-di-soccorso-diplomato-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
   },
   "dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal": {
-    "en": "/en/find-jobs-ticino/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
-    "it": "/cerca-lavoro-ticino/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
-    "de": "/de/jobs-im-tessin/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
-    "fr": "/fr/trouver-emploi-tessin/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
+    "en": "/en/find-jobs-bern/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
+    "it": "/cerca-lavoro-berna/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
+    "de": "/de/jobs-in-bern/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
+    "fr": "/fr/trouver-emploi-berne/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
   },
   "dipl-rettungssanitater-in-hf-60-100-sro-langenthal": {
-    "de": "/de/jobs-im-tessin/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
-    "it": "/cerca-lavoro-ticino/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
-    "en": "/en/find-jobs-ticino/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
-    "fr": "/fr/trouver-emploi-tessin/dipl-rettungssanitater-in-hf-60-100-sro-langenthal"
+    "de": "/de/jobs-in-bern/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
+    "it": "/cerca-lavoro-berna/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
+    "en": "/en/find-jobs-bern/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
+    "fr": "/fr/trouver-emploi-berne/dipl-rettungssanitater-in-hf-60-100-sro-langenthal"
   },
   "dipl-assistant-sanitaire-hf-60-100-sro-ag-spital-region-oberaargau-langenthal": {
     "fr": "/fr/trouver-emploi-tessin/dipl-assistant-sanitaire-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
@@ -115613,22 +115613,22 @@
     "de": "/de/jobs-im-tessin/dipl-assistant-sanitaire-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
   },
   "dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2"
+    "it": "/cerca-lavoro-berna/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
+    "en": "/en/find-jobs-bern/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
+    "fr": "/fr/trouver-emploi-berne/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
+    "de": "/de/jobs-in-bern/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2"
   },
   "field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch": {
-    "en": "/en/find-jobs-ticino/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
-    "it": "/cerca-lavoro-ticino/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
-    "de": "/de/jobs-im-tessin/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
-    "fr": "/fr/trouver-emploi-tessin/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch"
+    "en": "/en/find-jobs-solothurn/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
+    "it": "/cerca-lavoro-soletta/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
+    "de": "/de/jobs-in-solothurn/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
+    "fr": "/fr/trouver-emploi-soleure/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch"
   },
   "feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach": {
-    "de": "/de/jobs-im-tessin/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
-    "it": "/cerca-lavoro-ticino/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
-    "en": "/en/find-jobs-ticino/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
-    "fr": "/fr/trouver-emploi-tessin/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach"
+    "de": "/de/jobs-in-solothurn/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
+    "it": "/cerca-lavoro-soletta/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
+    "en": "/en/find-jobs-solothurn/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
+    "fr": "/fr/trouver-emploi-soleure/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach"
   },
   "assistente-medico-klinik-sudhang-ambulatorium-biel-bienne": {
     "it": "/cerca-lavoro-ticino/assistente-medico-klinik-sudhang-ambulatorium-biel-bienne",
@@ -118901,10 +118901,10 @@
     "fr": "/fr/trouver-emploi-tessin/assistente-a-medico-a-m-f-leukerbad-clinic-leukerbad"
   },
   "medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad": {
-    "de": "/de/jobs-im-tessin/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad",
-    "it": "/cerca-lavoro-ticino/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad",
-    "en": "/en/find-jobs-ticino/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad",
-    "fr": "/fr/trouver-emploi-tessin/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad"
+    "de": "/de/jobs-im-wallis/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad",
+    "it": "/cerca-lavoro-vallese/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad",
+    "en": "/en/find-jobs-valais/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad",
+    "fr": "/fr/trouver-emploi-valais/medizinische-r-praxisassistent-in-m-w-leukerbad-clinic-leukerbad"
   },
   "medical-practice-assistant-m-f-leukerbad-clinic-leukerbad": {
     "en": "/en/find-jobs-ticino/medical-practice-assistant-m-f-leukerbad-clinic-leukerbad",
@@ -119081,40 +119081,40 @@
     "it": "/cerca-lavoro-ticino/mitarbeiterin-mitarbeiter-hotellerieservice-privatstationen-pdag-windisch"
   },
   "leitende-arztin-leitender-arzt-pdag-windisch": {
-    "it": "/cerca-lavoro-ticino/leitende-arztin-leitender-arzt-pdag-windisch",
-    "de": "/de/jobs-im-tessin/leitende-arztin-leitender-arzt-pdag-windisch",
-    "en": "/en/find-jobs-ticino/leitende-arztin-leitender-arzt-pdag-windisch",
-    "fr": "/fr/trouver-emploi-tessin/leitende-arztin-leitender-arzt-pdag-windisch"
+    "it": "/cerca-lavoro-argovia/leitende-arztin-leitender-arzt-pdag-windisch",
+    "de": "/de/jobs-im-aargau/leitende-arztin-leitender-arzt-pdag-windisch",
+    "en": "/en/find-jobs-aargau/leitende-arztin-leitender-arzt-pdag-windisch",
+    "fr": "/fr/trouver-emploi-argovie/leitende-arztin-leitender-arzt-pdag-windisch"
   },
   "fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch": {
-    "it": "/cerca-lavoro-ticino/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch",
-    "de": "/de/jobs-im-tessin/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch",
-    "en": "/en/find-jobs-ticino/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch"
+    "it": "/cerca-lavoro-argovia/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch",
+    "de": "/de/jobs-im-aargau/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch",
+    "en": "/en/find-jobs-aargau/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch",
+    "fr": "/fr/trouver-emploi-argovie/fachfrau-fachmann-gesundheit-nachtwachen-equipe-pdag-windisch"
   },
   "assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch": {
-    "it": "/cerca-lavoro-ticino/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch",
-    "en": "/en/find-jobs-ticino/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch",
-    "de": "/de/jobs-im-tessin/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch",
-    "fr": "/fr/trouver-emploi-tessin/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch"
+    "it": "/cerca-lavoro-argovia/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch",
+    "en": "/en/find-jobs-aargau/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch",
+    "de": "/de/jobs-im-aargau/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch",
+    "fr": "/fr/trouver-emploi-argovie/assistenzpsychologin-assistenzpsychologe-o-fachpsychologin-fachpsychologe-psychiatrische-dienste-aargau-pdag-windisch"
   },
   "assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch": {
-    "de": "/de/jobs-im-tessin/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch",
-    "en": "/en/find-jobs-ticino/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch",
-    "fr": "/fr/trouver-emploi-tessin/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch",
-    "it": "/cerca-lavoro-ticino/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch"
+    "de": "/de/jobs-im-aargau/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch",
+    "en": "/en/find-jobs-aargau/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch",
+    "fr": "/fr/trouver-emploi-argovie/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch",
+    "it": "/cerca-lavoro-argovia/assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-pdag-windisch"
   },
   "dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie"
+    "it": "/cerca-lavoro-argovia/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie",
+    "de": "/de/jobs-im-aargau/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie",
+    "en": "/en/find-jobs-aargau/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie",
+    "fr": "/fr/trouver-emploi-argovie/dipl-pflegefachfrau-dipl-pflegefachmann-hf-nachtdienst-im-klinikbereich-neuropsychiatrie"
   },
   "dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch"
+    "it": "/cerca-lavoro-argovia/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch",
+    "de": "/de/jobs-im-aargau/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch",
+    "en": "/en/find-jobs-aargau/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch",
+    "fr": "/fr/trouver-emploi-argovie/dipl-pflegefachfrau-dipl-pflegefachmann-abhangigkeitserkrankungen-pdag-windisch"
   },
   "assistente-sociale-psychiatrische-dienste-aargau-pdag-windisch": {
     "it": "/cerca-lavoro-ticino/assistente-sociale-psychiatrische-dienste-aargau-pdag-windisch",
@@ -119123,10 +119123,10 @@
     "fr": "/fr/trouver-emploi-tessin/assistente-sociale-psychiatrische-dienste-aargau-pdag-windisch"
   },
   "medecin-chef-psychiatrische-dienste-aargau-pdag-windisch": {
-    "fr": "/fr/trouver-emploi-tessin/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch",
-    "it": "/cerca-lavoro-ticino/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch",
-    "en": "/en/find-jobs-ticino/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch",
-    "de": "/de/jobs-im-tessin/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch"
+    "fr": "/fr/trouver-emploi-argovie/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch",
+    "it": "/cerca-lavoro-argovia/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch",
+    "en": "/en/find-jobs-aargau/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch",
+    "de": "/de/jobs-im-aargau/medecin-chef-psychiatrische-dienste-aargau-pdag-windisch"
   },
   "collaboratrice-collaboratore-servizio-alberghiero-stazioni-private-psychiatrische-dienste-aargau-pdag-windisch": {
     "it": "/cerca-lavoro-ticino/collaboratrice-collaboratore-servizio-alberghiero-stazioni-private-psychiatrische-dienste-aargau-pdag-windisch",
@@ -119147,10 +119147,10 @@
     "de": "/de/jobs-im-tessin/employe-e-service-hotelier-stations-privees-psychiatrische-dienste-aargau-pdag-windisch"
   },
   "dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch": {
-    "it": "/cerca-lavoro-ticino/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch",
-    "en": "/en/find-jobs-ticino/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch",
-    "de": "/de/jobs-im-tessin/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch",
-    "fr": "/fr/trouver-emploi-tessin/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch"
+    "it": "/cerca-lavoro-argovia/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch",
+    "en": "/en/find-jobs-aargau/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch",
+    "de": "/de/jobs-im-aargau/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch",
+    "fr": "/fr/trouver-emploi-argovie/dirigente-medico-psychiatrische-dienste-aargau-pdag-windisch"
   },
   "assistant-psychologist-psychiatrische-dienste-aargau-pdag-windisch": {
     "en": "/en/find-jobs-ticino/assistant-psychologist-psychiatrische-dienste-aargau-pdag-windisch",
@@ -119489,10 +119489,10 @@
     "de": "/de/jobs-im-tessin/expert-e-en-soins-d-urgence-diplome-ou-infirmier-ere-expert-e-en-soins-spital-emmental-langnau"
   },
   "interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5": {
-    "it": "/cerca-lavoro-ticino/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
-    "en": "/en/find-jobs-ticino/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
-    "de": "/de/jobs-im-tessin/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
-    "fr": "/fr/trouver-emploi-tessin/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5"
+    "it": "/cerca-lavoro-turgovia/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
+    "en": "/en/find-jobs-thurgau/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
+    "de": "/de/jobs-im-thurgau/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
+    "fr": "/fr/trouver-emploi-thurgovie/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5"
   },
   "tissot-sales-associate-the-swatch-group-u-s-inc-ticino": {
     "it": "/cerca-lavoro-ticino/tissot-sales-associate-the-swatch-group-u-s-inc-ticino",
@@ -119591,10 +119591,10 @@
     "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-gesundheit-cfc-a-interdisziplinare-rehabilitation-innere-medizin-klinik-barmelweid-barmelweid"
   },
   "fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern": {
-    "it": "/cerca-lavoro-ticino/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
-    "en": "/en/find-jobs-ticino/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
-    "de": "/de/jobs-im-tessin/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern"
+    "it": "/cerca-lavoro-lucerna/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
+    "en": "/en/find-jobs-lucerne/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
+    "de": "/de/jobs-in-luzern/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern"
   },
   "cc-place-d-apprentissage-cfc-2027-agence-generale-berne-ouest-die-mobiliar-bern": {
     "it": "/cerca-lavoro-ticino/cc-place-d-apprentissage-cfc-2027-agence-generale-berne-ouest-die-mobiliar-bern",
@@ -119645,52 +119645,52 @@
     "fr": "/fr/trouver-emploi-tessin/assistente-a-alla-salute-e-al-sociale-40-100-turni-diurni-o-notturni-tertianum-rich-d80pq1"
   },
   "high-watchmaking-client-relationship-manager-richemont-plan-les-ouates": {
-    "en": "/en/find-jobs-ticino/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
-    "de": "/de/jobs-im-tessin/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
-    "fr": "/fr/trouver-emploi-tessin/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates"
+    "en": "/en/find-jobs-geneva/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
+    "de": "/de/jobs-in-genf/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
+    "fr": "/fr/trouver-emploi-geneve/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates"
   },
   "boutique-assistant-intern-cartier-zurich": {
-    "en": "/en/find-jobs-ticino/boutique-assistant-intern-cartier-zurich",
-    "it": "/cerca-lavoro-ticino/boutique-assistant-intern-cartier-zurich",
-    "de": "/de/jobs-im-tessin/boutique-assistant-intern-cartier-zurich",
-    "fr": "/fr/trouver-emploi-tessin/boutique-assistant-intern-cartier-zurich"
+    "en": "/en/find-jobs-zurich/boutique-assistant-intern-cartier-zurich",
+    "it": "/cerca-lavoro-zurigo/boutique-assistant-intern-cartier-zurich",
+    "de": "/de/jobs-in-zurich/boutique-assistant-intern-cartier-zurich",
+    "fr": "/fr/trouver-emploi-zurich/boutique-assistant-intern-cartier-zurich"
   },
   "boutique-assistant-intern-richemont-zurich": {
-    "en": "/en/find-jobs-ticino/boutique-assistant-intern-cartier-zurich",
-    "it": "/cerca-lavoro-ticino/boutique-assistant-intern-richemont-zurich",
-    "de": "/de/jobs-im-tessin/boutique-assistant-intern-richemont-zurich",
-    "fr": "/fr/trouver-emploi-tessin/boutique-assistant-intern-richemont-zurich"
+    "en": "/en/find-jobs-zurich/boutique-assistant-intern-cartier-zurich",
+    "it": "/cerca-lavoro-zurigo/boutique-assistant-intern-richemont-zurich",
+    "de": "/de/jobs-in-zurich/boutique-assistant-intern-richemont-zurich",
+    "fr": "/fr/trouver-emploi-zurich/boutique-assistant-intern-richemont-zurich"
   },
   "dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern": {
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
+    "de": "/de/jobs-in-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "en": "/en/find-jobs-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "fr": "/fr/trouver-emploi-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "it": "/cerca-lavoro-zurigo/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
   },
   "dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-e-nachtschicht-spital-affoltern-ag-affoltern-am-albis": {
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-e-nachtschicht-spital-affoltern-ag-affoltern-am-albis",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
+    "de": "/de/jobs-in-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "it": "/cerca-lavoro-zurigo/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-e-nachtschicht-spital-affoltern-ag-affoltern-am-albis",
+    "en": "/en/find-jobs-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "fr": "/fr/trouver-emploi-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
   },
   "fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf": {
-    "de": "/de/jobs-im-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "en": "/en/find-jobs-ticino/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "it": "/cerca-lavoro-ticino/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
+    "de": "/de/jobs-in-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "en": "/en/find-jobs-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "fr": "/fr/trouver-emploi-berne/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "it": "/cerca-lavoro-berna/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
   },
   "fachperson-per-neurophysiologische-diagnostik-a-spital-emmental-burgdorf": {
-    "de": "/de/jobs-im-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "it": "/cerca-lavoro-ticino/fachperson-per-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "en": "/en/find-jobs-ticino/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
+    "de": "/de/jobs-in-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "it": "/cerca-lavoro-berna/fachperson-per-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "en": "/en/find-jobs-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "fr": "/fr/trouver-emploi-berne/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
   },
   "fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil": {
-    "de": "/de/jobs-im-tessin/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil",
-    "it": "/cerca-lavoro-ticino/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil",
-    "en": "/en/find-jobs-ticino/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil"
+    "de": "/de/jobs-in-st-gallen/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil",
+    "it": "/cerca-lavoro-san-gallo/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil",
+    "en": "/en/find-jobs-st-gallen/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil",
+    "fr": "/fr/trouver-emploi-saint-gall/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil"
   },
   "brand-creative-senior-designer-100-swatch-ltd-job-location-rue-nicolas-g-hayek-strasse-2502-biel-bienne-ber-7uaw3z": {
     "it": "/cerca-lavoro-ticino/brand-creative-senior-designer-100-swatch-ltd-job-location-rue-nicolas-g-hayek-strasse-2502-biel-bienne-ber-7uaw3z",
@@ -119699,10 +119699,10 @@
     "fr": "/fr/trouver-emploi-tessin/brand-creative-senior-designer-100-swatch-ltd-job-location-rue-nicolas-g-hayek-strasse-2502-biel-bienne-ber-7uaw3z"
   },
   "berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt": {
-    "it": "/cerca-lavoro-ticino/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
-    "en": "/en/find-jobs-ticino/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
-    "de": "/de/jobs-im-tessin/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
-    "fr": "/fr/trouver-emploi-tessin/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt"
+    "it": "/cerca-lavoro-argovia/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
+    "en": "/en/find-jobs-aargau/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
+    "de": "/de/jobs-im-aargau/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
+    "fr": "/fr/trouver-emploi-argovie/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt"
   },
   "alle": {
     "it": "/cerca-lavoro-ticino/alle",
@@ -120215,10 +120215,10 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-specialista-di-cura-hf-fh-medicina-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "dipl-medicina-specialistica-spital-thurgau-stgag-kantonsspital-frauenfeld": {
     "it": "/cerca-lavoro-ticino/dipl-medicina-specialistica-spital-thurgau-stgag-kantonsspital-frauenfeld",

--- a/scripts/migrate-all-known-job-slugs-canton-aware.mjs
+++ b/scripts/migrate-all-known-job-slugs-canton-aware.mjs
@@ -129,9 +129,15 @@ function resolveJobCanton(job) {
 const tracking = JSON.parse(fs.readFileSync(TRACKING_PATH, 'utf8'));
 const jobs = JSON.parse(fs.readFileSync(JOBS_PATH, 'utf8'));
 
-// 1. Index every job slug-alias -> job (so we can resolve its canton).
+// 1. Index exact job slugs separately from slug aliases. A translated slug or
+// previousSlug can collide with another job's canonical slug; the canonical
+// owner must win when the tracking key exactly matches `job.slug`.
+const exactSlugToJob = new Map();
 const slugToJob = new Map();
 for (const job of jobs) {
+  if (job?.slug && !exactSlugToJob.has(String(job.slug))) {
+    exactSlugToJob.set(String(job.slug), job);
+  }
   const aliases = new Set();
   if (job?.slug) aliases.add(String(job.slug));
   if (job?.slugByLocale && typeof job.slugByLocale === 'object') {
@@ -166,7 +172,7 @@ for (const [trackingSlug, entry] of Object.entries(tracking)) {
     out[trackingSlug] = entry;
     continue;
   }
-  const job = slugToJob.get(trackingSlug);
+  const job = exactSlugToJob.get(trackingSlug) ?? slugToJob.get(trackingSlug);
   if (!job) {
     orphanKept++;
     out[trackingSlug] = entry;

--- a/tests/build-plugins/salary-hub-ownership.test.ts
+++ b/tests/build-plugins/salary-hub-ownership.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SALARY_HUB_SCENARIO_INDEX_OWNERSHIP_PATTERN,
+  SALARY_HUB_SCENARIO_OWNERSHIP_PATTERN,
+} from '../../build-plugins/salaryHubPlugin';
+
+describe('salaryHubPlugin shared path ownership patterns', () => {
+  it('covers generated salary scenario variants, not only the base salary slug', () => {
+    expect(
+      SALARY_HUB_SCENARIO_OWNERSHIP_PATTERN.test(
+        '/tmp/dist/fr/calculer-salaire/salaire-net-95000-chf-marie-3-enfants-nouveau-frontalier-plus-20km/index.html',
+      ),
+    ).toBe(true);
+    expect(
+      SALARY_HUB_SCENARIO_OWNERSHIP_PATTERN.test(
+        '/tmp/dist/en/calculate-salary/net-salary-60000-chf-married-2-children-new-crossborder-within-20km.html',
+      ),
+    ).toBe(true);
+    expect(
+      SALARY_HUB_SCENARIO_OWNERSHIP_PATTERN.test('/tmp/dist/calcola-stipendio/confronta-stipendi/index.html'),
+    ).toBe(false);
+  });
+
+  it('covers the browseable scenario indexes in every locale', () => {
+    expect(SALARY_HUB_SCENARIO_INDEX_OWNERSHIP_PATTERN.test('/tmp/dist/calcola-stipendio/scenari/index.html')).toBe(true);
+    expect(SALARY_HUB_SCENARIO_INDEX_OWNERSHIP_PATTERN.test('/tmp/dist/en/calculate-salary/scenarios.html')).toBe(true);
+    expect(SALARY_HUB_SCENARIO_INDEX_OWNERSHIP_PATTERN.test('/tmp/dist/de/gehalt-berechnen/szenarien/index.html')).toBe(true);
+    expect(SALARY_HUB_SCENARIO_INDEX_OWNERSHIP_PATTERN.test('/tmp/dist/fr/calculer-salaire/scenarios/index.html')).toBe(true);
+  });
+});

--- a/tests/orphan-query-landings.test.ts
+++ b/tests/orphan-query-landings.test.ts
@@ -15,6 +15,12 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  buildOrphanLandingHubPath,
+  buildOrphanLandingHubUrl,
+  renderOrphanLandingHubHreflang,
+} from '../build-plugins/orphanQueryLandingPlugin';
+
+import {
   ORPHAN_LANDING_LOCALES,
   ORPHAN_LANDING_SECTION,
   ORPHAN_LANDING_LOCALE_PREFIX,
@@ -71,6 +77,23 @@ describe('orphanQueryData — path helpers', () => {
   it('produces distinct prefixes per locale', () => {
     const prefixes = Object.values(ORPHAN_LANDING_LOCALE_PREFIX);
     expect(new Set(prefixes).size).toBe(prefixes.length);
+  });
+
+  it('builds hub hreflang URLs without collapsing https:// and includes x-default', () => {
+    expect(buildOrphanLandingHubPath('it')).toBe('/ricerca/');
+    expect(buildOrphanLandingHubUrl('fr')).toBe('https://frontaliereticino.ch/fr/recherche/');
+
+    const html = renderOrphanLandingHubHreflang({
+      it: true,
+      en: true,
+      de: true,
+      fr: true,
+    });
+
+    expect(html.match(/rel="alternate"/g)).toHaveLength(5);
+    expect(html).toContain('hreflang="x-default" href="https://frontaliereticino.ch/ricerca/"');
+    expect(html).toContain('hreflang="de" href="https://frontaliereticino.ch/de/suche/"');
+    expect(html).not.toContain('https:/frontaliereticino.ch');
   });
 
   it('buildOrphanLandingRoutes emits one route per cluster', () => {

--- a/tests/seo/cathedral-expired-tracking-canton.test.ts
+++ b/tests/seo/cathedral-expired-tracking-canton.test.ts
@@ -17,6 +17,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 const PLUGIN_PATH = path.resolve(__dirname, '../../build-plugins/jobsSeoPagesPlugin.ts');
+const MIGRATION_PATH = path.resolve(__dirname, '../../scripts/migrate-all-known-job-slugs-canton-aware.mjs');
 const TRACKING_PATH = path.resolve(__dirname, '../../data/all-known-job-slugs.json');
 const JOBS_PATH = path.resolve(__dirname, '../../data/jobs.json');
 
@@ -95,6 +96,24 @@ describe('Phase 8c — expired-tracking is canton-aware', () => {
           expect(p, `non-TI job ${job.slug} (canton=${job.canton}) [${locale}] still references ${frag}: ${p}`).not.toContain(frag);
         }
       }
+    }
+  });
+
+  it('data: exact job slugs keep ownership when aliases collide', () => {
+    const migrationSrc = fs.readFileSync(MIGRATION_PATH, 'utf8');
+    expect(migrationSrc).toContain('exactSlugToJob.get(trackingSlug) ?? slugToJob.get(trackingSlug)');
+
+    if (!fs.existsSync(TRACKING_PATH)) return;
+    const tracking: Record<string, Record<string, string>> = JSON.parse(
+      fs.readFileSync(TRACKING_PATH, 'utf8'),
+    );
+
+    const baselEntry = tracking['assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel'];
+    if (baselEntry) {
+      expect(baselEntry.it).toContain('/cerca-lavoro-basilea/');
+      expect(baselEntry.en).toContain('/find-jobs-basel/');
+      expect(baselEntry.de).toContain('/jobs-in-basel/');
+      expect(baselEntry.fr).toContain('/trouver-emploi-bale/');
     }
   });
 });

--- a/tests/sitemap-news-canonical.test.ts
+++ b/tests/sitemap-news-canonical.test.ts
@@ -26,6 +26,7 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -45,84 +46,42 @@ const ALLOWED_REFERENCES = new Set<string>([
   'tests/post-build/thin-content-guard.test.ts',
 ]);
 
-/**
- * Recursively collect candidate source files under one or more roots.
- * Skips node_modules, dist, .git, coverage, and build caches.
- */
-function collectSources(roots: readonly string[]): string[] {
-  const SKIP_DIRS = new Set([
-    'node_modules',
-    'dist',
-    '.git',
-    'coverage',
-    '.vite',
-    '.turbo',
-    '.cache',
-  ]);
-  const SOURCE_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|json|xml|txt|md|yml|yaml|html)$/i;
-
-  const out: string[] = [];
-
-  function walk(dir: string): void {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      if (entry.name.startsWith('.') && entry.name !== '.github') continue;
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (SKIP_DIRS.has(entry.name)) continue;
-        walk(fullPath);
-      } else if (entry.isFile() && SOURCE_EXT.test(entry.name)) {
-        out.push(fullPath);
-      }
-    }
-  }
-
-  for (const root of roots) walk(path.join(ROOT, root));
-  return out;
-}
-
 describe('sitemap-news canonical filename — A4 Google News compliance', () => {
   it('no source file emits the legacy underscore variant `sitemap_news.xml`', () => {
-    const sources = collectSources([
-      'build-plugins',
-      'scripts',
-      'public',
-      'services',
-      'components',
-      'tests',
-    ]);
-
-    // Also include top-level config files
-    const topLevel = ['vite.config.ts', 'package.json', 'tsconfig.json'];
-    for (const f of topLevel) {
-      const p = path.join(ROOT, f);
-      if (fs.existsSync(p)) sources.push(p);
+    const offenders: { file: string; line: number; text: string }[] = [];
+    let output = '';
+    try {
+      output = execFileSync(
+        'rg',
+        [
+          '--fixed-strings',
+          '--line-number',
+          '--no-heading',
+          '--glob',
+          '*.{ts,tsx,js,jsx,mjs,cjs,json,xml,txt,md,yml,yaml,html}',
+          'sitemap_news',
+          'build-plugins',
+          'scripts',
+          'public',
+          'services',
+          'components',
+          'tests',
+          'vite.config.ts',
+          'package.json',
+          'tsconfig.json',
+        ],
+        { cwd: ROOT, encoding: 'utf-8' },
+      );
+    } catch (error) {
+      const status = (error as { status?: number }).status;
+      if (status !== 1) throw error;
     }
 
-    const offenders: { file: string; line: number; text: string }[] = [];
-
-    for (const file of sources) {
-      const rel = path.relative(ROOT, file).split(path.sep).join('/');
+    for (const row of output.split('\n')) {
+      if (!row.trim()) continue;
+      const [rel = '', lineNo = '', ...textParts] = row.split(':');
       if (ALLOWED_REFERENCES.has(rel)) continue;
-
-      let content: string;
-      try {
-        content = fs.readFileSync(file, 'utf-8');
-      } catch {
-        continue;
-      }
-      if (!content.includes('sitemap_news')) continue;
-
-      content.split('\n').forEach((line, idx) => {
-        if (line.includes('sitemap_news')) {
-          offenders.push({ file: rel, line: idx + 1, text: line.trim() });
-        }
-      });
+      offenders.push({ file: rel, line: Number(lineNo), text: textParts.join(':').trim() });
     }
 
     if (offenders.length > 0) {


### PR DESCRIPTION
## Summary
- emit flat static/orphan/salary siblings as noindex redirect bridges instead of full duplicate pages
- fix orphan landing hub hreflang URLs and add x-default coverage
- migrate non-TI job slug tracking to canton-aware paths and harden the migration against slug alias collisions
- speed up the sitemap_news guard so the full suite does not timeout while preserving the same gate

## Verification
- npx tsc --noEmit
- git diff --check
- vitest run tests/search-console-compat.test.ts tests/sitemap-news-canonical.test.ts tests/seo/cathedral-no-ti-hardcodes.test.ts tests/seo/cathedral-expired-tracking-canton.test.ts --reporter=dot
- vitest run tests/orphan-query-landings.test.ts tests/build-plugins/salary-hub-ownership.test.ts tests/related-search-clusters-shell.test.ts tests/flat-html-redirect.test.ts --reporter=dot
- npm test (initial full run: all assertions passed except 3 timeout failures; reran those timeout files individually after optimizing sitemap-news-canonical)