### PR TITLE
fix(crawler-lis): preserve prior slice on partial fetch + restore 13 LIS jobs

### DIFF
--- a/data/jobs/by-crawler/lis-lugano-istituti-sociali.json
+++ b/data/jobs/by-crawler/lis-lugano-istituti-sociali.json
@@ -1,7 +1,991 @@
 {
   "crawlerKey": "lis-lugano-istituti-sociali",
-  "assembledAt": "2026-05-25T22:48:48.771Z",
+  "assembledAt": "2026-05-25T13:19:20.932Z",
   "jobs": [
+    {
+      "title": "Capireparto",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=25-capireparto-pregassona&language=it",
+      "slug": "capireparto-lis-lugano-istituti-sociali-pregassona",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di capireparto alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma di infermiere in cure generali SSSCI o SUP o titolo equivalente; - diploma of Advanced Studies SUPSI in gestione sanitaria DAS GES o l'impegno a intraprendere la specifica formazione e a ottenerlo nei tempi concordati; - attitudine alla conduzione del personale e capacità organizzative, di coordinamento e di controllo; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia XIII (capireparto), classi 14-15-16 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 classe 16: min CHF 92'919.50 / max CHF 109'644.90 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Capireparto",
+        "en": "Chapter",
+        "de": "Kapitel",
+        "fr": "Capireparto"
+      },
+      "slugByLocale": {
+        "it": "capireparto-lis-lugano-istituti-sociali-pregassona",
+        "en": "chapter-lis-lugano-istituti-sociali-pregassona",
+        "de": "kapitel-lis-lugano-istituti-sociali-pregassona",
+        "fr": "capireparto-lis-lugano-istituti-sociali-pregassona-845mpk"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di capireparto alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma di infermiere in cure generali SSSCI o SUP o titolo equivalente; - diploma of Advanced Studies SUPSI in gestione sanitaria DAS GES o l'impegno a intraprendere la specifica formazione e a ottenerlo nei tempi concordati; - attitudine alla conduzione del personale e capacità organizzative, di coordinamento e di controllo; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia XIII (capireparto), classi 14-15-16 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 classe 16: min CHF 92'919.50 / max CHF 109'644.90 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for taking part in the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) zur Teilnahme an den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - Diplom der Krankenschwestern in der allgemeinen Pflege SSSCI oder SUP oder gleichwertigen Titel; - Diplom der Advanced Studies SUPSI in der Gesundheitsverwaltung DAS GES oder Verpflichtung zur Durchführung spezifischer Ausbildung und erhalten sie in vereinbarten Zeiten; - Einstellungen für Personalmanagement und Organisation, Koordination und Kontrolle Fähigkeiten; - Sensitivität im Zusammenhang mit der älteren Person; - Erleichterung der Kommunikation Allgemeine Referenz für den sozio-sanitären Sektor Jahreslohn - Gruppe XIII (capireparto), Klassen 14-15-16 Klasse 14: min CHF 82'372.30 / max CHF 97'199.35 Klasse 15: min CHF 86'927.80 / max CHF 102'574.80 Klasse 16: min CHF 92'919.50 / max CHF 109'644.90 Im Rahmen der oben genannten Löhne kann die wichtigste Tätigkeit erkannt werden, wenn die vorliegende Die Angebote müssen von den folgenden Dokumenten begleitet werden: - Präsentationsschreiben - Lehrplan vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung des Gerichtssaals Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment erforderlich sein, um den Auszug der Gerichtskammer für Privatpersonen darzustellen. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
+        "fr": "Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public (valable pour l'année 2026) pour participer aux conditions de la réglementation organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Exigences particulières: - diplôme d'infirmières en soins généraux SSSCI ou SUP ou titre équivalent; - diplôme d'études supérieures SUPSI en gestion de la santé DAS GES ou engagement à entreprendre une formation spécifique et à l'obtenir dans des délais convenus; - attitudes à l'égard de la gestion du personnel et des compétences en matière d'organisation, de coordination et de contrôle; - sensibilité à l'approche relationnelle avec la personne âgée; - facilité de communication Référence générale pour le secteur socio-sanitaire: Gérer, participer et/ou fournir personnellement les soins aux hôtes des Maisons pour personnes âgées et du Centre de la Journée thérapeutique du Corps autonome Lugano Instituts sociaux sur la base des programmes de travail, des besoins et des quotas des priorités définis par les supérieurs, selon la formation acquise et la fonction attribuée. Salaires annuels - Groupe XIII (capireparto), classes 14-15-16 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 classe 16: min CHF 92'919.50 / max CHF 109'644.90 Dans le contexte des salaires mentionnés ci-dessus, l'activité la plus importante peut être reconnue si le Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de la boîte judiciaire En plus des documents à joindre initialement, dans un second moment peut être nécessaire de présenter l'extrait de la boîte judiciaire pour les particuliers. Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
+      },
+      "salaryMin": 92920,
+      "salaryMax": 109645,
+      "salaryCurrency": "CHF",
+      "salaryClass": "16",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "previousSlugs": [
+        "capireparto",
+        "capireparto-lis-lugano-istituti-sociali-lugano",
+        "capireparto-lis-lugano-istituti-sociali-pregassona-845mpk",
+        "capo-reparto-lis-lugano-istituti-sociali-pregassona"
+      ],
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 92920,
+          "maxValue": 109645,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "f764159368679325e7a2",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-15T11:24:04.342Z"
+      },
+      "id": "lis-lugano-istituti-sociali-141ef52d04c5",
+      "previousSlugsByLocale": {
+        "it": [
+          "capireparto",
+          "capireparto-lis-lugano-istituti-sociali-lugano"
+        ],
+        "en": [
+          "capireparto-lis-lugano-istituti-sociali-pregassona-845mpk"
+        ],
+        "de": [
+          "capireparto-lis-lugano-istituti-sociali-pregassona-845mpk"
+        ]
+      },
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T11:20:10.630Z",
+      "needsRetranslation": true
+    },
+    {
+      "title": "Infermieri",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=29-infermieri-pregassona&language=it",
+      "slug": "infermieri-lis-lugano-istituti-sociali-pregassona",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di infermieri alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma di infermiere in cure generali SSSCI o SUP o titolo equivalente; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia XII (infermieri), classi 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Infermieri",
+        "en": "Nurses",
+        "de": "Krankenschwestern",
+        "fr": "Infirmières"
+      },
+      "slugByLocale": {
+        "it": "infermieri-lis-lugano-istituti-sociali-pregassona",
+        "en": "nurses-lis-lugano-istituti-sociali-pregassona",
+        "de": "krankenschwestern-lis-lugano-istituti-sociali-pregassona",
+        "fr": "infirmieres-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di infermieri alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma di infermiere in cure generali SSSCI o SUP o titolo equivalente; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia XII (infermieri), classi 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of nurses under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Rekrutierung von Krankenschwestern unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - Diplom der Krankenschwestern in der allgemeinen Pflege SSSCI oder SUP oder gleichwertiger Titel; - Sensitivität in Bezug auf die ältere Person; - Erleichterung der zwischenmenschlichen Kommunikation und starke relationale Fähigkeiten; - Kenntnisse des Managementinstruments RAI. Allgemeine Referenz für den sozio-sanitären Sektor: Verwalten, teilnehmen und/oder persönlich die Betreuung der Gäste der Häuser für ältere Menschen und des Zentrums für therapeutische Tage der autonomen Körper-Lugano-Sozialinstitute auf der Grundlage der Programme der Arbeit, der Bedürfnisse und der Quoten der Prioritäten, die von den Vorgesetzten definiert werden, nach der erreichten Ausbildung und der zugewiesenen Funktion. Jahreslohn - Papier XII (firmen), Klassen 13-14-15 Klasse 13: min CHF 77'526.15 / max CHF 91'481.05 Klasse 14: min CHF 82'372.30 / max CHF 97'199.35 Klasse 15: min CHF 86'927.80 / max CHF 102'574.80 Im Rahmen der oben genannten Lohnmöglichkeiten erfolgt die zuvor durchgeführte Tätigkeit, wenn sie der vorliegenden Die Angebote müssen von den folgenden Dokumenten begleitet werden: - Präsentationsschreiben - Lehrplan vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung des Gerichtssaals Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment erforderlich sein, um den Auszug der Gerichtskammer für Privatpersonen darzustellen. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
+        "fr": "Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public (valable pour l'année 2026) pour le recrutement d'infirmières dans les conditions du règlement organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Exigences particulières: - diplôme d'infirmier en soins généraux SSSCI ou SUP ou titre équivalent; - sensibilité vis-à-vis de la personne âgée; - facilité de communication interpersonnelle et fortes aptitudes relationnelles; - connaissance de l'instrument de gestion RAI. Référence générale pour le secteur socio-sanitaire: Gérer, participer et/ou fournir personnellement les soins des hôtes des Maisons pour personnes âgées et du Centre de la Journée thérapeutique du Corps autonome Lugano Instituts sociaux sur la base des programmes de travail, des besoins et des quotas des priorités définies par les supérieurs, selon la formation acquise et la fonction attribuée. Salaire annuel - Papier XII (infirmes), classes 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Dans le cadre des possibilités de rémunération mentionnées ci-dessus, l'activité effectuée antérieurement, si elle est conforme au présent Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de la boîte judiciaire En plus des documents à joindre initialement, dans un second moment peut être nécessaire de présenter l'extrait de la boîte judiciaire pour les particuliers. Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
+      },
+      "salaryMin": 86928,
+      "salaryMax": 102575,
+      "salaryCurrency": "CHF",
+      "salaryClass": "15",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "previousSlugs": [
+        "infermieri",
+        "infermieri-lis-lugano-istituti-sociali-lugano",
+        "infermieri-lis-lugano-istituti-sociali-pregassona-isfspc"
+      ],
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 86928,
+          "maxValue": 102575,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "acb49732bfd362e6fefb",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-15T22:11:48.104Z"
+      },
+      "id": "lis-lugano-istituti-sociali-f650fe01210f",
+      "previousSlugsByLocale": {
+        "it": [
+          "infermieri",
+          "infermieri-lis-lugano-istituti-sociali-lugano"
+        ],
+        "en": [
+          "infermieri-lis-lugano-istituti-sociali-pregassona-isfspc"
+        ],
+        "de": [
+          "infermieri-lis-lugano-istituti-sociali-pregassona-isfspc"
+        ],
+        "fr": [
+          "infermieri-lis-lugano-istituti-sociali-pregassona-isfspc"
+        ]
+      },
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T22:20:25.346Z"
+    },
+    {
+      "title": "Operatori Sociosanitari",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=33-operatori-sociosanitari-pregassona&language=it",
+      "slug": "operatori-sociosanitari-lis-lugano-istituti-sociali-pregassona",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "# Concorso per Operatori Sociosanitari ## Descrizione Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico per l'assunzione di operatori sociosanitari alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine e incarichi per funzione stabile interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale. ##\n• Requisiti di Ordine Generale - Cittadinanza svizzera o stranieri con permesso di lavoro - Condotta ineccepibile - Costituzione fisica e psichica sana - Idoneità alla funzione ##\n• Requisiti di Ordine Particolare - Attestato federale di capacità quale operatore sociosanitario o titolo equivalente - Sensibilità nell'approccio relazionale con la persona anziana - Facilità di comunicazione interpersonale e spiccate doti relazionali - Conoscenza dello strumento gestionale RAI ## Mansioni Generali di Riferimento per il Settore Sociosanitario - Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita ## Stipendio Annuo - Fascia IX (operatori sociosanitari), classi 10-11-12 - Classe 10: min CHF 65'679.90 / max CHF 77'502.35 - Classe 11: min CHF 69'193.30 / max CHF 81'648.20 - Classe 12: min CHF 73'140.05 / max CHF 86'305.45 - Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio ## Documenti Richiesti - Lettera di presentazione - Curriculum vitae - Fotografia recente - Certificati di studio e di lavoro - Questionario sullo stato di salute - Autocertificazione casellario giudiziale - Estratto del casellario giudiziale per privati (richiesto in un secondo momento) ## Condizioni di Presentazione delle Candidature - Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali <https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/> entro le ore 23:59 di domenica 13 dicembre 2026 - L'Ufficio Risorse Umane resta a disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo per candidarsi - Non saranno considerate candidature e allegati trasmessi tramite altri canali (forma cartacea, email, fax, ecc.) ## Contatto LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE ## Capitolati e Questionari - Capitolato di concorso - Questionario sullo stato di salute - Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Operatori Sociosanitari",
+        "en": "Corporate operators",
+        "de": "Unternehmen",
+        "fr": "Entreprises"
+      },
+      "slugByLocale": {
+        "it": "operatori-sociosanitari-lis-lugano-istituti-sociali-pregassona",
+        "en": "corporate-operators-lis-lugano-istituti-sociali-pregassona",
+        "de": "unternehmen-lis-lugano-istituti-sociali-pregassona",
+        "fr": "entreprises-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "# Concorso per Operatori Sociosanitari ## Descrizione Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico per l'assunzione di operatori sociosanitari alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine e incarichi per funzione stabile interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale. ##\n• Requisiti di Ordine Generale - Cittadinanza svizzera o stranieri con permesso di lavoro - Condotta ineccepibile - Costituzione fisica e psichica sana - Idoneità alla funzione ##\n• Requisiti di Ordine Particolare - Attestato federale di capacità quale operatore sociosanitario o titolo equivalente - Sensibilità nell'approccio relazionale con la persona anziana - Facilità di comunicazione interpersonale e spiccate doti relazionali - Conoscenza dello strumento gestionale RAI ## Mansioni Generali di Riferimento per il Settore Sociosanitario - Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita ## Stipendio Annuo - Fascia IX (operatori sociosanitari), classi 10-11-12 - Classe 10: min CHF 65'679.90 / max CHF 77'502.35 - Classe 11: min CHF 69'193.30 / max CHF 81'648.20 - Classe 12: min CHF 73'140.05 / max CHF 86'305.45 - Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio ## Documenti Richiesti - Lettera di presentazione - Curriculum vitae - Fotografia recente - Certificati di studio e di lavoro - Questionario sullo stato di salute - Autocertificazione casellario giudiziale - Estratto del casellario giudiziale per privati (richiesto in un secondo momento) ## Condizioni di Presentazione delle Candidature - Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali <https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/> entro le ore 23:59 di domenica 13 dicembre 2026 - L'Ufficio Risorse Umane resta a disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo per candidarsi - Non saranno considerate candidature e allegati trasmessi tramite altri canali (forma cartacea, email, fax, ecc.) ## Contatto LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE ## Capitolati e Questionari - Capitolato di concorso - Questionario sullo stato di salute - Questionario relativo al casellario giudiziale",
+        "en": "Competition for Corporate Operators Description The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition for the recruitment of social workers under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments and assignments for a stable internal function. The positions are open to both female and male applications. This competition is also open in the absence of an actual staff requirement. General Order\n• Requirements - Swiss or foreign citizenship with work permit - Unexceptionable conduct - Healthy physical and mental constitution - Function suitability Special Order\n• Requirements - Federal certificate of capacity as a social worker or equivalent title - Sensitivity in relation to the elderly person - Ease of interpersonal communication and strong relational skills - Knowledge of the RAI management tool General Supply of Reference for the Company Sector - Managing, participating and/or providing personally to the care of the guests of the Houses for the elderly and the therapeutic centre of the Autonomous Body Lugano Social Institutes on the basis of the work programmes, quota needs and priorities defined by the superiors, according to the training achieved and the function attributed Annuo - Issue IX (Social Workers), classes 10-11- 12 - Class 10: min CHF 65'679.90 / max CHF 77'502.35 - Class 11: min CHF 69'193.30 / max CHF 81'648.20 - Class 12: min CHF 73'140.05 / max CHF 86'305.45 - In the context of the above-mentioned possibilities of pay, the activity carried out previously, if conform to this Chapter, assigning one or more year of service Documents Requested - Letter of presentation - Curriculum vitae - Recent photography - Study and work certificates - Questionnaire on health - Self-certification judicial box - Excerpt of the judicial box for private individuals (required at a later time) Terms of Application Presentation - Applications must be submitted electronically via the online desk following the procedure indicated on the website of the Lugano Institutes Social Institutes by 23:59 on Sunday 13 December 2026 - The Human Resources Office remains available (T. 058 866 34 11) of those who do not have a device to apply - Applications and attachments will not be considered by other channels (paper, email, fax, etc.) Contact SOCIAL INSTITUTIONS THE COUNCIL OF ADMINISTRATION Chapters and Questions - Competition chapter - Questionnaire on health - Questionnaire relating to the judicial box",
+        "de": "Wettbewerb für Unternehmensbeteiligte Warenbezeichnung Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb für die Einstellung von Sozialarbeitern unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Ernennungen und Zuweisungen für eine stabile interne Funktion vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen. Allgemeine\n• Anforderungen - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis - Unausgenommenes Verhalten - Gesunde körperliche und geistige Verfassung - Funktionsfähigkeit Besondere\n• Anforderungen - Föderales Zertifikat als Sozialarbeiter oder gleichwertiger Titel - Empfindlichkeit gegenüber älteren Menschen - Ease der zwischenmenschlichen Kommunikation und starken relationalen Fähigkeiten - Kenntnis des RAI-Management-Tools Allgemeine Referenzversorgung des Unternehmenssektors - Verwaltung, Teilnahme und/oder Bereitstellung persönlicher Betreuung der Gäste des Hauses für ältere Menschen und des therapeutischen Zentrums der Autonomen Körper-Lugano-Sozialinstitute auf der Grundlage der von den Vorgesetzten definierten Arbeitsprogramme, Quotenbedarf und Prioritäten nach der erreichten Ausbildung und der zugeschriebenen Funktion Annuo - Ausgabe IX (Sozialarbeiter), Klassen 10-11- 12 - Klasse 10: min CHF 65'679.90 / max CHF 77'502.35 - Klasse 11: min CHF 69'193.30 / max CHF 81'648.20 - Klasse 12: min CHF 73'140.05 / max CHF 86'305.45 - Im Rahmen der oben genannten Zahlungsmöglichkeiten hat die zuvor geleistete Tätigkeit, sofern sie diesem Kapitel entspricht, ein oder mehrere Jahre Dienstzeit zugeteilt. Angeforderte Dokumente - Präsentationsschreiben - Lebenslauf - Neue Fotografie - Studien- und Arbeitszeugnisse - Frage zum Thema Gesundheit - Selbstzertifizierung gerichtliches Feld - Auszug der Gerichtsdose für Privatpersonen (zu einem späteren Zeitpunkt erforderlich) Bewerbungsbedingungen Präsentation - Die Anmeldungen müssen elektronisch über den Online-Desk nach dem auf der Website der Lugano Institute Social Institutes angegebenen Verfahren bis 23:59 am Sonntag, 13. Dezember 2026 eingereicht werden - Das Personalbüro bleibt verfügbar (T. 058 866 34 11) von denen, die kein Gerät zur Anwendung haben - Anwendungen und Anhänge werden nicht von anderen Kanälen betrachtet (Papier, E-Mail, Fax, etc.) Kontakt SOZIALE INSTITUTIONEN DER RAT DER VERWALTUNG Kapitel und Fragen - Kapitel des Wettbewerbs - Frage zum Thema Gesundheit - Fragebögen zum Gerichtssaal",
+        "fr": "Concurrence pour les opérateurs d'entreprise Désignation des marchandises Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public pour le recrutement de travailleurs sociaux dans les conditions du règlement organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations et des affectations pour une fonction interne stable. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général - Citoyenneté suisse ou étrangère avec permis de travail - Conduite exceptionnelle - Constitution physique et mentale saine - Capacité fonctionnelle\n• Exigences spéciales - Certificat fédéral de capacité de travailleur social ou titre équivalent - Sensibilité à l'égard de la personne âgée - Facilité de communication interpersonnelle et forte capacité relationnelle - Connaissance de l'outil de gestion RAI Fourniture générale de référence pour le secteur de l'entreprise - La gestion, la participation et/ou la prise en charge personnelle des hôtes des Maisons pour personnes âgées et du centre thérapeutique des Instituts Sociaux du Corps Autonome de Lugano sur la base des programmes de travail, des besoins de quotas et des priorités définis par les supérieurs, selon la formation acquise et la fonction attribuée Annuaire - Numéro IX (Travailleurs sociaux), classes 10-11-12 - Classe 10: min CHF 65'679.90 / max CHF 77'502.35 - Classe 11: min CHF 69'193.30 / max CHF 81'648.20 - Classe 12: min CHF 73'140.05 / max CHF 86'305.45 - Dans le contexte des possibilités de rémunération susmentionnées, l'activité exercée antérieurement, si elle est conforme au présent chapitre, en attribuant une ou plusieurs années de service Documents demandés - Lettre de présentation - Curriculum vitae - Photographie récente - Certificats d'études et de travail Questionnaire sur la santé - Boîte judiciaire d'autocertification - Extrait de la boîte judiciaire pour les particuliers (obligatoire ultérieurement) Présentation des conditions d'application - Les demandes doivent être soumises par voie électronique via le bureau en ligne suivant la procédure indiquée sur le site des Instituts de Lugano Instituts sociaux avant 23:59 le dimanche 13 décembre 2026 - Le Bureau des ressources humaines reste disponible (T. 058 866 34 11) de ceux qui n'ont pas de dispositif à appliquer - Les demandes et pièces jointes ne seront pas examinées par d'autres voies (papier, courriel, télécopie, etc.) Personne à contacter INSTITUTIONS SOCIALES LE CONSEIL D ' ADMINISTRATION Chapitres et questions - Chapitre Concurrence Questionnaire sur la santé - Questionnaire relatif à la boîte judiciaire"
+      },
+      "salaryMin": 73140,
+      "salaryMax": 86305,
+      "salaryCurrency": "CHF",
+      "salaryClass": "12",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "previousSlugs": [
+        "operatori-sociosanitari",
+        "operatori-sociosanitari-lis-lugano-istituti-sociali-pregassona-ceayh7",
+        "operatori-sociosanitari-lis-lugano-istituti-sociali-lugano"
+      ],
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 73140,
+          "maxValue": 86305,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "a260c57b63fb42569d03",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-24T22:36:16.166Z"
+      },
+      "id": "lis-lugano-istituti-sociali-46ddf621dede",
+      "previousSlugsByLocale": {
+        "it": [
+          "operatori-sociosanitari"
+        ],
+        "en": [
+          "operatori-sociosanitari-lis-lugano-istituti-sociali-pregassona-ceayh7"
+        ],
+        "de": [
+          "operatori-sociosanitari-lis-lugano-istituti-sociali-pregassona-ceayh7"
+        ],
+        "fr": [
+          "operatori-sociosanitari-lis-lugano-istituti-sociali-pregassona-ceayh7"
+        ]
+      },
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T11:20:10.630Z"
+    },
+    {
+      "title": "Assistenti di cura",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=34-assistenti-di-cura-pregassona&language=it",
+      "slug": "assistenti-di-cura",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di assistenti di cura alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - certificato federale di capacità quale addetto alle cure sociosanitarie o titolo equivalente; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia VII (assistenti di cura), classi 8-9-10 classe 8: min CHF 59'808.05 / max CHF 70'573.50 classe 9: min CHF 62'560.85 / max CHF 73'821.70 classe 10: min CHF 65'679.90 / max CHF 77'502.35 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Assistenti di cura",
+        "en": "Care assistants",
+        "de": "Assistenti di cura",
+        "fr": "Assistants de soins"
+      },
+      "slugByLocale": {
+        "it": "assistenti-di-cura",
+        "en": "care-assistants-lis-lugano-istituti-sociali-pregassona",
+        "de": "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona-d2blfr",
+        "fr": "assistants-de-soins-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di assistenti di cura alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - certificato federale di capacità quale addetto alle cure sociosanitarie o titolo equivalente; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia VII (assistenti di cura), classi 8-9-10 classe 8: min CHF 59'808.05 / max CHF 70'573.50 classe 9: min CHF 62'560.85 / max CHF 73'821.70 classe 10: min CHF 65'679.90 / max CHF 77'502.35 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of care assistants under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Einstellung von Pflegekräften unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - Eidgenössische Kapazitätsbescheinigung als Sozialhilfebeauftragter oder gleichwertiger Titel; - Sensitivität in Bezug auf ältere Menschen; - Erleichterung der zwischenmenschlichen Kommunikation und starke relationale Fähigkeiten; - Kenntnisse des Managementinstruments RAI. Allgemeine Referenz für den sozio-sanitären Sektor: Verwalten, teilnehmen und/oder persönlich die Betreuung der Gäste der Häuser für ältere Menschen und des Zentrums für therapeutische Tage der autonomen Körper-Lugano-Sozialinstitute auf der Grundlage der Programme der Arbeit, der Bedürfnisse und der Quoten der Prioritäten, die von den Vorgesetzten definiert werden, nach der erreichten Ausbildung und der zugewiesenen Funktion. Jahreslohn - Papier VII (Betreuer), Klassen 8-9-10 Klasse 8: min CHF 59'808.05 / max CHF 70'573.50 Klasse 9: min CHF 62'560.85 / max CHF 73'821.70 Klasse 10: min CHF 65'679.90 / max CHF 77'502.35 Im Rahmen der oben genannten Bezahlungsmöglichkeiten erfolgt die zuvor durchgeführte Tätigkeit, wenn Die Angebote müssen von den folgenden Dokumenten begleitet werden: - Präsentationsschreiben - Lehrplan vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung des Gerichtssaals Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment erforderlich sein, um den Auszug der Gerichtskammer für Privatpersonen darzustellen. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
+        "fr": "Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public (valable pour l'année 2026) pour le recrutement d'assistants de soins dans les conditions du règlement organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Exigences particulières: - Certificat fédéral de capacité en tant qu'agent de protection sociale ou titre équivalent; - sensibilité à l'égard de la personne âgée; - facilité de communication interpersonnelle et fortes compétences relationnelles; - connaissance de l'instrument de gestion RAI. Référence générale pour le secteur socio-sanitaire: Gérer, participer et/ou fournir personnellement les soins des hôtes des Maisons pour personnes âgées et du Centre de la Journée thérapeutique du Corps autonome Lugano Instituts sociaux sur la base des programmes de travail, des besoins et des quotas des priorités définies par les supérieurs, selon la formation acquise et la fonction attribuée. Salaire annuel - Papier VII (assistants de soins), classes 8-9-10 classe 8: min CHF 59'808.05 / max CHF 70'573.50 classe 9: min CHF 62'568.85 / max CHF 73'821.70 classe 10: min CHF 65'679.90 / max CHF 77'502.35 Dans le cadre des possibilités de rémunération mentionnées ci-dessus, l'activité effectuée antérieurement, si elle est conforme Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de la boîte judiciaire En plus des documents à joindre initialement, dans un second moment peut être nécessaire de présenter l'extrait de la boîte judiciaire pour les particuliers. Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
+      },
+      "salaryMin": 65680,
+      "salaryMax": 77502,
+      "salaryCurrency": "CHF",
+      "salaryClass": "10",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 65680,
+          "maxValue": 77502,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "0b47f4d84431a08262bb",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-15T22:11:48.106Z"
+      },
+      "id": "lis-lugano-istituti-sociali-3e5d8c322840",
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T22:20:25.346Z",
+      "previousSlugsByLocale": {
+        "en": [
+          "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona-d2blfr"
+        ],
+        "fr": [
+          "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona-d2blfr",
+          "assistant-di-cura-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "it": [
+          "assistenti-di-cura-lis-lugano-istituti-sociali-lugano",
+          "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona"
+        ]
+      },
+      "previousSlugs": [
+        "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona-d2blfr",
+        "assistant-di-cura-lis-lugano-istituti-sociali-pregassona",
+        "assistenti-di-cura-lis-lugano-istituti-sociali-lugano",
+        "assistenti-di-cura-lis-lugano-istituti-sociali-pregassona",
+        "assistente-di-cura-lis-lugano-istituti-sociali-pregassona"
+      ],
+      "needsRetranslation": true
+    },
+    {
+      "title": "Collaboratori sanitari",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=35-collaboratori-sanitari-pregassona&language=it",
+      "slug": "collaboratori-sanitari-lis-lugano-istituti-sociali-lugano",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "# Concorso Pubblico per Addetti Servizi alla Casa (Collaboratori Sanitari) ## Mansioni - Assistere gli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali nell'ambito di cure di base e dello svolgimento delle altre attività di vita quotidiana sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. ##\n• Requisiti di Ordine Generale - Cittadinanza svizzera o stranieri con permesso di lavoro - Condotta ineccepibile - Costituzione fisica e psichica sana - Idoneità alla funzione ##\n• Requisiti di Ordine Particolare - Certificato CRS, titolo equivalente, comprovata esperienza ## Mansioni Generali di Riferimento per il Settore Sociosanitario ## Stipendio Annuale - IV (addetti servizi alla casa), classi 5-6-7 - Classe 5: min. CHF 53'518.55 / max. CHF 63'115.95 - Classe 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Classe 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibilità di riconoscimento dell'attività svolta precedentemente, assegnando una o più annualità di servizio ## Documenti Richiesti - Lettera di presentazione - Curriculum vitae - Fotografia recente - Certificati di studio e di lavoro - Questionario sullo stato di salute - Autocertificazione casellario giudiziale - Estratto del casellario giudiziale per privati (richiesto in un secondo momento) ## Condizioni di Presentazione delle Candidature - Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali (<https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/>) entro le ore 23:59 di domenica 13 dicembre 2026 - L'Ufficio Risorse Umane resta a disposizione (t. 058 866 34 11) per coloro che non possiedono un dispositivo per candidarsi - Non saranno considerate candidature e allegati trasmessi tramite altri canali (forma cartacea, email, fax, ecc.) ## Contatto - LUGANO ISTITUTI SOCIALI - IL CONSIGLIO DI AMMINISTRAZIONE - Capitolato di concorso - Questionario sullo stato di salute - Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Collaboratori sanitari",
+        "en": "Health workers",
+        "de": "Gesundheitliche Mitarbeiter",
+        "fr": "Collaborateurs de santé"
+      },
+      "slugByLocale": {
+        "it": "collaboratori-sanitari-lis-lugano-istituti-sociali-lugano",
+        "en": "health-workers-lis-lugano-istituti-sociali-pregassona",
+        "de": "gesundheitliche-mitarbeiter-lis-lugano-istituti-sociali-pregassona",
+        "fr": "collaborateurs-de-sante-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "# Concorso Pubblico per Addetti Servizi alla Casa (Collaboratori Sanitari) ## Mansioni - Assistere gli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali nell'ambito di cure di base e dello svolgimento delle altre attività di vita quotidiana sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. ##\n• Requisiti di Ordine Generale - Cittadinanza svizzera o stranieri con permesso di lavoro - Condotta ineccepibile - Costituzione fisica e psichica sana - Idoneità alla funzione ##\n• Requisiti di Ordine Particolare - Certificato CRS, titolo equivalente, comprovata esperienza ## Mansioni Generali di Riferimento per il Settore Sociosanitario ## Stipendio Annuale - IV (addetti servizi alla casa), classi 5-6-7 - Classe 5: min. CHF 53'518.55 / max. CHF 63'115.95 - Classe 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Classe 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibilità di riconoscimento dell'attività svolta precedentemente, assegnando una o più annualità di servizio ## Documenti Richiesti - Lettera di presentazione - Curriculum vitae - Fotografia recente - Certificati di studio e di lavoro - Questionario sullo stato di salute - Autocertificazione casellario giudiziale - Estratto del casellario giudiziale per privati (richiesto in un secondo momento) ## Condizioni di Presentazione delle Candidature - Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali (<https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/>) entro le ore 23:59 di domenica 13 dicembre 2026 - L'Ufficio Risorse Umane resta a disposizione (t. 058 866 34 11) per coloro che non possiedono un dispositivo per candidarsi - Non saranno considerate candidature e allegati trasmessi tramite altri canali (forma cartacea, email, fax, ecc.) ## Contatto - LUGANO ISTITUTI SOCIALI - IL CONSIGLIO DI AMMINISTRAZIONE - Capitolato di concorso - Questionario sullo stato di salute - Questionario relativo al casellario giudiziale",
+        "en": "Public Competition for Workers Services at the House (Health Processors) Shipments - To assist the guests of the Houses for the elderly and the Therapeutic Day Centre of the Autonomous Body Lugano Social Institutes in the field of basic care and the conduct of other activities of daily life on the basis of the work programmes, quota needs and priorities defined by the superiors, according to the training achieved and the function attributed. General Order\n• Requirements - Swiss or foreign citizenship with work permit - Unexceptionable conduct - Healthy physical and mental constitution - Function suitability Special Order\n• Requirements - CRS certificate, equivalent title, proven experience General Supply of Reference for the Company Sector Annual wage - IV (home services), classes 5-6-7 - Class 5: min. CHF 53'518.55 / max. CHF 63 115.95 - Class 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Class 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibility of recognition of the activity carried out previously, assigning one or more year of service Documents Requested - Letter of presentation - Curriculum vitae - Recent photography - Study and work certificates - Questionnaire on health - Self-certification judicial box - Excerpt of the judicial box for private individuals (required at a later time) Terms of Application Presentation - Applications must be submitted electronically via the online desk following the procedure indicated on the website of the Lugano Institutes Social ( ) by 23:59 on Sunday 13 December 2026 - The Human Resources Office remains available (No 058 866 34 11) for those who do not have a device to apply - Applications and attachments will not be considered by other channels (paper, email, fax, etc.) Contact - SOCIAL INSTITUTIONS - THE COUNCIL OF ADMINISTRATION - Competition chapter - Questionnaire on health - Questionnaire relating to the judicial box",
+        "de": "Öffentlicher Wettbewerb für Arbeitsdienste im Haus (Gesundheitsverarbeiter) Sendungen - Um den Gästen der Häuser für ältere Menschen und das Therapeutische Tageszentrum des autonomen Körpers Lugano Sozialinstitute im Bereich der Grundversorgung und das Verhalten anderer Aktivitäten des täglichen Lebens auf der Grundlage der von den Vorgesetzten definierten Arbeitsprogramme, Quotenbedarf und Prioritäten nach der erreichten Ausbildung und der zugeschriebenen Funktion zu unterstützen. Allgemeine\n• Anforderungen - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis - Unausgenommenes Verhalten - Gesunde körperliche und geistige Verfassung - Funktionsfähigkeit Besondere\n• Anforderungen - CRS-Zertifikat, gleichwertiger Titel, nachgewiesene Erfahrung Allgemeine Referenzversorgung des Unternehmenssektors Jahreslohn - IV (Haushaltsleistungen), Klassen 5-6-7 - Klasse 5: min. CHF 53'518.55 / max. CHF 63 115.95 - Klasse 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Klasse 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Möglichkeit der Anerkennung der zuvor durchgeführten Tätigkeit, die ein oder mehrere Jahre des Dienstes zuweist Angeforderte Dokumente - Präsentationsschreiben - Lebenslauf - Neue Fotografie - Studien- und Arbeitszeugnisse - Frage zum Thema Gesundheit - Selbstzertifizierung gerichtliches Feld - Auszug der Gerichtsdose für Privatpersonen (zu einem späteren Zeitpunkt erforderlich) Bewerbungsbedingungen Präsentation - Die Anmeldungen müssen elektronisch über den Online-Desk nach dem auf der Website der Lugano Institutes Social ( ) angegebenen Verfahren bis 23:59 am Sonntag, 13. Dezember 2026 eingereicht werden - Das Personalbüro bleibt verfügbar (Nr. 058 866 34 11) für diejenigen, die kein Gerät zur Anwendung haben - Anwendungen und Anhänge werden nicht von anderen Kanälen betrachtet (Papier, E-Mail, Fax, etc.) Kontakt - SOZIALE INSTITUTIONEN - DER RAT DER VERWALTUNG - Kapitel des Wettbewerbs - Frage zum Thema Gesundheit - Fragebögen zum Gerichtssaal",
+        "fr": "Concours public pour les services aux travailleurs à la maison (processeurs de santé) Expéditions - Aider les hôtes des Maisons pour personnes âgées et du Centre de jour thérapeutique des Instituts sociaux du Corps autonome Lugano dans le domaine des soins de base et de la conduite d'autres activités de la vie quotidienne sur la base des programmes de travail, des besoins en quotas et des priorités définis par les supérieurs, en fonction de la formation acquise et de la fonction attribuée.\n• Exigences d'ordre général - Citoyenneté suisse ou étrangère avec permis de travail - Conduite exceptionnelle - Constitution physique et mentale saine - Capacité fonctionnelle\n• Exigences spéciales - Certificat CRS, titre équivalent, expérience prouvée Fourniture générale de référence pour le secteur de l'entreprise Salaire annuel - IV (services à domicile), classes 5-6-7 - Classe 5: min. CHF 53'518.55 / max. CHF 63 115.95 - Classe 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Classe 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibilité de reconnaissance de l'activité effectuée antérieurement, en attribuant une ou plusieurs années de service Documents demandés - Lettre de présentation - Curriculum vitae - Photographie récente - Certificats d'études et de travail Questionnaire sur la santé - Boîte judiciaire d'autocertification - Extrait de la boîte judiciaire pour les particuliers (obligatoire ultérieurement) Présentation des conditions d'application - Les demandes doivent être soumises par voie électronique par le bureau en ligne suivant la procédure indiquée sur le site web des Instituts Lugano Social ( ) avant 23:59 le dimanche 13 décembre 2026 - Le Bureau des ressources humaines reste disponible (n° 058 866 34 11) pour ceux qui n'ont pas de dispositif à appliquer - Les demandes et pièces jointes ne seront pas examinées par d'autres voies (papier, courriel, télécopie, etc.) Personne à contacter - LES INSTITUTIONS SOCIALES - LE CONSEIL D'ADMINISTRATION - Chapitre Concurrence Questionnaire sur la santé - Questionnaire relatif à la boîte judiciaire"
+      },
+      "salaryMin": 57394,
+      "salaryMax": 67725,
+      "salaryCurrency": "CHF",
+      "salaryClass": "7",
+      "crawledAt": "",
+      "requirementsByLocale": {
+        "en": [
+          "Swiss citizenship or foreign nationals with a work permit",
+          "Impeccable conduct",
+          "Healthy physical and mental constitution",
+          "Suitability for the function",
+          "CRS certificate, equivalent title, proven experience"
+        ],
+        "de": [
+          "Schweizer Staatsbürgerschaft oder Ausländer mit Arbeitsbewilligung",
+          "Einwandfreies Verhalten",
+          "Gesunde körperliche und geistige Konstitution",
+          "Eignung für die Funktion",
+          "CRS-Zertifikat, gleichwertiger Titel, nachgewiesene Erfahrung"
+        ],
+        "fr": [
+          "Citoyenneté suisse ou ressortissants étrangers avec permis de travail",
+          "Conduite irréprochable",
+          "Constitution physique et psychique saine",
+          "Aptitude à la fonction",
+          "Certificat CRS, titre équivalent, expérience avérée"
+        ]
+      },
+      "previousSlugs": [
+        "collaboratori-sanitari",
+        "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona-o2ljp6",
+        "health-workers-lis-lugano-istituti-sociali-pregassona",
+        "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona",
+        "arbeitnehmer-lis-lugano-istituti-sociali-pregassona",
+        "healthcare-workers-lis-lugano-istituti-sociali-pregassona",
+        "gesundheitsfachkrafte-lis-lugano-istituti-sociali-pregassona",
+        "travailleurs-de-la-sante-lis-lugano-istituti-sociali-pregassona",
+        "healthcare-assistants-lis-lugano-istituti-sociali-pregassona",
+        "healthcare-collaborators-lis-lugano-istituti-sociali-pregassona",
+        "gesundheitsassistenten-lis-lugano-istituti-sociali-pregassona",
+        "collaborateurs-sanitaires-lis-lugano-istituti-sociali-pregassona",
+        "kindergartner-lis-lugano-istituti-sociali-pregassona"
+      ],
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 57394,
+          "maxValue": 67725,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "52edf10e42789351d4d1",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-24T22:36:16.168Z"
+      },
+      "sourceLang": "it",
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "id": "lis-lugano-istituti-sociali-3d122d9fd62d",
+      "previousSlugsByLocale": {
+        "it": [
+          "collaboratori-sanitari",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona-o2ljp6",
+          "health-workers-lis-lugano-istituti-sociali-pregassona",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona",
+          "arbeitnehmer-lis-lugano-istituti-sociali-pregassona",
+          "healthcare-workers-lis-lugano-istituti-sociali-pregassona",
+          "gesundheitsfachkrafte-lis-lugano-istituti-sociali-pregassona",
+          "travailleurs-de-la-sante-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "en": [
+          "collaboratori-sanitari",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona-o2ljp6",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona",
+          "arbeitnehmer-lis-lugano-istituti-sociali-pregassona",
+          "healthcare-workers-lis-lugano-istituti-sociali-pregassona",
+          "gesundheitsfachkrafte-lis-lugano-istituti-sociali-pregassona",
+          "travailleurs-de-la-sante-lis-lugano-istituti-sociali-pregassona",
+          "healthcare-assistants-lis-lugano-istituti-sociali-pregassona",
+          "healthcare-collaborators-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "de": [
+          "collaboratori-sanitari",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona-o2ljp6",
+          "health-workers-lis-lugano-istituti-sociali-pregassona",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona",
+          "arbeitnehmer-lis-lugano-istituti-sociali-pregassona",
+          "healthcare-workers-lis-lugano-istituti-sociali-pregassona",
+          "gesundheitsfachkrafte-lis-lugano-istituti-sociali-pregassona",
+          "travailleurs-de-la-sante-lis-lugano-istituti-sociali-pregassona",
+          "gesundheitsassistenten-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "fr": [
+          "collaboratori-sanitari",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona-o2ljp6",
+          "health-workers-lis-lugano-istituti-sociali-pregassona",
+          "collaboratori-sanitari-lis-lugano-istituti-sociali-pregassona",
+          "arbeitnehmer-lis-lugano-istituti-sociali-pregassona",
+          "healthcare-workers-lis-lugano-istituti-sociali-pregassona",
+          "gesundheitsfachkrafte-lis-lugano-istituti-sociali-pregassona",
+          "travailleurs-de-la-sante-lis-lugano-istituti-sociali-pregassona",
+          "collaborateurs-sanitaires-lis-lugano-istituti-sociali-pregassona"
+        ]
+      },
+      "firstSeenAt": "2026-04-13T22:02:43.951Z",
+      "needsRetranslation": true
+    },
+    {
+      "title": "Operatori settore animazione",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=36-operatori-settore-animazione-pregassona&language=it",
+      "slug": "operatori-settore-animazione-lis-lugano-istituti-sociali-pregassona",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di operatori settore animazione alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale. ##\n• Requisiti di ordine generale - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione. ##\n• Requisiti di ordine particolare - diploma quale specialista d'attivazione dipl. SSS o titolo equivalente in ambito socio-educativo; - esperienza in ambito sociosanitario o socio-educativo, in particolare in progetti di animazione terapeutica, finalizzati al mantenimento del benessere fisico e psicofisico della persona; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. ## Mansioni generali di riferimento per il settore sociosanitario - Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. ## Stipendio annuo - Fascia XI (operatori socio-educativi - specialisti d'attivazione), classi 12-13-15 - classe 12: min CHF 73'140.05 / max CHF 86'305.45 - classe 13: min CHF 77'526.15 / max CHF 91'481.05 - classe 14: min CHF 82'372.30 / max CHF 97'199.35 - Fascia IX (animatori), classi 10-11-12 - classe 10: min CHF 65'679.90 / max CHF 77'502.35 - classe 11: min CHF 69'193.30 / max CHF 81'648.20 - classe 12: min CHF 73'140.05 / max CHF 86'305.45 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. ## Documenti richiesti - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale ## Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.).",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Operatori settore animazione",
+        "en": "Animation sector operators",
+        "de": "Betreiber des Sektors",
+        "fr": "Opérateurs du secteur de l'animation"
+      },
+      "slugByLocale": {
+        "it": "operatori-settore-animazione-lis-lugano-istituti-sociali-pregassona",
+        "en": "animation-sector-operators-lis-lugano-istituti-sociali-pregassona",
+        "de": "betreiber-des-sektors-lis-lugano-istituti-sociali-pregassona",
+        "fr": "operateurs-du-secteur-de-l-animation-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di operatori settore animazione alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale. ##\n• Requisiti di ordine generale - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione. ##\n• Requisiti di ordine particolare - diploma quale specialista d'attivazione dipl. SSS o titolo equivalente in ambito socio-educativo; - esperienza in ambito sociosanitario o socio-educativo, in particolare in progetti di animazione terapeutica, finalizzati al mantenimento del benessere fisico e psicofisico della persona; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. ## Mansioni generali di riferimento per il settore sociosanitario - Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. ## Stipendio annuo - Fascia XI (operatori socio-educativi - specialisti d'attivazione), classi 12-13-15 - classe 12: min CHF 73'140.05 / max CHF 86'305.45 - classe 13: min CHF 77'526.15 / max CHF 91'481.05 - classe 14: min CHF 82'372.30 / max CHF 97'199.35 - Fascia IX (animatori), classi 10-11-12 - classe 10: min CHF 65'679.90 / max CHF 77'502.35 - classe 11: min CHF 69'193.30 / max CHF 81'648.20 - classe 12: min CHF 73'140.05 / max CHF 86'305.45 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. ## Documenti richiesti - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale ## Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.).",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of operators animation sector under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Einstellung der Betreiber-Animationssektor unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Allgemeine Anforderungen - Schweizer oder ausländische Staatsangehörige mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen - Diplom als Aktivierungsspezialist Dipl. SSS oder gleichwertiger Titel im sozio-pädagogischen Bereich; - Erfahrung im sozio-gesunden oder sozio-pädagogischen, insbesondere in therapeutischen Animationsprojekten, die darauf abzielen, das körperliche und psychophysische Wohlbefinden der Person zu erhalten; - Sensitivität im relationalen Umgang mit der älteren Person; - Leichtigkeit der zwischenmenschlichen Kommunikation und starken Beziehungsqualitäten; - Kenntnisse des Management-Tools RAI. Allgemeine Hinweise für den sozio-sanitären Sektor - Verwaltung, Teilnahme und/oder Bereitstellung persönlich der Betreuung der Gäste des Hauses für ältere Menschen und das therapeutische Tageszentrum der Lugano Autonomen Körper-Sozialinstitute auf der Grundlage der Arbeitsprogramme, der Quotenanforderungen und Prioritäten, die von den Vorgesetzten definiert werden, nach der erreichten Ausbildung und der zugeschriebenen Funktion. CHF 1050 pro Jahr pro Jahr pro Jahr pro Jahr pro Jahr. Erforderliche Dokumente - Präsentationsschreiben - Curriculum vitae - jüngste Fotografie - Zeugnisse des Studiums und der Arbeit - Fragebogen über den Gesundheitszustand - Selbstzertifizierung gerichtliche Feld. Bewerbungsbedingungen Anträge müssen elektronisch über den Online-Desk nach dem auf der Website des Lugano Institutes Social innerhalb von 23:59 Stunden vom Sonntag 13 Dezember 2026 eingereicht werden.",
+        "fr": "Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public (valable pour l'année 2026) pour le recrutement des opérateurs du secteur de l'animation dans les conditions du règlement organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences générales - ressortissants suisses ou étrangers titulaires d'un permis de travail; - conduite exceptionnelle; - constitution physique et mentale saine; - aptitude à fonctionner.\n• Exigences spéciales - diplôme de spécialiste de l'activation SSS ou titre équivalent dans le domaine socio-éducatif; - expérience en socio-santé ou socio-éducatif, en particulier dans les projets d'animation thérapeutique, visant à maintenir le bien-être physique et psychophysique de la personne; - sensibilité dans l'approche relationnelle avec la personne âgée; - facilité de communication interpersonnelle et fortes qualités relationnelles; - connaissance de l'outil de gestion RAI. ## Références générales pour le secteur socio-sanitaire - Gestion, participation et/ou fourniture de soins personnels aux hôtes des Maisons pour personnes âgées et au centre de jour thérapeutique des Instituts Sociaux Autonomes de Lugano sur la base des programmes de travail, des besoins de quotas et des priorités définis par les supérieurs, selon la formation acquise et la fonction attribuée. CHF 1050 par an et par an et par an et par an. ## Documents requis - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification case judiciaire ## Conditions de la demande Les demandes doivent être soumises par voie électronique par l'intermédiaire du bureau en ligne suivant la procédure indiquée sur le site Web des Instituts de Lugano Social dans les 23h59 du dimanche 13 décembre 2026."
+      },
+      "salaryMin": 65680,
+      "salaryMax": 97199,
+      "salaryCurrency": "CHF",
+      "salaryClass": "14",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "previousSlugs": [
+        "operatori-settore-animazione",
+        "operatori-settore-animazione-lis-lugano-istituti-sociali-pregassona-6skb5e",
+        "operatori-settore-animazione-lis-lugano-istituti-sociali-lugano"
+      ],
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 65680,
+          "maxValue": 97199,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "68652d8595f73d41a69e",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-25T13:19:20.839Z"
+      },
+      "id": "lis-lugano-istituti-sociali-7eba8dbeeb0a",
+      "previousSlugsByLocale": {
+        "it": [
+          "operatori-settore-animazione"
+        ],
+        "en": [
+          "operatori-settore-animazione-lis-lugano-istituti-sociali-pregassona-6skb5e"
+        ],
+        "de": [
+          "operatori-settore-animazione-lis-lugano-istituti-sociali-pregassona-6skb5e"
+        ],
+        "fr": [
+          "operatori-settore-animazione-lis-lugano-istituti-sociali-pregassona-6skb5e"
+        ]
+      },
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T11:20:10.630Z"
+    },
+    {
+      "title": "Fisioterapisti / Ergoterapisti",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=37-fisioterapisti-ergoterapisti-pregassona&language=it",
+      "slug": "fisioterapisti-ergoterapisti-lis-lugano-istituti-sociali-pregassona",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di fisioterapisti / ergoterapisti alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma SUP quale fisioterapista o titolo equivalente; - diploma SUP quale ergoterapista o titolo equivalente; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia XII (fisioterapisti, ergoterapisti), classi 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-25",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Fisioterapisti / Ergoterapisti",
+        "en": "Physiotherapists / Ergotherapists",
+        "de": "Physiotherapeuten / Ergotherapisten",
+        "fr": "Physiothérapeutes / Ergothérapeutes"
+      },
+      "slugByLocale": {
+        "it": "fisioterapisti-ergoterapisti-lis-lugano-istituti-sociali-pregassona",
+        "en": "physiotherapists-ergotherapists-lis-lugano-istituti-sociali-pregassona",
+        "de": "physiotherapeuten-ergotherapisten-lis-lugano-istituti-sociali-pregassona",
+        "fr": "physiotherapeutes-ergotherapeutes-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di fisioterapisti / ergoterapisti alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma SUP quale fisioterapista o titolo equivalente; - diploma SUP quale ergoterapista o titolo equivalente; - sensibilità nell'approccio relazionale con la persona anziana; - facilità di comunicazione interpersonale e spiccate doti relazionali; - conoscenza dello strumento gestionale RAI. Mansioni generali di riferimento per il settore sociosanitario: Gestire, partecipare e/o provvedere personalmente alle cure degli ospiti delle Case per anziani e del Centro Diurno Terapeutico dell'Ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - Fascia XII (fisioterapisti, ergoterapisti), classi 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of physiotherapists / ergotherapists under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition capitulate. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Rekrutierung von Physiotherapeuten / Ergotherapisten unter den Bedingungen der Organic Regulation of Collaborators (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbsgeheimnisses. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - SUP-Diplom als physiotherapist oder gleichwertiger Titel; - SUP-Diplom als ergotherapist oder gleichwertiger Titel; - Sensitivität in Bezug auf die ältere Person; - einfache zwischenmenschliche Kommunikation und starke relationale Fähigkeiten; - Kenntnisse des Management-Tools RAI. Allgemeine Referenz für den sozio-sanitären Sektor: Verwalten, teilnehmen und/oder persönlich die Betreuung der Gäste der Häuser für ältere Menschen und des Zentrums für therapeutische Tage der autonomen Körper-Lugano-Sozialinstitute auf der Grundlage der Programme der Arbeit, der Bedürfnisse und der Quoten der Prioritäten, die von den Vorgesetzten definiert werden, nach der erreichten Ausbildung und der zugewiesenen Funktion. Jahreslohn - Fascia XII (physiotherapists, ergotherapists), Klassen 13-14-15 Klasse 13: min CHF 77'526.15 / max CHF 91'481.05 Klasse 14: min CHF 82'372.30 / max CHF 97'199.35 Klasse 15: min CHF 86'927.80 / max CHF 102'574.80 Die Angebote müssen von den folgenden Dokumenten begleitet werden: - Präsentationsschreiben - Lehrplan vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung des Gerichtssaals Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment erforderlich sein, um den Auszug der Gerichtskammer für Privatpersonen darzustellen. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
+        "fr": "Le Conseil d'administration des Instituts Sociaux du Corps Autonome de Lugano ouvre le concours public (valable pour l'année 2026) pour le recrutement de physiothérapeutes / ergothérapeutes dans les conditions du règlement organique des collaborateurs (ROCIS) des Instituts Sociaux du Corps Autonome de Lugano (LIS) et du concours capitulant. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Exigences particulières: - diplôme SUP en physiothérapeute ou titre équivalent; - diplôme SUP en ergothérapeute ou titre équivalent; - sensibilité vis-à-vis de la personne âgée; - facilité de communication interpersonnelle et fortes aptitudes relationnelles; - connaissance de l'outil de gestion RAI. Référence générale pour le secteur socio-sanitaire: Gérer, participer et/ou fournir personnellement les soins des hôtes des Maisons pour personnes âgées et du Centre de la Journée thérapeutique du Corps autonome Lugano Instituts sociaux sur la base des programmes de travail, des besoins et des quotas des priorités définies par les supérieurs, selon la formation acquise et la fonction attribuée. Salaire annuel - Fascia XII (physiothérapeutes, ergothérapeutes), classes 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de la boîte judiciaire En plus des documents à joindre initialement, dans un second moment peut être nécessaire de présenter l'extrait de la boîte judiciaire pour les particuliers. Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
+      },
+      "salaryMin": 86928,
+      "salaryMax": 102575,
+      "salaryCurrency": "CHF",
+      "salaryClass": "15",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "previousSlugs": [
+        "fisioterapisti-ergoterapisti",
+        "fisioterapisti-ergoterapisti-lis-lugano-istituti-sociali-pregassona-qdaggp",
+        "fisioterapisti-ergoterapisti-lis-lugano-istituti-sociali-lugano"
+      ],
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 86928,
+          "maxValue": 102575,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "cae0fc9eefa01e1e2f72",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-15T22:11:48.108Z"
+      },
+      "id": "lis-lugano-istituti-sociali-7642ecdf144c",
+      "previousSlugsByLocale": {
+        "it": [
+          "fisioterapisti-ergoterapisti"
+        ],
+        "en": [
+          "fisioterapisti-ergoterapisti-lis-lugano-istituti-sociali-pregassona-qdaggp"
+        ],
+        "de": [
+          "fisioterapisti-ergoterapisti-lis-lugano-istituti-sociali-pregassona-qdaggp"
+        ],
+        "fr": [
+          "fisioterapisti-ergoterapisti-lis-lugano-istituti-sociali-pregassona-qdaggp"
+        ]
+      },
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T22:20:25.346Z",
+      "needsRetranslation": true
+    },
+    {
+      "title": "Educatori sociali",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=38-educatori-sociali-pregassona&language=it",
+      "slug": "educatori-sociali-lis-lugano-istituti-sociali-lugano",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di educatori sociali alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - formazione conclusa quale educatore/trice SUP oppure universitaria in ambito sociale o titolo equivalente; - facilità di comunicazione interpersonale e spiccate doti relazionali; Mansioni generali di riferimento per il settore socioeducativo: Gestire, partecipare e/o provvedere personalmente ai bisogno degli utenti delle strutture per minorenni dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi i lavoro, delle necessità contingenti e delle priorità definitte dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - XII (educatori sociali), classi 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati e l'estratto specifico per privati. Partecipando al concorso la/il candidata/o autorizza l'Ente a sottoporre all'UFAG il nominativo per il controllo sulla base della Legge e Ordinanza federale sul casellario giudiziale informatizzato VOSTRA (LCaGI e OCaGI). Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Educatori sociali",
+        "en": "Social educators",
+        "de": "Sozialpädagogik",
+        "fr": "Éducateurs sociaux"
+      },
+      "slugByLocale": {
+        "it": "educatori-sociali-lis-lugano-istituti-sociali-lugano",
+        "en": "social-educators-lis-lugano-istituti-sociali-pregassona",
+        "de": "sozialpadagogik-lis-lugano-istituti-sociali-pregassona",
+        "fr": "educateurs-sociaux-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di educatori sociali alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - formazione conclusa quale educatore/trice SUP oppure universitaria in ambito sociale o titolo equivalente; - facilità di comunicazione interpersonale e spiccate doti relazionali; Mansioni generali di riferimento per il settore socioeducativo: Gestire, partecipare e/o provvedere personalmente ai bisogno degli utenti delle strutture per minorenni dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi i lavoro, delle necessità contingenti e delle priorità definitte dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - XII (educatori sociali), classi 13-14-15 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 classe 15: min CHF 86'927.80 / max CHF 102'574.80 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati e l'estratto specifico per privati. Partecipando al concorso la/il candidata/o autorizza l'Ente a sottoporre all'UFAG il nominativo per il controllo sulla base della Legge e Ordinanza federale sul casellario giudiziale informatizzato VOSTRA (LCaGI e OCaGI). Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of social educators under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Einstellung von Sozialpädagogen unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Spezifische Anforderungen: - abgeschlossene Ausbildung als SUP-Erzieher oder Universität im sozialen Bereich oder gleichwertiger Titel; - einfache zwischenmenschliche Kommunikation und starke relationale Fähigkeiten; Allgemeine Referenz für den sozio-pädagogischen Sektor: Verwalten, beteiligen und/oder persönlich bieten den Benutzern Einrichtungen für Minderjährige der unabhängigen Lugano Sozialinstitute auf der Grundlage der von den Vorgesetzten definierten Programme Arbeit, Quotenbedarf und Prioritäten nach der erreichten Ausbildung und der zugeschriebenen Funktion. Jahreslohn - XII (Sozialpädagogen), Klassen 13-14-15 Klasse 13: min CHF 77'526.15 / max CHF 91'481.05 Klasse 14: min CHF 82'372.30 / max CHF 97'199.35 Klasse 15: min CHF 86'927.80 / max CHF 102'574.80 Im Rahmen der oben genannten Zahlungsmöglichkeiten kann die zuvor durchgeführte Tätigkeit anerkannt werden, wenn sie diesem Kapitel entspricht. Die Angebote müssen von folgenden Unterlagen begleitet werden: - Präsentationsschreiben - Curriculum vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung des Gerichtskastens Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment der Privatperson der Auszug des Gerichtskastens vorgelegt werden. Durch die Teilnahme am Wettbewerb ermächtigt der Kandidat/oder die Einrichtung, der UFAG den Namen zur Kontrolle auf der Grundlage des Gesetzes und der Bundesverordnung über das VOSTRA-Rechtsregister (LCaGI und OCaGI) zu unterbreiten. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
+        "fr": "Le Conseil d'Administration de l'Organisme Autonome Lugano Instituti Sociali ouvre le concours public (valable pour l'année 2026) pour l'embauche d'éducateurs sociaux dans les conditions du Règlement Organique des Collaborateurs (ROCIS) de l'Organisme Autonome Lugano Instituti Sociali (lis) et du cahier des charges du concours. Le Conseil d'Administration peut prévoir l'attribution de nominations (art. 5 et suiv. ROCIS) et missions pour fonction stable (art. 11 et suiv. ROCIS) internes. Les postes sont ouverts aux candidatures féminines et masculines. Le présent concours reste ouvert même en l'absence de besoins effectifs en personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier : - nationalité suisse ou étrangère avec permis de travail ; - conduite irréprochable ; - constitution physique et psychique saine ; - aptitude à la fonction.\n• Exigences particulières : - formation conclue en tant qu'éducateur/trice sup ou universitaire dans le domaine social ou équivalent ; - facilité de communication interpersonnelle et compétences relationnelles marquées ; Fonctions générales de référence pour le secteur socio-éducatif : Gérer, participer et/ou répondre personnellement aux besoins des utilisateurs des structures pour mineurs de l'organisme autonome Lugano Instituts sociaux sur la base des programmes de travail, des besoins éventuels et des priorités définies par les supérieurs, en fonction de la formation obtenue et de la fonction attribuée. Salaire annuel - XII (éducateurs sociaux),"
+      },
+      "salaryMin": 86928,
+      "salaryMax": 102575,
+      "salaryCurrency": "CHF",
+      "salaryClass": "15",
+      "crawledAt": "",
+      "requirementsByLocale": {
+        "en": [
+          "Swiss citizenship or foreigners with a work permit",
+          "impeccable conduct",
+          "physical and mental health",
+          "suitability for the function",
+          "education concluded as a social educator SUP or university degree in the social field or equivalent title",
+          "ease of interpersonal communication and outstanding relational skills"
+        ],
+        "de": [
+          "Schweizer Staatsbürgerschaft oder Ausländer mit Arbeitsgenehmigung",
+          "unbescholtenes Verhalten",
+          "körperliche und geistige Gesundheit",
+          "Eignung für die Funktion",
+          "Abschluss als Sozialpädagoge SUP oder Universitätsabschluss im sozialen Bereich oder äquivalentes Titel",
+          "Einfachheit der interpersonellen Kommunikation und ausgezeichnete Beziehungsqualitäten"
+        ],
+        "fr": [
+          "Citoyenneté suisse ou étrangers avec permis de travail",
+          "Comportement irreprochable",
+          "Santé physique et mentale",
+          "Adaptabilité à la fonction",
+          "Formation terminée en tant qu'éducateur social SUP ou diplôme universitaire dans le domaine social ou titre équivalent",
+          "Facilité de communication interpersonnelle et qualités relationnelles exceptionnelles"
+        ]
+      },
+      "previousSlugs": [
+        "educatori-sociali",
+        "educatori-sociali-lis-lugano-istituti-sociali-pregassona-mncghv",
+        "educatori-sociali-lis-lugano-istituti-sociali-pregassona",
+        "sozialpadagogik-lis-lugano-istituti-sociali-pregassona",
+        "sozialpadagogen-lis-lugano-istituti-sociali-pregassona",
+        "soziale-bildner-lis-lugano-istituti-sociali-pregassona",
+        "les-educateurs-sociaux-lis-lugano-istituti-sociali-pregassona"
+      ],
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 86928,
+          "maxValue": 102575,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "c9bf005c4ea04824b84c",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-11T22:27:45.070Z"
+      },
+      "sourceLang": "it",
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "id": "lis-lugano-istituti-sociali-80dcd2586afe",
+      "previousSlugsByLocale": {
+        "it": [
+          "educatori-sociali",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona-mncghv",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona",
+          "sozialpadagogik-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "en": [
+          "educatori-sociali",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona-mncghv",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona",
+          "sozialpadagogik-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "de": [
+          "educatori-sociali",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona-mncghv",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona",
+          "sozialpadagogen-lis-lugano-istituti-sociali-pregassona",
+          "soziale-bildner-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "fr": [
+          "educatori-sociali",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona-mncghv",
+          "educatori-sociali-lis-lugano-istituti-sociali-pregassona",
+          "sozialpadagogik-lis-lugano-istituti-sociali-pregassona",
+          "les-educateurs-sociaux-lis-lugano-istituti-sociali-pregassona"
+        ]
+      },
+      "firstSeenAt": "2026-04-13T22:02:43.951Z",
+      "needsRetranslation": true
+    },
+    {
+      "title": "Operatori socioassistenziali (infanza)",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=39-operatori-socioassistenziali-infanza-pregassona&language=it",
+      "slug": "operatori-socioassistenziali-infanza-lis-lugano-istituti-sociali-pregassona",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di operatori socioassistenziali (infanzia) alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - attestato federale di capacità quale operatore socioassistenziale indirizzo infanzia o titolo equivalente; - facilità di comunicazione interpersonale e spiccate doti relazionali; Mansioni generali di riferimento per il settore socioeducativo: Gestire, partecipare e/o provvedere personalmente ai bisogno degli utenti delle strutture per minorenni dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi i lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - IX (operatori socioassistenziali), classi 10-11-12 classe 10: min CHF 65'679.90 / max CHF 77'502.35 classe 11: min CHF 69'193.30 / max CHF 81'648.20 classe 12: min CHF 73'140.05 / max CHF 86'305.45 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati e l'estratto specifico per privati. Partecipando al concorso la/il candidata/o autorizza l'Ente a sottoporre all'UFAG il nominativo per il controllo sulla base della Legge e Ordinanza federale sul casellario giudiziale informatizzato VOSTRA (LCaGI e OCaGI). Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Operatori socioassistenziali (infanza)",
+        "en": "Social workers (in fact)",
+        "de": "Sozialarbeiter (in der Tat)",
+        "fr": "Travailleurs sociaux (en fait)"
+      },
+      "slugByLocale": {
+        "it": "operatori-socioassistenziali-infanza-lis-lugano-istituti-sociali-pregassona",
+        "en": "social-workers-in-fact-lis-lugano-istituti-sociali-pregassona",
+        "de": "sozialarbeiter-in-der-tat-lis-lugano-istituti-sociali-pregassona",
+        "fr": "travailleurs-sociaux-en-fait-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di operatori socioassistenziali (infanzia) alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - attestato federale di capacità quale operatore socioassistenziale indirizzo infanzia o titolo equivalente; - facilità di comunicazione interpersonale e spiccate doti relazionali; Mansioni generali di riferimento per il settore socioeducativo: Gestire, partecipare e/o provvedere personalmente ai bisogno degli utenti delle strutture per minorenni dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi i lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - IX (operatori socioassistenziali), classi 10-11-12 classe 10: min CHF 65'679.90 / max CHF 77'502.35 classe 11: min CHF 69'193.30 / max CHF 81'648.20 classe 12: min CHF 73'140.05 / max CHF 86'305.45 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati e l'estratto specifico per privati. Partecipando al concorso la/il candidata/o autorizza l'Ente a sottoporre all'UFAG il nominativo per il controllo sulla base della Legge e Ordinanza federale sul casellario giudiziale informatizzato VOSTRA (LCaGI e OCaGI). Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of socio-assistance workers (infancy) under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Lugano Autonomous Body Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Rekrutierung von Sozio-Assistenten (Infancy) unter den Bedingungen der Organic Regulation of Collaborators (ROCIS) der Lugano Autonomous Body Social Institute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - Eidgenössisches Zertifikat als sozio-assistante Kinderadresse oder gleichwertiger Titel; - einfache zwischenmenschliche Kommunikation und starke relationale Fähigkeiten; Allgemeine Referenz für den sozio-pädagogischen Sektor: Verwalten, beteiligen und/oder persönlich bieten den Benutzern die Einrichtungen für Minderjährige der unabhängigen Lugano Sozialinstitute auf der Grundlage der von den Vorgesetzten definierten Programme Arbeit, Quotenbedarf und Prioritäten nach der erreichten Ausbildung und der zugeschriebenen Funktion. Jahreslohn - IX ( sozioökonomische Arbeiter), Klassen 10-11-12 Klasse 10: min CHF 65'679.90 / max CHF 77'502.35 Klasse 11: min CHF 69'193.30 / max CHF 81'648.20 Klasse 12: min CHF 73'140.05 / max CHF 86'305.45 Im Rahmen der oben genannten Lohnmöglichkeiten erfolgt die zuvor durchgeführte Tätigkeit, wenn sie der vorliegenden Die Angebote müssen von folgenden Dokumenten begleitet werden: - Präsentationsschreiben - Curriculum vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung der Gerichtsdose Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment erforderlich sein, um den Auszug der Gerichtsdose für Privatpersonen und den spezifischen Auszug für Privatpersonen darzustellen. Durch die Teilnahme am Wettbewerb ermächtigt der Kandidat/oder die Einrichtung, der UFAG den Namen zur Kontrolle auf der Grundlage des Gesetzes und der Bundesverordnung über das VOSTRA-Rechtsregister (LCaGI und OCaGI) zu unterbreiten. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
+        "fr": "Le Conseil d'Administration des Instituts Sociaux du Corps Autonome de Lugano ouvre le concours public (valable pour l'année 2026) pour le recrutement des travailleurs socio-assistés (enfance) dans les conditions du règlement organique des collaborateurs (ROCIS) des Instituts Sociaux du Corps Autonome de Lugano (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Exigences particulières: - Certificat fédéral de capacité en tant qu'adresse d'enfant socio-assistante ou titre équivalent; - facilité de communication interpersonnelle et compétences relationnelles fortes; Référence générale pour le secteur socio-éducatif: Gérer, participer et/ou fournir personnellement aux utilisateurs les installations pour mineurs des Instituts sociaux indépendants de Lugano sur la base du travail des programmes, des besoins de quotas et des priorités définis par les supérieurs, selon la formation acquise et la fonction attribuée. Salaire annuel - IX (travailleurs socio-économiques), classes 10-11-12 classe 10: min CHF 65'679.90 / max CHF 77'502.35 classe 11: min CHF 69'193.30 / max CHF 81'648.20 classe 12: min CHF 73'140.05 / max CHF 86'305.45 Dans le cadre des possibilités de rémunération mentionnées ci-dessus, l'activité effectuée antérieurement, si elle est conforme au présent Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de la boîte judiciaire En plus des documents à joindre initialement, dans un second moment peut être nécessaire de présenter l'extrait de la boîte judiciaire pour les particuliers et l'extrait spécifique pour les particuliers. En participant au concours, le candidat/ou autorise l'organisme à soumettre à l'UFAG le nom de contrôle sur la base de la loi et de l'ordonnance fédérale sur le registre judiciaire VOSTRA (LCaGI et OCaGI). Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
+      },
+      "salaryMin": 73140,
+      "salaryMax": 86305,
+      "salaryCurrency": "CHF",
+      "salaryClass": "12",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "previousSlugs": [
+        "operatori-socioassistenziali-infanza",
+        "operatori-socioassistenziali-infanza-lis-lugano-istituti-sociali-pregassona-5xg3s1",
+        "operatori-socioassistenziali-infanza-lis-lugano-istituti-sociali-lugano"
+      ],
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 73140,
+          "maxValue": 86305,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "a28e65d4344543fb048e",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-15T11:24:04.351Z"
+      },
+      "id": "lis-lugano-istituti-sociali-7296ba54869b",
+      "previousSlugsByLocale": {
+        "it": [
+          "operatori-socioassistenziali-infanza"
+        ],
+        "en": [
+          "operatori-socioassistenziali-infanza-lis-lugano-istituti-sociali-pregassona-5xg3s1"
+        ],
+        "de": [
+          "operatori-socioassistenziali-infanza-lis-lugano-istituti-sociali-pregassona-5xg3s1"
+        ],
+        "fr": [
+          "operatori-socioassistenziali-infanza-lis-lugano-istituti-sociali-pregassona-5xg3s1"
+        ]
+      },
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T11:20:10.630Z"
+    },
+    {
+      "title": "Educatori dell'infanzia",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=40-educatori-dell-infanzia-pregassona&language=it",
+      "slug": "educatori-dell-infanzia-lis-lugano-istituti-sociali-pregassona",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di educatori dell'infanzia alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma quale educatore/trice dell'infanzia dipl. SSS o titolo equivalente; - facilità di comunicazione interpersonale e spiccate doti relazionali; Mansioni generali di riferimento per il settore socioeducativo: Gestire, partecipare e/o provvedere personalmente ai bisogno degli utenti delle strutture per minorenni dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi i lavoro, delle necessità contingenti e delle priorità definitte dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - XII (educatori dell'infanzia), classi 12-13-14 classe 12: min CHF 73'140.05 / max CHF 86'305.45 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati e l'estratto specifico per privati. Partecipando al concorso la/il candidata/o autorizza l'Ente a sottoporre all'UFAG il nominativo per il controllo sulla base della Legge e Ordinanza federale sul casellario giudiziale informatizzato VOSTRA (LCaGI e OCaGI). Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Educatori dell'infanzia",
+        "en": "Childhood educators",
+        "de": "Kindererziehung",
+        "fr": "Éducateurs d ' enfants"
+      },
+      "slugByLocale": {
+        "it": "educatori-dell-infanzia-lis-lugano-istituti-sociali-pregassona",
+        "en": "childhood-educators-lis-lugano-istituti-sociali-pregassona",
+        "de": "kindererziehung-lis-lugano-istituti-sociali-pregassona",
+        "fr": "educateurs-d-enfants-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di educatori dell'infanzia alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - diploma quale educatore/trice dell'infanzia dipl. SSS o titolo equivalente; - facilità di comunicazione interpersonale e spiccate doti relazionali; Mansioni generali di riferimento per il settore socioeducativo: Gestire, partecipare e/o provvedere personalmente ai bisogno degli utenti delle strutture per minorenni dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi i lavoro, delle necessità contingenti e delle priorità definitte dai superiori, secondo la formazione conseguita e la funzione attribuita. Stipendio annuo - XII (educatori dell'infanzia), classi 12-13-14 classe 12: min CHF 73'140.05 / max CHF 86'305.45 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati e l'estratto specifico per privati. Partecipando al concorso la/il candidata/o autorizza l'Ente a sottoporre all'UFAG il nominativo per il controllo sulla base della Legge e Ordinanza federale sul casellario giudiziale informatizzato VOSTRA (LCaGI e OCaGI). Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of educators of childhood under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Lugano Autonomous Body Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
+        "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Einstellung von Pädagogen der Kindheit unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Lugano Autonomen Körper-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - Diplom als Pädagoge/Kinderlehrer Dipl. SSS oder gleichwertiger Titel; - Erleichterung der zwischenmenschlichen Kommunikation und starken relationalen Fähigkeiten; Allgemeine Referenz für den sozio-pädagogischen Sektor: Verwalten, teilnehmen und/oder persönlich bieten Benutzern Einrichtungen für Minderjährige der unabhängigen Lugano Sozialinstitute auf der Grundlage der Programme Arbeit, Quotenbedarf und Prioritäten, die von den Vorgesetzten definiert werden, nach der erreichten Ausbildung und der zugeschriebenen Funktion. Jahreslohn - XII (Erzieher der Kindheit), Klassen 12-13-14 Klasse 12: min CHF 73'140.05 / max CHF 86'305.45 Klasse 13: min CHF 77'526.15 / max CHF 91'481.05 Klasse 14: min CHF 82'372.30 / max CHF 97'199.35 Im Rahmen der oben genannten Bezahlungsmöglichkeiten kann die zuvor durchgeführte Tätigkeit erkannt werden, wenn sie diesem Dienst entspricht. Die Angebote müssen von folgenden Dokumenten begleitet werden: - Präsentationsschreiben - Curriculum vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung der Gerichtsdose Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment erforderlich sein, um den Auszug der Gerichtsdose für Privatpersonen und den spezifischen Auszug für Privatpersonen darzustellen. Durch die Teilnahme am Wettbewerb ermächtigt der Kandidat/oder die Einrichtung, der UFAG den Namen zur Kontrolle auf der Grundlage des Gesetzes und der Bundesverordnung über das VOSTRA-Rechtsregister (LCaGI und OCaGI) zu unterbreiten. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
+        "fr": "Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public (valable pour l'année 2026) pour le recrutement d'éducateurs de l'enfance dans les conditions du règlement organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Conditions particulières: - diplôme d'éducateur/d'enseignant dipl. SSS ou titre équivalent; - facilité de communication interpersonnelle et fortes compétences relationnelles; Référence générale pour le secteur socio-éducatif: Gérer, participer et/ou fournir personnellement aux utilisateurs des installations pour mineurs des Instituts Sociaux de Lugano indépendants sur la base du travail des programmes, des besoins de quotas et des priorités définis par les supérieurs, selon la formation acquise et la fonction attribuée. Salaire annuel - XII (élèves de l'enfance), classes 12-13-14 classe 12: min CHF 73'140.05 / max CHF 86'305.45 classe 13: min CHF 77'526.15 / max CHF 91'481.05 classe 14: min CHF 82'372.30 / max CHF 97'199.35 Dans le contexte des possibilités de rémunération susmentionnées, on peut reconnaître l'activité exercée antérieurement, si elle est conforme à ce service. Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de la boîte judiciaire En plus des documents à joindre initialement, dans un second moment peut être nécessaire de présenter l'extrait de la boîte judiciaire pour les particuliers et l'extrait spécifique pour les particuliers. En participant au concours, le candidat/ou autorise l'organisme à soumettre à l'UFAG le nom de contrôle sur la base de la loi et de l'ordonnance fédérale sur le registre judiciaire VOSTRA (LCaGI et OCaGI). Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
+      },
+      "salaryMin": 82372,
+      "salaryMax": 97199,
+      "salaryCurrency": "CHF",
+      "salaryClass": "14",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "previousSlugs": [
+        "educatori-dell-infanzia",
+        "educatori-dell-infanzia-lis-lugano-istituti-sociali-pregassona-arxo48",
+        "child-educators-lis-lugano-istituti-sociali-pregassona",
+        "educatori-dell-infanzia-lis-lugano-istituti-sociali-lugano"
+      ],
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 82372,
+          "maxValue": 97199,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "47ac3fd860ffe7cc2059",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-15T22:11:48.111Z"
+      },
+      "id": "lis-lugano-istituti-sociali-a24dc6ee20f4",
+      "previousSlugsByLocale": {
+        "it": [
+          "educatori-dell-infanzia"
+        ],
+        "en": [
+          "educatori-dell-infanzia-lis-lugano-istituti-sociali-pregassona-arxo48",
+          "child-educators-lis-lugano-istituti-sociali-pregassona"
+        ],
+        "fr": [
+          "educatori-dell-infanzia-lis-lugano-istituti-sociali-pregassona-arxo48"
+        ],
+        "de": [
+          "educatori-dell-infanzia-lis-lugano-istituti-sociali-pregassona-arxo48"
+        ]
+      },
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T22:20:25.346Z"
+    },
     {
       "title": "Capisquadra - chef di cucina",
       "company": "LIS – Lugano Istituti Sociali",
@@ -34,7 +1018,7 @@
       },
       "descriptionByLocale": {
         "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di capisquadra - chef di cucina alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - attestato federale di cuoco/a e comprovata esperienza nella gestione di una brigata di cucina; - capacità di conduzione del personale, organizzative, di coordinamento e di controllo Mansioni generali di riferimento per la funzione di caposquadra - chef di cucina: Gestire le attività della squadra di cucina sulla scorta di disposizioni e indicazioni interne e delle norme igieniche vigenti. Stipendio annuo - IX (capisquadra), classi 10-11-12 classe 10: min CHF 65'679.90 / max CHF 77'502.35 classe 11: min CHF 69'193.30 / max CHF 81'648.20 classe 12: min CHF 73'140.05 / max CHF 86'305.45 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
-        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of chefs - chefs of cuisine under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable function (Art. 11 and S. ROCIS) within. The positions are open to both female and male applications. This competition is also open in the absence of an actual staff requirement.\n• Requirements of general order, those provided for by ROCIS and in particular: - Swiss or foreign citizenship with work permit; - unexceptionable conduct; - healthy physical and mental constitution; - suitability to function.\n• Special requirements: - Federal certification of cook/cook and proven experience in the management of a kitchen brigade; - management capacity of staff, organizational, coordination and control General reference orders for the function of caposquadra - kitchen chef: Manage the activities of the kitchen team on the basis of internal regulations and hygiene regulations in force. Yearly wages - IX (capisquadra), classes 10-11-12 class 10: min CHF 65'679.90 / max CHF 77'502.35 class 11: min CHF 69'193.30 / max CHF 81'648.20 class 12: min CHF 73'140.05 / max CHF 86'305.45 In the context of the above-mentioned opportunities of pay, the activity previously performed may be recognised, if conforming to this Chapter The offers must be accompanied by the following documents: - presentation letter - curriculum vitae - recent photography - certificates of study and work - questionnaire on the state of health - self-certification of the judicial box In addition to the documents to be attached initially, in a second moment may be required to present the extract of the judicial box for private individuals. Application conditions Applications must be submitted electronically through the online desk, following the procedure indicated on the website of the Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita­ta­tion/ within 23:59 on Sunday 13th December 2026 The Human Resources Office remains at a reasonable disposal (T. 058 866 34 11) of those who do not have a smartphone (PC) Lugano Social Institutes cannot, in any case, consider applications and attachments transmitted through high channels (paper, email, fax, etc.). SOCIAL INSTITUTIONS THE COUNCIL OF ADMINISTRATION Awareness of competition Questionnaire on the state of health Questionnaire concerning the judicial box",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of chefs - chefs of cuisine under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
         "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Einstellung von Köchen - Küchenchefs unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - Bundeszertifizierung von Koch/Koch und bewährte Erfahrung in der Verwaltung einer Küchenbrigade; - Managementkapazität von Personal, Organisation, Koordination und Kontrolle Allgemeine Referenzaufträge für die Funktion von Caposquadra - Küchenchef: Verwalten Sie die Aktivitäten des Küchenteams auf der Grundlage interner Vorschriften und Hygienevorschriften in Kraft. Jahreslohn - IX (capisquadra), Klassen 10-11-12 Klasse 10: min CHF 65'679.90 / max CHF 77'502.35 Klasse 11: min CHF 69'193.30 / max CHF 81'648.20 Klasse 12: min CHF 73'140.05 / max CHF 86'305.45 Im Zusammenhang mit den oben genannten Zahlungsmöglichkeiten kann die zuvor durchgeführte Tätigkeit anerkannt werden, wenn sie diesem Kapitel entspricht. Die Angebote müssen mit folgenden Unterlagen ergänzt werden: - Präsentationsschreiben - Curriculum vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung des Gerichtskastens Neben den anfangs anzubringenden Unterlagen kann in einem zweiten Moment erforderlich sein, um den Auszug des Gerichtskastens für Privatpersonen darzustellen. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
         "fr": "Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public (valable pour l'année 2026) pour le recrutement des chefs - chefs de cuisine dans les conditions du règlement organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Exigences particulières : - Certification fédérale du cuisinier/cuisinier et expérience prouvée dans la gestion d'une brigade de cuisine ; - Capacité de gestion du personnel, organisation, coordination et contrôle Commandes générales de référence pour la fonction de chef de cuisine caposquadra : Gérer les activités de l'équipe de cuisine sur la base des règlements internes et d'hygiène en vigueur. Salaires annuels - IX (capisquadra), classes 10-11-12 classe 10: min CHF 65'679.90 / max CHF 77'502.35 classe 11: min CHF 69'193.30 / max CHF 81'648.20 classe 12: min CHF 73'140.05 / max CHF 86'305.45 Dans le cadre des possibilités de rémunération susmentionnées, l'activité précédemment exercée peut être reconnue, si elle est conforme au présent chapitre. Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de la case judiciaire En plus des documents à joindre initialement, il peut être nécessaire, dans un second moment, de présenter l'extrait de la case judiciaire pour les particuliers. Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
       },
