### PR TITLE
feat(jobboard): prefix-stem matching + cross-locale tier-4 fallback

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -1648,6 +1648,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  // "no in-canton results" banner. Populated only via the legacy path; when
  // shards land it'll need a separate aggregator fetch (deferred).
  const [unscopedJobs, setUnscopedJobs] = useState<JobListing[]>([]);
+ // Tier 4 (cross-locale) pool: lazily loaded slim indexes for the locales the
+ // user is NOT currently browsing. Activates only when Tiers 1-3 all return
+ // zero so the search box never returns "0 risultati" while jobs in other
+ // locale corpora (DE/FR/EN titles for the same canton) would have matched.
+ // Same slug + canonical job id across locale shards, so the displayed result
+ // is the IT-locale record when available (see crossLocaleFetchAttempted).
+ const [crossLocaleJobs, setCrossLocaleJobs] = useState<JobListing[]>([]);
+ const crossLocaleFetchAttempted = useRef(false);
  const [jobsLoading, setJobsLoading] = useState(true);
  const [enrichmentLoading, setEnrichmentLoading] = useState(false);
  // FRO-353: Feature flag for Job Alerts (controlled via Firebase Remote Config)
@@ -2473,10 +2481,12 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const queryTokens = normalizeSearchText(query).split(' ').filter(Boolean).map(stemSearchToken);
  if (queryTokens.length === 0) return true;
  const haystack = searchIndex.get(job) ?? '';
- // Each stemmed query token must match a whole haystack word
- // (haystack is wrapped in spaces, words are stemmed → ' infermier uffic ').
- // Trailing space prevents false positives: 'cas' must not match 'cassa'.
- return queryTokens.every((token) => haystack.includes(` ${token} `));
+ // Stemmed query tokens prefix-match haystack words.
+ // Why: 'infermie' (stem 'infermi') must match haystack word 'infermier'
+ // — partial typing common in incremental search. Leading-space anchor
+ // still enforces word-start alignment; trailing-space dropped so the
+ // stem is treated as a prefix, not a closed token.
+ return queryTokens.every((token) => haystack.includes(` ${token}`));
  },
  [searchIndex],
  );
@@ -2564,7 +2574,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  const haystack = searchIndex.get(job) ?? '';
  let score = 0;
  for (const t of queryTokens) {
- if (haystack.includes(` ${t} `)) score++;
+ if (haystack.includes(` ${t}`)) score++;
  }
  if (score > 0) scored.push({ job, score });
  }
@@ -2614,7 +2624,7 @@ const JobBoard: React.FC<JobBoardProps> = ({
  );
  let score = 0;
  for (const t of queryTokens) {
- if (haystack.includes(` ${t} `)) score++;
+ if (haystack.includes(` ${t}`)) score++;
  }
  if (score > 0) scored.push({ job, score });
  }
@@ -2622,19 +2632,121 @@ const JobBoard: React.FC<JobBoardProps> = ({
  return scored.slice(0, MAX_FALLBACK_RESULTS).map((x) => x.job);
  }, [strictFilteredJobs.length, orFallbackInCantonJobs.length, sortedJobs, deferredSearchQuery, selectedDateRange, passingNonSearchFilters, unscopedJobs, locale]);
 
