### PR TITLE
perf(related-search): parallel postings pre-pass + profiler instrumentation

### DIFF
--- a/build-plugins/canonicalFallbackWorker.mjs
+++ b/build-plugins/canonicalFallbackWorker.mjs
@@ -33,7 +33,13 @@ if (!parentPort) {
   throw new Error('[canonicalFallbackWorker] must be spawned via worker_threads');
 }
 
+// Worker wall breakdown so the coordinator can attribute the 147s pre-pass
+// across spawn-to-import / tsx-loader / pure-work. Boot starts the moment
+// the worker code begins executing — before the dynamic .ts import which
+// triggers the tsx loader (the heaviest single overhead, ~250-500 ms).
+const __tBoot = process.hrtime.bigint();
 const { canonicalizeFallbackCleaned } = await import('../services/jobs/canonicalFallback.ts');
+const __tImported = process.hrtime.bigint();
 
 const { tuples } = /** @type {{ tuples: Array<{ key: string, description: string, requirements: string[] }> }} */ (
   workerData
@@ -45,5 +51,9 @@ for (let i = 0; i < tuples.length; i++) {
   const t = tuples[i];
   out[i] = { key: t.key, cleaned: canonicalizeFallbackCleaned(t.description, t.requirements) };
 }
+const __tWorkEnd = process.hrtime.bigint();
 
-parentPort.postMessage({ entries: out });
+const importMs = Number(__tImported - __tBoot) / 1_000_000;
+const workMs = Number(__tWorkEnd - __tImported) / 1_000_000;
+
+parentPort.postMessage({ entries: out, profile: { importMs, workMs, count: tuples.length } });

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -2223,6 +2223,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const tStart = Date.now();
  // Phase 1: enumerate unique tuples (skip cache hits — usually none at
  // this point, but harmless to check).
+ const tStartEnum = Date.now();
  const seen = new Set<string>();
  const tuples: Array<{ key: string; description: string; requirements: string[] }> = [];
  for (const job of validJobs) {
@@ -2240,6 +2241,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  tuples.push({ key, description, requirements });
  }
  }
+ const enumMs = Date.now() - tStartEnum;
  if (tuples.length === 0) return;
 
  // Phase 2: decide on parallelism. Below 500 unique tuples the worker
@@ -2276,16 +2278,22 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // Phase 3: round-robin chunk + dispatch. Round-robin balances
  // description length (shorter descriptions = faster parse) across
  // workers — slicing would give one worker all the heavy ones.
+ const tStartChunk = Date.now();
  const chunks: Array<typeof tuples> = Array.from({ length: workerCount }, () => []);
  for (let i = 0; i < tuples.length; i++) {
  chunks[i % workerCount].push(tuples[i]);
  }
+ const chunkMs = Date.now() - tStartChunk;
+ const tStartDispatch = Date.now();
  const workerUrl = new URL('./canonicalFallbackWorker.mjs', import.meta.url);
+ type WorkerResult = {
+ entries: Array<{ key: string; cleaned: CleanedFallbackContent }>;
+ profile: { importMs: number; workMs: number; count: number };
+ };
  const results = await Promise.all(
  chunks.map(
  (assignedTuples) =>
- new Promise<{ entries: Array<{ key: string; cleaned: CleanedFallbackContent }> }>(
- (resolve, reject) => {
+ new Promise<WorkerResult>((resolve, reject) => {
  const worker = new Worker(workerUrl, {
  workerData: { tuples: assignedTuples },
  execArgv: ['--import', 'tsx'],
@@ -2295,22 +2303,28 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  worker.once('exit', (code) => {
  if (code !== 0) reject(new Error(`canonicalFallbackWorker exited with code ${code}`));
  });
- },
- ),
+ }),
  ),
  );
+ const dispatchMs = Date.now() - tStartDispatch;
 
  // Phase 4: merge — populate cache. The cache cap is intentionally
  // bypassed here: the pre-pass output is exactly what the main loop will
  // need, so evicting would just cause inline recomputation right after.
+ const tStartMerge = Date.now();
  for (const r of results) {
  for (const entry of r.entries) {
  canonicalCleanedCache.set(entry.key, entry.cleaned);
  }
  }
+ const mergeMs = Date.now() - tStartMerge;
+ const workerImportP99 = Math.max(...results.map((r) => r.profile.importMs));
+ const workerWorkP99 = Math.max(...results.map((r) => r.profile.workMs));
+ const workerWorkAvg = results.reduce((s, r) => s + r.profile.workMs, 0) / results.length;
+ const workerWorkMin = Math.min(...results.map((r) => r.profile.workMs));
  // eslint-disable-next-line no-console
  console.log(
- `[jobs-seo-profile] canonical-fallback-pre-pass tuples=${tuples.length} workers=${workerCount} wall_ms=${Date.now() - tStart}`,
+ `[jobs-seo-profile] canonical-fallback-pre-pass tuples=${tuples.length} workers=${workerCount} wall_ms=${Date.now() - tStart} enum_ms=${enumMs} chunk_ms=${chunkMs} dispatch_ms=${dispatchMs} merge_ms=${mergeMs} worker_import_p99_ms=${workerImportP99.toFixed(0)} worker_work_min_ms=${workerWorkMin.toFixed(0)} worker_work_avg_ms=${workerWorkAvg.toFixed(0)} worker_work_p99_ms=${workerWorkP99.toFixed(0)}`,
  );
  })();
 
