### PR TITLE
fix(seo): derive SECTION_TO_LOCALE from SECTION_SLUG (cathedral hotfix for #644)

### DIFF
--- a/build-plugins/companyHubBridgePlugin.ts
+++ b/build-plugins/companyHubBridgePlugin.ts
@@ -154,12 +154,13 @@ function buildAggregatorCanonical(locale: Locale): string {
   return `${BASE_URL}${LOCALE_PREFIX[locale]}/${AGGREGATOR_SLUG[locale]}/`.replace(/(?<!:)\/+/g, '/');
 }
 
-const SECTION_TO_LOCALE: ReadonlyArray<readonly [string, Locale]> = [
-  ['cerca-lavoro-ticino', 'it'],
-  ['find-jobs-ticino', 'en'],
-  ['jobs-im-tessin', 'de'],
-  ['trouver-emploi-tessin', 'fr'],
-];
+// Reverse-derive [sectionSlug, locale] tuples from the cathedral-allowed
+// SECTION_SLUG map above so the cathedral-no-ti-hardcodes guard only has
+// to track a single canonical source for the TI legacy section literals.
+const SECTION_TO_LOCALE: ReadonlyArray<readonly [string, Locale]> =
+  (Object.entries(SECTION_SLUG) as Array<[Locale, string]>).map(
+    ([loc, slug]) => [slug, loc] as const,
+  );
 
 const COMP_PREFIX_TO_LOCALE: Record<string, Locale> = {
   azienda: 'it',
@@ -271,7 +272,7 @@ function autoDiscoverCompanyHubs(rootDir: string): HubEntry[] {
           seen.set(key, {
             locale: 'it',
             companySlug: slug,
-            url: `${BASE_URL}/cerca-lavoro-ticino/azienda-${slug}/`,
+            url: `${BASE_URL}${buildHubPath('it', slug)}`,
             kind: 'unmatched',
             displayName: sample.company,
             jobCount: 0,


### PR DESCRIPTION
## Summary
Hotfix for cathedral-no-ti-hardcodes test failure introduced by PR #644. New SECTION_TO_LOCALE tuple array and an inline \`\${BASE_URL}/cerca-lavoro-ticino/...\` URL hardcoded the 4 TI legacy section literals outside the allowlist. Reverse-derive the tuples from the cathedral-allowed SECTION_SLUG map; use the existing buildHubPath helper for the URL. No runtime behaviour change.

## Test plan
- [x] tests/seo/cathedral-no-ti-hardcodes.test.ts — 5/5 green
- [ ] Post-merge: main deploy goes green and Grace bridge URL serves 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)