@@ -121,7 +1105,7 @@
       },
       "descriptionByLocale": {
         "it": "Il Consiglio di Amministrazione dell'Ente Autonomo Lugano Istituti Sociali apre il concorso pubblico (valido per l'anno 2026) per l'assunzione di cuochi alle condizioni del Regolamento Organico dei Collaboratori (ROCIS) dell'Ente Autonomo Lugano Istituti Sociali (LIS) e del capitolato di concorso. Il Consiglio di Amministrazione può prevedere l'attribuzione di nomine (art. 5 e ss. ROCIS) e incarichi per funzione stabile (art. 11 e ss. ROCIS) interni. Le posizioni sono aperte sia a candidature femminili che maschili. Il presente concorso resta aperto anche in assenza di un effettivo fabbisogno di personale.\n• Requisiti di ordine generale, quelli previsti dal ROCIS e in particolare: - cittadinanza svizzera o stranieri con permesso di lavoro; - condotta ineccepibile; - costituzione fisica e psichica sana; - idoneità alla funzione.\n• Requisiti di ordine particolare: - attestato federale nella professionale di cuoco o titolo equivalente, comprovata esperienza; Mansioni generali di riferimento per la funzione di cuoco: Sulla base dei programmi di lavoro, delle necessità di servizio, delle normative vigenti e delle indicazioni dei responsabili, garantisce la preparazione dei pasti. Stipendio annuo - VII (cuochi), classi 8-9-10 classe 8: min CHF 59'808.05 / max CHF 70'573.50 classe 9: min CHF 62'560.85 / max CHF 73'821.70 classe 10: min CHF 65'679.90 / max CHF 77'502.35 Nell'ambito delle anzidette possibilità di retribuzione può essere riconosciuta l'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio. Le offerte devono essere corredate dai seguenti documenti: - lettera di presentazione - curriculum vitae - fotografia recente - certificati di studio e di lavoro - questionario sullo stato di salute - autocertificazione casellario giudiziale Oltre ai documenti da allegare inizialmente, in un secondo momento potrà essere richiesto di presentare l'estratto del casellario giudiziale per privati. Condizioni di presentazione delle candidature Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/ entro le ore 23:59 di domenica 13 dicembre 2026 L'Ufficio Risorse Umane resta a cortese disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo (PC, tablet, smartphone, ecc) tramite il quale candidarsi. Lugano Istituti Sociali non potrà, in nessun caso, considerare candidature e allegati trasmessi tramite alti canali (forma cartacea, email, fax, ecc.). LUGANO ISTITUTI SOCIALI IL CONSIGLIO DI AMMINISTRAZIONE Capitolato di concorso Questionario sullo stato di salute Questionario relativo al casellario giudiziale",
-        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of chefs under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and of the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable function (Art. 11 and S. ROCIS) within. The positions are open to both female and male applications. This competition is also open in the absence of an actual staff requirement.\n• Requirements of general order, those provided for by ROCIS and in particular: - Swiss or foreign citizenship with work permit; - unexceptionable conduct; - healthy physical and mental constitution; - suitability to function.\n• Special requirements: - Federal certificate in the profession of cook or equivalent title, proven experience; General reference for the cook function: On the basis of the work programmes, the needs of service, the regulations in force and the indications of the managers, guarantees the preparation of meals. Yearly wage - VII (cuoche), classes 8-9-10 class 8: min CHF 59'808.05 / max CHF 70'573.50 class 9: min CHF 62'560.85 / max CHF 73'821.70 class 10: min CHF 65'679.90 / max CHF 77'502.35 In the context of the above-mentioned payment possibilities, the activity carried out previously may be recognised, if conforming to this Chapter The offers must be accompanied by the following documents: - presentation letter - curriculum vitae - recent photography - certificates of study and work - questionnaire on the state of health - self-certification of the judicial box In addition to the documents to be attached initially, in a second moment may be required to present the extract of the judicial box for private individuals. Application conditions Applications must be submitted electronically through the online desk, following the procedure indicated on the website of the Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita­ta­tion/ within 23:59 on Sunday 13th December 2026 The Human Resources Office remains at a reasonable disposal (T. 058 866 34 11) of those who do not have a smartphone (PC) Lugano Social Institutes cannot, in any case, consider applications and attachments transmitted through high channels (paper, email, fax, etc.). SOCIAL INSTITUTIONS THE COUNCIL OF ADMINISTRATION Awareness of competition Questionnaire on the state of health Questionnaire concerning the judicial box",
+        "en": "The Board of Directors of the Autonomous Body Lugano Social Institutes opens the public competition (valid for the year 2026) for the recruitment of chefs under the conditions of the Organic Regulation of Collaborators (ROCIS) of the Autonomous Body Lugano Social Institutes (LIS) and of the competition chapter. The Board of Directors may provide for the allocation of appointments (Art. 5 and S. ROCIS) and assignments for stable",
         "de": "Der Verwaltungsrat der Autonomen Körper-Lugano-Sozialinstitute eröffnet den öffentlichen Wettbewerb (gültig für das Jahr 2026) für die Einstellung von Köchen unter den Bedingungen der Organischen Verordnung der Mitarbeiter (ROCIS) der Autonomen Körper-Lugano-Sozialinstitute (LIS) und des Wettbewerbskapitels. Der Verwaltungsrat kann die Zuweisung von Terminen (Art. 5 und S. ROCIS) und Zuweisungen für eine stabile Funktion (Art. 11 und S. ROCIS) innerhalb des Verwaltungsrats vorsehen. Die Positionen sind offen für weibliche und männliche Anwendungen. Dieser Wettbewerb ist auch in Abwesenheit eines tatsächlichen Personalbedarfs offen.\n• Anforderungen der allgemeinen Ordnung, die von ROCIS bereitgestellt werden und insbesondere: - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis; - unausgenommenes Verhalten; - gesunde körperliche und geistige Verfassung; - Funktionsfähigkeit.\n• Besondere Anforderungen: - Föderales Zertifikat im Beruf des Kochs oder gleichwertigen Titels, nachgewiesene Erfahrung; Allgemeine Referenz für die Kochfunktion: Auf der Grundlage der Arbeitsprogramme garantiert der Bedarf an Dienstleistungen, die geltenden Vorschriften und die Angaben der Manager die Zubereitung von Mahlzeiten. Jahreslohn - VII (cuoche), Klassen 8-9-10 Klasse 8: min CHF 59'808.05 / max CHF 70'573.50 Klasse 9: min CHF 62'560.85 / max CHF 73'821.70 Klasse 10: min CHF 65'679.90 / max CHF 77'502.35 Im Zusammenhang mit den oben genannten Zahlungsmöglichkeiten kann die zuvor durchgeführte Tätigkeit anerkannt werden, wenn sie diesem Kapitel entspricht. Die Angebote müssen mit folgenden Unterlagen ergänzt werden: - Präsentationsschreiben - Curriculum vitae - jüngste Fotografie - Studien- und Arbeitszeugnisse - Fragebogen über den Gesundheitszustand - Selbstzertifizierung des Gerichtssaals Zusätzlich zu den anfangs anzubringenden Dokumenten kann in einem zweiten Moment erforderlich sein, um den Auszug des Gerichtskastens für Privatpersonen darzustellen. Bewerbungsbedingungen Die Bewerbungsunterlagen sind elektronisch über den Online-Desk einzureichen, nach dem auf der Website der Lugano Institutes Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ innerhalb von 23:59 am Sonntag, 13. Dezember 2026 Das Personalbüro steht weiterhin zu einer angemessenen Verfügung (T. 058 866 34 11) derjenigen, die kein Smartphone (PC) Lugano Social Institute haben, können in jedem Fall Anwendungen und Anhänge, die über hohe Kanäle übertragen werden (Papier, E-Mail, Fax, etc.). SOZIALE INSTITUTIONEN DES RATES Bekanntheit des Wettbewerbs Fragebögen über den Gesundheitszustand Fragebögen über die Justiz",
         "fr": "Le Conseil d'administration de l'organisme autonome Lugano Social Institutes ouvre le concours public (valable pour l'année 2026) pour le recrutement des chefs dans les conditions du règlement organique des collaborateurs (ROCIS) de l'organisme autonome Lugano Social Institutes (LIS) et du chapitre du concours. Le conseil d'administration peut prévoir la répartition des nominations (art. 5 et S. ROCIS) et des affectations pour des fonctions stables (art. 11 et S. ROCIS) à l'intérieur. Les postes sont ouverts aux candidatures féminines et masculines. Ce concours est également ouvert en l'absence d'exigence réelle en matière de personnel.\n• Exigences d'ordre général, celles prévues par le ROCIS et en particulier: - citoyenneté suisse ou étrangère avec permis de travail; - conduite non exceptionnelle; - constitution physique et mentale saine; - aptitude au fonctionnement.\n• Conditions particulières: - Certificat fédéral dans la profession de cuisinier ou titre équivalent, expérience prouvée; Sur la base des programmes de travail, des besoins de service, de la réglementation en vigueur et des indications des gestionnaires, garantit la préparation des repas. Salaire annuel - VII (cuoche), classes 8-9-10 classe 8: min CHF 59'808.05 / max CHF 70'573.50 classe 9: min CHF 62'568.85 / max CHF 73'821.70 classe 10: min CHF 65'679.90 / max CHF 77'502.35 Dans le cadre des possibilités de paiement susmentionnées, l'activité effectuée antérieurement peut être reconnue, si elle est conforme au présent chapitre Les offres doivent être accompagnées des documents suivants: - lettre de présentation - curriculum vitae - photographie récente - certificats d'études et de travail - questionnaire sur l'état de santé - autocertification de l'encadré judiciaire En plus des documents à joindre initialement, il peut être nécessaire, dans un second moment, de présenter l'extrait de l'encadré judiciaire pour les particuliers. Conditions d'admission Les demandes doivent être soumises par voie électronique par le biais du bureau en ligne, selon la procédure indiquée sur le site web des Instituts de Lugano Social https://lugano-lis.ch/work-con-noi/opportunita-tion/ dans les 23h59 du dimanche 13 décembre 2026 Le Bureau des ressources humaines demeure à la disposition (T. 058 866 34 11) de ceux qui n'ont pas de smartphone (PC) Les Instituts sociaux de Lugano ne peuvent en aucun cas examiner les demandes et les pièces jointes transmises par les canaux élevés (papier, courriel, télécopie, etc.). INSTITUTIONS SOCIALES LE CONSEIL D'ADMINISTRATION Sensibilisation à la concurrence Questionnaire sur l'état de santé Questionnaire concernant l'encadré judiciaire"
       },
