### PR TITLE
perf(jobs-seo): clear jobHtmlCache after last reader (cross-locale bridge)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10981,6 +10981,15 @@ ${staticAnalyticsHtml}
  console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m Generated ${crossLocaleCount} cross-locale reconciliation pages`);
  }
 
+ // Cross-locale-active-bridge was the last reader of `jobHtmlCache`. The
+ // cache holds the FULL minified active-job HTML for every (locale, slug)
+ // pair — ~24k entries × ~30 KB ≈ ~720 MB held in the closeBundle heap
+ // until end of plugin. Release it now so the heap headroom is reclaimed
+ // before the heaviest writes (self-healing + flush) follow. Build run
+ // 26494155252 OOM'd at heap=10.8 GB during this stretch with the 12 GB
+ // cap — freeing this Map removes the biggest single accumulator.
+ jobHtmlCache.clear();
+
  /* ── Self-healing: cover any tracking paths not yet written ──── */
  // Safety net: any tracking path that wasn't covered by active, soft-landing,
  // or bridge pages gets a minimal redirect page pointing to the job listing.


### PR DESCRIPTION
## Why

Run 26494155252 OOM'd at **heap=10.8 GB** during the jobs-seo-pages closeBundle (FATAL `Ineffective mark-compacts near heap limit`), even with the 12 GB cap + `global.gc()` between plugins (PR #627) + WriteCollector backpressure (PR #628 + #629) + canonicalCleanedCache early-clear (PR #623) already in place.

Build memory headroom was ~300 MB before this commit — CI runner variance randomly tips us over.

## What

`jobHtmlCache` (declared line 2063, populated in the active-job render loop line 3130) holds the FULL minified active-job HTML for every `(locale, slug)` pair — **~24k entries × ~30 KB ≈ ~720 MB** held alive until end of plugin.

The two downstream readers are:
- `previous-slug-bridge` emit (line 10754)
- `cross-locale-active-bridge` emit (line 10936)

After the "Generated N cross-locale reconciliation pages" log (10981) the cache is **dead state** — the heavier self-healing + flush phases that follow do NOT touch it.

## Fix

Add `jobHtmlCache.clear()` right after the cross-locale log line. Frees ~720 MB of heap before the rest of closeBundle runs.

Mirrors PR #623's `canonicalCleanedCache.clear()` pattern — same file, same plugin, same "release biggest accumulator at end-of-life within closeBundle so V8 doesn't keep ~1 GB alive through the rest of the build".

## SEO-safety

- No HTML output change. Cache is dead state from this line onward — no reader touches it.
- 3/3 jobs-seo-pages-plugin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)