- // filteredJobs: the three-tier search result.
+ // Tier 4 trigger: lazy-load DE/FR/EN slim indexes when all in-locale tiers
+ // returned zero for a non-empty query. Same job ID across locale shards so
+ // we dedup against the already-loaded pool (sortedJobs ∪ unscopedJobs) to
+ // avoid surfacing jobs the user already saw filtered-out. Fetch is one-shot
+ // per session (crossLocaleFetchAttempted ref) — cross-locale corpora are
+ // similarly sized to the IT one, so a per-keystroke refetch would waste
+ // bandwidth without changing results.
+ useEffect(() => {
+ if (crossLocaleFetchAttempted.current) return;
+ if (jobsLoading) return;
+ const q = deferredSearchQuery.trim();
+ if (!q) return;
+ if (strictFilteredJobs.length > 0) return;
+ if (orFallbackInCantonJobs.length > 0) return;
+ if (crossCantonFallbackJobs.length > 0) return;
+ crossLocaleFetchAttempted.current = true;
+ let cancelled = false;
+ const allLocales: ReadonlyArray<Locale> = ['it', 'en', 'de', 'fr'];
+ const otherLocales = allLocales.filter((l) => l !== locale);
+ (async () => {
+ try {
+ const responses = await Promise.allSettled(
+ otherLocales.map(async (l) => {
+ const res = await fetch(`/data/jobs-${l}-index.json`);
+ if (!res.ok) return [] as unknown[];
+ const data = await res.json();
+ return Array.isArray(data) ? (data as unknown[]) : [];
+ }),
+ );
+ if (cancelled) return;
+ const seen = new Set<string>();
+ for (const j of unscopedJobs) seen.add(String(j.id || ''));
+ for (const j of sortedJobs) seen.add(String(j.id || ''));
+ const collected: JobListing[] = [];
+ for (const r of responses) {
+ if (r.status !== 'fulfilled') continue;
+ for (const raw of r.value) {
+ const id = String((raw as { id?: unknown })?.id ?? '');
+ if (!id || seen.has(id)) continue;
+ seen.add(id);
+ collected.push(normalizeIncomingJob(raw));
+ }
+ }
+ if (cancelled) return;
+ setCrossLocaleJobs(dedupeJobsForListing(collected));
+ } catch (err: unknown) {
+ reportCaughtError(err, 'jobBoard.loadJobs.crossLocale');
+ }
+ })();
+ return () => { cancelled = true; };
+ }, [
+ deferredSearchQuery, jobsLoading, locale,
+ strictFilteredJobs.length, orFallbackInCantonJobs.length, crossCantonFallbackJobs.length,
+ unscopedJobs, sortedJobs,
+ ]);
+
+ // Tier 4: cross-locale OR fallback. Same scoring as Tier 3, run against the
+ // lazily-loaded DE/FR/EN pool. Job ID + slug are canonical across locale
+ // shards, so the result still routes to the Italian URL via the existing
+ // slug field — the only thing that may render in another language is the
+ // title when no IT translation exists for that record.
+ const crossLocaleFallbackJobs = useMemo<JobListing[]>(() => {
+ const query = deferredSearchQuery.trim();
+ if (!query) return [];
+ if (strictFilteredJobs.length > 0) return [];
+ if (orFallbackInCantonJobs.length > 0) return [];
+ if (crossCantonFallbackJobs.length > 0) return [];
+ if (crossLocaleJobs.length === 0) return [];
+
+ const queryTokens = normalizeSearchText(query).split(' ').filter(Boolean).map(stemSearchToken);
+ if (queryTokens.length === 0) return [];
+
+ const now = Date.now();
+ const dateRangeMs: Record<DateRange, number> = {
+ all: 0, '24h': 24 * 60 * 60 * 1000, '3d': 3 * 24 * 60 * 60 * 1000,
+ '7d': 7 * 24 * 60 * 60 * 1000, '30d': 30 * 24 * 60 * 60 * 1000, '90d': 90 * 24 * 60 * 60 * 1000,
+ };
+ const cutoff = selectedDateRange === 'all' ? 0 : now - dateRangeMs[selectedDateRange];
+
+ const scored: { job: JobListing; score: number }[] = [];
+ for (const job of crossLocaleJobs) {
+ if (isForeignLocation(job.addressLocality || job.location || '')) continue;
+ if (!passingNonSearchFilters(job, now, cutoff)) continue;
+ const description = job.descriptionByLocale?.[locale] ?? job.description;
+ const localizedTitle = sanitizeJobTitle(job.titleByLocale?.[locale] ?? job.title);
+ const haystack = buildStemmedHaystack(
+ `${localizedTitle} ${job.company} ${job.location} ${job.contract} ${job.category} ${job.sector || ''} ${description || ''}`,
+ );
+ let score = 0;
+ for (const t of queryTokens) {
+ if (haystack.includes(` ${t}`)) score++;
+ }
+ if (score > 0) scored.push({ job, score });
+ }
+ scored.sort((a, b) => b.score - a.score);
+ return scored.slice(0, MAX_FALLBACK_RESULTS).map((x) => x.job);
+ }, [
+ strictFilteredJobs.length, orFallbackInCantonJobs.length, crossCantonFallbackJobs.length,
+ crossLocaleJobs, deferredSearchQuery, selectedDateRange, passingNonSearchFilters, locale,
+ ]);
+
+ // filteredJobs: the four-tier search result.
  //   1. strictFilteredJobs (AND across all tokens, in-canton)
  //   2. orFallbackInCantonJobs (partial-token OR, in-canton)
- //   3. crossCantonFallbackJobs (partial-token OR, other cantons)
+ //   3. crossCantonFallbackJobs (partial-token OR, other cantons, same locale)
+ //   4. crossLocaleFallbackJobs (partial-token OR, other locale shards)
  // Each tier is consulted only when the previous one yielded zero, so the
