### PR TITLE
fix(crawlers): retry 5xx + ALTEN transient skip

### DIFF
--- a/scripts/lib/jobup-ch-feed-common.mjs
+++ b/scripts/lib/jobup-ch-feed-common.mjs
@@ -82,25 +82,46 @@ function normalizeSpace(s = '') {
 
 async function fetchFeed(url) {
   const timeoutMs = Number(process.env.JOBS_CRAWLER_TIMEOUT_MS) || 20000;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(url, {
-      headers: { Accept: 'application/json,text/javascript,*/*', 'User-Agent': USER_AGENT },
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-    if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
-    const text = await res.text();
-    // Some jobup masks wrap in a JSONP callback like `xCallback({...})`. Strip it.
-    const trimmed = text.trim();
-    const jsonpMatch = trimmed.match(/^[a-zA-Z_$][\w$]*\s*\(\s*([\s\S]+)\s*\)\s*;?\s*$/);
-    const jsonText = jsonpMatch ? jsonpMatch[1] : trimmed;
-    return JSON.parse(jsonText);
-  } catch (err) {
-    clearTimeout(timer);
-    throw err;
+  const maxAttempts = Math.max(1, Number(process.env.JOBS_CRAWLER_FETCH_ATTEMPTS) || 3);
+  let lastErr;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        headers: { Accept: 'application/json,text/javascript,*/*', 'User-Agent': USER_AGENT },
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (!res.ok) {
+        const retriable = res.status === 408 || res.status === 429 || res.status >= 500;
+        const err = new Error(`HTTP ${res.status} from ${url}`);
+        if (retriable && attempt < maxAttempts) {
+          lastErr = err;
+          await new Promise((r) => setTimeout(r, 500 * attempt));
+          continue;
+        }
+        throw err;
+      }
+      const text = await res.text();
+      // Some jobup masks wrap in a JSONP callback like `xCallback({...})`. Strip it.
+      const trimmed = text.trim();
+      const jsonpMatch = trimmed.match(/^[a-zA-Z_$][\w$]*\s*\(\s*([\s\S]+)\s*\)\s*;?\s*$/);
+      const jsonText = jsonpMatch ? jsonpMatch[1] : trimmed;
+      return JSON.parse(jsonText);
+    } catch (err) {
+      clearTimeout(timer);
+      const isNetwork = err?.name === 'AbortError'
+        || /fetch failed|ECONN|ENOTFOUND|ETIMEDOUT|EAI_AGAIN/i.test(err?.message || '');
+      if (isNetwork && attempt < maxAttempts) {
+        lastErr = err;
+        await new Promise((r) => setTimeout(r, 500 * attempt));
+        continue;
+      }
+      throw err;
+    }
   }
+  throw lastErr || new Error(`fetchFeed exhausted retries for ${url}`);
 }
 
 /**

--- a/scripts/update-alten-jobs.mjs
+++ b/scripts/update-alten-jobs.mjs
@@ -178,7 +178,8 @@ async function discoverListings() {
 }
 
 async function buildJobs(listings) {
-  return withBrowser(async (page) => {
+  try {
+    return await withBrowser(async (page) => {
     // Warm the browser session on the listing page first so that Cloudflare
     // challenge cookies are established before navigating to detail pages.
     await page.goto(CAREERS_URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
@@ -240,7 +241,17 @@ async function buildJobs(listings) {
       console.warn(`  ⚠️  Skipped ${skipped}/${listings.length} detail pages due to errors`);
     }
     return jobs;
-  });
+    });
+  } catch (err) {
+    const msg = err?.message || String(err);
+    const isTransient = /listing session could not be initialized|did not become available|net::ERR_|timeout|TimeoutError|403/i.test(msg);
+    if (isTransient) {
+      console.warn(`⚠️  ALTEN detail session unavailable: ${msg}`);
+      console.log('ℹ️  Keeping existing data — no updates this run.');
+      return null;
+    }
+    throw err;
+  }
 }
 
 function jobMatchKey(job = {}) {
@@ -337,6 +348,11 @@ async function main() {
     return;
   }
   const jobs = await buildJobs(listings);
+  if (!jobs) {
+    console.log('⏩ Skipping ALTEN update — detail session unavailable.');
+    printCrawlChangeSummary({ newJobs: [], updatedJobs: [], removedJobs: [], unchangedCount: 0 }, 'ALTEN Switzerland');
+    return;
+  }
   const result = mergeJobs(jobs);
   const diff = result.diff;
   updateAdapterConfig(jobs);


### PR DESCRIPTION
## Summary
- `fetchFeed` (shared jobup feed: CNP, ehnv, pole-sante-pays-enhaut): retry on 408/429/5xx and network errors up to `JOBS_CRAWLER_FETCH_ATTEMPTS` (default 3) with linear backoff. Closes #577 (single upstream HTTP 500 from jobup.ch).
- `update-alten-jobs`: convert recurring evening-window session-init failure into a graceful skip (preserves existing jobs instead of crashing the workflow). Closes #576.

## Why
Both #576 and #577 were single-failure flakes in workflows that are otherwise overwhelmingly green. CNP saw an upstream HTTP 500 from jobup.ch; ALTEN saw a Cloudflare/session-init timing failure on the 21z run (recurring at ~21z on 2026-05-21 and 2026-05-25). Adding bounded retries + transient-skip matches the existing `discoverListings()` pattern in the same file.

## Test plan
- [x] `node --check` both files
- [x] Diff scope: only the two intended files
- [ ] Post-merge: observe next CNP + ALTEN scheduled dispatch on main
- [ ] If green, close issues #576/#577

🤖 Generated with [Claude Code](https://claude.com/claude-code)