### PR TITLE
feat(assemble): per-locale slug collision guard against translator hallucination

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -153,6 +153,58 @@ function assemblerIdentity(job = {}) {
   // Delegate to the shared identity for non-URL fallbacks
   return buildStableJobIdentity(job);
 }
+
+/**
+ * Cross-job per-locale slug collision guard.
+ *
+ * The IT base slug (`job.slug`) is the natural owner of its (canton, slug)
+ * tuple across all locales. When another job's translated locale slug
+ * (`slugByLocale.en/de/fr`) coincides with someone else's IT base in the
+ * same canton, the translation is suspected hallucinated — drop the slug
+ * and the matching `titleByLocale` entry (so build's localizedSlug() falls
+ * back to job.slug) and set `needsRetranslation` so a future crawler run
+ * regenerates a fresh slug.
+ *
+ * Pure: mutates the passed jobs in-place AND returns a report. Exported so
+ * the gate has a unit-testable surface independent of the assembler IO.
+ *
+ * @param {Array<object>} jobs jobs already deduped by IT base slug
+ * @returns {{ count: number, details: string[] }}
+ */
+export function applyPerLocaleSlugCollisionGuard(jobs) {
+  const baseSlugOwners = new Map();
+  for (const job of jobs) {
+    const baseSlug = String(job?.slug || '').trim();
+    if (!baseSlug) continue;
+    const canton = String(job?.canton || 'TI').toUpperCase();
+    const key = `${canton}|${baseSlug}`;
+    if (!baseSlugOwners.has(key)) baseSlugOwners.set(key, assemblerIdentity(job));
+  }
+  let count = 0;
+  const details = [];
+  for (const job of jobs) {
+    if (!job?.slugByLocale || typeof job.slugByLocale !== 'object') continue;
+    const myId = assemblerIdentity(job);
+    const myBaseSlug = String(job.slug || '').trim();
+    const canton = String(job.canton || 'TI').toUpperCase();
+    for (const locale of ['en', 'de', 'fr']) {
+      const slug = String(job.slugByLocale[locale] || '').trim();
+      if (!slug || slug === myBaseSlug) continue;
+      const owner = baseSlugOwners.get(`${canton}|${slug}`);
+      if (!owner || owner === myId) continue;
+      delete job.slugByLocale[locale];
+      if (job.titleByLocale && typeof job.titleByLocale === 'object') {
+        delete job.titleByLocale[locale];
+      }
+      job.needsRetranslation = true;
+      count++;
+      if (details.length < 10) {
+        details.push(`${canton}/${locale}/${slug}: ${myId} → owned by ${owner}`);
+      }
+    }
+  }
+  return { count, details };
+}
 const ROOT = path.resolve(__dirname, '..');
 
 const JOBS_SLICES_DIR = path.join(ROOT, 'data', 'jobs', 'by-crawler');
