### PR TITLE
perf(profiler): break down ph:ejp:shell into tpl + minify sub-phases

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9786,6 +9786,12 @@ ${staticAnalyticsHtml}
  const buildSoftLandingHtml = (locale: string, pageTitle: string, pageDesc: string, robotsTag: string,
  selfUrl: string, hreflangLinks: string, jsonLdScripts: string, expiredWindowData: string,
  staticBody: string): string => {
+ // Sub-phase profiler: ph:ejp:shell measured at 48.7s (45% of expired-
+ // soft-landing) in run 26469566046. Break it down so the next round
+ // can target either the template assembly (likely cheap) or minifyHtml
+ // (regex-heavy, suspected dominant). Gated by JOBS_SEO_PROFILE_PHASES=1
+ // already on in deploy.yml.
+ const __tShellTpl = phaseTimer();
  const shell = localeShells[locale];
  // Single early-boot tag covers BOTH dark-mode and spa-action-redirect
  // (merged into /assets/early-boot-{hash}.js via EARLY_BOOT_SCRIPT). The
@@ -9830,7 +9836,11 @@ ${staticAnalyticsHtml}
  <script>window.__STATIC_BODY_HTML__=(document.querySelector('.ft-static-article')||{}).innerHTML||'';</script>${spaBundleJs}
  </body>
 </html>`;
- return minifyHtml(html);
+ recordPhase('ejp:shell:tpl', __tShellTpl);
+ const __tShellMinify = phaseTimer();
+ const out = minifyHtml(html);
+ recordPhase('ejp:shell:minify', __tShellMinify);
+ return out;
  };
  const writeSoftLandingPage = (outRelPath: string, html: string) => {
  // Normalize: strip trailing slashes to prevent flat files like ".html" (hidden files)


### PR DESCRIPTION
## Summary

- `ph:ejp:shell` was measured at **48.7 s (45 % of expired-soft-landing)** in run 26469566046 — the single biggest phase.
- The helper does two distinct things, currently lumped into one timer: ~30-slot template literal assembly + a regex-heavy `minifyHtml` pass.
- Splits the existing timer into two sub-phases so the next round of optimization knows where to cut.

New `[jobs-seo-profile]` rows on next CI build:
- `ph:ejp:shell:tpl`    — template assembly (likely cheap, head/body interpolation)
- `ph:ejp:shell:minify` — `minifyHtml(html)` (suspected dominant — regex passes over the assembled HTML)

Gated by `JOBS_SEO_PROFILE_PHASES=1` (already on in `deploy.yml` + `post-build-matrix-test`); zero overhead with the flag off.

## Output byte-identity

Timers + Map.set only. The function still returns `minifyHtml(html)` exactly as before. 3/3 jobs-seo-pages-plugin tests pass.

## Test plan

- [x] Vitest local suite (3/3 passing)
- [ ] Next deploy: confirm both `ph:ejp:shell:tpl` and `ph:ejp:shell:minify` rows appear in `[jobs-seo-profile]` summary, sum ≈ previous `ph:ejp:shell` 48.7 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)