### PR TITLE
fix(lhci): drop budgetPath conflicting with assert.assertions

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: 'npm'
 
       - name: Run Lighthouse CI against production
-        uses: treosh/lighthouse-ci-action@v10
+        uses: treosh/lighthouse-ci-action@v12
         with:
           # URLs must exist in the live sitemap and serve 200 (no redirect).
           # Lighthouse aborts the whole run on any 404 — see issue
@@ -61,7 +61,11 @@ jobs:
             https://frontaliereticino.ch/prezzi-diesel/chiasso/oggi/
             https://frontaliereticino.ch/premi-cassa-malati/ticino/
             https://frontaliereticino.ch/traffico-dogane/chiasso-brogeda/oggi/
-          budgetPath: ./lighthouse-budget.json
+          # lhci rejects both budgetPath + configPath:assert.assertions
+          # ("Cannot use both budgets AND assertions"). Assertions in
+          # lighthouserc.json supersede budgets — they cover the same
+          # timings plus category-level scores (perf/seo/a11y).
+          # lighthouse-budget.json is kept for reference but no longer wired.
           configPath: ./lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true


### PR DESCRIPTION
## Summary

- Drops `budgetPath: ./lighthouse-budget.json` from the LHCI workflow. lhci rejects passing both `budgetPath` and `configPath` when the config contains `assert.assertions` (\`Error: Cannot use both budgets AND assertions\`), so every recent run aborted before producing CLS/LCP/TBT scores.
- Bumps `treosh/lighthouse-ci-action` to v12 — v10's `uploadArtifacts: true` returns \`artifact name lighthouse-results is not valid\` on the current GitHub Actions API.
- Combined with PR #597 (404 URL fix), this completes the LHCI re-enable that has been blocking #544's CLS p75 measurement.

Reference run that failed: https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26494155098

## Test plan

- [ ] Merge to main
- [ ] Next push triggers LHCI on main with no \`budgets AND assertions\` error
- [ ] Reports include real CLS/LCP/TBT numbers for the 6 URLs
- [ ] Re-run revenue-monitor afterwards to refresh #544 metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)