### PR TITLE
perf(expired-soft-landing): hoist dedup check before shell/jsonld build

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10028,6 +10028,15 @@ ${staticAnalyticsHtml}
  if (!relPath) continue;
  // Skip paths claimed by bridge pages to avoid canonical conflicts
  if (bridgeClaimedPaths.has(relPath)) continue;
+ // Hoisted dedup pre-check: when a previous (most-recent) slug already
+ // claimed this exact locale-prefixed path, skip BEFORE assembling
+ // title / body / wc-robots / jsonld / shell. Run 26469566046 profiling
+ // showed ~7k iterations doing the full ph:ejp:* pipeline only to be
+ // dropped by the dedup `continue` later — wasted ~3-4s wall. The set
+ // is still populated AT WRITE TIME below so dedup membership reflects
+ // actually-emitted paths, not just attempted ones.
+ const __slPathKey = relPath.replace(/^\//, '').replace(/\/+$/, '');
+ if (emittedSoftLandingPaths.has(__slPathKey)) continue;
  const __tExpiredSoftLanding = startTimer();
  const __tEjpTitle = phaseTimer();
  const selfUrl = `${BASE_URL}${withSlash(relPath)}`;
@@ -10441,14 +10450,11 @@ ${staticAnalyticsHtml}
  );
  recordPhase('ejp:shell', __tEjpShell);
 
- // Skip if a previous (most-recent due to sort) slug already emitted
- // a soft-landing at this exact locale-prefixed path. Avoids the
- // write-registry collision that surfaces in dist/.write-collisions.json
- // when many slugs converge on one path. Map.set last-add-wins would
- // also dedup at the collector level, but the registry still RECORDS
- // each collision attempt — this Set keeps the report clean.
- const __slPathKey = relPath.replace(/^\//, '').replace(/\/+$/, '');
- if (emittedSoftLandingPaths.has(__slPathKey)) continue;
+ // Dedup membership: __slPathKey is computed and checked at the top of
+ // this locale iteration (hoisted to avoid running the full ph:ejp:*
+ // pipeline on doomed paths). Only the `.add()` lives here so the set
+ // reflects ACTUALLY-emitted paths, not just attempted ones — keeps
+ // dist/.write-collisions.json clean across slugs that converge here.
  emittedSoftLandingPaths.add(__slPathKey);
 
  const __tEjpWrite = phaseTimer();


### PR DESCRIPTION
## Summary

- Run 26469566046's `[jobs-seo-profile]` table exposed a 6,957-iteration count mismatch between `ph:ejp:title/body/wc-robots/jsonld/shell` (143,094) and `expired-soft-landing` / `ph:ejp:write` (136,137).
- Those 7k iterations ran the full title + body + wc-robots + jsonld + shell pipeline only to be dropped by the deferred `if (emittedSoftLandingPaths.has(__slPathKey)) continue;` check downstream.
- Hoist the dedup check to the top of the locale loop, right after the existing `bridgeClaimedPaths` skip. The `.add()` stays inline at write time so the set still reflects ACTUALLY-emitted paths (not attempted ones).

## Measured impact

Extrapolating per-phase avg from run 26469566046:
- ejp:shell 0.34 ms + wc-robots 0.09 ms + body 0.03 ms + jsonld 0.01 ms + title 0.01 ms ≈ 0.48 ms saved per dropped iteration
- 6,957 dropped iterations × 0.48 ms = **~3.3 s wall** on expired-soft-landing

Small but free — touches one file, no algorithmic risk.

## Output byte-identity

- Dedup membership is unchanged: set is populated only at write time, same paths still get emitted, same legacy slug bridges still fire.
- The hoisted check is semantically equivalent — it just bails earlier on paths that would have bailed at the bottom of the iteration anyway.
- 3/3 jobs-seo-pages-plugin tests pass.

## Test plan

- [x] Vitest local suite (3/3 passing)
- [ ] Verify on next deploy run: `ph:ejp:*` counts converge (no more 7k delta), `expired-soft-landing` total drops by ~3 s
- [ ] Sitemap parity unchanged (same `expiredCount` reported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)