@@ -176,6 +1160,82 @@
       "addressCountry": "CH",
       "employmentType": "FULL_TIME",
       "firstSeenAt": "2026-05-14T22:20:25.346Z"
+    },
+    {
+      "title": "Addetti servizi alla casa",
+      "company": "LIS – Lugano Istituti Sociali",
+      "companyKey": "lis-lugano-istituti-sociali",
+      "companyDomain": "lugano-lis.ch",
+      "url": "https://lavoraconnoi.lugano-lis.ch/job/view-job.php?id=43-addetti-servizi-alla-casa-pregassona&language=it",
+      "slug": "addetti-servizi-alla-casa",
+      "location": "Pregassona",
+      "canton": "TI",
+      "country": "CH",
+      "postalCode": "6963",
+      "streetAddress": "Via alla Bozzoreda 15",
+      "description": "# Concorso per Addetti Servizi alla Casa ## Mansioni - Eseguire lavori di pulizia e/o di supporto al personale curante e al personale addetto alla cucina, all'interno delle strutture dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e l'esperienza - Eseguire lavori all'interno del servizio di lavanderia centralizzata LIS situata ad Agno. Può inoltre essere chiamato a svolgere lavori di pulizia e/o di supporto al personale curante e al personale addetto alla cucina, all'interno delle strutture dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori. ##\n• Requisiti di Ordine Generale - Cittadinanza svizzera o stranieri con permesso di lavoro - Condotta ineccepibile - Costituzione fisica e psichica sana - Idoneità alla funzione ##\n• Requisiti di Ordine Particolare - Attestato federale di capacità quale impiegato/a di economia domestica, titolo equivalente, comprovata esperienza ## Stipendio Annuale - IV (addetti servizi alla casa), classi 5-6-7 - Classe 5: min. CHF 53'518.55 / max. CHF 63'151.95 - Classe 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Classe 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibilità di riconoscimento dell'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio ## Documenti Richiesti - Lettera di presentazione - Curriculum vitae - Fotografia recente - Certificati di studio e di lavoro - Questionario sullo stato di salute - Autocertificazione casellario giudiziale - Estratto del casellario giudiziale per privati (richiesto in un secondo momento) ## Condizioni di Presentazione delle Candidature - Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali <https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/> entro le ore 23:59 di domenica 13 dicembre 2026 - L'Ufficio Risorse Umane resta a disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo per candidarsi - Non saranno considerate candidature e allegati trasmessi tramite altri canali (forma cartacea, email, fax, ecc.) ## Contatto - LUGANO ISTITUTI SOCIALI - IL CONSIGLIO DI AMMINISTRAZIONE - Capitolato di concorso - Questionario sullo stato di salute - Questionario relativo al casellario giudiziale",
+      "datePosted": "2026-01-26",
+      "validThrough": "2026-12-13",
+      "sector": "Ospedaliero/Medicale/Sanitario/Educativo",
+      "role": "Medicina/Sanità",
+      "source": "arca24",
+      "titleByLocale": {
+        "it": "Addetti servizi alla casa",
+        "en": "Additions to the house",
+        "de": "Ergänzungen zum Haus",
+        "fr": "Ajouts à la maison"
+      },
+      "slugByLocale": {
+        "it": "addetti-servizi-alla-casa",
+        "en": "additions-to-the-house-lis-lugano-istituti-sociali-pregassona",
+        "de": "erganzungen-zum-haus-lis-lugano-istituti-sociali-pregassona",
+        "fr": "ajouts-a-la-maison-lis-lugano-istituti-sociali-pregassona"
+      },
+      "descriptionByLocale": {
+        "it": "# Concorso per Addetti Servizi alla Casa ## Mansioni - Eseguire lavori di pulizia e/o di supporto al personale curante e al personale addetto alla cucina, all'interno delle strutture dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori, secondo la formazione conseguita e l'esperienza - Eseguire lavori all'interno del servizio di lavanderia centralizzata LIS situata ad Agno. Può inoltre essere chiamato a svolgere lavori di pulizia e/o di supporto al personale curante e al personale addetto alla cucina, all'interno delle strutture dell'ente autonomo Lugano Istituti Sociali sulla base dei programmi di lavoro, delle necessità contingenti e delle priorità definite dai superiori. ##\n• Requisiti di Ordine Generale - Cittadinanza svizzera o stranieri con permesso di lavoro - Condotta ineccepibile - Costituzione fisica e psichica sana - Idoneità alla funzione ##\n• Requisiti di Ordine Particolare - Attestato federale di capacità quale impiegato/a di economia domestica, titolo equivalente, comprovata esperienza ## Stipendio Annuale - IV (addetti servizi alla casa), classi 5-6-7 - Classe 5: min. CHF 53'518.55 / max. CHF 63'151.95 - Classe 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Classe 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibilità di riconoscimento dell'attività svolta precedentemente, se conforme al presente capitolato, assegnando una o più annualità di servizio ## Documenti Richiesti - Lettera di presentazione - Curriculum vitae - Fotografia recente - Certificati di studio e di lavoro - Questionario sullo stato di salute - Autocertificazione casellario giudiziale - Estratto del casellario giudiziale per privati (richiesto in un secondo momento) ## Condizioni di Presentazione delle Candidature - Le candidature devono essere inoltrate in forma elettronica tramite lo sportello online seguendo la procedura indicata sul sito internet dell'Ente Lugano Istituti Sociali <https://lugano-lis.ch/lavora-con-noi/opportunitaimpiego/> entro le ore 23:59 di domenica 13 dicembre 2026 - L'Ufficio Risorse Umane resta a disposizione (t. 058 866 34 11) di coloro che non possiedono un dispositivo per candidarsi - Non saranno considerate candidature e allegati trasmessi tramite altri canali (forma cartacea, email, fax, ecc.) ## Contatto - LUGANO ISTITUTI SOCIALI - IL CONSIGLIO DI AMMINISTRAZIONE - Capitolato di concorso - Questionario sullo stato di salute - Questionario relativo al casellario giudiziale",
+        "en": "Competition for Addiction Services at the House Shipments - Perform cleaning and/or support work to the caregiver and to the staff responsible for the kitchen, within the structures of the autonomous body Lugano Social Institutes on the basis of the programs of work, the quotas and the priorities defined by the superiors, according to the training achieved and the experience - Perform work within the centralized LIS laundry service located in Agno. It can also be called to carry out cleaning and/or support works for the caregiver and the staff responsible for the kitchen, within the structures of the autonomous body Lugano Social Institutes on the basis of the work programs, the quota needs and the priorities defined by the superiors. General Order\n• Requirements - Swiss or foreign citizenship with work permit - Unexceptionable conduct - Healthy physical and mental constitution - Function suitability Special Order\n• Requirements - Federal certificate of capacity as employee of domestic economy, equivalent title, proven experience Annual wage - IV (home services), classes 5-6-7 - Class 5: min. CHF 53'518.55 / max. CHF 63'151.95 - Class 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Class 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibility of recognition of the activity carried out previously, if conforming to this chapter, assigning one or more year of service Documents Requested - Letter of presentation - Curriculum vitae - Recent photography - Study and work certificates - Questionnaire on health - Self-certification judicial box - Excerpt of the judicial box for private individuals (required at a later time) Terms of Application Presentation - Applications must be submitted electronically via the online desk following the procedure indicated on the website of the Lugano Institutes Social Institutes by 23:59 on Sunday 13 December 2026 - The Human Resources Office remains available (T. 058 866 34 11) of those who do not have a device to apply - Applications and attachments will not be considered by other channels (paper, email, fax, etc.) Contact - SOCIAL INSTITUTIONS - THE COUNCIL OF ADMINISTRATION - Competition chapter - Questionnaire on health - Questionnaire relating to the judicial box",
+        "de": "Wettbewerb für Addiction Services im Haus Sendungen - Durchführung von Reinigungs- und/oder Unterstützungsarbeiten an den Pflegekräften und an das für die Küche zuständige Personal innerhalb der Strukturen des autonomen Organs Lugano Sozialinstitute auf der Grundlage der Arbeitsprogramme, der Quoten und der Prioritäten, die von den Vorgesetzten festgelegt werden, nach der erreichten Ausbildung und der Erfahrung - Arbeiten im zentralisierten LIS Wäscheservice in Agno durchführen. Es kann auch gefordert werden, Reinigungs- und/oder Unterstützungsarbeiten für den Pfleger und das für die Küche zuständige Personal innerhalb der Strukturen des autonomen Organs Lugano Sozialinstitute auf der Grundlage der Arbeitsprogramme, der Quotenbedarf und der von den Vorgesetzten definierten Prioritäten durchzuführen. Allgemeine\n• Anforderungen - Schweizer oder ausländische Staatsbürgerschaft mit Arbeitserlaubnis - Unausgenommenes Verhalten - Gesunde körperliche und geistige Verfassung - Funktionsfähigkeit Besondere\n• Anforderungen - Bundeskapazitätszertifikat als Arbeitnehmer der Inlandswirtschaft, gleichwertiger Titel, nachgewiesene Erfahrung Jahreslohn - IV (Haushaltsleistungen), Klassen 5-6-7 - Klasse 5: min. CHF 53'518.55 / max. CHF 63'151.95 - Klasse 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Klasse 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Möglichkeit der Anerkennung der zuvor durchgeführten Tätigkeit, wenn sie diesem Kapitel entspricht, ein oder mehrere Jahre Dienst Angeforderte Dokumente - Präsentationsschreiben - Lebenslauf - Neue Fotografie - Studien- und Arbeitszeugnisse - Frage zum Thema Gesundheit - Selbstzertifizierung gerichtliches Feld - Auszug der Gerichtsdose für Privatpersonen (zu einem späteren Zeitpunkt erforderlich) Bewerbungsbedingungen Präsentation - Die Anmeldungen müssen elektronisch über den Online-Desk nach dem auf der Website der Lugano Institute Social Institutes angegebenen Verfahren bis 23:59 am Sonntag, 13. Dezember 2026 eingereicht werden - Das Personalbüro bleibt verfügbar (T. 058 866 34 11) von denen, die kein Gerät zur Anwendung haben - Anwendungen und Anhänge werden nicht von anderen Kanälen betrachtet (Papier, E-Mail, Fax, etc.) Kontakt - SOZIALE INSTITUTIONEN - DER RAT DER VERWALTUNG - Kapitel des Wettbewerbs - Frage zum Thema Gesundheit - Fragebögen zum Gerichtssaal",
+        "fr": "Concours pour les services de toxicomanie à la Chambre Expéditions - Effectuer des travaux de nettoyage et/ou de soutien au soignant et au personnel responsable de la cuisine, dans les structures de l'organisme autonome Lugano Social Institutes sur la base des programmes de travail, des quotas et des priorités définis par les supérieurs, selon la formation acquise et l'expérience acquise - Effectuer des travaux dans le service de blanchisserie LIS centralisé situé à Agno. Il peut également être appelé à effectuer des travaux de nettoyage et/ou de soutien pour le soignant et le personnel responsable de la cuisine, au sein des structures de l'organisme autonome Lugano Social Institutes sur la base des programmes de travail, des besoins de quotas et des priorités définies par les supérieurs.\n• Exigences d'ordre général - Citoyenneté suisse ou étrangère avec permis de travail - Conduite exceptionnelle - Constitution physique et mentale saine - Capacité fonctionnelle\n• Exigences spéciales - Certificat fédéral de capacité en tant qu'employé de l'économie nationale, titre équivalent, expérience prouvée Salaire annuel - IV (services à domicile), classes 5-6-7 - Classe 5: min. CHF 53'518.55 / max. CHF 63'151.95 - Classe 6: min. CHF 55'301.35 / max. CHF 65'255.75 - Classe 7: min. CHF 57'393.95 / max. CHF 67'724.85 - Possibilité de reconnaissance de l'activité effectuée antérieurement, si elle est conforme au présent chapitre, en attribuant une ou plusieurs années de service Documents demandés - Lettre de présentation - Curriculum vitae - Photographie récente - Certificats d'études et de travail Questionnaire sur la santé - Boîte judiciaire d'autocertification - Extrait de la boîte judiciaire pour les particuliers (obligatoire ultérieurement) Présentation des conditions d'application - Les demandes doivent être soumises par voie électronique via le bureau en ligne suivant la procédure indiquée sur le site des Instituts de Lugano Instituts sociaux avant 23:59 le dimanche 13 décembre 2026 - Le Bureau des ressources humaines reste disponible (T. 058 866 34 11) de ceux qui n'ont pas de dispositif à appliquer - Les demandes et pièces jointes ne seront pas examinées par d'autres voies (papier, courriel, télécopie, etc.) Personne à contacter - LES INSTITUTIONS SOCIALES - LE CONSEIL D'ADMINISTRATION - Chapitre Concurrence Questionnaire sur la santé - Questionnaire relatif à la boîte judiciaire"
+      },
+      "salaryMin": 57394,
+      "salaryMax": 67725,
+      "salaryCurrency": "CHF",
+      "salaryClass": "7",
+      "crawledAt": "",
+      "requirementsByLocale": {},
+      "sourceLang": "it",
+      "currency": "CHF",
+      "baseSalary": {
+        "@type": "MonetaryAmount",
+        "currency": "CHF",
+        "value": {
+          "@type": "QuantitativeValue",
+          "minValue": 57394,
+          "maxValue": 67725,
+          "unitText": "YEAR"
+        }
+      },
+      "salaryExtraction": {
+        "strategyVersion": "lis_salary_v2",
+        "textHash": "533ab422a3272fd9fab4",
+        "source": "lis_regex_text",
+        "confidence": 0.98,
+        "extractedAt": "2026-05-24T22:36:16.175Z"
+      },
+      "id": "lis-lugano-istituti-sociali-728912efd55d",
+      "addressLocality": "Pregassona",
+      "addressRegion": "TI",
+      "addressCountry": "CH",
+      "employmentType": "FULL_TIME",
+      "firstSeenAt": "2026-05-14T22:20:25.346Z",
+      "previousSlugs": [
+        "addetti-servizi-alla-casa-lis-lugano-istituti-sociali-pregassona"
+      ],
+      "previousSlugsByLocale": {
+        "it": [
+          "addetti-servizi-alla-casa-lis-lugano-istituti-sociali-pregassona"
+        ]
+      }
     }
   ]
 }

