### PR TITLE
fix(crawler/grace): use trailing job-id digits as merge key

### DIFF
--- a/scripts/update-grace-jobs.mjs
+++ b/scripts/update-grace-jobs.mjs
@@ -81,7 +81,23 @@ function stripHtml(html = '') {
     .replace(/&#39;/g, "'").replace(/\s+/g, ' ').trim();
 }
 
-function jobMatchKey(job) {
+export function jobMatchKey(job) {
+  // hotelcareer.com URLs have shape
+  //   /jobs/{companySlug}-{companyId}/{titleSlug}-{jobId}
+  // where companyId is a 6-digit number (120155 for Grace La Margna) and
+  // jobId is the 7-digit identifier we want to key on. The shared
+  // extractStableJobId helper matches the FIRST 6+ digit run in the URL,
+  // which lands on the companyId and collapses every Grace job onto the
+  // same key — mergeJobs then merges all new jobs into the same prev,
+  // pulling Sommelier's titleByLocale/slugByLocale onto every job and
+  // triggering an 8-of-9 within-slice duplicate-slug archive in
+  // cleanup-jobs. Prefer the trailing-digit token of the URL's last path
+  // segment for hotelcareer jobs; fall back to extractStableJobId for
+  // any other URL shape so PwC UUID rename detection stays intact.
+  const url = String(job?.url || '').toLowerCase().replace(/[?#].*$/, '').replace(/\/+$/, '');
+  const lastSeg = url.split('/').pop() || '';
+  const trailing = lastSeg.match(/(\d{6,})$/);
+  if (trailing) return `num:${trailing[1]}`;
   return extractStableJobId(job.url) || String(job.slug || '').trim().toLowerCase();
 }
 
@@ -681,13 +697,18 @@ async function main() {
   await assembleJobsDataset();
 }
 
-main().catch((err) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  if (msg.includes('challenge did not resolve') || msg.includes('still blocked')) {
-    console.warn(`⚠️ Hotelcareer.com anti-bot challenge blocked crawl: ${msg}`);
-    console.warn('ℹ️ Existing job data in slice preserved. Will retry next run.');
-    process.exit(0);
-  }
-  console.error('❌ Fatal crawler error:', err);
-  process.exit(1);
-});
+// Guard top-level execution so the module can be imported by tests without
+// triggering a live Playwright crawl. Run only when invoked directly via
+// `node scripts/update-grace-jobs.mjs` (npm script `jobs:update:grace`).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('challenge did not resolve') || msg.includes('still blocked')) {
+      console.warn(`⚠️ Hotelcareer.com anti-bot challenge blocked crawl: ${msg}`);
+      console.warn('ℹ️ Existing job data in slice preserved. Will retry next run.');
+      process.exit(0);
+    }
+    console.error('❌ Fatal crawler error:', err);
+    process.exit(1);
+  });
+}

