### PR TITLE
fix(crawlers): pin registry slug + lock AI re-translation on stable titles

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -4811,6 +4811,32 @@ export function mergePreserveLocaleData(existingJobs, freshJobs, opts = {}) {
       fresh.needsRetranslation = true;
     }
 
+    // Translation stability lock (Fix 2): when the source-locale title is
+    // bytewise unchanged from the previous crawl AND the previous record has
+    // full locale coverage for titles/descriptions/slugs, clear
+    // `needsRetranslation`. Many dedicated parsers (KSBL, etc.) set
+    // `needsRetranslation: true` unconditionally on every fetch, which forces
+    // the AI pipeline to re-translate the same source title and produce
+    // non-deterministic IT/EN/FR variants on each run. That title churn
+    // cascades into slugByLocale changes — captureLostSlugs then demotes the
+    // original (already-indexed) slug to previousSlugs and emits a SEO bridge
+    // page at the indexed URL pointing canonical at a fresh slug, splitting
+    // SEO equity and confusing users (the address bar shows the old URL but
+    // the page renders the new title).
+    if (fresh.needsRetranslation && srcLang) {
+      const oldSrcTitle = normalizeSpace(String(old?.titleByLocale?.[srcLang] || old?.title || ''));
+      const newSrcTitle = normalizeSpace(String(fresh?.titleByLocale?.[srcLang] || fresh?.title || ''));
+      const sourceTitleStable = oldSrcTitle.length >= 3 && oldSrcTitle === newSrcTitle;
+      if (sourceTitleStable) {
+        const titleCoverageOk = localeTextCoverage(old?.titleByLocale || {}, 3) >= LOCALES.length;
+        const slugCoverageOk = localeTextCoverage(old?.slugByLocale || {}, 3) >= LOCALES.length;
+        const descCoverageOk = localeTextCoverage(old?.descriptionByLocale || {}, 120) >= LOCALES.length;
+        if (titleCoverageOk && slugCoverageOk && descCoverageOk) {
+          fresh.needsRetranslation = false;
+        }
+      }
+    }
+
     // Preserve sourceLang from existing
     if (old.sourceLang && !fresh.sourceLang) {
       fresh.sourceLang = old.sourceLang;
@@ -5453,17 +5479,53 @@ export function mergeAndDeduplicate(existingJobs, incomingJobs, qualityCfg, opti
   const slugRegistry = loadSlugRegistry();
   let registryHits = 0;
   let registryNewEntries = 0;
+  let registryDemotions = 0;
   const usedSlugs = new Set();
   for (const job of deduped) {
     const registered = getRegisteredSlug(job, slugRegistry);
     if (registered && registered.canonicalSlug) {
-      job.slug = registered.canonicalSlug;
+      // Registry is the immutable canonical slug. When the current job carries
+      // a diverging slug (typically because AI re-translated the source title
+      // into a different IT/EN/FR form and isSlugStable demoted the original),
+      // demote the diverging form into previousSlugsByLocale[locale] and
+      // restore the registry-pinned slug. Without this destructive override,
+      // bridge pages would be emitted at the registry URL while the listing
+      // page resolves to the AI-derived slug — splitting SEO equity.
+      //
+      // BUT: skip enforcing a per-locale registry value when it is bytewise
+      // identical to the source-locale registry slug. Early KSBL entries were
+      // registered before the AI localization step finished, so every locale
+      // slot was a copy of the source-locale slug. Pinning those copies would
+      // revert real translations (e.g. AI-derived IT slug) back to the source
+      // (DE) slug — worse than the drift we're fixing.
+      const srcLang = job.sourceLang || null;
+      const regSrcSlug = srcLang && registered.slugByLocale
+        ? normalizeSpace(String(registered.slugByLocale[srcLang] || ''))
+        : '';
+      const prevSlugByLocale = job.slugByLocale ? { ...job.slugByLocale } : {};
+      const prevSlug = job.slug || '';
+      if (!job.slugByLocale || typeof job.slugByLocale !== 'object') job.slugByLocale = {};
       if (registered.slugByLocale && typeof registered.slugByLocale === 'object') {
-        if (!job.slugByLocale || typeof job.slugByLocale !== 'object') job.slugByLocale = {};
         for (const [loc, s] of Object.entries(registered.slugByLocale)) {
-          if (s && !job.slugByLocale[loc]) job.slugByLocale[loc] = s;
+          const norm = normalizeSpace(String(s || ''));
+          if (!norm) continue;
+          // Non-source-locale entry that just copies the source slug = no real
+          // translation was registered. Keep whatever the current crawl has.
+          if (srcLang && loc !== srcLang && regSrcSlug && norm === regSrcSlug) continue;
+          job.slugByLocale[loc] = norm;
         }
       }
+      // Master slug is used by the IT path on canton sections. Only enforce
+      // when registry value looks like a real IT slug (registered IT slug
+      // differs from source-locale slug or no source-locale slug is recorded).
+      const enforceMaster = !srcLang
+        || !regSrcSlug
+        || normalizeSpace(String(registered.canonicalSlug)) !== regSrcSlug;
+      if (enforceMaster) {
+        job.slug = registered.canonicalSlug;
+      }
+      const lost = captureLostSlugs(job, prevSlugByLocale, prevSlug);
+      if (lost.length > 0) registryDemotions += lost.length;
       usedSlugs.add(job.slug);
       registryHits += 1;
       continue;
@@ -5483,8 +5545,8 @@ export function mergeAndDeduplicate(existingJobs, incomingJobs, qualityCfg, opti
     if (Object.keys(slugRegistry).length > sizeBefore) registryNewEntries += 1;
   }
   saveSlugRegistry(slugRegistry);
-  if (registryHits > 0 || registryNewEntries > 0) {
-    console.log(`🔒 Slug registry: ${registryHits} locked from registry, ${registryNewEntries} new entries added (${Object.keys(slugRegistry).length} total)`);
+  if (registryHits > 0 || registryNewEntries > 0 || registryDemotions > 0) {
+    console.log(`🔒 Slug registry: ${registryHits} locked from registry (${registryDemotions} drift slugs demoted to previousSlugs), ${registryNewEntries} new entries added (${Object.keys(slugRegistry).length} total)`);
   }
 
   return {

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -5109,6 +5109,14 @@ async function main() {
       }
       const enrichedMap = new Map();
       if (selectedQueue.length > 0) {
+        // Load registry once for post-AI pinning enforcement: mergeAndDeduplicate
+        // pinned slugs from the immutable registry, but enrichJobLocalesWithRetry
+        // can re-derive slugByLocale from a freshly AI-translated title. Without
+        // re-pinning here the AI's slug wins and the SEO bridge / canonical
+        // mismatch returns (old URL serves a page whose H1+canonical point at
+        // the new slug). Demote any AI-derived drift to previousSlugsByLocale so
+        // legacy URLs keep resolving via the slug-map.
+        const postAiRegistry = loadSlugRegistry();
         const localizedEntries = await runWithConcurrency(
           selectedQueue.map((job, index) => ({ job, index })),
           async ({ job, index }) => {
@@ -5125,6 +5133,36 @@ async function main() {
             const enriched = await enrichJobLocalesWithRetry(job, crawlerConfig);
             if (enriched && (enriched.slug !== _preAiSlug || _slugByLocaleDiffer(enriched.slugByLocale, _preAiSlugByLocale))) {
               captureLostSlugs(enriched, _preAiSlugByLocale, _preAiSlug);
+            }
+            // Re-pin registry over any AI-derived slug drift (Fix 1B). Mirrors
+            // the source-copy guard in mergeAndDeduplicate: skip per-locale
+            // entries whose registry value is just a copy of the source-locale
+            // slug (no real translation was registered) so AI's new
+            // translation isn't reverted to the source slug.
+            if (enriched) {
+              const pin = getRegisteredSlug(enriched, postAiRegistry);
+              if (pin && pin.canonicalSlug) {
+                const aiSlugByLocale = enriched.slugByLocale ? { ...enriched.slugByLocale } : {};
+                const aiSlug = enriched.slug || '';
+                const srcLang = enriched.sourceLang || null;
+                const regSrc = srcLang && pin.slugByLocale ? String(pin.slugByLocale[srcLang] || '').trim() : '';
+                if (!enriched.slugByLocale || typeof enriched.slugByLocale !== 'object') {
+                  enriched.slugByLocale = {};
+                }
+                if (pin.slugByLocale && typeof pin.slugByLocale === 'object') {
+                  for (const [loc, s] of Object.entries(pin.slugByLocale)) {
+                    const norm = String(s || '').trim();
+                    if (!norm) continue;
+                    if (srcLang && loc !== srcLang && regSrc && norm === regSrc) continue;
+                    enriched.slugByLocale[loc] = norm;
+                  }
+                }
+                const enforceMaster = !srcLang
+                  || !regSrc
+                  || String(pin.canonicalSlug).trim() !== regSrc;
+                if (enforceMaster) enriched.slug = pin.canonicalSlug;
+                captureLostSlugs(enriched, aiSlugByLocale, aiSlug);
+              }
             }
             return { fp: fingerprintJob(job), enriched };
           },


### PR DESCRIPTION
## Summary

Two coordinated fixes to stop the slug-drift bridge-page incident that surfaced on KSBL (`ostetrica-di-sala-parto-...` → `clinica-femminile-...`):

- **Registry pinning is now destructive**: `mergeAndDeduplicate` overwrites `slugByLocale[locale]` and the master slug with the immutable registry values, demoting any diverging current slug into `previousSlugsByLocale[locale]` via `captureLostSlugs`. The same enforcement is re-applied in the AI loop in `shared-jobs-crawler.mjs` so post-AI slug drift cannot leak through. A guard skips locale slots whose registry value is just a copy of the source-locale slug (early entries with no real translation registered).
- **Translation stability lock**: `mergePreserveLocaleData` clears `needsRetranslation` when the source-locale title is bytewise unchanged from the prior crawl and the prior record already has full locale coverage (titles, descriptions, slugs ≥ 3/120 chars across IT/EN/DE/FR). This neutralises parsers (KSBL etc.) that hard-code `needsRetranslation: true` and otherwise trigger non-deterministic AI re-translation churn each run.

## Why

`f49fc1a7-...` was first registered with IT slug `ostetrica-di-sala-parto-...`; a later AI re-translation of the same German title produced `Clinica femminile (a)`, isSlugStable marked it non-stable, the new slug became canonical and the original was demoted to `previousSlugs`. The site emitted a bridge page at the indexed URL with `<link rel=canonical>` pointing at the new slug, so the address bar stays on the old URL but the H1/title render the new job. Twelve other KSBL jobs show the same drift pattern.

## Test plan

- [ ] CI: existing crawler-template + dedup tests pass (no behavioural change on first registration).
- [ ] Live: next KSBL run logs `🔒 Slug registry: N locked from registry (M drift slugs demoted to previousSlugs)` with M > 0 for the 13 drifted entries.
- [ ] Live: re-crawl of unchanged KSBL job no longer triggers AI localization (queue size drops).
- [ ] Spot-check `https://frontaliereticino.ch/cerca-lavoro-basilea/ostetrica-di-sala-parto-a-kantonsspital-baselland-ksbl-liestal/` after next deploy: canonical points back at `ostetrica-di-sala-parto-...` and the H1 reads "Ostetrica di sala parto".

🤖 Generated with [Claude Code](https://claude.com/claude-code)