--- a/scripts/lib/lis-lugano-istituti-sociali-job-parser.mjs
+++ b/scripts/lib/lis-lugano-istituti-sociali-job-parser.mjs
@@ -328,38 +328,61 @@ export function parseArca24DetailPage(html, pageUrl = '') {
 
 // ── Network helpers ──────────────────────────────────────────
 
-async function fetchPage(url, { userAgent = DEFAULT_UA, timeoutMs = 15000 } = {}) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(url, {
-      headers: { 'User-Agent': userAgent },
-      signal: controller.signal,
-      redirect: 'follow',
-    });
-    if (!res.ok) return null;
-    return await res.text();
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
+async function fetchPage(url, { userAgent = DEFAULT_UA, timeoutMs = 15000, retries = 2, backoffMs = 1000 } = {}) {
+  // Retry transient failures (network/5xx/timeout) with exponential backoff.
+  // 4xx (except 408/429) are treated as terminal — the page genuinely doesn't exist.
+  let lastErrorReason = '';
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': userAgent },
+        signal: controller.signal,
+        redirect: 'follow',
+      });
+      if (res.ok) return await res.text();
+      const status = res.status;
+      // 408/429/5xx are retryable; other 4xx are not.
+      const retryable = status === 408 || status === 429 || (status >= 500 && status <= 599);
+      lastErrorReason = `HTTP ${status}`;
+      if (!retryable) return null;
+    } catch (err) {
+      lastErrorReason = err?.name === 'AbortError' ? 'timeout' : (err?.message || 'fetch_error');
+    } finally {
+      clearTimeout(timer);
+    }
+    if (attempt < retries) {
+      await new Promise((r) => setTimeout(r, backoffMs * Math.pow(2, attempt)));
+    }
   }
