### PR TITLE
fix(seo): lift text/html ratio above 12% on related-search hub pages

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -1314,7 +1314,10 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
 interface HubItem {
   keyword: string;
   city: string | null;
+  /** Absolute URL — used in JSON-LD where Schema.org / Google expect absolute. */
   url: string;
+  /** Site-relative path — used in body <a href> to keep HTML lean (browsers resolve against <link rel="canonical">). */
+  path: string;
   slug: string;
 }
 
@@ -1379,7 +1382,7 @@ function renderHubPage(input: HubPageInput): { urlPath: string; html: string; lo
     const list = (byCity.get(city) || []).sort((a, b) => a.keyword.localeCompare(b.keyword, locale));
     return `<section class="s-USY9TF">
       <h3 class="s-vZUVtO">${esc(city)}</h3>
-      <ul class="s-MwMbiH">${list.map((it) => `<li><a href="${esc(it.url)}" style="${LINK_ACCENT_STYLE}">${esc(capitalize(it.keyword))}</a></li>`).join('')}</ul>
+      <ul class="s-MwMbiH">${list.map((it) => `<li><a class="s-la" href="${esc(it.path)}">${esc(capitalize(it.keyword))}</a></li>`).join('')}</ul>
     </section>`;
   }).join('');
 
@@ -1387,7 +1390,7 @@ function renderHubPage(input: HubPageInput): { urlPath: string; html: string; lo
   const uncatBlock = sortedUncat.length > 0
     ? `<section class="s-USY9TF">
         <h3 class="s-vZUVtO">${esc(copy.alphabeticalLabel)}</h3>
-        <ul class="s-MwMbiH">${sortedUncat.map((it) => `<li><a href="${esc(it.url)}" style="${LINK_ACCENT_STYLE}">${esc(capitalize(it.keyword))}</a></li>`).join('')}</ul>
+        <ul class="s-MwMbiH">${sortedUncat.map((it) => `<li><a class="s-la" href="${esc(it.path)}">${esc(capitalize(it.keyword))}</a></li>`).join('')}</ul>
       </section>`
     : '';
 
@@ -1405,8 +1408,13 @@ function renderHubPage(input: HubPageInput): { urlPath: string; html: string; lo
     dateModified: new Date().toISOString(),
     mainEntity: {
       '@type': 'ItemList',
+      // numberOfItems reports the full list size; itemListElement is a sample.
+      // Schema.org permits sampling — `numberOfItems > itemListElement.length`
+      // — and Google treats the array as representative. Capped at 30 (was 100)
+      // to shrink emitted HTML by ~10 KB per page, lifting the text/html ratio
+      // above the 10 % audit floor without dropping any visible body content.
       numberOfItems: items.length,
-      itemListElement: items.slice(0, 100).map((it, i) => ({
+      itemListElement: items.slice(0, 30).map((it, i) => ({
         '@type': 'ListItem',
         position: i + 1,
         name: capitalize(it.keyword),
@@ -1925,12 +1933,16 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
 
       // ── Per-locale hub pages ──────────────────────────────────────────
       for (const [locale, list] of byLocale.entries()) {
-        const items: HubItem[] = list.map((ctx) => ({
-          keyword: ctx.keyword,
-          city: ctx.city,
-          slug: ctx.candidate.slug,
-          url: `${BASE_URL}${buildClusterPath(locale, ctx.candidate.slug)}`,
-        }));
+        const items: HubItem[] = list.map((ctx) => {
+          const path = buildClusterPath(locale, ctx.candidate.slug);
+          return {
+            keyword: ctx.keyword,
+            city: ctx.city,
+            slug: ctx.candidate.slug,
+            url: `${BASE_URL}${path}`,
+            path,
+          };
+        });
         const totalPages = Math.max(1, Math.ceil(items.length / HUB_PAGE_SIZE));
 
         for (let page = 1; page <= totalPages; page++) {

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -304,6 +304,8 @@ main.seo-static-content { max-width: 1120px; margin: 0 auto; display: grid; gap:
 .cbl a { color: var(--color-link); text-decoration: underline; font-weight: 700; }
 .rul { list-style: none; padding: 0; margin: 0; }
 .lnk-acc { color: var(--color-link); text-decoration: none; font-weight: 600; }
+/* Plain accent link (no font-weight bump) — used in dense link lists on related-search hub pages where ~200 anchors per page would otherwise inline `style="color:var(--color-link);text-decoration:none"`. Class form saves ~37 B × N anchors, keeping the text/html ratio above the 10 % audit floor. */
+.s-la { color: var(--color-link); text-decoration: none; }
 .pill { display: inline-flex; padding: 8px 14px; border-radius: 999px; text-decoration: none; font-weight: 700; font-size: 13px; }
 .pill-a { background: var(--color-accent-subtle); color: var(--color-accent); }
 .pill-w { background: var(--color-warning-subtle); color: var(--color-warning); }

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -81,7 +81,12 @@ function classifyFeature(relPath) {
 }
 
 export function createAuditor(opts = {}) {
-  const threshold = opts.threshold ?? 10; // percent
+  const threshold = opts.threshold ?? 10; // percent — hard fail floor (Semrush gate)
+  // Soft warn band (threshold, warnThreshold]. Pages here pass today but are
+  // within 2 pp of the floor; one cron content refresh can push them under.
+  // Surfaced in `extra.nearFloor` so reviewers see drift before it becomes a
+  // hard-fail regression.
+  const warnThreshold = opts.warnThreshold ?? 12;
   const limit = opts.limit ?? 30;
   const featureFilter = opts.featureFilter ?? null;
   const includeNoindex = !!opts.includeNoindex;
@@ -183,8 +188,31 @@ export function createAuditor(opts = {}) {
         textBytes: r.textBytes,
       }));
 
+      // Near-floor band: pages that pass the hard gate but sit in the
+      // (threshold, warnThreshold] zone. Treated as an early-warning signal,
+      // never blocks the build.
+      const nearFloorSamples = samples
+        .filter((r) => r.ratio > threshold && r.ratio <= warnThreshold)
+        .sort((a, b) => a.ratio - b.ratio);
+      const nearFloorByFeature = {};
+      for (const r of nearFloorSamples) {
+        nearFloorByFeature[r.feature] = (nearFloorByFeature[r.feature] ?? 0) + 1;
+      }
+      const nearFloor = {
+        warnThreshold,
+        total: nearFloorSamples.length,
+        byFeature: nearFloorByFeature,
+        top: nearFloorSamples.slice(0, limit).map((r) => ({
+          path: r.file,
+          feature: r.feature,
+          ratio: Number(r.ratio.toFixed(2)),
+          htmlBytes: r.htmlBytes,
+          textBytes: r.textBytes,
+        })),
+      };
+
       const humanSummary = passed
-        ? `${offenders.length} offender(s) within baseline (threshold ${threshold} %)`
+        ? `${offenders.length} offender(s) within baseline (threshold ${threshold} %), ${nearFloor.total} page(s) in near-floor band (${threshold}-${warnThreshold} %)`
         : `${offenders.length} offender(s) ≤ ${threshold} % — regressed features: ${regressedFeatures.map(r => `${r.feature}(${r.count}>${r.max})`).join(', ') || 'total cap exceeded'}`;
 
       return {
@@ -195,7 +223,7 @@ export function createAuditor(opts = {}) {
         baselineFile: relBaseline(baselinePath),
         baselineDelta,
         byFeature,
-        extra: { scanned: samples.length, skippedNoindex, skippedEjpStripped, regressedFeatures, limit, threshold, rawSamples: samples },
+        extra: { scanned: samples.length, skippedNoindex, skippedEjpStripped, regressedFeatures, limit, threshold, warnThreshold, nearFloor, rawSamples: samples },
         humanSummary,
       };
     },


### PR DESCRIPTION
## Summary

- Fixes `validate-dist` run 26440498634 failure: `text-html-ratio job-board 342>340` (+2 pages slipping under the 10% Semrush floor).
- Root cause: ~180 paginated hub pages (`/find-jobs-ticino/search/page-N/` and locale equivalents) sit at 9.95–10.5% ratio because each carries 200 body anchors with absolute hrefs + inline `LINK_ACCENT_STYLE`, plus a 100-item JSON-LD ItemList. Cron content refresh nudges a couple under each deploy.
- Fix tightens the HTML chrome on those pages without touching visible content: body hrefs absolute→relative, `style="..."` → `class="s-la"` for the two pure occurrences, JSON-LD `itemListElement` cap 100→30 (`numberOfItems` still reports the real total; Schema.org permits sampling).
- Sample page `en/find-jobs-ticino/search/page-136/`: 119.8 KB → 94.8 KB HTML, text unchanged at 12.0 KB, ratio **10.05% → 12.69%**.
- Prevention: `audit-text-html-ratio.mjs` now reports a near-floor band (10–12%) in `extra.nearFloor`. Soft-only; surfaces drift before it becomes a hard regression.

## What changed

- `build-plugins/relatedSearchClustersPlugin.ts` — `HubItem` gets a `path` field; body anchors use it; JSON-LD ItemList capped at 30.
- `public/assets/seo-static.css` — new `.s-la` class (color + no-decoration, no font-weight bump).
- `scripts/audit-text-html-ratio.mjs` — new `warnThreshold` option (default 12) + `extra.nearFloor` block.

## Test plan

- [x] `vitest run tests/related-search-clusters{,-shell}.test.ts tests/jobboard-related-search-navigation.test.ts` — 64/64 pass
- [x] `tsc --noEmit` — no new errors
- [x] Sample-page replay (`en/find-jobs-ticino/search/page-136/`) — ratio 10.05% → 12.69%
- [ ] Post-merge `validate-dist` job on `main` returns green; near-floor count visible in audit report

🤖 Generated with [Claude Code](https://claude.com/claude-code)