@@ -10015,6 +10029,7 @@ ${staticAnalyticsHtml}
  // Skip paths claimed by bridge pages to avoid canonical conflicts
  if (bridgeClaimedPaths.has(relPath)) continue;
  const __tExpiredSoftLanding = startTimer();
+ const __tEjpTitle = phaseTimer();
  const selfUrl = `${BASE_URL}${withSlash(relPath)}`;
  const listingPath = `${localePrefix[locale]}/${sectionByLocale[locale]}/`.replace(/\/+/g, '/');
  const copy = expiredBannerCopy[locale] ?? expiredBannerCopy.it;
@@ -10119,6 +10134,8 @@ ${staticAnalyticsHtml}
  }
  const expiredWindowData = JSON.stringify(expiredDataObj);
 
+ recordPhase('ejp:title', __tEjpTitle);
+ const __tEjpBody = phaseTimer();
  // FRO-320: Generate static body content so Google sees real text, not an empty SPA shell.
  // Enriched template ensures >100 words per page for every expired job.
  // (jobCanton, displayCanton, sameCompanyActiveJobs, etc. are hoisted above.)
@@ -10319,7 +10336,9 @@ ${staticAnalyticsHtml}
  // skip pages carrying this marker, since prose has been deliberately stripped.
  if (STRIP_EXPIRED_JOB_PROSE) staticBodyParts.push(EJP_STRIPPED_MARKER);
  const staticBody = staticBodyParts.join('\n');
+ recordPhase('ejp:body', __tEjpBody);
 
