### PR TITLE
Fix job-board audit regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Agent sessions inherit `FAST_BUILD=1`; override it when validating SEO plugin ou
 FAST_BUILD= npx vite build
 ```
 
-Full local SEO builds can OOM. Prefer audit replay for dist-only audit verification:
+Full local SEO builds can OOM and waste local I/O. Use remote CI or audit replay for full SEO/build-plugin validation; do not run full local SEO builds unless the user explicitly asks. Prefer audit replay for dist-only audit verification:
 
 ```bash
 gh workflow run audit-dist-from-run.yml -f deploy_run_id=<run_id> -f audits=<audit-list>

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -25,7 +25,7 @@ import {
  type JobCardJob,
  type JobCardLocale,
 } from './shared/jobCardHtml';
-import { renderListingPaginationProse } from './shared/jobListingProse';
+import { renderJobBoardListingDensityProse, renderListingPaginationProse } from './shared/jobListingProse';
 import {
  renderJobBoardCommuterContext,
  renderSearchQueryIntro,
@@ -5757,6 +5757,8 @@ ${staticAnalyticsHtml}
  const pgPrevLink = ` <link rel="prev" href="${pgPrevHref}">`;
  const pgNextLink = pgNextHref ? `\n <link rel="next" href="${pgNextHref}">` : '';
  const pgListHtml = pgJobs.map((job: any) => renderJobCardLi(job, locale)).join('');
+ const pgCompanyCount = new Set(pgJobs.map((job: any) => String(job.company || '')).filter(Boolean)).size;
+ const pgLocationCount = new Set(pgJobs.map((job: any) => String(job.location || '')).filter(Boolean)).size;
  const pgCollLd = JSON.stringify({ '@context': 'https://schema.org', '@type': 'CollectionPage', name: pgTitle, url: pgCanonicalUrl, description: pgDesc, inLanguage: locale, isPartOf: { '@type': 'WebSite', name: 'Frontaliere Ticino', url: BASE_URL } });
  const pgItemLd = JSON.stringify({ '@context': 'https://schema.org', '@type': 'ItemList', name: pgTitle, numberOfItems: pgJobs.length, itemListElement: pgJobs.slice(0, 10).map((job: any, i: number) => {
  // Canton-aware item URL: pagination is TI-section by design but the jobs
@@ -5794,7 +5796,7 @@ ${staticAnalyticsHtml}
  hreflangHtml: `${pgAlternates}\n${pgXDefault}`,
  extraHeadHtml: `${pgPrevLink}${pgNextLink}`,
  jsonLdScripts: [pgCollLd, pgItemLd, pgBreadcrumbLd],
- bodyHtml: `<h1>${esc(pgCopy.heading(pageNum))}</h1>\n <p>${esc(pgDesc)}</p>\n <ul class="s-0WjlyL">${pgListHtml}</ul>\n <nav class="s-HarBzc">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: 'Ticino', omitCommute: true }))}`,
+ bodyHtml: `<h1>${esc(pgCopy.heading(pageNum))}</h1>\n <p>${esc(pgDesc)}</p>\n <ul class="s-0WjlyL">${pgListHtml}</ul>\n ${renderJobBoardListingDensityProse(locale, { subject: pgListName, location: 'Ticino', resultCount: pgJobs.length, companyCount: pgCompanyCount, locationCount: pgLocationCount, pageLabel: String(pageNum) })}\n <nav class="s-HarBzc">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: 'Ticino', omitCommute: true }))}`,
  distDir,
  });
  const pgOutDir = np.join(distDir, pgCanonicalPath.slice(1));
@@ -5858,10 +5860,11 @@ ${staticAnalyticsHtml}
  const cDisplay = cantonDisplayLocal(canton, locale);
  const pgFrom = startIdx + 1;
  const pgTo = Math.min(startIdx + JOBS_PER_LISTING_PAGE, cSorted.length);
- const pgTitle = locale === 'it' ? `Lavoro in ${cDisplay} - Pagina ${pageNum} | Frontaliere Ticino`
- : locale === 'en' ? `Jobs in ${cDisplay} - Page ${pageNum} | Frontaliere Ticino`
- : locale === 'de' ? `Stellen ${cDisplay} - Seite ${pageNum} | Frontaliere Ticino`
- : `Emploi \u00e0 ${cDisplay} - Page ${pageNum} | Frontaliere Ticino`;
+ const pgTitleBase = locale === 'it' ? `Lavoro in ${cDisplay} - Pagina ${pageNum}`
+ : locale === 'en' ? `Jobs in ${cDisplay} - Page ${pageNum}`
+ : locale === 'de' ? `Stellen ${cDisplay} - Seite ${pageNum}`
+ : `Emploi \u00e0 ${cDisplay} - Page ${pageNum}`;
+ const pgTitle = buildTitleWithBrand(pgTitleBase);
  const pgDesc = locale === 'it' ? `Pagina ${pageNum}: annunci di lavoro dal ${pgFrom} al ${pgTo} in ${cDisplay}. Offerte aggiornate quotidianamente.`
  : locale === 'en' ? `Page ${pageNum}: job listings ${pgFrom}\u2013${pgTo} in ${cDisplay}. Updated daily from Swiss career portals.`
  : locale === 'de' ? `Seite ${pageNum}: Stellenangebote ${pgFrom}\u2013${pgTo} in ${cDisplay}. T\u00e4glich aktualisiert.`
@@ -5884,6 +5887,8 @@ ${staticAnalyticsHtml}
  const pgPrevLink = ` <link rel="prev" href="${pgPrevHref}">`;
  const pgNextLink = pgNextHref ? `\n <link rel="next" href="${pgNextHref}">` : '';
  const pgListHtml = pgJobs.map((job: any) => renderJobCardLi(job, locale)).join('');
+ const pgCompanyCount = new Set(pgJobs.map((job: any) => String(job.company || '')).filter(Boolean)).size;
+ const pgLocationCount = new Set(pgJobs.map((job: any) => String(job.location || '')).filter(Boolean)).size;
  const pgCollLd = JSON.stringify({ '@context': 'https://schema.org', '@type': 'CollectionPage', name: pgTitle, url: pgCanonicalUrl, description: pgDesc, inLanguage: locale, isPartOf: { '@type': 'WebSite', name: 'Frontaliere Ticino', url: BASE_URL } });
  const pgItemLd = JSON.stringify({ '@context': 'https://schema.org', '@type': 'ItemList', name: pgTitle, numberOfItems: pgJobs.length, itemListElement: pgJobs.slice(0, 10).map((job: any, i: number) => ({ '@type': 'ListItem', position: i + 1, name: String(job?.titleByLocale?.[locale] || job.title || ''), url: `${BASE_URL}${withSlash(`${localePrefix[locale]}/${sectionSlug}/${localizedSlug(job, locale)}`.replace(/\/+/g, '/'))}` })) });
  const pgMainUrl = `${BASE_URL}${withSlash(pgSectionPath)}`;
@@ -5914,7 +5919,7 @@ ${staticAnalyticsHtml}
  hreflangHtml: `${pgAlternates}\n${pgXDefault}`,
  extraHeadHtml: `${pgPrevLink}${pgNextLink}`,
  jsonLdScripts: [pgCollLd, pgItemLd, pgBreadcrumbLd],
- bodyHtml: `<h1>${esc(pgHeading)}</h1>\n <p>${esc(pgDesc)}</p>\n <ul class="s-0WjlyL">${pgListHtml}</ul>\n <nav class="s-HarBzc">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, cantonDisplay: cDisplay, cantonSlot: 'canton-hub' }))}`,
+ bodyHtml: `<h1>${esc(pgHeading)}</h1>\n <p>${esc(pgDesc)}</p>\n <ul class="s-0WjlyL">${pgListHtml}</ul>\n ${renderJobBoardListingDensityProse(locale, { subject: pgListName, location: cDisplay, resultCount: pgJobs.length, companyCount: pgCompanyCount, locationCount: pgLocationCount, pageLabel: String(pageNum) })}\n <nav class="s-HarBzc">${pgNav.join(' &middot; ')}</nav>\n <p><a href="${pgMainUrl}">${esc(pgBackLabel)}</a></p>\n${renderListingPaginationProse(locale, pageNum)}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, cantonDisplay: cDisplay, cantonSlot: 'canton-hub' }))}`,
  distDir,
  });
  const pgOutDir = np.join(distDir, pgCanonicalPath.slice(1));
@@ -6056,7 +6061,7 @@ ${staticAnalyticsHtml}
  title: catTitle,
  };
  const catH1 = formatSeoH1(catLocaleParts) + (catPage > 1 ? (locale === 'it' ? ` — Pagina ${catPage}` : locale === 'de' ? ` — Seite ${catPage}` : locale === 'fr' ? ` — Page ${catPage}` : ` — Page ${catPage}`) : '');
