### PR TITLE
fix(cls): useLayoutEffect for static-DOM cleanup (#544 cascade)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo, useCallback, Suspense, useDeferredValue } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback, Suspense, useDeferredValue } from 'react';
 import { createPortal } from 'react-dom';
 import { lazyRetry } from '@/services/lazyRetry';
 // Analytics proxy: lazy, fire-and-forget, deferred to user interaction (FRO-367)
@@ -194,7 +194,14 @@ const App: React.FC = () => {
  // static fallback so the hydrated SPA view is what the user sees, while crawlers (no JS)
  // continue to receive the original HTML. Restore on cleanup if the route flips back to
  // a staticOverlay variant during client-side navigation. See CLAUDE.md rule #14.
- useEffect(() => {
+ //
+ // Use useLayoutEffect (not useEffect) so the display toggle happens synchronously
+ // before the browser paints the first hydrated frame. Otherwise the static SEO body
+ // is briefly visible after hydration, then collapsed → a ~500px upward shift on
+ // every SPA-route page that has a static fallback. Measured CLS = 0.59 on
+ // /cerca-lavoro-ticino/ (2026-05-27 desktop). On the server pass useLayoutEffect
+ // falls back to a no-op, which is fine — the toggle is purely a client concern.
+ useLayoutEffect(() => {
    const staticMain = document.querySelector<HTMLElement>('main.seo-static-content');
    if (!staticMain) return;
    if (staticOverlay) {
@@ -214,7 +221,10 @@ const App: React.FC = () => {
  // direct child of `<body>` once React has mounted; the SPA's own copy lives
  // inside the App wrapper (deeper than body) and is untouched.
  // See CLAUDE.md rule #14.
- useEffect(() => {
+ // Use useLayoutEffect to remove the duplicate before paint — same reasoning
+ // as the staticOverlay toggle above: a post-paint removal causes the SPA
+ // sub-nav (and everything below it) to shift upward by the static nav's height.
+ useLayoutEffect(() => {
    const body = document.body;
    if (!body) return;
    for (const nav of Array.from(body.children)) {


### PR DESCRIPTION
## Summary

Field CLS p75 desktop on \`/cerca-lavoro-ticino/\` was **0.729** (target ≤0.5). Lab Lighthouse on the same URL was **0.041** — the shift is post-hydration, not first-paint.

PerformanceObserver capture on prod (real Chrome, 1366×900, slow-scroll):

| t | value | element | movement |
|---:|---:|---|---|
| 1005ms | 0.228 | \`footer\` | h 0 → 516 (mount) |
| 1700ms | **0.590** | \`footer\` | y 384 → 0 (collapsed up) |

Root cause: \`App.tsx:197\` \`useEffect\` collapses \`main.seo-static-content\` (display:none) **after** paint. Browser paints the hydrated React tree on top of the still-visible static body, then on the next frame the static body disappears and the footer (~500px tall, sitting below it) snaps upward. CLS = 0.59.

\`useLayoutEffect\` runs synchronously after DOM mutations but **before** paint — same commit hides the static body and mounts React, no visible shift.

Same one-line fix applied to the \`nav.seo-hub-subnav\` body-child removal at \`App.tsx:217\` (identical shape, smaller blast radius).

**Auto Ads untouched** per AGENTS.md non-negotiable #7.

## Why not bigger refactor

- Static SEO HTML emit unchanged (no plugin rewrites)
- No CSS changes, no min-height reservations
- 13 line diff in one file (import + 2 hook renames + 1 explanatory comment block per call site)

## Expected effect

- Field CLS desktop \`/cerca-lavoro-ticino/\` from ~0.73 to ~0.13 within 24-48h
- CrUX 28d rolling will reflect this within 4 weeks
- GSC ranking signal recovers as CLS leaves Google's "poor" bucket
- AdSense bid/RPM follows ranking + viewability

## Test plan

- [x] Local measurement (PerformanceObserver attribution) confirms shift source
- [x] Local TypeScript check — only type added is React.useLayoutEffect, already typed
- [ ] Merge to main
- [ ] Live re-measure on prod ~5 min after deploy: \`node scripts/audit-cls-live.mjs --json --strategy=desktop\` + the PerformanceObserver capture script
- [ ] 24h field measurement via PostHog \`\$web_vitals\` query (same as in #544)

🤖 Generated with [Claude Code](https://claude.com/claude-code)