- // canton-scoped intent stays primary and cross-canton is purely a safety
- // net for pages like `ricerca-genitori-liestal` whose query token has no
- // in-canton support.
+ // canton-scoped intent stays primary and the safety nets only kick in when
+ // the local query has no support whatsoever.
  const filteredJobs = useMemo<JobListing[]>(() => {
  if (strictFilteredJobs.length > 0) return strictFilteredJobs;
  if (orFallbackInCantonJobs.length > 0) return orFallbackInCantonJobs;
- return crossCantonFallbackJobs;
- }, [strictFilteredJobs, orFallbackInCantonJobs, crossCantonFallbackJobs]);
+ if (crossCantonFallbackJobs.length > 0) return crossCantonFallbackJobs;
+ return crossLocaleFallbackJobs;
+ }, [strictFilteredJobs, orFallbackInCantonJobs, crossCantonFallbackJobs, crossLocaleFallbackJobs]);
 
  // True when the result set is the in-canton OR-fallback (Tier 2). Keeps
  // the existing "No exact match for «…»" banner triggered.
@@ -2653,6 +2765,16 @@ const JobBoard: React.FC<JobBoardProps> = ({
  && orFallbackInCantonJobs.length === 0
  && crossCantonFallbackJobs.length > 0;
  }, [deferredSearchQuery, strictFilteredJobs.length, orFallbackInCantonJobs.length, crossCantonFallbackJobs.length]);
