### PR TITLE
test(job-card): align canonical markers with .jc-* atoms

### DIFF
--- a/tests/build-plugins/job-card-canonical-adoption.test.ts
+++ b/tests/build-plugins/job-card-canonical-adoption.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
+// Post 5e715f73e6 Tailwind→CSS-atom refactor: the literal utility strings
+// (`rounded-xl border p-3 sm:p-4`, `w-10 h-10 sm:w-14 sm:h-14 rounded-lg`)
+// moved into `.jc-card` + `.jc-logoslot` atoms in `index.css`. The atoms
+// `@apply` the same tokens so the rendered styling is unchanged; the
+// per-card HTML now only carries the atom class name.
 const CANONICAL_MARKERS = [
-  /<article class="rounded-xl border p-3 sm:p-4/,
-  /<div class="w-10 h-10 sm:w-14 sm:h-14 rounded-lg/,
+  /<article class="jc-card/,
+  /<div class="jc-logoslot/,
   /class="lucide lucide-map-pin/,
   /data-posted="/,
 ];

--- a/tests/build-plugins/jobCardHtml.test.ts
+++ b/tests/build-plugins/jobCardHtml.test.ts
@@ -100,13 +100,15 @@ describe('jobCardHtml — isJobNew', () => {
 });
 
 describe('jobCardHtml — renderJobCardHtml', () => {
-  it('renders an article with SPA Tailwind classes', () => {
+  it('renders an article with the .jc-card atom (Tailwind tokens applied via @apply in index.css)', () => {
     const html = renderJobCardHtml(baseJob, {
       href: '/cerca-lavoro-ticino/full-stack-net-sviluppatore-alten-switzerland-ticino/',
       locale: 'it',
     });
-    expect(html.startsWith('<article class="rounded-xl border p-3 sm:p-4')).toBe(true);
-    expect(html).toContain('border-edge bg-surface/50 hover:border-accent-border');
+    // Post 5e715f73e6 refactor: `rounded-xl border p-3 sm:p-4` +
+    // `border-edge bg-surface/50 hover:border-accent-border` ship via the
+    // `.jc-card` atom in `index.css` (@layer components).
+    expect(html.startsWith('<article class="jc-card')).toBe(true);
     expect(html).toContain('Full Stack .Net Sviluppatore');
     expect(html).toContain('ALTEN Switzerland');
     // Salary chip
@@ -126,7 +128,9 @@ describe('jobCardHtml — renderJobCardHtml', () => {
   it('renders the featured warning palette when job.featured is true', () => {
     const featured = { ...baseJob, featured: true };
     const html = renderJobCardHtml(featured, { href: '/x/', locale: 'it' });
-    expect(html).toContain('border-warning-border bg-warning-subtle hover:border-warning');
+    // Featured palette ships via the `.jc-card-fea` modifier atom (which
+    // `@apply`s `border-warning-border bg-warning-subtle hover:border-warning`).
+    expect(html).toContain('jc-card-fea');
     expect(html).toContain('lucide-star');
   });
 

--- a/tests/build-plugins/weeklyEmployersJobCardSpa.test.ts
+++ b/tests/build-plugins/weeklyEmployersJobCardSpa.test.ts
@@ -77,22 +77,30 @@ const fixture: CompanyCityPageInputs = {
 };
 
 describe('weeklyEmployersPlugin — SPA job-card migration', () => {
+  // Post 5e715f73e6: the SPA-canonical job-card signature moved from the
+  // inline `rounded-xl border p-3 sm:p-4 …` Tailwind string to the
+  // `.jc-card` atom in `index.css`. The rendered styling is identical via
+  // `@apply` — the assertion just tracks the new class name. Note: the
+  // weeklyEmployers shell goes through the HTML minifier which strips
+  // attribute quotes when the value has no spaces, so the rendered output
+  // is `<article class=jc-card>` — the regex tolerates either form.
+  const articleJcCardRe = /<article class=("?)jc-card\1/;
+  const articleJcCardReG = /<article class=("?)jc-card\1/g;
+
   it('emits the SPA-canonical job-card <article> for at least one open job', () => {
     const html = renderCompanyCityPage(fixture);
-    // The shared renderer's signature class block (must appear at least once
-    // for the per-employer open-jobs list).
-    expect(html).toContain('<article class="rounded-xl border p-3 sm:p-4');
+    expect(html).toMatch(articleJcCardRe);
   });
 
   it('renders one SPA card per active job', () => {
     const html = renderCompanyCityPage(fixture);
-    const matches = html.match(/<article class="rounded-xl border p-3 sm:p-4/g) || [];
+    const matches = html.match(articleJcCardReG) || [];
     expect(matches.length).toBeGreaterThanOrEqual(fixture.stats.activeJobs.length);
   });
 
   it('preserves the numbered <ol> ranking wrapper around the cards', () => {
     const html = renderCompanyCityPage(fixture);
-    expect(html).toMatch(/<ol[^>]*>[\s\S]*<article class="rounded-xl border p-3 sm:p-4/);
+    expect(html).toMatch(/<ol[^>]*>[\s\S]*<article class=("?)jc-card\1/);
   });
 
   it('keeps each job linked to its canonical detail path', () => {


### PR DESCRIPTION
## Summary

Mirror of #608 for the job-card surface. The Tailwind→CSS-atom refactor in #5e715f73e6 (`perf(html): extract Tailwind utility strings in job/employer cards to CSS atoms`) also replaced the literal `rounded-xl border p-3 sm:p-4 …`, `border-warning-border bg-warning-subtle hover:border-warning`, and `w-10 h-10 sm:w-14 sm:h-14 rounded-lg` strings with `.jc-card`, `.jc-card-fea`, and `.jc-logoslot` atoms in \`index.css\` (via \`@apply\`). The Tailwind tokens still ship — the atom names just hide them from the per-card HTML.

The matching tests (\`tests/build-plugins/job-card-canonical-adoption.test.ts\`, \`tests/build-plugins/jobCardHtml.test.ts\`, \`tests/build-plugins/weeklyEmployersJobCardSpa.test.ts\`) still asserted the old literal strings and stayed red on main — surfaced when #607's CI completed.

The weeklyEmployers shell goes through the HTML minifier (strips attribute quotes when the value has no spaces), so the regex now tolerates both \`class=jc-card\` and \`class=\"jc-card\"\` forms.

## Test plan

- [x] \`npx vitest run tests/build-plugins/job-card-canonical-adoption.test.ts tests/build-plugins/jobCardHtml.test.ts tests/build-plugins/weeklyEmployersJobCardSpa.test.ts\` (36 pass)
- [ ] Post-merge: verify the \`tests\` workflow goes green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)