+ const __tEjpWcRobots = phaseTimer();
  // Track IT word count for sitemap inclusion decision
  if (locale === 'it') {
  itBodyWordCount = countHtmlBodyWords(staticBody);
@@ -10329,7 +10348,9 @@ ${staticAnalyticsHtml}
  // Pages with >= MIN_INDEXABLE_WORDS of real text get index,follow (SEO value
  // from long-tail searches). Pages below threshold get noindex,follow.
  const expiredRobotsTag = robotsMetaForContent(staticBody);
+ recordPhase('ejp:wc-robots', __tEjpWcRobots);
 
+ const __tEjpJsonld = phaseTimer();
  // Build JSON-LD scripts (BreadcrumbList + optional JobPosting)
  const breadcrumbLd = `<script type="application/ld+json">${JSON.stringify({
  '@context': 'https://schema.org',
@@ -10410,12 +10431,15 @@ ${staticAnalyticsHtml}
  })();
 
  const jsonLdScripts = breadcrumbLd + (jobPostingLd ? '\n ' + jobPostingLd : '');
+ recordPhase('ejp:jsonld', __tEjpJsonld);
 
+ const __tEjpShell = phaseTimer();
  const softLandingHtml = buildSoftLandingHtml(
  locale, pageTitle, pageDesc, expiredRobotsTag,
  selfUrl, hreflangLinks, jsonLdScripts, expiredWindowData,
  staticBody
  );
+ recordPhase('ejp:shell', __tEjpShell);
 
  // Skip if a previous (most-recent due to sort) slug already emitted
  // a soft-landing at this exact locale-prefixed path. Avoids the
@@ -10427,6 +10451,7 @@ ${staticAnalyticsHtml}
  if (emittedSoftLandingPaths.has(__slPathKey)) continue;
  emittedSoftLandingPaths.add(__slPathKey);
 
+ const __tEjpWrite = phaseTimer();
  writeSoftLandingPage(relPath.slice(1), softLandingHtml);
  const cacheKey = `${locale}:${slug}`;
  if (expiredCacheKeys.has(cacheKey)) {
@@ -10444,6 +10469,7 @@ ${staticAnalyticsHtml}
  legacyCount++;
  }
  }
+ recordPhase('ejp:write', __tEjpWrite);
  recordEmit('expired-soft-landing', __tExpiredSoftLanding);
  }
 

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -528,8 +528,13 @@ class TokenIndex {
       this.postingsByLocale.set(locale, perLocale);
     }
     const cached = perLocale.get(token);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined) {
+      const __tHit = profileStart();
+      profileRecord('bc:postings-hit', __tHit);
+      return cached;
+    }
 
+    const __tMiss = profileStart();
     const haystacks = this.getHaystacks(locale);
     const candidateJobs = this.candidateJobsForToken(locale, token);
     const list: number[] = [];
@@ -537,6 +542,7 @@ class TokenIndex {
       if (haystacks[idx].includes(token)) list.push(idx);
     }
     perLocale.set(token, list);
+    profileRecord('bc:postings-miss', __tMiss);
     return list;
   }
 
@@ -547,16 +553,25 @@ class TokenIndex {
    * avoid materializing/sorting the full match universe for every candidate.
    */
   matchingJobs(locale: Locale, tokens: readonly string[], maxJobs: number): RawJob[] {
+    const __tPostings = profileStart();
     const lists = tokens.map((tok) => this.postings(locale, tok));
+    profileRecord('bc:mj-postings-batch', __tPostings);
     if (lists.length === 0) return [];
 
     if (lists.length === 1) {
-      return lists[0].slice(0, maxJobs).map((idx) => this.jobs[idx]);
+      const __tSingle = profileStart();
+      const out = lists[0].slice(0, maxJobs).map((idx) => this.jobs[idx]);
+      profileRecord('bc:mj-single', __tSingle);
+      return out;
     }
 
+    const __tAnd = profileStart();
     const matchingIdx = this.firstAndMatches(lists, maxJobs);
+    profileRecord('bc:mj-and', __tAnd);
     if (matchingIdx.length < maxJobs) {
+      const __tOr = profileStart();
       this.fillOrMatches(lists, tokens.length, matchingIdx, maxJobs);
+      profileRecord('bc:mj-or', __tOr);
     }
 
     return matchingIdx.map((idx) => this.jobs[idx]);
@@ -573,11 +588,13 @@ class TokenIndex {
   private getHaystacks(locale: Locale): string[] {
     const cached = this.haystacksByLocale.get(locale);
     if (cached) return cached;
+    const __t = profileStart();
     const arr = new Array<string>(this.jobs.length);
     for (let i = 0; i < this.jobs.length; i++) {
       arr[i] = buildJobHaystack(this.jobs[i], locale);
     }
     this.haystacksByLocale.set(locale, arr);
+    profileRecord('bc:lazy-haystacks', __t);
     return arr;
   }
 
@@ -585,6 +602,7 @@ class TokenIndex {
     const cached = this.gramPostingsByLocale.get(locale);
     if (cached) return cached;
 
+    const __t = profileStart();
     const haystacks = this.getHaystacks(locale);
     const grams = new Map<string, number[]>();
     const seenInJob = new Set<string>();
@@ -612,6 +630,7 @@ class TokenIndex {
     }
 
     this.gramPostingsByLocale.set(locale, grams);
+    profileRecord('bc:lazy-grams', __t);
     return grams;
   }
 
@@ -733,13 +752,21 @@ function buildClusterContext(
   index: TokenIndex,
   jobs: ReadonlyArray<RawJob>,
 ): ClusterContext | null {
+  const __tTokenize = profileStart();
   const sampleTerm = (candidate.sampleTerms || [])[0] || '';
-  if (!sampleTerm) return null;
+  if (!sampleTerm) {
+    profileRecord('bc:tokenize', __tTokenize);
+    return null;
+  }
   const city = detectCity(sampleTerm);
   const keyword = stripCityFromKeyword(sampleTerm, city);
-  if (!keyword) return null;
+  if (!keyword) {
+    profileRecord('bc:tokenize', __tTokenize);
+    return null;
+  }
 
   const tokens = tokenizeQuery(sampleTerm);
+  profileRecord('bc:tokenize', __tTokenize);
   if (tokens.length === 0) return null;
 
   // Two-phase matching:
@@ -758,7 +785,9 @@ function buildClusterContext(
   // then selects only the first MAX_JOBS_PER_PAGE results in the same order as
   // the former full Map+sort path: AND matches in corpus order, then OR
   // matches by score desc with corpus-order tie breaks.
+  const __tMatch = profileStart();
   const matching = index.matchingJobs(candidate.locale, tokens, MAX_JOBS_PER_PAGE);
+  profileRecord('bc:match', __tMatch);
 
   if (matching.length < MIN_MATCHING_JOBS) return null;
   // Note: with MIN_MATCHING_JOBS=0 the line above is a no-op (length is
@@ -766,6 +795,7 @@ function buildClusterContext(
   // constant stays the single source of truth — flip it back to ≥1 here
   // by raising MIN_MATCHING_JOBS, not by editing the predicate.
 
+  const __tTop = profileStart();
   const counts = new Map<string, number>();
   for (const j of matching) {
     const c = (j.company || '').trim();
@@ -776,6 +806,7 @@ function buildClusterContext(
     .sort((a, b) => b[1] - a[1])
     .slice(0, 3)
     .map(([name]) => name);
+  profileRecord('bc:top-companies', __tTop);
 
   return { candidate, keyword: keyword.trim(), city, matchingJobs: matching, topCompanies };
 }

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -717,17 +717,15 @@ class TokenIndex {
       }
     }
 
-    // Iterate `touched` (typically tens to hundreds, bounded by sum of
-    // posting list sizes) instead of scanning the full scratchScores array
-    // (5819 entries × scoreLevels). For 2-token queries — 89% of calls per
-    // bc:mj-or profiling — this turns a 5819-entry scan into a ~100-entry
-    // scan. Sort once so that within each score level we emit indices in
-    // corpus order, byte-identical to the previous full-scan ordering.
-    touched.sort((a, b) => a - b);
-
+    // Full Uint8Array scan was empirically faster than a sort+touched
+    // iteration: V8's Array.prototype.sort with a comparator costs more
+    // than a sequential typed-array walk for the typical small touched
+    // sizes (~100 entries), and the run 26467347040 measurement showed
+    // the sort variant added +11s across 161,542 OR-merge calls vs the
+    // straight scan. Keep the scan; the scratchScores typed array is
+    // cache-friendly and bounded by jobs.length (5819).
     for (let score = fullScore - 1; score >= 1 && out.length < maxJobs; score--) {
-      for (let i = 0; i < touched.length && out.length < maxJobs; i++) {
-        const idx = touched[i];
+      for (let idx = 0; idx < scores.length && out.length < maxJobs; idx++) {
         if (scores[idx] === score) out.push(idx);
       }
     }

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -43,6 +43,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
+import { Worker } from 'node:worker_threads';
 import type { Plugin } from 'vite';
 
 import { WriteCollector } from './batchWrite';
@@ -511,13 +512,34 @@ class TokenIndex {
   private haystacksByLocale = new Map<Locale, string[]>();
   private postingsByLocale = new Map<Locale, Map<string, number[]>>();
   private gramPostingsByLocale = new Map<Locale, Map<string, number[]>>();
-  private readonly scratchScores: Uint16Array;
+  private readonly scratchScores: Uint8Array;
   private readonly touchedIdx: number[] = [];
   private readonly jobs: ReadonlyArray<RawJob>;
 
   constructor(jobs: ReadonlyArray<RawJob>) {
     this.jobs = jobs;
-    this.scratchScores = new Uint16Array(jobs.length);
+    // Per-call score buckets (0..fullScore). fullScore is bounded by the
+    // candidate's token count which never exceeds tokenizeQuery's word cap,
+    // so Uint8 (max 255) is generous.
+    this.scratchScores = new Uint8Array(jobs.length);
+  }
+
+  /**
+   * Seed cold posting lists computed off the main thread (via
+   * relatedSearchPostingsWorker). The build-contexts loop's `postings()`
+   * cache will then hit on these entries instead of falling into the
+   * synchronous haystack scan path. Idempotent: re-seeding the same token
+   * overwrites with a byte-identical list.
+   */
+  seedPostings(locale: Locale, entries: ReadonlyArray<{ token: string; list: number[] }>): void {
+    let perLocale = this.postingsByLocale.get(locale);
+    if (!perLocale) {
+      perLocale = new Map<string, number[]>();
+      this.postingsByLocale.set(locale, perLocale);
+    }
+    for (const { token, list } of entries) {
+      perLocale.set(token, list);
+    }
   }
 
   /** Posting list for (locale, token), sorted ascending by jobIdx (corpus order). */
@@ -695,8 +717,17 @@ class TokenIndex {
       }
     }
 
+    // Iterate `touched` (typically tens to hundreds, bounded by sum of
+    // posting list sizes) instead of scanning the full scratchScores array
+    // (5819 entries × scoreLevels). For 2-token queries — 89% of calls per
+    // bc:mj-or profiling — this turns a 5819-entry scan into a ~100-entry
+    // scan. Sort once so that within each score level we emit indices in
+    // corpus order, byte-identical to the previous full-scan ordering.
+    touched.sort((a, b) => a - b);
+
     for (let score = fullScore - 1; score >= 1 && out.length < maxJobs; score--) {
-      for (let idx = 0; idx < scores.length && out.length < maxJobs; idx++) {
+      for (let i = 0; i < touched.length && out.length < maxJobs; i++) {
+        const idx = touched[i];
         if (scores[idx] === score) out.push(idx);
       }
     }
@@ -1846,6 +1877,66 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       // postings before the heavier render+emit phase to keep peak heap
       // down for the rest of closeBundle.
       const tokenIndex = new TokenIndex(jobs);
+
+      // Postings pre-pass: build the per-locale haystack + 2/3-gram index
+      // and resolve every token that build-contexts will need OFF the main
+      // thread, one worker per locale. Profiling on run 26457892172 showed
+      // bc:postings-miss = 70.7s (68% of build-contexts) — 30,715 cold
+      // posting builds each costing ~2.3ms. Splitting across 4 workers (one
+      // per locale) lets us reclaim ~75% of that wall-clock while the
+      // build-contexts loop runs the OR/AND merges on cache hits only.
+      //
+      // Skip the pre-pass for very small token sets (worker spawn ~250-500ms
+      // each is dead weight below the threshold) or when explicitly disabled.
+      const __tPrePass = profileStart();
+      const POSTINGS_PREPASS_MIN_TOKENS = 200;
+      const prepassDisabled = process.env.RELATED_SEARCH_POSTINGS_PREPASS === '0';
+      const tokensByLocale = new Map<Locale, Set<string>>();
+      if (!prepassDisabled) {
+        for (const cand of candidates) {
+          const sampleTerm = (cand.sampleTerms || [])[0] || '';
+          if (!sampleTerm) continue;
+          const tokens = tokenizeQuery(sampleTerm);
+          if (tokens.length === 0) continue;
+          let set = tokensByLocale.get(cand.locale);
+          if (!set) {
+            set = new Set<string>();
+            tokensByLocale.set(cand.locale, set);
+          }
+          for (const t of tokens) set.add(t);
+        }
+      }
+      const totalTokens = Array.from(tokensByLocale.values()).reduce((s, set) => s + set.size, 0);
+      if (!prepassDisabled && totalTokens >= POSTINGS_PREPASS_MIN_TOKENS) {
+        const workerUrl = new URL('./relatedSearchPostingsWorker.mjs', import.meta.url);
+        const localeKeys = Array.from(tokensByLocale.keys());
+        const results = await Promise.all(
+          localeKeys.map((workerLocale) => {
+            const localeTokens = Array.from(tokensByLocale.get(workerLocale) as Set<string>);
+            return new Promise<{ locale: Locale; entries: Array<{ token: string; list: number[] }> }>(
+              (resolve, reject) => {
+                const worker = new Worker(workerUrl, {
+                  workerData: { jobs, locale: workerLocale, tokens: localeTokens },
+                });
+                worker.once('message', resolve);
+                worker.once('error', reject);
+                worker.once('exit', (code) => {
+                  if (code !== 0) reject(new Error(`relatedSearchPostingsWorker exited with code ${code}`));
+                });
+              },
+            );
+          }),
+        );
+        for (const r of results) {
+          tokenIndex.seedPostings(r.locale, r.entries);
+        }
+        const seededCount = results.reduce((s, r) => s + r.entries.length, 0);
+        console.log(
+          `\x1b[36m[related-search-clusters]\x1b[0m postings pre-pass: ${localeKeys.length} worker(s) seeded ${seededCount} token postings`,
+        );
+      }
+      profileRecord('postings-prepass', __tPrePass);
+
       const contexts: ClusterContext[] = [];
       const __tContextBuild = profileStart();
       for (const cand of candidates) {

--- a/build-plugins/relatedSearchPostingsWorker.mjs
+++ b/build-plugins/relatedSearchPostingsWorker.mjs
@@ -1,0 +1,119 @@
+/**
+ * Worker for relatedSearchClustersPlugin's postings pre-pass.
+ *
+ * Each instance owns ONE locale. It receives the full jobs array + the set
+ * of tokens that will be queried during `build-contexts`. For that locale
+ * it:
+ *   1. builds the per-locale haystack array (mirror of TokenIndex.getHaystacks),
+ *   2. builds the 2/3-gram inverted index (mirror of getGramPostings),
+ *   3. for each requested token, resolves the posting list via the same
+ *      "rarest 3-gram" strategy as TokenIndex.candidateJobsForToken,
+ *      then filters by `haystack.includes(token)`.
+ *
+ * Returns `{ locale, entries: [{ token, list }] }`. The coordinator seeds
+ * `TokenIndex.postingsByLocale` with these before the build-contexts loop
+ * runs, turning every cold postings-miss into a cache hit.
+ *
+ * Output is byte-identical: the helper functions below are verbatim copies
+ * of their counterparts in relatedSearchClustersPlugin.ts. Pure JS, no I/O,
+ * no .ts imports — boots without tsx loader.
+ */
+import { parentPort, workerData } from 'node:worker_threads';
+
+if (!parentPort) {
+  throw new Error('[relatedSearchPostingsWorker] must be spawned via worker_threads');
+}
+
+/** @param {string} value */
+function normalizeText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '');
+}
+
+/**
+ * @param {{ titleByLocale?: Record<string,string>, descriptionByLocale?: Record<string,string>, title?: string, description?: string, company?: string, location?: string }} job
+ * @param {string} locale
+ */
+function buildJobHaystack(job, locale) {
+  const title = job.titleByLocale?.[locale] ?? job.title ?? '';
+  const description = job.descriptionByLocale?.[locale] ?? job.description ?? '';
+  return normalizeText(`${title} ${job.company ?? ''} ${job.location ?? ''} ${description}`);
+}
+
+/** @param {string} value */
+function isSearchTokenGram(value) {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    const isDigit = code >= 48 && code <= 57;
+    const isLowerAscii = code >= 97 && code <= 122;
+    if (!isDigit && !isLowerAscii) return false;
+  }
+  return true;
+}
+
+const { jobs, locale, tokens } = /** @type {{ jobs: any[], locale: string, tokens: string[] }} */ (workerData);
+
+const haystacks = new Array(jobs.length);
+for (let i = 0; i < jobs.length; i++) {
+  haystacks[i] = buildJobHaystack(jobs[i], locale);
+}
+
+/** @type {Map<string, number[]>} */
+const grams = new Map();
+const seenInJob = new Set();
+for (let jobIdx = 0; jobIdx < haystacks.length; jobIdx++) {
+  const haystack = haystacks[jobIdx];
+  seenInJob.clear();
+  for (const width of [2, 3]) {
+    if (haystack.length < width) continue;
+    for (let i = 0; i <= haystack.length - width; i++) {
+      const gram = haystack.slice(i, i + width);
+      if (!isSearchTokenGram(gram)) continue;
+      if (seenInJob.has(gram)) continue;
+      seenInJob.add(gram);
+      let list = grams.get(gram);
+      if (!list) {
+        list = [];
+        grams.set(gram, list);
+      }
+      list.push(jobIdx);
+    }
+  }
+}
+
+/** @param {string} token */
+function candidateJobsForToken(token) {
+  if (token.length <= 2) {
+    return grams.get(token) ?? [];
+  }
+  /** @type {number[] | null} */
+  let rarest = null;
+  const seenTokenGrams = new Set();
+  for (let i = 0; i <= token.length - 3; i++) {
+    const gram = token.slice(i, i + 3);
+    if (seenTokenGrams.has(gram)) continue;
+    seenTokenGrams.add(gram);
+    const list = grams.get(gram) ?? [];
+    if (rarest === null || list.length < rarest.length) {
+      rarest = list;
+      if (rarest.length === 0) break;
+    }
+  }
+  return rarest ?? [];
+}
+
+/** @type {Array<{ token: string, list: number[] }>} */
+const entries = new Array(tokens.length);
+for (let i = 0; i < tokens.length; i++) {
+  const token = tokens[i];
+  const candidates = candidateJobsForToken(token);
+  const list = [];
+  for (const idx of candidates) {
+    if (haystacks[idx].includes(token)) list.push(idx);
+  }
+  entries[i] = { token, list };
+}
+
+parentPort.postMessage({ locale, entries });


### PR DESCRIPTION
## Summary

- Parallel worker-pool postings pre-pass for `relatedSearchClustersPlugin` eliminates 70.7 s of cold posting-list builds inside `build-contexts`. One worker per locale rebuilds haystack + 2/3-gram inverted index + resolves every token off the main thread; results pre-seed `TokenIndex.postingsByLocale` so the build-contexts loop hits the cache path on every call.
- Phase profiler markers (`bc:tokenize`, `bc:match`, `bc:mj-postings-batch`, `bc:mj-and`, `bc:mj-or`, `bc:mj-single`, `bc:postings-hit/miss`, `bc:lazy-haystacks`, `bc:lazy-grams`, `bc:top-companies`) make the previously opaque 100 s `build-contexts` step measurable, gated by existing `RELATED_SEARCH_CLUSTERS_PROFILE` / `BUILD_PROFILE` envs.
- Default profilers added to two other opaque hot paths:
  - `canonical-fallback-pre-pass` log line now reports `enum_ms / chunk_ms / dispatch_ms / merge_ms / worker_import_p99_ms / worker_work_{min,avg,p99}_ms` so we can attribute the 150 s wall across tsx-loader, structured-clone, parallel work, load imbalance.
  - `expired-soft-landing` emits 6 `ph:ejp:*` phase samples inside the locale loop (`title / body / wc-robots / jsonld / shell / write`), mirroring active-job's pattern, gated by `JOBS_SEO_PROFILE_PHASES=1` (already on in `deploy.yml`).

## Measured impact (run 26469566046, branch HEAD)

| metric | baseline (26447505654) | this PR |
|---|---|---|
| **build wall** | **44m33s** | **38m21s** (−6m12s, −14 %) |
| jobs-seo-pages | 1138.5 s | 1011.6 s (−127 s) |
| build-contexts | 100.6 s (opaque) | 26.8 s (−73 s) |
| bc:postings-miss | 70.7 s | 0 s (eliminated by worker pool) |
| bc:match | 94.8 s | 18.4 s |
| bc:mj-or | 22.3 s | 16.8 s |
| postings-prepass (new) | — | 20.2 s (worker wall, runs in parallel) |

Worker pool spread: `worker_work_min=143s / avg=145s / p99=150s` → load balance within 4.5 %, ~97 % of theoretical 4-worker minimum (25 ms/tuple × 23 287 / 4).

## What this exposes for the next round

- `ph:ejp:shell` = 48.7 s (45 % of expired-soft-landing) → next target inside `buildSoftLandingHtml`.
- `ph:ejp:write` = 41.8 s (39 %) → IO-bound, batched.
- 7 k expired pages run all 6 phases then get dropped by the dedup `continue;` — easy quick win to move the check earlier.

## Output byte-identity

- Posting lists computed in workers vs inline use the same `normalizeText / buildJobHaystack / candidate selection` code (verbatim copy in worker .mjs). Pure functions of `(jobs, locale, token)`.
- OR-merge `touched.sort` micro-optimization was attempted then **reverted** — the C-mode measurement (run 26467347040) showed it added +11 s vs the original full Uint8Array scan. The reverted variant in this PR keeps only the `Uint16 → Uint8` scratchScores downsize.
- 57/57 `related-search-clusters` + 3/3 `jobs-seo-pages-plugin` test suites pass.

## Test plan

- [x] Vitest suites local (57/57 related-search-clusters, 3/3 jobs-seo-pages-plugin)
- [x] `post-build-matrix-test` `build_only=true` runs on this branch confirmed no build-time errors (runs 26467347040, 26469566046)
- [x] Phase profiler measurements compared against baseline `[related-search-profile]` + `[jobs-seo-profile]` tables — wins above are measured, not estimated
- [ ] Observe post-merge deploy on `main` for live wall-clock validation + sitemap parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)