### PR TITLE
fix: harden minified static audits

### DIFF
--- a/scripts/audit-footer-root-presence.mjs
+++ b/scripts/audit-footer-root-presence.mjs
@@ -37,17 +37,14 @@ import { fileURLToPath } from 'node:url';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { writeAuditReport } from './lib/auditReport.mjs';
 
-// Quote-flexible: PR #478 baked `removeAttributeQuotes` into the per-page
-// htmlMinify.ts pass, so single-token attribute values lose their quotes
-// in dist/ (`id="footer-root"` → `id=footer-root`, `id="root"` → `id=root`).
-// `class="..."` values are space-separated (Tailwind utility classes) so
-// quotes are preserved — those regexes stay quote-mandatory.
-const SEO_STATIC_RE = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b/i;
+// Quote-flexible: build-plugins/shared/htmlMinify.ts removes quotes from
+// single-token HTML5-safe class/id values, e.g. class=seo-static-content.
+const SEO_STATIC_RE = /<main\b(?=[^>]*\bclass=(?:"[^"]*\bseo-static-content\b[^"]*"|'[^']*\bseo-static-content\b[^']*'|seo-static-content)(?=[\s>]))[^>]*>/i;
 const FOOTER_ROOT_RE = /<div\b[^>]*\bid=["']?footer-root["']?(?=[\s/>])/i;
 // Buggy legacy shell: `<div id="root">` immediately followed by `<main class="static-job-page">`.
 // Mirrors the regression check in tests/city-jobs-hub.test.ts:358.
 const STATIC_JOB_INSIDE_ROOT_RE =
-  /<div\b[^>]*\bid=["']?root["']?(?=[\s/>])[^>]*>\s*<main\b[^>]*class=["'][^"']*\bstatic-job-page\b/i;
+  /<div\b[^>]*\bid=["']?root["']?(?=[\s/>])[^>]*>\s*<main\b(?=[^>]*\bclass=(?:"[^"]*\bstatic-job-page\b[^"]*"|'[^']*\bstatic-job-page\b[^']*'|static-job-page)(?=[\s>]))[^>]*>/i;
 
 /**
  * Factory that creates a fresh stateful Auditor closure.

--- a/scripts/audit-no-literal-markdown.mjs
+++ b/scripts/audit-no-literal-markdown.mjs
@@ -27,11 +27,9 @@ import { join, relative } from 'node:path';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
 import { writeAuditReport } from './lib/auditReport.mjs';
 
-// Quote-flexible only for single-token attrs (`id`, `rel`, `name`, etc).
-// `class="..."` values are space-separated Tailwind utility classes so
-// removeAttributeQuotes (PR #478) preserves the quotes — this regex stays
-// quote-mandatory.
-const SEO_STATIC_OPEN = /<main\b[^>]*class=["'][^"']*\bseo-static-content\b[^>]*>/i;
+// Quote-flexible: minified pages may ship single-token classes without
+// quotes, e.g. `<main class=seo-static-content>`.
+const SEO_STATIC_OPEN = /<main\b(?=[^>]*\bclass=(?:"[^"]*\bseo-static-content\b[^"]*"|'[^']*\bseo-static-content\b[^']*'|seo-static-content)(?=[\s>]))[^>]*>/i;
 const MAIN_CLOSE = /<\/main>/i;
 
 // `\*\*[^*\n]{1,200}\*\*` — bold tokens with non-empty body

--- a/tests/seo/audit-footer-root-presence.test.ts
+++ b/tests/seo/audit-footer-root-presence.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import * as auditorModule from '../../scripts/audit-footer-root-presence.mjs';
+import { minifyHtml } from '../../build-plugins/shared/htmlMinify';
 
 interface Offender {
   path: string;
@@ -76,6 +77,18 @@ describe('audit-footer-root-presence', () => {
     expect(r.extra.scannedStaticJob).toBe(0);
   });
 
+  it('accepts minified unquoted seo-static-content class attributes', () => {
+    const a = createAuditor();
+    const minified = minifyHtml(SAFE_SHELL);
+    expect(minified).toContain('class=seo-static-content');
+    expect(minified).toContain('id=footer-root');
+    a.collect('/dist/fr/calculer-salaire/simuler-fiche-de-paie/index.html', minified);
+    const r = a.report();
+    expect(r.passed).toBe(true);
+    expect(r.offendersTotal).toBe(0);
+    expect(r.extra.scannedSeoStatic).toBe(1);
+  });
+
   it('flags seo-static-content pages missing footer-root', () => {
     const a = createAuditor();
     a.collect('/dist/calcola-stipendio/lugano/index.html', MISSING_FOOTER_ROOT);
@@ -98,6 +111,18 @@ describe('audit-footer-root-presence', () => {
     expect(r.offenders[0].kind).toBe('static-job-page-inside-root');
     expect(r.extra.insideRoot).toBe(1);
     expect(r.extra.missingFooter).toBe(0);
+  });
+
+  it('flags the minified legacy <div id=root><main class=static-job-page> shell', () => {
+    const a = createAuditor();
+    const minified = minifyHtml(LEGACY_STATIC_JOB_PAGE);
+    expect(minified).toContain('id=root');
+    expect(minified).toContain('class=static-job-page');
+    a.collect('/dist/cerca-lavoro-ticino/pagina-2/index.html', minified);
+    const r = a.report();
+    expect(r.passed).toBe(false);
+    expect(r.offendersTotal).toBe(1);
+    expect(r.offenders[0].kind).toBe('static-job-page-inside-root');
   });
 
   it('accumulates offenders across files and preserves per-file kind', () => {

--- a/tests/seo/audit-no-literal-markdown.test.ts
+++ b/tests/seo/audit-no-literal-markdown.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { createAuditor } from '../../scripts/audit-no-literal-markdown.mjs';
+import { ROOT } from '../../scripts/lib/audit-runner.mjs';
+import { minifyHtml } from '../../build-plugins/shared/htmlMinify';
+
+const JOB_PATH = `${ROOT}/dist/cerca-lavoro-ticino/sviluppatore-acme/index.html`;
+
+describe('audit-no-literal-markdown', () => {
+  it('scans minified unquoted seo-static-content shells', () => {
+    const html = minifyHtml(`<!doctype html><html><body>
+      <main class="seo-static-content"><h1>Offerta</h1><p>Testo **non convertito**</p></main>
+    </body></html>`);
+    expect(html).toContain('class=seo-static-content');
+
+    const audit = createAuditor();
+    audit.collect(JOB_PATH, html);
+    const report = audit.report();
+
+    expect(report.passed).toBe(false);
+    expect(report.offendersTotal).toBe(1);
+    expect(report.offenders[0].literalBoldSamples).toEqual(['**non convertito**']);
+  });
+});


### PR DESCRIPTION
## Summary
- make footer-root and no-literal-markdown audits recognize valid minified static shells with unquoted single-token class attributes
- keep the gates strict: missing footer-root and literal markdown are still reported
- add regression coverage using the same htmlMinify path that produces deploy artifacts

## Verification
- npx vitest run tests/seo/audit-footer-root-presence.test.ts tests/seo/audit-no-literal-markdown.test.ts tests/audit-salary-landing-template.test.ts --reporter=dot
- git diff --check --cached
- node scripts/assemble-jobs-dataset.mjs --stats
- npx tsc --noEmit
- GitNexus detect changes: risk 0.00, no test gaps