--- a/tests/grace-crawler-merge-key.test.ts
+++ b/tests/grace-crawler-merge-key.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Grace La Margna crawler merge-key regression test.
+ *
+ * hotelcareer.com URLs embed both a company-page id (6 digits, e.g. 120155
+ * for Grace La Margna) and a job-specific id (7 digits, e.g. 3694182) in
+ * the URL path: `/jobs/{companySlug}-{companyId}/{titleSlug}-{jobId}`.
+ *
+ * The shared `extractStableJobId` helper falls back to the FIRST 6+ digit
+ * run in the URL, which lands on the companyId for every Grace job and
+ * collapses all 9 listings onto the same merge key. mergeJobs then merges
+ * every new job into the same prev, pulling Sommelier's locale fields
+ * onto every job and triggering an 8-of-9 within-slice duplicate-slug
+ * archive in cleanup-jobs.
+ *
+ * Grace's local `jobMatchKey` must prefer the trailing-digit token of the
+ * URL's last path segment so each of the 9 listings produces a distinct
+ * key.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - .mjs file with implicit exports
+import { jobMatchKey } from '../scripts/update-grace-jobs.mjs';
+
+describe('Grace La Margna jobMatchKey', () => {
+  it('produces a distinct key per hotelcareer job-id, not the shared company-page id', () => {
+    const urls = [
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/sommelier-be-the-master-of-bottles-3694182',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/assistant-outlet-manager-restaurants-are-your-stage-3694115',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/concierge-creator-of-unique-experiences-3694083',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/front-office-trainee-kickstart-your-career-with-us-3694090',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/head-waiter-waitress-be-the-hero-in-the-restaurant-3694112',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/reservation-agent-be-the-master-3694108',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/reservation-supervisor-be-the-master-3694109',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/restaurant-supervisor-restaurant-is-your-stage-3694113',
+      'https://www.hotelcareer.com/jobs/grace-la-margna-st-moritz-120155/assistant-waiter-waitress-be-the-hero-in-the-restaurant-3694114',
+    ];
+    const keys = urls.map((url) => jobMatchKey({ url }));
+    const unique = new Set(keys);
+    expect(unique.size).toBe(urls.length);
+    expect(keys[0]).toBe('num:3694182');
+    expect(keys[1]).toBe('num:3694115');
+    // None of the keys should be the company-page id.
+    for (const k of keys) expect(k).not.toBe('num:120155');
+  });
+
+  it('normalises trailing slashes and query strings before extracting the job id', () => {
+    expect(jobMatchKey({ url: 'https://www.hotelcareer.com/jobs/foo-120155/bar-3694182/' })).toBe('num:3694182');
+    expect(jobMatchKey({ url: 'https://www.hotelcareer.com/jobs/foo-120155/bar-3694182?intcid=auto' })).toBe('num:3694182');
+  });
+
+  it('falls back to extractStableJobId for non-trailing-digit URLs (e.g. PwC UUID)', () => {
+    const url = 'https://jobs.pwc.ch/job-vacancies/some-title/0441e237-ebd9-4263-9fe5-e21facbd03ba';
+    expect(jobMatchKey({ url })).toBe('uuid:0441e237-ebd9-4263-9fe5-e21facbd03ba');
+  });
+
+  it('falls back to the job slug when the URL is empty', () => {
+    expect(jobMatchKey({ url: '', slug: 'My-Slug' })).toBe('my-slug');
+  });
+});


### PR DESCRIPTION
## Summary
Grace La Margna crawler shipped only 1 of 9 discovered jobs per run because all 9 hotelcareer URLs collapsed onto the same merge key. Local `jobMatchKey` now prefers the trailing-digit token of the URL's last path segment so each listing gets a distinct key. The shared `extractStableJobId` helper is untouched (would regress 14 other crawler URL shapes).

## Bug repro
hotelcareer URL pattern:

```
/jobs/grace-la-margna-st-moritz-120155/sommelier-be-the-master-of-bottles-3694182
                                ^^^^^^                                     ^^^^^^^
                                company id (matched, wrong)                job id (should match)
```

`extractStableJobId` greedy-matches the first 6+ digit run → `num:120155` for every Grace job. `mergeJobs` then merged all 9 new jobs into the same `prev` (Sommelier), pulling its `titleByLocale` / `slugByLocale` onto each new job. `cleanup-jobs` saw 9 identical Italian slugs and archived 8 as within-slice duplicates.

## Fix
Override `jobMatchKey` in `scripts/update-grace-jobs.mjs` to prefer `lastSegment.match(/(\d{6,})$/)` after stripping query / fragment / trailing slashes. Falls back to `extractStableJobId` so PwC UUID rename detection stays intact.

The shared helper is **not** changed: a full-crawler audit showed 14 URL shapes (Zegna `?JobID=…&Team=…`, Lavigny UUID without dashes, …) where the current first-match behaviour is correct, and a global switch would invalidate existing merge keys and orphan locale data.

Also guards top-level `main()` behind `import.meta.url === argv[1]` so tests can import the module without booting a live Playwright crawl.

## Test plan
- [x] `tests/grace-crawler-merge-key.test.ts` — 4 cases, all green: 9 distinct hotelcareer keys, query/slash normalisation, PwC UUID fallback, slug fallback.
- [x] `tests/job-match-key-stable-id.test.ts` — 7 cases, still green.
- [ ] After merge, run `gh workflow run update-jobs-grace.yml --ref main`; `data/jobs/by-crawler/grace-la-margna.json` should contain 9 jobs (Sommelier + Concierge + Front Office Trainee + Head Waiter + Assistant Outlet Manager + Assistant Waiter + Reservation Agent + Reservation Supervisor + Restaurant Supervisor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)