### PR TITLE
feat(border-wait): unify history + editorial averages on totalCrossingMinutes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'data/border-wait-current.json'
       - 'data/border-wait-history/**'
+      - 'data/border-wait-averages.json'
       - 'data/weather-snapshot.json'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/traffic-scheduler.yml
+++ b/.github/workflows/traffic-scheduler.yml
@@ -60,13 +60,16 @@ jobs:
           ENABLE_WEBCAM_ANALYSIS: '1'
         run: node scripts/collect-traffic.mjs
 
+      - name: Recompute rolling 30-day averages
+        run: node scripts/compute-border-wait-averages.mjs
+
       - name: Commit + push (with rebase-retry)
         # Centralized rebase-retry helper (scripts/lib/git-push-with-retry.sh)
         # survives concurrent pushes from other data-refresh workflows.
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add data/border-wait-current.json data/border-wait-history
+          git add data/border-wait-current.json data/border-wait-history data/border-wait-averages.json
           if git diff --staged --quiet; then
             echo "No changes to commit"
             exit 0
@@ -74,7 +77,7 @@ jobs:
           git commit -m "chore(border-wait): live snapshot $(date -u +%Y-%m-%dT%H:%MZ)"
           bash scripts/lib/git-push-with-retry.sh \
             --branch "${GITHUB_REF_NAME:-main}" \
-            --regenerate-cmd "node scripts/collect-traffic.mjs && git add data/border-wait-current.json data/border-wait-history"
+            --regenerate-cmd "node scripts/collect-traffic.mjs && node scripts/compute-border-wait-averages.mjs && git add data/border-wait-current.json data/border-wait-history data/border-wait-averages.json"
         # NOTE: Commit + push goes to main BUT deploy.yml has paths-ignore on
         # data/border-wait-* so this won't trigger a deploy storm — periodic
         # deploys will pick up the new JSON.

--- a/data/border-wait-averages.json
+++ b/data/border-wait-averages.json
@@ -1,0 +1,17 @@
+{
+  "chiasso-brogeda": {
+    "morning": "1-8 min",
+    "evening": "0-8 min"
+  },
+  "chiasso-strada": {
+    "morning": "1-8 min",
+    "evening": "0-7 min"
+  },
+  "ponte-tresa": {
+    "morning": "0-2 min"
+  },
+  "porto-ceresio-brusino": {
+    "morning": "4-6 min",
+    "evening": "2-3 min"
+  }
+}

--- a/data/borderCrossings.ts
+++ b/data/borderCrossings.ts
@@ -540,3 +540,36 @@ export const borderCrossings: BorderCrossing[] = [
  tips: 'border.tips.dumenzaCassinone',
  },
 ];
+
+// ── Computed averages overlay ────────────────────────────────────
+//
+// `data/border-wait-averages.json` is regenerated daily by
+// `scripts/compute-border-wait-averages.mjs` from the rolling 30-day
+// history aggregates. The numbers are TOTAL minutes (approach delay +
+// checkpoint queue), matching the live "Ora" card metric.
+//
+// Editorial defaults above stay as fallback for crossings with no history
+// yet, and as a sane baseline before the first compute run lands in
+// `data/`.
+import computedAverages from './border-wait-averages.json';
+
+function slugifyName(name: string): string {
+ return name
+ .normalize('NFKD')
+ .replace(/[̀-ͯ]/g, '')
+ .replace(/\([^)]*\)/g, '')
+ .replace(/[^a-zA-Z0-9]+/g, '-')
+ .replace(/-+/g, '-')
+ .replace(/^-|-$/g, '')
+ .toLowerCase();
+}
+
+const computed = computedAverages as Record<string, { morning?: string; evening?: string }>;
+for (const c of borderCrossings) {
+ const slug = slugifyName(c.name);
+ const entry = computed[slug];
+ if (!entry) continue;
+ if (entry.morning) c.avgWaitMorning = entry.morning;
+ if (entry.evening) c.avgWaitEvening = entry.evening;
+}
+