- return `<h1>${esc(catH1)}</h1>\n <p>${esc(catDescription)}</p>\n ${catIntro}\n <ul class="s-0WjlyL">${catListHtml}</ul>\n <p><a href="${catSectionUrl}">${esc(catOpenAllLabel)}</a></p>\n ${catMarketSection}\n <nav class="s-_ZFTu5">${catNavLabel}: ${catOtherLinks.join(' \u00b7 ')}</nav>\n ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: 'Ticino', omitCommute: true, sectorOrType: catLabel }))}`;
+ return `<h1>${esc(catH1)}</h1>\n <p>${esc(catDescription)}</p>\n ${catIntro}\n <ul class="s-0WjlyL">${catListHtml}</ul>\n <p><a href="${catSectionUrl}">${esc(catOpenAllLabel)}</a></p>\n ${catMarketSection}\n ${renderJobBoardListingDensityProse(locale, { subject: catLabel, location: 'Ticino', resultCount: catJobs.length, companyCount: catUniqueCompanies.length, locationCount: catUniqueLocations.length, pageLabel: catPage > 1 ? String(catPage) : undefined })}\n <nav class="s-_ZFTu5">${catNavLabel}: ${catOtherLinks.join(' \u00b7 ')}</nav>\n ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: 'Ticino', omitCommute: true, sectorOrType: catLabel }))}`;
  })(),
  });
  const catOutDir = np.join(distDir, catCanonicalPath.slice(1));
