### PR TITLE
Fix sitemap canonical test on CI

### DIFF
--- a/tests/sitemap-news-canonical.test.ts
+++ b/tests/sitemap-news-canonical.test.ts
@@ -52,14 +52,13 @@ describe('sitemap-news canonical filename — A4 Google News compliance', () => 
     let output = '';
     try {
       output = execFileSync(
-        'rg',
+        'git',
         [
-          '--fixed-strings',
-          '--line-number',
-          '--no-heading',
-          '--glob',
-          '*.{ts,tsx,js,jsx,mjs,cjs,json,xml,txt,md,yml,yaml,html}',
+          'grep',
+          '-n',
+          '-F',
           'sitemap_news',
+          '--',
           'build-plugins',
           'scripts',
           'public',


### PR DESCRIPTION
## Summary
- replace the sitemap_news guard's ripgrep dependency with git grep, which is available on GitHub-hosted runners
- keep the same offender allowlist and gate semantics

## Verification
- vitest run tests/sitemap-news-canonical.test.ts --reporter=dot
- npx tsc --noEmit (after local assemble-jobs dataset generation)
- git diff --check