--- a/scripts/compute-border-wait-averages.mjs
+++ b/scripts/compute-border-wait-averages.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Compute morning/evening average ranges per crossing from the on-disk
+ * border-wait history (`data/border-wait-history/*.json`).
+ *
+ * Output: `data/border-wait-averages.json`, keyed by crossing slug:
+ *
+ *   {
+ *     "chiasso-strada": { "morning": "12-22 min", "evening": "20-35 min" },
+ *     ...
+ *   }
+ *
+ * The numbers are TOTAL minutes (approach delay + checkpoint queue) because
+ * `snapshot-border-wait-history.mjs` aggregates buckets on
+ * `totalCrossingMinutes`. The card "Ora" and the per-card averages share the
+ * same metric — no more visual discontinuity between live and historical
+ * values.
+ *
+ * Window definitions (Europe/Rome commuter pattern):
+ *   - morning: 06:00-09:59 (UTC; matches Firestore `hour` field stored by
+ *               the scheduler, which uses local hour at write time)
+ *   - evening: 16:00-19:59
+ *
+ * Range = [p25, p75] of bucket averages across the rolling window. Falls back
+ * to [min, max] when fewer than four samples are available.
+ *
+ * Output omits crossings with no history; consumers fall back to the
+ * editorial defaults in `data/borderCrossings.ts`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+const HISTORY_DIR = path.join(REPO_ROOT, 'data', 'border-wait-history');
+const OUTPUT_PATH = path.join(REPO_ROOT, 'data', 'border-wait-averages.json');
+const ROLLING_DAYS = 30;
+const MORNING_HOURS = [6, 7, 8, 9];
+const EVENING_HOURS = [16, 17, 18, 19];
+
+function pickRecentFiles() {
+  if (!fs.existsSync(HISTORY_DIR)) return [];
+  const cutoff = Date.now() - ROLLING_DAYS * 24 * 60 * 60 * 1000;
+  return fs
+    .readdirSync(HISTORY_DIR)
+    .filter((f) => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
+    .filter((f) => {
+      const day = f.slice(0, 10);
+      const t = new Date(day).getTime();
+      return Number.isFinite(t) && t >= cutoff;
+    })
+    .sort();
+}
+
+function percentile(sortedAsc, p) {
+  if (sortedAsc.length === 0) return null;
+  if (sortedAsc.length === 1) return sortedAsc[0];
+  const idx = Math.min(sortedAsc.length - 1, Math.max(0, Math.round((p / 100) * (sortedAsc.length - 1))));
+  return sortedAsc[idx];
+}
+
+function rangeFor(samples) {
+  if (samples.length === 0) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  if (sorted.length < 4) {
+    return { low: sorted[0], high: sorted[sorted.length - 1] };
+  }
+  return { low: percentile(sorted, 25), high: percentile(sorted, 75) };
+}
+
+function formatRange(range) {
+  if (!range) return null;
+  const low = Math.max(0, Math.round(range.low));
+  const high = Math.max(low, Math.round(range.high));
+  // Drop degenerate ranges — editorial fallback in `data/borderCrossings.ts`
+  // is more useful than "0 min" / "0-1 min" placeholders for low-traffic
+  // crossings or crossings without enough history yet to characterise the
+  // commuter peak.
+  if (high < 2) return null;
+  if (low === high) return `${low} min`;
+  return `${low}-${high} min`;
+}
+
+function main() {
+  const files = pickRecentFiles();
+  if (files.length === 0) {
+    console.warn(`[averages] no history files in ${HISTORY_DIR} — writing empty averages`);
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify({}, null, 2) + '\n', 'utf-8');
+    return;
+  }
+
+  /** @type {Record<string, { morning: number[]; evening: number[] }>} */
+  const acc = {};
+  for (const f of files) {
+    const raw = fs.readFileSync(path.join(HISTORY_DIR, f), 'utf-8');
+    let doc;
+    try {
+      doc = JSON.parse(raw);
+    } catch (err) {
+      console.warn(`[averages] skip ${f}: ${err.message}`);
+      continue;
+    }
+    const per = doc.perCrossing || {};
+    for (const [slug, hours] of Object.entries(per)) {
+      if (!Array.isArray(hours) || hours.length !== 24) continue;
+      const bucket = acc[slug] || { morning: [], evening: [] };
+      for (const h of MORNING_HOURS) {
+        const cell = hours[h];
+        if (cell && typeof cell.avg === 'number') bucket.morning.push(cell.avg);
+      }
+      for (const h of EVENING_HOURS) {
+        const cell = hours[h];
+        if (cell && typeof cell.avg === 'number') bucket.evening.push(cell.avg);
+      }
+      acc[slug] = bucket;
+    }
+  }
+
+  /** @type {Record<string, { morning: string; evening: string }>} */
+  const out = {};
+  for (const [slug, { morning, evening }] of Object.entries(acc)) {
+    const m = formatRange(rangeFor(morning));
+    const e = formatRange(rangeFor(evening));
+    if (m === null && e === null) continue;
+    out[slug] = {
+      ...(m !== null ? { morning: m } : {}),
+      ...(e !== null ? { evening: e } : {}),
+    };
+  }
+
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  console.log(`✅ Wrote ${OUTPUT_PATH} (${Object.keys(out).length} crossings)`);
+}
+
+main();

