### PR TITLE
fix(seo-hubs): link seo-static.css from hub head — restore .s-* class styling

### DIFF
--- a/build-plugins/seoHubsPlugin.ts
+++ b/build-plugins/seoHubsPlugin.ts
@@ -1172,6 +1172,7 @@ function buildHtml(args: BuildHtmlArgs): string {
 ${hreflangs}${xDefault}${prevLink}${nextLink}
     <script type="application/ld+json">${breadcrumbLd}</script>
     <script type="application/ld+json">${collectionLd}</script>${hasSpaBundle ? `\n    <link rel="stylesheet" href="/assets/${entryCss}" crossorigin media="all">` : ''}
+    ${SEO_STATIC_CSS_LINK}
     ${ADSENSE_SNIPPET}
   </head>
   <body class="bg-surface-alt text-heading overflow-x-hidden">


### PR DESCRIPTION
## Summary
- Hub pages (`/cerca-lavoro-ticino/settori/`, companies, openings indexes) emit `.s-*` scoped class names introduced by #454 but never linked the `seo-static-<hash>.css` stylesheet that defines them.
- Live result: settori page renders with unstyled body — no grid, no card styling, no spacing.
- Fix: add `${SEO_STATIC_CSS_LINK}` to the hub head, matching the sibling emit at line 1721 and every other static plugin (`jobsSeoPagesPlugin`, `staticPagesPlugin`, `affiliateRedirectPlugin`).

## Root cause
- PR #454 extracted inline `style=` attrs to content-hashed `.s-*` classes in `seo-static.css`.
- One of the two `<head>` blocks in `seoHubsPlugin.ts` (line 1156) was missed when wiring the stylesheet `<link>`.
- The other emit (line 1705) already has it.

## Test plan
- [ ] CI build green
- [ ] After deploy, `curl https://frontaliereticino.ch/cerca-lavoro-ticino/settori/` contains `seo-static-<hash>.css` `<link>`
- [ ] Visually verify settori, companies, openings hubs render styled grids/cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)