+
+ // True when the result set is the cross-locale fallback (Tier 4). Banner
+ // signals that the displayed titles may not be in the current UI locale.
+ const isCrossLocaleFallback = useMemo(() => {
+ return Boolean(deferredSearchQuery.trim())
+ && strictFilteredJobs.length === 0
+ && orFallbackInCantonJobs.length === 0
+ && crossCantonFallbackJobs.length === 0
+ && crossLocaleFallbackJobs.length > 0;
+ }, [deferredSearchQuery, strictFilteredJobs.length, orFallbackInCantonJobs.length, crossCantonFallbackJobs.length, crossLocaleFallbackJobs.length]);
 
  // Resolve the display name of the company when a company slug filter is active
  const companyDisplayName = useMemo(() => {
@@ -6713,6 +6835,25 @@ const JobBoard: React.FC<JobBoardProps> = ({
  </p>
  <p className="text-xs text-subtle mt-1">
  {t('jobBoard.crossCantonFallback.hint')}
+ </p>
+ </div>
+ </div>
+ </div>
+ )}
+ {isCrossLocaleFallback && (
+ <div
+ role="status"
+ aria-live="polite"
+ className="rounded-xl border border-info-border bg-info-subtle px-4 py-3 text-sm text-body"
+ >
+ <div className="flex items-start gap-2">
+ <Search className="w-4 h-4 mt-0.5 shrink-0 text-info-strong" />
+ <div>
+ <p className="font-semibold font-display text-strong">
+ {t('jobBoard.crossLocaleFallback.title', { query: deferredSearchQuery.trim(), count: String(filteredJobs.length) })}
+ </p>
+ <p className="text-xs text-subtle mt-1">
+ {t('jobBoard.crossLocaleFallback.hint')}
  </p>
  </div>
  </div>

--- a/services/locales/de-core.ts
+++ b/services/locales/de-core.ts
@@ -710,6 +710,8 @@ const deCore: Record<string, string> = {
  'jobBoard.searchFallback.hint': 'Zeige verwandte Angebote basierend auf den Stichwörtern Ihrer Suche, sortiert nach Relevanz.',
  'jobBoard.crossCantonFallback.title': 'Keine Angebote im Kanton für «{query}» — {count} Treffer aus anderen Kantonen',
  'jobBoard.crossCantonFallback.hint': 'Für Grenzgänger aus Italien kann jeder Schweizer Kanton relevant sein: Wir zeigen die nächstgelegenen Treffer in der ganzen Schweiz.',
+ 'jobBoard.crossLocaleFallback.title': 'Keine deutschen Treffer für «{query}» — {count} Inserate aus anderssprachigen Listings',
+ 'jobBoard.crossLocaleFallback.hint': 'Wir zeigen Schweizer Inserate, deren Titel auf Italienisch, Französisch oder Englisch ist: der Detail-Link bleibt auf der deutschen URL.',
  'jobBoard.companyHeading': 'Unternehmen',
  'jobBoard.sourceLabel': 'Quelle',
  'jobBoard.snapshotTitle': 'Stellen-Snapshot',

--- a/services/locales/en-core.ts
+++ b/services/locales/en-core.ts
@@ -710,6 +710,8 @@ const enCore: Record<string, string> = {
  'jobBoard.searchFallback.hint': 'Showing related offerings based on the keywords from your search, ranked by relevance.',
  'jobBoard.crossCantonFallback.title': 'No in-canton offers for «{query}» — {count} matches from other cantons',
  'jobBoard.crossCantonFallback.hint': 'For Italian cross-border workers any Swiss canton can still be relevant: showing the closest matches anywhere in Switzerland.',
+ 'jobBoard.crossLocaleFallback.title': 'No English results for «{query}» — {count} listings from other-language postings',
+ 'jobBoard.crossLocaleFallback.hint': 'Showing Swiss listings whose title is in German, French or Italian: the detail link stays on the English URL.',
  'jobBoard.companyHeading': 'Company',
  'jobBoard.sourceLabel': 'Source',
  'jobBoard.snapshotTitle': 'Job snapshot',

--- a/services/locales/fr-core.ts
+++ b/services/locales/fr-core.ts
@@ -710,6 +710,8 @@ const frCore: Record<string, string> = {
  'jobBoard.searchFallback.hint': 'Affichage d\'offres similaires basées sur les mots-clés de votre recherche, classées par pertinence.',
  'jobBoard.crossCantonFallback.title': 'Aucune offre dans le canton pour «{query}» — {count} résultats d\'autres cantons',
  'jobBoard.crossCantonFallback.hint': 'Pour les frontaliers italiens, n\'importe quel canton suisse peut être pertinent : nous montrons les correspondances les plus proches partout en Suisse.',
+ 'jobBoard.crossLocaleFallback.title': 'Aucun résultat en français pour «{query}» — {count} annonces depuis des listings dans d\'autres langues',
+ 'jobBoard.crossLocaleFallback.hint': 'Nous affichons des annonces suisses dont le titre est en italien, allemand ou anglais : le lien du détail reste sur l\'URL française.',
  'jobBoard.companyHeading': 'Entreprise',
  'jobBoard.sourceLabel': 'Source',
  'jobBoard.snapshotTitle': 'Aperçu de l’offre',

--- a/services/locales/it-core.ts
+++ b/services/locales/it-core.ts
@@ -747,6 +747,8 @@ const translations: Record<string, string> = {
  'jobBoard.searchFallback.hint': 'Mostriamo offerte affini in base alle parole chiave della tua ricerca, ordinate per pertinenza.',
  'jobBoard.crossCantonFallback.title': 'Nessuna offerta nel cantone per «{query}» — {count} risultati da altri cantoni',
  'jobBoard.crossCantonFallback.hint': 'Per i frontalieri italiani le offerte di confine sono comunque rilevanti: mostriamo i match più vicini ovunque siano in Svizzera.',
+ 'jobBoard.crossLocaleFallback.title': 'Nessun risultato in italiano per «{query}» — {count} annunci da listing in altre lingue',
+ 'jobBoard.crossLocaleFallback.hint': 'Ti mostriamo offerte svizzere il cui titolo è in tedesco, francese o inglese: il link al dettaglio resta in italiano.',
  'jobBoard.companyHeading': 'Azienda',
  'jobBoard.sourceLabel': 'Fonte',
  'jobBoard.snapshotTitle': 'Snapshot annuncio',


### PR DESCRIPTION
## Summary
- Drop trailing-space anchor in the 3 stemmed haystack matchers so partial-stem queries (`?q=infermie` → stem `infermi`) prefix-match haystack word `infermier` (stem of `infermiere`/`infermieri`). Leading-space anchor keeps word-start alignment intact.
- Add tier-4 cross-locale fallback: when tiers 1-3 all return zero for a non-empty query, lazy-fetch DE/FR/EN slim indexes, dedup against the loaded IT pool by canonical id, and score-match the same way as tier 3. Jobs share id + slug across locale shards, so the detail link stays on the current-locale URL; only the displayed title may surface in another language.
- New i18n strings `jobBoard.crossLocaleFallback.{title,hint}` in all 4 locales + banner so users understand they are seeing other-language listings.

Reproduces the user-reported issues:
- `/cerca-lavoro-ticino/?q=infermie` → currently 0; with prefix fix, finds all `infermiere`/`infermieri`.
- `/cerca-lavoro-ticino/?q=pizzaiolo` → tier 3 already in main but until now no listing surfaced when the IT corpus had no match; tier 4 now pulls from DE/FR/EN.

## Test plan
- [ ] `/cerca-lavoro-ticino/?q=infermie` returns the same set as `?q=infermiere` (prefix match on stem)
- [ ] `/cerca-lavoro-ticino/?q=pizzaiolo` falls back to the GR-Laax Pizzaiolo via tier 3 (in IT corpus) or tier 4 (cross-locale) and shows the appropriate banner
- [ ] Tiers 1-3 unchanged behaviour for queries with in-canton matches
- [ ] Detail link for cross-locale fallback navigates to the current-locale URL (slug shared across shards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)