### PR TITLE
perf(expired-soft-landing): drop minifyHtml, keep cheap newline collapse

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -9837,8 +9837,16 @@ ${staticAnalyticsHtml}
  </body>
 </html>`;
  recordPhase('ejp:shell:tpl', __tShellTpl);
+ // Skip minifyHtml on soft-landings. Run 26472312864 measured
+ // ph:ejp:shell:minify at 55.8s (99.5% of ph:ejp:shell, 8.7% of
+ // jobsSeoPagesPlugin) — and the per-page max hit 4026ms, indicating
+ // regex catastrophic backtracking on at least one input. Soft-landings
+ // are 143k pages × ~30 bytes of leading-whitespace overhead = ~4 MB on
+ // a 1.74 GB dist (irrelevant). The template literal below is already
+ // tightly indented; raw output is DOM-equivalent. The cheap newline-
+ // indent collapse keeps the worst of the boilerplate noise out.
  const __tShellMinify = phaseTimer();
- const out = minifyHtml(html);
+ const out = html.replace(/\n[ \t]+/g, '\n');
  recordPhase('ejp:shell:minify', __tShellMinify);
  return out;
  };


### PR DESCRIPTION
## Summary

Run 26472312864 (matrix #618) measured `ph:ejp:shell:minify` at **55.8 s = 99.5 %** of `ph:ejp:shell` and **8.7 % of jobsSeoPagesPlugin**. Single-page max hit **4026 ms** — almost certainly regex catastrophic backtracking inside `minifyHtml`'s `MASK_RX` backreference (`<\/\1\s*>` against an unclosed opaque tag).

This PR drops the full `minifyHtml` pipeline on soft-landings and replaces it with a single linear `\n[ \t]+` → `\n` replace — the only minify rule with material byte savings on a template that's already tightly indented.

## Output impact

- DOM-equivalent: same elements, same attributes, same text.
- Wire format: +~30 B/page of inter-tag whitespace × 143 k pages ≈ **+4 MB** on a 1.74 GB dist (negligible vs the dist-size discussion).
- No attribute unquoting, no comment stripping, no block-gap collapse — those are tiny absolute savings here and not worth the regex risk.

## Why this matters NOW

Every deploy since 14:27Z today dies mid-closeBundle with SIGTERM (`exit code 143`, step 7 build log missing from archive). The 4 s catastrophic-backtracking event on a single page is exactly the kind of resource spike that a memory-pressured GHA runner cannot recover from. Cutting the worst regex cost might let the deploy complete the build phase.

## Test plan

- [x] 3/3 jobs-seo-pages-plugin tests pass locally
- [ ] Verify matrix `post-build-matrix-test build_only=true` on this branch — expect `ph:ejp:shell` total ≈ 2-3 s and `ph:ejp:shell:minify` avg ≈ 0.02 ms with max < 5 ms (no 4 s outlier)
- [ ] If matrix green AND deploy on `main` completes the build phase: success criterion met

## Followups (not in this PR)

- Audit which soft-landing input triggers the 4 s `MASK_RX` outlier so the regex can be hardened for the rest of the site too.
- Extend the cheap-minify pattern to other static SEO plugins if measurements show similar minify domination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)