### PR TITLE
fix(article-gen): catch non-Italian model output before budget burns (run 26446721285)

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -117,6 +117,7 @@ import { fetchWordpressSearchHeadlines } from './lib/topic-sources/wordpressSear
 import { extractArticleText } from './lib/extract-article-text.mjs';
 import { hasDomainAnchor } from './lib/discovery/domainAnchor.mjs';
 import { matchesFrontaliereAnchor, matchesFrontaliereUnambiguousAnchor } from './lib/discovery/frontaliereAnchor.mjs';
+import { isNonItalianScript, nonItalianScriptRatio } from './lib/itLanguageCheck.mjs';
 
 // ── Smarter generator inputs (Phase 3 — spec 2026-05-06) ───────
 // data/article-performance.json is produced weekly by Phase 1A.
@@ -2397,6 +2398,17 @@ async function callLLM(messages, opts = {}) {
           }
         }
         if (itContent.body2 && itContent.body2.trim().length < 40) missing.push('body2<40');
+        // Language sanity — fallback models occasionally drift to CJK /
+        // Cyrillic when prompted in Italian. Treat as malformed output:
+        // penalises the model, chain rotates, no budget burned at the
+        // outer headline-validation layer. See run 26446721285.
+        for (const field of ['title', 'excerpt', 'body1', 'body2', 'body3']) {
+          const val = itContent?.[field];
+          if (typeof val === 'string' && val.length > 0 && isNonItalianScript(val)) {
+            const ratio = (nonItalianScriptRatio(val) * 100).toFixed(0);
+            missing.push(`${field} non-IT script (${ratio}% non-Latin)`);
+          }
+        }
       }
 
       if (missing.length > 0) {

--- a/scripts/lib/itLanguageCheck.mjs
+++ b/scripts/lib/itLanguageCheck.mjs
@@ -1,0 +1,52 @@
+/**
+ * Non-Italian script detector for model-output sanity checks.
+ *
+ * History — run 26446721285 (2026-05-26): the fallback chain rotated to
+ * nvidia/llama-3.3-nemotron-super-49b-v1 which produced a 100%-Chinese
+ * headline ("AVS超過2.6百万人领取老年金"). The validator rejected it as
+ * "1 parola, range 2-22" but only AFTER consuming the entire headline-
+ * retry budget — the run hard-failed with no article published.
+ *
+ * This helper catches the drift at the JSON-validation layer so the chain
+ * rotates to a different model (via `recordModelContentFailure`) without
+ * burning the outer headline-validation budget. The threshold is
+ * deliberately permissive (10%): Italian editorial titles may legitimately
+ * contain single CJK names (e.g. "北京") in quoted brand references, but
+ * >10% means the body of the text is non-IT.
+ */
+
+// Non-Latin "letter" ranges that we treat as evidence the model has
+// switched language. Covers Cyrillic, Armenian, Hebrew, Arabic, CJK
+// punctuation/Hiragana/Katakana, CJK Ext-A, CJK Unified, and Hangul.
+const NON_LATIN_SCRIPT_RE = /[Ѐ-ԯ԰-֏֐-׿؀-ۿ　-〿぀-ゟ゠-ヿ㐀-䶿一-鿿가-힯]/gu;
+// All Unicode letters — denominator for the ratio.
+const ANY_LETTER_RE = /\p{L}/gu;
+
+/**
+ * Returns the fraction of "letter" characters in `text` that belong to a
+ * non-Latin script (CJK / Cyrillic / Hebrew / Arabic / Hangul / Armenian).
+ * Range 0..1. Returns 0 for non-strings, empty strings, or strings with
+ * no letters at all.
+ *
+ * @param {string} text
+ * @returns {number}
+ */
+export function nonItalianScriptRatio(text) {
+  if (typeof text !== 'string' || text.length === 0) return 0;
+  const letters = text.match(ANY_LETTER_RE) || [];
+  if (letters.length === 0) return 0;
+  const nonLatin = text.match(NON_LATIN_SCRIPT_RE) || [];
+  return nonLatin.length / letters.length;
+}
+
+/**
+ * `true` if more than `threshold` (default 10%) of the letters in `text`
+ * belong to a non-Latin script. Use to gate fallback model output.
+ *
+ * @param {string} text
+ * @param {number} [threshold=0.1]
+ * @returns {boolean}
+ */
+export function isNonItalianScript(text, threshold = 0.1) {
+  return nonItalianScriptRatio(text) > threshold;
+}

--- a/tests/non-italian-script-detector.test.ts
+++ b/tests/non-italian-script-detector.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the non-Italian script detector that gates fallback-model output.
+ *
+ * Background — run 26446721285 (2026-05-26): the fallback chain rotated to
+ * nvidia/llama-3.3-nemotron-super-49b-v1 which produced a 100%-Chinese
+ * headline ("AVS超過2.6百万人领取老年金"). The validator rejected it as
+ * "1 parola, range 2-22" but only AFTER consuming the entire headline-
+ * retry budget — the run hard-failed with no article. The detector now
+ * catches this drift at the JSON-validation layer so the chain rotates
+ * to a different model without burning the budget.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isNonItalianScript,
+  nonItalianScriptRatio,
+} from '../scripts/lib/itLanguageCheck.mjs';
+
+describe('non-Italian script detector', () => {
+  it('flags the run 26446721285 CJK headline', () => {
+    const headline = 'AVS超過2.6百万人领取老年金';
+    expect(isNonItalianScript(headline)).toBe(true);
+    expect(nonItalianScriptRatio(headline)).toBeGreaterThan(0.5);
+  });
+
+  it('flags full-CJK body content', () => {
+    const body = '日本の高齢者年金システムは複雑です。';
+    expect(isNonItalianScript(body)).toBe(true);
+  });
+
+  it('flags Cyrillic body content', () => {
+    const body = 'Швейцария — это страна в Европе.';
+    expect(isNonItalianScript(body)).toBe(true);
+  });
+
+  it('accepts pure Italian editorial content', () => {
+    const headlines = [
+      'AVS 2030: cosa cambia per i frontalieri del Ticino',
+      'Ristorni frontalieri: il Ticino propone una soluzione',
+      "L'imposta alla fonte salirà nel 2026",
+      'LAMal 2026, premi in aumento del 6% in Ticino',
+      'Lavorare in Svizzera, vivere in Italia: la guida 2026',
+    ];
+    for (const h of headlines) {
+      expect(isNonItalianScript(h), `should accept IT: ${h}`).toBe(false);
+      expect(nonItalianScriptRatio(h)).toBeLessThan(0.1);
+    }
+  });
+
+  it('accepts Italian with German/French/English borrowings (accented Latin only)', () => {
+    const samples = [
+      'Berna alle banche: tutti devono contribuire',
+      'AHV-Renten — un confronto Italia-Svizzera',
+      'Frontaliere résident en France: le cas particulier',
+      'È vero che la Svizzera è membro dell’UE?',
+    ];
+    for (const s of samples) {
+      expect(isNonItalianScript(s), `should accept Latin-extended: ${s}`).toBe(false);
+    }
+  });
+
+  it('tolerates occasional CJK brand/quote tokens below threshold', () => {
+    // "TikTok" name in Chinese 抖音 appears inside a longer Italian title.
+    // 2 CJK chars vs ~50 Latin → ~4% ratio, below the 10% threshold.
+    const headline = 'Frontalieri e TikTok (抖音): la piattaforma divide il mercato del lavoro ticinese';
+    expect(isNonItalianScript(headline)).toBe(false);
+  });
+
+  it('handles edge cases safely', () => {
+    expect(isNonItalianScript('')).toBe(false);
+    expect(isNonItalianScript(null as unknown as string)).toBe(false);
+    expect(isNonItalianScript(undefined as unknown as string)).toBe(false);
+    expect(nonItalianScriptRatio('')).toBe(0);
+    expect(nonItalianScriptRatio('12345.67')).toBe(0); // no letters → ratio 0
+  });
+
+  it('honours a custom threshold', () => {
+    const halfHalf = 'Ticino 北京 Lugano 上海 Bellinzona 广州 Mendrisio';
+    // ~6 CJK letters vs ~30 Latin letters → ~20% ratio.
+    expect(isNonItalianScript(halfHalf, 0.5)).toBe(false);
+    expect(isNonItalianScript(halfHalf, 0.05)).toBe(true);
+  });
+
+  it('flags Arabic and Hebrew too (less common but observed in some Cerebras models)', () => {
+    expect(isNonItalianScript('السلام عليكم — frontaliere è una parola italiana')).toBe(true);
+    expect(isNonItalianScript('שלום — ciao in ebraico')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem**: Run [26446721285](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26446721285) hard-failed after the fallback chain rotated to \`nvidia/llama-3.3-nemotron-super-49b-v1\` which produced a 100%-Chinese headline (\`AVS超過2.6百万人领取老年金\`). The headline validator caught it as \"1 parola, range 2-22\" but only at the outer layer, after consuming the entire 6-attempt headline-retry budget. PR #593's pre-spend gate fix was already working — the AVS topic correctly bypassed the classifier via the unambiguous anchor. What broke was downstream model-output quality.
- **Fix**: At the JSON-validation layer (next to the existing \`REQUIRED_IT_BODY_FIELDS\` check), detect when any of \`title/excerpt/body1/body2/body3\` contains > 10% non-Latin letter chars (CJK / Cyrillic / Hebrew / Arabic / Hangul / Armenian). Treat as a malformed field — \`recordModelContentFailure()\` penalises the model and the chain rotates without consuming the outer headline-validation budget.
- **Why 10%**: tolerates occasional CJK brand tokens (e.g. \"TikTok (抖音)\") in Italian editorial while catching the runaway mode where the model has switched language entirely. Anything in the 70-100% range (like the run 26446721285 headline) is well above the threshold.

## Test plan

- [x] \`tests/non-italian-script-detector.test.ts\` — 9 cases including the exact run 26446721285 headline, full-CJK / Cyrillic / Arabic / Hebrew bodies, pure-IT acceptance, IT-with-Latin-extended acceptance, custom threshold, edge cases. All pass.
- [x] Existing \`tests/pre-spend-topic-gate.test.ts\` + \`tests/article-frontaliere-density.test.ts\` still pass (33 total).
- [ ] Post-merge: trigger \`generate-article.yml\` live and verify no run hard-fails on a CJK headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)