@@ -6203,7 +6208,7 @@ ${staticAnalyticsHtml}
  title: catTitle,
  };
  const catH1 = formatSeoH1(catLocaleParts) + (catPage > 1 ? (locale === 'it' ? ` — Pagina ${catPage}` : locale === 'de' ? ` — Seite ${catPage}` : locale === 'fr' ? ` — Page ${catPage}` : ` — Page ${catPage}`) : '');
- return `<h1>${esc(catH1)}</h1>\n <p>${esc(catDescription)}</p>\n ${catIntro}\n <ul class="s-0WjlyL">${catListHtml}</ul>\n <p><a href="${catSectionUrl}">${esc(catOpenAllLabel)}</a></p>\n ${catMarketSection}\n <nav class="s-_ZFTu5">${catNavLabel}: ${catOtherLinks.join(' · ')}</nav>\n ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: catLabel, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
+ return `<h1>${esc(catH1)}</h1>\n <p>${esc(catDescription)}</p>\n ${catIntro}\n <ul class="s-0WjlyL">${catListHtml}</ul>\n <p><a href="${catSectionUrl}">${esc(catOpenAllLabel)}</a></p>\n ${catMarketSection}\n ${renderJobBoardListingDensityProse(locale, { subject: catLabel, location: cDisplay, resultCount: catJobs.length, companyCount: catUniqueCompanies.length, locationCount: catUniqueLocations.length, pageLabel: catPage > 1 ? String(catPage) : undefined })}\n <nav class="s-_ZFTu5">${catNavLabel}: ${catOtherLinks.join(' · ')}</nav>\n ${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: catLabel, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
  })(),
  });
  const catOutDir = np.join(distDir, catCanonicalPath.slice(1));