--- a/scripts/snapshot-border-wait-history.mjs
+++ b/scripts/snapshot-border-wait-history.mjs
@@ -53,6 +53,11 @@ function toEpochMs(docId) {
 /**
  * Aggregate a list of snapshots for a single crossing into 24 hour buckets.
  * Each bucket: { min, avg, max, samples }.
+ *
+ * Buckets capture `totalCrossingMinutes` (approach delay + checkpoint queue)
+ * with `waitTimeMinutes` as legacy fallback for snapshots that predate the
+ * `totalCrossingMinutes` field. Keeps hourly charts, weekly heatmap, archive
+ * stats and computed averages on the same metric as the live "Ora" card.
  */
 function aggregateByHour(snapshots) {
   /** @type {Array<number[]>} */
@@ -62,8 +67,14 @@ function aggregateByHour(snapshots) {
       ? s.hour
       : new Date(s._epochMs).getUTCHours();
     if (hour < 0 || hour > 23) continue;
-    if (typeof s.waitTimeMinutes !== 'number') continue;
-    hours[hour].push(s.waitTimeMinutes);
+    const minutes =
+      typeof s.totalCrossingMinutes === 'number'
+        ? s.totalCrossingMinutes
+        : typeof s.waitTimeMinutes === 'number'
+          ? s.waitTimeMinutes
+          : null;
+    if (minutes === null) continue;
+    hours[hour].push(minutes);
   }
   return hours.map((samples) => {
     if (samples.length === 0) return null;

--- a/tests/compute-border-wait-averages.test.ts
+++ b/tests/compute-border-wait-averages.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Verifies the per-crossing rolling-30-day averages script
+ * (`scripts/compute-border-wait-averages.mjs`).
+ *
+ * The script reads `data/border-wait-history/*.json` and emits
+ * `data/border-wait-averages.json`. We exercise the formatting + the
+ * degenerate-range filter through a temp repo root and a minimal fixture.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'compute-border-wait-averages.mjs');
+
+function nDaysAgo(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+function bucket(avg: number) {
+  return { min: avg, avg, max: avg, samples: 1 };
+}
+
+describe('compute-border-wait-averages', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bw-averages-'));
+    fs.mkdirSync(path.join(tmp, 'data', 'border-wait-history'), { recursive: true });
+    fs.mkdirSync(path.join(tmp, 'scripts'), { recursive: true });
+    // The script resolves repo root via `__dirname/..`, so when copied into
+    // `<tmp>/scripts/` it will treat `<tmp>` as the repo root.
+    fs.copyFileSync(SCRIPT, path.join(tmp, 'scripts', 'compute-border-wait-averages.mjs'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('writes morning/evening ranges per crossing and drops degenerate values', () => {
+    const day = nDaysAgo(1);
+    const hours: Array<{ min: number; avg: number; max: number; samples: number } | null> =
+      Array(24).fill(null);
+    // Morning peak (06-09): avg 5..8 → range "5-8 min"
+    [5, 6, 7, 8].forEach((v, i) => (hours[6 + i] = bucket(v)));
+    // Evening peak (16-19): avg 12..18 → range "12-18 min"
+    [12, 14, 16, 18].forEach((v, i) => (hours[16 + i] = bucket(v)));
+
+    const degenerateHours: Array<{ min: number; avg: number; max: number; samples: number } | null> =
+      Array(24).fill(null);
+    [0, 0, 1, 1].forEach((v, i) => (degenerateHours[6 + i] = bucket(v)));
+    [0, 1, 0, 1].forEach((v, i) => (degenerateHours[16 + i] = bucket(v)));
+
+    fs.writeFileSync(
+      path.join(tmp, 'data', 'border-wait-history', `${day}.json`),
+      JSON.stringify({
+        date: day,
+        perCrossing: {
+          'chiasso-strada': hours,
+          'biegno-indemini': degenerateHours,
+        },
+      }),
+    );
+
+    execFileSync('node', [path.join(tmp, 'scripts', 'compute-border-wait-averages.mjs')]);
+
+    const out = JSON.parse(
+      fs.readFileSync(path.join(tmp, 'data', 'border-wait-averages.json'), 'utf-8'),
+    );
+
+    expect(out['chiasso-strada']).toBeDefined();
+    expect(out['chiasso-strada'].morning).toMatch(/\b\d+-\d+ min\b/);
+    expect(out['chiasso-strada'].evening).toMatch(/\b\d+-\d+ min\b/);
+
+    // Degenerate (high < 2) → filtered out, editorial fallback wins.
+    expect(out['biegno-indemini']).toBeUndefined();
+  });
+
+  it('returns an empty object when no history files are present', () => {
+    execFileSync('node', [path.join(tmp, 'scripts', 'compute-border-wait-averages.mjs')]);
+    const out = JSON.parse(
+      fs.readFileSync(path.join(tmp, 'data', 'border-wait-averages.json'), 'utf-8'),
+    );
+    expect(out).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
Brings the whole border-wait surface onto the same metric the live "Ora" card uses (`totalCrossingMinutes` = approach delay + checkpoint queue). Eliminates the visual clash users saw between the live value and the editorial morning/evening averages on `/vivere-in-ticino/comuni-di-frontiera/` and the leaf hourly chart.

## Changes
- `scripts/snapshot-border-wait-history.mjs`: hourly bucket aggregator reads `totalCrossingMinutes` (legacy `waitTimeMinutes` fallback). Hourly charts, weekly heatmap and archive stats follow automatically.
- `scripts/compute-border-wait-averages.mjs` (new): rolling 30d morning (06-09) / evening (16-19) P25-P75 range per crossing → `data/border-wait-averages.json`. Degenerate ranges (`high < 2`) drop so the editorial fallback wins for low-traffic crossings.
- `data/borderCrossings.ts`: module-load overlay merges computed averages over editorial defaults per slug.
- `.github/workflows/traffic-scheduler.yml`: runs the compute step after every snapshot and stages the new JSON.
- `.github/workflows/deploy.yml`: adds `data/border-wait-averages.json` to `paths-ignore` so the 15-min cadence does not trigger deploy storms.

## Transition note
Existing history files contain queue-only buckets for ~30d. Computed averages start as queue-derived; as the snapshot script writes total buckets going forward, the rolling window naturally migrates to total ranges.

## Test plan
- [x] `npx vitest run tests/border-wait-pages.test.ts tests/border-wait-hydration.test.ts tests/snapshot-border-wait-helper.test.ts tests/border-wait-snapshot-script.test.ts tests/border-wait-webcam.test.ts tests/border-wait-og-webcam.test.ts tests/compute-border-wait-averages.test.ts tests/regression/border-wait-hub-links.test.tsx` — 120 passed
- [ ] Post-merge: confirm `traffic-scheduler.yml` writes `data/border-wait-averages.json` and overlay applies on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)