### PR TITLE
fix: prevent Pages retry cancellation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,6 @@ jobs:
     timeout-minutes: 360
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || steps.deployment_first.outputs.page_url }}
     steps:
       # Free ~25-30 GB on the ubuntu-latest runner before any cache restore
       # or build output lands on disk. Without this the runner ships with
@@ -818,7 +817,7 @@ jobs:
       contents: read
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || steps.deployment_first.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -858,34 +857,15 @@ jobs:
             echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
           fi
 
-      # GitHub Pages allows only one deployment at a time. When concurrent
-      # pushes trigger this workflow, the second run can hit "in progress
-      # deployment" errors. Retry once after a short wait to handle this.
+      # GitHub Pages allows only one deployment at a time. Let the job fail
+      # if deploy-pages times out: running deploy-pages again can cancel a
+      # deployment that is still progressing through Pages file sync.
       - name: Deploy to GitHub Pages
-        id: deployment_first
-        uses: actions/deploy-pages@v5
-        continue-on-error: true
-        with:
-          timeout: 1800000
-          error_count: 100
-
-      - name: Wait for previous Pages deployment to finish
-        if: steps.deployment_first.outcome == 'failure'
-        run: |
-          echo "::warning::First deploy attempt failed (likely Pages busy). Retrying in 30s..."
-          sleep 30
-
-      - name: Deploy to GitHub Pages (retry)
         id: deployment
-        if: steps.deployment_first.outcome == 'failure'
         uses: actions/deploy-pages@v5
         with:
           timeout: 1800000
           error_count: 100
-
-      - name: Fail if both deploy attempts failed
-        if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome != 'success'
-        run: exit 1
 
       - name: Save deploy metadata to Firestore
         if: success()


### PR DESCRIPTION
## Summary
- remove the second actions/deploy-pages retry from the Pages deploy job
- keep a single deploy-pages attempt so timeouts remain visible failures without canceling an in-progress Pages file sync
- remove the stale deployment_first environment URL fallback

## Root cause
Run 26427711236 uploaded a 9.6G tar / 1,722,656,147 byte Pages artifact, then deploy-pages timed out after its hard 600000 ms cap while Pages was still syncing. The workflow retry invoked deploy-pages again and the action canceled the active deployment at finished_file_sync. This PR removes that destructive retry path.

## Verification
- ruby YAML.load_file on .github/workflows/deploy.yml: yaml ok
- git diff --check
- actionlint .github/workflows/deploy.yml: only existing SC2005 on line 153 remains; no deployment_first/reference errors
- GitNexus detect changes: risk 0.00, no test gaps

Not merged while a Pages deploy is in progress, per deploy safety rule.
