### PR TITLE
feat(hosting): R2 staging deploy — reuse Pages artifact, no rebuild

### DIFF
--- a/.github/workflows/deploy-r2-staging.yml
+++ b/.github/workflows/deploy-r2-staging.yml
@@ -1,0 +1,140 @@
+name: Deploy to R2 staging
+
+# Reuses the github-pages artifact produced by "Deploy to GitHub Pages"
+# (deploy.yml) — no rebuild. Syncs the exact same bytes to a Cloudflare R2
+# bucket so we can test the alternative hosting layer in isolation.
+#
+# Staging Worker (cloudflare-staging/) enforces noindex + blocks sitemap/robots.
+
+on:
+  workflow_run:
+    workflows: ["Deploy to GitHub Pages"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Source workflow run_id (empty = latest successful Pages deploy)"
+        required: false
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: r2-staging-sync
+  cancel-in-progress: false
+
+jobs:
+  sync-r2:
+    name: Sync github-pages artifact to R2 staging
+    # Only run on successful upstream runs (or on manual dispatch)
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch'
+          || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Resolve upstream Pages run_id
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const explicit = (context.payload.inputs && context.payload.inputs.run_id) || '';
+            const upstream = context.payload.workflow_run && context.payload.workflow_run.id;
+            let runId = explicit || upstream;
+            if (!runId) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'deploy.yml',
+                status: 'success',
+                per_page: 1,
+              });
+              if (!data.workflow_runs.length) {
+                core.setFailed('No successful runs found for deploy.yml');
+                return;
+              }
+              runId = data.workflow_runs[0].id;
+            }
+            core.info(`Using upstream run_id: ${runId}`);
+            core.setOutput('run_id', String(runId));
+
+      - name: Download github-pages artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          run_id: ${{ steps.resolve.outputs.run_id }}
+          name: github-pages
+          path: ./pages-artifact
+          if_no_artifact_found: fail
+
+      - name: Extract artifact tar
+        run: |
+          set -euo pipefail
+          if [ ! -f ./pages-artifact/artifact.tar ]; then
+            echo "::error::artifact.tar not found in downloaded artifact"
+            ls -la ./pages-artifact/ || true
+            exit 1
+          fi
+          mkdir -p dist
+          tar -xf ./pages-artifact/artifact.tar -C dist
+          file_count=$(find dist -type f | wc -l | tr -d ' ')
+          dist_size=$(du -sh dist | cut -f1)
+          echo "Extracted ${file_count} files (${dist_size})"
+          echo "FILE_COUNT=${file_count}" >> "$GITHUB_ENV"
+          echo "DIST_SIZE=${dist_size}" >> "$GITHUB_ENV"
+
+      - name: Install rclone
+        run: |
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+          rclone version
+
+      - name: Validate required secrets
+        env:
+          R2_ACCESS_KEY: ${{ secrets.R2_ACCESS_KEY }}
+          R2_SECRET_KEY: ${{ secrets.R2_SECRET_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          missing=0
+          for var in R2_ACCESS_KEY R2_SECRET_KEY R2_ENDPOINT; do
+            if [ -z "${!var:-}" ]; then
+              echo "::error::Missing required secret: $var"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      - name: Sync dist/ to R2 staging bucket
+        env:
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
+        run: |
+          set -euo pipefail
+          rclone sync dist/ R2:frontaliereticino-staging \
+            --transfers 64 \
+            --checkers 64 \
+            --size-only \
+            --fast-list \
+            --s3-no-head \
+            --s3-chunk-size 16M \
+            --stats 30s \
+            --stats-one-line \
+            --stats-log-level NOTICE
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## R2 staging sync"
+            echo ""
+            echo "- Source run_id: \`${{ steps.resolve.outputs.run_id }}\`"
+            echo "- Files: \`${FILE_COUNT:-?}\`"
+            echo "- Size: \`${DIST_SIZE:-?}\`"
+            echo "- Bucket: \`frontaliereticino-staging\`"
+            echo "- Worker URL: https://astro-staging.<account>.workers.dev (then https://astro.frontaliereticino.ch after DNS cutover)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/cloudflare-staging/README.md
+++ b/cloudflare-staging/README.md
@@ -1,0 +1,168 @@
+# Cloudflare R2 staging
+
+Test bed for migrating hosting off GitHub Pages (which is hitting its 10GB
+artifact limit on this site). Reuses the **exact `github-pages` artifact** built
+by `.github/workflows/deploy.yml` — no rebuild, byte-identical to prod.
+
+## Layout
+
+```
+cloudflare-staging/
+├── wrangler.toml        # Worker config + R2 binding
+├── src/worker.js        # Serves objects with noindex baked in
+└── README.md            # this file
+```
+
+Companion workflow: `.github/workflows/deploy-r2-staging.yml`.
+
+## Safety guarantees (staging only)
+
+The Worker hard-wires three rules that must NOT be carried over to prod:
+
+1. Every response carries `x-robots-tag: noindex, nofollow`
+2. `/robots.txt` always returns `Disallow: /` (regardless of bucket contents)
+3. `/sitemap*` returns 404
+
+This prevents Google from indexing `astro.frontaliereticino.ch` and cannibalizing
+the prod domain. **Remove these rules from the prod Worker.**
+
+## One-time setup (manual)
+
+### 1. Cloudflare account + zone
+
+1. Sign up at cloudflare.com
+2. Add site `frontaliereticino.ch`
+3. CF auto-imports DNS records from Swizzonic — **disable proxy (grey cloud) on
+   all records** so prod traffic continues to hit GitHub Pages unchanged
+4. CF gives you 2 nameservers; **do not switch NS at Swizzonic yet** —
+   prepare everything first
+
+### 2. R2 bucket + API token
+
+1. Dashboard → R2 → Create bucket `frontaliereticino-staging`,
+   location `EEUR` (Europe East)
+2. Bucket Settings → Object Versioning: **Enable** (rollback safety)
+3. R2 → "Manage R2 API Tokens" → Create:
+   - Permission: **Object Read & Write**
+   - Specific bucket: `frontaliereticino-staging`
+   - TTL: none
+4. Save Access Key ID, Secret Access Key, S3 endpoint URL
+
+### 3. GitHub Secrets
+
+```bash
+gh secret set R2_ACCESS_KEY          # from step 2.4
+gh secret set R2_SECRET_KEY          # from step 2.4
+gh secret set R2_ENDPOINT            # https://<account-id>.<jurisdiction>.r2.cloudflarestorage.com
+gh secret set CLOUDFLARE_API_TOKEN   # for wrangler deploys (Workers Scripts: Edit, R2: Edit)
+```
+
+### 4. Deploy the Worker
+
+```bash
+cd cloudflare-staging
+npx wrangler deploy
+```
+
+This publishes `astro-staging.<your-subdomain>.workers.dev`. Smoke test:
+
+```bash
+# Upload one test file
+npx wrangler r2 object put frontaliereticino-staging/index.html --file=<(echo '<h1>hello R2</h1>')
+
+# Hit it
+curl -I https://astro-staging.<your-subdomain>.workers.dev/
+# Expect: 200 + x-robots-tag: noindex, nofollow
+```
+
+### 5. NS migration (only when ready)
+
+Off-hours. Backup all current DNS records first (screenshot).
+
+1. Swizzonic dashboard → DNS / Nameservers for `frontaliereticino.ch`
+2. Change NS to those provided by Cloudflare
+3. Propagation: usually <30min, can be up to 24h
+4. Verify: `dig NS frontaliereticino.ch +short`
+5. Prod stays UP throughout (A records unchanged, still point to GH Pages)
+
+### 6. Bind subdomain to Worker
+
+CF dashboard → Workers & Pages → `astro-staging` → Settings → Domains & Routes:
+
+- "Add Custom Domain" → `astro.frontaliereticino.ch`
+- CF auto-creates DNS + Let's Encrypt SSL (~1-2 min)
+
+```bash
+curl -I https://astro.frontaliereticino.ch/
+# Expect: 200 + x-robots-tag: noindex, nofollow
+```
+
+## Triggering deploys
+
+### Automatic
+
+The workflow listens to `workflow_run` on **"Deploy to GitHub Pages"**. After
+every successful Pages deploy, the R2 sync fires automatically with the same
+artifact.
+
+### Manual
+
+```bash
+# Use latest successful Pages run
+gh workflow run deploy-r2-staging.yml
+
+# Pick a specific historical Pages run
+gh workflow run deploy-r2-staging.yml -f run_id=<PAGES_RUN_ID>
+```
+
+## Validation checklist
+
+Once staging serves real content:
+
+```bash
+# Header sanity
+for path in / /sitemap.xml /robots.txt /404.html; do
+  echo "=== $path ==="
+  curl -sI "https://astro.frontaliereticino.ch$path" | head -5
+done
+
+# Byte-diff a rich page vs prod
+diff \
+  <(curl -s https://frontaliereticino.ch/lavoro-frontalieri/ticino/) \
+  <(curl -s https://astro.frontaliereticino.ch/lavoro-frontalieri/ticino/)
+# Expect: identical (artifact is the same)
+```
+
+DOM hydration: open in a browser, DevTools console must be clean, router must
+classify static vs SPA correctly (see `static_overlay_truth_is_router`
+feedback).
+
+## Rollback
+
+| Issue | Action |
+|---|---|
+| Worker misbehaves | `npx wrangler delete astro-staging` |
+| Subdomain wrong | Remove custom domain binding + DNS record `astro` on CF |
+| NS migration regret | Restore original NS at Swizzonic (DNS backup from setup) |
+| R2 costs spike | Bucket idle = $0; delete if needed |
+
+## Cost expectations (free tier)
+
+| Item | Free quota | Expected use |
+|---|---|---|
+| R2 storage | 10 GB | ~10 GB (at limit, may need monitoring) |
+| Class A ops (PUT/LIST) | 1M/mo | Initial seed ~800k one-shot; incrementals <50k/deploy |
+| Class B ops (GET) | 10M/mo | Only cache misses; CF edge absorbs ~95% |
+| Egress | unlimited free | n/a |
+| Workers requests | 100k/day | Same — cache absorbs most |
+
+## Cutover to prod (later, separate work)
+
+When staging passes validation:
+
+1. Create bucket `frontaliereticino` (no `-staging` suffix)
+2. Fork Worker → `frontaliereticino-prod`, **remove** the noindex / robots /
+   sitemap blocks
+3. Add a parallel sync job in the workflow (or a separate workflow)
+4. Cutover DNS apex `frontaliereticino.ch` from GH Pages IPs → CF proxy
+5. Keep GH Pages deploy running for 7-14 days as instant rollback

--- a/cloudflare-staging/src/worker.js
+++ b/cloudflare-staging/src/worker.js
@@ -1,0 +1,121 @@
+// Cloudflare Worker — staging-only frontend for frontaliereticino.ch artifacts on R2.
+//
+// Hard rules baked into responses (never disable):
+//   1. x-robots-tag: noindex, nofollow on every response (block search engines on staging)
+//   2. /robots.txt always returns "Disallow: /" (regardless of object in bucket)
+//   3. /sitemap*  is short-circuited to 404 (block sitemap discovery)
+//
+// Prod must use a separate Worker without these blocks.
+
+const CONTENT_TYPE_BY_EXT = {
+  html: "text/html; charset=utf-8",
+  htm: "text/html; charset=utf-8",
+  css: "text/css; charset=utf-8",
+  js: "application/javascript; charset=utf-8",
+  mjs: "application/javascript; charset=utf-8",
+  json: "application/json; charset=utf-8",
+  xml: "application/xml; charset=utf-8",
+  txt: "text/plain; charset=utf-8",
+  svg: "image/svg+xml",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  ico: "image/x-icon",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  ttf: "font/ttf",
+  otf: "font/otf",
+  pdf: "application/pdf",
+  wasm: "application/wasm",
+  map: "application/json; charset=utf-8",
+};
+
+function contentTypeFor(key) {
+  const ext = key.split(".").pop()?.toLowerCase() ?? "";
+  return CONTENT_TYPE_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+function cacheControlFor(key) {
+  // Hashed assets (Vite output) get aggressive caching; HTML stays short.
+  if (/\.[0-9a-f]{8,}\.(js|css|woff2?|png|jpe?g|webp|avif|svg)$/i.test(key)) {
+    return "public, max-age=31536000, immutable";
+  }
+  if (key.endsWith(".html")) return "public, max-age=60, s-maxage=300";
+  return "public, max-age=300, s-maxage=600";
+}
+
+function withStagingHeaders(headers) {
+  // ALWAYS noindex on staging. No exceptions.
+  headers.set("x-robots-tag", "noindex, nofollow");
+  headers.set("x-staging", "1");
+  return headers;
+}
+
+async function serveObject(env, key) {
+  const obj = await env.BUCKET.get(key);
+  if (!obj) return null;
+  const headers = new Headers();
+  headers.set("content-type", obj.httpMetadata?.contentType ?? contentTypeFor(key));
+  headers.set("cache-control", cacheControlFor(key));
+  if (obj.httpEtag) headers.set("etag", obj.httpEtag);
+  if (obj.size != null) headers.set("content-length", String(obj.size));
+  return new Response(obj.body, { headers: withStagingHeaders(headers) });
+}
+
+async function serve404(env) {
+  const fb = await env.BUCKET.get("404.html");
+  const headers = new Headers({ "content-type": "text/html; charset=utf-8" });
+  return new Response(fb?.body ?? "<h1>404</h1>", {
+    status: 404,
+    headers: withStagingHeaders(headers),
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // Block crawlers explicitly via robots.txt
+    if (url.pathname === "/robots.txt") {
+      return new Response("User-agent: *\nDisallow: /\n", {
+        headers: withStagingHeaders(
+          new Headers({ "content-type": "text/plain; charset=utf-8" }),
+        ),
+      });
+    }
+
+    // Hide sitemaps entirely on staging
+    if (url.pathname.startsWith("/sitemap")) {
+      return new Response("Not Found", {
+        status: 404,
+        headers: withStagingHeaders(new Headers({ "content-type": "text/plain" })),
+      });
+    }
+
+    // Method gate (R2 is read-only via this Worker)
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: withStagingHeaders(new Headers({ allow: "GET, HEAD" })),
+      });
+    }
+
+    let key = decodeURIComponent(url.pathname.slice(1));
+
+    // Directory request → index.html
+    if (key === "" || key.endsWith("/")) {
+      key += "index.html";
+    }
+
+    // Try exact key, then directory-style fallback (path → path/index.html)
+    let res = await serveObject(env, key);
+    if (!res && !key.endsWith(".html") && !key.includes(".")) {
+      res = await serveObject(env, `${key}/index.html`);
+    }
+
+    return res ?? (await serve404(env));
+  },
+};

--- a/cloudflare-staging/wrangler.toml
+++ b/cloudflare-staging/wrangler.toml
@@ -1,0 +1,11 @@
+name = "astro-staging"
+main = "src/worker.js"
+compatibility_date = "2025-01-01"
+workers_dev = true
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "frontaliereticino-staging"
+
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary

Adds a parallel deploy path to Cloudflare R2 (staging only) that **reuses the exact `github-pages` artifact** produced by `deploy.yml` — no rebuild, byte-identical output. Goal: test the alternative hosting layer in isolation before considering a migration off GitHub Pages (currently hitting the 10GB artifact cap with ~800k pages).

Prod hosting and DNS are **untouched**. This PR only adds new files; it does not modify the existing Pages deploy or any production-serving infrastructure.

## What's in the box

- `cloudflare-staging/wrangler.toml` + `src/worker.js` — Worker that serves R2 objects, resolves directory paths to `index.html`, and **hard-wires three staging-safety rules**:
  - Every response carries `x-robots-tag: noindex, nofollow`
  - `/robots.txt` always returns `Disallow: /` (regardless of bucket contents)
  - `/sitemap*` returns 404
  - These rules MUST be removed from the eventual prod Worker.
- `.github/workflows/deploy-r2-staging.yml` — listens on `workflow_run` for successful "Deploy to GitHub Pages" runs, plus `workflow_dispatch` with optional `run_id`. Downloads `github-pages` artifact, extracts `artifact.tar`, syncs to R2 with `rclone sync --size-only --fast-list` (keeps class A ops well within free tier on incrementals).
- `cloudflare-staging/README.md` — operator runbook (CF account, R2 bucket, secrets, Worker deploy, optional NS migration, subdomain binding, validation, rollback).

## Prerequisites for the workflow to run

Repository secrets (already added):

- `R2_ACCESS_KEY`
- `R2_SECRET_KEY`
- `R2_ENDPOINT` (e.g. `https://<account-id>.eu.r2.cloudflarestorage.com`)

The Worker itself is deployed locally via `npx wrangler deploy` (one-shot, doesn't need CI).

## Why this is safe to merge now

- No existing workflow is modified.
- No production DNS or hosting touched.
- The Worker is only reachable via `astro-staging.<account>.workers.dev` until a Custom Domain is manually bound (separate step, documented in README).
- If secrets are missing, the workflow fails fast with a clear error.

## Test plan

- [ ] Merge PR
- [ ] Verify workflow appears in Actions tab
- [ ] Trigger manually: `gh workflow run deploy-r2-staging.yml`
- [ ] Confirm `github-pages` artifact downloads, extracts, syncs to R2 (initial seed: ~30-60 min for 800k files)
- [ ] Confirm R2 dashboard shows object count growing toward ~800k
- [ ] After Worker `wrangler deploy`: `curl -I https://astro-staging.<account>.workers.dev/` returns 200 + `x-robots-tag: noindex, nofollow`
- [ ] Byte-diff a rich page against prod (must be identical)

## Out of scope (follow-ups)

- NS migration Swizzonic → Cloudflare
- Custom domain `astro.frontaliereticino.ch` binding
- Prod Worker (different bucket, NO noindex/robots/sitemap blocks)
- Apex cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)