### PR TITLE
fix(seo): restore flat bridge OG meta

### DIFF
--- a/build-plugins/flatHtmlRedirectPlugin.ts
+++ b/build-plugins/flatHtmlRedirectPlugin.ts
@@ -35,7 +35,7 @@ import fs from 'node:fs';
 import type { Plugin } from 'vite';
 
 /**
- * Extract only preview-critical meta tags from the sibling index.html
+ * Extract og:* / description meta tags from the sibling index.html
  * so the bridge can serve them to crawlers (Facebook, Twitter, LinkedIn, Slack…)
  * that don't follow the JS location.replace redirect. The bridge keeps
  * `noindex,follow` for Google — only social crawlers care about OG.
@@ -46,10 +46,6 @@ import type { Plugin } from 'vite';
  *
  * Defense-in-depth for deploy run #25033670793: even if a crawler hits the
  * no-slash URL, it now gets correct preview metadata instead of a blank bridge.
- * Keep this list tight: flat bridges are high-volume noindex pages, so
- * repeated non-essential OG tags quickly become hundreds of MB in the Pages
- * artifact.
- *
  * Re-applied 2026-04-28 after confirming the text-html-ratio regression
  * was caused by the SPA-style job-card refactor (commit affb542cc), NOT by
  * this OG injection (offender count was identical with/without it).
@@ -70,13 +66,9 @@ function extractOgTags(indexHtml: string): string {
     }
     const property = String(attrs.property || '').toLowerCase();
     const name = String(attrs.name || '').toLowerCase();
-    const isOgPreview =
-      property === 'og:title' ||
-      property === 'og:description' ||
-      property === 'og:image' ||
-      property === 'og:image:alt';
+    const isOg = property.startsWith('og:');
     const isDescription = name === 'description';
-    if (isOgPreview || isDescription) {
+    if (isOg || isDescription) {
       tags.push(tag);
     }
   }

--- a/tests/flat-html-redirect.test.ts
+++ b/tests/flat-html-redirect.test.ts
@@ -97,7 +97,7 @@ describe('flatHtmlRedirectPlugin redirect bridge', () => {
     expect(bridge).not.toMatch(/http-equiv\s*=\s*["']refresh["']/i);
   });
 
-  it('keeps only preview-critical social meta on noindex bridge pages', async () => {
+  it('keeps social preview meta on noindex bridge pages', async () => {
     fixture = setupFixture(
       '<!DOCTYPE html><html><head><title>Foo Bar</title>' +
         '<meta name="description" content="Useful summary">' +
@@ -124,13 +124,13 @@ describe('flatHtmlRedirectPlugin redirect bridge', () => {
     expect(bridge).toContain('<meta property="og:description" content="Share description">');
     expect(bridge).toContain('<meta property="og:image" content="https://frontaliereticino.ch/og/foo.webp">');
     expect(bridge).toContain('<meta property="og:image:alt" content="Preview alt">');
-    expect(bridge).not.toContain('og:type');
-    expect(bridge).not.toContain('og:site_name');
-    expect(bridge).not.toContain('og:locale');
-    expect(bridge).not.toContain('og:url');
-    expect(bridge).not.toContain('og:image:width');
-    expect(bridge).not.toContain('og:image:height');
-    expect(bridge).not.toContain('og:image:type');
+    expect(bridge).toContain('og:type');
+    expect(bridge).toContain('og:site_name');
+    expect(bridge).toContain('og:locale');
+    expect(bridge).toContain('og:url');
+    expect(bridge).toContain('og:image:width');
+    expect(bridge).toContain('og:image:height');
+    expect(bridge).toContain('og:image:type');
     expect(bridge).not.toContain('twitter:title');
   });
 


### PR DESCRIPTION
## Summary
- Roll back the preview-critical-only OG trimming from 11de387
- Keep all og:* metadata on noindex flat bridge pages for conservative social previews
- Continue excluding twitter:* tags per review

## Verification
- npm test -- --run tests/flat-html-redirect.test.ts tests/related-search-clusters-shell.test.ts
- git diff --check
- GitNexus detect changes against origin/main

Full build intentionally not run locally; validate through GitHub Actions.