### PR TITLE
perf(related-search): apply backpressure inside render-cluster-page loop

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2072,7 +2072,20 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       // has ~15 transitive .ts deps. Proper fix requires extracting
       // renderClusterPage into a standalone module with explicit `.ts`
       // imports (deferred). For now we keep the sequential loop.
+      let __renderClusterCounter = 0;
       for (const ctx of contexts) {
+        // Backpressure every 2000 iterations — relatedSearchClustersPlugin
+        // emits ~360k files (180k cluster pages × 2 [index.html + flat]).
+        // Without this, WriteCollector closures pile up the same way they
+        // did in jobsSeoPagesPlugin pre-PR #628: render-cluster-page
+        // measured 1.18 ms avg in run 26490352942 (~213 s total), doubled
+        // from the 0.59 ms / 106 s baseline because heap pressure under
+        // the 12 GB cap forced V8 into constant scavenges. Capping
+        // in-flight at 2 keeps pending HTML closures bounded → V8 GC has
+        // less to chase → per-page render returns to baseline speed.
+        if (++__renderClusterCounter % 2000 === 0) {
+          await collector.awaitDrainSlot(2);
+        }
         const __tRenderCluster = profileStart();
         const locale = ctx.candidate.locale;
         const altKey = `${normalizeText(ctx.keyword)}|${normalizeText(ctx.city || '')}`;


### PR DESCRIPTION
## Summary

Run 26490352942 (first green build with PR #627 + #628 fix stack) showed `render-cluster-page` now dominates the related-search-clusters wall:

```
render-cluster-page  180,779 × 1.18 ms = 212.7 s (47% of plugin)
collector-flush                          94.9 s  (21%)
```

The **1.18 ms/page is 2× the 0.59 ms baseline** from matrix run 26469566046. The plugin emits ~360 k files (180 k cluster pages × 2 each: index.html + flat .html bridge). Same closure-pile-up that PR #628 fixed for jobs-seo-pages — but here it manifests as V8 GC pressure slowing render under the 12 GB heap cap from PR #627.

## Fix

Add `await collector.awaitDrainSlot(2)` every 2000 cluster iterations. At ~180 k contexts that's 90 backpressure checks. Bounds in-memory HTML closures at ~150 MB → V8 GC has less to chase → per-page render returns to baseline.

## Expected impact

- `render-cluster-page` 213 s → ~106 s (−100 s, back to baseline)
- `collector-flush` 95 s → ~60 s (less to drain at the end)
- Total build wall ~38 min → ~36 min

## Test plan

- [x] 57/57 related-search-clusters tests pass
- [ ] Next deploy: `render-cluster-page` avg back to ~0.6 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)