@@ -863,6 +915,22 @@ async function assembleJobs() {
 
   if (slugDupeCount > 0) {
     console.log(`  🧹 Slug dedup: removed ${slugDupeCount} entries with duplicate slugs (${deduped.length} remaining)`);
+  }
+
+  // ── Per-locale slug collision guard (translator-hallucination defense) ─
+  // The dedup above protects only the master IT base slug (`job.slug`).
+  // It misses the case where one job's translated `slugByLocale[en|de|fr]`
+  // (derived from a hallucinated AI title) equals ANOTHER job's IT base slug.
+  // Example incident 2026-05-26: axpo-group-3b351c9ebffe's EN title was
+  // hallucinated as "Projektmanager (m/w/d)" → slug
+  // `projektmanager-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt` which
+  // exactly matched axpo-group-b16db3a9513c's IT base slug. Both jobs
+  // emit at /en/find-jobs-aargau/projektmanager-.../ and the resulting
+  // canonical drift failed `audit:sitemap-canonicals` and blocked deploy.
+  const collisionReport = applyPerLocaleSlugCollisionGuard(deduped);
+  if (collisionReport.count > 0) {
+    console.log(`  🧹 Per-locale slug collisions resolved: ${collisionReport.count} (translator hallucination guard)`);
+    for (const d of collisionReport.details) console.log(`     • ${d}`);
   }
 
   // ── Defensive location sanitization ─────────────────────────────────

--- a/tests/scripts/assemble-per-locale-slug-collision-guard.test.ts
+++ b/tests/scripts/assemble-per-locale-slug-collision-guard.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+/**
+ * Unit tests for the per-locale slug collision guard exported by
+ * scripts/assemble-jobs-dataset.mjs.
+ *
+ * Regression source: incident 2026-05-26 (PR #614). A hallucinated EN title
+ * for job axpo-group-3b351c9ebffe produced an EN slug that exactly matched
+ * sibling job axpo-group-b16db3a9513c's IT base slug, blew up
+ * audit:sitemap-canonicals, and blocked Deploy to GitHub Pages. The guard
+ * runs after the IT-base-slug dedup, detects cross-job locale-slug
+ * collisions, drops the offending translation, and flags
+ * needsRetranslation so the next crawler run regenerates a fresh slug.
+ */
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — assemble-jobs-dataset.mjs has no .d.ts companion
+import { applyPerLocaleSlugCollisionGuard } from '../../scripts/assemble-jobs-dataset.mjs';
+
+describe('applyPerLocaleSlugCollisionGuard', () => {
+  it('drops EN slug + title when it collides with another job IT base in same canton', () => {
+    const jobA = {
+      url: 'https://employer.example/jobs/a',
+      canton: 'AG',
+      slug: 'ingegnere-di-calcolo-meccanica-strutturale-m-f-d-acme-corp-leibstadt',
+      slugByLocale: {
+        it: 'ingegnere-di-calcolo-meccanica-strutturale-m-f-d-acme-corp-leibstadt',
+        en: 'projektmanager-m-w-d-acme-corp-leibstadt',
+        de: 'berechnungsingenieur-strukturmechanik-m-w-d-acme-corp-leibstadt',
+        fr: 'projektmanager-m-m-j-acme-corp-leibstadt',
+      },
+      titleByLocale: {
+        it: 'Ingegnere di calcolo',
+        en: 'Projektmanager (m/w/d)',
+        de: 'Berechnungsingenieur',
+        fr: 'Projektmanager (m/m/j)',
+      },
+    };
+    const jobB = {
+      url: 'https://employer.example/jobs/b',
+      canton: 'AG',
+      slug: 'projektmanager-m-w-d-acme-corp-leibstadt',
+      slugByLocale: {
+        it: 'projektmanager-m-w-d-acme-corp-leibstadt',
+        en: 'it-demand-manager-m-w-d-acme-corp-leibstadt',
+      },
+      titleByLocale: {
+        it: 'Projektmanager (m/w/d)',
+        en: 'IT Demand Manager',
+      },
+    };
+
+    const report = applyPerLocaleSlugCollisionGuard([jobA, jobB]);
+
+    expect(report.count).toBe(1);
+    expect(jobA.slugByLocale.en).toBeUndefined();
+    expect(jobA.titleByLocale.en).toBeUndefined();
+    expect(jobA.needsRetranslation).toBe(true);
+    // fr did NOT collide (no other job claims projektmanager-m-m-j-...): keep.
+    expect(jobA.slugByLocale.fr).toBe('projektmanager-m-m-j-acme-corp-leibstadt');
+    // de did NOT collide: keep.
+    expect(jobA.slugByLocale.de).toBe('berechnungsingenieur-strukturmechanik-m-w-d-acme-corp-leibstadt');
+    // Owner is untouched.
+    expect(jobB.slug).toBe('projektmanager-m-w-d-acme-corp-leibstadt');
+    expect(jobB.slugByLocale.en).toBe('it-demand-manager-m-w-d-acme-corp-leibstadt');
+    expect(jobB.needsRetranslation).toBeUndefined();
+  });
+
+  it('does NOT flag a self-match (locale slug equals job own IT base)', () => {
+    const job = {
+      url: 'https://employer.example/jobs/x',
+      canton: 'ZH',
+      slug: 'my-role-acme-corp-zurich',
+      slugByLocale: {
+        it: 'my-role-acme-corp-zurich',
+        en: 'my-role-acme-corp-zurich',
+      },
+      titleByLocale: { it: 'My role', en: 'My role' },
+    };
+    const report = applyPerLocaleSlugCollisionGuard([job]);
+    expect(report.count).toBe(0);
+    expect(job.slugByLocale.en).toBe('my-role-acme-corp-zurich');
+    expect(job.needsRetranslation).toBeUndefined();
+  });
+
+  it('ignores collisions across different cantons (per-canton scoping)', () => {
+    const jobAg = {
+      url: 'https://employer.example/jobs/a',
+      canton: 'AG',
+      slug: 'projektmanager-m-w-d-acme-corp-leibstadt',
+      slugByLocale: { it: 'projektmanager-m-w-d-acme-corp-leibstadt' },
+    };
+    const jobZh = {
+      url: 'https://employer.example/jobs/b',
+      canton: 'ZH',
+      slug: 'engineer-acme-corp-zurich',
+      slugByLocale: {
+        it: 'engineer-acme-corp-zurich',
+        en: 'projektmanager-m-w-d-acme-corp-leibstadt',
+      },
+      titleByLocale: { en: 'Projektmanager' },
+    };
+    const report = applyPerLocaleSlugCollisionGuard([jobAg, jobZh]);
+    // Different canton → not a collision; the AG natural owner doesn't reserve
+    // the slug in ZH.
+    expect(report.count).toBe(0);
+    expect(jobZh.slugByLocale.en).toBe('projektmanager-m-w-d-acme-corp-leibstadt');
+  });
+
+  it('returns count=0 and no mutations when inputs are clean', () => {
+    const jobs = [
+      { url: 'a', canton: 'TI', slug: 'a-slug', slugByLocale: { it: 'a-slug', en: 'a-slug-en' } },
+      { url: 'b', canton: 'TI', slug: 'b-slug', slugByLocale: { it: 'b-slug', en: 'b-slug-en' } },
+    ];
+    const before = JSON.stringify(jobs);
+    const report = applyPerLocaleSlugCollisionGuard(jobs);
+    expect(report.count).toBe(0);
+    expect(JSON.stringify(jobs)).toBe(before);
+  });
+
+  it('caps the details list at 10 to keep build logs short', () => {
+    const owner = {
+      url: 'owner', canton: 'AG', slug: 'shared-slug-acme-corp-aarau',
+      slugByLocale: { it: 'shared-slug-acme-corp-aarau' },
+    };
+    const claimants = Array.from({ length: 25 }, (_, i) => ({
+      url: `claimant-${i}`,
+      canton: 'AG',
+      slug: `unique-${i}-acme-corp-aarau`,
+      slugByLocale: {
+        it: `unique-${i}-acme-corp-aarau`,
+        en: 'shared-slug-acme-corp-aarau',
+      },
+      titleByLocale: { en: 'Hallucinated Title' },
+    }));
+    const report = applyPerLocaleSlugCollisionGuard([owner, ...claimants]);
+    expect(report.count).toBe(25);
+    expect(report.details).toHaveLength(10);
+    for (const c of claimants) {
+      expect(c.slugByLocale.en).toBeUndefined();
+      expect(c.needsRetranslation).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Follow-up to PR #614: catches the failure mode at the **source** instead of fixing data by hand.
- AI translator can hallucinate a job title in EN/DE/FR — when the resulting slug coincides with another job's IT base slug, both jobs emit at the same path and `audit:sitemap-canonicals` flags a mismatch, blocking deploy.
- New gate in \`assembleJobs()\` (after the existing IT-base slug dedup): for every job, scans \`slugByLocale.{en,de,fr}\` and drops any value that matches another job's \`job.slug\` in the same canton. The job's matching \`titleByLocale[locale]\` is also dropped and \`needsRetranslation = true\` is set so the next crawler run regenerates.
- Exported as pure \`applyPerLocaleSlugCollisionGuard(jobs)\` with 5 unit tests (collision, self-match, cross-canton, clean input, details cap).

## Test plan
- [x] \`npx vitest run tests/scripts/assemble-per-locale-slug-collision-guard.test.ts\` — 5/5 green
- [x] Sanity: assemble-jobs-cache, slug-history-journal, boilerplate-guard, clean-crawler-artifacts — 38/38 green
- [ ] Merge → observe Deploy to GitHub Pages workflow
- [ ] First assemble run on main: confirm log line \`🧹 Per-locale slug collisions resolved: N (translator hallucination guard)\` reports 0 (data already clean post-#614)

🤖 Generated with [Claude Code](https://claude.com/claude-code)