### PR TITLE
fix(lhci): swap dead URLs to live ones to re-enable CLS/perf measurement

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -50,13 +50,17 @@ jobs:
       - name: Run Lighthouse CI against production
         uses: treosh/lighthouse-ci-action@v10
         with:
+          # URLs must exist in the live sitemap and serve 200 (no redirect).
+          # Lighthouse aborts the whole run on any 404 — see issue
+          # diagnosed 2026-05-26: 4/6 old URLs were 404, blanking every audit
+          # incl. CLS. URL slugs changed after the cathedral rewrite.
           urls: |
             https://frontaliereticino.ch/
             https://frontaliereticino.ch/cerca-lavoro-ticino/
-            https://frontaliereticino.ch/aziende-che-assumono/lugano
-            https://frontaliereticino.ch/prezzi-carburanti/chiasso
-            https://frontaliereticino.ch/casse-malati/ticino
-            https://frontaliereticino.ch/tempi-di-attesa-dogana/chiasso-brogeda
+            https://frontaliereticino.ch/aziende-che-assumono/ticino/settimana-corrente/
+            https://frontaliereticino.ch/prezzi-diesel/chiasso/oggi/
+            https://frontaliereticino.ch/premi-cassa-malati/ticino/
+            https://frontaliereticino.ch/traffico-dogane/chiasso-brogeda/oggi/
           budgetPath: ./lighthouse-budget.json
           configPath: ./lighthouserc.json
           uploadArtifacts: true


### PR DESCRIPTION
## Summary
LHCI was failing silently on every main push since the cathedral URL rewrite. 4 of 6 URLs returned 404 → Lighthouse aborted the whole run before any gatherer collected data → `traces gatherer, required by audit cumulative-layout-shift, did not run` (and all other CWV audits).

URLs replaced (verified live, 200, no redirect):
| Old (404) | New (200) |
|---|---|
| `/aziende-che-assumono/lugano` | `/aziende-che-assumono/ticino/settimana-corrente/` |
| `/prezzi-carburanti/chiasso` | `/prezzi-diesel/chiasso/oggi/` |
| `/casse-malati/ticino` | `/premi-cassa-malati/ticino/` |
| `/tempi-di-attesa-dogana/chiasso-brogeda` | `/traffico-dogane/chiasso-brogeda/oggi/` |

## Why
#544 (P8 recovery) flags CLS p75 0.91 above target 0.5, but the CI gate is blind — every run since the rewrite has been a no-op. This restores measurability so any subsequent CLS fix can actually be verified.

## Test plan
- [x] All 6 URLs checked with `curl -I` — 200 without redirect
- [ ] Post-merge: confirm next LHCI run on main collects traces (no `did not run` warnings) and reports CLS values

Refs: #544, #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)