### PR TITLE
fix(article-gen): un-block pre-spend gate when classifier rejects all (run 26440805420)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -116,7 +116,7 @@ import { isNearDuplicate as _isNearDuplicateHeadline } from './lib/scheduler/slu
 import { fetchWordpressSearchHeadlines } from './lib/topic-sources/wordpressSearch.mjs';
 import { extractArticleText } from './lib/extract-article-text.mjs';
 import { hasDomainAnchor } from './lib/discovery/domainAnchor.mjs';
-import { matchesFrontaliereAnchor } from './lib/discovery/frontaliereAnchor.mjs';
+import { matchesFrontaliereAnchor, matchesFrontaliereUnambiguousAnchor } from './lib/discovery/frontaliereAnchor.mjs';
 
 // ── Smarter generator inputs (Phase 3 — spec 2026-05-06) ───────
 // data/article-performance.json is produced weekly by Phase 1A.
@@ -414,22 +414,43 @@ async function applyPreSpendTopicGate(headlines, opts = {}) {
   const maxClassifier = Number(opts.maxClassifier ?? headlines.length);
 
   const kept = [];
-  const filtered = []; // { headline, reason }
+  let filtered = []; // { headline, reason, rawHeadline, rawAnchor }
   let classifierCalls = 0;
+  let unambiguousBypasses = 0;
+  // Track strict-anchor matches so the D-backstop can restore top-N if the
+  // classifier rejects every candidate (run 26440805420: classifier rejected
+  // 39/39 → empty proven pool → 8-cycle no_changes streak).
+  const strictAnchorMatched = []; // [{ h, anchor }]
 
   for (const h of headlines) {
     const headlineText = String(h?.headline || '');
     const urlText = String(h?.url || '');
     const combined = `${headlineText} ${urlText}`;
+    const strictAnchor = matchesFrontaliereAnchor(combined);
+    if (strictAnchor) strictAnchorMatched.push({ h, anchor: strictAnchor });
 
     // Legacy emergency rollback: anchor-only acceptance (no LLM).
     if (!classifierEnabled) {
-      const anchor = matchesFrontaliereAnchor(combined);
-      if (anchor) {
+      if (strictAnchor) {
         kept.push(h);
       } else {
-        filtered.push({ headline: headlineText.slice(0, 80), reason: 'anchor-miss (classifier disabled)' });
+        filtered.push({ headline: headlineText.slice(0, 80), reason: 'anchor-miss (classifier disabled)', rawHeadline: headlineText });
       }
+      continue;
+    }
+
+    // A — Unambiguous anchor → skip classifier (re-enabled 2026-05-26 on
+    // a narrower regex set vs the 2026-05-15 rollback). The unambiguous
+    // anchors are fiscal/legal terms-of-art (ristorni, LAMal, AVS, doppia
+    // imposizione, accordo fiscale Italia-Svizzera, …) that do not leak
+    // into cronaca/sports — so a hit is a high-precision keep signal and
+    // does not need the classifier to confirm. The wider FRONTALIERE_STRICT
+    // anchors (bare "frontalier", "valico chiasso", …) still go through
+    // the classifier.
+    const unambiguous = matchesFrontaliereUnambiguousAnchor(combined);
+    if (unambiguous) {
+      kept.push(h);
+      unambiguousBypasses += 1;
       continue;
     }
 
@@ -442,9 +463,10 @@ async function applyPreSpendTopicGate(headlines, opts = {}) {
       continue;
     }
 
-    // Classifier path — runs for EVERY candidate, no anchor short-circuit.
-    // The anchor signal could be passed as a hint, but anchor match alone
-    // must NOT bypass the classifier (see comment block above).
+    // Classifier path — for candidates that did not hit an unambiguous
+    // anchor. The strict-anchor signal could be passed as a hint, but
+    // strict-anchor match alone (e.g. bare "frontalier") must NOT bypass
+    // the classifier (see comment block above).
     classifierCalls += 1;
     const summary = Array.isArray(h?.relatedHeadlines) && h.relatedHeadlines.length > 0
       ? h.relatedHeadlines.slice(0, 2).join(' · ')
@@ -461,16 +483,33 @@ async function applyPreSpendTopicGate(headlines, opts = {}) {
     if (verdict.relevant) {
       kept.push(h);
     } else {
-      filtered.push({ headline: headlineText.slice(0, 80), reason: verdict.reason });
+      filtered.push({ headline: headlineText.slice(0, 80), reason: verdict.reason, rawHeadline: headlineText });
     }
   }
 
+  // D — Backstop: if the classifier rejected every candidate but at least
+  // one had a strict-anchor match, restore the top-3 anchor-matched. This
+  // prevents the 100%-rejection failure mode that produced the run
+  // 26440805420 no_changes streak. REGOLA #0 inside article-gen stays as
+  // the final defense if the restored candidate is actually off-topic.
+  if (kept.length === 0 && strictAnchorMatched.length > 0) {
+    const RESTORE_N = 3;
+    const restore = strictAnchorMatched.slice(0, RESTORE_N);
+    const restoreSet = new Set(restore.map(r => String(r.h?.headline || '')));
+    for (const { h, anchor } of restore) {
+      kept.push(h);
+      const ht = String(h?.headline || '').slice(0, 80);
+      console.error(`  🛟 Pre-spend gate backstop: ripristinato headline anchor-matched (anchor="${anchor}"): "${ht}…"`);
+    }
+    filtered = filtered.filter(f => !restoreSet.has(f.rawHeadline));
+  }
+
   const dropped = headlines.length - kept.length;
-  if (classifierCalls > 0 || dropped > 0) {
+  if (classifierCalls > 0 || dropped > 0 || unambiguousBypasses > 0) {
     const reasonsSummary = filtered.slice(0, 3).map(f => f.reason).join(' | ');
     console.error(
       `  🔍 Pre-spend topic gate: ${headlines.length} candidates → ${kept.length} frontaliere-relevant `
-      + `(classifier-calls=${classifierCalls}, dropped=${dropped}${reasonsSummary ? `: ${reasonsSummary}` : ''})`,
+      + `(classifier-calls=${classifierCalls}, anchor-bypass=${unambiguousBypasses}, dropped=${dropped}${reasonsSummary ? `: ${reasonsSummary}` : ''})`,
     );
     if (filtered.length > 0) {
       for (const f of filtered.slice(0, 5)) {
@@ -6408,6 +6447,11 @@ async function main() {
     let _discoveryHeadlines = null;
     let _discoveryCandidatesById = new Map();
     let _provenHeadlinesForDiscovery = [];
+    // Captured before applyPreSpendTopicGate so the discovery fallback can
+    // resolve Google News RSS URLs even when the gate empties the proven
+    // pool (run 26440805420). The fuzzy matcher in resolveGoogleNewsHeadline
+    // needs the FULL proven scan, not the post-gate residue.
+    let _provenHeadlinesPreGate = [];
     RUN_REPORT.poolSlotKind = slotKind;
     RUN_REPORT.poolCounterValue = slotDecision.counterValue;
     RUN_REPORT.poolCurrentQuota = slotDecision.currentQuota;
@@ -6537,6 +6581,12 @@ async function main() {
       // `applyPreSpendTopicGate` doc block above. REGOLA #0 in the
       // article-gen prompt stays in place as defense-in-depth.
       const beforePreSpendGate = headlines.length;
+      // Snapshot the proven scan BEFORE the gate. If the gate empties the
+      // pool, the cross-pool fallback (proven→discovery) still needs the
+      // direct-source URLs to resolve Google News RSS items against. See
+      // run 26440805420: 193 RSS candidates dropped because the gate had
+      // already emptied headlines[] used as the resolver atlas.
+      _provenHeadlinesPreGate = headlines.slice();
       headlines = await applyPreSpendTopicGate(headlines);
       if (beforePreSpendGate > headlines.length) {
         console.error(`  📋 Post-pre-spend gate: ${headlines.length}/${beforePreSpendGate} headline rimanenti\n`);
@@ -6809,8 +6859,17 @@ async function main() {
         console.error('POOL_FALLBACK from=proven to=discovery reason=empty');
         RUN_REPORT.poolFallbacks.push({ from: 'proven', to: 'discovery', reason: 'empty' });
         try {
-          const provenStrings = (headlines || []).map((h) => String(h.headline || ''));
-          _provenHeadlinesForDiscovery = headlines || [];
+          // Use the PRE-gate proven scan as the URL atlas. The gate may have
+          // dropped legitimate direct-source headlines that the Google News
+          // RSS resolver still needs to fuzzy-match against. Falling back
+          // to post-gate headlines empties the atlas and drops every RSS
+          // candidate as "non risolto a fonte diretta" (run 26440805420:
+          // 193 RSS items, 0 resolved).
+          const atlas = _provenHeadlinesPreGate.length > 0
+            ? _provenHeadlinesPreGate
+            : (headlines || []);
+          const provenStrings = atlas.map((h) => String(h.headline || ''));
+          _provenHeadlinesForDiscovery = atlas;
           const pool = await _buildDiscoveryPool(evidenceForDiscovery, { provenHeadlines: provenStrings });
           console.error(`DISCOVERY_POOL_BUILD_FALLBACK orphan=${pool.perSource.orphan} suggest=${pool.perSource.suggest} news=${pool.perSource.news} postDedup=${pool.postDedupCount}`);
           const fbHeadlines = _discoveryCandidatesToHeadlines(pool.candidates);

--- a/scripts/lib/discovery/frontaliereAnchor.mjs
+++ b/scripts/lib/discovery/frontaliereAnchor.mjs
@@ -69,3 +69,61 @@ export function matchesFrontaliereAnchor(text) {
   }
   return null;
 }
+
+/**
+ * Unambiguous frontaliere anchors — strict subset that CANNOT appear outside
+ * a frontaliere-policy / fiscal / regulatory context. These bypass the
+ * pre-spend classifier safely (re-introduced 2026-05-26 after run
+ * 26440805420: gemini-flash-lite was rejecting 100% of pre-filtered
+ * candidates, no_changes streak hit 8, fallback Google News RSS could not
+ * resolve URLs because the proven pool went empty).
+ *
+ * Excluded vs FRONTALIERE_STRICT_ANCHORS — these are the patterns that leak
+ * into cronaca/sports/general news (origin of the 2026-05-15 rollback):
+ *   - bare `\bfrontalier/i`        — cittadino frontaliere multato, …
+ *   - bare `\btransfrontalier/i`   — area transfrontaliera, …
+ *   - bare `\bpendolar[ie]\b/i`    — any commuter, not just italo-svizzeri
+ *   - bare `\bcross[- ]border\b/i` — generic; matches IT outside TI
+ *   - `valico`/`dogana` municipality variants — kept in strict for ranking
+ *     but cronaca leaks (incidenti in dogana, etc.)
+ *   - bare `\bcambio\s+(?:chf|franco|eur)/i` — finanza market chatter
+ *
+ * Anything kept here must be a term-of-art for the frontaliere fiscal /
+ * social-security / cross-border-employment domain.
+ */
+export const FRONTALIERE_UNAMBIGUOUS_ANCHORS = [
+  /\bristorn[oi]\b/i,
+  /\bimposta\s+alla\s+fonte\b/i,
+  /\bdoppia\s+imposizion/i,
+  /\baccordo\s+(?:fiscale|bilaterale)\s+(?:italia[- ]svizzera|ch[- ]it|cra)/i,
+  /\bnuovo\s+accordo\s+fiscale/i,
+  /\b(?:tassa|imposta)\s+salute\b/i,
+  /\b(?:lamal|cassa\s+malati)\b/i,
+  /\b(?:avs|ahv)\b/i,
+  /\blpp\b/i,
+  /\b(?:secondo|terzo)\s+pilastro\b/i,
+  /\bbusta\s+paga\s+svizzer/i,
+  /\bstipendi[oi]\s+svizzer/i,
+  /\bnetto\s+svizzer/i,
+  /\bpermess[oi]\s+[bgcdl]\b/i,
+  /\btelelavoro\s+frontalier/i,
+  /\bmercato\s+del\s+lavoro\s+ticines/i,
+  /\baziende?\s+che\s+assumon[oa]\s+frontalier/i,
+  /\beur\s*\/\s*chf|chf\s*\/\s*eur/i,
+];
+
+/**
+ * Returns the first matched substring if any unambiguous anchor hits `text`,
+ * else null. Safe for pre-spend classifier bypass.
+ *
+ * @param {string} text
+ * @returns {string | null}
+ */
+export function matchesFrontaliereUnambiguousAnchor(text) {
+  if (!text || typeof text !== 'string') return null;
+  for (const re of FRONTALIERE_UNAMBIGUOUS_ANCHORS) {
+    const m = text.match(re);
+    if (m) return m[0];
+  }
+  return null;
+}

--- a/tests/pre-spend-topic-gate.test.ts
+++ b/tests/pre-spend-topic-gate.test.ts
@@ -46,7 +46,9 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
   FRONTALIERE_STRICT_ANCHORS,
+  FRONTALIERE_UNAMBIGUOUS_ANCHORS,
   matchesFrontaliereAnchor,
+  matchesFrontaliereUnambiguousAnchor,
 } from '../scripts/lib/discovery/frontaliereAnchor.mjs';
 
 const SRC = readFileSync(
@@ -170,35 +172,120 @@ describe('pre-spend topic gate — wiring into main()', () => {
     expect(SRC).toMatch(/abort_topical_relevance/);
   });
 
-  it('classifier-always: anchor match does NOT short-circuit the classifier', () => {
+  it('strict-anchor match (bare frontalier/transfrontalier/…) does NOT short-circuit the classifier', () => {
     // 2026-05-15 evening regression — run #25889568431 wasted 25 min when
-    // 6/6 anchor-matched headlines bypassed the LLM step. The new gate
-    // must NOT contain an `if (anchor) { kept.push(...); continue; }`
-    // accept-on-anchor block. The legacy anchor-only path still exists
-    // but ONLY under `!classifierEnabled` (rollback env).
+    // 6/6 STRICT-anchor-matched headlines bypassed the LLM step. The gate
+    // must NOT contain a bypass branch based on the wider
+    // matchesFrontaliereAnchor() (strict) set. The narrower UNAMBIGUOUS
+    // anchor set IS a valid bypass (added 2026-05-26 to fix the inverse
+    // failure mode — see the dedicated describe block below).
     const gateBlock = SRC.match(
       /async function applyPreSpendTopicGate[\s\S]*?\n\}\n/,
     );
     expect(gateBlock, 'applyPreSpendTopicGate block not found').toBeTruthy();
     const body = gateBlock![0];
-    // No counter for the removed fast-path.
+    // No counter for the removed strict-anchor fast-path.
     expect(body).not.toMatch(/anchor-fast-path=/);
     expect(body).not.toMatch(/let\s+anchorHits/);
-    // Every candidate hits classifyFrontaliereRelevance (only one call
-    // site inside the gate); the anchor lookup only runs in the
-    // classifier-disabled rollback branch.
+    // The strict anchor variable must not appear in a kept.push branch.
+    // We allow `matchesFrontaliereAnchor(...)` to be CALLED (it feeds the
+    // D-backstop and the !classifierEnabled rollback) but a top-level
+    // `kept.push(h)` immediately after the strict-anchor test is the
+    // disallowed regression. Approximate this with a structural check:
+    // any `kept.push(h)` in the main loop must follow either a classifier
+    // verdict.relevant branch or the UNAMBIGUOUS anchor branch.
+    expect(body).not.toMatch(/const\s+anchor\s*=\s*matchesFrontaliereAnchor\(combined\)[\s\S]{0,60}kept\.push\(h\)/);
+    // Every candidate that did not hit an unambiguous anchor hits
+    // classifyFrontaliereRelevance.
     expect(body).toMatch(/classifyFrontaliereRelevance\(/);
   });
 
-  it('log line uses the new classifier-only format (no anchor-fast-path field)', () => {
+  it('log line includes classifier-calls, anchor-bypass and dropped counters', () => {
     const gateBlock = SRC.match(
       /async function applyPreSpendTopicGate[\s\S]*?\n\}\n/,
     )![0];
     expect(gateBlock).toMatch(/Pre-spend topic gate:/);
     expect(gateBlock).toMatch(/classifier-calls=\$\{classifierCalls\}/);
+    expect(gateBlock).toMatch(/anchor-bypass=\$\{unambiguousBypasses\}/);
     expect(gateBlock).toMatch(/dropped=\$\{dropped\}/);
-    // Old field must be gone.
+    // Legacy field must stay gone.
     expect(gateBlock).not.toMatch(/anchor-fast-path=\$\{/);
+  });
+});
+
+describe('pre-spend topic gate — unambiguous-anchor bypass (run 26440805420 fix, 2026-05-26)', () => {
+  // Run 26440805420 (no_changes streak 8): gemini-flash-lite rejected
+  // 39/39 pre-filtered candidates as "non riguarda i frontalieri", so the
+  // proven pool went empty and the Google News RSS fallback could not
+  // resolve URLs. Fix: re-enable the anchor bypass but on a NARROWER set
+  // that excludes the patterns that leaked cronaca in 2026-05-15.
+  const unambiguousHeadlines = [
+    'Ristorni ai comuni italiani di confine, possibile sblocco a giugno',
+    'Tassa salute frontalieri: il Ticino pronto a bloccare i ristorni',
+    'LAMal 2026, premi in aumento del 6% in Ticino',
+    'Cassa malati: i premi LAMal salgono nel Cantone Ticino',
+    'Imposta alla fonte: nuova circolare AFC',
+    'Doppia imposizione, chiarimenti per i lavoratori transfrontalieri',
+    'AVS 2030: cosa cambia per i frontalieri del Ticino',
+    'Permesso G: rinnovo annuale, ecco le nuove regole',
+    'LPP, riforma del secondo pilastro: cosa cambia',
+    'Telelavoro frontalieri: il nuovo limite del 25% spiegato',
+    'Nuovo accordo fiscale Italia-Svizzera ratificato',
+  ];
+
+  const adjectiveOnlyButNotUnambiguous = [
+    // Strict-anchor matches that must NOT bypass — adjective-only or
+    // generic financial chatter that historically leaked cronaca.
+    'Multa per rifiuti a un cittadino frontaliere svizzero a Cantello',
+    'Cantello, multa al frontaliere per smaltimento illecito di rifiuti',
+    'Festival del cinema area frontaliera Locarno: il programma',
+    'Incidente in via Trieste: ferito un automobilista frontaliere',
+    'Dogana di Chiasso, lunghe code per i pendolari al mattino',
+    'Cambio CHF-EUR sotto pressione: la BNS interviene sui mercati',
+  ];
+
+  it('exports a non-trivial unambiguous anchor list', () => {
+    expect(FRONTALIERE_UNAMBIGUOUS_ANCHORS.length).toBeGreaterThanOrEqual(10);
+    for (const re of FRONTALIERE_UNAMBIGUOUS_ANCHORS) {
+      expect(re).toBeInstanceOf(RegExp);
+    }
+  });
+
+  it('matches policy/fiscal terms-of-art', () => {
+    for (const h of unambiguousHeadlines) {
+      const m = matchesFrontaliereUnambiguousAnchor(h);
+      expect(m, `should match unambiguous: ${h}`).not.toBeNull();
+    }
+  });
+
+  it('does NOT match adjective-only or generic-finance headlines (no cronaca leak)', () => {
+    for (const h of adjectiveOnlyButNotUnambiguous) {
+      const m = matchesFrontaliereUnambiguousAnchor(h);
+      expect(m, `should NOT bypass classifier: ${h}`).toBeNull();
+    }
+  });
+
+  it('matchesFrontaliereUnambiguousAnchor handles null/empty safely', () => {
+    expect(matchesFrontaliereUnambiguousAnchor('')).toBeNull();
+    expect(matchesFrontaliereUnambiguousAnchor(null as unknown as string)).toBeNull();
+    expect(matchesFrontaliereUnambiguousAnchor(undefined as unknown as string)).toBeNull();
+  });
+
+  it('gate body uses matchesFrontaliereUnambiguousAnchor to bypass classifier', () => {
+    const gateBlock = SRC.match(
+      /async function applyPreSpendTopicGate[\s\S]*?\n\}\n/,
+    )![0];
+    expect(gateBlock).toMatch(/matchesFrontaliereUnambiguousAnchor\(/);
+    expect(gateBlock).toMatch(/unambiguousBypasses\s*\+=\s*1/);
+  });
+
+  it('gate body has the D-backstop (restore top-N strict-anchor when classifier rejects all)', () => {
+    const gateBlock = SRC.match(
+      /async function applyPreSpendTopicGate[\s\S]*?\n\}\n/,
+    )![0];
+    expect(gateBlock).toMatch(/kept\.length\s*===\s*0/);
+    expect(gateBlock).toMatch(/strictAnchorMatched/);
+    expect(gateBlock).toMatch(/backstop/i);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Problem**: Run [26440805420](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26440805420) hit no_changes streak 8 → 1800s backoff. The pre-spend topic gate (gemini-2.5-flash-lite) rejected **39/39** pre-filtered candidates as "non riguarda i frontalieri italo-svizzeri" — including obvious matches (Ristorni, Tassa salute, AVS, busta paga frontalieri). The proven pool emptied; the discovery fallback could not resolve any of its 193 Google News RSS URLs to direct sources; evergreen exhausted 10 keyword attempts against 2596 existing articles. Zero articles.
- **Fix A** — Re-introduce an anchor bypass on a NARROWER set (`FRONTALIERE_UNAMBIGUOUS_ANCHORS`) that excludes the patterns that leaked cronaca in 2026-05-15 (bare \`frontalier\`/\`transfrontalier\`/\`pendolar\`/\`cross-border\`, valico/dogana, bare \`cambio CHF\`) and keeps only fiscal/legal terms-of-art. Hits skip the LLM classifier.
- **Fix B** — Capture proven scan PRE-gate (\`_provenHeadlinesPreGate\`) and pass it to \`_buildDiscoveryPool\` / \`resolveGoogleNewsHeadline\` in the cross-pool fallback so the Google News URL atlas survives an empty post-gate pool.
- **Fix D** — Backstop: if classifier rejects 100% of candidates but at least one strict-anchor match exists, restore the top-3 strict-anchor headlines. REGOLA #0 in the article-gen prompt remains as defense-in-depth.

## Test plan

- [x] \`tests/pre-spend-topic-gate.test.ts\` — 23 tests passing (6 new for unambiguous anchors + bypass + D-backstop wiring).
- [x] Full \`npm test\` locally: 654 files pass / 6 fail (pre-existing — all due to missing \`data/jobs.json\`, assembled by CI gate before \`npm test\`).
- [ ] Post-merge: trigger \`generate-article.yml\` live on \`main\` and verify a commit (or a non-zero \`anchor-bypass=\` in the log) before the next cron beat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)