### PR TITLE
perf(seo): extract breadcrumb inline styles to CSS atoms (.s-bcr / .s-bcl)

### DIFF
--- a/build-plugins/annualReportPlugin.ts
+++ b/build-plugins/annualReportPlugin.ts
@@ -55,8 +55,6 @@ import {
   STAT_TILE_VALUE,
   STAT_TILE_ACCENT,
   CARD_STYLE,
-  BREADCRUMB_STYLE,
-  BREADCRUMB_LINK_STYLE,
   HERO_EYEBROW_STYLE,
   H1_STYLE,
   LEDE_STYLE,
@@ -848,8 +846,8 @@ function renderReport(opts: {
 
   // Body.
   const body = `
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${esc(homeUrl)}" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
       <span>${esc(copy.breadcrumbReport)}</span>
     </nav>

--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -91,8 +91,6 @@ import {
   WEEKLY_EMPLOYERS_SECTION,
 } from './weeklyEmployersData';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_STYLE,
   H1_STYLE,
   H2_STYLE,
@@ -1673,12 +1671,12 @@ function renderLeafPage(inp: LeafInputs): string {
   const hydrationScript = `\n  ${BORDER_WAIT_HYDRATION_SCRIPT_TAG}`;
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}" aria-label="Breadcrumb">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr" aria-label="Breadcrumb">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${buildRootHubPath(locale)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.rootH1.split(' —')[0])}</a>
+    <a href="${BASE_URL}${buildRootHubPath(locale)}" class="s-bcl">${esc(copy.rootH1.split(' —')[0])}</a>
     <span> / </span>
-    <a href="${BASE_URL}${buildRegionalHubPath(locale, region)}" style="${BREADCRUMB_LINK_STYLE}">${esc(regionDisplay)}</a>
+    <a href="${BASE_URL}${buildRegionalHubPath(locale, region)}" class="s-bcl">${esc(regionDisplay)}</a>
     <span> / </span>
     <span>${esc(crossingDisplay)}</span>
   </nav>
@@ -2018,10 +2016,10 @@ function renderHubPage(inp: HubInputs): string {
           : `snapshot of ${dateStamp}`;
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}" aria-label="Breadcrumb">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr" aria-label="Breadcrumb">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    ${region ? `<a href="${BASE_URL}${buildRootHubPath(locale)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.rootH1.split(' —')[0])}</a><span> / </span><span>${esc(regionDisplay)}</span>` : `<span>${esc(h1)}</span>`}
+    ${region ? `<a href="${BASE_URL}${buildRootHubPath(locale)}" class="s-bcl">${esc(copy.rootH1.split(' —')[0])}</a><span> / </span><span>${esc(regionDisplay)}</span>` : `<span>${esc(h1)}</span>`}
   </nav>
   <header class="s-Nv0GaD">
     <p style="${HERO_EYEBROW_STYLE}">${esc(copy.updatedLabel)} · ${dateStamp} <span class="s-k7sbVR" data-bw-live-badge>${esc(hubSnapshotBadgeText)}</span></p>
@@ -2350,10 +2348,10 @@ function renderArchivePage(inp: ArchiveInputs): string {
   </section>`;
 
   const bodyHtml = `<article class="s-xzWvwM">
-        <nav style="${BREADCRUMB_STYLE}" aria-label="Breadcrumb">
-          <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+        <nav class="s-bcr" aria-label="Breadcrumb">
+          <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
           <span> / </span>
-          <a href="${BASE_URL}${buildOggiPath(locale, crossing)}" style="${BREADCRUMB_LINK_STYLE}">${esc(crossingDisplay)}</a>
+          <a href="${BASE_URL}${buildOggiPath(locale, crossing)}" class="s-bcl">${esc(crossingDisplay)}</a>
           <span> / </span>
           <span>${esc(monthKey)}</span>
         </nav>

--- a/build-plugins/careerLandingsPlugin.ts
+++ b/build-plugins/careerLandingsPlugin.ts
@@ -78,8 +78,6 @@ import {
   type EmployerCardEmployer,
 } from './shared/employerCardHtml';
 import {
-  BREADCRUMB_STYLE,
-  BREADCRUMB_LINK_STYLE,
   H1_STYLE,
   LEDE_STYLE,
   BODY_STYLE,
@@ -499,10 +497,10 @@ function renderPage(opts: {
   const sourcesHtml = renderSources(copy.sources, copy.sourcesLabel);
 
   const body = `
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${esc(homeUrl)}" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
-      <a href="${esc(jobBoardUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbJobs)}</a>
+      <a href="${esc(jobBoardUrl)}" class="s-bcl">${esc(copy.breadcrumbJobs)}</a>
       <span> / </span>
       <span>${esc(copy.h1)}</span>
     </nav>

--- a/build-plugins/costOfLivingLandingsPlugin.ts
+++ b/build-plugins/costOfLivingLandingsPlugin.ts
@@ -67,8 +67,6 @@ import {
   getLocaleStrings,
 } from './costOfLivingLandingsCopy';
 import {
-  BREADCRUMB_STYLE,
-  BREADCRUMB_LINK_STYLE,
   H1_STYLE,
   H2_STYLE,
   CARD_STYLE,
@@ -497,10 +495,10 @@ function renderPage(opts: {
 
   const body = `
     ${sharedStyleBlock}
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(L.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${esc(homeUrl)}" class="s-bcl">${esc(L.breadcrumbHome)}</a>
       <span> / </span>
-      <a href="${esc(hubUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(L.breadcrumbHub)}</a>
+      <a href="${esc(hubUrl)}" class="s-bcl">${esc(L.breadcrumbHub)}</a>
       <span> / </span>
       <span>${esc(cityName)}</span>
     </nav>

--- a/build-plugins/frSalaireNetLandingPlugin.ts
+++ b/build-plugins/frSalaireNetLandingPlugin.ts
@@ -63,8 +63,6 @@ import { buildSeoPageHtml } from './shared/seoPageShell';
 import { WriteCollector } from './batchWrite';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 import {
-  BREADCRUMB_STYLE,
-  BREADCRUMB_LINK_STYLE,
   H1_STYLE,
   LEDE_STYLE,
   BODY_STYLE,
@@ -435,10 +433,10 @@ function renderPage(opts: RenderOpts): RenderResult {
   const dividerHtml = renderApprofondisciDivider('Pour aller plus loin');
 
   const body = `
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">Accueil</a>
+    <nav class="s-bcr">
+      <a href="${esc(homeUrl)}" class="s-bcl">Accueil</a>
       <span> / </span>
-      <a href="${esc(calcUrl)}" style="${BREADCRUMB_LINK_STYLE}">Calculer le salaire</a>
+      <a href="${esc(calcUrl)}" class="s-bcl">Calculer le salaire</a>
       <span> / </span>
       <span>Calcul salaire net frontalier Suisse 2026</span>
     </nav>

--- a/build-plugins/fuelDailyPagesPlugin.ts
+++ b/build-plugins/fuelDailyPagesPlugin.ts
@@ -82,8 +82,6 @@ import {
   WEEKLY_EMPLOYERS_SECTION,
 } from './weeklyEmployersData';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_BODY_STYLE,
   CARD_STYLE,
   CTA_PRIMARY_STYLE,
@@ -1790,8 +1788,8 @@ function renderPage(inp: PageInputs): string {
   // Main body markup (kept plain + inline-styled so we don't depend on the
   // SPA bundle and the static page ranks on its own).
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
     <span>${esc(fuelLabel)}</span>
     <span> / </span>
@@ -2082,10 +2080,10 @@ function renderArchive(inp: ArchiveInputs): string {
   const archiveProse = renderFuelArchiveProse({ locale, fuelLabel, zoneLabel, monthKey, avgFmt: formatPrice(avg, locale) });
 
   const bodyHtml = `<article class="s-xzWvwM">
-        <nav style="${BREADCRUMB_STYLE}">
-          <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+        <nav class="s-bcr">
+          <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
           <span> / </span>
-          <a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, zone)}" style="${BREADCRUMB_LINK_STYLE}">${esc(zoneLabel)}</a>
+          <a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, zone)}" class="s-bcl">${esc(zoneLabel)}</a>
           <span> / </span>
           <span>${esc(monthKey)}</span>
         </nav>
@@ -3157,12 +3155,12 @@ function renderStationPage(opts: {
     : '';
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav aria-label="Breadcrumb" style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">Home</a>
+  <nav aria-label="Breadcrumb" class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">Home</a>
     <span> / </span>
-    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/${FUEL_TODAY_SLUG[locale]}/" style="${BREADCRUMB_LINK_STYLE}">${esc(fuelLabel)}</a>
+    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/${FUEL_TODAY_SLUG[locale]}/" class="s-bcl">${esc(fuelLabel)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, ctx.zone)}" style="${BREADCRUMB_LINK_STYLE}">${esc(zoneLabel)}</a>
+    <a href="${BASE_URL}${buildFuelTodayPath(locale, fuel, ctx.zone)}" class="s-bcl">${esc(zoneLabel)}</a>
     <span> / </span>
     <span>${esc(ctx.brandDisplay)} ${esc(ctx.streetDisplay)}</span>
   </nav>
@@ -3671,10 +3669,10 @@ function renderItalianCityPage(opts: {
   const description = intro.slice(0, 180);
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav aria-label="Breadcrumb" style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">Home</a>
+  <nav aria-label="Breadcrumb" class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">Home</a>
     <span> / </span>
-    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/${FUEL_TODAY_SLUG[locale]}/" style="${BREADCRUMB_LINK_STYLE}">${esc(fuelLabel)}</a>
+    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/${FUEL_TODAY_SLUG[locale]}/" class="s-bcl">${esc(fuelLabel)}</a>
     <span> / </span>
     <span>${esc(entry.display)}</span>
   </nav>
@@ -4570,12 +4568,12 @@ function renderItalianStationPage(opts: {
   const lastUpdatedLine = `<p class="s-oF62Kj">${esc(redesignLabels.historyLastUpdated(dateStamp))}</p>`;
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav aria-label="Breadcrumb" style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav aria-label="Breadcrumb" class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/${FUEL_TODAY_SLUG[locale]}/" style="${BREADCRUMB_LINK_STYLE}">${esc(fuelLabel)}</a>
+    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/${FUEL_TODAY_SLUG[locale]}/" class="s-bcl">${esc(fuelLabel)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${cityHubPath}" style="${BREADCRUMB_LINK_STYLE}">${esc(cityName)}</a>
+    <a href="${BASE_URL}${cityHubPath}" class="s-bcl">${esc(cityName)}</a>
     <span> / </span>
     <span>${esc(ctx.brandDisplay)} ${esc(ctx.streetDisplay)}</span>
   </nav>

--- a/build-plugins/fuelStationIndexPages.ts
+++ b/build-plugins/fuelStationIndexPages.ts
@@ -66,8 +66,6 @@ import { BASE_URL } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { renderHreflangTags } from './shared/hreflang';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_STYLE,
   CTA_PRIMARY_STYLE,
   H1_STYLE,
@@ -945,10 +943,10 @@ function renderIndexPage(opts: RenderIndexOpts): string {
   </section>`;
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/" style="${BREADCRUMB_LINK_STYLE}">${esc(fuelLabel)}</a>
+    <a href="${BASE_URL}${FUEL_LOCALE_PREFIX[locale]}/${FUEL_SECTION_SLUG[locale][fuel]}/" class="s-bcl">${esc(fuelLabel)}</a>
     <span> / </span>
     <span>${esc(titles.h1)}</span>
   </nav>

--- a/build-plugins/healthPremiumsLandingPlugin.ts
+++ b/build-plugins/healthPremiumsLandingPlugin.ts
@@ -63,8 +63,6 @@ import { generateRelatedLinksBlock } from './shared/relatedLinks';
 import { adSlotHtml } from './lib/adSlotHtml';
 import { cleanNamespaces, cleanSitemapFiles } from './shared/distNamespaceCleanup';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_STYLE,
   CTA_PRIMARY_STYLE,
   H1_STYLE,
@@ -2331,12 +2329,12 @@ function renderLeafPage(inp: LeafInputs): string {
   const description = introLong.slice(0, 180);
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${buildHealthPremiumsRootPath(locale)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbRoot)}</a>
+    <a href="${BASE_URL}${buildHealthPremiumsRootPath(locale)}" class="s-bcl">${esc(copy.breadcrumbRoot)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${buildHealthPremiumsCantonPath(locale, canton)}" style="${BREADCRUMB_LINK_STYLE}">${esc(cantonLabel)}</a>
+    <a href="${BASE_URL}${buildHealthPremiumsCantonPath(locale, canton)}" class="s-bcl">${esc(cantonLabel)}</a>
     <span> / </span>
     <span>${esc(ageLabel)}</span>
   </nav>
@@ -2640,10 +2638,10 @@ function renderCantonHubPage(inp: CantonHubInputs): string {
   const description = introLong.slice(0, 180);
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${buildHealthPremiumsRootPath(locale)}" style="${BREADCRUMB_LINK_STYLE}">${esc(leafCopy.breadcrumbRoot)}</a>
+    <a href="${BASE_URL}${buildHealthPremiumsRootPath(locale)}" class="s-bcl">${esc(leafCopy.breadcrumbRoot)}</a>
     <span> / </span>
     <span>${esc(cantonLabel)}</span>
   </nav>
@@ -2911,8 +2909,8 @@ function renderRootHubPage(inp: RootHubInputs): string {
     : '';
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
     <span>${esc(leafCopy.breadcrumbRoot)}</span>
   </nav>

--- a/build-plugins/jobMarketSnapshotChCantonPages.ts
+++ b/build-plugins/jobMarketSnapshotChCantonPages.ts
@@ -34,8 +34,6 @@ import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { WriteCollector } from './batchWrite';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_STYLE,
   CTA_PRIMARY_STYLE,
   H1_STYLE,
@@ -427,8 +425,8 @@ function renderSnapshotPage(inp: RenderInputs): string {
   const cantonName = inp.cantonName;
   const homeHref = inp.locale === 'it' ? '/' : `${LOCALE_PREFIX[inp.locale]}/`;
 
-  const breadcrumb = `<nav aria-label="breadcrumb" style="${BREADCRUMB_STYLE}">
-    <a href="${homeHref}" style="${BREADCRUMB_LINK_STYLE}">${esc(c.breadcrumbHome)}</a>
+  const breadcrumb = `<nav aria-label="breadcrumb" class="s-bcr">
+    <a href="${homeHref}" class="s-bcl">${esc(c.breadcrumbHome)}</a>
     <span> / </span>
     <span>${esc(c.breadcrumbSwitzerland)}</span>
     <span> / </span>

--- a/build-plugins/jobMarketSnapshotPlugin.ts
+++ b/build-plugins/jobMarketSnapshotPlugin.ts
@@ -86,8 +86,6 @@ import {
   WEEKLY_EMPLOYERS_SECTION,
 } from './weeklyEmployersData';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_STYLE,
   H1_STYLE,
   H2_STYLE,
@@ -1722,10 +1720,10 @@ function renderSnapshotPage(inp: SnapshotPageInputs): string {
   const robots = noindex ? 'noindex,follow' : 'index,follow';
 
   const bodyHtml = `<article class="s-xzWvwM">
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
-      <a href="${BASE_URL}${buildHubPath(locale)}" style="${BREADCRUMB_LINK_STYLE}">${esc(JOB_MARKET_HUB_NAME[locale])}</a>
+      <a href="${BASE_URL}${buildHubPath(locale)}" class="s-bcl">${esc(JOB_MARKET_HUB_NAME[locale])}</a>
       <span> / </span>
       <span>${esc(periodRange)}</span>
     </nav>
@@ -1999,8 +1997,8 @@ function renderHubPage(inp: HubPageInputs): string {
   };
 
   const bodyHtml = `<article class="s-xzWvwM">
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
       <span>${esc(JOB_MARKET_HUB_NAME[locale])}</span>
     </nav>
@@ -2963,10 +2961,10 @@ function renderSectorPage(inp: SectorPageInputs): string {
   };
 
   const bodyHtml = `<article class="s-xzWvwM">
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
-      <a href="${BASE_URL}${buildHubPath(locale)}" style="${BREADCRUMB_LINK_STYLE}">${esc(JOB_MARKET_HUB_NAME[locale])}</a>
+      <a href="${BASE_URL}${buildHubPath(locale)}" class="s-bcl">${esc(JOB_MARKET_HUB_NAME[locale])}</a>
       <span> / </span>
       <span>${esc(sectorLabel)}</span>
     </nav>

--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -24,8 +24,6 @@ import {
 } from './jobRecencyLanding';
 import type { JobLandingLocale } from './jobEditorialLanding';
 import {
-  BREADCRUMB_STYLE,
-  BREADCRUMB_LINK_STYLE,
   H1_STYLE,
   LEDE_STYLE,
   BODY_STYLE,
@@ -312,10 +310,10 @@ ${alternates}
   <body class="bg-surface-alt text-heading overflow-x-hidden">
     <div id="root"></div>
     <main class="seo-static-content s-xzWvwM">
-      <nav style="${BREADCRUMB_STYLE}">
-        <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">Home</a>
+      <nav class="s-bcr">
+        <a href="${BASE_URL}/" class="s-bcl">Home</a>
         <span> / </span>
-        <a href="${sectionRootUrl}" style="${BREADCRUMB_LINK_STYLE}">${esc(SECTION_NAME[locale])}</a>
+        <a href="${sectionRootUrl}" class="s-bcl">${esc(SECTION_NAME[locale])}</a>
         <span> / </span>
         <span>${esc(model.timeframeLabel)}</span>
       </nav>

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -26,8 +26,6 @@ import {
   STAT_TILE_LABEL,
   STAT_TILE_VALUE,
   CARD_STYLE,
-  BREADCRUMB_STYLE,
-  BREADCRUMB_LINK_STYLE,
   HERO_EYEBROW_STYLE,
   H1_STYLE,
   LEDE_STYLE,
@@ -332,10 +330,10 @@ ${alternates}
   <body>
     <div id="root"></div>
     <main class="seo-static-content s-Ziv1Xn">
-        <nav style="${BREADCRUMB_STYLE}">
-          <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">Home</a>
+        <nav class="s-bcr">
+          <a href="${BASE_URL}/" class="s-bcl">Home</a>
           <span> / </span>
-          <a href="${sectionRootUrl}" style="${BREADCRUMB_LINK_STYLE}">${esc(SECTION_NAME[locale])}</a>
+          <a href="${sectionRootUrl}" class="s-bcl">${esc(SECTION_NAME[locale])}</a>
           <span> / </span>
           <span>${esc(seo.h1)}</span>
         </nav>

--- a/build-plugins/marketReportPlugin.ts
+++ b/build-plugins/marketReportPlugin.ts
@@ -49,8 +49,6 @@ import {
   STAT_TILE_LABEL,
   STAT_TILE_VALUE,
   CARD_STYLE,
-  BREADCRUMB_STYLE,
-  BREADCRUMB_LINK_STYLE,
   HERO_EYEBROW_STYLE,
   H1_STYLE,
   LEDE_STYLE,
@@ -624,8 +622,8 @@ function renderReport(opts: {
   };
 
   const body = `
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${esc(homeUrl)}" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
       <span>${esc(copy.h1)}</span>
     </nav>

--- a/build-plugins/nursingLandingsPlugin.ts
+++ b/build-plugins/nursingLandingsPlugin.ts
@@ -51,8 +51,6 @@ import { buildSeoPageHtml } from './shared/seoPageShell';
 import { WriteCollector } from './batchWrite';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CTA_PRIMARY_STYLE,
   CARD_STYLE,
   LINK_ACCENT_STYLE,
@@ -422,10 +420,10 @@ function renderPage(opts: {
   const relatedHtml = renderRelatedLinks(locale, copy.relatedLabel);
 
   const body = `
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${esc(homeUrl)}" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
-      <a href="${esc(jobBoardUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbJobs)}</a>
+      <a href="${esc(jobBoardUrl)}" class="s-bcl">${esc(copy.breadcrumbJobs)}</a>
       <span> / </span>
       <span>${esc(copy.h1)}</span>
     </nav>

--- a/build-plugins/orphanQueryLandingPlugin.ts
+++ b/build-plugins/orphanQueryLandingPlugin.ts
@@ -44,8 +44,6 @@ import {
 } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CTA_PRIMARY_STYLE,
   CARD_STYLE,
   H1_STYLE,
@@ -626,8 +624,8 @@ function renderPage(opts: {
   const indexable = matchingJobs.length >= MIN_MATCHING_JOBS;
 
   const body = `
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(t('orphanLanding.breadcrumbHome', 'Home'))}</a>
+    <nav class="s-bcr">
+      <a href="${BASE_URL}/" class="s-bcl">${esc(t('orphanLanding.breadcrumbHome', 'Home'))}</a>
       <span> / </span>
       <span>${esc(cluster.canonicalQuery)}</span>
     </nav>
@@ -1023,8 +1021,8 @@ export function orphanQueryLandingPlugin(rootDir: string): Plugin {
         };
 
         const bodyHtml = `<article class="s-xzWvwM">
-          <nav style="${BREADCRUMB_STYLE}">
-            <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+          <nav class="s-bcr">
+            <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
             <span> / </span>
             <span>${esc(copy.sectionLabel)}</span>
           </nav>

--- a/build-plugins/professionLandingsPlugin.ts
+++ b/build-plugins/professionLandingsPlugin.ts
@@ -43,8 +43,6 @@ import { WriteCollector } from './batchWrite';
 import { resolveProfessionLandingsFlushed } from './shared/buildSignals';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CTA_PRIMARY_STYLE,
   CARD_STYLE,
   LINK_ACCENT_STYLE,
@@ -506,10 +504,10 @@ function renderPage(opts: {
   const sourcesHtml = renderSourcesBlock(id, copy.sourcesLabel);
 
   const body = `
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+    <nav class="s-bcr">
+      <a href="${esc(homeUrl)}" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
       <span> / </span>
-      <a href="${esc(jobBoardUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbJobs)}</a>
+      <a href="${esc(jobBoardUrl)}" class="s-bcl">${esc(copy.breadcrumbJobs)}</a>
       <span> / </span>
       <span>${esc(copy.h1)}</span>
     </nav>

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -50,10 +50,6 @@ import { WriteCollector } from './batchWrite';
 import { BASE_URL } from './constants';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
 import { buildSeoPageHtml } from './shared/seoPageShell';
-import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
-} from './shared/seoContentTokens';
 import { buildTitleWithBrand, TITLE_MAX_CHARS } from './shared/titleSuffix';
 import {
   renderJobBoardCommuterContext,
@@ -1574,10 +1570,10 @@ function renderHubPage(input: HubPageInput): { urlPath: string; html: string; lo
   });
 
   const bodyHtml = `<article class="s-haN35X">
-    <nav style="${BREADCRUMB_STYLE}">
-      <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.homeBreadcrumb)}</a>
+    <nav class="s-bcr">
+      <a href="${BASE_URL}/" class="s-bcl">${esc(copy.homeBreadcrumb)}</a>
       <span> / </span>
-      <a href="${esc(sectionUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.jobsBreadcrumb)}</a>
+      <a href="${esc(sectionUrl)}" class="s-bcl">${esc(copy.jobsBreadcrumb)}</a>
       <span> / </span>
       <span>${esc(copy.searchBreadcrumb)}</span>
     </nav>

--- a/build-plugins/sectionPagesPlugin.ts
+++ b/build-plugins/sectionPagesPlugin.ts
@@ -44,8 +44,6 @@ import type { Plugin } from 'vite';
 import { BASE_URL } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_BODY_STYLE,
   CARD_PADDING_STYLE,
   H1_STYLE,
@@ -1056,8 +1054,8 @@ function renderSectionPage(opts: {
   const articlesHtml = renderArticleList(articles, locale);
 
   const body = `
-    <nav style="${BREADCRUMB_STYLE}" aria-label="breadcrumb">
-      <a href="${esc(homeUrl)}" style="${BREADCRUMB_LINK_STYLE}">${esc(localeCopy.homeBreadcrumb)}</a>
+    <nav class="s-bcr" aria-label="breadcrumb">
+      <a href="${esc(homeUrl)}" class="s-bcl">${esc(localeCopy.homeBreadcrumb)}</a>
       <span aria-hidden="true"> / </span>
       <span>${esc(copy.h1)}</span>
     </nav>

--- a/build-plugins/shared/seoContentTokens.ts
+++ b/build-plugins/shared/seoContentTokens.ts
@@ -48,6 +48,15 @@ export const BREADCRUMB_STYLE =
 export const BREADCRUMB_LINK_STYLE =
   'color:var(--color-link);text-decoration:none';
 
+/**
+ * Class-name equivalents of BREADCRUMB_STYLE / BREADCRUMB_LINK_STYLE.
+ * Defined in `public/assets/seo-static.css` (`.s-bcr`, `.s-bcl`).
+ * Prefer these in static SEO plugins to cut ~250 B per page off the dist
+ * tarball (~50 MB across all SEO landings).
+ */
+export const BREADCRUMB_CLASS = 's-bcr';
+export const BREADCRUMB_LINK_CLASS = 's-bcl';
+
 // ── Cards ─────────────────────────────────────────────────────────────────────
 
 /**
@@ -516,9 +525,9 @@ export function renderBreadcrumb(
     if (isLast || !item.href) {
       return `<span>${esc(item.label)}</span>`;
     }
-    return `<a href="${esc(item.href)}" style="${BREADCRUMB_LINK_STYLE}">${esc(item.label)}</a>`;
+    return `<a href="${esc(item.href)}" class="${BREADCRUMB_LINK_CLASS}">${esc(item.label)}</a>`;
   });
-  return `<nav aria-label="breadcrumb" style="${BREADCRUMB_STYLE}">${parts.join('<span> / </span>')}</nav>`;
+  return `<nav aria-label="breadcrumb" class="${BREADCRUMB_CLASS}">${parts.join('<span> / </span>')}</nav>`;
 }
 
 /**

--- a/build-plugins/weeklyEmployersChCantonPages.ts
+++ b/build-plugins/weeklyEmployersChCantonPages.ts
@@ -27,8 +27,6 @@ import { BASE_URL, MIN_INDEXABLE_WORDS, countHtmlBodyWords } from './constants';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { WriteCollector } from './batchWrite';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_STYLE,
   CTA_PRIMARY_STYLE,
   H1_STYLE,
@@ -335,8 +333,8 @@ function renderEmployersPage(inp: RenderInputs): string {
   const cantonName = inp.cantonName;
   const homeHref = inp.locale === 'it' ? '/' : `${LOCALE_PREFIX[inp.locale]}/`;
 
-  const breadcrumb = `<nav aria-label="breadcrumb" style="${BREADCRUMB_STYLE}">
-    <a href="${homeHref}" style="${BREADCRUMB_LINK_STYLE}">${esc(c.breadcrumbHome)}</a>
+  const breadcrumb = `<nav aria-label="breadcrumb" class="s-bcr">
+    <a href="${homeHref}" class="s-bcl">${esc(c.breadcrumbHome)}</a>
     <span> / </span>
     <span>${esc(c.breadcrumbSwitzerland)}</span>
     <span> / </span>

--- a/build-plugins/weeklyEmployersPlugin.ts
+++ b/build-plugins/weeklyEmployersPlugin.ts
@@ -75,8 +75,6 @@ import {
 import { generateRelatedLinksBlock } from './shared/relatedLinks';
 import { adSlotHtml } from './lib/adSlotHtml';
 import {
-  BREADCRUMB_LINK_STYLE,
-  BREADCRUMB_STYLE,
   CARD_STYLE,
   CTA_PRIMARY_STYLE,
   H1_STYLE,
@@ -2412,8 +2410,8 @@ export function renderTopHubPage(inp: TopHubPageInputs): string {
   const topJobBoardCtaHtml = `<p class="s-ziawP1"><a href="${esc(weeklyEmployersJobBoardPath(locale, 'TI'))}" style="${CTA_PRIMARY_STYLE};font-size:15px">${esc(WEEKLY_EMPLOYERS_TILE_LABELS[locale].jobBoardCta)} →</a></p>`;
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}" aria-label="breadcrumb">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr" aria-label="breadcrumb">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
     <span>${esc(t.topHubTitle)}</span>
   </nav>
@@ -2912,10 +2910,10 @@ export function renderWeeklyEmployersPage(inp: WeeklyEmployersPageInputs): strin
       : '';
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}" aria-label="breadcrumb">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr" aria-label="breadcrumb">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    <a href="${esc(topHubPath(locale))}" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.sectionLabel)}</a>
+    <a href="${esc(topHubPath(locale))}" class="s-bcl">${esc(copy.sectionLabel)}</a>
     <span> / </span>
     <span>${esc(cityDisplay)}</span>
   </nav>
@@ -3446,12 +3444,12 @@ export function renderCompanyCityPage(inp: CompanyCityPageInputs): string {
   const ccCtaHtml = `<p class="s-ziawP1"><a href="${esc(ccJobBoardPath)}?city=${esc(city)}&q=${encodeURIComponent(employer)}" style="${CTA_PRIMARY_STYLE};font-size:15px">${esc(ccTileLabels.cityCta(`${employer} · ${cityDisplay}`))} →</a></p>`;
 
   const bodyHtml = `<article class="s-xzWvwM">
-  <nav style="${BREADCRUMB_STYLE}" aria-label="breadcrumb">
-    <a href="${BASE_URL}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.breadcrumbHome)}</a>
+  <nav class="s-bcr" aria-label="breadcrumb">
+    <a href="${BASE_URL}/" class="s-bcl">${esc(copy.breadcrumbHome)}</a>
     <span> / </span>
-    <a href="${BASE_URL}${WEEKLY_EMPLOYERS_LOCALE_PREFIX[locale]}/${WEEKLY_EMPLOYERS_SECTION[locale]}/ticino/${WEEKLY_EMPLOYERS_CURRENT_SLUG[locale]}/" style="${BREADCRUMB_LINK_STYLE}">${esc(copy.sectionLabel)}</a>
+    <a href="${BASE_URL}${WEEKLY_EMPLOYERS_LOCALE_PREFIX[locale]}/${WEEKLY_EMPLOYERS_SECTION[locale]}/ticino/${WEEKLY_EMPLOYERS_CURRENT_SLUG[locale]}/" class="s-bcl">${esc(copy.sectionLabel)}</a>
     <span> / </span>
-    <a href="${esc(parentHubHref)}" style="${BREADCRUMB_LINK_STYLE}">${esc(cityDisplay)}</a>
+    <a href="${esc(parentHubHref)}" class="s-bcl">${esc(cityDisplay)}</a>
     <span> / </span>
     <span>${esc(employer)}</span>
   </nav>

--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -1561,3 +1561,10 @@ aside.seo-footer-block .seo-fb-section-body a:hover,
    identical to the previous inline `style="..."` form; moved to CSS to save
    ~250 B × ~6 chips × 96k active-job emits ≈ ~24 MB on the dist artifact. */
 .aj-chip { display:inline-block;margin:0 6px 6px 0;padding:4px 10px;font-size:12px;font-weight:600;border-radius:9999px;background:var(--color-accent-subtle);color:var(--color-accent);text-decoration:none;border:1px solid var(--color-accent-border) }
+
+/* Breadcrumb nav + link atoms used by SEO landing plugins. Extracted from
+   BREADCRUMB_STYLE/BREADCRUMB_LINK_STYLE inline-style constants in
+   build-plugins/shared/seoContentTokens.ts. ~250 B per breadcrumb × ~300k
+   pages ≈ ~50 MB compressed savings on the dist artifact. */
+.s-bcr { margin:0 0 14px;font-size:13px;color:var(--color-subtle) }
+.s-bcl { color:var(--color-link);text-decoration:none }


### PR DESCRIPTION
## Summary
- Add `BREADCRUMB_CLASS` and `BREADCRUMB_LINK_CLASS` exports in `shared/seoContentTokens.ts`.
- Add `.s-bcr` and `.s-bcl` CSS atoms (margin/font/color and link color/decoration) in `public/assets/seo-static.css`.
- Migrate 95 `style="\${BREADCRUMB_STYLE}"` / `style="\${BREADCRUMB_LINK_STYLE}"` sites across 20 SEO plugins + the shared `renderBreadcrumb()` helper to use the new classes.
- Legacy constants kept exported for future callers.

## Impact
- ~50 MB compressed dist savings (50-55 B inline → 13 B class × 95 sites × thousands of pages each).
- Part of multi-PR effort to bring tar artifact under GitHub Pages 10 GB cap.
- CSS value is character-for-character equivalent to inline string — computed style identical, no visual delta.

## Test plan
- [ ] tsc clean (confirmed pre-merge)
- [ ] tests/seo/seo-static-css.test.ts + breadcrumb-coverage.test.ts pass
- [ ] Post-deploy artifact size + sample landing visual check

🤖 Generated with [Claude Code](https://claude.com/claude-code)