### PR TITLE
fix(jobs-data): resolve sitemap canonical collision blocking deploy

### DIFF
--- a/data/jobs/by-crawler/axpo-group.json
+++ b/data/jobs/by-crawler/axpo-group.json
@@ -323,9 +323,9 @@
       "description": "## Deine Aufgaben:\n\n- Durchführung und Überprüfung von strukturmechanischen Berechnungen\n- Umsetzung von einschlägigen Normen und Regelwerken\n- Definition der Anforderungen für rechnerische und experimentelle Nachweise zb. Seismik etc.\n- Überprüfung entsprechender Komponenten hinsichtlich seismischer Qualifikation\n- Durchführung Rohr- und Flanschberechnungen auf Basis konventioneller und kerntechnischer Regelwerke (analytisch und mit gängiger Software, z.B. ANSYS, ROHR2, R-STAB etc.)\n\n## Dein Profil:\n\n- Hochschulabschluss (ETH oder Universität) in einem technischen oder mathematisch-naturwissenschaftlichen Fach\n- Vertiefte Kenntnisse der einschlägigen kerntechnischen Regelwerke und Normen (ASME, KTA)\n- Methodenkompetenz in der Durchführung und Berichterstattung von strukturmechanischen Berechnungen und Nachweisen\n- Kenntnisse der Auslegung kerntechnischer Anlagen\n- Idealerweise langjährige Erfahrung in der Kerntechnik\n- Deutsch, Englisch in Wort und Schrift",
       "titleByLocale": {
         "it": "Ingegnere di calcolo Meccanica strutturale (m/f/d)",
-        "en": "Projektmanager (m/w/d)",
+        "en": "Berechnungsingenieur Strukturmechanik (m/w/d)",
         "de": "Berechnungsingenieur Strukturmechanik (m/w/d)",
-        "fr": "Projektmanager (m/m/j)"
+        "fr": "Berechnungsingenieur Strukturmechanik (m/w/d)"
       },
       "descriptionByLocale": {
         "it": "I vostri compiti: - Attuazione e verifica dei calcoli meccanici strutturali - Attuazione delle norme e dei regolamenti pertinenti - Definizione dei requisiti per prove computazionali e sperimentali, ad esempio sismica ecc. - Controllo dei componenti appropriati per la qualificazione sismica - Calcoli di tubazioni e flange basati su sistemi di controllo convenzionali e nucleari (analiticamente e con software comune, ad esempio ANSYS, ROHR2, R-STAB ecc.) Il tuo profilo: - Laurea in scienze tecniche o matematiche (ETH o università) - Conoscenza approfondita delle normative e degli standard nucleari rilevanti (ASME, KTA) - Competenza metodologica nell'attuazione e nella segnalazione dei calcoli meccanici strutturali e delle prove - conoscenza della progettazione di impianti nucleari - Idealmente molti anni di esperienza nella tecnologia nucleare - tedesco, inglese in Word e scrittura",
@@ -335,9 +335,9 @@
       },
       "slugByLocale": {
         "it": "ingegnere-di-calcolo-meccanica-strutturale-m-f-d-kernkraftwerk-leibstadt-ag-leibstadt",
-        "en": "projektmanager-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
+        "en": "berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
         "de": "berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
-        "fr": "projektmanager-m-m-j-kernkraftwerk-leibstadt-ag-leibstadt"
+        "fr": "berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt"
       },
       "crawledAt": "2026-05-25T21:25:53.509Z",
       "id": "axpo-group-3b351c9ebffe",


### PR DESCRIPTION
## Summary
- Single offender in \`audit:sitemap-canonicals\` blocking deploys (runs 26461281005, 26461299986)
- Job \`axpo-group-3b351c9ebffe\` (Berechnungsingenieur Strukturmechanik) had stale AI-hallucinated EN/FR titles "Projektmanager (m/w/d)" / "Projektmanager (m/m/j)"
- Derived EN slug collided with sibling \`axpo-group-b16db3a9513c\`'s IT base slug (\`projektmanager-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt\`)
- Align EN/FR titles + slugs with German source (matches slug-registry pin) — no fake translation, no SEO content loss

## Test plan
- [ ] Merge → observe Deploy to GitHub Pages workflow
- [ ] \`audit:sitemap-canonicals\` passes (0 offenders)
- [ ] Live: /de/jobs-in-aargau/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt/ self-canonicalizes in EN/DE/FR/IT
- [ ] Live: /en/find-jobs-aargau/it-demand-manager-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt/ still serves Job B correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)