### PR TITLE
feat(clusters): canton-aware related-search URLs + cross-canton SPA fallback

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -65,6 +65,11 @@ import {
   getJobBoardSectionSlug,
   getSearchSlugPrefix,
 } from '../services/relatedSearchClusters';
+import {
+  resolveCantonSection,
+  resolveJobCanton,
+  type CantonLocale,
+} from './shared/cantonSection';
 import type { Locale } from '../services/i18n';
 import {
   COPY,
@@ -492,6 +497,16 @@ interface ClusterContext {
   city: string | null;
   matchingJobs: RawJob[];
   topCompanies: string[];
+  /**
+   * URL canton group key derived from the cluster's top-ranked matching job
+   * (`resolveJobCanton(matchingJobs[0])` → e.g. 'TI', 'BASILEA', 'ZH').
+   * Drives `buildClusterPath` so a Liestal-only cluster lands at
+   * `/cerca-lavoro-basilea/ricerca-{slug}/` instead of the legacy TI hardcode
+   * that produced empty SERPs after the SPA's canton filter ran.
+   *
+   * Falls back to `'TI'` when no jobs match (MIN_MATCHING_JOBS=0 allows it).
+   */
+  cantonGroup: string;
 }
 
 // ── Inverted index for token → posting list of jobIdx ────────────────────
@@ -777,7 +792,17 @@ function buildClusterContext(
     .slice(0, 3)
     .map(([name]) => name);
 
-  return { candidate, keyword: keyword.trim(), city, matchingJobs: matching, topCompanies };
+  // Pin the cluster page to its source canton's URL section. Without this
+  // every cluster lands at `/cerca-lavoro-ticino/ricerca-{slug}/` regardless
+  // of where the matching jobs live. The SPA then applies a TI canton filter
+  // and the BL/ZH/etc jobs disappear → 0-result SERP. `matchingJobs[0]` is
+  // the highest-ranked match (corpus-order AND-match, then OR), so it best
+  // represents the cluster's locality intent. `resolveJobCanton` collapses
+  // half-cantons (AI/AR→APPENZELLO, BL/BS→BASILEA) and falls back to the
+  // BFS city map when job.canton is missing.
+  const cantonGroup = matching.length > 0 ? resolveJobCanton(matching[0]) : 'TI';
+
+  return { candidate, keyword: keyword.trim(), city, matchingJobs: matching, topCompanies, cantonGroup };
 }
 
 // ── Page emission ───────────────────────────────────────────────────────
@@ -797,14 +822,28 @@ interface PageOutput {
   loc: string;
 }
 
-/** Build the canonical URL path for a cluster page. */
-function buildClusterPath(locale: Locale, slug: string): string {
+/**
+ * Build the canonical URL path for a cluster page.
+ *
+ * `cantonGroup` defaults to `'TI'` (legacy hardcode) to keep call sites that
+ * don't yet thread the cluster's home canton working unchanged. Real callers
+ * pass `ctx.cantonGroup` so clusters whose top match is in BL/ZH/etc emit
+ * under `/cerca-lavoro-basilea/`, `/cerca-lavoro-zurigo/`, ...
+ */
+function buildClusterPath(locale: Locale, slug: string, cantonGroup: string = 'TI'): string {
   const prefix = LOCALE_PREFIX[locale];
-  const section = getJobBoardSectionSlug(locale);
+  const section = resolveCantonSection(locale as CantonLocale, cantonGroup);
   return `${prefix}/${section}/${slug}/`.replace(/\/+/g, '/');
 }
 
-/** Build the URL path for the per-locale hub. */
+/**
+ * Build the URL path for the per-locale hub.
+ *
+ * The hub aggregates every cluster across cantons, so it stays on the legacy
+ * TI section (the existing hub URL — clusters are linked into it from there).
+ * Re-routing the hub per-canton would shard the index across 22 URLs without
+ * a corresponding navigation entry — deferred.
+ */
 function buildHubPath(locale: Locale, page: number = 1): string {
   const prefix = LOCALE_PREFIX[locale];
   const section = getJobBoardSectionSlug(locale);
@@ -813,13 +852,26 @@ function buildHubPath(locale: Locale, page: number = 1): string {
   return page > 1 ? `${base}page-${page}/` : base;
 }
 
-/** Build a localized job-detail URL. */
+/**
+ * Build a localized job-detail URL.
+ *
+ * Each job's canonical detail page is emitted by jobsSeoPagesPlugin under the
+ * job's OWN canton (`/cerca-lavoro-zurigo/{slug}/` for a ZH job, etc — see
+ * `buildCantonAwareSection` there). Linking via the legacy TI section made
+ * every cross-canton card target an unroutable URL (router resolves to TI
+ * canton, slug not in TI shard → "Annuncio non trovato"). Per-job canton
+ * resolution mirrors the emit side.
+ */
 function jobLocalizedUrl(job: RawJob, locale: Locale): string {
   const prefix = LOCALE_PREFIX[locale];
-  const section = getJobBoardSectionSlug(locale);
+  const jobCantonGroup = resolveJobCanton(job);
+  const section = resolveCantonSection(locale as CantonLocale, jobCantonGroup);
   const slug = job.slugByLocale?.[locale] || job.slug || '';
-  if (!slug) return `${BASE_URL}${prefix}/${section}/`.replace(/\/+/g, '/');
-  return `${BASE_URL}${prefix}/${section}/${slug}/`.replace(/\/+/g, '/');
+  // Collapse only the path portion — a naive replace on the whole URL
+  // would turn `https://` into `https:/` (the original prior-to-call bug
+  // was masked because no caller exercised this helper).
+  const collapsedPath = `${prefix}/${section}/${slug ? `${slug}/` : ''}`.replace(/\/+/g, '/');
+  return `${BASE_URL}${collapsedPath}`;
 }
 
 /** Build the page headline. Keeps under 44 chars where possible. */
@@ -1112,7 +1164,7 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
   const copy = COPY[locale];
   const chrome = CHROME_COPY[locale];
 
-  const urlPath = buildClusterPath(locale, candidate.slug);
+  const urlPath = buildClusterPath(locale, candidate.slug, ctx.cantonGroup);
   const canonicalUrl = `${BASE_URL}${urlPath}`;
   const headline = buildHeadline(ctx.keyword, ctx.city);
   const description = buildDescription(ctx, locale);
@@ -1268,9 +1320,27 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
   // sub-nav strip we previously emitted as a static sibling is gone.
   // SEO content stays in DOM (Googlebot indexes it with the same weight
   // as standard `<details>` accordion content per Search Central docs).
+  // Crawler-indexable job list. Always emitted (off-screen, no visual impact)
+  // so the static HTML carries cross-canton job references even when the
+  // SPA's canton-scoped grid would render zero — mirrors the SPA's Tier 3
+  // cross-canton fallback at the build layer. Each link points to the job's
+  // OWN canton-aware detail URL (see `jobLocalizedUrl`) so we never link a
+  // BL job into a TI section path that the router can't resolve.
+  const jobLinksHtml = ctx.matchingJobs.length > 0
+    ? `<ul class="cluster-seo-jobs">${ctx.matchingJobs.map((job) => {
+        const jobTitle = String(job.titleByLocale?.[locale] ?? job.title ?? '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+        const company = String(job.company || '').trim();
+        const loc = String(job.location || '').trim();
+        const meta = [company, loc].filter(Boolean).join(' · ');
+        const href = jobLocalizedUrl(job, locale);
+        return `<li><a href="${esc(href)}">${esc(jobTitle)}${meta ? ` — ${esc(meta)}` : ''}</a></li>`;
+      }).join('')}</ul>`
+    : '';
+
   const srOnlyStyle = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0';
   const bodyHtml = `<div class="related-search-cluster" style="${srOnlyStyle}">
     <h1>${esc(headlineH1)}</h1>
+    ${jobLinksHtml}
     ${seoContextBlock}
   </div>`;
 
@@ -1890,7 +1960,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         const hreflang = altMap
           ? Array.from(altMap.entries()).map(([loc, otherCtx]) => ({
               locale: loc,
-              url: `${BASE_URL}${buildClusterPath(loc, otherCtx.candidate.slug)}`,
+              url: `${BASE_URL}${buildClusterPath(loc, otherCtx.candidate.slug, otherCtx.cantonGroup)}`,
             }))
           : [];
 
@@ -1901,7 +1971,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           .slice(0, 8)
           .map((other) => ({
             keyword: other.city ? `${capitalize(other.keyword)} — ${other.city}` : capitalize(other.keyword),
-            url: `${BASE_URL}${buildClusterPath(locale, other.candidate.slug)}`,
+            url: `${BASE_URL}${buildClusterPath(locale, other.candidate.slug, other.cantonGroup)}`,
           }));
 
         const enrichedKey = `${locale}::${ctx.candidate.slug}`;
@@ -1934,7 +2004,7 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       // ── Per-locale hub pages ──────────────────────────────────────────
       for (const [locale, list] of byLocale.entries()) {
         const items: HubItem[] = list.map((ctx) => {
-          const path = buildClusterPath(locale, ctx.candidate.slug);
+          const path = buildClusterPath(locale, ctx.candidate.slug, ctx.cantonGroup);
           return {
             keyword: ctx.keyword,
             city: ctx.city,

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -1639,6 +1639,15 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const killSwitches = useKillSwitches();
 
  const [jobs, setJobs] = useState<JobListing[]>([]);
+ // Cross-canton fallback pool: the locale-wide unscoped corpus loaded by
+ // `loadLegacyLocaleJobs` BEFORE `scopeJobsToCanton` narrows it. When a
+ // canton-scoped search yields zero strict+OR matches we re-run the OR-match
+ // against this pool (minus already-scoped IDs) so users on a cluster URL
+ // always see something — e.g. `/cerca-lavoro-basilea/ricerca-genitori-...`
+ // with no in-canton match surfaces matches from other cantons under a
+ // "no in-canton results" banner. Populated only via the legacy path; when
+ // shards land it'll need a separate aggregator fetch (deferred).
+ const [unscopedJobs, setUnscopedJobs] = useState<JobListing[]>([]);
  const [jobsLoading, setJobsLoading] = useState(true);
  const [enrichmentLoading, setEnrichmentLoading] = useState(false);
  // FRO-353: Feature flag for Job Alerts (controlled via Firebase Remote Config)
@@ -1924,12 +1933,19 @@ const JobBoard: React.FC<JobBoardProps> = ({
  }
  };
 
- const finalize = (raw: ReadonlyArray<JobListing>): void => {
+ const finalize = (raw: ReadonlyArray<JobListing>, unscopedRaw?: ReadonlyArray<JobListing>): void => {
  if (cancelled) return;
  const normalized = raw.map((job) => normalizeIncomingJob(job));
  const deduped = dedupeJobsForListing(normalized);
  setJobs(deduped);
  registerJobSlugMap(deduped);
+ // Capture the unscoped pool for cross-canton fallback when canton-scoped
+ // searches return zero. Same normalize+dedupe so cross-canton matches share
+ // the JobListing shape downstream consumers expect.
+ if (unscopedRaw && unscopedRaw.length > 0) {
+ const normalizedFull = unscopedRaw.map((job) => normalizeIncomingJob(job));
+ setUnscopedJobs(dedupeJobsForListing(normalizedFull));
+ }
  setJobsLoading(false);
  };
 
@@ -1955,7 +1971,16 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (shardJobs.length === 0) {
  const legacy = await loadLegacyLocaleJobs();
  const legacyArr = Array.isArray(legacy) ? legacy : [];
- finalize(scopeJobsToCanton(legacyArr, targetCanton));
+ // legacyArr is the unscoped locale-wide pool. Pass it as the second
+ // arg so the cross-canton fallback layer can search it when the
+ // canton-scoped result set is empty (see `filteredJobs` cross-canton
+ // tier). Only meaningful when targetCanton isn't the aggregator —
+ // for the aggregator the scope IS already everywhere.
+ const isAggregate = targetCanton === AGGREGATE_CANTON_CODE;
+ finalize(
+ scopeJobsToCanton(legacyArr, targetCanton),
+ isAggregate ? undefined : legacyArr,
+ );
  return;
  }
 
@@ -1967,7 +1992,11 @@ const JobBoard: React.FC<JobBoardProps> = ({
  try {
  const legacy = await loadLegacyLocaleJobs();
  const legacyArr = Array.isArray(legacy) ? legacy : [];
- finalize(scopeJobsToCanton(legacyArr, targetCanton));
+ const isAggregate = targetCanton === AGGREGATE_CANTON_CODE;
+ finalize(
+ scopeJobsToCanton(legacyArr, targetCanton),
+ isAggregate ? undefined : legacyArr,
+ );
  } catch (legacyErr: unknown) {
  console.warn('Legacy locale-jobs fallback also failed:', legacyErr);
  reportCaughtError(legacyErr, 'jobBoard.loadJobs.legacy');
@@ -2510,18 +2539,17 @@ const JobBoard: React.FC<JobBoardProps> = ({
  });
  }, [sortedJobs, selectedDateRange, deferredSearchQuery, indexedQueryMatch, passingNonSearchFilters]);
 
- // filteredJobs: strict-AND result, OR a partial-match fallback ranked by
- // how many tokens hit. Mirrors the build plugin's two-phase matching at
- // build/relatedSearchClustersPlugin.ts so users landing on a slug URL
- // see the SAME job set the static cluster page would show. Capped at
- // MAX_FALLBACK to keep the UI responsive even for high-frequency tokens.
+ // In-canton OR-fallback: partial token matches ranked by hit count, capped
+ // at MAX_FALLBACK_RESULTS. Mirrors the build plugin's two-phase matching at
+ // build/relatedSearchClustersPlugin.ts so users landing on a slug URL see
+ // the SAME job set the static cluster page would show.
  const MAX_FALLBACK_RESULTS = 30;
- const filteredJobs = useMemo(() => {
+ const orFallbackInCantonJobs = useMemo<JobListing[]>(() => {
  const query = deferredSearchQuery.trim();
- if (!query || strictFilteredJobs.length > 0) return strictFilteredJobs;
+ if (!query || strictFilteredJobs.length > 0) return [];
 
  const queryTokens = normalizeSearchText(query).split(' ').filter(Boolean).map(stemSearchToken);
- if (queryTokens.length < 2) return strictFilteredJobs; // single token: AND === OR, nothing to add
+ if (queryTokens.length < 2) return []; // single token: AND === OR, nothing to add
 
  const now = Date.now();
  const dateRangeMs: Record<DateRange, number> = {
@@ -2544,12 +2572,87 @@ const JobBoard: React.FC<JobBoardProps> = ({
  return scored.slice(0, MAX_FALLBACK_RESULTS).map((x) => x.job);
  }, [strictFilteredJobs, sortedJobs, deferredSearchQuery, searchIndex, selectedDateRange, passingNonSearchFilters]);
 
- // True when the result set is the OR-fallback (strict yielded zero but
- // we found partial matches). Used by the UI to render an explanatory
- // banner so users know why these jobs appear despite the query.
+ // Cross-canton OR-fallback (Tier 3): only fires when strict AND the in-
+ // canton OR-fallback both returned zero. Searches the unscoped locale-wide
+ // pool (jobs from BL, ZH, GE, … when the URL pinned us to TI/BS/etc) so
+ // pages like `/cerca-lavoro-basilea/ricerca-genitori-liestal/` always
+ // surface SOMETHING. Excludes IDs already in the canton-scoped pool so we
+ // never double-render a job that the in-canton tiers already discarded by
+ // date-range or non-search filter. Builds the haystack inline (no memoised
+ // index) because this path runs only when both prior tiers are empty —
+ // rare enough that an O(n) scan over ~13k jobs per relevant keystroke is
+ // acceptable, and skipping the index keeps memory flat in the common case.
+ const crossCantonFallbackJobs = useMemo<JobListing[]>(() => {
+ const query = deferredSearchQuery.trim();
+ if (!query) return [];
+ if (strictFilteredJobs.length > 0) return [];
+ if (orFallbackInCantonJobs.length > 0) return [];
+ if (unscopedJobs.length === 0) return [];
+
+ const queryTokens = normalizeSearchText(query).split(' ').filter(Boolean).map(stemSearchToken);
+ if (queryTokens.length === 0) return [];
+
+ const now = Date.now();
+ const dateRangeMs: Record<DateRange, number> = {
+ all: 0, '24h': 24 * 60 * 60 * 1000, '3d': 3 * 24 * 60 * 60 * 1000,
+ '7d': 7 * 24 * 60 * 60 * 1000, '30d': 30 * 24 * 60 * 60 * 1000, '90d': 90 * 24 * 60 * 60 * 1000,
+ };
+ const cutoff = selectedDateRange === 'all' ? 0 : now - dateRangeMs[selectedDateRange];
+
+ const scopedIds = new Set<string>();
+ for (const j of sortedJobs) scopedIds.add(j.id);
+
+ const scored: { job: JobListing; score: number }[] = [];
+ for (const job of unscopedJobs) {
+ if (scopedIds.has(job.id)) continue;
+ if (isForeignLocation(job.addressLocality || job.location || '')) continue;
+ if (!passingNonSearchFilters(job, now, cutoff)) continue;
+ const description = job.descriptionByLocale?.[locale] ?? job.description;
+ const localizedTitle = sanitizeJobTitle(job.titleByLocale?.[locale] ?? job.title);
+ const haystack = buildStemmedHaystack(
+ `${localizedTitle} ${job.company} ${job.location} ${job.contract} ${job.category} ${job.sector || ''} ${description || ''}`,
+ );
+ let score = 0;
+ for (const t of queryTokens) {
+ if (haystack.includes(` ${t} `)) score++;
+ }
+ if (score > 0) scored.push({ job, score });
+ }
+ scored.sort((a, b) => b.score - a.score);
+ return scored.slice(0, MAX_FALLBACK_RESULTS).map((x) => x.job);
+ }, [strictFilteredJobs.length, orFallbackInCantonJobs.length, sortedJobs, deferredSearchQuery, selectedDateRange, passingNonSearchFilters, unscopedJobs, locale]);
+
+ // filteredJobs: the three-tier search result.
+ //   1. strictFilteredJobs (AND across all tokens, in-canton)
+ //   2. orFallbackInCantonJobs (partial-token OR, in-canton)
+ //   3. crossCantonFallbackJobs (partial-token OR, other cantons)
+ // Each tier is consulted only when the previous one yielded zero, so the
+ // canton-scoped intent stays primary and cross-canton is purely a safety
+ // net for pages like `ricerca-genitori-liestal` whose query token has no
+ // in-canton support.
+ const filteredJobs = useMemo<JobListing[]>(() => {
+ if (strictFilteredJobs.length > 0) return strictFilteredJobs;
+ if (orFallbackInCantonJobs.length > 0) return orFallbackInCantonJobs;
+ return crossCantonFallbackJobs;
+ }, [strictFilteredJobs, orFallbackInCantonJobs, crossCantonFallbackJobs]);
+
+ // True when the result set is the in-canton OR-fallback (Tier 2). Keeps
+ // the existing "No exact match for «…»" banner triggered.
  const isUsingSearchFallback = useMemo(() => {
- return Boolean(deferredSearchQuery.trim()) && strictFilteredJobs.length === 0 && filteredJobs.length > 0;
- }, [deferredSearchQuery, strictFilteredJobs.length, filteredJobs.length]);
+ return Boolean(deferredSearchQuery.trim())
+ && strictFilteredJobs.length === 0
+ && orFallbackInCantonJobs.length > 0;
+ }, [deferredSearchQuery, strictFilteredJobs.length, orFallbackInCantonJobs.length]);
+
+ // True when the result set is the cross-canton fallback (Tier 3). Drives
+ // a distinct banner so users understand they're seeing jobs from outside
+ // the canton they navigated into.
+ const isCrossCantonFallback = useMemo(() => {
+ return Boolean(deferredSearchQuery.trim())
+ && strictFilteredJobs.length === 0
+ && orFallbackInCantonJobs.length === 0
+ && crossCantonFallbackJobs.length > 0;
+ }, [deferredSearchQuery, strictFilteredJobs.length, orFallbackInCantonJobs.length, crossCantonFallbackJobs.length]);
 
  // Resolve the display name of the company when a company slug filter is active
  const companyDisplayName = useMemo(() => {
@@ -6591,6 +6694,25 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </p>
  <p className="text-xs text-subtle mt-1">
  {t('jobBoard.searchFallback.hint')}
+ </p>
+ </div>
+ </div>
+ </div>
+ )}
+ {isCrossCantonFallback && (
+ <div
+ role="status"
+ aria-live="polite"
+ className="rounded-xl border border-info-border bg-info-subtle px-4 py-3 text-sm text-body"
+ >
+ <div className="flex items-start gap-2">
+ <Search className="w-4 h-4 mt-0.5 shrink-0 text-info-strong" />
+ <div>
+ <p className="font-semibold font-display text-strong">
+ {t('jobBoard.crossCantonFallback.title', { query: deferredSearchQuery.trim(), count: String(filteredJobs.length) })}
+ </p>
+ <p className="text-xs text-subtle mt-1">
+ {t('jobBoard.crossCantonFallback.hint')}
  </p>
  </div>
  </div>

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -708,6 +708,8 @@ const deCore: Record<string, string> = {
  'jobBoard.noResultsHint': 'Versuchen Sie, Ihre Suchfilter anzupassen.',
  'jobBoard.searchFallback.title': 'Keine exakten Treffer für «{query}»',
  'jobBoard.searchFallback.hint': 'Zeige verwandte Angebote basierend auf den Stichwörtern Ihrer Suche, sortiert nach Relevanz.',
+ 'jobBoard.crossCantonFallback.title': 'Keine Angebote im Kanton für «{query}» — {count} Treffer aus anderen Kantonen',
+ 'jobBoard.crossCantonFallback.hint': 'Für Grenzgänger aus Italien kann jeder Schweizer Kanton relevant sein: Wir zeigen die nächstgelegenen Treffer in der ganzen Schweiz.',
  'jobBoard.companyHeading': 'Unternehmen',
  'jobBoard.sourceLabel': 'Quelle',
  'jobBoard.snapshotTitle': 'Stellen-Snapshot',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -708,6 +708,8 @@ const enCore: Record<string, string> = {
  'jobBoard.noResultsHint': 'Try adjusting your search filters.',
  'jobBoard.searchFallback.title': 'No exact match for «{query}»',
  'jobBoard.searchFallback.hint': 'Showing related offerings based on the keywords from your search, ranked by relevance.',
+ 'jobBoard.crossCantonFallback.title': 'No in-canton offers for «{query}» — {count} matches from other cantons',
+ 'jobBoard.crossCantonFallback.hint': 'For Italian cross-border workers any Swiss canton can still be relevant: showing the closest matches anywhere in Switzerland.',
  'jobBoard.companyHeading': 'Company',
  'jobBoard.sourceLabel': 'Source',
  'jobBoard.snapshotTitle': 'Job snapshot',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -708,6 +708,8 @@ const frCore: Record<string, string> = {
  'jobBoard.noResultsHint': 'Essayez de modifier vos filtres de recherche.',
  'jobBoard.searchFallback.title': 'Aucun résultat exact pour «{query}»',
  'jobBoard.searchFallback.hint': 'Affichage d\'offres similaires basées sur les mots-clés de votre recherche, classées par pertinence.',
+ 'jobBoard.crossCantonFallback.title': 'Aucune offre dans le canton pour «{query}» — {count} résultats d\'autres cantons',
+ 'jobBoard.crossCantonFallback.hint': 'Pour les frontaliers italiens, n\'importe quel canton suisse peut être pertinent : nous montrons les correspondances les plus proches partout en Suisse.',
  'jobBoard.companyHeading': 'Entreprise',
  'jobBoard.sourceLabel': 'Source',
  'jobBoard.snapshotTitle': 'Aperçu de l’offre',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -745,6 +745,8 @@ const translations: Record<string, string> = {
  'jobBoard.noResultsHint': 'Prova a modificare i filtri di ricerca.',
  'jobBoard.searchFallback.title': 'Nessun risultato esatto per «{query}»',
  'jobBoard.searchFallback.hint': 'Mostriamo offerte affini in base alle parole chiave della tua ricerca, ordinate per pertinenza.',
+ 'jobBoard.crossCantonFallback.title': 'Nessuna offerta nel cantone per «{query}» — {count} risultati da altri cantoni',
+ 'jobBoard.crossCantonFallback.hint': 'Per i frontalieri italiani le offerte di confine sono comunque rilevanti: mostriamo i match più vicini ovunque siano in Svizzera.',
  'jobBoard.companyHeading': 'Azienda',
  'jobBoard.sourceLabel': 'Fonte',
  'jobBoard.snapshotTitle': 'Snapshot annuncio',

--- a/tests/related-search-clusters-shell.test.ts
+++ b/tests/related-search-clusters-shell.test.ts
@@ -23,6 +23,63 @@ afterEach(() => {
   for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
+describe('canton-aware cluster URL emission', () => {
+  it('pins a Liestal-only cluster under /cerca-lavoro-basilea/ via cantonGroup', () => {
+    const distDir = makeDist();
+    const page = renderClusterPage({
+      distDir,
+      dateStamp: '2026-05-26',
+      ctx: {
+        candidate: {
+          slug: 'ricerca-genitori-liestal',
+          locale: 'it',
+          jobCount: 1,
+          sampleTerms: ['genitori Liestal'],
+          editorialCollision: null,
+        },
+        keyword: 'genitori',
+        city: 'Liestal',
+        matchingJobs: [
+          { id: 'ksbl-x', title: 'Hebamme', company: 'Kantonsspital Baselland (KSBL)', location: 'Liestal', canton: 'BL', slug: 'hebamme-liestal' },
+        ],
+        topCompanies: ['Kantonsspital Baselland (KSBL)'],
+        cantonGroup: 'BASILEA',
+      } as any,
+      enriched: undefined,
+      hreflang: [],
+      related: [],
+    });
+
+    expect(page.urlPath).toBe('/cerca-lavoro-basilea/ricerca-genitori-liestal/');
+    expect(page.loc).toBe('https://frontaliereticino.ch/cerca-lavoro-basilea/ricerca-genitori-liestal/');
+    // The HTML minifier strips quotes from attributes whose value has no
+    // spaces, so `rel` becomes unquoted but `href` keeps its quotes.
+    expect(page.html).toMatch(/<link rel=canonical href="https:\/\/frontaliereticino\.ch\/cerca-lavoro-basilea\/ricerca-genitori-liestal\/"/);
+    // Job link uses the job's OWN canton-aware section (BL → basilea).
+    expect(page.html).toContain('href="https://frontaliereticino.ch/cerca-lavoro-basilea/hebamme-liestal/"');
+  });
+
+  it('falls back to TI when cantonGroup is omitted (backwards-compat)', () => {
+    const distDir = makeDist();
+    const page = renderClusterPage({
+      distDir,
+      dateStamp: '2026-05-26',
+      ctx: {
+        candidate: { slug: 'ricerca-test', locale: 'it', jobCount: 0, sampleTerms: ['test'], editorialCollision: null },
+        keyword: 'test',
+        city: null,
+        matchingJobs: [],
+        topCompanies: [],
+      } as any,
+      enriched: undefined,
+      hreflang: [],
+      related: [],
+    });
+
+    expect(page.urlPath).toBe('/cerca-lavoro-ticino/ricerca-test/');
+  });
+});
+
 describe('related search cluster SEO shell', () => {
   it('keeps the full SEO shell, indexation tags, SPA assets, and crawl links', () => {
     const distDir = makeDist();


### PR DESCRIPTION
## Summary

- Move related-search cluster pages from the hardcoded `cerca-lavoro-ticino` section to the URL section that matches their source job's canton (BL/BS → basilea, ZH → zurigo, …). Driven by `resolveJobCanton(matchingJobs[0])` + `resolveCantonSection` from `build-plugins/shared/cantonSection`.
- Add a Tier-3 cross-canton fallback in `JobBoard.tsx`: when both the in-canton strict-AND and the in-canton OR-fallback yield zero, search the unscoped locale-wide pool and surface the closest matches under a distinct banner. Localized strings for IT/EN/DE/FR added.
- Each job link in the static cluster body now points to the job's OWN canton-aware detail URL (no more cross-canton links into the TI section that the router can't resolve).
- Emit a sr-only `<ul>` of `matchingJobs` in the static body so crawlers see the same set the SPA renders post-hydration.

## Why

`/cerca-lavoro-ticino/ricerca-genitori-liestal/` returns 0 results in production: the cluster's only matching job is in canton BL (Kantonsspital Baselland, Liestal) but the URL pinned the SPA to a TI canton filter that excluded every Liestal job. The router and `scopeJobsToCanton` are both correct — the cluster was emitted at the wrong section. With this change the same cluster lands at `/cerca-lavoro-basilea/ricerca-genitori-liestal/`, the SPA loads BL+BS shards, and the Tier-2 OR-fallback returns 30 jobs. The Tier-3 cross-canton fallback covers the residual edge case (clusters with no in-canton match) so the user always sees something.

## Test plan

- [x] `npx vitest run tests/related-search-clusters.test.ts tests/related-search-clusters-shell.test.ts tests/jobboard-related-search-navigation.test.ts tests/multi-canton-seo.test.ts tests/router.test.ts tests/jobs-seo-pages-plugin.test.ts tests/job-board-stats.test.ts` (574 pass)
- [x] 2 new shell tests cover the canton-aware URL emission (`/cerca-lavoro-basilea/`) and the TI fallback for backwards-compat
- [x] TypeScript clean (only the pre-existing `data/jobs.json` missing-locally warnings)
- [ ] Post-merge: verify on production at `/cerca-lavoro-basilea/ricerca-genitori-liestal/` that the SPA shows results, and that the old TI URL falls through cleanly
- [ ] Post-merge: spot-check 3-5 other BL/ZH/GE clusters in the sitemap to confirm they emit under their home canton

🤖 Generated with [Claude Code](https://claude.com/claude-code)