### PR TITLE
test(employer-card): align canonical markers with .ec-* atoms

### DIFF
--- a/tests/build-plugins/employer-card-canonical-adoption.test.ts
+++ b/tests/build-plugins/employer-card-canonical-adoption.test.ts
@@ -5,15 +5,18 @@ import { describe, it, expect } from 'vitest';
  * costOfLiving) use the canonical `renderEmployerCardListHtml` renderer
  * (compact variant) instead of their old inline-style grid cells.
  *
- * Canonical markers emitted by renderEmployerCardListHtml:
- *   - <ul role="list"   — the list wrapper attribute
- *   - bg-surface-raised — Tailwind token on the logo slot
- *   - border-edge       — Tailwind token on the card border
+ * Canonical markers emitted by renderEmployerCardListHtml after the
+ * Tailwind→CSS-atom refactor (commit 5e715f73e6 — `bg-surface-raised` /
+ * `border-edge` were extracted out of the per-card markup into `.ec-cmpct`
+ * + `.ec-logoslot` atoms in `index.css`):
+ *   - `<ul role="list"` — the list wrapper attribute
+ *   - `.ec-cmpct`       — compact card atom (carries border-edge + bg-surface/50)
+ *   - `.ec-logoslot`    — logo slot atom (carries bg-surface-raised + border-edge)
  */
 const CANONICAL_EMPLOYER_MARKERS = [
   /<ul[^>]+role="list"/,
-  /bg-surface-raised/,
-  /border-edge/,
+  /class="ec-cmpct"/,
+  /class="ec-logoslot/,
 ];
 
 const FIXTURE_SNAPSHOT = {
@@ -78,7 +81,9 @@ describe('weeklyEmployersPlugin uses canonical employer cards (detailed)', () =>
       { employer: 'Lonza', employerKey: 'lonza', active: 35, delta: 3 },
       { employer: 'Migros', employerKey: 'migros', active: 18, delta: 0 },
     ]);
-    expect(html).toMatch(/<article class="rounded-xl border border-edge/);
+    // Detailed variant emits the `.ec-card` atom (carries rounded-xl +
+    // border + border-edge + bg-surface/50 via @apply in index.css).
+    expect(html).toMatch(/<article class="ec-card"/);
     expect(html).toContain('Lonza');
     expect(html).toContain('Migros');
     expect(html).toContain('text-success');  // Lonza has positive delta → success tone

--- a/tests/build-plugins/employer-card-html.test.ts
+++ b/tests/build-plugins/employer-card-html.test.ts
@@ -32,14 +32,19 @@ describe('renderEmployerCardHtml (compact)', () => {
     expect(html).not.toMatch(/>0</);
   });
 
-  it('uses bg-surface-raised + border-edge (Tailwind tokens, no inline hex)', () => {
+  it('emits the .ec-cmpct + .ec-logoslot atoms (Tailwind tokens applied via @apply in index.css, no inline hex)', () => {
     const html = renderEmployerCardHtml(employer, {
       href: '/x',
       locale: 'it',
       variant: 'compact',
     });
-    expect(html).toContain('bg-surface-raised');
-    expect(html).toContain('border-edge');
+    // Post 5e715f73e6 refactor: `bg-surface/50` + `border-edge` ship via
+    // `.ec-cmpct`, and `bg-surface-raised` + `border-edge` via `.ec-logoslot`
+    // (see `index.css` @layer components). The per-card HTML no longer
+    // inlines the Tailwind utility strings; verifying the atoms is the new
+    // contract.
+    expect(html).toMatch(/class="ec-cmpct"/);
+    expect(html).toMatch(/class="ec-logoslot/);
     expect(html).not.toMatch(/style="[^"]*background-color:\s*#/);
   });
 


### PR DESCRIPTION
## Summary

PR #5e715f73e6 (`perf(html): extract Tailwind utility strings in job/employer cards to CSS atoms`) replaced inline `rounded-xl border border-edge bg-surface-raised …` strings with `.ec-cmpct`, `.ec-card`, and `.ec-logoslot` atoms in `index.css` (via `@apply`). The Tailwind tokens still ship, just one level deeper in the CSS graph.

The associated tests in `tests/build-plugins/employer-card-{html,canonical-adoption}.test.ts` still asserted the literal `bg-surface-raised` / `border-edge` / `<article class=\"rounded-xl border border-edge` strings and stayed red — first surfaced on main after #607's deploy ran (prior runs were cancelled / failed on infra issues).

This PR updates the assertions to match the new atom contract.

## Test plan

- [x] `npx vitest run tests/build-plugins/employer-card-html.test.ts tests/build-plugins/employer-card-canonical-adoption.test.ts` (17 pass)
- [ ] Post-merge: verify the `tests` workflow goes green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)