+  if (lastErrorReason) {
+    console.warn(`  ⚠️ fetchPage exhausted retries for ${url}: ${lastErrorReason}`);
+  }
+  return null;
 }
 
 // ── Public API ───────────────────────────────────────────────
 
 /**
  * Discover all job URLs from the Arca24 listing pages.
- * Returns an array of { url, title, location, snippet, dates }.
+ *
+ * Returns `{ jobs, attempted, succeeded, failed, failedUrls }`. The caller is
+ * expected to use `failed > 0` as the signal that the discovery was partial
+ * and the previous slice should be merged (not replaced) \u2014 see run
+ * 26422783451 (2026-05-25) where a single listing-fetch failure silently
+ * truncated the slice from 13 to 2 LIS jobs.
  */
 export async function fetchLisJobUrls({ userAgent = DEFAULT_UA, timeoutMs = 15000 } = {}) {
   const allJobs = [];
   const seenUrls = new Set();
+  const failedUrls = [];
 
   for (const listingUrl of LISTING_URLS) {
     const html = await fetchPage(listingUrl, { userAgent, timeoutMs });
     if (!html) {
       console.warn(`  \u26a0\ufe0f Failed to fetch listing page: ${listingUrl}`);
+      failedUrls.push(listingUrl);
       continue;
     }
     const jobs = parseArca24ListingPage(html, listingUrl);
@@ -372,7 +395,13 @@ export async function fetchLisJobUrls({ userAgent = DEFAULT_UA, timeoutMs = 1500
     }
   }
 
-  return allJobs;
+  return {
+    jobs: allJobs,
+    attempted: LISTING_URLS.length,
+    succeeded: LISTING_URLS.length - failedUrls.length,
+    failed: failedUrls.length,
+    failedUrls,
+  };
 }
 
 /**

--- a/scripts/update-lis-jobs.mjs
+++ b/scripts/update-lis-jobs.mjs
@@ -940,11 +940,23 @@ function runBaseCrawler() {
  */
 async function crawlArca24Direct() {
   console.log('\n🔍 Direct Arca24 scraping: discovering job URLs...');
-  const listingJobs = await fetchLisJobUrls({
+  const discovery = await fetchLisJobUrls({
     userAgent: LIS_USER_AGENT,
     timeoutMs: 15000,
   });
-  console.log(`📋 Found ${listingJobs.length} job URLs on Arca24 listing pages`);
+  const listingJobs = discovery.jobs;
+  const partialDiscovery = discovery.failed > 0;
+  console.log(`📋 Found ${listingJobs.length} job URLs on Arca24 listing pages (listings: ${discovery.succeeded}/${discovery.attempted} ok)`);
+
+  // Bail out completely when every listing page failed — writing nothing
+  // preserves the prior slice intact. Without this guard a transient outage
+  // (run 26422783451, 2026-05-25) silently truncates the slice and the
+  // build emits expired soft-landings for jobs still live on the ATS.
+  if (discovery.succeeded === 0) {
+    console.warn('⚠️  All listing pages failed to fetch — leaving existing LIS jobs untouched.');
+    return { discovered: 0, parsed: 0, merged: 0, preservedExisting: 0, aborted: 'all_listings_failed' };
+  }
+
   if (listingJobs.length === 0) {
     console.warn('⚠️  No job URLs found on Arca24 listing pages — the ATS may be down or structure changed');
     return { discovered: 0, parsed: 0, merged: 0 };
@@ -953,6 +965,7 @@ async function crawlArca24Direct() {
   // Fetch and parse each detail page
   console.log('\n📄 Fetching Arca24 detail pages...');
   const parsedJobs = [];
+  const detailFailedUrls = new Set();
   const DETAIL_DELAY_MS = 800;
   for (const listing of listingJobs) {
     const detail = await fetchLisDetailPage(listing.url, {
@@ -966,9 +979,11 @@ async function crawlArca24Direct() {
         parsedJobs.push(job);
       } else {
         console.log(`  ⏭️  ${listing.title} → could not build job object`);
+        detailFailedUrls.add(listing.url);
       }
     } else {
       console.log(`  ⚠️  ${listing.url} → detail page parse failed`);
+      detailFailedUrls.add(listing.url);
     }
     // Polite delay between requests
     if (parsedJobs.length < listingJobs.length) {
@@ -977,9 +992,9 @@ async function crawlArca24Direct() {
   }
 
   console.log(`\n🏛️ Parsed LIS jobs: ${parsedJobs.length} / ${listingJobs.length}`);
-  if (parsedJobs.length === 0) {
-    console.warn('⚠️  All detail pages failed to parse — Arca24 structure may have changed');
-    return { discovered: listingJobs.length, parsed: 0, merged: 0 };
+  if (parsedJobs.length === 0 && !partialDiscovery) {
+    console.warn('⚠️  All detail pages failed to parse — Arca24 structure may have changed; leaving existing LIS jobs untouched.');
+    return { discovered: listingJobs.length, parsed: 0, merged: 0, aborted: 'all_details_failed' };
   }
 
   // Deduplicate by title+location
@@ -1009,8 +1024,10 @@ async function crawlArca24Direct() {
 
   let added = 0;
   let updated = 0;
+  const seenUrlKeys = new Set();
   const mergedLis = deduplicated.map((job) => {
     const key = normalizeLisUrlForDedup(job.url);
+    if (key) seenUrlKeys.add(key);
     const prev = existingByUrl.get(key);
     if (!prev) {
       added += 1;
@@ -1027,14 +1044,39 @@ async function crawlArca24Direct() {
     };
   });
 
-  const allJobs = [...nonLisJobs, ...mergedLis];
+  // Preserve existing LIS jobs that aren't in this crawl whenever the crawl
+  // was partial — either listing-page fetch failed, or some detail pages
+  // failed to parse. Without this guard, a single transient listing/detail
+  // failure drops the affected job from the slice; that job's URL then
+  // emits a thin expired soft-landing on the next build (run 26422783451).
+  // Detail-only failures are tolerated even on a complete listing crawl,
+  // because the detail page may have been temporarily unavailable for an
+  // otherwise still-active job.
+  const preservedExisting = [];
+  if (partialDiscovery || detailFailedUrls.size > 0) {
+    for (const prev of lisExisting) {
+      const key = normalizeLisUrlForDedup(prev.url);
+      if (!key || seenUrlKeys.has(key)) continue;
+      // Always preserve when listing was partial (job may exist on the
+      // unfetched listing page). When listing was complete, preserve only
+      // jobs whose detail page failed in this run.
+      if (partialDiscovery || detailFailedUrls.has(prev.url)) {
+        preservedExisting.push(prev);
+      }
+    }
+    if (preservedExisting.length > 0) {
+      console.warn(`⚠️  Preserving ${preservedExisting.length} existing LIS jobs from prior slice (partial crawl).`);
+    }
+  }
+
+  const allJobs = [...nonLisJobs, ...mergedLis, ...preservedExisting];
   fs.writeFileSync(DATA_JOBS, JSON.stringify(allJobs, null, 2) + '\n');
   if (fs.existsSync(PUBLIC_DATA_JOBS) || fs.existsSync(path.dirname(PUBLIC_DATA_JOBS))) {
     fs.writeFileSync(PUBLIC_DATA_JOBS, JSON.stringify(allJobs, null, 2) + '\n');
   }
 
-  console.log(`\n📊 Merge result: ${mergedLis.length} LIS jobs (${added} added, ${updated} updated)`);
-  return { discovered: listingJobs.length, parsed: deduplicated.length, merged: mergedLis.length };
+  console.log(`\n📊 Merge result: ${mergedLis.length} LIS jobs (${added} added, ${updated} updated, ${preservedExisting.length} preserved from prior slice)`);
+  return { discovered: listingJobs.length, parsed: deduplicated.length, merged: mergedLis.length, preservedExisting: preservedExisting.length };
 }
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Restored the LIS slice from 2 → 13 jobs (run 26422783451 had silently truncated it via partial-fetch overwrite).
- Hardened `fetchPage` with retry+backoff for transient 408/429/5xx/timeout.
- `fetchLisJobUrls` now returns `{ jobs, attempted, succeeded, failed, failedUrls }` so callers can detect partial discovery.
- `crawlArca24Direct` bails out if all listings fail, and preserves previously-existing LIS jobs in the slice whenever the current crawl is partial (any listing or detail page failed). No more "single bad run wipes the slice."

## Root cause
Run [26422783451](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26422783451) at 2026-05-25 22:48 UTC: listing page 1 failed to fetch, only page 2 returned 3 URLs, detail id=43 failed to parse → slice rewritten with 2 jobs. The previously-indexed URL `/cerca-lavoro-ticino/addetti-servizi-alla-casa/` (traffic-bearing) started rendering a thin "non più attiva" soft-landing despite the job still being live on `lavoraconnoi.lugano-lis.ch`.

## Test plan
- [ ] Post-merge: trigger `update-lis-jobs.yml` workflow and verify the run preserves all 13 jobs even if a listing page momentarily fails (retry path) — check log for `listings: N/N ok` and absence of the "Preserving X existing LIS jobs" warning when full success.
- [ ] Visit `https://frontaliereticino.ch/cerca-lavoro-ticino/addetti-servizi-alla-casa/` after the next deploy and confirm it returns an active job page (not the "non più attiva" soft-landing).
- [ ] Repeat for the other 10 missing slugs (Capireparto, Infermieri, Operatori Sociosanitari, Assistenti di cura, Collaboratori sanitari, Operatori settore animazione, Fisioterapisti, Educatori sociali, Operatori socioassistenziali, Educatori dell'infanzia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)