### PR TITLE
perf(profiler): log process.memoryUsage between plugins for OOM diagnosis

### DIFF
--- a/build-plugins/profilePlugin.ts
+++ b/build-plugins/profilePlugin.ts
@@ -78,6 +78,20 @@ export function withProfile(plugin: Plugin): Plugin {
           `[profile-detail] ${name.padEnd(40)} wall_s=${(dur / 1000).toFixed(2)} cpu_s=${(cpuMs / 1000).toFixed(2)}`,
         );
       }
+      // Memory profile per-plugin. Deploy runs since 2026-05-26 14:27Z have
+      // died with SIGTERM mid-closeBundle (exit code 143) — pre-existing
+      // analysis pegs the runner OOM as the likely cause (Node V8 told
+      // `--max-old-space-size=18432` on a 7 GB GHA free-tier box; peak
+      // memory accumulates across sequential plugins). Logging RSS + heap
+      // after every plugin gives us the smoking gun the next time the
+      // build dies: the LAST `[profile-mem]` line before the SIGTERM
+      // pinpoints which plugin tipped us over the kernel OOM threshold.
+      // ~1 process.memoryUsage() call per plugin (~30 plugins) → < 1 ms total
+      // overhead, no behaviour change.
+      const m = process.memoryUsage();
+      console.log(
+        `[profile-mem] ${name.padEnd(40)} rss_mb=${(m.rss / 1048576).toFixed(0)} heapUsed_mb=${(m.heapUsed / 1048576).toFixed(0)} heapTotal_mb=${(m.heapTotal / 1048576).toFixed(0)} external_mb=${(m.external / 1048576).toFixed(0)} arrayBuffers_mb=${(m.arrayBuffers / 1048576).toFixed(0)}`,
+      );
     }
   };
 


### PR DESCRIPTION
## Summary

Deploy runs since 2026-05-26 14:27Z die with SIGTERM (exit 143) mid-closeBundle; the build step stdout is missing from the run archive before the kill signal hits.

This commit adds **one diagnostic line per plugin** alongside the existing `[profile]` output:

```
[profile-mem] <name padded> rss_mb=N heapUsed_mb=N heapTotal_mb=N external_mb=N arrayBuffers_mb=N
```

Next failed deploy log will contain a tail of `[profile-mem]` lines ending precisely on the plugin that tipped peak RSS past the 7 GB GHA free-tier cap → we'll know which Map/cache/buffer to clear.

## Why

Pre-existing analysis pegs the runner OOM as the SIGTERM cause: Node V8 told `--max-old-space-size=18432` on a 7 GB box, peak accumulates across sequential plugins. Without per-plugin memory data we're guessing. This PR is the cheapest possible diagnostic — `process.memoryUsage()` is a syscall, ~5 µs, runs in the existing `finally` block of `withProfile()`.

## Impact

- Cost: ~30 plugins × ~5 µs = < 1 ms total overhead per build
- Gated by existing `BUILD_PROFILE` env (default on in `deploy.yml` + `post-build-matrix-test.yml`); set `BUILD_PROFILE=0` to opt out
- Zero behaviour change: just stdout

## Test plan

- [x] No test changes — pure diagnostic output
- [ ] Next deploy/matrix run: confirm `[profile-mem]` lines appear after every `[profile]` line, with reasonable RSS values (200-3000 MB range expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)