@@ -6372,7 +6377,7 @@ ${staticAnalyticsHtml}
  })();
  const openAllLabel = locale === 'it' ? `Apri tutte le offerte in ${cDisplay}` : locale === 'en' ? `View all jobs in ${cDisplay}` : locale === 'de' ? `Alle Stellen ${cDisplay}` : `Voir toutes les offres à ${cDisplay}`;
  const listHtml = cappedJobs.map((job: any) => renderJobCardLi(job, locale)).join('');
- const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul class="s-0WjlyL">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: sectorDisplay, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
+ const bodyHtml = `<h1>${esc(pageHeading)}</h1>\n<p>${esc(pageDesc)}</p>\n${intro}\n<ul class="s-0WjlyL">${listHtml}</ul>\n<p><a href="${sectionRootUrl}">${esc(openAllLabel)}</a></p>\n${marketSection}\n${renderJobBoardListingDensityProse(locale, { subject: sectorDisplay, location: cDisplay, resultCount: sJobs.length, companyCount: sUniqueCompanies.length, locationCount: sUniqueLocations.length })}\n${wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({ locale, location: cDisplay, omitCommute: true, sectorOrType: sectorDisplay, cantonDisplay: cDisplay, cantonSlot: 'sectors-hub' }))}`;
  // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
  const html = buildSeoPageHtml({
  locale,
@@ -6894,7 +6899,7 @@ ${staticAnalyticsHtml}
  // role / city / employer hubs. The Italian landing preserves its curated
  // `itCopy.title` because that was hand-tuned per query in keyword config.
  const kwTitle = locale === 'it'
- ? itCopy.title
+ ? buildTitleWithBrand(String(itCopy.title || '').replace(/\s*\|\s*Frontaliere Ticino\s*$/i, ''))
  : buildRoleHubTitle({
  locale,
  roleDisplay: kwQueryDisplay || 'Jobs',
@@ -6977,7 +6982,7 @@ ${staticAnalyticsHtml}
  ogLocale: localeOg[locale],
  hreflangHtml: kwAlternates,
  jsonLdScripts: [kwBreadcrumbLd, kwCollLd],
- bodyHtml: `<h1>${esc(itCopy.heading)}</h1>\n <p>${esc(kwDesc)}</p>\n ${kwQueryIntro}\n ${kwIntro}\n <p>${esc(kwCta)}</p>\n <ul class="s-0WjlyL">${kwListHtml}</ul>\n <p><a href="${kwSectionUrl}">${esc(kwOpenAllLabel)}</a></p>\n ${kwMarketSection}\n ${kwCommuterBlock}`,
+ bodyHtml: `<h1>${esc(itCopy.heading)}</h1>\n <p>${esc(kwDesc)}</p>\n ${kwQueryIntro}\n ${kwIntro}\n <p>${esc(kwCta)}</p>\n <ul class="s-0WjlyL">${kwListHtml}</ul>\n <p><a href="${kwSectionUrl}">${esc(kwOpenAllLabel)}</a></p>\n ${kwMarketSection}\n ${renderJobBoardListingDensityProse(locale, { subject: _kwQuery || kwQueryDisplay || itCopy.heading, location: _kwCity ? _kwCity.charAt(0).toUpperCase() + _kwCity.slice(1) : 'Ticino', resultCount: kwJobs.length, companyCount: kwUniqueCompanies.length, locationCount: kwUniqueLocations.length })}\n ${kwCommuterBlock}`,
  distDir,
  });
  const kwOutDir = np.join(distDir, kwCanonicalPath.slice(1));
@@ -7105,6 +7110,13 @@ ${staticAnalyticsHtml}
  // queries (Chur, Zurich, etc.) we fall back to general-Ticino prose.
  const _isTicino = isKnownTicinoCommuterCity(name);
  searchBodyParts.unshift(renderSearchQueryIntro(locale, name, matchingJobs.length, uniqueCompanies, uniqueLocations));
+ searchBodyParts.push(renderJobBoardListingDensityProse(locale, {
+ subject: name,
+ location: _isTicino ? name : 'Ticino',
+ resultCount: matchingJobs.length,
+ companyCount: uniqueCompanies.length,
+ locationCount: uniqueLocations.length,
+ }));
  searchBodyParts.push(wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({
  locale,
  location: _isTicino ? name : 'Ticino',
@@ -7210,6 +7222,7 @@ ${staticAnalyticsHtml}
  const canonicalPath = withSlash(`${localePrefix[locale]}/${sectionByLocale[locale]}/${fullSlug}`.replace(/\/+/g, '/'));
  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
  const copy = copyByLocale[locale];
+ const comboTitle = buildTitleWithBrand(String(copy.title || '').replace(/\s*\|\s*Frontaliere Ticino\s*$/i, ''));
  const description = copy.description(matchingJobs.length);
  const _altPairs = localeList
  .map((altLocale) => {
@@ -7263,6 +7276,13 @@ ${staticAnalyticsHtml}
  })();
  const _comboQuery = String(copy.heading || '').trim();
  comboBodyParts.unshift(renderSearchQueryIntro(locale, _comboQuery, matchingJobs.length, cUniqueCompanies, cUniqueLocations));
+ comboBodyParts.push(renderJobBoardListingDensityProse(locale, {
+ subject: _comboQuery || copy.heading,
+ location: _comboCity ? _comboCity.charAt(0).toUpperCase() + _comboCity.slice(1) : 'Ticino',
+ resultCount: matchingJobs.length,
+ companyCount: cUniqueCompanies.length,
+ locationCount: cUniqueLocations.length,
+ }));
  comboBodyParts.push(wrapHubSeoContext(locale as 'it' | 'en' | 'de' | 'fr', renderJobBoardCommuterContext({
  locale,
  location: _comboCity ? _comboCity.charAt(0).toUpperCase() + _comboCity.slice(1) : 'Ticino',
@@ -7285,7 +7305,7 @@ ${staticAnalyticsHtml}
  // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
  const comboHtml = buildSeoPageHtml({
  locale,
- title: copy.title,
+ title: comboTitle,
  description,
  canonicalUrl,
  ogLocale: localeOg[locale],
@@ -7922,29 +7942,29 @@ ${staticAnalyticsHtml}
      switch (locale) {
        case 'it':
          return {
-           title: `Lavoro in ${display} | Frontaliere Ticino`,
-           lede: `Pagina indice del job board per il cantone ${display}.`,
-           ctaLabel: `Vedi tutte le offerte`,
-         };
+          title: buildTitleWithBrand(`Lavoro in ${display}`),
+          lede: `Pagina indice del job board per il cantone ${display}.`,
+          ctaLabel: `Vedi tutte le offerte`,
+        };
        case 'en':
          return {
-           title: `Jobs in ${display} | Frontaliere Ticino`,
-           lede: `Job board index page for canton ${display}.`,
-           ctaLabel: `View all listings`,
-         };
+          title: buildTitleWithBrand(`Jobs in ${display}`),
+          lede: `Job board index page for canton ${display}.`,
+          ctaLabel: `View all listings`,
+        };
        case 'de':
          return {
-           title: `Jobs ${germanCantonPrep(display)} | Frontaliere Ticino`,
-           lede: `Job-Board-Übersicht für den Kanton ${display}.`,
-           ctaLabel: `Alle Stellen anzeigen`,
-         };
+          title: buildTitleWithBrand(`Jobs ${germanCantonPrep(display)}`),
+          lede: `Job-Board-Übersicht für den Kanton ${display}.`,
+          ctaLabel: `Alle Stellen anzeigen`,
+        };
        case 'fr':
        default:
          return {
-           title: `Emploi ${frenchCantonPrep(display)} | Frontaliere Ticino`,
-           lede: `Index du job board pour le canton ${display}.`,
-           ctaLabel: `Voir toutes les offres`,
-         };
+          title: buildTitleWithBrand(`Emploi ${frenchCantonPrep(display)}`),
+          lede: `Index du job board pour le canton ${display}.`,
+          ctaLabel: `Voir toutes les offres`,
+        };
      }
    };
 

--- a/build-plugins/shared/jobListingProse.ts
+++ b/build-plugins/shared/jobListingProse.ts
@@ -413,6 +413,63 @@ export function renderListingPaginationProse(
 </section>`;
 }
 
+export function renderJobBoardListingDensityProse(
+  locale: ListingProseLocale,
+  opts: {
+    subject: string;
+    location: string;
+    resultCount: number;
+    companyCount: number;
+    locationCount: number;
+    pageLabel?: string;
+  },
+): string {
+  const subject = escAttr(opts.subject || (locale === 'it' ? 'queste offerte' : locale === 'en' ? 'these listings' : locale === 'de' ? 'diese Stellen' : 'ces offres'));
+  const location = escAttr(opts.location || (locale === 'de' ? 'Tessin' : 'Ticino'));
+  const pageLabel = opts.pageLabel ? escAttr(opts.pageLabel) : '';
+  const resultCount = Math.max(0, Math.trunc(opts.resultCount || 0));
+  const companyCount = Math.max(0, Math.trunc(opts.companyCount || 0));
+  const locationCount = Math.max(0, Math.trunc(opts.locationCount || 0));
+
+  if (locale === 'it') {
+    return `<section class="s-A_RnbE">
+  <h2 class="s-jEiAXZ">Come valutare ${subject}${pageLabel ? ` (${pageLabel})` : ''}</h2>
+  <p class="s-clIDbe">Questa selezione raccoglie ${resultCount} annunci collegati a ${subject} in ${location}, distribuiti su ${companyCount} aziende e ${locationCount} località operative. Prima di inviare il CV, confronta sempre tre segnali: stabilità del datore, distanza reale dal valico e coerenza fra mansione, livello richiesto e salario lordo indicato. Una posizione apparentemente più alta può perdere convenienza se richiede un tragitto quotidiano lungo o se il cambio CHF/EUR del tuo istituto applica uno spread elevato.</p>
+  <p class="s-clIDbe">Per i frontalieri con Permesso G la lettura dell'annuncio non finisce alla retribuzione lorda. Nel netto entrano imposta alla fonte svizzera, AVS/AI/IPG, LPP, assicurazione infortuni, eventuale LAMal e conguaglio italiano secondo vecchio o nuovo accordo. Per questo le offerte vanno ordinate anche per qualità delle informazioni: sede precisa, percentuale di impiego, tipo di contratto, turni, reperibilità e modalità di candidatura diretta.</p>
+  <p class="s-clIDbe">Quando una pagina contiene molti annunci simili, usa il titolo come primo filtro ma leggi anche azienda e luogo: la stessa mansione può cambiare molto tra Lugano, Mendrisio, Bellinzona, Locarno o un cantone oltre il Ticino. Le schede con sede chiara aiutano a stimare carburante, parcheggio, autostrada e tempo al confine; quelle con descrizione tecnica dettagliata sono di solito più affidabili per preparare una candidatura mirata.</p>
+  <p class="s-clIDbe">Il metodo consigliato è semplice: salva 5-8 annunci compatibili, calcola il netto su due scenari di cambio, verifica il tragitto nelle fasce 06:30-08:00 e 17:00-19:00, poi candidati prima sulle aziende che pubblicano requisiti concreti e link ufficiale. Così la lista non resta una raccolta generica di offerte, ma diventa una short-list misurabile per decidere se il passaggio in Svizzera migliora davvero reddito, tempo e qualità di vita.</p>
+</section>`;
+  }
+
+  if (locale === 'en') {
+    return `<section class="s-A_RnbE">
+  <h2 class="s-jEiAXZ">How to assess ${subject}${pageLabel ? ` (${pageLabel})` : ''}</h2>
+  <p class="s-clIDbe">This selection contains ${resultCount} listings related to ${subject} in ${location}, spread across ${companyCount} employers and ${locationCount} work locations. Before applying, compare three signals: employer stability, real commute from the border, and whether the role level matches the gross salary and responsibilities described. A higher salary can lose value if the daily route is long or if your CHF/EUR conversion carries a costly spread.</p>
+  <p class="s-clIDbe">For cross-border workers on a G permit, the gross figure is only the starting point. Swiss withholding tax, AVS/AI/IPG, LPP pension contributions, accident insurance, possible LAMal coverage and the Italian tax adjustment all shape the real take-home amount. Strong listings make these checks easier because they state the workplace, workload percentage, contract type, shifts, on-call duties and the official application channel.</p>
+  <p class="s-clIDbe">When a page includes many similar roles, use the job title as the first filter but read the company and location with the same care. The same occupation can mean very different routines in Lugano, Mendrisio, Bellinzona, Locarno or a canton beyond Ticino. Clear location data helps estimate fuel, parking, motorway fees and border time; detailed technical requirements usually signal a more serious hiring process.</p>
+  <p class="s-clIDbe">A practical workflow is to shortlist 5-8 compatible roles, calculate the net salary under two exchange-rate scenarios, check the commute during 06:30-08:00 and 17:00-19:00, then apply first to employers that publish concrete requirements and a direct official link. The listing page then becomes a measurable shortlist, not just a long feed of vacancies.</p>
+</section>`;
+  }
+
+  if (locale === 'de') {
+    return `<section class="s-A_RnbE">
+  <h2 class="s-jEiAXZ">So bewerten Sie ${subject}${pageLabel ? ` (${pageLabel})` : ''}</h2>
+  <p class="s-clIDbe">Diese Auswahl umfasst ${resultCount} Stellen rund um ${subject} in ${location}, verteilt auf ${companyCount} Arbeitgeber und ${locationCount} Arbeitsorte. Vor einer Bewerbung sollten drei Punkte geprüft werden: Stabilität des Arbeitgebers, tatsächlicher Weg ab Grenze und Verhältnis zwischen Aufgaben, Erfahrungsniveau und Bruttolohn. Ein höherer Lohn kann an Wert verlieren, wenn der tägliche Arbeitsweg lang ist oder der CHF/EUR-Wechselkurs hohe Spesen enthält.</p>
+  <p class="s-clIDbe">Für Grenzgänger mit G-Bewilligung ist der Bruttolohn nur der Anfang. Quellensteuer, AHV/IV/EO, BVG, Unfallversicherung, mögliche LAMal-Prämien und der italienische Steuerausgleich bestimmen den realen Nettobetrag. Gute Inserate nennen deshalb Arbeitsort, Pensum, Vertragsform, Schichten, Pikettdienst und den direkten offiziellen Bewerbungsweg.</p>
+  <p class="s-clIDbe">Wenn viele ähnliche Stellen auf einer Seite stehen, reicht der Titel als Filter nicht aus. Das gleiche Berufsbild kann in Lugano, Mendrisio, Bellinzona, Locarno oder in einem anderen Kanton einen sehr anderen Alltag bedeuten. Ein klarer Standort hilft bei der Schätzung von Treibstoff, Parkplatz, Autobahnkosten und Wartezeiten; konkrete technische Anforderungen sprechen meist für einen seriösen Recruiting-Prozess.</p>
+  <p class="s-clIDbe">Sinnvoll ist eine kurze Arbeitsroutine: 5-8 passende Inserate vormerken, den Nettolohn mit zwei Wechselkurs-Szenarien berechnen, die Pendelzeit zwischen 06:30-08:00 und 17:00-19:00 prüfen und zuerst bei Arbeitgebern mit klaren Anforderungen und direktem Link bewerben. So wird aus der Liste eine belastbare Shortlist für die Entscheidung Schweiz oder Italien.</p>
+</section>`;
+  }
+
+  return `<section class="s-A_RnbE">
+  <h2 class="s-jEiAXZ">Comment évaluer ${subject}${pageLabel ? ` (${pageLabel})` : ''}</h2>
+  <p class="s-clIDbe">Cette sélection regroupe ${resultCount} annonces liées à ${subject} à ${location}, réparties entre ${companyCount} employeurs et ${locationCount} lieux de travail. Avant de postuler, comparez trois signaux : solidité de l'employeur, trajet réel depuis la frontière et cohérence entre responsabilités, niveau demandé et salaire brut. Une rémunération plus élevée peut perdre de son intérêt si le trajet quotidien est long ou si le change CHF/EUR applique une marge importante.</p>
+  <p class="s-clIDbe">Pour les frontaliers avec permis G, le brut suisse n'est qu'un point de départ. Impôt à la source, AVS/AI/APG, LPP, assurance accident, éventuelle LAMal et ajustement fiscal italien déterminent le revenu réellement disponible. Les annonces les plus utiles précisent donc le lieu, le taux d'activité, le type de contrat, les horaires, les astreintes et le canal officiel de candidature.</p>
+  <p class="s-clIDbe">Lorsqu'une page contient de nombreux postes proches, utilisez le titre comme premier filtre mais lisez aussi l'entreprise et la localisation. Le même métier peut impliquer un quotidien très différent à Lugano, Mendrisio, Bellinzone, Locarno ou dans un autre canton. Une adresse claire aide à estimer carburant, stationnement, autoroute et attente à la frontière; des exigences techniques précises signalent souvent un recrutement plus fiable.</p>
+  <p class="s-clIDbe">La méthode la plus efficace consiste à retenir 5-8 offres compatibles, calculer le net avec deux scénarios de change, vérifier le trajet entre 06:30-08:00 et 17:00-19:00, puis postuler d'abord auprès des employeurs qui publient des critères concrets et un lien officiel direct. La page devient ainsi une short-list mesurable, pas seulement un long flux d'annonces.</p>
+</section>`;
+}
+
 /**
  * Render the methodology + extended FAQ block appended to the recency hubs
  * (`/cerca-lavoro-ticino/ultimi-3-giorni/`, etc.).

--- a/tests/seo/job-board-text-ratio-regression.test.ts
+++ b/tests/seo/job-board-text-ratio-regression.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { renderJobBoardCommuterContext } from '../../build-plugins/shared/jobBoardCommuterContext';
+import { renderJobBoardListingDensityProse } from '../../build-plugins/shared/jobListingProse';
 
 /**
  * Strip HTML to its visible-text portion using the same heuristic Semrush
@@ -43,6 +44,21 @@ function ratio(html: string): number {
 const RATIO_FLOOR_PCT = 12; // 2pt margin above Semrush 10 % gate
 
 describe('renderJobBoardCommuterContext — text-to-HTML ratio', () => {
+  it('listing-density prose adds substantive visible text for heavy job-board lists', () => {
+    const block = renderJobBoardListingDensityProse('en', {
+      subject: 'Engineering jobs',
+      location: 'Ticino',
+      resultCount: 30,
+      companyCount: 18,
+      locationCount: 7,
+      pageLabel: '3',
+    });
+    expect(block).toContain('Engineering jobs');
+    expect(block).toContain('30');
+    expect(block.length).toBeGreaterThan(1_800);
+    expect(ratio(block)).toBeGreaterThan(RATIO_FLOOR_PCT);
+  });
+
   it('Lugano IT city landing: text >12 % of standalone block HTML', () => {
     const block = renderJobBoardCommuterContext({ locale: 'it', location: 'Lugano' });
     expect(block.length).toBeGreaterThan(2_000);


### PR DESCRIPTION
## Summary
- add job-board-only density prose to heavy listing/search/category templates
- drop the Frontaliere Ticino title suffix when canton/search titles would exceed the 66-char gate
- record remote-only full SEO validation guidance in AGENTS.md
- add a focused regression test for the new listing-density prose

## Verification
- npm test -- tests/seo/job-board-text-ratio-regression.test.ts
- code_review_graph detect_changes: risk 0.40, no affected flows

Full SEO build/audit validation is intentionally left to GitHub Actions per repo workflow preference.