### PR TITLE
fix(seo): trailing slash on canonical paths + audit gate to prevent regression

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -379,6 +379,8 @@ jobs:
             npm run audit:hreflang
           spawn_capped audit:sitemap-canonicals      /tmp/g15.log \
             npm run audit:sitemap-canonicals
+          spawn_capped audit:canonical-trailing-slash /tmp/g15b.log \
+            npm run audit:canonical-trailing-slash
           spawn_capped audit:news-sitemap            /tmp/g16.log \
             npm run audit:news-sitemap
           # audit:image-object-license migrated into `npm run audit:all`

--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
     "audit:salary-landing-template": "node scripts/audit-salary-landing-template.mjs",
     "audit:jsonld-no-nested-scripts": "node scripts/audit-jsonld-no-nested-scripts.mjs",
     "audit:sitemap-canonicals": "node scripts/audit-sitemap-canonicals.mjs",
+    "audit:canonical-trailing-slash": "node scripts/audit-canonical-trailing-slash.mjs",
     "audit:h1-title-duplicates": "node scripts/audit-h1-title-duplicates.mjs --baseline=data/h1-title-duplicates-baseline.json",
     "audit:h1-title-duplicates:rebaseline": "node scripts/audit-h1-title-duplicates.mjs --write-baseline=data/h1-title-duplicates-baseline.json",
     "audit:title-length": "node scripts/audit-title-length.mjs --threshold=66 --baseline=data/title-length-baseline.json",

--- a/scripts/audit-canonical-trailing-slash.mjs
+++ b/scripts/audit-canonical-trailing-slash.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * audit-canonical-trailing-slash.mjs
+ *
+ * Hard gate: every `<link rel="canonical" href="…">` emitted into a dist/*.html
+ * page MUST end with a trailing slash (or be a homepage / asset URL). The
+ * canonical URL is the form Google indexes; emitting `…/articoli-frontaliere/foo`
+ * (no slash) trains Google to canonicalize the no-slash form, which then
+ * collides with the trailing-slash form used by the sitemap and internal
+ * links. The result is ~2.5% of GSC impressions arriving on the wrong shape.
+ *
+ * This audit is the regression net for the canonicalPath trailing-slash fix
+ * in services/seo/*.ts. Companion to `audit-sitemap-canonicals` — that one
+ * checks self-canonicalisation, this one checks URL shape hygiene.
+ *
+ * Pass conditions for a canonical href:
+ *   - equals `https://frontaliereticino.ch/` (homepage)              → OK
+ *   - ends with `/`                                                  → OK
+ *   - last path segment has a file extension (.html/.pdf/.xml/…)     → OK
+ *
+ * Fail condition:
+ *   - canonical href present, not homepage, no extension, no slash   → FAIL
+ *
+ * WARN (does NOT fail the gate):
+ *   - canonical href missing                                          → WARN
+ *     (covered by audit-sitemap-canonicals; surfacing here keeps the
+ *      two reports symmetric and easy to diff.)
+ *
+ * Run AFTER `npm run build` so dist/ is fresh.
+ *
+ * Usage:
+ *   node scripts/audit-canonical-trailing-slash.mjs
+ *   node scripts/audit-canonical-trailing-slash.mjs --limit=10000
+ *
+ * Pure Node, no deps.
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { writeAuditReport } from './lib/auditReport.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const DIST = join(ROOT, 'dist');
+const HOST = 'https://frontaliereticino.ch';
+const HOST_ROOT = `${HOST}/`;
+
+// File-extension regex for the last path segment. If the last segment after a
+// slash contains a `.` followed by a short alphanumeric suffix, treat the URL
+// as an asset (PDF, XML, sitemap-style HTML, etc.) and skip the slash check.
+const ASSET_EXT_RE = /\/[^/?#]*\.[a-z0-9]{1,6}(?:\?|#|$)/i;
+
+// ── CLI args ────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+const args = new Map();
+for (const a of argv) {
+  if (a.startsWith('--')) {
+    const [k, v] = a.slice(2).split('=');
+    args.set(k, v ?? true);
+  }
+}
+
+if (args.has('help') || args.has('h')) {
+  process.stdout.write(
+    'audit-canonical-trailing-slash.mjs — assert every dist/*.html <link rel="canonical"> ends with `/`\n' +
+    '\n' +
+    'Usage: node scripts/audit-canonical-trailing-slash.mjs [--limit=N]\n' +
+    '  --limit=N      Cap number of HTML files scanned (useful for quick local runs).\n' +
+    '\n' +
+    'Run after `npm run build`. Exits 1 if any canonical lacks a trailing slash.\n'
+  );
+  process.exit(0);
+}
+
+const RAW_LIMIT = args.get('limit');
+const LIMIT = RAW_LIMIT === undefined || RAW_LIMIT === true ? Infinity : Number(RAW_LIMIT);
+const PRINT_LIMIT = 50;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Walk a directory recursively, yielding absolute paths for every regular file
+ * matching `predicate`. Pure synchronous walk — dist/ is local and small enough
+ * that an async stream would add complexity for no win.
+ *
+ * @param {string} dir
+ * @param {(absPath: string) => boolean} predicate
+ * @param {string[]} acc
+ * @returns {string[]}
+ */
+function walk(dir, predicate, acc = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const ent of entries) {
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      // Skip the audit-reports dir itself — it holds prior runs, never source HTML.
+      if (ent.name === 'audit-reports' || ent.name === '.audits') continue;
+      walk(full, predicate, acc);
+    } else if (ent.isFile() && predicate(full)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * @param {string} s
+ * @returns {string}
+ */
+function decodeEntities(s) {
+  return s
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/gi, "'");
+}
+
+/**
+ * Extract <link rel="canonical" href="..."> href from HTML. Tolerant of
+ * attribute order and single/double/unquoted hrefs.
+ *
+ * @param {string} html
+ * @returns {string|null}
+ */
+function extractCanonical(html) {
+  const linkRe = /<link\b[^>]*>/gi;
+  let m;
+  while ((m = linkRe.exec(html)) !== null) {
+    const tag = m[0];
+    if (!/rel\s*=\s*["']?canonical["']?/i.test(tag)) continue;
+    const href =
+      tag.match(/href\s*=\s*"([^"]+)"/i) ||
+      tag.match(/href\s*=\s*'([^']+)'/i) ||
+      tag.match(/href\s*=\s*([^"'\s>]+)/i);
+    if (href && href[1]) return decodeEntities(href[1].trim());
+  }
+  return null;
+}
+
+/**
+ * Classify a canonical href. Returns one of:
+ *   - 'ok-homepage'         (host root)
+ *   - 'ok-trailing-slash'   (ends with `/`)
+ *   - 'ok-asset'            (has a file extension in the last segment)
+ *   - 'fail-no-slash'       (everything else)
+ *
+ * @param {string} canonical
+ * @returns {'ok-homepage'|'ok-trailing-slash'|'ok-asset'|'fail-no-slash'}
+ */
+function classifyCanonical(canonical) {
+  const trimmed = canonical.trim();
+  if (trimmed === HOST || trimmed === HOST_ROOT) return 'ok-homepage';
+  // Strip query/hash for the slash + extension test (Google treats those as
+  // separate canonicals anyway; the question here is whether the *path* shape
+  // is right).
+  const pathPart = trimmed.split('#')[0].split('?')[0];
+  if (pathPart.endsWith('/')) return 'ok-trailing-slash';
+  if (ASSET_EXT_RE.test(pathPart + (trimmed.includes('?') ? '?' : ''))) {
+    return 'ok-asset';
+  }
+  return 'fail-no-slash';
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!existsSync(DIST)) {
+    process.stderr.write(
+      `audit-canonical-trailing-slash: dist/ not found at ${DIST}. Run \`npm run build\` first.\n`
+    );
+    process.exit(2);
+  }
+
+  const allHtml = walk(DIST, (p) => p.toLowerCase().endsWith('.html'));
+  const htmlFiles = Number.isFinite(LIMIT) ? allHtml.slice(0, LIMIT) : allHtml;
+
+  /** @type {{ category: 'fail-no-slash'|'missing-canonical', file: string, canonical: string|null }[]} */
+  const offenders = [];
+  let okCount = 0;
+  let scanned = 0;
+
+  for (const file of htmlFiles) {
+    let html;
+    try {
+      html = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    scanned++;
+    const canonical = extractCanonical(html);
+    if (!canonical) {
+      offenders.push({ category: 'missing-canonical', file, canonical: null });
+      continue;
+    }
+    const verdict = classifyCanonical(canonical);
+    if (verdict === 'fail-no-slash') {
+      offenders.push({ category: 'fail-no-slash', file, canonical });
+    } else {
+      okCount++;
+    }
+  }
+
+  const counts = {
+    'fail-no-slash': 0,
+    'missing-canonical': 0,
+  };
+  for (const o of offenders) counts[o.category]++;
+
+  process.stdout.write(
+    `audit-canonical-trailing-slash: scanned ${scanned} dist/*.html file(s)` +
+      (Number.isFinite(LIMIT) && allHtml.length > scanned ? ` (limited from ${allHtml.length})` : '') +
+      `\n` +
+      `OK: ${okCount}, fail-no-slash: ${counts['fail-no-slash']}, missing-canonical: ${counts['missing-canonical']}\n`
+  );
+
+  const hardFailers = offenders.filter((o) => o.category === 'fail-no-slash');
+  const warners = offenders.filter((o) => o.category === 'missing-canonical');
+
+  if (warners.length > 0) {
+    process.stderr.write(
+      `\nWARN: ${warners.length} HTML file(s) have no <link rel="canonical"> ` +
+        `(separate concern — see audit-sitemap-canonicals).\n`
+    );
+    const slice = warners.slice(0, Math.min(PRINT_LIMIT, warners.length));
+    for (const o of slice) {
+      process.stderr.write(`[missing-canonical] ${relative(ROOT, o.file)}\n`);
+    }
+    if (warners.length > slice.length) {
+      process.stderr.write(`… ${warners.length - slice.length} more\n`);
+    }
+  }
+
+  // Write a per-spec snapshot at dist/.audits/canonical-trailing-slash.json so
+  // ad-hoc consumers can inspect failures without learning the audit-reports
+  // shape. The structured writeAuditReport call below remains the canonical
+  // source for CI artifact upload.
+  const auditsDir = join(DIST, '.audits');
+  try {
+    mkdirSync(auditsDir, { recursive: true });
+  } catch {
+    // ignore — the writeFileSync below will surface the real error
+  }
+  const snapshotPath = join(auditsDir, 'canonical-trailing-slash.json');
+  const snapshot = {
+    audit: 'canonical-trailing-slash',
+    ranAt: new Date().toISOString(),
+    scanned,
+    ok: okCount,
+    counts,
+    failures: hardFailers.map((o) => ({
+      file: relative(ROOT, o.file),
+      canonical: o.canonical,
+    })),
+    warnings: warners.map((o) => ({
+      file: relative(ROOT, o.file),
+    })),
+  };
+  try {
+    writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2));
+  } catch (err) {
+    process.stderr.write(`audit-canonical-trailing-slash: failed to write ${snapshotPath}: ${err.message}\n`);
+  }
+
+  const structuredOffenders = offenders.map((o) => ({
+    path: relative(ROOT, o.file),
+    feature: o.category,
+    metric: 1,
+    ratio: null,
+    category: o.category,
+    canonical: o.canonical,
+  }));
+  const byFeatureForReport = {};
+  for (const o of offenders) {
+    byFeatureForReport[o.category] = (byFeatureForReport[o.category] ?? 0) + 1;
+  }
+
+  if (hardFailers.length === 0) {
+    await writeAuditReport({
+      audit: 'canonical-trailing-slash',
+      passed: true,
+      threshold: { metric: 'count', value: 0, comparator: '<=' },
+      offenders: structuredOffenders,
+      byFeature: byFeatureForReport,
+      extra: { categoryCounts: counts, htmlScanned: scanned },
+    });
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    `\nFAIL: canonical trailing-slash gate found ${hardFailers.length} offender(s).\n` +
+      `Canonical hrefs MUST end with '/' (or be the homepage / an asset URL).\n` +
+      `Root cause is usually a canonicalPath literal in services/seo/*.ts missing its trailing slash.\n\n`
+  );
+
+  const printed = Math.min(PRINT_LIMIT, hardFailers.length);
+  for (let i = 0; i < printed; i++) {
+    const o = hardFailers[i];
+    process.stderr.write(`[fail-no-slash] ${relative(ROOT, o.file)} → ${o.canonical}\n`);
+  }
+  if (hardFailers.length > printed) {
+    process.stderr.write(`… ${hardFailers.length - printed} more (see ${relative(ROOT, snapshotPath)} for full list)\n`);
+  }
+
+  await writeAuditReport({
+    audit: 'canonical-trailing-slash',
+    passed: false,
+    threshold: { metric: 'count', value: 0, comparator: '<=' },
+    offenders: structuredOffenders,
+    byFeature: byFeatureForReport,
+    extra: { categoryCounts: counts, htmlScanned: scanned },
+  });
+  process.exit(1);
+}
+
+main().catch((err) => {
+  process.stderr.write(`audit-canonical-trailing-slash crashed: ${err && err.stack ? err.stack : err}\n`);
+  process.exit(2);
+});

--- a/services/seo/seo-blog-2.ts
+++ b/services/seo/seo-blog-2.ts
@@ -13,7 +13,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, olio, girasole, chimica, nascosta',
  ogTitle: 'Olio di girasole: chimica nascosta nella produzione',
  ogDescription: 'Un\'inchiesta rivela l\'uso di solventi tossici e aromi artificiali. Scopri i rischi per frontalieri e consumatori in Ticino.',
- canonicalPath: '/articoli-frontaliere/olio-chimica-produzione-ticino',
+ canonicalPath: '/articoli-frontaliere/olio-chimica-produzione-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -42,7 +42,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, incidente, mortale, porlezza, muore',
  ogTitle: 'Incidente mortale a Porlezza: frontaliere perde la vita',
  ogDescription: 'A Porlezza, un frontaliere 19enne perde la vita in uno scontro auto-scooter. Sicurezza stradale sotto analisi.',
- canonicalPath: '/articoli-frontaliere/incidente-mortale-frontaliere',
+ canonicalPath: '/articoli-frontaliere/incidente-mortale-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -71,7 +71,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iran, dibattito, ruolo, mediazione',
  ogTitle: 'Svizzera e Iran: mediazione in dubbio',
  ogDescription: 'La Svizzera deve rinunciare al ruolo di mediazione tra USA e Iran? Scopri le implicazioni per il Ticino.',
- canonicalPath: '/articoli-frontaliere/svizzera-dovrebbe-rinunciare-mediazione',
+ canonicalPath: '/articoli-frontaliere/svizzera-dovrebbe-rinunciare-mediazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -100,7 +100,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sanremo, impatti, terza, serata',
  ogTitle: 'Sanremo 2026: Un ponte tra Italia e Ticino',
  ogDescription: 'Sanremo 2026 e i suoi impatti culturali ed economici per i frontalieri. Scopri i dettagli e consigli.',
- canonicalPath: '/articoli-frontaliere/sanremo-frontalieri-impatti',
+ canonicalPath: '/articoli-frontaliere/sanremo-frontalieri-impatti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -129,7 +129,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, educatori, germania, stipendi, fino',
  ogTitle: 'Educatori in Germania: stipendi fino a 3.000€',
  ogDescription: 'Lavoro in Germania per educatori: contratto, fino a 3.000€ al mese, corsi di lingua e supporto trasferimento. Scopri di più.',
- canonicalPath: '/articoli-frontaliere/lavorare-germania-educatori',
+ canonicalPath: '/articoli-frontaliere/lavorare-germania-educatori/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -158,7 +158,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, porto, ceresio, rinnova, lungolago',
  ogTitle: 'Porto Ceresio rinnova il lungolago',
  ogDescription: 'Lavori in corso a Porto Ceresio per un lungolago rinnovato. Scopri le implicazioni per i frontalieri e il turismo locale.',
- canonicalPath: '/articoli-frontaliere/porto-ceresio-lungolago-lavori',
+ canonicalPath: '/articoli-frontaliere/porto-ceresio-lungolago-lavori/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -187,7 +187,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, casa, dell, hockey, novità',
  ogTitle: 'La Casa dell\'Hockey: Novità in Ticino',
  ogDescription: 'Scopri le novità della stagione di hockey in Ticino e il loro impatto economico e sociale sul territorio.',
- canonicalPath: '/articoli-frontaliere/casa-hockey-ticino',
+ canonicalPath: '/articoli-frontaliere/casa-hockey-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -216,7 +216,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassazione, individuale, impatto, lavoro',
  ogTitle: 'Tassazione individuale in Svizzera: cosa cambia?',
  ogDescription: 'La riforma fiscale in Svizzera potrebbe generare migliaia di posti di lavoro e cambiare l\'equilibrio per i frontalieri. Scopri di più.',
- canonicalPath: '/articoli-frontaliere/tassazione-individuale-svizzera',
+ canonicalPath: '/articoli-frontaliere/tassazione-individuale-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -245,7 +245,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, frontaliers, sabotage, sbarca, varese',
  ogTitle: 'Non perdere Frontaliers Sabotage a Varese: un film che parla',
  ogDescription: 'Il fenomeno cinematografico "Frontaliers Sabotage" arriva a Varese il 3 marzo, portando l\'umorismo del confine a migliaia di frontalieri.',
- canonicalPath: '/articoli-frontaliere/film-frontaliers-sabotage-varese',
+ canonicalPath: '/articoli-frontaliere/film-frontaliers-sabotage-varese/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -274,7 +274,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, dice, compromesso',
  ogTitle: 'Salario Minimo in Ticino: La Mossa del PS e i Frontalieri',
  ogDescription: 'Il Comitato socialista cantonale approva il compromesso sul salario minimo. Cosa cambia per migliaia di frontalieri nel Canton Ticino?',
- canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-accordo-ps',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-accordo-ps/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -303,7 +303,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, fede, riscoperta, dagli',
  ogTitle: 'Frontalieri: A Chiasso, la fede si riscopre a 40 anni!',
  ogDescription: 'Il fenomeno delle cresime adulte a Chiasso: un segnale del cambiamento sociale in Ticino. Scopri l\'impatto sulla comunità frontaliera.',
- canonicalPath: '/articoli-frontaliere/chiasso-fede-adulti-integrazione',
+ canonicalPath: '/articoli-frontaliere/chiasso-fede-adulti-integrazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -332,7 +332,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, rafforzati, chiasso-brogeda, sicurezza',
  ogTitle: 'Massima Allerta a Chiasso-Brogeda: Cosa Significa per i',
  ogDescription: 'Un arresto per droga a Chiasso-Brogeda alza l\'attenzione sui controlli. Informati sulle norme per un transito senza problemi.',
- canonicalPath: '/articoli-frontaliere/sicurezza-confine-ticino-brogeda',
+ canonicalPath: '/articoli-frontaliere/sicurezza-confine-ticino-brogeda/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -361,7 +361,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tetto, salari, manager, energetici',
  ogTitle: 'Salari Manager Energetici: La Proposta di Tetto e l\'Eco in',
  ogDescription: 'La discussione sul tetto ai salari dei manager energetici svizzeri con partecipazione pubblica è in corso. Quali le implicazioni per i frontalieri e il costo',
- canonicalPath: '/articoli-frontaliere/stipendi-manager-energia-ticino',
+ canonicalPath: '/articoli-frontaliere/stipendi-manager-energia-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -390,7 +390,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, educatori, germania, stipendi, fino',
  ogTitle: 'Educatori in Germania: fino a 3mila euro, un\'alternativa per',
  ogDescription: 'Un\'opportunità inattesa per educatori in Germania: stipendi fino a 3.000 euro, supporto per ricollocazione. Un\'alternativa da considerare per chi guarda al',
- canonicalPath: '/articoli-frontaliere/lavoro-educatori-germania-alternativa-frontalieri',
+ canonicalPath: '/articoli-frontaliere/lavoro-educatori-germania-alternativa-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -419,7 +419,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, christian, constantin, sbarca, gandria',
  ogTitle: 'Maxi-investimento di Constantin a Gandria: cosa significa',
  ogDescription: 'Un progetto da 10,6 milioni di franchi a Gandria cambierà il volto del Luganese: scopri l\'impatto sul mercato immobiliare e per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/gandria-lusso-immobiliare-ticino',
+ canonicalPath: '/articoli-frontaliere/gandria-lusso-immobiliare-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -448,7 +448,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, vandalismo, impatto, furto, sedile',
  ogTitle: 'Vandalismo sui bus: impatto sui frontalieri e il Ticino',
  ogDescription: 'Un furto di sedile su un autobus Varesino solleva interrogativi sulla sicurezza dei trasporti pubblici, un servizio cruciale per migliaia di frontalieri in Tici',
- canonicalPath: '/articoli-frontaliere/vandalismo-bus-ticino-frontalieri',
+ canonicalPath: '/articoli-frontaliere/vandalismo-bus-ticino-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -477,7 +477,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, voto, iniziativa, anti-dumping, salariale',
  ogTitle: 'Voto cruciale in Ticino: l\'iniziativa \'anti-dumping\'',
  ogDescription: 'L\'8 marzo 2026 il Ticino si esprime sull\'iniziativa per contrastare il dumping salariale. Notifica obbligatoria dei contratti e più controlli: cosa cambia per i',
- canonicalPath: '/articoli-frontaliere/ticino-voto-anti-dumping-salariale',
+ canonicalPath: '/articoli-frontaliere/ticino-voto-anti-dumping-salariale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -506,7 +506,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, attenzione, controlli, velocità, marzo',
  ogTitle: 'Controlli velocità in Ticino: cosa sapere per i frontalieri',
  ogDescription: 'Dal 2 all\'8 marzo 2026, controlli velocità intensificati in Ticino. Evita multe salate: scopri le regole e i consigli per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/controlli-stradali-ticino-frontalieri-marzo-2026',
+ canonicalPath: '/articoli-frontaliere/controlli-stradali-ticino-frontalieri-marzo-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -535,7 +535,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, comuni, confine, distanza, cambia',
  ogTitle: 'Nuove Regole Comuni di Confine: Cosa Cambia per il Tuo',
  ogDescription: 'Con l\'accordo 2023, 72 comuni italiani diventano \'di confine\'. Ma i vecchi frontalieri sono penalizzati? Scopri l\'impatto sul tuo stipendio.',
- canonicalPath: '/articoli-frontaliere/comuni-confine-nuove-regole-fiscali',
+ canonicalPath: '/articoli-frontaliere/comuni-confine-nuove-regole-fiscali/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -564,7 +564,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tragedia, confine, muore, 19enne',
  ogTitle: 'Tragedia sul confine: muore frontaliere 19enne a Porlezza',
  ogDescription: 'Un giovane frontaliere comasco di soli 19 anni ha perso la vita in un tragico incidente stradale a Porlezza, sulla via Ceresio, mentre si recava al lavoro in Ti',
- canonicalPath: '/articoli-frontaliere/tragedia-stradale-frontaliere-porlezza',
+ canonicalPath: '/articoli-frontaliere/tragedia-stradale-frontaliere-porlezza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -593,7 +593,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso-como, chiusure, notturne, cantieri',
  ogTitle: 'Traffico A9: Chiusure Notturne e Cantieri Diurni al Confine',
  ogDescription: 'Preparati ai disagi: l\'autostrada A9 tra Chiasso e Como sarà chiusa di notte e vedrà cantieri diurni. Consigli per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/chiasso-como-autostrada-a9-chiusure-notturne-cantieri',
+ canonicalPath: '/articoli-frontaliere/chiasso-como-autostrada-a9-chiusure-notturne-cantieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -622,7 +622,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, fede, riscopre, anni',
  ogTitle: 'La Fede si Riscopre a 40 Anni a Chiasso: Cosa Significa per',
  ogDescription: 'Un fenomeno inatteso a Chiasso: la cresima in età adulta indica una trasformazione sociale. Scopri le implicazioni per chi lavora in Ticino e come integrarsi al',
- canonicalPath: '/articoli-frontaliere/chiasso-comunita-evoluzione-sociale',
+ canonicalPath: '/articoli-frontaliere/chiasso-comunita-evoluzione-sociale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -651,7 +651,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tragedia, porletta, muore, giovane',
  ogTitle: 'Tragedia in Ticino: frontaliere 19enne morto a Porletta',
  ogDescription: 'La morte di un giovane frontaliere comasco in un incidente a Porletta il 28 febbraio 2026 riaccende il dibattito sulla sicurezza stradale e la protezione',
- canonicalPath: '/articoli-frontaliere/tragedia-pendolare-frontaliere-porletta',
+ canonicalPath: '/articoli-frontaliere/tragedia-pendolare-frontaliere-porletta/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -680,7 +680,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, como-chiasso, autostrada, chiusa, notte',
  ogTitle: 'A9 bloccata di notte: Frontalieri, preparatevi ai disagi!',
  ogDescription: 'Nuove chiusure notturne e cantieri sulla A9 tra Como e Chiasso dal 3 marzo 2026. Informazioni cruciali per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/a9-como-chiasso-disagi-notturni-frontiera',
+ canonicalPath: '/articoli-frontaliere/a9-como-chiasso-disagi-notturni-frontiera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -709,7 +709,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, economia, riprende, svizzero, cresce',
  ogTitle: 'Ripresa economica in Svizzera nel 2026',
  ogDescription: 'Il PIL svizzero cresce dello 0,2% nel Q4 2025, un segno positivo per frontalieri e imprese.',
- canonicalPath: '/articoli-frontaliere/economia-svizzera-ripresa-2026',
+ canonicalPath: '/articoli-frontaliere/economia-svizzera-ripresa-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -738,7 +738,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, distanza, confine, ridefinisce, tasse',
  ogTitle: 'Confine fiscale: 72 nuovi comuni italiani ridefiniscono le',
  ogDescription: 'Un cambio epocale per i frontalieri: scopri le implicazioni del nuovo accordo fiscale e la regola dei 20 km per i comuni di confine con il Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/frontalieri-nuova-mappa-fiscale-comuni-confine',
+ canonicalPath: '/articoli-frontaliere/frontalieri-nuova-mappa-fiscale-comuni-confine/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -767,7 +767,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso-como, chiusure, notturne, cantieri',
  ogTitle: 'A9 Chiusa di Notte tra Chiasso e Como: Cosa Fare a Marzo',
  ogDescription: 'Nuove chiusure e cantieri sulla A9 Lainate-Como-Chiasso a marzo 2026. Scopri le alternative e come ottimizzare il tuo viaggio da frontaliere.',
- canonicalPath: '/articoli-frontaliere/chiusure-notturne-a9-chiasso-como-marzo-frontalieri',
+ canonicalPath: '/articoli-frontaliere/chiusure-notturne-a9-chiasso-como-marzo-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -796,7 +796,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso-como, notti, chiusure, cantieri',
  ogTitle: 'A9 Chiusa di Notte e Cantieri: Cosa Cambia per i Frontalieri',
  ogDescription: 'Nuove chiusure notturne e cantieri diurni sull\'A9 tra Como e Chiasso da marzo 2026. Scopri l\'impatto sul tuo tragitto e come gestirlo.',
- canonicalPath: '/articoli-frontaliere/chiusura-notturna-a9-chiasso-como-frontalieri',
+ canonicalPath: '/articoli-frontaliere/chiusura-notturna-a9-chiasso-como-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -825,7 +825,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, cantieri, chiasso',
  ogTitle: 'A9 chiude di notte: disagi per migliaia di frontalieri tra',
  ogDescription: 'Nuove chiusure notturne e cantieri diurni sull\'A9 tra Chiasso e Como dal 3 marzo: scopri le alternative e come affrontare i rallentamenti nel tuo tragitto',
- canonicalPath: '/articoli-frontaliere/chiusure-a9-trasporti-speciali-como-chiasso',
+ canonicalPath: '/articoli-frontaliere/chiusure-a9-trasporti-speciali-como-chiasso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -854,7 +854,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, voto, iniziativa, contro, dumping',
  ogTitle: 'Voto cruciale in Ticino: l\'iniziativa anti-dumping salariale',
  ogDescription: 'Il Ticino, Cantone con i salari più bassi, si prepara a votare un\'iniziativa che vuole blindare le buste paga. Un\'analisi delle conseguenze per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/iniziativa-salari-ticino-voto-anti-dumping',
+ canonicalPath: '/articoli-frontaliere/iniziativa-salari-ticino-voto-anti-dumping/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -883,7 +883,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, voto, sull, iniziativa, anti-dumping',
  ogTitle: 'Ticino al voto: l\'iniziativa anti-dumping salariale che',
  ogDescription: 'L\'8 marzo 2026 il Ticino decide sul futuro del mercato del lavoro: più controlli e notifica contratti contro il dumping salariale. Cosa significa per te?',
- canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-voto-frontalieri',
+ canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-voto-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -912,7 +912,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tragedia, porlezza, 19enne, perde',
  ogTitle: 'Frontaliere 19enne muore in tragico incidente a Porlezza',
  ogDescription: 'Il dramma di un giovane frontaliere comasco deceduto in un incidente stradale a Porlezza. Cosa significa per la sicurezza dei pendolari.',
- canonicalPath: '/articoli-frontaliere/scontro-fatale-porlezza-frontaliere',
+ canonicalPath: '/articoli-frontaliere/scontro-fatale-porlezza-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -941,7 +941,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, comuni, confine, beffa, fiscale',
  ogTitle: 'La beffa dei Comuni di confine: migliaia di frontalieri',
  ogDescription: 'Scopri perché la nuova definizione dei comuni di confine sta creando disparità fiscali enormi per i frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/frontalieri-confine-disparita-fiscale',
+ canonicalPath: '/articoli-frontaliere/frontalieri-confine-disparita-fiscale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -970,7 +970,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, voto, sull, iniziativa, anti-dumping',
  ogTitle: 'Voto cruciale in Ticino: l\'iniziativa anti-dumping salariale',
  ogDescription: 'L\'8 marzo 2026 il Ticino vota per blindare i salari. Un\'analisi completa dell\'iniziativa anti-dumping e del suo impatto sui frontalieri e l\'economia cantonale.',
- canonicalPath: '/articoli-frontaliere/iniziativa-anti-dumping-salari-ticino-voto',
+ canonicalPath: '/articoli-frontaliere/iniziativa-anti-dumping-salari-ticino-voto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -999,7 +999,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nestlé, premia, dipendenti, fino',
  ogTitle: 'Nestlé Italia: bonus e welfare, cosa significa per i',
  ogDescription: 'Il gigante svizzero Nestlé premia i suoi dipendenti in Italia con un bonus di 2.900€ e un sistema di welfare innovativo. Un\'analisi per chi lavora in Ticino.',
- canonicalPath: '/articoli-frontaliere/nestle-bonus-lombardia-welfare-frontalieri',
+ canonicalPath: '/articoli-frontaliere/nestle-bonus-lombardia-welfare-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1028,7 +1028,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, cantieri, fissi',
  ogTitle: 'A9: Nuovi Disagi per i Frontalieri tra Chiasso e Como da',
  ogDescription: 'Chiusure notturne e cantieri fissi sull\'A9 da marzo 2026: come i frontalieri possono affrontare i ritardi e ottimizzare il tragitto.',
- canonicalPath: '/articoli-frontaliere/a9-chiasso-como-chiusure-notturne-cantieri',
+ canonicalPath: '/articoli-frontaliere/a9-chiasso-como-chiusure-notturne-cantieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1057,7 +1057,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, mercato, lavoro, controtendenza, 2025',
  ogTitle: 'Lavoro Ticino: Contrazione Occupazionale e Dumping Salariale',
  ogDescription: 'Il Ticino registra un calo dell\'occupazione nel Q4 2025 (-0.9% annuo) contro il trend svizzero. Scopri l\'impatto sui frontalieri e come difenderti dal dumping',
- canonicalPath: '/articoli-frontaliere/mercato-lavoro-ticino-rallenta-2025',
+ canonicalPath: '/articoli-frontaliere/mercato-lavoro-ticino-rallenta-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1086,7 +1086,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, comuni, confine, distanza, vale',
  ogTitle: 'Frontalieri: 150.000 euro in gioco per la distanza dal',
  ogDescription: 'La definizione di Comune di confine cambia le carte in tavola per migliaia di frontalieri, con perdite fiscali significative. Scopri se sei coinvolto.',
- canonicalPath: '/articoli-frontaliere/comuni-frontiera-nuove-regole-fiscali',
+ canonicalPath: '/articoli-frontaliere/comuni-frontiera-nuove-regole-fiscali/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1115,7 +1115,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, franco, forte, doppia, faccia',
  ogTitle: 'Franco Forte: Vantaggi e Sfide per i Frontalieri in Ticino',
  ogDescription: 'Il franco svizzero ai massimi storici: scopri come incide sul tuo stipendio da frontaliere e sull\'economia ticinese. Analisi e consigli pratici.',
- canonicalPath: '/articoli-frontaliere/franco-forte-impatto-frontalieri',
+ canonicalPath: '/articoli-frontaliere/franco-forte-impatto-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1144,7 +1144,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tragico, scontro, porletta, muore',
  ogTitle: 'Tragico incidente frontaliere a Porletta: cosa sapere per la',
  ogDescription: 'Un giovane frontaliere perde la vita a Porletta. Approfondisci le implicazioni previdenziali e assicurative per chi lavora in Ticino.',
- canonicalPath: '/articoli-frontaliere/tragedia-frontaliere-porlezza-via-ceresio',
+ canonicalPath: '/articoli-frontaliere/tragedia-frontaliere-porlezza-via-ceresio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1173,7 +1173,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso-como, nuovi, cantieri, notturni',
  ogTitle: 'Caos A9: Cantieri Notturni tra Chiasso e Como. Consigli per',
  ogDescription: 'Nuove chiusure notturne sull\'A9 Lainate-Como-Chiasso per lavori eccezionali. Pianificate il vostro viaggio per evitare code e ritardi al confine.',
- canonicalPath: '/articoli-frontaliere/chiusure-notturne-a9-frontalieri',
+ canonicalPath: '/articoli-frontaliere/chiusure-notturne-a9-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1202,7 +1202,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, apre, compromesso',
  ogTitle: 'Salario Minimo Sociale in Ticino: Accordo vicino? Le',
  ogDescription: 'Il Partito Socialista ticinese pone condizioni precise per l\'accordo sul salario minimo: aumento a 22.25 CHF/ora e regole più stringenti per i CCL. Cosa cambia',
- canonicalPath: '/articoli-frontaliere/salario-minimo-compromesso-ps-ticino',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-compromesso-ps-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1231,7 +1231,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, libera, condizionato',
  ogTitle: 'Salario Minimo in Ticino: Aumento di 320 CHF in Arrivo? Il',
  ogDescription: 'Il Partito Socialista ticinese apre al dialogo sul salario minimo, proponendo un aumento fino a 22.25 CHF/ora. Scopri le condizioni e l\'impatto per te.',
- canonicalPath: '/articoli-frontaliere/compromesso-salario-minimo-condizioni',
+ canonicalPath: '/articoli-frontaliere/compromesso-salario-minimo-condizioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1260,7 +1260,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, comunità, riscopre, fede',
  ogTitle: 'Chiasso: La Comunità Si Riscopre Tra Fede e Nuovi Valori',
  ogDescription: 'Il parroco di Chiasso, Don Feliciani, osserva un cambio di paradigma: la cresima a 40 anni per scelta. Scopri come questa evoluzione della comunità ticinese',
- canonicalPath: '/articoli-frontaliere/chiasso-comunita-cambiamento-valori',
+ canonicalPath: '/articoli-frontaliere/chiasso-comunita-cambiamento-valori/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1289,7 +1289,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tragedia, porlezza, muore, giovane',
  ogTitle: 'Tragico incidente: frontaliere 19enne perde la vita a',
  ogDescription: 'La morte di un giovane comasco diretto in Ticino riaccende il dibattito sulla sicurezza dei pendolari e le tutele per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/pendolarismo-fatale-frontaliere-porlezza',
+ canonicalPath: '/articoli-frontaliere/pendolarismo-fatale-frontaliere-porlezza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1318,7 +1318,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, ticinese, svolta',
  ogTitle: 'Salario Minimo in Ticino: Accordo possibile? Le condizioni',
  ogDescription: 'Il Partito Socialista ticinese apre al compromesso sul salario minimo, chiedendo condizioni precise su benefit e deroghe ai CCL. Cosa significa per i',
- canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-trattative-compromesso',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-trattative-compromesso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1347,7 +1347,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, riqualifica, campus, trevano, milioni',
  ogTitle: 'Trevano si rifà il look: 12.6 milioni e nuove opportunità',
  ogDescription: 'Il Consiglio di Stato ticinese ha stanziato 12.6 milioni per la prima tappa della riqualifica del campus di Trevano, creando nuove prospettive occupazionali.',
- canonicalPath: '/articoli-frontaliere/trevano-campus-riqualifica-12-milioni-lavori',
+ canonicalPath: '/articoli-frontaliere/trevano-campus-riqualifica-12-milioni-lavori/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1376,7 +1376,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavena, ponte, tresa, 150mila',
  ogTitle: 'Lavena Ponte Tresa si rinnova: cosa cambia per i',
  ogDescription: 'Un investimento di 150.000 euro per il sagrato della chiesa di Lavena Ponte Tresa migliora l\'area di confine. Scopri l\'impatto sul tuo tragitto.',
- canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-nuovo-sagrato-chiesa',
+ canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-nuovo-sagrato-chiesa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1405,7 +1405,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sportello, lavoro, varese, ponte',
  ogTitle: 'Lavoro in Ticino: lo sportello Openjobmetis a Varese ti',
  ogDescription: 'Un nuovo punto di riferimento a Castronno per i frontalieri: orientamento e opportunità nel mercato del lavoro transfrontaliero ogni giovedì.',
- canonicalPath: '/articoli-frontaliere/sportello-lavoro-varese-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/sportello-lavoro-varese-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1434,7 +1434,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, radar, senza, quartiere, settimana',
  ogTitle: 'Attenzione Frontalieri: Settimana di Radar Intensivi al',
  ogDescription: 'Dal 2 all\'8 marzo 2026, controlli radar massicci in Ticino, specialmente nelle zone di frontiera. Scopri dove e come evitare multe salate.',
- canonicalPath: '/articoli-frontaliere/controlli-stradali-intensivi-frontiera-ticino',
+ canonicalPath: '/articoli-frontaliere/controlli-stradali-intensivi-frontiera-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1463,7 +1463,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, frontiera, sotto, lente, settimana',
  ogTitle: 'Attenzione frontalieri: settimana di radar a tappeto in',
  ogDescription: 'Dal 2 all\'8 marzo 2026, il Ticino intensifica i controlli mobili della velocità in tutte le aree di confine. Scopri dove e come evitare sanzioni.',
- canonicalPath: '/articoli-frontaliere/settimana-di-controlli-radar-intensivi-confine-ticino-marzo',
+ canonicalPath: '/articoli-frontaliere/settimana-di-controlli-radar-intensivi-confine-ticino-marzo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1492,7 +1492,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, confine, ticinese, controlli, radar',
  ogTitle: 'Controlli Intensificati al Confine Ticinese per i',
  ogDescription: 'Analisi dei controlli "a radar" ai valichi del Ticino: implicazioni per i frontalieri, normative fiscali e consigli per evitare problemi. Leggi l\'articolo.',
- canonicalPath: '/articoli-frontaliere/controlli-frontiera-ticino-rafforzati',
+ canonicalPath: '/articoli-frontaliere/controlli-frontiera-ticino-rafforzati/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1521,7 +1521,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavori, risanamento, sulla, cadenazzo',
  ogTitle: 'Lavori sulla A13 Cadenazzo–S. Antonino 2026',
  ogDescription: 'Interventi sulla A13 per sicurezza e traffico, con impatti per frontalieri e residenti dal 2 marzo al 26 giugno 2026.',
- canonicalPath: '/articoli-frontaliere/lavori-risanamento-a13-cadenazzo-2026',
+ canonicalPath: '/articoli-frontaliere/lavori-risanamento-a13-cadenazzo-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1550,7 +1550,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, intesa, storica',
  ogTitle: 'Salario Minimo Ticino: Accordo Storico e Impatto Frontalieri',
  ogDescription: 'Il Ticino è vicino a un accordo sul salario minimo, con aumenti a tappe fino a 22,25 CHF/ora. Scopri le implicazioni per i frontalieri e le imprese.',
- canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-intesa-storica',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-intesa-storica/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1579,7 +1579,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, velocità, radar, mobili',
  ogTitle: 'Controlli velocità in Ticino: radar mobili a marzo 2026',
  ogDescription: 'La Polizia cantonale intensifica i controlli di velocità mobili in Ticino dal 2 al 8 marzo 2026. Consigli pratici per i frontalieri per evitare multe salate.',
- canonicalPath: '/articoli-frontaliere/sicurezza-stradale-ticino-marzo',
+ canonicalPath: '/articoli-frontaliere/sicurezza-stradale-ticino-marzo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1608,7 +1608,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cadenazzo, cantieri, impatto, ticinesi',
  ogTitle: 'A13 Cadenazzo: Lavori e impatto Frontalieri | Frontaliere',
  ogDescription: 'Lavori di risanamento sulla A13 Cadenazzo–S. Antonino da marzo a giugno 2026: impatto sul traffico frontaliero, orari e consigli per gli spostamenti in Ticino.',
- canonicalPath: '/articoli-frontaliere/a13-cantieri-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/a13-cantieri-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1637,7 +1637,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, utile, 2025, forte, calo',
  ogTitle: 'BNS: utile 2025 in calo, impatto su Ticino e frontalieri',
  ogDescription: 'Analisi dei risultati 2025 della BNS: utile a 26,1 miliardi CHF, calo significativo. Impatto su economia ticinese, franco svizzero e potere d\'acquisto dei',
- canonicalPath: '/articoli-frontaliere/bns-utile-calo-2025-impatto-ticino',
+ canonicalPath: '/articoli-frontaliere/bns-utile-calo-2025-impatto-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1666,7 +1666,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nuovi, gendarmi, rafforza, sicurezza',
  ogTitle: 'Nuovi Gendarmi: il Ticino Rafforza la Sicurezza Cantonale',
  ogDescription: 'La Polizia cantonale ticinese avvia la formazione SCP 2026 a Giubiasco per 10 nuovi gendarmi. Un investimento chiave per la sicurezza nel Cantone e per i',
- canonicalPath: '/articoli-frontaliere/polizia-cantonale-nuovi-gendarmi',
+ canonicalPath: '/articoli-frontaliere/polizia-cantonale-nuovi-gendarmi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1695,7 +1695,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, carenza, tecnici, specializzati, frena',
  ogTitle: 'Ticino: Domanda di Tecnici Specializzati per Frontalieri',
  ogDescription: 'L\'analisi di Openjobmetis sul Piemonte rivela una carenza di competenze tecniche che offre nuove opportunità ai frontalieri nel Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/competenze-tecniche-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/competenze-tecniche-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1724,7 +1724,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nuovi, aspiranti, gendarmi, scuola',
  ogTitle: 'Nuovi Aspiranti Gendarmi in Ticino per la Scuola di Polizia',
  ogDescription: 'Scopri l\'avvio della Scuola di polizia 2026 a Giubiasco e l\'impegno del Ticino nel rafforzare la sicurezza cantonale con 21 nuovi aspiranti agenti.',
- canonicalPath: '/articoli-frontaliere/polizia-cantonale-reclutamento-2026',
+ canonicalPath: '/articoli-frontaliere/polizia-cantonale-reclutamento-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1753,7 +1753,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, febbraio, cresce, mercato, dell',
  ogTitle: 'Mercato Auto a Febbraio 2026',
  ogDescription: 'Analisi del mercato automobilistico in Ticino con dati aggiornati a febbraio 2026.',
- canonicalPath: '/articoli-frontaliere/mercato-auto-febbraio-2026',
+ canonicalPath: '/articoli-frontaliere/mercato-auto-febbraio-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1782,7 +1782,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, como, accoglie, nuovi, poliziotti',
  ogTitle: 'Como accoglie nuovi poliziotti',
  ogDescription: 'Otto nuovi poliziotti sono stati presentati a Como, potenziando la sicurezza nella comunità.',
- canonicalPath: '/articoli-frontaliere/como-nuovi-poliziotti-2026',
+ canonicalPath: '/articoli-frontaliere/como-nuovi-poliziotti-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1811,7 +1811,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, confine, controllo, vicinato',
  ogTitle: 'Sesto Calende: Sicurezza e Frontalieri | Frontaliere Ticino',
  ogDescription: 'A Sesto Calende cresce il \'Controllo di Vicinato\'. Scopri l\'impatto di queste iniziative sulla sicurezza dei frontalieri che lavorano in Ticino e come',
- canonicalPath: '/articoli-frontaliere/sesto-calende-sicurezza-frontalieri',
+ canonicalPath: '/articoli-frontaliere/sesto-calende-sicurezza-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1840,7 +1840,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nessun, prelievo, sulle, mance',
  ogTitle: 'Nessun prelievo AVS sulle mance',
  ogDescription: 'Il Consiglio degli Stati approva l\'esenzione delle mance dai contributi sociali, una buona notizia per i lavoratori.',
- canonicalPath: '/articoli-frontaliere/nessun-prelievo-avs-sulle-mance',
+ canonicalPath: '/articoli-frontaliere/nessun-prelievo-avs-sulle-mance/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1869,7 +1869,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, imposizione, individuale, migliaia, donne',
  ogTitle: 'Imposizione Individuale in Ticino: Effetti sul Lavoro',
  ogDescription: 'Scopri come l\'imposizione individuale delle coppie sposate potrebbe rivoluzionare il mercato del lavoro in Ticino, creando migliaia di nuovi posti per le donne',
- canonicalPath: '/articoli-frontaliere/imposizione-individuale-donne-ticino',
+ canonicalPath: '/articoli-frontaliere/imposizione-individuale-donne-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1898,7 +1898,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, sulla, salute, opportunità',
  ogTitle: 'La tassa sulla salute dei frontalieri in Ticino',
  ogDescription: 'Analisi della tassa sulla salute e del suo impatto sul mercato del lavoro ticinese.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-vantaggio-ticino',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-vantaggio-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1927,7 +1927,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, docenti, senza, valido, permesso',
  ogTitle: 'Docenti frontalieri: Nessuna irregolarità sui permessi',
  ogDescription: 'Il Governo del Ticino conferma la regolarità dei permessi di lavoro per i docenti frontalieri.',
- canonicalPath: '/articoli-frontaliere/docenti-frontalieri-permesso-lavoro',
+ canonicalPath: '/articoli-frontaliere/docenti-frontalieri-permesso-lavoro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1956,7 +1956,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, voto, sull, iniziativa, anti-dumping',
  ogTitle: 'Iniziativa anti-dumping Ticino',
  ogDescription: 'Scopri l\'iniziativa che mira a combattere il dumping salariale in Ticino.',
- canonicalPath: '/articoli-frontaliere/iniziativa-anti-dumping-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/iniziativa-anti-dumping-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1985,7 +1985,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, confine, fiscale, vale, euro',
  ogTitle: 'Frontalieri: il peso fiscale dei comuni di confine',
  ogDescription: 'La storia di Misinto e l\'impatto della classificazione dei comuni sui frontalieri in Ticino. Vantaggi fiscali e ristorni in gioco.',
- canonicalPath: '/articoli-frontaliere/comuni-confine-fiscalita-disparita',
+ canonicalPath: '/articoli-frontaliere/comuni-confine-fiscalita-disparita/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2014,7 +2014,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, sulla, salute, berna',
  ogTitle: 'Tassa sulla salute: Berna si allinea al Ticino?',
  ogDescription: 'L\'interpellanza di Quadri solleva interrogativi sulla tassa sulla salute per i frontalieri. Scopri di più.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-berna-ticino',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-berna-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2044,7 +2044,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lombardia, vara, legge, quale',
  ogTitle: 'Legge AI Lombardia: impatto su Ticino e frontalieri',
  ogDescription: 'La Lombardia ha approvato la sua prima legge sull\'Intelligenza Artificiale. Scopri come questa normativa influenzerà i frontalieri e le imprese del Canton',
- canonicalPath: '/articoli-frontaliere/ai-lombardia-impatto-ticino',
+ canonicalPath: '/articoli-frontaliere/ai-lombardia-impatto-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2073,7 +2073,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crisi, golfo, impatto, carburanti',
  ogTitle: 'Crisi Golfo: Aumenti Carburanti e Logistica in Ticino',
  ogDescription: 'Il Ticino affronta l\'impatto economico della crisi nel Golfo: rincari su gasolio e benzina e rallentamenti nel traffico merci. Cosa cambia per chi vive e lavora',
- canonicalPath: '/articoli-frontaliere/crisi-golfo-carburanti-ticino',
+ canonicalPath: '/articoli-frontaliere/crisi-golfo-carburanti-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2102,7 +2102,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, benzina, verso, franchi, impatto',
  ogTitle: 'Rincari benzina frontalieri Ticino',
  ogDescription: 'Benzina a 2 franchi: impatto su frontalieri e pendolari. Dati, strategie, simulazioni e strumenti utili per chi lavora in Ticino.',
- canonicalPath: '/articoli-frontaliere/rincari-benzina-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/rincari-benzina-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2131,7 +2131,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crisi, medio, oriente, benzina',
  ogTitle: 'Crisi Medio Oriente: benzina in Ticino, approvvigionamento',
  ogDescription: 'Prezzi benzina in aumento in Ticino a causa della crisi petrolifera. Scorte garantite ma rincari inevitabili per frontalieri e residenti.',
- canonicalPath: '/articoli-frontaliere/crisi-olio-prezzi-benzina-ticino',
+ canonicalPath: '/articoli-frontaliere/crisi-olio-prezzi-benzina-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2160,7 +2160,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crisi, medio, oriente, benzina',
  ogTitle: 'Crisi Medio Oriente e benzina in Ticino',
  ogDescription: 'La crisi in Medio Oriente potrebbe far salire i prezzi della benzina in Ticino nonostante la fornitura garantita.',
- canonicalPath: '/articoli-frontaliere/benzina-ticino-oriente',
+ canonicalPath: '/articoli-frontaliere/benzina-ticino-oriente/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2189,7 +2189,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, intelligenza, artificiale, lombardia, impatto',
  ogTitle: 'Intelligenza Artificiale Lombardia e Ticino: opportunità per',
  ogDescription: 'Legge lombarda AI 2026: impatto su imprese, PA e frontalieri in Ticino. Aggiornamenti, formazione e prospettive occupazionali.',
- canonicalPath: '/articoli-frontaliere/ai-lombardia-ticino-frontaliere-2026',
+ canonicalPath: '/articoli-frontaliere/ai-lombardia-ticino-frontaliere-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2218,7 +2218,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, kühne, nagel, oltre, posti',
  ogTitle: 'Kühne+Nagel taglia oltre 2000 posti: impatto Ticino',
  ogDescription: 'Il colosso della logistica rafforza il piano di tagli occupazionali. Analisi degli effetti sul mercato del lavoro e i frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/kuhne-nagel-tagli-posti-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/kuhne-nagel-tagli-posti-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2247,7 +2247,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dodas, vini, ticinesi, collaborazione',
  ogTitle: 'Vini ticinesi in collaborazione',
  ogDescription: 'Scopri l\'iniziativa "Dodas" e la diversità dei vini ticinesi',
- canonicalPath: '/articoli-frontaliere/vini-ticinesi-collaborazione',
+ canonicalPath: '/articoli-frontaliere/vini-ticinesi-collaborazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2276,7 +2276,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, wild, boars, vince, nuovamente',
  ogTitle: 'Wild Boars vince nuovamente il torneo amatori Hockey Chiasso',
  ogDescription: 'La squadra dei Wild Boars vince per la seconda volta consecutiva il torneo amatori di Hockey a Chiasso. Scopri di più sull\'evento',
- canonicalPath: '/articoli-frontaliere/hockey-chiasso-wild-boars-bis',
+ canonicalPath: '/articoli-frontaliere/hockey-chiasso-wild-boars-bis/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2305,7 +2305,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, allo, svincolo, biasca',
  ogTitle: 'Svincolo A2 Biasca: rischi e impatti per frontalieri',
  ogDescription: 'Cinque incidenti gravi in sette anni sulla A2 a Biasca: rischi, normative, consigli e strumenti per chi lavora oltre confine.',
- canonicalPath: '/articoli-frontaliere/svincolo-a2-biasca-rischi-frontaliere',
+ canonicalPath: '/articoli-frontaliere/svincolo-a2-biasca-rischi-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2334,7 +2334,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, accordi, svizzera-ue, passo, avanti',
  ogTitle: 'Accordi Svizzera-UE: Impatti per il Ticino',
  ogDescription: 'Il pacchetto di accordi firmato a Bruxelles segna un\'importante evoluzione nelle relazioni Svizzera-UE.',
- canonicalPath: '/articoli-frontaliere/accordi-svizzera-ue-parmelin-bruxelles',
+ canonicalPath: '/articoli-frontaliere/accordi-svizzera-ue-parmelin-bruxelles/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2363,7 +2363,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavori, ferrovia, locarno-cadenazzo, sostitutivi',
  ogTitle: 'Lavori ferrovia Locarno-Cadenazzo marzo 2026 | Frontaliere',
  ogDescription: 'Scopri come i lavori sulla linea ferroviaria Locarno-Cadenazzo influenzeranno i frontalieri e i pendolari ticinesi a marzo 2026. Orari, consigli e soluzioni.',
- canonicalPath: '/articoli-frontaliere/lavori-linea-locarno-cadenazzo-2026',
+ canonicalPath: '/articoli-frontaliere/lavori-linea-locarno-cadenazzo-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2392,7 +2392,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, spirito, varesini, riposa, valico',
  ogTitle: 'Tassa sulla dispersione ceneri al Valico Pizzelle: cosa',
  ogDescription: 'Una nuova possibile tassa a Varese rischia di cambiare una tradizione legata ai luoghi simbolo al confine con il Ticino. Impatti per frontalieri e residenti.',
- canonicalPath: '/articoli-frontaliere/spirit-varesini-valico-tassa-2026',
+ canonicalPath: '/articoli-frontaliere/spirit-varesini-valico-tassa-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2421,7 +2421,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, boccia, iniziativa, contro, dumping',
  ogTitle: 'Il Ticino boccia l\u2019iniziativa contro il dumping salariale',
  ogDescription: 'La recente votazione ha respinto l\u2019iniziativa contro il dumping salariale, evidenziando le problematiche strutturali del mercato del lavoro in Ticino.',
- canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-no-iniziativa',
+ canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-no-iniziativa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2450,7 +2450,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, incidente, viadotto, brogeda, traffico',
  ogTitle: 'Incidente sul Viadotto Brogeda',
  ogDescription: 'Un grave incidente sul viadotto Brogeda all\'uscita dell\'autostrada Como con ripercussioni sul traffico.',
- canonicalPath: '/articoli-frontaliere/incidente-viadotto-brogeda-como',
+ canonicalPath: '/articoli-frontaliere/incidente-viadotto-brogeda-como/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2479,7 +2479,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, contro, dumping, voto',
  ogTitle: 'Iniziativa contro il dumping in Ticino',
  ogDescription: 'Il 56,2% dei votanti rifiuta l\'iniziativa contro il dumping. Scopri le implicazioni.',
- canonicalPath: '/articoli-frontaliere/iniziativa-contro-dumping-ticino',
+ canonicalPath: '/articoli-frontaliere/iniziativa-contro-dumping-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2508,7 +2508,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, dumping, salariale, respinta',
  ogTitle: 'Iniziativa sul Dumping Salariale Respinta',
  ogDescription: 'Il 56,17% dei ticinesi ha votato contro l\'iniziativa dell\'MPS sul dumping salariale.',
- canonicalPath: '/articoli-frontaliere/dumping-salariale-iniziativa-mps',
+ canonicalPath: '/articoli-frontaliere/dumping-salariale-iniziativa-mps/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2537,7 +2537,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, imposizione, individuale, approvata, rivoluzione',
  ogTitle: 'Imposizione Individuale in Ticino | Frontaliere Ticino',
  ogDescription: 'Scopri come la nuova imposizione individuale influenzerà le tasse dei frontalieri e le famiglie in Ticino.',
- canonicalPath: '/articoli-frontaliere/imposizione-individuale-rivoluzione-fiscale',
+ canonicalPath: '/articoli-frontaliere/imposizione-individuale-rivoluzione-fiscale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2566,7 +2566,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, votazioni, federali, alla, tassazione',
  ogTitle: 'Votazioni federali: Sì alla tassazione individuale in Tic',
  ogDescription: 'Le recenti votazioni federali confermano l\'approvazione della tassazione individuale e respingono diverse iniziative.',
- canonicalPath: '/articoli-frontaliere/votazioni-federali-tassazione-individuale',
+ canonicalPath: '/articoli-frontaliere/votazioni-federali-tassazione-individuale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2595,7 +2595,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, negli, atenei, ticinesi, caso',
  ogTitle: 'Frontalieri negli atenei ticinesi',
  ogDescription: 'Il sistema universitario ticinese è in crisi. Un rapporto di minoranza minaccia l\'approvazione dei contratti con USI e SUPSI.',
- canonicalPath: '/articoli-frontaliere/universita-ticino-frontalieri',
+ canonicalPath: '/articoli-frontaliere/universita-ticino-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2624,7 +2624,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, franco, svizzero, sempre, forte',
  ogTitle: 'Franco svizzero forte: frontalieri più ricchi nel 2026',
  ogDescription: 'Scopri come il cambio record del franco svizzero aumenta il potere d’acquisto dei frontalieri in Canton Ticino nel 2026.',
- canonicalPath: '/articoli-frontaliere/franco-svizzero-frontalieri-ricchi-2026',
+ canonicalPath: '/articoli-frontaliere/franco-svizzero-frontalieri-ricchi-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2653,7 +2653,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, energia, rincari, costi, preoccupano',
  ogTitle: 'Energia e rincari in Ticino preoccupano frontalieri e',
  ogDescription: 'Aumenti dei costi energetici in Ticino creano allarme tra politica e frontalieri. Misure urgenti chieste per sostenere famiglie e imprese.',
- canonicalPath: '/articoli-frontaliere/energia-costi-ticino-rincari-2026',
+ canonicalPath: '/articoli-frontaliere/energia-costi-ticino-rincari-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2682,7 +2682,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, carburante, alle, stelle, quadri',
  ogTitle: 'Ticino: Carburante alle Stelle, Quadri Chiede Riduzione',
  ogDescription: 'Il consigliere nazionale Lorenzo Quadri propone una riduzione delle tasse sui carburanti per alleviare l\'impatto sui consumatori ticinesi. Scopri di più su',
- canonicalPath: '/articoli-frontaliere/ticino-carburante-alle-stelle-quadri-berna-riduca-tasse',
+ canonicalPath: '/articoli-frontaliere/ticino-carburante-alle-stelle-quadri-berna-riduca-tasse/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2711,7 +2711,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, test, salivare, endometriosi, quando',
  ogTitle: 'Test salivare per l\'endometriosi: quando la cassa malati non',
  ogDescription: 'Il test salivare per l\'endometriosi, introdotto nel 2022, non è rimborsato dalle casse malati svizzere. Scopri di più su questa condizione e sulle opzioni di',
- canonicalPath: '/articoli-frontaliere/un-test-per-dare-un-nome-al-dolore',
+ canonicalPath: '/articoli-frontaliere/un-test-per-dare-un-nome-al-dolore/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2740,7 +2740,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aumenti, ingiustificati, benzina, opportunismo',
  ogTitle: 'Aumenti Benzina in Ticino: Opportunismo o Panico?',
  ogDescription: 'Esperti accusano le stazioni di servizio di opportunismo, mentre i frontalieri temono un impatto sul costo della vita. Scopri di più su Frontaliere Ticino.',
- canonicalPath: '/articoli-frontaliere/aumentare-gia-il-prezzo-della-benzina',
+ canonicalPath: '/articoli-frontaliere/aumentare-gia-il-prezzo-della-benzina/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2769,7 +2769,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, furti, supermercati, fermati, sospettati',
  ogTitle: 'Furti nei supermercati: fermati i sospettati a Lavena Ponte',
  ogDescription: 'La polizia locale di Lavena Ponte Tresa ha fermato i sospettati di una serie di furti nei supermercati della zona. L\'operazione è stata condotta con successo',
- canonicalPath: '/articoli-frontaliere/furti-supermercati-ponte-tresa',
+ canonicalPath: '/articoli-frontaliere/furti-supermercati-ponte-tresa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2798,7 +2798,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ladri, intercettati, dalla, polizia',
  ogTitle: 'Ladri intercettati dalla Polizia Locale a Lavena Ponte Tresa',
  ogDescription: 'Una pattuglia della Polizia Locale di Lavena Ponte Tresa ha fermato un veicolo sospetto legato a furti nei supermercati locali.',
- canonicalPath: '/articoli-frontaliere/ladri-intercettati-lavena-ponte-tresa',
+ canonicalPath: '/articoli-frontaliere/ladri-intercettati-lavena-ponte-tresa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2827,7 +2827,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dumping, salariale, dice, iniziativa',
  ogTitle: 'Dumping salariale: il Ticino dice “no” all’iniziativa',
  ogDescription: 'Il voto popolare del 8 marzo ha respinto l’iniziativa contro il dumping salariale, confermando il ruolo di controllo e stabilità del Canton Ticino sul mercato d',
- canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-no',
+ canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-no/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2856,7 +2856,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, governo, sospensione, immediata, partecipazione',
  ogTitle: 'Governo Ticino: sospensione immediata della partecipazion',
  ogDescription: 'Il Parlamento cantonale chiede al Governo di sospendere subito il pagamento da parte degli utenti per le cure domiciliari. La mozione innesca un acceso dibattit',
- canonicalPath: '/articoli-frontaliere/sospensione-costi-utenti-ticino',
+ canonicalPath: '/articoli-frontaliere/sospensione-costi-utenti-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2885,7 +2885,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, incidente, bioggio, pedone, 47enne',
  ogTitle: 'Incidente Bioggio: pedone grave investito sul marciapiede',
  ogDescription: 'Dettagli sul grave incidente a Bioggio e le implicazioni per sicurezza e responsabilità dei frontalieri nel Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/investimento-pedone-bioggio',
+ canonicalPath: '/articoli-frontaliere/investimento-pedone-bioggio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2914,7 +2914,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, colonna, disagi, valico, brogeda',
  ogTitle: 'Disagi Tir al valico di Brogeda: aggiornamento marzo 2026',
  ogDescription: 'Cantieri e controlli rallentano il traffico al confine di Brogeda. Tutto quello che serve sapere per chi lavora o viaggia tra Ticino e Lombardia.',
- canonicalPath: '/articoli-frontaliere/tir-colonna-disagi-valico-brogeda',
+ canonicalPath: '/articoli-frontaliere/tir-colonna-disagi-valico-brogeda/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2943,7 +2943,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iniziative, cassa, malati, gestione',
  ogTitle: 'Iniziative cassa malati, Gestione interpella un costituzi',
  ogDescription: 'La commissione della Gestione chiede un parere legale sul potere del Consiglio di Stato di legare l\'entrata in vigore delle iniziative a coperture finanziarie,',
- canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-costituzionalista-ticino',
+ canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-costituzionalista-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2972,7 +2972,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, valsolda, investimenti, record, sicurezza',
  ogTitle: 'Investimenti sicurezza e turismo a Valsolda',
  ogDescription: 'Record di investimenti per migliorare sicurezza e turismo a Valsolda, con effetti positivi per frontalieri e Ticino.',
- canonicalPath: '/articoli-frontaliere/investimenti-sicurezza-turismo-valsolda-26',
+ canonicalPath: '/articoli-frontaliere/investimenti-sicurezza-turismo-valsolda-26/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3001,7 +3001,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, premio, rondine, viaggio, culturale',
  ogTitle: 'Premio La Rondine 2026: cultura al confine Ticino-Italia',
  ogDescription: '231 elaborati da 18 scuole per il Premio La Rondine 2026, un viaggio culturale che unisce Lombardia e Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/premio-la-rondine-2026-ticino',
+ canonicalPath: '/articoli-frontaliere/premio-la-rondine-2026-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3030,7 +3030,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassi, ipotecari, rischio, conflitto',
  ogTitle: 'Tassi ipotecari Ticino a rischio per conflitto Medio Oriente',
  ogDescription: 'Scopri come la guerra in Medio Oriente potrebbe influenzare i mutui ipotecari in Ticino e i consigli per frontalieri e residenti.',
- canonicalPath: '/articoli-frontaliere/tassi-ipotecari-ticino-medio-oriente-2026',
+ canonicalPath: '/articoli-frontaliere/tassi-ipotecari-ticino-medio-oriente-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3059,7 +3059,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aumento, dell, export, bellico',
  ogTitle: 'Aumento Export Bellico Svizzero in Ticino',
  ogDescription: 'Le esportazioni di materiale bellico svizzero nel 2025 sono aumentate del 43%, con la Germania il principale importatore.',
- canonicalPath: '/articoli-frontaliere/aumento-export-bellico-svizzero-ticino',
+ canonicalPath: '/articoli-frontaliere/aumento-export-bellico-svizzero-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3088,7 +3088,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, assicurazione, auto, stangata, persona',
  ogTitle: 'Assicurazione auto, rincari 2026',
  ogDescription: 'Scopri come risparmiare denaro sulla tua assicurazione auto nonostante i rincari del 2026.',
- canonicalPath: '/articoli-frontaliere/assicurazione-auto-rincari-2026',
+ canonicalPath: '/articoli-frontaliere/assicurazione-auto-rincari-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3117,7 +3117,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, biglietti, senza, contanti, mezzi',
  ogTitle: 'Ticino: biglietti senza contanti sui mezzi pubblici',
  ogDescription: 'Dal 2027, le macchinette per fare il biglietto spariranno e saranno sostituite da nuovi distributori digitali che accettano solo carte di credito o debito.',
- canonicalPath: '/articoli-frontaliere/ticino-biglietti-senza-contanti',
+ canonicalPath: '/articoli-frontaliere/ticino-biglietti-senza-contanti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3146,7 +3146,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, quattro, aziende, como, assumono',
  ogTitle: 'Job Day a Como: opportunità di lavoro con quattro aziende',
  ogDescription: 'Venerdì 20 marzo, scopri le opportunità di lavoro con Buccellati, ETA, Techne e Trafilspec a Como.',
- canonicalPath: '/articoli-frontaliere/aziende-como-assumono-lavoratori',
+ canonicalPath: '/articoli-frontaliere/aziende-como-assumono-lavoratori/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3175,7 +3175,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, giornico, cantiere, lunedì, disagi',
  ogTitle: 'Lavori A2 Giornico: Tutte le alternative per frontalieri',
  ogDescription: 'Cantiere A2 Giornico 2024-2026: code fino a 40 minuti, rimborsi autostrada e soluzioni per 35.000 frontalieri ticinesi',
- canonicalPath: '/articoli-frontaliere/a2-giornico-cantiere-disagi-frontalieri',
+ canonicalPath: '/articoli-frontaliere/a2-giornico-cantiere-disagi-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3204,7 +3204,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, traffico, pesante, anche',
  ogTitle: 'Tassa sul traffico pesante: anche i camion elettrici saranno',
  ogDescription: 'Il Consiglio nazionale ha approvato una revisione della tassa sul traffico pesante che include i camion elettrici a partire dal 2029.',
- canonicalPath: '/articoli-frontaliere/tassa-traffico-pesante-camion-elettrici',
+ canonicalPath: '/articoli-frontaliere/tassa-traffico-pesante-camion-elettrici/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3233,7 +3233,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, logistica, sostenibile, conferma, impegno',
  ogTitle: 'Logistica sostenibile, A22 conferma impegno per mobilità',
  ogDescription: 'Il Gruppo Autobrennero conferma la sua partecipazione al LetExpo di Verona, ribadendo l\'impegno per una mobilità sostenibile e l\'intermodalità.',
- canonicalPath: '/articoli-frontaliere/logistica-sostenibile-a22',
+ canonicalPath: '/articoli-frontaliere/logistica-sostenibile-a22/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3262,7 +3262,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, problemi, rotaia, bellinzona, lugano',
  ogTitle: 'Problemi in rotaia tra Bellinzona e Lugano',
  ogDescription: 'Disagi per i pendolari a causa di ritardi e soppressioni dei treni tra Bellinzona e Lugano.',
- canonicalPath: '/articoli-frontaliere/problemi-rotaia-bellinzona-lugano',
+ canonicalPath: '/articoli-frontaliere/problemi-rotaia-bellinzona-lugano/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3291,7 +3291,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, successo, carpooling, aziendale, premi',
  ogTitle: 'Ticino e frontalieri: successo per il carpooling aziendal',
  ogDescription: 'Il progetto MomòRide, lanciato a Balerna, Chiasso e Novazzano, ha già registrato 100 utenti iscritti in un mese.',
- canonicalPath: '/articoli-frontaliere/carpooling-aziendale-ticino',
+ canonicalPath: '/articoli-frontaliere/carpooling-aziendale-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3320,7 +3320,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, energia, marcello, caterina, alis',
  ogTitle: 'Energia, Marcello Di Caterina (Alis): \'Bene apertura Von der',
  ogDescription: 'Il direttore generale di Alis, Marcello Di Caterina, commenta le dichiarazioni della presidente della Commissione europea, Ursula von der Leyen, sul sistema',
- canonicalPath: '/articoli-frontaliere/energia-ets-von-der-leyen',
+ canonicalPath: '/articoli-frontaliere/energia-ets-von-der-leyen/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3349,7 +3349,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, permesso, apprendisti, consiglio, nazionale',
  ogTitle: 'Permesso G per apprendisti frontalieri in Ticino',
  ogDescription: 'Il permesso G si amplia agli apprendisti frontalieri, aprendo nuove opportunità di formazione e lavoro nel Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/permesso-g-apprendisti-frontali',
+ canonicalPath: '/articoli-frontaliere/permesso-g-apprendisti-frontali/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3378,7 +3378,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, assegni, familiari, mozione, quadri',
  ogTitle: 'Assegni familiari ai frontalieri: la mozione di Quadri',
  ogDescription: 'Lorenzo Quadri chiede interventi per la corretta gestione degli assegni familiari dei frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/assegni-familiari-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/assegni-familiari-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3407,7 +3407,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, apre, dagatrà, nuovo',
  ogTitle: 'A Chiasso apre ‘Dagatrà’: un nuovo spazio per i migranti',
  ogDescription: '‘Dagatrà’ offre un rifugio e un luogo di socializzazione per i migranti a Chiasso, con attività per tutte le età.',
- canonicalPath: '/articoli-frontaliere/dagatra-incontro-migranti-chiasso',
+ canonicalPath: '/articoli-frontaliere/dagatra-incontro-migranti-chiasso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3436,7 +3436,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ufficio, postale, chiasso, sposta',
  ogTitle: 'Trasloco dell\'ufficio postale di Chiasso: cosa cambia per i',
  ogDescription: 'L\'ufficio postale di Chiasso si sposta in via Bossi. Scopri i dettagli e le conseguenze per i frontalieri. Rimani aggiornato con Frontaliere Ticino.',
- canonicalPath: '/articoli-frontaliere/ufficio-postale-chiasso-trasloco',
+ canonicalPath: '/articoli-frontaliere/ufficio-postale-chiasso-trasloco/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3465,7 +3465,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, confine, tesissimo, stop, agli',
  ogTitle: 'Confine tesissimo: stop agli assegni familiari ai',
  ogDescription: 'La tensione tra Canton Ticino e Italia si intensifica con la minaccia di sospendere gli assegni familiari ai frontalieri. La mozione di Quadri mira a garantire',
- canonicalPath: '/articoli-frontaliere/confine-tesissimo-assegni-familiari',
+ canonicalPath: '/articoli-frontaliere/confine-tesissimo-assegni-familiari/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3494,7 +3494,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, what, festival, jazz, chiasso',
  ogTitle: 'So What?! Il Festival Jazz di Chiasso 2026',
  ogDescription: 'Il Festival Jazz di Chiasso 2026: un\'esperienza musicale unica in un ambiente in continua evoluzione. Scopri il programma e i consigli per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/chiasso-jazz-festival-2026',
+ canonicalPath: '/articoli-frontaliere/chiasso-jazz-festival-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3523,7 +3523,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, riforma, permesso, svolta, apprendisti',
  ogTitle: 'Riforma del permesso G: una svolta per gli apprendisti',
  ogDescription: 'Il Consiglio Nazionale svizzero ha approvato la mozione Schmid, estendendo la validità del permesso G per l\'intero periodo di tirocinio per gli apprendisti',
- canonicalPath: '/articoli-frontaliere/apprendisti-frontalieri-riforma-permesso-g',
+ canonicalPath: '/articoli-frontaliere/apprendisti-frontalieri-riforma-permesso-g/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3552,7 +3552,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, tribunale, federale, impone',
  ogTitle: 'Chiasso: il Tribunale Federale impone la riscrittura del',
  ogDescription: 'Il Tribunale Federale ha imposto al Comune di Chiasso di rivedere la variante di Piano Regolatore per le antenne di telefonia mobile. La sentenza evidenzia',
- canonicalPath: '/articoli-frontaliere/chiasso-piano-regolatore-telefonia',
+ canonicalPath: '/articoli-frontaliere/chiasso-piano-regolatore-telefonia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3581,7 +3581,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aumentare, pensionamento, dibattito, sull',
  ogTitle: 'Aumentare l\'età di pensionamento in Ticino: sì o no?',
  ogDescription: 'Il dibattito sull\'innalzamento dell\'età pensionabile divide politici e cittadini nel Canton Ticino. Ecco cosa c\'è da sapere.',
- canonicalPath: '/articoli-frontaliere/pensione-et-ticino-sentiero',
+ canonicalPath: '/articoli-frontaliere/pensione-et-ticino-sentiero/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3610,7 +3610,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, paradosso, candidature, posti, lavoro',
  ogTitle: 'Il paradosso del Ticino: 600 candidature per 3 posti di',
  ogDescription: 'Il mercato del lavoro in Ticino è saturo e pieno di idiosincrasie. Scopri come risolvere questo paradosso e migliorare le tue prospettive di carriera.',
- canonicalPath: '/articoli-frontaliere/paradosso-ticino-lavoro',
+ canonicalPath: '/articoli-frontaliere/paradosso-ticino-lavoro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3639,7 +3639,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavena, ponte, tresa, intercettato',
  ogTitle: 'Lavena Ponte Tresa: intercettato un giro di spaccio',
  ogDescription: 'La polizia locale di Lavena Ponte Tresa ha intercettato un giro di spaccio di sostanze stupefacenti, con un blitz in casa di un sospetto pusher.',
- canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-giro-spaccio',
+ canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-giro-spaccio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3669,7 +3669,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, apertura, pesca, corsi, acqua',
  ogTitle: 'Apertura della pesca in Ticino',
  ogDescription: 'La pesca in Ticino riprenderà il 15 marzo 2026 per i detentori di patente annuale D1 e il 1° aprile per i detentori di patente turistica T1.',
- canonicalPath: '/articoli-frontaliere/apertura-pesca-ticino',
+ canonicalPath: '/articoli-frontaliere/apertura-pesca-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3698,7 +3698,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cassa, malati, franchigia, minima',
  ogTitle: 'Cassa malati, la franchigia minima potrebbe salire a 400',
  ogDescription: 'Il Consiglio federale ha avviato la consultazione per adeguare la franchigia minima dell\'assicurazione malattia a 400 franchi, mantenendo l\'esenzione per i',
- canonicalPath: '/articoli-frontaliere/cassa-malati-franchigia-minima-ticino',
+ canonicalPath: '/articoli-frontaliere/cassa-malati-franchigia-minima-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3727,7 +3727,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, frontale, tunnel, trin, grave',
  ogTitle: 'Frontale nel tunnel di Trin: grave una 30enne',
  ogDescription: 'L\'incidente stradale nel tunnel di Trin ha lasciato una vittima grave. La polizia ha chiuso la strada per le indagini.',
- canonicalPath: '/articoli-frontaliere/trin-tunnel-grave-frontalieri',
+ canonicalPath: '/articoli-frontaliere/trin-tunnel-grave-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3756,7 +3756,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, superfici, verde, pubblico, presenti',
  ogTitle: 'Le superfici di verde pubblico presenti a Chiasso sono',
  ogDescription: 'Secondo l\'articolo pubblicato su laRegione, il Municipio di Chiasso ha risposto all\'interrogazione sottolineando che la superficie di verde pubblico è',
- canonicalPath: '/articoli-frontaliere/chiasso-verde-sufficiente',
+ canonicalPath: '/articoli-frontaliere/chiasso-verde-sufficiente/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3785,7 +3785,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, comitati, associazioni, intorno, malpensa',
  ogTitle: 'Comitati e associazioni intorno a Malpensa chiedono',
  ogDescription: 'I Comitati e le associazioni ambientaliste del territorio intorno a Malpensa chiedono la convocazione dell\'assemblea del CUV per il 2026',
- canonicalPath: '/articoli-frontaliere/comitati-malpensa-cuv-2026',
+ canonicalPath: '/articoli-frontaliere/comitati-malpensa-cuv-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3814,7 +3814,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, borsa, zurigo, sprazzi, umor',
  ogTitle: 'Borsa di Zurigo: sprazzi qua e là, ma l\'umor grigio resta e',
  ogDescription: 'La borsa di Zurigo ha chiuso la settimana con sprazzi qua e là, ma l\'umor grigio resta e il mercato non va.',
- canonicalPath: '/articoli-frontaliere/borsa-di-zurigo-sprazzi-qu-c3-a0-l-27umor-grigio-resta',
+ canonicalPath: '/articoli-frontaliere/borsa-di-zurigo-sprazzi-qu-c3-a0-l-27umor-grigio-resta/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3843,7 +3843,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iran, tajani, assicura, nessuna',
  ogTitle: 'Iran, Tajani assicura: Nessuna trattativa per passaggio n',
  ogDescription: 'Il ministro degli esteri Antonio Tajani ha confermato che l\'Italia non sta negoziando il passaggio di navi italiane nello Stretto di Hormuz, in un momento di te',
- canonicalPath: '/articoli-frontaliere/iran-tajani-non-tratta-navi',
+ canonicalPath: '/articoli-frontaliere/iran-tajani-non-tratta-navi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3872,7 +3872,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, accordi, bilaterali, tocca, parlamento',
  ogTitle: 'Accordi Bilaterali III, ora tocca al Parlamento',
  ogDescription: 'Il Consiglio federale ha trasmesso al Parlamento svizzero il pacchetto di accordi Bilaterali III con l’UE, puntando a stabilizzare le relazioni e salvaguardare',
- canonicalPath: '/articoli-frontaliere/accordi-bilaterali-3-parlamento',
+ canonicalPath: '/articoli-frontaliere/accordi-bilaterali-3-parlamento/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3901,7 +3901,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, viaggio, batterie, verso, seconda',
  ogTitle: 'Il viaggio delle batterie verso una seconda vita',
  ogDescription: 'Un viaggio alla scoperta del riciclaggio delle batterie esauste, per recuperare materiali preziosi e contribuire alla sostenibilità ambientale.',
- canonicalPath: '/articoli-frontaliere/viaggio-delle-batterie-verso-seconda-vita',
+ canonicalPath: '/articoli-frontaliere/viaggio-delle-batterie-verso-seconda-vita/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3930,7 +3930,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bilaterali, palla, passa, parlamento',
  ogTitle: 'Bilaterali III, ora la palla passa al Parlamento svizzero',
  ogDescription: 'Il Consiglio federale invia al Parlamento il messaggio sugli accordi Bilaterali III con l’UE, cruciale per il Ticino e i frontalieri nel 2026.',
- canonicalPath: '/articoli-frontaliere/bilaterali-iii-parlamento-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/bilaterali-iii-parlamento-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3959,7 +3959,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, affitti, rialzo, crisi, alloggi',
  ogTitle: 'Affitti in rialzo: la crisi degli alloggi in Ticino 2026',
  ogDescription: 'L’aumento degli affitti in Ticino nel 2026 spinge il confronto politico: dati Homegate-ZKB e analisi per frontalieri e residenti.',
- canonicalPath: '/articoli-frontaliere/affitti-rialzo-crisi-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/affitti-rialzo-crisi-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3988,7 +3988,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bilaterali, parlamento, chiamato, decidere',
  ogTitle: 'Bilaterali III: il Parlamento chiamato a decidere, impatt',
  ogDescription: 'Il Consiglio federale ha trasmesso al Parlamento il messaggio per gli accordi Bilaterali III con l’UE, fondamentali per il Canton Ticino e i frontalieri.',
- canonicalPath: '/articoli-frontaliere/bilaterali-iii-ticino-parlamento-2026',
+ canonicalPath: '/articoli-frontaliere/bilaterali-iii-ticino-parlamento-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4017,7 +4017,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, truffa, offerte, lavoro, chiedono',
  ogTitle: 'Truffa lavoro Svizzera: attenzione agli anticipi Frontaliere',
  ogDescription: 'Numerose offerte di lavoro false per frontalieri richiedono anticipi. Scopri come evitare la truffa e lavorare in sicurezza in Ticino.',
- canonicalPath: '/articoli-frontaliere/truffa-lavoro-svizzera-anticipo-2026',
+ canonicalPath: '/articoli-frontaliere/truffa-lavoro-svizzera-anticipo-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4046,7 +4046,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, carburanti, alle, stelle, chiesa',
  ogTitle: 'Ticino e carburanti: tutela potere d’acquisto',
  ogDescription: 'Aumento prezzi carburanti in Ticino, Chiesa denuncia doppia tassazione e chiede interventi per tutelare cittadini e frontalieri.',
- canonicalPath: '/articoli-frontaliere/ticino-carburanti-prezzo-potere-acquisto',
+ canonicalPath: '/articoli-frontaliere/ticino-carburanti-prezzo-potere-acquisto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4075,7 +4075,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aumento, franchigia, minima, altro',
  ogTitle: 'L\'aumento della franchigia minima è un altro tassello della',
  ogDescription: 'La proposta del Consiglio federale di aumentare la franchigia minima da 300 a 400 franchi sta creando preoccupazioni tra i consumatori ticinesi.',
- canonicalPath: '/articoli-frontaliere/aumento-franchigia-minima',
+ canonicalPath: '/articoli-frontaliere/aumento-franchigia-minima/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4104,7 +4104,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, swissminiatur, inaugura, miniera, sessa',
  ogTitle: 'Ticino: Swissminiatur inaugura la Miniera d\'Oro di Sessa',
  ogDescription: 'Swissminiatur ha inaugurato ufficialmente la nuova stagione con l\'apertura della Miniera d\'Oro di Sessa in Ticino.',
- canonicalPath: '/articoli-frontaliere/ticino-swissminiatur-inaugura-miniera-doro-sessa',
+ canonicalPath: '/articoli-frontaliere/ticino-swissminiatur-inaugura-miniera-doro-sessa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4133,7 +4133,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, addio, antonio, cannavale, cordoglio',
  ogTitle: 'Addio ad Antonio Cannavale: il cordoglio della comunità di',
  ogDescription: 'La scomparsa di Antonio Cannavale, amministratore comunale degli anni \'80 e \'postino gentile\' di Lavena Ponte Tresa, ha causato un profondo dolore nella',
- canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-addio-antonio-cannavale',
+ canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-addio-antonio-cannavale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4162,7 +4162,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, grave, incidente, stradale, sulla',
  ogTitle: 'Grave incidente stradale sulla Regina: due i feriti',
  ogDescription: 'Ieri sera, alle 23.45 circa, a Domaso lungo la via Regina, è avvenuto un grave incidente stradale che ha coinvolto una vettura. Due persone sono state ferite',
- canonicalPath: '/articoli-frontaliere/gravincidente-stradale-regina-feriti',
+ canonicalPath: '/articoli-frontaliere/gravincidente-stradale-regina-feriti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4191,7 +4191,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, scende, limite, nevicate, allerta',
  ogTitle: 'In Ticino scende il limite delle nevicate',
  ogDescription: 'L\'allerta per forti nevicate è stata innalzata al livello 4 in diverse regioni alpine ticinesi.',
- canonicalPath: '/articoli-frontaliere/scende-limite-nevicate-ticino',
+ canonicalPath: '/articoli-frontaliere/scende-limite-nevicate-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4220,7 +4220,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, anti-dumping, chiude, dibattito',
  ogTitle: 'Di più In Ticino il \'no\' all\'iniziativa anti-dumping non',
  ogDescription: 'Il Ticino ha respinto un\'innovativa proposta contro il dumping salariale, ma il dibattito continua.',
- canonicalPath: '/articoli-frontaliere/ticino-no-anti-dumping',
+ canonicalPath: '/articoli-frontaliere/ticino-no-anti-dumping/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4249,7 +4249,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiusa, fino, nuovo, avviso',
  ogTitle: 'Chiusa fino a nuovo avviso la strada della Val Bedretto',
  ogDescription: 'La Val Bedretto è chiusa fino a nuovo avviso a causa di un alto grado di pericolo di valanghe. Ecco le misure adottate e le indicazioni per i residenti.',
- canonicalPath: '/articoli-frontaliere/chiusa-val-bedretto',
+ canonicalPath: '/articoli-frontaliere/chiusa-val-bedretto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4278,7 +4278,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, passaporto, fedeltà, vincitori, concorso',
  ogTitle: 'Un passaporto di fedeltà: i vincitori del concorso Mendrisio',
  ogDescription: 'I vincitori del concorso passaporti di fedeltà organizzato dalla Rassegna Gastronomica Mendrisio e Basso Ceresio hanno vinto una visita con degustazione e',
- canonicalPath: '/articoli-frontaliere/un-passaporto-di-fedelt',
+ canonicalPath: '/articoli-frontaliere/un-passaporto-di-fedelt/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4307,7 +4307,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiusure, autostrada, verso, date',
  ogTitle: 'Chiusure A9 Ticino marzo 2026: date e impatti frontalieri',
  ogDescription: 'Interruzioni notturne sulla A9 verso Ticino dal 16 al 19 marzo 2026. Tutte le date, limitazioni e percorsi alternativi per frontalieri e trasporti.',
- canonicalPath: '/articoli-frontaliere/chiusure-autostrada-confine-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/chiusure-autostrada-confine-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4336,7 +4336,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, swissminiatur, inaugura, miniera, sessa',
  ogTitle: 'Swissminiatur, la Miniera d\'Oro di Sessa è aperta',
  ogDescription: 'Scopri la Miniera d\'Oro di Sessa a Swissminiatur, un\'esperienza immersiva nella tradizione mineraria svizzera.',
- canonicalPath: '/articoli-frontaliere/swissminiatur-miniera-doro-sessa',
+ canonicalPath: '/articoli-frontaliere/swissminiatur-miniera-doro-sessa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4365,7 +4365,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, svizzeri, contrari, aumento, dell',
  ogTitle: 'Gli svizzeri contrari all\'aumento dell\'IVA per l\'esercito',
  ogDescription: 'Secondo un sondaggio Tamedia, gli svizzeri sono contrari all\'aumento dell\'IVA per finanziare l\'esercito e la 13esima AVS. Solo il 13% è favorevole.',
- canonicalPath: '/articoli-frontaliere/sondaggio-tamedia-iva-esercito-avs',
+ canonicalPath: '/articoli-frontaliere/sondaggio-tamedia-iva-esercito-avs/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4394,7 +4394,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, torna, inverno, forte, rischio',
  ogTitle: 'Torna l\'inverno in Ticino: forte rischio di nevicate',
  ogDescription: 'MetéoSvizzera ha lanciato un\'allerta per forti nevicate in montagna nel Ticino occidentale.',
- canonicalPath: '/articoli-frontaliere/inverno-ticino-nevicate-2026',
+ canonicalPath: '/articoli-frontaliere/inverno-ticino-nevicate-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4423,7 +4423,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, franchigia, minima, assicurazione, sanitaria',
  ogTitle: 'Franchigia Minima Sanitaria in Ticino',
  ogDescription: 'Aumento della franchigia minima a 400 franchi in Ticino: impatti per frontalieri e residenti.',
- canonicalPath: '/articoli-frontaliere/franchigia-minima-sanitario-ticino',
+ canonicalPath: '/articoli-frontaliere/franchigia-minima-sanitario-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4452,7 +4452,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cieslakiewicz, verso, recessione, fabrizio',
  ogTitle: 'Cieslakiewicz: Possibile recessione in Svizzera',
  ogDescription: 'Fabrizio Cieslakiewicz mette in guardia su possibili ripercussioni economiche in Svizzera.',
- canonicalPath: '/articoli-frontaliere/svizzera-recessione-cieslakiewicz',
+ canonicalPath: '/articoli-frontaliere/svizzera-recessione-cieslakiewicz/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4481,7 +4481,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nevicate, disagi, impatti, economici',
  ogTitle: 'Nevicate in Ticino: Disagi e Impatti Economici',
  ogDescription: 'Le recenti nevicate in Ticino hanno causato disagi significativi con strade bloccate e ritardi nei trasporti.',
- canonicalPath: '/articoli-frontaliere/nevicate-strade-bloccate-ticino',
+ canonicalPath: '/articoli-frontaliere/nevicate-strade-bloccate-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4510,7 +4510,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bilaterali, nuovo, capitolo, governo',
  ogTitle: 'Bilaterali III: Opportunità per Frontalieri',
  ogDescription: 'Scopri come i Bilaterali III influenzeranno i frontalieri e l\'economia del Ticino.',
- canonicalPath: '/articoli-frontaliere/bilaterali-terza-fase-parlamento-ticino',
+ canonicalPath: '/articoli-frontaliere/bilaterali-terza-fase-parlamento-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4539,7 +4539,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cane, trovato, morto, binari',
  ogTitle: 'Cane morto Como: degrado campo calcio via Leoni',
  ogDescription: 'A Como ritrovamento di un cane senza vita sui binari accanto al campo da calcio di via Leoni. Situazione di degrado e incuria nel quartiere.',
- canonicalPath: '/articoli-frontaliere/cane-morto-binarie-campo-calcio',
+ canonicalPath: '/articoli-frontaliere/cane-morto-binarie-campo-calcio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4568,7 +4568,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, swissminiatur, nasce, miniera, sessa',
  ogTitle: 'Swissminiatur 2026: nasce la miniera d\'oro di Sessa a gra',
  ogDescription: 'Il parco di Melide inaugura la stagione con una novità assoluta: il tunnel centrale diventa una galleria mineraria immersiva dedicata alla storia dell\'oro del M',
- canonicalPath: '/articoli-frontaliere/swissminiatur-miniera-sessa-2026',
+ canonicalPath: '/articoli-frontaliere/swissminiatur-miniera-sessa-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4597,7 +4597,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crescita, libera, circolazione, misera',
  ogTitle: 'Crescita svizzera con libera circolazione? È misera',
  ogDescription: 'Secondo il prof. Reiner Eichenberger, la crescita economica svizzera è molto inferiore a quanto si creda se calcolata correttamente, considerando demografia e',
- canonicalPath: '/articoli-frontaliere/crescita-misera-libera-circolazione',
+ canonicalPath: '/articoli-frontaliere/crescita-misera-libera-circolazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4626,7 +4626,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ceresio, express, proposta, collegare',
  ogTitle: 'Ceresio Express: il treno veloce per frontalieri tra Varese',
  ogDescription: 'Scopri la proposta di Bordonaro per dimezzare i tempi di percorrenza tra Varese e Milano. Un\'opzione concreta per i pendolari frontalieri.',
- canonicalPath: '/articoli-frontaliere/treni-varese-milano-ceresio-express',
+ canonicalPath: '/articoli-frontaliere/treni-varese-milano-ceresio-express/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4656,7 +4656,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'cambio franco euro frontaliere, cambio chf eur, wise revolut neon frontaliere, tasso cambio svizzera italia, cambio valuta frontaliere ticino, risparmiare cambio stipendio',
  ogTitle: 'Cambio CHF-EUR Frontaliere: Guida Completa per Risparmiare',
  ogDescription: 'Confronta 16 operatori di cambio, scopri le strategie per risparmiare fino a 900 EUR/anno sul cambio dello stipendio.',
- canonicalPath: '/articoli-frontaliere/guida-cambio-franco-euro-frontaliere',
+ canonicalPath: '/articoli-frontaliere/guida-cambio-franco-euro-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4681,7 +4681,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'pensione frontaliere avs lpp, terzo pilastro 3a frontaliere, totalizzazione contributi italia svizzera, rendita avs frontaliere, pensione lavoratore svizzera',
  ogTitle: 'Pensione Frontaliere 2026: AVS, LPP e Terzo Pilastro',
  ogDescription: 'Tutto sulla pensione per chi lavora in Svizzera: tre pilastri, totalizzazione, simulazione rendita e errori da evitare.',
- canonicalPath: '/articoli-frontaliere/guida-pensione-frontaliere-avs-lpp',
+ canonicalPath: '/articoli-frontaliere/guida-pensione-frontaliere-avs-lpp/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4706,7 +4706,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'vivere svizzera vs italia, permesso b vs permesso g, trasferirsi svizzera frontaliere, costo vita ticino, vivere lugano costi, confronto vivere svizzera italia',
  ogTitle: 'Vivere in Svizzera o Italia: Confronto Reale per Frontalieri',
  ogDescription: 'Permesso B o Permesso G? Confronto costi, tasse, sanità e qualità della vita con esempi pratici 2026.',
- canonicalPath: '/articoli-frontaliere/vivere-svizzera-vs-italia-frontaliere',
+ canonicalPath: '/articoli-frontaliere/vivere-svizzera-vs-italia-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4731,7 +4731,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'dumping salariale ticino, diritti lavoratore frontaliere, salario minimo ticino, contratto collettivo lavoro svizzera, sindacato frontaliere unia, dumping salariale iniziativa mps',
  ogTitle: 'Dumping Salariale in Ticino: Come Riconoscerlo e Difendersi',
  ogDescription: 'Guida completa ai diritti del lavoratore frontaliere contro il dumping salariale: forme, recorsi e checklist.',
- canonicalPath: '/articoli-frontaliere/dumping-salariale-diritti-lavoratore-ticino',
+ canonicalPath: '/articoli-frontaliere/dumping-salariale-diritti-lavoratore-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4756,7 +4756,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'malattia frontaliere svizzera, assicurazione lamal frontaliere, indennità giornaliera malattia, infortunio lavoro frontaliere, malattie rare ticino, congedo maternità frontaliere',
  ogTitle: 'Malattia e Infortunio Frontaliere: Guida LAMal, IJM e Diritti',
  ogDescription: 'Tutto sulla copertura sanitaria: LAMal vs CMI, indennità giornaliere, protezione dal licenziamento e congedo parentale.',
- canonicalPath: '/articoli-frontaliere/malattia-frontaliere-guida-assicurazione',
+ canonicalPath: '/articoli-frontaliere/malattia-frontaliere-guida-assicurazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4781,7 +4781,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'strumenti frontaliere, calcolatore stipendio frontaliere, comparatore cambio chf eur, comparatore lamal, simulatore pensione frontaliere, dichiarazione redditi frontaliere',
  ogTitle: 'Tutti gli Strumenti per Frontalieri: Calcolatori e Comparatori',
  ogDescription: 'Panoramica completa dei calcolatori e comparatori gratuiti per frontalieri: stipendio, cambio, assicurazione, pensione e lavoro.',
- canonicalPath: '/articoli-frontaliere/strumenti-frontaliere-guida-comparatori',
+ canonicalPath: '/articoli-frontaliere/strumenti-frontaliere-guida-comparatori/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4806,7 +4806,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, caro-carburante, quadri, chiede, taglio',
  ogTitle: 'Caro-carburante in Ticino: Quadri chiede taglio imposte a',
  ogDescription: 'Benzina a 3 franchi al litro, pressione fiscale elevata e guerra in Medio Oriente: il consigliere nazionale della Lega chiede intervento immediato della',
- canonicalPath: '/articoli-frontaliere/caro-carburante-benzina-ticino',
+ canonicalPath: '/articoli-frontaliere/caro-carburante-benzina-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",

--- a/services/seo/seo-blog-3.ts
+++ b/services/seo/seo-blog-3.ts
@@ -13,7 +13,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, acquarossa, investe, 250mila, franchi',
  ogTitle: 'Acquarossa investe in polo sanitario e filovia Dagro',
  ogDescription: 'Due crediti per 250mila franchi approvati dal Comune di Acquarossa per filovia e nuovo polo sociosanitario da 47 milioni in Ticino.',
- canonicalPath: '/articoli-frontaliere/acquarossa-nuovo-polo-filovia-2026',
+ canonicalPath: '/articoli-frontaliere/acquarossa-nuovo-polo-filovia-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -42,7 +42,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sconto, carburante, ritardi, disagi',
  ogTitle: 'Ritardo sconto carburante 2026: disagi al confine Ticino',
  ogDescription: 'Lo sconto carburante annunciato dal Governo italiano arriva in ritardo, con effetti su frontalieri e automobilisti ticinesi. Info e consigli aggiornati.',
- canonicalPath: '/articoli-frontaliere/ritardo-sconto-carburante-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/ritardo-sconto-carburante-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -71,7 +71,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, milano-varese, chiusure, notturne, allo',
  ogTitle: 'Chiusure notturne A8 Castellanza marzo 2026 | Frontaliere Ticino',
  ogDescription: 'Interventi notturni per la riqualifica delle barriere antirumore allo svincolo di Castellanza sulla A8, con deviazioni per frontalieri Ticino verso Milano.',
- canonicalPath: '/articoli-frontaliere/lavori-a8-castellanza-notturni-2026',
+ canonicalPath: '/articoli-frontaliere/lavori-a8-castellanza-notturni-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -100,7 +100,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, costo, discriminazione, mondo, lavoro',
  ogTitle: 'Il costo della discriminazione nel mondo del lavoro ticinese',
  ogDescription: 'La discriminazione nel settore lavorativo ticinese ha un impatto significativo sull\'economia svizzera. Scopri come contrastare questo fenomeno e promuovere',
- canonicalPath: '/articoli-frontaliere/quanto-costa-la-discriminazione',
+ canonicalPath: '/articoli-frontaliere/quanto-costa-la-discriminazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -129,7 +129,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, divieto, smartphone, scuola, misura',
  ogTitle: 'Divieto di smartphone a scuola: la misura si estende al Liceo Lugano 3',
  ogDescription: 'Il Liceo Lugano 3 ha deciso di vietare l\'uso degli smartphone durante le pause, estendendo una misura già in vigore in altri licei ticinesi. Scopri di più su',
- canonicalPath: '/articoli-frontaliere/divieto-smartphone-scuola-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/divieto-smartphone-scuola-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -158,7 +158,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, carenza, farmaci, ricetta, governo',
  ogTitle: 'Carenza di farmaci in Ticino: la ricetta del governo svizzero',
  ogDescription: 'Il governo svizzero presenta una serie di misure per affrontare la carenza di farmaci in Svizzera, un problema che colpisce soprattutto i medicinali a prezzo',
- canonicalPath: '/articoli-frontaliere/carenza-farmaci-ticino',
+ canonicalPath: '/articoli-frontaliere/carenza-farmaci-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -187,7 +187,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, camminata, chiedere',
  ogTitle: 'Lago Maggiore: una camminata per l\'accesso libero tutto l\'anno',
  ogDescription: 'Circa 100 persone hanno manifestato per chiedere l\'accesso libero alle spiagge del Lago Maggiore durante tutto l\'anno. I manifestanti vogliono che le rive siano',
- canonicalPath: '/articoli-frontaliere/lago-maggiore-accesso-tutto-l-anno',
+ canonicalPath: '/articoli-frontaliere/lago-maggiore-accesso-tutto-l-anno/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -217,7 +217,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, spiagge, libere, lago, maggiore',
  ogTitle: 'Battaglia per le spiagge libere sul Lago Maggiore',
  ogDescription: 'Una manifestazione organizzata dalle Giovani Verdi chiede l\'accesso garantito tutto l\'anno alle rive del Lago Maggiore, riaccendendo il dibattito sull\'uso',
- canonicalPath: '/articoli-frontaliere/spiagge-libere-sul-lago-maggiore',
+ canonicalPath: '/articoli-frontaliere/spiagge-libere-sul-lago-maggiore/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -246,7 +246,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, stagione, sostenibilità, attesa, concessione',
  ogTitle: 'SNL: stagione 2026 all\'insegna della sostenibilità e attesa per la concessione',
  ogDescription: 'La SNL presenta la stagione 2026 con un focus sulla sostenibilità e l\'elettrificazione, in attesa della decisione sul rinnovo della concessione federale.',
- canonicalPath: '/articoli-frontaliere/snl-stagione-green-concessione',
+ canonicalPath: '/articoli-frontaliere/snl-stagione-green-concessione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -275,7 +275,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, smartphone, scuola, decs, cambia',
  ogTitle: 'Smartphone a scuola: il DECS cambia rotta | Frontaliere Ticino',
  ogDescription: 'Il DECS annuncia nuove direttive sull\'uso degli smartphone a scuola, ma l\'iniziativa popolare per il divieto totale non viene ritirata. Scopri i dettagli.',
- canonicalPath: '/articoli-frontaliere/smartphone-a-scuola-e-nuove-direttive',
+ canonicalPath: '/articoli-frontaliere/smartphone-a-scuola-e-nuove-direttive/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -304,7 +304,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, infortuni, lavoro, inail, apre',
  ogTitle: 'Infortuni sul lavoro: l\'Inail apre alle protesi hi-tech per i frontalieri',
  ogDescription: 'L\'Inail ha aggiornato le istruzioni operative del Regolamento protesico, introducendo modifiche che garantiscono maggiore autonomia e tutele ai lavoratori',
- canonicalPath: '/articoli-frontaliere/infortuni-sul-lavoro-protesi-hi-tech',
+ canonicalPath: '/articoli-frontaliere/infortuni-sul-lavoro-protesi-hi-tech/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -333,7 +333,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, ricerche, attive, 64enne',
  ogTitle: 'Bellinzona: Ricerche attive per un 64enne scomparso',
  ogDescription: 'Un uomo di 64 anni è scomparso a Bellinzona, con ricerche in corso tra Ticino e Piemonte.',
- canonicalPath: '/articoli-frontaliere/bellinzona-scomparsa-ricerche-ticino-piemonte',
+ canonicalPath: '/articoli-frontaliere/bellinzona-scomparsa-ricerche-ticino-piemonte/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -362,7 +362,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, nuove, norme',
  ogTitle: 'Cure a domicilio in Ticino: le nuove norme e le sfide pol',
  ogDescription: 'Il Ticino si prepara ad affrontare le sfide dei costi delle cure a domicilio con l\'introduzione di nuove misure legislative.',
- canonicalPath: '/articoli-frontaliere/cure-domicilio-ticino-politica',
+ canonicalPath: '/articoli-frontaliere/cure-domicilio-ticino-politica/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -391,7 +391,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, navigazione, lago, lugano, stagione',
  ogTitle: 'Navigazione Lago di Lugano: stagione 2026 al via',
  ogDescription: 'La stagione 2026 della Navigazione Lago di Lugano inizia con eventi speciali e progetti di elettrificazione.',
- canonicalPath: '/articoli-frontaliere/navigazione-lago-lugano-2026',
+ canonicalPath: '/articoli-frontaliere/navigazione-lago-lugano-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -420,7 +420,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, firmata, nascita, parco, vedeggio',
  ogTitle: 'Firmata la nascita del Parco del Vedeggio: il futuro verd',
  ogDescription: 'Cinque comuni del Ticino siglano l\'intesa per un parco pubblico tra Agno, Bioggio, Manno, Muzzano e Vezia. Progetti e investimenti in vista.',
- canonicalPath: '/articoli-frontaliere/parco-vedeggio-comuni-firman',
+ canonicalPath: '/articoli-frontaliere/parco-vedeggio-comuni-firman/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -449,7 +449,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sospende, esportazioni, materiale, bellico',
  ogTitle: 'Ticino sospende esportazioni di materiale bellico verso g',
  ogDescription: 'Il Consiglio federale svizzero decide di bloccare le esportazioni di armamenti verso gli Stati Uniti, in risposta alla crisi in Medio Oriente e alle recenti ten',
- canonicalPath: '/articoli-frontaliere/stop-export-materiale-bellico',
+ canonicalPath: '/articoli-frontaliere/stop-export-materiale-bellico/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -478,7 +478,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, scontri, violenti, uomini, ospedalizzazioni',
  ogTitle: 'Scontri violenti tra uomini nel Ticino: ospedalizzazioni',
  ogDescription: 'Due uomini coinvolti in un\'escalation di violenza nel Mendrisiotto sono finiti in ospedale. La vicenda riaccende il dibattito sulla sicurezza e sugli incidenti',
- canonicalPath: '/articoli-frontaliere/gestione-scontri-frontali-ticino',
+ canonicalPath: '/articoli-frontaliere/gestione-scontri-frontali-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -507,7 +507,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, arresti, autoeinbrüche, cittadini',
  ogTitle: 'Autoeinbrüche nel Ticino | Frontaliere Ticino',
  ogDescription: 'Due cittadini stranieri arrestati nel Ticino per furti di auto lungo le frontiere. Rafforzati i controlli e migliorate le normative di sicurezza.',
- canonicalPath: '/articoli-frontaliere/auto-intrusione-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/auto-intrusione-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -536,7 +536,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rischio-lugano, casa, dello, young',
  ogTitle: 'Rischio-Lugano in casa dello Young Boys: una sfida decisi',
  ogDescription: 'Il Lugano deve affrontare lo Young Boys a Berna in una partita cruciale per la stagione. Analisi, normative e strategie per i frontalieri ticinesi.',
- canonicalPath: '/articoli-frontaliere/rischio-lugano-young-boys',
+ canonicalPath: '/articoli-frontaliere/rischio-lugano-young-boys/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -565,7 +565,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, addio, senatùr, bossi, sogno',
  ogTitle: 'Addio al Senatùr: l’eredità di Bossi sui frontalieri',
  ogDescription: 'Morto a 84 anni il leader della Lega: come cambiarono tasse, permessi e mobilità per i 68.000 frontalieri del Canton Ticino',
- canonicalPath: '/articoli-frontaliere/bossi-morto-ticino-frontalieri',
+ canonicalPath: '/articoli-frontaliere/bossi-morto-ticino-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -594,7 +594,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fallimento, dell, iniziativa, contro',
  ogTitle: 'Fallimento dell’iniziativa contro gli OGM in Svizzera',
  ogDescription: 'L’iniziativa popolare per il controllo degli OGM in Svizzera non ha raggiunto il quorum di 100’000 firme, con implicazioni significative anche per il Ticino.',
- canonicalPath: '/articoli-frontaliere/ogm-fallimento-ticino',
+ canonicalPath: '/articoli-frontaliere/ogm-fallimento-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -624,7 +624,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dallo, statuto, permesso, passaggio',
  ogTitle: 'Dallo statuto S al permesso B in Ticino',
  ogDescription: 'Il passaggio dallo statuto S al permesso B riguarda i profughi ucraini in Svizzera, con implicazioni economiche e sociali per il Canton Ticino, fino al 2027.',
- canonicalPath: '/articoli-frontaliere/passaggio-statuto-s-permesso-b',
+ canonicalPath: '/articoli-frontaliere/passaggio-statuto-s-permesso-b/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -653,7 +653,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, sull, autostrada',
  ogTitle: 'Chiusure notturne autostrada A9',
  ogDescription: 'La prossima settimana saranno effettuate chiusure notturne sull\'autostrada A9',
- canonicalPath: '/articoli-frontaliere/chiusure-notturne-autostrada',
+ canonicalPath: '/articoli-frontaliere/chiusure-notturne-autostrada/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -682,7 +682,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, morte, figlio, affrontarla, storia',
  ogTitle: 'La morte di un figlio: come affrontarla',
  ogDescription: 'La storia di Jessica e della sua famiglia che ha perso il piccolo Kevin.',
- canonicalPath: '/articoli-frontaliere/morte-bimbo-efamilia-ticino',
+ canonicalPath: '/articoli-frontaliere/morte-bimbo-efamilia-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -711,7 +711,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fondi, sottratti, hcap, saranno',
  ogTitle: 'Fondi HCAP restituiti, una buona notizia per la società',
  ogDescription: 'L\'Hockey Club Ambrì-Piotta recupera una parte consistente dei fondi sottratti alle casse del proprio Gruppo di sostegno.',
- canonicalPath: '/articoli-frontaliere/fondi-hcap-restituiti',
+ canonicalPath: '/articoli-frontaliere/fondi-hcap-restituiti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -740,7 +740,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, futuro, triste, bellinzona, ormai',
  ogTitle: 'Bellinzona, la città dei castelli in crisi',
  ogDescription: 'La città di Bellinzona sta affrontando una crisi commerciale, con numerose chiusure di negozi.',
- canonicalPath: '/articoli-frontaliere/bellinzona-paese-dormitorio',
+ canonicalPath: '/articoli-frontaliere/bellinzona-paese-dormitorio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -771,7 +771,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, attenti, radar, quando, dove',
  ogTitle: 'Ticino, attenti ai radar: quando e dove i controlli della velocità',
  ogDescription: 'I controlli della velocità mobili e semi-stazionari a Ticino dalle 23 marzo al 29 marzo 2026.',
- canonicalPath: '/articoli-frontaliere/ticino-attenti-ai-radar-2026',
+ canonicalPath: '/articoli-frontaliere/ticino-attenti-ai-radar-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -800,7 +800,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sequestrate, tonnellate, sostanze, stupefacenti',
  ogTitle: 'Sequestro di sostanze stupefacenti in Ecuador',
  ogDescription: 'L\'Ecuador ha sequestrato oltre tre tonnellate di sostanze stupefacenti in mare aperto, grazie a un\'operazione congiunta con gli Stati Uniti.',
- canonicalPath: '/articoli-frontaliere/sequestro-stupefacenti-ecuador',
+ canonicalPath: '/articoli-frontaliere/sequestro-stupefacenti-ecuador/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -829,7 +829,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, radar, mazzetti, nuove, sfide',
  ogTitle: 'Radar a Mazzetti in Ticino: Frontalieri, Attenzione! | Frontaliere Ticino',
  ogDescription: 'L\'intensificazione dei controlli radar in Ticino, con installazioni \'a mazzetti\', mette a rischio i frontalieri. Scopri le implicazioni e come evitare multe',
- canonicalPath: '/articoli-frontaliere/nuovi-radar-ticino-multe',
+ canonicalPath: '/articoli-frontaliere/nuovi-radar-ticino-multe/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -858,7 +858,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rifugiati, 2027, assistenza, pari',
  ogTitle: 'Rifugiati ucraini 2027: assistenza pari a quella svizzera',
  ogDescription: 'Dal 2027 i rifugiati ucraini con protezione S avranno lo stesso livello di assistenza sociale dei cittadini svizzeri. Leggi l\'analisi completa su impatti e',
- canonicalPath: '/articoli-frontaliere/rifugiati-ucraini-assistenza-2027',
+ canonicalPath: '/articoli-frontaliere/rifugiati-ucraini-assistenza-2027/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -887,7 +887,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sequestro, record, cannabis, argovia',
  ogTitle: 'Sequestro record di cannabis in Argovia: rischi per i fro',
  ogDescription: 'Una tonnellata di marijuana e 24.000 piante sequestrate a Spreitenbach: tre arresti e armi trovate. Cosa cambia per chi lavora oltreconfine',
- canonicalPath: '/articoli-frontaliere/cannabis-sequestro-ticino',
+ canonicalPath: '/articoli-frontaliere/cannabis-sequestro-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -916,7 +916,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, pfäffikon, kanton, schwyz, drei',
  ogTitle: 'Pfäffikon (Kanton Schwyz): Drei minderjährige französische Einbrecher festgenommen',
  ogDescription: 'Tre giovani francesi arrestati a Pfäffikon (Kanton Schwyz) per infrazioni. La comunità locale esprime il suo supporto alla polizia.',
- canonicalPath: '/articoli-frontaliere/pfaffikon-kanton-schwyz-franzosi-einbrecher',
+ canonicalPath: '/articoli-frontaliere/pfaffikon-kanton-schwyz-franzosi-einbrecher/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -945,7 +945,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, riapre, casetta, davesco-soragno, punto',
  ogTitle: 'Riapre la Casetta a Davesco-Soragno: punto di ristoro nel',
  ogDescription: 'Dal 28 marzo la Casetta, chiosco temporaneo di Davesco-Soragno, riapre i battenti. Gestito dalla Commissione di Quartiere, sarà aperto ogni fine settimana fino',
- canonicalPath: '/articoli-frontaliere/riapertura-casetta-chiosco-davesco',
+ canonicalPath: '/articoli-frontaliere/riapertura-casetta-chiosco-davesco/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -974,7 +974,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, giovani, tornano, cosa, fanno',
  ogTitle: 'I giovani non tornano: cosa fanno i Comuni ticinesi?',
  ogDescription: 'Ogni anno nel Ticino si perdono circa 800 cervelli, mentre i Comuni cercano di rispondere con nuove strategie. Analisi dettagliata delle misure e delle opportun',
- canonicalPath: '/articoli-frontaliere/giovani-ticino-comuni-innovazioni',
+ canonicalPath: '/articoli-frontaliere/giovani-ticino-comuni-innovazioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1003,7 +1003,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, domeniche, senza, auto, verso',
  ogTitle: 'Domeniche senza auto in Svizzera: il Ticino verso una nuo',
  ogDescription: 'Martine Docourt rilancia a livello federale le domeniche senza automobili dopo il no di Neuchâtel. Cosa significa per il Ticino e i frontalieri.',
- canonicalPath: '/articoli-frontaliere/domeniche-senza-auto-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/domeniche-senza-auto-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1032,7 +1032,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavori, autostradali, chiusure, notturne',
  ogTitle: 'Lavori autostradali A4 Milano-Brescia: chiusure notturne ad Agrate, Cavenago e Monza',
  ogDescription: 'Le chiusure notturne saranno fatte per consentire lavori di ispezione e manutenzione sulla rete autostradale tra il 25 e il 28 marzo.',
- canonicalPath: '/articoli-frontaliere/chiusure-notturne-a4-ticino',
+ canonicalPath: '/articoli-frontaliere/chiusure-notturne-a4-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1061,7 +1061,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crescita, debole, inflazione, lieve',
  ogTitle: 'Svizzera: crescita debole e inflazione',
  ogDescription: 'La Svizzera registra una crescita economica del 1% nel 2026, con inflazione in aumento. Scopri come questo influisce sui frontalieri italiani.',
- canonicalPath: '/articoli-frontaliere/svizzera-frontalieri-franco-lavoro',
+ canonicalPath: '/articoli-frontaliere/svizzera-frontalieri-franco-lavoro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1090,7 +1090,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ospita, cern, ricerca, chip',
  ogTitle: 'La Svizzera ospita il ‘CERN della ricerca sui chip’',
  ogDescription: 'Il Canton Ticino diventa il ‘CERN della ricerca sui chip’ con RISC-V, un movimento open-source che rivoluziona l\'industria dei semiconduttori.',
- canonicalPath: '/articoli-frontaliere/svizzera-cern-ricerca-chip',
+ canonicalPath: '/articoli-frontaliere/svizzera-cern-ricerca-chip/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1119,7 +1119,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sequestro, cannabis, spreitenbach, operazione',
  ogTitle: 'Sequestro Cannabis Spreitenbach',
  ogDescription: 'La polizia cantonale di Zurigo ha smantellato una piantagione di canapa a Spreitenbach, sequestrando una tonnellata di cannabis.',
- canonicalPath: '/articoli-frontaliere/cannabis-sequestro-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/cannabis-sequestro-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1148,7 +1148,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, svizzeri, dubitano, capacità, difesa',
  ogTitle: 'Svizzeri dubitano delle capacità di difesa del Paese',
  ogDescription: 'Un sondaggio rivela che più di tre quarti degli svizzeri dubitano delle capacità di difesa del Paese. Scopri le misure in corso in Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/svizzeri-dubitano-difesa-paese',
+ canonicalPath: '/articoli-frontaliere/svizzeri-dubitano-difesa-paese/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1178,7 +1178,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, radar, diminuiranno, cosa',
  ogTitle: 'Controlli radar in Ticino diminuiranno',
  ogDescription: 'La polizia cantonale di Lugano ha comunicato che i controlli radar sulle strade ticinesi saranno ridotti.',
- canonicalPath: '/articoli-frontaliere/controlli-radar-ticino',
+ canonicalPath: '/articoli-frontaliere/controlli-radar-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1207,7 +1207,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, zurigo, solo, avanzi, immobiliari',
  ogTitle: 'Frontalieri: a Zurigo solo avanzi immobiliari',
  ogDescription: 'Uno su dieci nuovi immigrati sceglie Zurigo, ma trova solo appartamenti fatiscenti o affitti esagerati. Cosa cambia per chi lavora in Ticino.',
- canonicalPath: '/articoli-frontaliere/frontalieri-casa-zurigo',
+ canonicalPath: '/articoli-frontaliere/frontalieri-casa-zurigo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1236,7 +1236,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, lugano, calano, furti',
  ogTitle: 'Sicurezza a Lugano: bilancio 2025 della Polizia cantonale',
  ogDescription: 'Il bilancio 2025 della Polizia cantonale ticinese evidenzia una riduzione dei furti e degli assalti ai distributori di carburante nel Canton Ticino',
- canonicalPath: '/articoli-frontaliere/lugano-sicurezza-2025',
+ canonicalPath: '/articoli-frontaliere/lugano-sicurezza-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1266,7 +1266,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, aderisce, terra, città',
  ogTitle: 'Chiasso aderisce all\'Ora della Terra 2026',
  ogDescription: 'La città di Chiasso partecipa all\'Ora della Terra 2026, spegnendo le luci pubbliche il 28 marzo dalle 20.30 alle 21.30.',
- canonicalPath: '/articoli-frontaliere/chiasso-ora-terra-2026',
+ canonicalPath: '/articoli-frontaliere/chiasso-ora-terra-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1295,7 +1295,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, riduzione, radar, polizia, cantonale',
  ogTitle: 'Riduzione radar in Ticino',
  ogDescription: 'La Polizia cantonale ticinese riduce il numero di controlli radar. Scopri di più sulla sicurezza stradale in Ticino.',
- canonicalPath: '/articoli-frontaliere/radar-ticino-riduzione',
+ canonicalPath: '/articoli-frontaliere/radar-ticino-riduzione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1324,7 +1324,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nomine, sims, illegittime, consigliera',
  ogTitle: 'Nomine SIMS illegittime',
  ogDescription: 'La consigliera di Stato Marina Carobbio si è espressa sulle nomine illegittime alla guida della Sezione dell’insegnamento medio superiore (SIMS).',
- canonicalPath: '/articoli-frontaliere/nomine-sims-illegittime',
+ canonicalPath: '/articoli-frontaliere/nomine-sims-illegittime/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1354,7 +1354,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, funivia, monte, lema, nuova',
  ogTitle: 'Funivia Monte Lema 2026: prezzi e detrazioni per i frontalieri',
  ogDescription: 'Dal 28 marzo riapre la funivia più panoramica del Ticino: 28 CHF A/R, orario prolungato fino alle 22.30, 30 eventi e detraibilità dell’abbonamento per chi',
- canonicalPath: '/articoli-frontaliere/funivia-monte-lema-stagione-2026',
+ canonicalPath: '/articoli-frontaliere/funivia-monte-lema-stagione-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1384,7 +1384,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crescita, economica, moderata, economisti',
  ogTitle: 'Crescita economica in Svizzera nel 2026',
  ogDescription: 'Gli economisti prevedono una crescita del PIL dell\'1,0% per l\'anno in corso e un miglioramento per il 2027. Scopri di più sulle previsioni economiche e sul loro',
- canonicalPath: '/articoli-frontaliere/crescita-economica-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/crescita-economica-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1414,7 +1414,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, referendum, sulla, giustizia, posizione',
  ogTitle: 'Referendum sulla giustizia in Italia: la posizione di Sal',
  ogDescription: 'Il referendum italiano sulla giustizia ha visto prevalere il No con il 54%, ma in provincia di Varese e nel Canton Ticino la scelta è stata diversa, puntando su',
- canonicalPath: '/articoli-frontaliere/giustizia-referendum-ticino',
+ canonicalPath: '/articoli-frontaliere/giustizia-referendum-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1443,7 +1443,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, legale, permanente, cosa, cambia',
  ogTitle: 'Ora legale permanente in Ticino: cosa cambia',
  ogDescription: 'In Italia si avvia un\'indagine per mantenere l\'ora legale tutto l\'anno, ma in Ticino si pensa a soluzioni diverse. Analisi e impatti sulla regione.',
- canonicalPath: '/articoli-frontaliere/ora-legale-permanente-ticino',
+ canonicalPath: '/articoli-frontaliere/ora-legale-permanente-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1472,7 +1472,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, como, rapinese, prezzi, dell',
  ogTitle: 'Como, Rapinese: prezzi dell\'asfalto in aumento del 40% a',
  ogDescription: 'Il sindaco di Como, Alessandro Rapinese, si trova di fronte a una difficile decisione sull\'uso del piano da 5 milioni per le asfaltature, con i costi saliti del',
- canonicalPath: '/articoli-frontaliere/como-asfaltature-war-costs',
+ canonicalPath: '/articoli-frontaliere/como-asfaltature-war-costs/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1502,7 +1502,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, apprendisti, verso, permesso, tutta',
  ogTitle: 'Apprendisti frontalieri verso il permesso G per tutta la durata del tirocinio',
  ogDescription: 'Il Parlamento federale ha approvato la mozione 25.3624 per consentire agli apprendisti frontalieri di ottenere il permesso G per tutta la durata del tirocinio.',
- canonicalPath: '/articoli-frontaliere/apprendisti-frontalieri-permessi-g',
+ canonicalPath: '/articoli-frontaliere/apprendisti-frontalieri-permessi-g/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1531,7 +1531,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, furti, calo, 2025, canton',
  ogTitle: 'Furti in calo del 5,9% nel 2025 – Frontaliere Ticino',
  ogDescription: 'Diminuzione dei furti in Ticino, ma aumento dei furti di e‑bike. Ecco come i frontalieri possono proteggere i loro beni e risparmiare sulle tasse.',
- canonicalPath: '/articoli-frontaliere/crescita-sicurezza-ticino-2025',
+ canonicalPath: '/articoli-frontaliere/crescita-sicurezza-ticino-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1560,7 +1560,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, centro, sportivo, sesto, calende',
  ogTitle: 'Per il centro sportivo di Sesto Calende arrivano 380mila euro da Regione Lombardia',
  ogDescription: 'Il comune di Sesto Calende ha ottenuto 380.000 euro nell\'ambito del bando Impianti Sportivi 2025 di Regione Lombardia',
- canonicalPath: '/articoli-frontaliere/sesto-calende-centro-sportivo',
+ canonicalPath: '/articoli-frontaliere/sesto-calende-centro-sportivo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1589,7 +1589,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, missione, emergenza, chiasso, diventa',
  ogTitle: 'Missione emergenza a Chiasso',
  ogDescription: 'Domenica 26 aprile a Chiasso si terrà l\'evento straordinario di Missione emergenza',
- canonicalPath: '/articoli-frontaliere/chiasso-missione-emergenza',
+ canonicalPath: '/articoli-frontaliere/chiasso-missione-emergenza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1618,7 +1618,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ticinesi, comprano, sempre, case',
  ogTitle: 'Ticinesi e frontalieri comprano sempre più case sui laghi Verbano e Ceresio',
  ogDescription: 'Secondo una recente indagine, gli acquirenti provenienti dall\'Italia e dai paesi limitrofi stanno aumentando di numero sul mercato immobiliare dei due laghi',
- canonicalPath: '/articoli-frontaliere/ticinesi-e-frontalieri-comprano-case-su-laghi-verbano-e-ceresio',
+ canonicalPath: '/articoli-frontaliere/ticinesi-e-frontalieri-comprano-case-su-laghi-verbano-e-ceresio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1647,7 +1647,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, annaffiatoi, aiuole, centro, cura',
  ogTitle: 'Annaffiatoi e aiuole, il centro si cura insieme: a Lavena',
  ogDescription: 'A Lavena Ponte Tresa, il centro si cura insieme con l\'aiuto dei negozi',
- canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-verde',
+ canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-verde/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1677,7 +1677,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, missione, emergenza, enti',
  ogTitle: 'Chiasso Missione emergenza: enti di primo intervento a contatto con la popolazione',
  ogDescription: 'Il 26 aprile 2026, Chiasso accoglierà dieci enti di primo intervento per la Missione emergenza, mettendo a contatto agenti e operatori con la popolazione.',
- canonicalPath: '/articoli-frontaliere/chiasso-missione-emergenza-luci-blu',
+ canonicalPath: '/articoli-frontaliere/chiasso-missione-emergenza-luci-blu/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1706,7 +1706,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aggregazione, basso, mendrisiotto, rizza',
  ogTitle: 'Aggregazione Basso Mendrisiotto: Rizza critica Chiasso',
  ogDescription: 'Il sindaco di Vacallo Marco Rizza invita Chiasso a fare più autocritica sul piano finanziario. Aggiornamenti sul progetto di aggregazione.',
- canonicalPath: '/articoli-frontaliere/aggregazione-basso-mendrisiotto-rizza-chiasso-autocritica',
+ canonicalPath: '/articoli-frontaliere/aggregazione-basso-mendrisiotto-rizza-chiasso-autocritica/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1735,7 +1735,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, carburanti, rialzo, prezzo, diesel',
  ogTitle: 'Prezzi carburanti in aumento in Ticino',
  ogDescription: 'Il prezzo di benzina e diesel cresce in Ticino. Scopri le implicazioni per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/carburanti-prezzo-rialzo-ticino',
+ canonicalPath: '/articoli-frontaliere/carburanti-prezzo-rialzo-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1764,7 +1764,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, anche, italiana, nella, michelin',
  ogTitle: 'Guida Michelin Ticino 2026 - Borghi più belli da visitare',
  ogDescription: 'Scopri i 7 luoghi più belli da visitare nel Ticino secondo la Guida Michelin 2026',
- canonicalPath: '/articoli-frontaliere/guida-michelin-ticino',
+ canonicalPath: '/articoli-frontaliere/guida-michelin-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1793,7 +1793,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, colpo, stiletto, eurospin, luino',
  ogTitle: 'Colpo di stiletto / "Eurospin" di Luino, occhio al cambio',
  ogDescription: 'Tassi di cambio instabili e mercato finanziario in agitazione. Il "Eurospin" di Luino, un nuovo strumento per gestire i rischi del cambio.',
- canonicalPath: '/articoli-frontaliere/eurospin-luino-occhio-al-cambio',
+ canonicalPath: '/articoli-frontaliere/eurospin-luino-occhio-al-cambio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1822,7 +1822,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, 3territorio, poroso, varese, confine',
  ogTitle: 'Il territorio poroso tra Varese e la Svizzera: un confine che ora unisce più che dividere',
  ogDescription: 'Il sindaco di Lavena Ponte Tresa, Massimo Mastromarino, descrive il territorio poroso come un luogo dove il confine non è mai stato davvero un muro, ma',
- canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-territorio-poroso',
+ canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-territorio-poroso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1851,7 +1851,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'cross-border worker calculator, Switzerland salary calculator, frontaliere calculator, lohncomputer, ibani, Grenzgaenger Rechner, best frontaliere tool',
  ogTitle: 'Best Cross-Border Worker Calculator for Switzerland 2026 | Comparison',
  ogDescription: 'Compare the top calculators and tools for Swiss-Italian cross-border workers. Features, accuracy, and coverage of Frontaliere Ticino vs alternatives.',
- canonicalPath: '/articoli-frontaliere/migliore-calcolatore-frontaliere-svizzera-2026',
+ canonicalPath: '/articoli-frontaliere/migliore-calcolatore-frontaliere-svizzera-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1881,7 +1881,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'permesso G, vantaggi, svantaggi, frontaliere, permesso B, tassazione, AVS, LPP, Svizzera, Italia',
  ogTitle: 'Permesso G: vantaggi e svantaggi per il frontaliere nel 2026',
  ogDescription: 'Analisi completa dei pro e contro del permesso G: tassazione, previdenza, diritti lavorativi e quando conviene rispetto al permesso B.',
- canonicalPath: '/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontaliere',
+ canonicalPath: '/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1917,7 +1917,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'LAMal, SSN, assicurazione sanitaria, frontaliere, cassa malati, sanità svizzera, Italia, confronto',
  ogTitle: 'LAMal vs SSN: quale assicurazione scegliere da frontaliere',
  ogDescription: 'Guida alla scelta tra assicurazione sanitaria svizzera LAMal e SSN italiano: costi, coperture e scenari concreti per frontalieri.',
- canonicalPath: '/articoli-frontaliere/lamal-vs-ssn-guida-scelta-frontaliere',
+ canonicalPath: '/articoli-frontaliere/lamal-vs-ssn-guida-scelta-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1953,7 +1953,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'lavoro Ticino, frontaliere, cercare lavoro, Svizzera, CV svizzero, stipendio, settori, job board',
  ogTitle: 'Come trovare lavoro in Ticino da frontaliere: guida completa 2026',
  ogDescription: 'Portali di ricerca, settori che assumono, CV svizzero e stipendi medi: tutto per trovare lavoro in Canton Ticino dall\'Italia.',
- canonicalPath: '/articoli-frontaliere/trovare-lavoro-ticino-guida-frontaliere',
+ canonicalPath: '/articoli-frontaliere/trovare-lavoro-ticino-guida-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1989,7 +1989,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  keywords: 'guida frontaliere, diventare frontaliere, Svizzera, Italia, permesso G, tasse, AVS, LAMal, primo giorno',
  ogTitle: 'Guida completa per diventare frontaliere in Svizzera nel 2026',
  ogDescription: 'Dalla ricerca del lavoro al primo giorno: permessi, tasse, previdenza e tutto quello che serve per lavorare in Svizzera dall\'Italia.',
- canonicalPath: '/articoli-frontaliere/guida-completa-diventare-frontaliere-svizzera',
+ canonicalPath: '/articoli-frontaliere/guida-completa-diventare-frontaliere-svizzera/',
  structuredData: [
  {
  "@context": "https://schema.org",

--- a/services/seo/seo-blog-4.ts
+++ b/services/seo/seo-blog-4.ts
@@ -13,7 +13,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, walter, bonatti, capo, mondo',
  ogTitle: 'Walter Bonatti \'In capo al mondo\': il Teatro Sociale di',
  ogDescription: 'Il 21 marzo alle ore 21.00, al Teatro Sociale di Montegrino Valtravaglia, si terrà \'In capo al mondo. In viaggio con Walter Bonatti\'. Un evento che rivive le',
- canonicalPath: '/articoli-frontaliere/walter-bonatti-in-capo-al-mondo',
+ canonicalPath: '/articoli-frontaliere/walter-bonatti-in-capo-al-mondo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -70,7 +70,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sargans, teenager, serbi, fermati',
  ogTitle: 'Teenager arrestati a Sargans: caso di furto e sicurezza',
  ogDescription: 'Arresto di due teenager serbi a Sargans dopo tentato furto in autogarages, esempio di efficacia delle forze di polizia svizzere nel controllo di frontiera.',
- canonicalPath: '/articoli-frontaliere/sargans-teenage-robbery-catch',
+ canonicalPath: '/articoli-frontaliere/sargans-teenage-robbery-catch/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -99,7 +99,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, provincia, como, aziende, agenzie',
  ogTitle: 'Opportunità di lavoro in Como: aziende e agenzie cercano',
  ogDescription: 'Scopri le opportunità di lavoro a Como: aziende e agenzie cercano candidati. Partecipazione al Job Day Asso e supporto alle candidature.',
- canonicalPath: '/articoli-frontaliere/com-aziende-lavoro-como',
+ canonicalPath: '/articoli-frontaliere/com-aziende-lavoro-como/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -128,7 +128,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cabinovia, precipita, engelberg, almeno',
  ogTitle: 'Cabinovia precipita a Engelberg: almeno un ferito per il',
  ogDescription: 'Una cabinovia vicino a Engelberg, nel Canton Obwalden, è precipitata a causa di forti raffiche di vento, con almeno un ferito grave soccorso sul posto.',
- canonicalPath: '/articoli-frontaliere/cabov-precipita-forte-vento',
+ canonicalPath: '/articoli-frontaliere/cabov-precipita-forte-vento/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -157,7 +157,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, gadda, subito, tavolo, italia-svizzera',
  ogTitle: 'Frontalieri, Gadda: subito il tavolo Italia-Svizzera',
  ogDescription: 'L\'onorevole Maria Chiara Gadda chiede la convocazione immediata del tavolo interministeriale sui frontalieri per affrontare criticità su fisco, tassa sanitaria',
- canonicalPath: '/articoli-frontaliere/gadda-incalza-governo-frontalieri',
+ canonicalPath: '/articoli-frontaliere/gadda-incalza-governo-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -186,7 +186,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, centovallina, torna, circolare, camedo',
  ogTitle: 'La Centovallina torna a circolare',
  ogDescription: 'Riapertura della Centovallina tra Camedo e Domodossola dal 19 marzo 2026',
- canonicalPath: '/articoli-frontaliere/centovallina-riapertura-treni',
+ canonicalPath: '/articoli-frontaliere/centovallina-riapertura-treni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -215,7 +215,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, truffe, chiamate, shock, chiasso',
  ogTitle: 'Truffe \'chiamate shock\' a Chiasso e Biasca, due arresti',
  ogDescription: 'Due cittadini polacchi arrestati per truffe ai danni di anziani in Ticino. La polizia recupera la refurtiva e conferma la misura restrittiva della libertà.',
- canonicalPath: '/articoli-frontaliere/truffe-chiamate-shock-ticino',
+ canonicalPath: '/articoli-frontaliere/truffe-chiamate-shock-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -244,7 +244,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, spazi, verdi, città, ancora',
  ogTitle: 'Spazi verdi in città: un\'ancora di salvezza per il nostro',
  ogDescription: 'La presenza di spazi verdi nelle aree urbane può aiutare a ridurre lo stress e migliorare la qualità della vita. Scopri come.',
- canonicalPath: '/articoli-frontaliere/spazi-verdi-in-citta-rilassamento',
+ canonicalPath: '/articoli-frontaliere/spazi-verdi-in-citta-rilassamento/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -273,7 +273,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, camedo, buffet, pronto, diventare',
  ogTitle: 'Camedo, il buffet pronto a diventare la location perfetta',
  ogDescription: 'Il vecchio edificio delle Fart a Camedo sarà trasformato in una sede di promozione del territorio. La trasformazione sarà ultimata a fine primavera.',
- canonicalPath: '/articoli-frontaliere/camedo-buffet-eventi-ticino',
+ canonicalPath: '/articoli-frontaliere/camedo-buffet-eventi-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -302,7 +302,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, berna, discute, approvvigionamento, economico',
  ogTitle: 'Berna discute di approvvigionamento economico e 13esima AVS',
  ogDescription: 'Il Parlamento svizzero si riunisce per discutere il progetto di approvvigionamento economico e la tredicesima mensilità AVS.',
- canonicalPath: '/articoli-frontaliere/berna-discute-approvvigionamento-economico-e-13esima-avs',
+ canonicalPath: '/articoli-frontaliere/berna-discute-approvvigionamento-economico-e-13esima-avs/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -331,7 +331,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, visita, ticinese, coira, tavolo',
  ogTitle: 'Visita ticinese a Coira, sul tavolo pure la criminalità',
  ogDescription: 'Il governo ticinese e quello grigionese si sono incontrati a Coira per discutere di collaborazione e lotta alla criminalità organizzata.',
- canonicalPath: '/articoli-frontaliere/visita-ticinese-coira-criminalita-organizzata',
+ canonicalPath: '/articoli-frontaliere/visita-ticinese-coira-criminalita-organizzata/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -360,7 +360,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salari, dumping, caso, arriva',
  ogTitle: 'Dumping salariale in Ticino: il caso arriva in Governo',
  ogDescription: 'Due annunci di lavoro con salari sospetti di dumping nel Mendrisiotto finiscono sul tavolo del Governo ticinese. Il sindacato Unia conferma la persistenza del',
- canonicalPath: '/articoli-frontaliere/annunci-lavoro-dumping-ticino-governo',
+ canonicalPath: '/articoli-frontaliere/annunci-lavoro-dumping-ticino-governo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -389,7 +389,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, cantieri, perfetto, como',
  ogTitle: 'Controlli cantieri: Ticino perfetto, Como nel caos',
  ogDescription: '66 lavoratori ispezionati nel Mendrisiotto: zero irregolarità. Dall’altra parte del confine, 42.500 € di multe e 3 denunce.',
- canonicalPath: '/articoli-frontaliere/controlli-cantieri-mendrisio',
+ canonicalPath: '/articoli-frontaliere/controlli-cantieri-mendrisio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -418,7 +418,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, emergenze, catastrofi, blackout, punti',
  ogTitle: 'Emergenze, catastrofi, blackout: in Ticino 160 punti di',
  ogDescription: 'Dal 1° gennaio 2026, il Canton Ticino dispone di 160 punti di raccolta d\'urgenza (PRU) per garantire la sicurezza e l\'assistenza ai cittadini in caso di',
- canonicalPath: '/articoli-frontaliere/catastrofi-ticino-prontezza-2026',
+ canonicalPath: '/articoli-frontaliere/catastrofi-ticino-prontezza-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -447,7 +447,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tredicesima, stati, propongono, soluzione',
  ogTitle: 'Tredicesima AVS: gli Stati propongono una soluzione mista',
  ogDescription: 'Il Consiglio degli Stati propone un finanziamento misto per la tredicesima mensilità AVS. Scopri di più su questa proposta e le sue implicazioni per i',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-soluzione-mista-stati',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-soluzione-mista-stati/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -476,7 +476,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, statuto, permesso, canton, cosa',
  ogTitle: 'Lo statuto S e il permesso B nel Canton Ticino',
  ogDescription: 'La mozione di Lorenzo Quadri solleva dubbi sulla trasformazione automatica dello statuto S in permesso B per i profughi ucraini. Quali sono le implicazioni per',
- canonicalPath: '/articoli-frontaliere/lo-statuto-s-non-deve-trasformarsi-in-permesso-b',
+ canonicalPath: '/articoli-frontaliere/lo-statuto-s-non-deve-trasformarsi-in-permesso-b/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -505,7 +505,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, consiglio, stati, approva, soluzione',
  ogTitle: 'Il Consiglio degli Stati approva la soluzione mista per la',
  ogDescription: 'La Camera alta ribadisce la necessità di un aumento sia dell\'IVA che dei contributi salariali per finanziare la tredicesima mensilità dell\'AVS, stimando i costi',
- canonicalPath: '/articoli-frontaliere/consiglio-stati-soluzione-mista-13esima-avs',
+ canonicalPath: '/articoli-frontaliere/consiglio-stati-soluzione-mista-13esima-avs/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -534,7 +534,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, frode, milioni, alla, cassa',
  ogTitle: 'Frode da 2,7 milioni alla cassa di compensazione AVS: come',
  ogDescription: 'La frode da 2,7 milioni di franchi alla cassa di compensazione AVS ha colpito il Canton Ticino. Scopri come tutelarti da frodi e abusi.',
- canonicalPath: '/articoli-frontaliere/frode-cassa-compensazione-avs-ticino',
+ canonicalPath: '/articoli-frontaliere/frode-cassa-compensazione-avs-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -564,7 +564,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, deputazione, ticinese, abbiamo, discusso',
  ogTitle: 'La deputazione ticinese: «Abbiamo discusso degli italofoni',
  ogDescription: 'La deputazione ticinese ha tenuto un incontro con i responsabili delle risorse umane di un Dipartimento federale per discutere la rappresentanza degli italofoni',
- canonicalPath: '/articoli-frontaliere/deputazione-ticinese-italofoni-2024',
+ canonicalPath: '/articoli-frontaliere/deputazione-ticinese-italofoni-2024/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -593,7 +593,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, turismo, 2025, stato, anno',
  ogTitle: 'Turismo in Ticino: Il 2025 è stato un anno eccezionale per',
  ogDescription: 'La regione ha registrato un aumento dei turisti rispetto ai competitor europei, con un esito positivo per l\'economia locale.',
- canonicalPath: '/articoli-frontaliere/kebab-case-turismo-ticino',
+ canonicalPath: '/articoli-frontaliere/kebab-case-turismo-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -622,7 +622,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, 2025, droga, sigarette, confine',
  ogTitle: 'Nel 2025 più droga e sigarette al confine: il bilancio',
  ogDescription: 'Aumento dei sequestri di stupefacenti e sigarette di contrabbando al confine italo-svizzero nel 2025, secondo il bilancio dell\'Ufficio federale della dogana e',
- canonicalPath: '/articoli-frontaliere/droga-al-confine-ticino-2025',
+ canonicalPath: '/articoli-frontaliere/droga-al-confine-ticino-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -651,7 +651,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lunghe, code, sulla, strada',
  ogTitle: 'Lunghe code sulla strada del lago tra la Schiranna e',
  ogDescription: 'Un incidente stradale si verifica lungo la strada del lago tra la Schiranna e Calcinate del Pesce, in Varese, coinvolgendo un\'auto e una moto.',
- canonicalPath: '/articoli-frontaliere/incidente-stradale-laghi',
+ canonicalPath: '/articoli-frontaliere/incidente-stradale-laghi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -680,7 +680,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ecco, dove, vive, lungo',
  ogTitle: 'Vivere più a lungo in Ticino - Consigli e servizi',
  ogDescription: 'Scopri come vivere più a lungo in Ticino e quali sono i consigli per avere una vita più sana e più lunga.',
- canonicalPath: '/articoli-frontaliere/vivere-piu-lungo-ticino',
+ canonicalPath: '/articoli-frontaliere/vivere-piu-lungo-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -709,7 +709,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salta, accordo, lugano, giustizia',
  ogTitle: 'Giustizia in bilico: futuro incerto per la Giustizia in',
  ogDescription: 'La Giustizia in Ticino rischia di saltare: un accordo tra il Cantone e il Municipio di Lugano è in bilico.',
- canonicalPath: '/articoli-frontaliere/giustizia-in-bilico-2026',
+ canonicalPath: '/articoli-frontaliere/giustizia-in-bilico-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -738,7 +738,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ampliamento, parco, eolico, gottardo',
  ogTitle: 'Ampliamento del Parco eolico del San Gottardo: al via la',
  ogDescription: 'Dopo cinque anni dalla sua entrata in funzione, il Parco eolico del San Gottardo può essere ampliato grazie alla consultazione digitale in corso',
- canonicalPath: '/articoli-frontaliere/ampliamento-parco-eolico-san-gottardo-digital-2026',
+ canonicalPath: '/articoli-frontaliere/ampliamento-parco-eolico-san-gottardo-digital-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -767,7 +767,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, eolico, gottardo, cantone, apre',
  ogTitle: 'Eolico al Gottardo, il Cantone apre la consultazione per',
  ogDescription: 'Il Cantone del Ticino ha avviato la consultazione pubblica per l\'ampliamento del parco eolico al Passo del San Gottardo.',
- canonicalPath: '/articoli-frontaliere/eolico-gottardo-ampliamento-2026',
+ canonicalPath: '/articoli-frontaliere/eolico-gottardo-ampliamento-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -796,7 +796,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, contrabbando, confini, aumentano, droga',
  ogTitle: 'Contrabbando ai confini: aumentano droga e sigarette |',
  ogDescription: 'Secondo i dati dell\'Ufficio federale della dogana e della sicurezza dei confini, sono state sequestrate 1,6 milioni di sigarette illegali nel 2025.',
- canonicalPath: '/articoli-frontaliere/contrabbando-ai-confine-aumentano-droga-e-sigarette',
+ canonicalPath: '/articoli-frontaliere/contrabbando-ai-confine-aumentano-droga-e-sigarette/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -825,7 +825,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bertolaso, varese, fare, presto',
  ogTitle: 'Salute Ticino: prevenzione e burocrazia 2026',
  ogDescription: 'Focus sulle strategie di Bertolaso per migliorare i servizi sanitari e snellire le procedure in Canton Ticino e regione di frontiera nel 2026.',
- canonicalPath: '/articoli-frontaliere/salute-prevenzione-burocrazia-svizzera',
+ canonicalPath: '/articoli-frontaliere/salute-prevenzione-burocrazia-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -854,7 +854,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, telefonate, choc, truffe, agli',
  ogTitle: 'Telefonate choc: truffe agli anziani in Ticino, rischi e',
  ogDescription: 'Due anziani in Ticino vittime di truffa telefonica nella regione della Mesolcina. Ecco cosa è successo, come difendersi e le misure preventive adottate dalle au',
- canonicalPath: '/articoli-frontaliere/telefonate-choc-truffa-anziani-ticino',
+ canonicalPath: '/articoli-frontaliere/telefonate-choc-truffa-anziani-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -883,7 +883,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cantiere, anni, salvataggio, credit',
  ogTitle: 'Il cantiere di UBS a tre anni dal salvataggio di Credit S',
  ogDescription: 'A tre anni dal salvataggio di Credit Suisse, UBS completa la migrazione di 1,2 milioni di clienti e annuncia 3.000 licenziamenti in Svizzera. Cresce l’attesa pe',
- canonicalPath: '/articoli-frontaliere/ubs-fusione-credit-suisse-ticino',
+ canonicalPath: '/articoli-frontaliere/ubs-fusione-credit-suisse-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -912,7 +912,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salari, minimi, nuove, direttive',
  ogTitle: 'Salari Minimi e CCL in Ticino: Nuove Direttive per il 202',
  ogDescription: 'Il Consiglio degli Stati approva il progetto di legge sui contratti collettivi di lavoro, con priorità sui salari minimi e il ruolo dei CCL dichiarati di obblig',
- canonicalPath: '/articoli-frontaliere/salari-minimi-ccl-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/salari-minimi-ccl-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -941,7 +941,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, migranti, problematici, governo, decide',
  ogTitle: 'Migranti problematici in Ticino: le nuove strutture dedicate',
  ogDescription: 'Il Canton Ticino investe in strutture dedicate per migranti problematici. Scopri le normative, i tempi e le implicazioni per la frontiera svizzero-italiana.',
- canonicalPath: '/articoli-frontaliere/strutture-dedicate-migranti-ticino',
+ canonicalPath: '/articoli-frontaliere/strutture-dedicate-migranti-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -970,7 +970,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, contratti, collettivi, lavoro, prevalenza',
  ogTitle: 'Contratti collettivi di lavoro in Ticino: prevalenza sui',
  ogDescription: 'Il Consiglio degli Stati svizzero ha approvato il prioritario ruolo dei CCL rispetto ai salari minimi cantonali, con implicazioni concrete per frontalieri e azi',
- canonicalPath: '/articoli-frontaliere/contratti-collettivi-salari-ticino',
+ canonicalPath: '/articoli-frontaliere/contratti-collettivi-salari-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -999,7 +999,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sanità, tutela, sovranità, dati',
  ogTitle: 'Sanità in Ticino: la tutela della sovranità dei dati sani',
  ogDescription: 'Il Canton Ticino si prepara a fronteggiare le sfide della sicurezza digitale e della protezione dei dati sanitari, seguendo le recenti dichiarazioni del senator',
- canonicalPath: '/articoli-frontaliere/tutela-sovranita-dati-sanitari',
+ canonicalPath: '/articoli-frontaliere/tutela-sovranita-dati-sanitari/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1028,7 +1028,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nomine, alla, sims, annullate',
  ogTitle: 'Nomine alla SIMS annullate: il Consiglio di Stato si arre',
  ogDescription: 'Il Tribunale amministrativo ha dichiarato illegittime le nomine dei direttori della SIMS. Il Consiglio di Stato ha deciso di non ricorrere al Tribunale federale',
- canonicalPath: '/articoli-frontaliere/nomine-annullate-sims-tram',
+ canonicalPath: '/articoli-frontaliere/nomine-annullate-sims-tram/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1057,7 +1057,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, altro, voto, pesante, alla',
  ogTitle: 'Tassa transito Svizzera | Frontaliere Ticino',
  ogDescription: 'Il Consiglio Nazionale approva una tassa di transito per attraversamenti rapidi in Svizzera, con impatti su Ticino e frontalieri. Leggi i dettagli.',
- canonicalPath: '/articoli-frontaliere/tassa-automobilisti-svizzera',
+ canonicalPath: '/articoli-frontaliere/tassa-automobilisti-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1086,7 +1086,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, richiedenti, asilo, ucraini, possono',
  ogTitle: 'Richiedenti asilo e ucraini: ora possono lavorare in Sviz',
  ogDescription: 'Nuove ordinanze federali permettono a richiedenti asilo e titolari di protezione S, compresi gli ucraini, di esercitare attività lucrativa in Svizzera, anche in',
- canonicalPath: '/articoli-frontaliere/lavoro-richiedenti-asilo-ucraini-ticino',
+ canonicalPath: '/articoli-frontaliere/lavoro-richiedenti-asilo-ucraini-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1115,7 +1115,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, riforma, scolastica, contesto, segnato',
  ogTitle: 'Riforma scolastica in Ticino: un contesto segnato da cres',
  ogDescription: 'Le associazioni chiedono risorse adeguate per affrontare le sfide della riforma del liceo, tra criticità normative e aumento del disagio tra studenti e docenti.',
- canonicalPath: '/articoli-frontaliere/riforma-scolastica-ticino-difficolta',
+ canonicalPath: '/articoli-frontaliere/riforma-scolastica-ticino-difficolta/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1144,7 +1144,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, transito, approvazione, impatti',
  ogTitle: 'La tassa di transito in Ticino tra approvazione e impatti',
  ogDescription: 'La tassa di transito, approvata dal Parlamento svizzero, potrebbe incidere sui costi dei frontalieri e sulle entrate cantonali. Ecco cosa aspettarsi.',
- canonicalPath: '/articoli-frontaliere/tassa-transito-parlamento-ticino',
+ canonicalPath: '/articoli-frontaliere/tassa-transito-parlamento-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1173,7 +1173,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, alis, nuove, strategie, inclusione',
  ogTitle: 'Integrazione migranti Ticino | Frontaliere Ticino',
  ogDescription: 'Alis e Cir collaborano per l\'inclusione dei migranti in Ticino, creando opportunità di formazione e inserimento professionale nel mercato locale.',
- canonicalPath: '/articoli-frontaliere/inclusione-migranti-ticino',
+ canonicalPath: '/articoli-frontaliere/inclusione-migranti-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1202,7 +1202,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, luss, attacca, franco, danneggia',
  ogTitle: 'Impatti del franco forte sul Ticino',
  ogDescription: 'Come il franco forte influisce sulle imprese e sui frontalieri del Ticino. Strategie, normative e strumenti per affrontare questa sfida.',
- canonicalPath: '/articoli-frontaliere/franco-svizzero-impatti-ticino',
+ canonicalPath: '/articoli-frontaliere/franco-svizzero-impatti-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1231,7 +1231,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, transito, cosa, cambia',
  ogTitle: 'Tassa di transito in Ticino: cosa cambia per gli automobi',
  ogDescription: 'Dal 2026, gli stranieri che attraversano il Ticino in auto senza soste significative dovranno pagare una tassa di transito dinamica. Analisi e dettagli pratici.',
- canonicalPath: '/articoli-frontaliere/tassa-transito-automobilisti-ticino',
+ canonicalPath: '/articoli-frontaliere/tassa-transito-automobilisti-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1260,7 +1260,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nubifragio, giugno, 2024, ristoro',
  ogTitle: 'Nubifragio Giugno 2024: Ristoro Finanziario in Ticino',
  ogDescription: 'Il nubifragio di giugno 2024 ha causato danni ingenti in Coira e Mesolcina. La risposta dello Stato include interventi di sostegno economico per le aree colpite',
- canonicalPath: '/articoli-frontaliere/nubifragio-coira-mesolcina-ristoro',
+ canonicalPath: '/articoli-frontaliere/nubifragio-coira-mesolcina-ristoro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1289,7 +1289,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sotto, attenzione, consiglio, europa',
  ogTitle: 'Ticino e Svizzera sotto l\'attenzione del Consiglio d\'Euro',
  ogDescription: 'Il 11 marzo una delegazione GREVIO ha visitato il Ticino, evidenziando i progressi nella prevenzione e le nuove raccomandazioni per il Canton e il Paese.',
- canonicalPath: '/articoli-frontaliere/lotta-violenza-di-genere-ticino',
+ canonicalPath: '/articoli-frontaliere/lotta-violenza-di-genere-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1318,7 +1318,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'switzerland transit fee 2026, tassa transito svizzera 2026, swiss highway vignette 2026, transit fee switzerland, frontalieri, ticino, tariffa transito, cross-border commuters',
  ogTitle: 'Switzerland Transit Fee 2026: la guida aggiornata per frontalieri',
  ogDescription: 'Switzerland transit fee 2026: tariffe di transito, vignetta autostradale e regole aggiornate per i frontalieri del Ticino.',
- canonicalPath: '/articoli-frontaliere/tassa-transito-svizzera-2026',
+ canonicalPath: '/articoli-frontaliere/tassa-transito-svizzera-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1347,7 +1347,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, operazione, controllo, cantieri, mendrisiotto',
  ogTitle: 'Operazione di controllo nei cantieri del Mendrisiotto: ne',
  ogDescription: 'Controlli rigorosi in sette cantieri del Mendrisiotto: coinvolti 66 lavoratori, nessuna irregolarità rilevata. Ecco cosa emerge.',
- canonicalPath: '/articoli-frontaliere/controlli-cantieri-mendrisiotto',
+ canonicalPath: '/articoli-frontaliere/controlli-cantieri-mendrisiotto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1376,7 +1376,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, acinque, lancia, piano, genitorialità',
  ogTitle: 'Acinque lancia piano \'Genitorialità\': un mese di congedo extra e bonus',
  ogDescription: 'La multiutility lombarda presenta un piano di supporto per i dipendenti delle province di Varese, Como, Lecco e Sondrio.',
- canonicalPath: '/articoli-frontaliere/acinque-lancia-piano-genitorialita',
+ canonicalPath: '/articoli-frontaliere/acinque-lancia-piano-genitorialita/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1405,7 +1405,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, danni, riparati, riapre, centovallina-vigezzina',
  ogTitle: 'Danni riparati, riapre la Centovallina-Vigezzina',
  ogDescription: 'La linea ferroviaria Centovallina-Vigezzina riapre dopo lavori di riparazione dei danni.',
- canonicalPath: '/articoli-frontaliere/danni-riparati-centovallina',
+ canonicalPath: '/articoli-frontaliere/danni-riparati-centovallina/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1434,7 +1434,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, porrentruy, potrà, vietare, accesso',
  ogTitle: 'Porrentruy potrà vietare l\'accesso alla piscina comunale ai non residenti',
  ogDescription: 'Il Consiglio comunale di Porrentruy ha approvato una modifica legale per autorizzare il Municipio a imporre restrizioni all\'accesso della piscina all\'aperto.',
- canonicalPath: '/articoli-frontaliere/porrentruy-piscina-comunale-divieto',
+ canonicalPath: '/articoli-frontaliere/porrentruy-piscina-comunale-divieto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1463,7 +1463,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sanità, fontana, fedriga, ospedale-centrismo',
  ogTitle: 'Sanità, Fontana e Fedriga: \'L\'ospedale-centrismo è superato\'',
  ogDescription: 'I presidenti di Lombardia e Friuli Venezia Giulia discutono la sostenibilità del sistema sanitario a Varese.',
- canonicalPath: '/articoli-frontaliere/sanita-fontana-fedriga',
+ canonicalPath: '/articoli-frontaliere/sanita-fontana-fedriga/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1492,7 +1492,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, gottardo, verso, ampliamento, parco',
  ogTitle: 'San Gottardo, verso l\'ampliamento del parco eolico',
  ogDescription: 'Il parco eolico di San Gottardo potrebbe ampliarsi: ecco cosa significa per la regione del Ticino.',
- canonicalPath: '/articoli-frontaliere/ampliamento-parco-eolico-san-gottardo',
+ canonicalPath: '/articoli-frontaliere/ampliamento-parco-eolico-san-gottardo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1521,7 +1521,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, nuova, tassa',
  ogTitle: 'Cure a domicilio: la nuova tassa divide politica e cittadini',
  ogDescription: 'La nuova tassa sulle cure a domicilio è stata introdotta in Ticino al 1° aprile 2026. La misura ha suscitato reazioni contrastanti fra politici e cittadini.',
- canonicalPath: '/articoli-frontaliere/cure-a-domicilio-tassa-ticino',
+ canonicalPath: '/articoli-frontaliere/cure-a-domicilio-tassa-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1550,7 +1550,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, contributo, cantonale, ripristino, strutture',
  ogTitle: 'Ticino: contributo cantonale per ripristino strutture agricole danneggiate dal nubifragio',
  ogDescription: 'Il governo grigionese concede 511\'000 franchi per ripristino strutture agricole danneggiate dal nubifragio del 2024 nella regione Grigioni.',
- canonicalPath: '/articoli-frontaliere/kebab-case-ticino-nubifragio-grigioni',
+ canonicalPath: '/articoli-frontaliere/kebab-case-ticino-nubifragio-grigioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1579,7 +1579,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, transito, bruxelles, storce',
  ogTitle: 'Tassa di transito, Bruxelles storce il naso - Frontaliere Ticino',
  ogDescription: 'La Svizzera introduce la tassa di transito per ridurre il traffico, ma la Commissione europea non è contenta.',
- canonicalPath: '/articoli-frontaliere/kebab-case-rossi-bruxelles-ticino',
+ canonicalPath: '/articoli-frontaliere/kebab-case-rossi-bruxelles-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1608,7 +1608,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rinnovo, concessioni, ampliamento, dell',
  ogTitle: 'Rinnovo delle concessioni e ampliamento dell\'offerta: i piani di SNL per il 2026',
  ogDescription: 'La Società Navigazione del Lago di Lugano (SNL) si appresta a presentare i suoi piani per il rinnovo delle concessioni e l\'ampliamento dell\'offerta per il 2026.',
- canonicalPath: '/articoli-frontaliere/rinnovo-concessioni-snl-2026',
+ canonicalPath: '/articoli-frontaliere/rinnovo-concessioni-snl-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1637,7 +1637,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fuga, globalisti, medio, oriente',
  ogTitle: 'Fuga dei Globalisti dal Medio Oriente: Opportunità per il',
  ogDescription: 'Il Ticino potrebbe beneficiare dell\'uscita di grandi patrimoni dal Medio Oriente, ma serve una strategia chiara.',
- canonicalPath: '/articoli-frontaliere/globalisti-fuga-medio-oriente-ticino',
+ canonicalPath: '/articoli-frontaliere/globalisti-fuga-medio-oriente-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1666,7 +1666,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, guasto, parabiago, ritardi, fino',
  ogTitle: 'Guasto tra Parabiago e Rho: ritardi fino a 30 minuti sulle linee per Milano',
  ogDescription: 'Disagi sulla direttrice ferroviaria verso Milano: possibili cancellazioni e variazioni per diversi collegamenti lombardi. Consulta lo stato delle corse e',
- canonicalPath: '/articoli-frontaliere/guasto-tra-parabiago-e-rho',
+ canonicalPath: '/articoli-frontaliere/guasto-tra-parabiago-e-rho/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1695,7 +1695,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, imposta, transito, potrebbe, funzionare',
  ogTitle: 'Tassa di transito in Svizzera: come funziona e cosa c\'è da sapere',
  ogDescription: 'La tassa di transito potrebbe essere un modo efficace per ridurre il traffico in Svizzera e per disincentivare la guida in orari di punta.',
- canonicalPath: '/articoli-frontaliere/tassa-transito-ticino-pedemontana',
+ canonicalPath: '/articoli-frontaliere/tassa-transito-ticino-pedemontana/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1724,7 +1724,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, franco, svizzero, valori, record',
  ogTitle: 'Il franco svizzero a valori record rende più ricchi i frontalieri, ma un annuncio può',
  ogDescription: 'Il franco svizzero ha raggiunto valori record, rendendo più ricchi i frontalieri, ma l\'annuncio della Banca Nazionale Svizzera potrebbe cambiare tutto.',
- canonicalPath: '/articoli-frontaliere/franco-svizzero-a-valori-record-2026',
+ canonicalPath: '/articoli-frontaliere/franco-svizzero-a-valori-record-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1753,7 +1753,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, taglio, alle, accise, mette',
  ogTitle: 'Il taglio alle accise mette sotto pressione i distributori ticinesi',
  ogDescription: 'La misura, decisa da Roma e valida per 20 giorni, prevede uno \'sconto\' di 25 centesimi al litro. L\'associazione di categoria ticinese si dice preoccupata e',
- canonicalPath: '/articoli-frontaliere/taglio-alle-accise-mette-sotto-pressione-i-distributori-ticinesi',
+ canonicalPath: '/articoli-frontaliere/taglio-alle-accise-mette-sotto-pressione-i-distributori-ticinesi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1782,7 +1782,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, industria, farmaceutica, essere, competitiva',
  ogTitle: 'L\'industria farmaceutica: per essere competitiva l\'Europa deve avere regole chiare e',
  ogDescription: 'L\'industria farmaceutica è un settore strategico per l\'economia italiana e europea. È un settore che crea posti di lavoro, innova e contribuisce alla crescita',
- canonicalPath: '/articoli-frontaliere/farmaci-competitiva-europa',
+ canonicalPath: '/articoli-frontaliere/farmaci-competitiva-europa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1811,7 +1811,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, cantieri, mendrisiotto, esito',
  ogTitle: 'Controlli nei Cantieri del Mendrisiotto | Frontaliere Ticino',
  ogDescription: 'Esito positivo per sette ispezioni nei cantieri del Mendrisiotto, con zero irregolarità.',
- canonicalPath: '/articoli-frontaliere/controlli-cantieri-mendrisiotto-2026',
+ canonicalPath: '/articoli-frontaliere/controlli-cantieri-mendrisiotto-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1840,7 +1840,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, espande, concessionari, entro, costruttore',
  ogTitle: 'BYD si espande in Ticino: 50 concessionari entro il 2026',
  ogDescription: 'Il costruttore cinese BYD punta a 50 concessionari in Svizzera entro il 2026, con due già operativi in Ticino.',
- canonicalPath: '/articoli-frontaliere/byd-expansion-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/byd-expansion-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1869,7 +1869,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, caro, affitti, nazionale, respinge',
  ogTitle: 'Caro affitti: il Nazionale respinge il controllo delle pi',
  ogDescription: 'Il Consiglio nazionale rifiuta proposte per un maggiore controllo sugli affitti, sollevando preoccupazioni per la crisi abitativa.',
- canonicalPath: '/articoli-frontaliere/controllo-affitti-nazionale-ticino',
+ canonicalPath: '/articoli-frontaliere/controllo-affitti-nazionale-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1898,7 +1898,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cioccolato, meno, consumo, prezzi',
  ogTitle: 'Cioccolato in Svizzera: meno consumo ma prezzi in aumento',
  ogDescription: 'Nel 2025 il consumo di cioccolato in Svizzera è calato, ma il fatturato è cresciuto del 11,8%, con una forte pressione sui costi.',
- canonicalPath: '/articoli-frontaliere/cioccolato-meno-ma-pagato-di-piu',
+ canonicalPath: '/articoli-frontaliere/cioccolato-meno-ma-pagato-di-piu/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1927,7 +1927,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'prezzo diesel ticino 2026, prezzo diesel svizzera 2026, dieselpreis tessin, prix diesel tessin, diesel price ticino, costo diesel litro svizzera, carburante ticino',
  ogTitle: 'Prezzo Diesel Ticino 2026 — Confronto Distributori Oggi',
  ogDescription: 'Diesel a CHF 2,10/litro in Ticino e Svizzera: classifica distributori, confronto con l\'Italia e consigli per risparmiare al pieno.',
- canonicalPath: '/articoli-frontaliere/diesel-aumento-prezzi-svizzera-2026',
+ canonicalPath: '/articoli-frontaliere/diesel-aumento-prezzi-svizzera-2026/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1968,7 +1968,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, varese, nasce, manifesto, welfare',
  ogTitle: 'A Varese nasce il Manifesto per il welfare sanitario',
  ogDescription: 'Un nuovo manifesto per il welfare a Varese: quindici pilastri per la voce dei pazienti nella sanità pubblica.',
- canonicalPath: '/articoli-frontaliere/sanita-manifesto-varese-2026',
+ canonicalPath: '/articoli-frontaliere/sanita-manifesto-varese-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1997,7 +1997,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bassa, immagine, ingannevole, nonostante',
  ogTitle: 'L\'IVA bassa in Svizzera: un\'immagine ingannevole',
  ogDescription: 'Un\'analisi critica sull\'aliquota IVA in Svizzera e le sue conseguenze fiscali.',
- canonicalPath: '/articoli-frontaliere/iva-bassa-svizzera-immagine-ingannevole',
+ canonicalPath: '/articoli-frontaliere/iva-bassa-svizzera-immagine-ingannevole/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2026,7 +2026,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, divieto, smartphone, nelle, scuole',
  ogTitle: 'Divieto di smartphone nelle scuole del Ticino: nuove misu',
  ogDescription: 'A partire dal 30 marzo, il Ticino estende il divieto di smartphone a tutte le scuole dell\'obbligo per tutelare la salute dei giovani.',
- canonicalPath: '/articoli-frontaliere/divieto-smartphone-scuola-ticino',
+ canonicalPath: '/articoli-frontaliere/divieto-smartphone-scuola-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2055,7 +2055,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, navigazione, offerte, potenziate, lago',
  ogTitle: 'Navigazione Ticino: Offerte potenziate per il 2026',
  ogDescription: 'La Navigazione Lago di Lugano si prepara per una nuova stagione con offerte potenziate, mirando a diventare un vettore turistico di riferimento.',
- canonicalPath: '/articoli-frontaliere/la-navigazione-rafforza-offerta-2026',
+ canonicalPath: '/articoli-frontaliere/la-navigazione-rafforza-offerta-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2084,7 +2084,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, scontro, sulla, sanità, integrativa',
  ogTitle: 'Sanità Integrativa in Lombardia',
  ogDescription: '27 sigle si oppongono alle convenzioni sanitarie nel pubblico.',
- canonicalPath: '/articoli-frontaliere/sanita-integrativa-lombardia-ticino',
+ canonicalPath: '/articoli-frontaliere/sanita-integrativa-lombardia-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2113,7 +2113,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fatture, mediche, gonfiate, problema',
  ogTitle: 'Fatture Mediche Gonfiate in Ticino',
  ogDescription: 'Scopri il fenomeno delle fatture mediche gonfiate in Ticino e come difenderti.',
- canonicalPath: '/articoli-frontaliere/fatture-mediche-gonfiate-ticino',
+ canonicalPath: '/articoli-frontaliere/fatture-mediche-gonfiate-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2142,7 +2142,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, divieto, cellulari, nelle, scuole',
  ogTitle: 'Divieto cellulari nelle scuole Ticino',
  ogDescription: 'Dal 30 marzo 2026, il Ticino estende il divieto di cellulari nelle scuole dell\'obbligo.',
- canonicalPath: '/articoli-frontaliere/divieto-cellulari-scuola-ticino',
+ canonicalPath: '/articoli-frontaliere/divieto-cellulari-scuola-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2171,7 +2171,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, consiglio, europa, valuta, progressi',
  ogTitle: 'Consiglio d’Europa e Lotta alla Violenza in Ticino',
  ogDescription: 'Il 11 marzo, il Consiglio d\'Europa ha monitorato i progressi della Svizzera e del Ticino nella lotta alla violenza di genere.',
- canonicalPath: '/articoli-frontaliere/violenza-donne-consiglio-europa-ticino',
+ canonicalPath: '/articoli-frontaliere/violenza-donne-consiglio-europa-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2200,7 +2200,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ticinese, capo, importanti, servizi',
  ogTitle: 'Un ticinese a capo di due importanti servizi dell\'esercito',
  ogDescription: 'Il colonnello SMG Stefano Trojani assumerà il comando del Servizio informazioni militare e del Servizio di protezione preventiva dell\'esercito dal 1° giugno',
- canonicalPath: '/articoli-frontaliere/trojani-capo-servizi-esercito-ticino',
+ canonicalPath: '/articoli-frontaliere/trojani-capo-servizi-esercito-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2229,7 +2229,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'funivia monteviasco, monteviasco seilbahn, orari funivia monteviasco 2026, funivia val veddasca, ponte di piero, frontalieri, ticino',
  ogTitle: 'Funivia Monteviasco: orari, prezzi e corse 2026',
  ogDescription: 'Funivia di Monteviasco: servizio ampliato a 6 giorni, collegamento affidabile Ponte di Piero - Val Veddasca. Orari e prezzi aggiornati.',
- canonicalPath: '/articoli-frontaliere/funivia-monteviasco-orari-corsi',
+ canonicalPath: '/articoli-frontaliere/funivia-monteviasco-orari-corsi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2258,7 +2258,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ricchi, fuga, medio, oriente',
  ogTitle: 'Ricchi in fuga dal Medio Oriente: opportunità per Ticino',
  ogDescription: 'Il Canton Ticino deve agire per attrarre capitali e contribuenti facoltosi in fuga dal Medio Oriente, sfruttando punti di forza e posizione strategica.',
- canonicalPath: '/articoli-frontaliere/ricchi-fuga-medio-oriente-ticino',
+ canonicalPath: '/articoli-frontaliere/ricchi-fuga-medio-oriente-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2287,7 +2287,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, scuola, dell, obbligo, scatta',
  ogTitle: 'Divieto cellulari scuole Ticino 2024',
  ogDescription: 'Il Canton Ticino impone il divieto totale di cellulari nelle scuole dell\'obbligo dal 2024, coinvolgendo studenti ticinesi e frontalieri.',
- canonicalPath: '/articoli-frontaliere/divieto-cellulari-scuola-ticino-2024',
+ canonicalPath: '/articoli-frontaliere/divieto-cellulari-scuola-ticino-2024/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2316,7 +2316,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sindacati, contro, salari, trasparenza',
  ogTitle: 'Sindacati contro SNL: salari e trasparenza in Ticino 2026',
  ogDescription: 'Critiche sindacali alla Società Navigazione Lago di Lugano per infrazioni e condizioni salariali inique nel 2026.',
- canonicalPath: '/articoli-frontaliere/sindacati-contro-snl-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/sindacati-contro-snl-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2345,7 +2345,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, quanto, costerà, aumento, dell',
  ogTitle: 'Quanto costerà l’aumento dell’IVA per le famiglie in Tici',
  ogDescription: 'Un aumento dell’IVA al 9,6% graverebbe tra 300 e 1’400 franchi annui per le famiglie ticinesi, con impatti differenziati per reddito e composizione.',
- canonicalPath: '/articoli-frontaliere/aumento-iva-costo-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/aumento-iva-costo-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2374,7 +2374,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, calanca, quattro, comuni, studiano',
  ogTitle: 'Fusione Comuni Calanca nel Ticino',
  ogDescription: 'Studio di fusione tra quattro Comuni in Calanca: un passo verso una gestione più efficace e sostenibile nella regione.',
- canonicalPath: '/articoli-frontaliere/fusione-valle-calanca-comuni',
+ canonicalPath: '/articoli-frontaliere/fusione-valle-calanca-comuni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2403,7 +2403,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavoro, carcere, posti, disponibili',
  ogTitle: 'Lavoro in carcere: 15 posti disponibili',
  ogDescription: 'Il Canton Ticino cerca 15 nuove guardie carcerarie. Scadenza del bando: 31 marzo 2026.',
- canonicalPath: '/articoli-frontaliere/lavoro-carceri-ticino',
+ canonicalPath: '/articoli-frontaliere/lavoro-carceri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2432,7 +2432,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavena, ponte, tresa, impegna',
  ogTitle: 'Lavena Ponte Tresa si impegna per la pulizia e il verde della zona',
  ogDescription: 'Il Comune di Lavena Ponte Tresa ha regalato agli attività presenti degli annaffiatoi per aiutare a mantenere la zona pulita e verde.',
- canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-annaffiatoi',
+ canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-annaffiatoi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2461,7 +2461,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, commemorazione, bossi, diventa, bagarre',
  ogTitle: 'La commemorazione di Bossi diventa bagarre in aula',
  ogDescription: 'La commemorazione per il fondatore della Lega Umberto Bossi è finita in bagarre con urla e accuse tra maggioranza e opposizione.',
- canonicalPath: '/articoli-frontaliere/bossi-commemorazione-bagarrata',
+ canonicalPath: '/articoli-frontaliere/bossi-commemorazione-bagarrata/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2490,7 +2490,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, corsi, scuola, media, ticinese',
  ogTitle: 'Via i corsi A e B: la scuola media ticinese cambia dal 2026',
  ogDescription: 'Il Consiglio di Stato ha deciso: dal 2026 niente più suddivisione in livelli per tedesco e matematica in tutte le scuole medie del Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/corsi-a-b-scuola-media-ticino',
+ canonicalPath: '/articoli-frontaliere/corsi-a-b-scuola-media-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2519,7 +2519,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, gallarate, pendolare, e-bike, arrestato',
  ogTitle: 'Gallarate: pendolare in e-bike arrestato per spaccio di droga',
  ogDescription: 'Un uomo di 47 anni è stato arrestato a Gallarate per spaccio di droga. Utilizzava una bicicletta elettrica per spostarsi.',
- canonicalPath: '/articoli-frontaliere/ticino-confine-droga',
+ canonicalPath: '/articoli-frontaliere/ticino-confine-droga/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2548,7 +2548,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, franco, svizzero, minimi, gennaio',
  ogTitle: 'Il franco svizzero ai minimi da gennaio sull\'euro',
  ogDescription: 'Il franco svizzero ha raggiunto i minimi da gennaio sull\'euro sfiorando 0,92 franchi.',
- canonicalPath: '/articoli-frontaliere/franco-svizzero-minimi-euro',
+ canonicalPath: '/articoli-frontaliere/franco-svizzero-minimi-euro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2577,7 +2577,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, benzina, conveniente, automobilisti, ticinesi',
  ogTitle: 'Benzina conveniente in Ticino',
  ogDescription: 'Gli automobilisti ticinesi cercano la benzina più conveniente a Como. Scopri come risparmiare sulla benzina in Ticino.',
- canonicalPath: '/articoli-frontaliere/benzina-conveniente',
+ canonicalPath: '/articoli-frontaliere/benzina-conveniente/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2606,7 +2606,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, interventi, soccorso, meno, vittime',
  ogTitle: 'Più interventi di soccorso, ma meno vittime in montagna nel 2025',
  ogDescription: 'Nel 2025, il Club Alpino Svizzero (CAS) ha registrato un aumento degli interventi di soccorso, ma una diminuzione delle vittime in montagna.',
- canonicalPath: '/articoli-frontaliere/piu-interventi-soccorso-meno-vittime-montagna-ticino-2025',
+ canonicalPath: '/articoli-frontaliere/piu-interventi-soccorso-meno-vittime-montagna-ticino-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2635,7 +2635,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, test, neonati, escluso, controlli',
  ogTitle: 'Test neonati Ticino: cosa fare',
  ogDescription: 'La Svizzera non ha effettuato screening sui lattanti ticinesi per la contaminazione: guida per i frontalieri',
- canonicalPath: '/articoli-frontaliere/nei-test-neonati-ticinesi',
+ canonicalPath: '/articoli-frontaliere/nei-test-neonati-ticinesi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2664,7 +2664,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aggregazione, basso, mendrisiotto, rischio',
  ogTitle: 'Aggregazione Basso Mendrisiotto: il debito ferma la fusione',
  ogDescription: 'Il progetto Terre di Breggia si arena sul debito di Chiasso. Rizza chiede garanzie, Arrigoni promette tagli. Il Cantone valuta la sospensione.',
- canonicalPath: '/articoli-frontaliere/aggregazione-rischio-basso-mendrisiotto',
+ canonicalPath: '/articoli-frontaliere/aggregazione-rischio-basso-mendrisiotto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2693,7 +2693,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, congresso, varese, aggiornamenti, fiscali',
  ogTitle: 'Congresso Svizzera‑Italia a Varese: aggiornamenti per i frontalieri ticinesi',
  ogDescription: 'Il 16 aprile 2026 a Villa Andrea, esperti illustrano le evoluzioni fiscali e previdenziali per chi vive e lavora tra Italia e Svizzera.',
- canonicalPath: '/articoli-frontaliere/congresso-svizzera-italia-varese-2026',
+ canonicalPath: '/articoli-frontaliere/congresso-svizzera-italia-varese-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2722,7 +2722,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, processo, mendrisio, capi, imputazione',
  ogTitle: 'Processo Mendrisio: 19 capi d\'imputazione e espulsione',
  ogDescription: 'Il caso del 37enne condannato con espulsione dopo 19 capi d\'imputazione. Guida pratica per i frontalieri su rischi e protezione legale.',
- canonicalPath: '/articoli-frontaliere/processo-mendrisio-19-capit',
+ canonicalPath: '/articoli-frontaliere/processo-mendrisio-19-capit/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2751,7 +2751,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, europa, corre, ripari, spagna',
  ogTitle: 'La Spagna riduce i prezzi del carburante di 30 centesimi al litro',
  ogDescription: 'La Spagna è stato il primo paese europeo a ridurre i prezzi del carburante dopo la crescita dei prezzi energetici.',
- canonicalPath: '/articoli-frontaliere/prezzi-carburanti-ticino-marzo-2026',
+ canonicalPath: '/articoli-frontaliere/prezzi-carburanti-ticino-marzo-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2780,7 +2780,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cammino, francisca, lavena, ponte',
  ogTitle: 'Cammino Via Francisca del Lucomagno',
  ogDescription: 'Il cammino della Via Francisca del Lucomagno è partito da Lavena Ponte Tresa',
- canonicalPath: '/articoli-frontaliere/via-francisca-cammino',
+ canonicalPath: '/articoli-frontaliere/via-francisca-cammino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2809,7 +2809,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavoro, sommerso, varesotto, casi',
  ogTitle: 'Lavoro ‘sommerso’ nel Varesotto, 46 casi scovati in pochi mesi',
  ogDescription: 'Il lavoro ‘sommerso’ è un fenomeno che sta diventando sempre più evidente nel Varesotto.',
- canonicalPath: '/articoli-frontaliere/lavoro-sommerso-varesotto',
+ canonicalPath: '/articoli-frontaliere/lavoro-sommerso-varesotto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2838,7 +2838,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rissa, nella, notte, lavena',
  ogTitle: 'Rissa notturna a Lavena Ponte Tresa',
  ogDescription: 'Due stranieri in ospedale dopo una rissa notturna a Lavena Ponte Tresa',
- canonicalPath: '/articoli-frontaliere/rissa-lavena-ponte-tres',
+ canonicalPath: '/articoli-frontaliere/rissa-lavena-ponte-tres/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2867,7 +2867,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavori, nuova, scuola, elementare',
  ogTitle: 'La nuova scuola elementare di Magliaso',
  ogDescription: 'La comunità locale di Magliaso è entusiasta della nuova scuola elementare, che promette di offrire un ambiente educativo moderno e funzionale per gli studenti.',
- canonicalPath: '/articoli-frontaliere/magliaso-zona-educativa-ripresa',
+ canonicalPath: '/articoli-frontaliere/magliaso-zona-educativa-ripresa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2896,7 +2896,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cassa, malati, iniziativa, leghista',
  ogTitle: 'Cassa malati: l\'iniziativa leghista va applicata subito',
  ogDescription: 'La Lega dei Ticinesi chiede la deducibilità fiscale integrale dei premi di cassa malati. Il Consiglio di Stato annuncia il proprio piano: applicazione parziale',
- canonicalPath: '/articoli-frontaliere/cassa-malati-leghista-applicata-subito',
+ canonicalPath: '/articoli-frontaliere/cassa-malati-leghista-applicata-subito/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2925,7 +2925,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rissa, ponte, tresa, persone',
  ogTitle: 'Rissa a Ponte Tresa',
  ogDescription: 'Due persone sono state ricoverate in ospedale dopo una rissa nella notte a Ponte Tresa.',
- canonicalPath: '/articoli-frontaliere/ronte-tresa-rissa',
+ canonicalPath: '/articoli-frontaliere/ronte-tresa-rissa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2954,7 +2954,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiusure, chiasso, como, impatto',
  ogTitle: 'Chiusure A9 Chiasso-Como: impatto sui frontalieri',
  ogDescription: 'Guida pratica alle chiusure A9 marzo 2026 per chi lavora tra Ticino e Lombardia',
- canonicalPath: '/articoli-frontaliere/a9-chiasso-como-chiusure-frontalieri',
+ canonicalPath: '/articoli-frontaliere/a9-chiasso-como-chiusure-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2983,7 +2983,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, code, gottardo, dieci, chilometri',
  ogTitle: 'Code al San Gottardo',
  ogDescription: 'Dieci chilometri di coda al portale nord del San Gottardo, tempi di attesa fino a un\'ora e trenta minuti',
- canonicalPath: '/articoli-frontaliere/code-nord-san-gottardo',
+ canonicalPath: '/articoli-frontaliere/code-nord-san-gottardo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3012,7 +3012,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, parmelin, trattative, oltre, marzo',
  ogTitle: 'Trattative commercio Usa Svizzera: oltre 31 marzo - Frontaliere Ticino',
  ogDescription: 'La Svizzera continuerà a negoziare un accordo commerciale con gli Stati Uniti anche dopo il termine previsto del 31 marzo.',
- canonicalPath: '/articoli-frontaliere/trattative-acordo-usa-oltre-31-marzo',
+ canonicalPath: '/articoli-frontaliere/trattative-acordo-usa-oltre-31-marzo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3041,7 +3041,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, innova, occhiali, intelligenti, vedenti',
  ogTitle: 'Occhiali intelligenti per non vedenti: l\'innovazione ticinese',
  ogDescription: 'La startup Lighthouse Tech presenta TAMI, occhiali con radar che vibrano per segnalare ostacoli. Test positivi da ipovedenti.',
- canonicalPath: '/articoli-frontaliere/occhiali-intelligenti-ticino-innovazione',
+ canonicalPath: '/articoli-frontaliere/occhiali-intelligenti-ticino-innovazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3070,7 +3070,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, trattative, dazi, termine, marzo',
  ogTitle: 'Trattative sui dazi: "Il termine del 31 marzo non è più valido" | Frontaliere Ticino',
  ogDescription: 'La Confederazione svizzera ha annunciato che il termine del 31 marzo per trovare un accordo sui dazi tra la Svizzera e gli Stati Uniti non è più valido. Lo ha',
- canonicalPath: '/articoli-frontaliere/trattative-dazi-non-valido-31-marzo',
+ canonicalPath: '/articoli-frontaliere/trattative-dazi-non-valido-31-marzo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3099,7 +3099,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fermato, trippa, troppo, 50enne',
  ogTitle: 'Fermato con della trippa di troppo',
  ogDescription: 'Un 50enne del Mendrisiotto è stato fermato e multato per aver superato il limite di carne trasportabile.',
- canonicalPath: '/articoli-frontaliere/trippa-dogana-novazzano',
+ canonicalPath: '/articoli-frontaliere/trippa-dogana-novazzano/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3128,7 +3128,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavori, sulla, rete, ferroviaria',
  ogTitle: 'Lavori sulla rete ferroviaria italiana, ecco cosa cambia',
  ogDescription: 'Dal 3 aprile i collegamenti TILO S30 subiscono importanti modifiche alla circolazione a causa di lavori infrastrutturali alla linea ferroviaria tra Pino Tronzan',
- canonicalPath: '/articoli-frontaliere/lavori-rete-ferroviaria-tilo',
+ canonicalPath: '/articoli-frontaliere/lavori-rete-ferroviaria-tilo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3157,7 +3157,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, mensa, asilo, chiasso',
  ogTitle: 'Tassa mensa asilo a Chiasso',
  ogDescription: 'Il Comune di Chiasso introduce una tassa sulla mensa scolastica per gli alunni dell\'asilo. Scopri di più sulla proposta e sul suo impatto sulle famiglie.',
- canonicalPath: '/articoli-frontaliere/tassa-mensa-asilo-chiasso',
+ canonicalPath: '/articoli-frontaliere/tassa-mensa-asilo-chiasso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3186,7 +3186,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sindacati, cambio, appalto, leonardo',
  ogTitle: 'Sindacati in Ticino: "Sul cambio d\'appalto a Leonardo Cas',
  ogDescription: 'I sindacati di Filt Cgil, Fit Cisl e Uiltrasporti chiedono un tavolo in Prefettura per discutere la vertenza.',
- canonicalPath: '/articoli-frontaliere/sindacati-ticino-leonardo-cascina-costa',
+ canonicalPath: '/articoli-frontaliere/sindacati-ticino-leonardo-cascina-costa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3215,7 +3215,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, introdurrà, tassa, refezione',
  ogTitle: 'Chiasso non introdurrà la tassa di refezione alla scuola dell\'infanzia',
  ogDescription: 'Il Consiglio comunale di Chiasso ha bocciato la proposta di introdurre la tassa di refezione alla scuola dell\'infanzia.',
- canonicalPath: '/articoli-frontaliere/chiasso-tassa-refezione-scuola-infanzia',
+ canonicalPath: '/articoli-frontaliere/chiasso-tassa-refezione-scuola-infanzia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3244,7 +3244,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavoro, ated, chiede, rappresentanza',
  ogTitle: 'Lavoro TIC in Ticino: ATED chiede rappresentanza nella Co',
  ogDescription: 'Il settore ICT ticinese, con oltre 14.000 professionisti e un peso economico di circa 1,4 miliardi di franchi, richiede un ruolo diretto nel processo decisional',
- canonicalPath: '/articoli-frontaliere/ict-reatto-commissione-tri',
+ canonicalPath: '/articoli-frontaliere/ict-reatto-commissione-tri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3273,7 +3273,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tenta, furbata, dogana, como',
  ogTitle: 'Tenta la furbata in dogana tra Como e Svizzera: nella Mus',
  ogDescription: 'Cittadino italiano fermato al valico di Ponte Chiasso con 7 kg di rare monete d\'argento nascoste nel bagagliaio di una Ford Mustang',
- canonicalPath: '/articoli-frontaliere/furbata-dogana-argento',
+ canonicalPath: '/articoli-frontaliere/furbata-dogana-argento/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3302,7 +3302,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rientro, dell, ambasciatore, italiano',
  ogTitle: 'Rientro dell\'ambasciatore italiano a Berna dopo polemiche',
  ogDescription: 'Gian Lorenzo Cornado si prepara a partecipare a una commemorazione a Crans-Montana, segnando un passo importante nel disgelo tra Italia e Svizzera. La cooperazi',
- canonicalPath: '/articoli-frontaliere/ambasciatore-italiano-ritorno-berna',
+ canonicalPath: '/articoli-frontaliere/ambasciatore-italiano-ritorno-berna/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3330,7 +3330,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, corto, uova, aumenta, contingente',
  ogTitle: 'Svizzera a corto di uova: aumenta il contingente doganale',
  ogDescription: 'Il Consiglio federale svizzero ha deciso di aumentare il contingente doganale per le uova del 71%, portandolo a 36.000 tonnellate.',
- canonicalPath: '/articoli-frontaliere/aumento-contingente-uova-svizzera',
+ canonicalPath: '/articoli-frontaliere/aumento-contingente-uova-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3360,7 +3360,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavori, notturni, pavimentazione, lavizzari',
  ogTitle: 'Lavori notturni di pavimentazione in Via Lavizzari a Chiasso',
  ogDescription: 'Informazioni sui lavori notturni di pavimentazione in Via Lavizzari a Chiasso dal 7 al 18 aprile 2026.',
- canonicalPath: '/articoli-frontaliere/lavori-notturni-via-lavizzari',
+ canonicalPath: '/articoli-frontaliere/lavori-notturni-via-lavizzari/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3388,7 +3388,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, limitare, popolazione, milioni, sfide',
  ogTitle: 'Limitare la popolazione in Ticino a 10 milioni: sfide e o',
  ogDescription: 'L\'iniziativa dell\'UDC mira a fissare un tetto di 10 milioni di abitanti in Svizzera entro il 2050, con ripercussioni dirette sul Canton Ticino e sui frontalieri',
- canonicalPath: '/articoli-frontaliere/limite-popolazione-10-milioni-ticino',
+ canonicalPath: '/articoli-frontaliere/limite-popolazione-10-milioni-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3417,7 +3417,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, settanta, chili, mozzarella, bagagliaio',
  ogTitle: 'Settanta chili di mozzarella nel bagagliaio del SUV. Doppio sequestro della dogana in',
  ogDescription: 'Due distinti casi di contrabbando di generi alimentari sono stati intercettati nello stesso giorno dalle forze dell’ordine.',
- canonicalPath: '/articoli-frontaliere/settanta-chili-di-mozzarella',
+ canonicalPath: '/articoli-frontaliere/settanta-chili-di-mozzarella/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3445,7 +3445,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, quasi, chili, mozzarella, ponte',
  ogTitle: 'Contrabbando in Ticino: un nuovo caso di contrabbando a Ponte Tresa',
  ogDescription: 'Un conducente italiano è stato fermato a Ponte Tresa con quasi 70 chili di mozzarella non dichiarati. Un altro caso di contrabbando è stato registrato a',
- canonicalPath: '/articoli-frontaliere/contrabbando-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/contrabbando-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3473,7 +3473,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aumenta, mobilità, internazionale, personale',
  ogTitle: 'Mobilità internazionale del personale infermieristico',
  ogDescription: 'Il sindacato Nursing Up denuncia la fuga di infermieri e infermiere dall\'Italia verso la Svizzera',
- canonicalPath: '/articoli-frontaliere/mobilita-infermieri-ticino',
+ canonicalPath: '/articoli-frontaliere/mobilita-infermieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3501,7 +3501,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, gottardo, code, giovedì, santo',
  ogTitle: 'San Gottardo, code da Giovedì Santo: niente sorpresa, tanta pazienza',
  ogDescription: 'Il San Gottardo autostradale in alta stagione: rallentamenti e code in direzione Ticino e Italia',
- canonicalPath: '/articoli-frontaliere/san-gottardo-code-giovedi-santo',
+ canonicalPath: '/articoli-frontaliere/san-gottardo-code-giovedi-santo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3529,7 +3529,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, como, lago, pasqua, boom',
  ogTitle: 'Como e il Lago, per Pasqua è boom: “Prenotazioni oltre il 90% in città”. Attenzione però',
  ogDescription: 'La Pasqua a Como e sul Lago è in boom con prenotazioni oltre il 90%. Ma ci sono timori per l’estate a causa della crisi internazionale.',
- canonicalPath: '/articoli-frontaliere/como-lago-pasqua-boom-prenotazioni',
+ canonicalPath: '/articoli-frontaliere/como-lago-pasqua-boom-prenotazioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3557,7 +3557,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, camion, panne, gottardo, traffico',
  ogTitle: 'Camion in panne al San Gottardo: traffico bloccato in Ticino',
  ogDescription: 'Blocco totale del traffico al San Gottardo a causa di un camion in panne. Scopri le cause, le alternative e i consigli pratici per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/camion-panne-san-gottardo-traffico-bloccato',
+ canonicalPath: '/articoli-frontaliere/camion-panne-san-gottardo-traffico-bloccato/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3585,7 +3585,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aumentano, inchieste, penali, 2025',
  ogTitle: 'Aumento Inchieste Penali in Svizzera nel 2025',
  ogDescription: 'Maggiore cooperazione internazionale e intensificazione dei controlli in Svizzera. Cosa cambia per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/aumento-inchieste-penali-2025',
+ canonicalPath: '/articoli-frontaliere/aumento-inchieste-penali-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3613,7 +3613,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dogana, chiasso, prepara, diventare',
  ogTitle: 'La dogana di Chiasso si prepara a diventare un moderno centro tecnologico',
  ogDescription: 'La dogana di Chiasso, punto di incontro tra merci e persone, si evolve con progetti innovativi e tecnologie avanzate.',
- canonicalPath: '/articoli-frontaliere/dogana-chiasso-centro-tecnologico',
+ canonicalPath: '/articoli-frontaliere/dogana-chiasso-centro-tecnologico/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3641,7 +3641,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, permessi, dubbi, roveredo, insoddisfatta',
  ogTitle: 'Permessi dubbi, Roveredo insoddisfatta e preoccupata dell',
  ogDescription: 'Il Comune di Roveredo critica la valutazione del rischio per i permessi di soggiorno e chiede un cambio di prassi.',
- canonicalPath: '/articoli-frontaliere/permessi-dubbi-roveredo-insoddisfatta',
+ canonicalPath: '/articoli-frontaliere/permessi-dubbi-roveredo-insoddisfatta/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3669,7 +3669,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, permessi, dimora, diverse, opinioni',
  ogTitle: 'Permessi di dimora: diverse opinioni sulla consultazione del casellario giudiziale |',
  ogDescription: 'La questione dei permessi di dimora è sempre più attuale, soprattutto dopo l\'operazione antimafia a Roveredo.',
- canonicalPath: '/articoli-frontaliere/permessi-dimora-diversi-opinioni',
+ canonicalPath: '/articoli-frontaliere/permessi-dimora-diversi-opinioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3697,7 +3697,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso, arma, contro, zanzara',
  ogTitle: 'Chiasso si Arma contro la Zanzara Tigre',
  ogDescription: 'La strategia del Comune di Chiasso per combattere la zanzara tigre: trattamenti e coinvolgimento dei privati.',
- canonicalPath: '/articoli-frontaliere/chiasso-zanzara-tigre-strategia-2026',
+ canonicalPath: '/articoli-frontaliere/chiasso-zanzara-tigre-strategia-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3725,7 +3725,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, trasferimento, ufficio, postale, chiasso',
  ogTitle: 'Trasferimento Ufficio Postale Chiasso',
  ogDescription: 'Il trasferimento dell\'Ufficio postale di Chiasso potrebbe essere un\'opportunità per il territorio. Scopri di più sulle novità e sui servizi offerti dalla Posta',
- canonicalPath: '/articoli-frontaliere/trasferimento-ufficio-postale-chiasso',
+ canonicalPath: '/articoli-frontaliere/trasferimento-ufficio-postale-chiasso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3753,7 +3753,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, esame, complementare, passerella, aperte',
  ogTitle: 'Esame complementare passerella: aperte le pre-iscrizioni',
  ogDescription: 'Il Dipartimento dell6educazione, della cultura e dello sport comunica che sono aperte le pre-iscrizioni al corso di preparazione all’esame complementare passer',
- canonicalPath: '/articoli-frontaliere/esame-complementare-passerella-aperte-pre-iscrizioni',
+ canonicalPath: '/articoli-frontaliere/esame-complementare-passerella-aperte-pre-iscrizioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3781,7 +3781,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lago, como, pullman, turistici',
  ogTitle: 'Lago di Como: Pullman Turistici e Bus di Linea Sotto Pres',
  ogDescription: 'La crisi del gasolio colpisce duramente il trasporto pubblico e turistico attorno al Lago di Como, con costi aggiuntivi di 40 milioni di euro al mese.',
- canonicalPath: '/articoli-frontaliere/gasolio-costi-pullman-ticino-lago-como',
+ canonicalPath: '/articoli-frontaliere/gasolio-costi-pullman-ticino-lago-como/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3809,7 +3809,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, turismo, pasquale, promette, gradite',
  ogTitle: 'Il turismo pasquale promette gradite sorprese in Ticino',
  ogDescription: 'Le prenotazioni per la Pasqua sono aumentate del 16,7% rispetto allo scorso anno.',
- canonicalPath: '/articoli-frontaliere/turismo-pasquale-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/turismo-pasquale-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3838,7 +3838,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, mozzarella, clandestina, fare, ricerca',
  ogTitle: 'Mozzarella \'clandestina\' in Ticino: come fare la ricerca giusta?',
  ogDescription: 'Scopri come fare la ricerca giusta per importare mozzarella in Svizzera senza problemi.',
- canonicalPath: '/articoli-frontaliere/mozzarella-clandestina-2026-ricerca',
+ canonicalPath: '/articoli-frontaliere/mozzarella-clandestina-2026-ricerca/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3866,7 +3866,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, accordi, svizzera-ue, verso, ratifica',
  ogTitle: 'Accordi Svizzera-UE verso ratifica nel 2026',
  ogDescription: 'Il pacchetto Bilaterali III tra Svizzera e UE potrebbe essere approvato entro il 2026. La conferma arriva da Bernd Lange, presidente della commissione europea.',
- canonicalPath: '/articoli-frontaliere/accordi-svizzera-ue-2026',
+ canonicalPath: '/articoli-frontaliere/accordi-svizzera-ue-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3894,7 +3894,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, vacanze, pasqua, colonna, gottardo',
  ogTitle: 'OG title | Frontaliere Ticino: Vacanze di Pasqua al San Gottardo, 21 chilometri di',
  ogDescription: 'Automobilisti in coda per le vacanze di Pasqua al San Gottardo: 21 chilometri di traffico bloccato. Come percorso alternativo, il TCS consiglia di utilizzare',
- canonicalPath: '/articoli-frontaliere/vacanze-di-pasqua-san-gottardo',
+ canonicalPath: '/articoli-frontaliere/vacanze-di-pasqua-san-gottardo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3922,7 +3922,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, varese, verbano, mancano, medici',
  ogTitle: 'Mancano 172 medici di base a Varese e Verbano',
  ogDescription: 'Situazione critica per i medici di medicina generale nel territorio dell’Asst Sette Laghi.',
- canonicalPath: '/articoli-frontaliere/medici-manca-verbano-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/medici-manca-verbano-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3950,7 +3950,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, taglia, accise, benzinai, preoccupati',
  ogTitle: 'L\'Italia taglia le accise, benzinai preoccupati',
  ogDescription: 'Il taglio delle accise deciso dal governo italiano preoccupa i benzinai ticinesi.',
- canonicalPath: '/articoli-frontaliere/italia-taglia-accise-benzinai-preoccupati',
+ canonicalPath: '/articoli-frontaliere/italia-taglia-accise-benzinai-preoccupati/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3978,7 +3978,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, contro, aumento, prezzi, mezzi',
  ogTitle: 'Contro l\'aumento dei prezzi dei mezzi pubblici in Ticino',
  ogDescription: 'I Verdi chiedono una riduzione del 25% dei costi dell\'abbonamento Arcobaleno',
- canonicalPath: '/articoli-frontaliere/aumento-mezzi-pubblici-ticino',
+ canonicalPath: '/articoli-frontaliere/aumento-mezzi-pubblici-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4008,7 +4008,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ladri, auto, scappano, chiavi',
  ogTitle: 'Ladri di auto scappano con 40 chiavi e una Skoda in Ticino',
  ogDescription: 'Due adolescenti hanno forzato la porta di un garage svizzero e sono fuggiti con una Skoda e 40 chiavi',
- canonicalPath: '/articoli-frontaliere/ladri-di-auto-scappano-con-40-chiavi-e-una-skoda',
+ canonicalPath: '/articoli-frontaliere/ladri-di-auto-scappano-con-40-chiavi-e-una-skoda/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4036,7 +4036,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, forte, pericolo, incendi, boschi',
  ogTitle: 'Forte pericolo di incendi nei boschi del Ticino',
  ogDescription: 'Il Canton Ticino è in allerta per il forte pericolo di incendi boschivi. La situazione è critica a causa della mancanza di precipitazioni e del forte vento.',
- canonicalPath: '/articoli-frontaliere/incendi-boschivi-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/incendi-boschivi-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4064,7 +4064,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, prezzo, benzina, troppo, basso',
  ogTitle: 'Benzina Ticino Taglio Accise',
  ogDescription: 'Il taglio delle accise sui carburanti in Italia genera un esodo di automobilisti ticinesi verso il confine italiano.',
- canonicalPath: '/articoli-frontaliere/benzina-ticino-taglio-accise',
+ canonicalPath: '/articoli-frontaliere/benzina-ticino-taglio-accise/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4092,7 +4092,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, abolizione, imposta, valore, locativo',
  ogTitle: 'Abolizione imposta sul valore locativo 2029 | Frontaliere Ticino',
  ogDescription: 'Scopri come la riforma fiscale del 2029 influenzerà i proprietari di abitazioni in Ticino.',
- canonicalPath: '/articoli-frontaliere/abolizione-imposta-valore-locativo-2029',
+ canonicalPath: '/articoli-frontaliere/abolizione-imposta-valore-locativo-2029/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4120,7 +4120,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, svizzero, fermato, pacchetti, figurine',
  ogTitle: 'Contrabbando di Pokémon: Svizzero fermato alla dogana',
  ogDescription: 'Un uomo di 33 anni è stato fermato alla dogana con un carico di 900 pacchetti di figurine Pokémon del valore di 6.900 euro.',
- canonicalPath: '/articoli-frontaliere/contrabbando-pokemon-ticino',
+ canonicalPath: '/articoli-frontaliere/contrabbando-pokemon-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4148,7 +4148,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sconto, benzina, allunga, governo',
  ogTitle: 'Sconto benzina: Italia allunga lo sconto',
  ogDescription: 'Il governo Meloni estende il taglio delle accise sulla benzina fino al 1° maggio. Impatto sulla Svizzera e sui frontalieri',
- canonicalPath: '/articoli-frontaliere/sconto-benzina-ticino',
+ canonicalPath: '/articoli-frontaliere/sconto-benzina-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4176,7 +4176,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, anziana, anni, difende, scippatrice',
  ogTitle: 'Anziana di 88 anni si difende da una scippatrice e la fa arrestare',
  ogDescription: 'Un\'anziana signora di 88 anni si è difesa da un tentativo di scippo a Muttenz, in Svizzera, e ha fatto arrestare la malvivente',
- canonicalPath: '/articoli-frontaliere/anziana-si-difende-da-una-scippatrice-e-la-fa-arrestare',
+ canonicalPath: '/articoli-frontaliere/anziana-si-difende-da-una-scippatrice-e-la-fa-arrestare/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4204,7 +4204,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, supsi, lancia, bachelor, sostenibilità',
  ogTitle: 'SUPSI lancia bachelor in Sostenibilità: dettagli 2027',
  ogDescription: 'Tutte le informazioni sul nuovo corso SUPSI per professionisti della transizione ecologica in Ticino',
- canonicalPath: '/articoli-frontaliere/supsi-bachelor-sostenibilita-2027',
+ canonicalPath: '/articoli-frontaliere/supsi-bachelor-sostenibilita-2027/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4232,7 +4232,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavena, ponte, tresa, bambino',
  ogTitle: 'Lavena Ponte Tresa: bambino sbalzato dal sellino della bicicletta è grave',
  ogDescription: 'Un bambino di 2 anni e 9 mesi è stato soccorso dall\'eliambulanza a Lavena Ponte Tresa dopo essere stato sbalzato dal sellino della bicicletta.',
- canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-bicicletta-grave',
+ canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-bicicletta-grave/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4260,7 +4260,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, roveredo, denuncia, permessi, sono',
  ogTitle: 'Roveredo denuncia: i permessi non sono un incidente',
  ogDescription: 'Il Municipio di Roveredo si oppone alla versione del Governo grigionese sul rilascio dei permessi di dimora, evidenziando rischi e criticità nel controllo inter',
- canonicalPath: '/articoli-frontaliere/roveredo-permessi-anticrimine',
+ canonicalPath: '/articoli-frontaliere/roveredo-permessi-anticrimine/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4288,7 +4288,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, alain, raemy, significato, pasqua',
  ogTitle: 'Alain de Raemy: il significato della Pasqua',
  ogDescription: 'L\'amministratore apostolico della diocesi di Lugano riflette sulle sofferenze cui è confrontato il mondo e sul senso della croce per i giovani.',
- canonicalPath: '/articoli-frontaliere/pasqua-messaggio-di-avvenire',
+ canonicalPath: '/articoli-frontaliere/pasqua-messaggio-di-avvenire/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4316,7 +4316,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tramonto, cadenazzo, morto, vigilante',
  ogTitle: 'Tramonto a Cadenazzo: morto il vigilante',
  ogDescription: 'Un incidente stradale a Cadenazzo ha causato la morte di un vigilante',
- canonicalPath: '/articoli-frontaliere/tramonto-a-cadenazzo',
+ canonicalPath: '/articoli-frontaliere/tramonto-a-cadenazzo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4344,7 +4344,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, traffico, paralizzato, gottardo, qualcuno',
  ogTitle: 'Traffico paralizzato al San Gottardo: "Qualcuno sa come a',
  ogDescription: 'La colonna di auto ferme al portale nord della galleria del San Gottardo ha raggiunto i 21 chilometri con picchi di oltre 3 ore e mezza di attesa',
- canonicalPath: '/articoli-frontaliere/traffico-san-gottardo-2026',
+ canonicalPath: '/articoli-frontaliere/traffico-san-gottardo-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4372,7 +4372,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, auto, ribalta, sulla, varese',
  ogTitle: 'Auto si ribalta sulla SP1 tra Varese e Gavirate: due vent',
  ogDescription: 'Due giovani sono stati feriti nella tarda serata di sabato 4 aprile quando un\'auto si è ribaltata sulla SP1 tra Varese e Gavirate. Una delle due ragazze è stata',
- canonicalPath: '/articoli-frontaliere/auto-si-ribalta-sulla-sp1-tra-varese-e-gavirate',
+ canonicalPath: '/articoli-frontaliere/auto-si-ribalta-sulla-sp1-tra-varese-e-gavirate/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4400,7 +4400,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nestle, apre, sede, lombardia',
  ogTitle: 'Nestle apre sede in Lombardia e offre 200 posti di lavoro',
  ogDescription: 'Nestle ha annunciato l\'apertura di una nuova sede in Lombardia e offre 200 posti di lavoro: ecco i profili ricercati',
- canonicalPath: '/articoli-frontaliere/nestle-200-posti-lombardia',
+ canonicalPath: '/articoli-frontaliere/nestle-200-posti-lombardia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4428,7 +4428,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, quinta, debole, milano, sono',
  ogTitle: 'La \'Quinta Svizzera\' che ha un debole per Milano',
  ogDescription: 'Sono quasi settemila i confederati che vivono nel capoluogo meneghino e nei comuni della sua provincia.',
- canonicalPath: '/articoli-frontaliere/la-quinta-svizzera-che-ha-un-debole-per-milano',
+ canonicalPath: '/articoli-frontaliere/la-quinta-svizzera-che-ha-un-debole-per-milano/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4456,7 +4456,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, comuni, ticinesi, investono, settore',
  ogTitle: 'Comuni ticinesi investono nel settore turistico: ecco i d',
  ogDescription: 'Gli ultimi mesi hanno visto diversi comuni ticinesi investire in infrastrutture turistiche.',
- canonicalPath: '/articoli-frontaliere/comuni-investono-turismo-ticino',
+ canonicalPath: '/articoli-frontaliere/comuni-investono-turismo-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4484,7 +4484,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tanti, agricoltori, verso, pensione',
  ogTitle: 'Tanti agricoltori verso la pensione: il ricambio è una sfida',
  ogDescription: 'Agricoltori ticinesi verso la pensione: chi è pronto a passare la testimone?. Dati aggiornati 2026 per frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/agriscambio',
+ canonicalPath: '/articoli-frontaliere/agriscambio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4512,7 +4512,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, galleria, monte, ceneri, stata',
  ogTitle: 'Galleria del Ceneri chiusa per problemi tecnici',
  ogDescription: 'La galleria del Monte Ceneri è stata chiusa per problemi tecnici sulla A2 in direzione del Ticino',
- canonicalPath: '/articoli-frontaliere/galleria-del-ceneri-chiusa-per-problemi-tecnici',
+ canonicalPath: '/articoli-frontaliere/galleria-del-ceneri-chiusa-per-problemi-tecnici/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4540,7 +4540,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, corso, pastori, nuovo, sviluppato',
  ogTitle: 'Corso per pastori in Ticino',
  ogDescription: 'Un nuovo corso per pastori in Ticino, per rispondere alla crescente richiesta di professionisti qualificati.',
- canonicalPath: '/articoli-frontaliere/corso-pastori-ticino',
+ canonicalPath: '/articoli-frontaliere/corso-pastori-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4568,7 +4568,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, diventare, pastore, canton, offre',
  ogTitle: 'Diventare pastore in Ticino',
  ogDescription: 'Scopri come diventare pastore in Ticino con la nostra formazione e corsi.',
- canonicalPath: '/articoli-frontaliere/diventare-pastore-ticino',
+ canonicalPath: '/articoli-frontaliere/diventare-pastore-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4596,7 +4596,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, trump, intesa, inferno, giallo',
  ogTitle: 'Trump: "Intesa o sar0 l\'inferno". Il giallo dell\'ultimatum spostato a marted8',
  ogDescription: 'Trump annuncia un ultimatum alla Cina durante la Pasqua in Ticino',
- canonicalPath: '/articoli-frontaliere/trump-intesa-o-inferno',
+ canonicalPath: '/articoli-frontaliere/trump-intesa-o-inferno/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4624,7 +4624,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, coop, richiama, formaggi, possono',
  ogTitle: 'Coop richiama formaggi: possono contenere salmonelle',
  ogDescription: 'Coop richiama formaggi per la presenza di salmonelle, particolarmente pericolosi per le persone immunodepresse, le donne in gravidanza, le bambine e i bambini e',
- canonicalPath: '/articoli-frontaliere/coop-richiama-formaggi-salmonelle',
+ canonicalPath: '/articoli-frontaliere/coop-richiama-formaggi-salmonelle/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4652,7 +4652,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, scambio, abiti, unisce',
  ogTitle: 'A Bellinzona lo scambio abiti unisce socialità e sostenibilità',
  ogDescription: 'L\'iniziativa dell\'associazione Meteora promuove convivialità, solidarietà e attenzione all\'ambiente.',
- canonicalPath: '/articoli-frontaliere/scambio-abiti-bellinzona',
+ canonicalPath: '/articoli-frontaliere/scambio-abiti-bellinzona/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4680,7 +4680,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, protesta, contro, costi, cure',
  ogTitle: 'Protesta contro i costi per le cure a domicilio',
  ogDescription: 'Protesta contro l\'introduzione dei costi per le cure a domicilio in Ticino.',
- canonicalPath: '/articoli-frontaliere/protesta-costi-cure-domicilio',
+ canonicalPath: '/articoli-frontaliere/protesta-costi-cure-domicilio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4708,7 +4708,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavizzara, acqua, potabile, alcune',
  ogTitle: 'Lavizzara: acqua non potabile in alcune località',
  ogDescription: 'Il Municipio di Lavizzara ha dichiarato l\'acqua di Piano di Peccia non potabile fino a nuovo avviso, coinvolgendo diverse frazioni della vallata.',
- canonicalPath: '/articoli-frontaliere/acqua-non-potabile-lavizzara',
+ canonicalPath: '/articoli-frontaliere/acqua-non-potabile-lavizzara/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4736,7 +4736,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nuova, direttrice, servizi, sociali',
  ogTitle: 'Nuova direttrice per i Servizi sociali di Bellinzona',
  ogDescription: 'Federica Giudici è stata nominata nuova direttrice dei Servizi sociali di Bellinzona',
- canonicalPath: '/articoli-frontaliere/nuova-direttrice-servizi-sociali-bellinzona',
+ canonicalPath: '/articoli-frontaliere/nuova-direttrice-servizi-sociali-bellinzona/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4764,7 +4764,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, riaperta, galleria, monte, ceneri',
  ogTitle: 'Riaperta la galleria del Monte Ceneri: tornata alla normalità la circolazione',
  ogDescription: 'La galleria del Monte Ceneri è stata riaperta dopo la chiusura temporanea causata da un infortunio Tecnico. La circolazione è tornata alla normalità e gli',
- canonicalPath: '/articoli-frontaliere/riaperta-galleria-monte-ceneri',
+ canonicalPath: '/articoli-frontaliere/riaperta-galleria-monte-ceneri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4792,7 +4792,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ucraini, permesso, aiuti, incognite',
  ogTitle: 'Ucraini in Ticino, il permesso S tra aiuti e incognite',
  ogDescription: 'Il Permesso S è stato concesso a circa 70.000 persone in Svizzera, mentre il Ticino ospita circa 3000 profughi ucraini',
- canonicalPath: '/articoli-frontaliere/ucraini-in-ticino-aiuti-incognite',
+ canonicalPath: '/articoli-frontaliere/ucraini-in-ticino-aiuti-incognite/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4820,7 +4820,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fuga, dubai, alternativa, conflitto',
  ogTitle: 'Fuga da Dubai, il Ticino come alternativa?',
  ogDescription: 'Il conflitto in Medio Oriente spinge imprenditori lontano dal Golfo persico, in cerca di nuove destinazioni',
- canonicalPath: '/articoli-frontaliere/fuga-da-dubai-ticino-alternativa',
+ canonicalPath: '/articoli-frontaliere/fuga-da-dubai-ticino-alternativa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4848,7 +4848,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, como, free, continua, crescere',
  ogTitle: 'Tax Free in crescita a Como',
  ogDescription: 'I clienti ticinesi contribuiscono alla crescita del Tax Free a Como con un aumento del 6% degli acquisti.',
- canonicalPath: '/articoli-frontaliere/tax-free-come-cresce',
+ canonicalPath: '/articoli-frontaliere/tax-free-come-cresce/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4876,7 +4876,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, coda, gottardo, disagi, record',
  ogTitle: '10 km di coda al San Gottardo: disagi record 2026',
  ogDescription: 'Analisi e soluzioni per i frontalieri bloccati nel rientro pasquale al confine svizzero',
- canonicalPath: '/articoli-frontaliere/traffico-san-gottardo-pasquetta-2026',
+ canonicalPath: '/articoli-frontaliere/traffico-san-gottardo-pasquetta-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4904,7 +4904,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, severi, auto, immatricolate',
  ogTitle: 'Controlli più severi per auto immatricolate Grigioni',
  ogDescription: 'Il Canton Ticino intensifica i controlli sulle auto con targhe grigionesi per verificare il rispetto delle norme federali.',
- canonicalPath: '/articoli-frontaliere/controlli-auto-immatricolate-grigioni',
+ canonicalPath: '/articoli-frontaliere/controlli-auto-immatricolate-grigioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4932,7 +4932,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, locarno-magadino, lago, cambiamo, nave',
  ogTitle: 'Trasporto lacustre Locarno-Magadino | Frontaliere Ticino',
  ogDescription: 'Il servizio di trasporto lacustre tra Locarno e Magadino rischia di essere sospeso. Scopri cosa sta succedendo e come risolvere il problema.',
- canonicalPath: '/articoli-frontaliere/locarno-magadino-trasporto',
+ canonicalPath: '/articoli-frontaliere/locarno-magadino-trasporto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4960,7 +4960,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, prezzi, benzina, dopo, mese',
  ogTitle: 'Prezzi benzina in Svizzera: aumento del 10% al 22%',
  ogDescription: 'I prezzi della benzina in Svizzera sono saliti a causa del conflitto in Medio Oriente.',
- canonicalPath: '/articoli-frontaliere/prezzi-benzina-ticino',
+ canonicalPath: '/articoli-frontaliere/prezzi-benzina-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4988,7 +4988,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lavizzara, problemi, alla, rete',
  ogTitle: 'Lavizzara: problemi alla rete idrica, niente acqua potabi',
  ogDescription: 'La rete idrica di Lavizzara è stata colpita da problemi, causando la mancanza di acqua potabile in varie zone',
- canonicalPath: '/articoli-frontaliere/lavizzara-problemi-alla-rete-idrica-niente-acqua-potabile-in-varie-zone',
+ canonicalPath: '/articoli-frontaliere/lavizzara-problemi-alla-rete-idrica-niente-acqua-potabile-in-varie-zone/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5016,7 +5016,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiusure, deviazioni, sulla, cosa',
  ogTitle: 'Chiusure e deviazioni sulla A9: cosa fare durante la raffica',
  ogDescription: 'Nuova settimana e subito raffica di chiusure e deviazioni sulla A9',
- canonicalPath: '/articoli-frontaliere/raffica-chiusure-a9-2026',
+ canonicalPath: '/articoli-frontaliere/raffica-chiusure-a9-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5044,7 +5044,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, conflitto, medio, oriente, impatto',
  ogTitle: 'Conflitto Medio Oriente: energia Ticino e Italia',
  ogDescription: 'Diesel supera 2 CHF/litro in Ticino. Rincari energetici: 5 miliardi CHF per Svizzera, impatto su frontalieri e famiglie.',
- canonicalPath: '/articoli-frontaliere/conflitto-medio-oriente-energia-ticino',
+ canonicalPath: '/articoli-frontaliere/conflitto-medio-oriente-energia-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5073,7 +5073,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, uomini, droni, lavoro, nella',
  ogTitle: 'Uomini e droni al lavoro nella notte per tenere sotto controllo l\'incendio di Laveno',
  ogDescription: 'Le emergenze notturne a Laveno Mombello richiedono un intervento rapido e coordinato.',
- canonicalPath: '/articoli-frontaliere/lavoro-notte-lincendio-laveno-mombello',
+ canonicalPath: '/articoli-frontaliere/lavoro-notte-lincendio-laveno-mombello/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5101,7 +5101,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, prevenzione, maschile, centro, beccaria',
  ogTitle: 'Prevenzione al maschile: il Centro Beccaria è punto di riferimento per ogni età',
  ogDescription: 'Il Centro Beccaria di Bellinzona offre servizi di prevenzione urologica per tutti gli età.',
- canonicalPath: '/articoli-frontaliere/prevenzione-maschile-centro-beccaria',
+ canonicalPath: '/articoli-frontaliere/prevenzione-maschile-centro-beccaria/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5129,7 +5129,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, cuore, varese, denuncia',
  ogTitle: 'Controlli nel cuore di Varese: denuncia e espulsione',
  ogDescription: 'Nel pomeriggio del 23 marzo, controlli estesi nel centro di Varese hanno portato a una denuncia penale e all\'espulsione di un uomo. I dettagli delle operazioni',
- canonicalPath: '/articoli-frontaliere/controlli-varese-esposto-espulsione',
+ canonicalPath: '/articoli-frontaliere/controlli-varese-esposto-espulsione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5157,7 +5157,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, incidente, arogno, 31enne, gravi',
  ogTitle: 'Incidente ad Arogno: 31enne in gravi condizioni | Frontaliere Ticino',
  ogDescription: 'Un uomo di 31 anni è precipitato in una scarpata durante una festa ad Arogno. Scopri i dettagli dell\'incidente e i consigli per la sicurezza.',
- canonicalPath: '/articoli-frontaliere/incidente-arogno-31enne-gravi-condizioni',
+ canonicalPath: '/articoli-frontaliere/incidente-arogno-31enne-gravi-condizioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5185,7 +5185,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'prezzi carburanti ticino 2026, prezzo benzina ticino, prezzo diesel ticino, tankstellen tessin preise, prix carburant tessin, distributori economici ticino',
  ogTitle: 'Prezzi Carburanti Ticino 2026 — Benzina e Diesel Aggiornati',
  ogDescription: 'Prezzi carburante Ticino 2026: +19 millesimi benzina, +46 millesimi diesel. Classifica distributori e confronto con l\'Italia per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/carburanti-ticino-aumento-prezzi',
+ canonicalPath: '/articoli-frontaliere/carburanti-ticino-aumento-prezzi/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -5226,7 +5226,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, provincia, varese, investe, manutenzione',
  ogTitle: 'Provincia di Varese: investimenti in manutenzione delle strade e del verde con i ristorni',
  ogDescription: 'La Provincia di Varese investe in manutenzione delle strade e del verde con i ristorni dei frontalieri relativi all’anno 2023, per un importo complessivo di',
- canonicalPath: '/articoli-frontaliere/provincia-di-varese-investe-su-manutenzione-delle-strade-e-del-verde-con-i-ristorni-dei-frontalieri-2026',
+ canonicalPath: '/articoli-frontaliere/provincia-di-varese-investe-su-manutenzione-delle-strade-e-del-verde-con-i-ristorni-dei-frontalieri-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5254,7 +5254,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, famigliola, turisti, investita, centro',
  ogTitle: 'La famigliola di turisti investita in centro a Como è una',
  ogDescription: 'Il tema dell\'affollamento del centro storico di Como è una questione molto complessa, che richiede attenzione e soluzioni concrete.',
- canonicalPath: '/articoli-frontaliere/turisti-in-como-ztl',
+ canonicalPath: '/articoli-frontaliere/turisti-in-como-ztl/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5282,7 +5282,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, niederländer, quattro, chili, cocaina',
  ogTitle: 'Niederländer con quattro chili di cocaina fermato al confine',
  ogDescription: 'Un cittadino olandese è stato fermato con quattro chili di cocaina al confine di Kreuzlingen, Svizzera.',
- canonicalPath: '/articoli-frontaliere/niederlander-droga-ticino',
+ canonicalPath: '/articoli-frontaliere/niederlander-droga-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5310,7 +5310,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, stop, agli, artigiani, caso',
  ogTitle: 'Stop agli \'artigiani per caso\' in Lombardia',
  ogDescription: 'La Lombardia introduce nuove regole per gli artigiani: stop agli \'artigiani per caso\' e multe severe per chi utilizza impropriamente il termine \'artigianale\'.',
- canonicalPath: '/articoli-frontaliere/stop-agli-artigiani-per-caso',
+ canonicalPath: '/articoli-frontaliere/stop-agli-artigiani-per-caso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5338,7 +5338,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, incendi, luganese, arrestato, piromane',
  ogTitle: 'Incendi nel Luganese: arrestato un piromane italiano',
  ogDescription: 'Bellinzona, 7 aprile 2026 - Un italiano arrestato per incendi nel Luganese',
- canonicalPath: '/articoli-frontaliere/incendi-nel-luganese-arrestato-un-piromane',
+ canonicalPath: '/articoli-frontaliere/incendi-nel-luganese-arrestato-un-piromane/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5366,7 +5366,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, soci, sagl, nuovi, nodi',
  ogTitle: 'Nodi fiscali frontalieri Italia-Svizzera 2026',
  ogDescription: 'Esploriamo i recenti sviluppi fiscali per i lavoratori transfrontalieri che sono anche soci di Sagl.',
- canonicalPath: '/articoli-frontaliere/front-alieri-soci-sagl-nodi-fiscali-2026',
+ canonicalPath: '/articoli-frontaliere/front-alieri-soci-sagl-nodi-fiscali-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5394,7 +5394,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, benzina, cara, ticinesi, fanno',
  ogTitle: 'Benzina più cara in Svizzera: ticinesi e frontalieri fann',
  ogDescription: 'L\'Italia ha prorogato il taglio delle accise fino al 1° maggio 2026, ma i prezzi della benzina sono saliti di nuovo in Svizzera.',
- canonicalPath: '/articoli-frontaliere/benzina-cara-ticino',
+ canonicalPath: '/articoli-frontaliere/benzina-cara-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",

--- a/services/seo/seo-blog-5.ts
+++ b/services/seo/seo-blog-5.ts
@@ -13,7 +13,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spese, bancarie, titoli, meierhans',
     ogTitle: 'Spese bancarie per titoli: Meierhans critica i costi',
     ogDescription: 'Le spese per il trasferimento di titoli in Svizzera sono tra i 60 e i 120 franchi, secondo la Sorveglianza dei prezzi.',
-    canonicalPath: '/articoli-frontaliere/spese-bancarie-titoli-frontalieri',
+    canonicalPath: '/articoli-frontaliere/spese-bancarie-titoli-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -41,7 +41,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pendolarismo, sostenibile, bici, insubria',
     ogTitle: 'In bicicletta all\'università dell\'Insubria: la sfida del pendolarismo sostenibile',
     ogDescription: 'Un docente racconta la sua esperienza di pendolarismo in bicicletta tra Milano e Varese, evidenziando le difficoltà e le potenzialità di un sistema più',
-    canonicalPath: '/articoli-frontaliere/bicicletta-insubria-varese-2026',
+    canonicalPath: '/articoli-frontaliere/bicicletta-insubria-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -69,7 +69,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, montessori, castellanza, menù, basso',
     ogTitle: 'Montessori Castellanza: menù a basso impatto e lotta agli sprechi',
     ogDescription: 'La scuola Montessori di Castellanza partecipa alla Green Food Week 2026 con menù vegetali e attività educative per ridurre gli sprechi alimentari.',
-    canonicalPath: '/articoli-frontaliere/montessori-green-food-week-2026',
+    canonicalPath: '/articoli-frontaliere/montessori-green-food-week-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -97,7 +97,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passi, solidarietà, camminata, porto',
     ogTitle: 'Passi di solidarietà: camminata a Porto Ceresio per la donazione di sangue',
     ogDescription: 'Domenica 3 maggio, Avis Valceresio organizza una camminata lungo il lago per sensibilizzare sulla donazione di sangue. Ritrovo alle 9 in piazza Bossi.',
-    canonicalPath: '/articoli-frontaliere/passi-solidarieta-porto-ceresio-2026',
+    canonicalPath: '/articoli-frontaliere/passi-solidarieta-porto-ceresio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -125,7 +125,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, karimova, archiviazione, parziale',
     ogTitle: 'Processo Karimova: archiviazione parziale per Gulnara',
     ogDescription: 'Il Tribunale penale federale archivia il caso contro Gulnara Karimova, figlia dell’ex presidente uzbeko, ma prosegue per la banca e il gestore patrimoniale',
-    canonicalPath: '/articoli-frontaliere/processo-karimova-archiviazione-parziale',
+    canonicalPath: '/articoli-frontaliere/processo-karimova-archiviazione-parziale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -153,7 +153,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cardiocentro, lugano, piani, panoramico',
     ogTitle: 'Cardiocentro Lugano: tre piani in più e un bar panoramico',
     ogDescription: 'Il Cardiocentro di Lugano si presenta con tre piani in più e un bar panoramico dopo tre anni di lavori. Comfort e panorami mozzafiato per pazienti e personale.',
-    canonicalPath: '/articoli-frontaliere/cardiocentro-lugano-ristrutturazione-2026',
+    canonicalPath: '/articoli-frontaliere/cardiocentro-lugano-ristrutturazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -181,7 +181,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, capo, dell, esercito, kaiser',
     ogTitle: 'Ex capo dell\'esercito nel Cda di Kaiser Partner Privatbank',
     ogDescription: 'Thomas Süssli, ex capo dell\'esercito svizzero, entra nel consiglio d\'amministrazione della banca di Vaduz. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ex-capo-esercito-kaiser-partner-privatbank',
+    canonicalPath: '/articoli-frontaliere/ex-capo-esercito-kaiser-partner-privatbank/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -209,7 +209,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, saronno, nuove, regole, centri',
     ogTitle: 'Nuove regole centri estivi Saronno 2026',
     ogDescription: 'Scopri le nuove regole per i centri estivi comunali di Saronno: regia unica, sconti per fratelli e contributi fino a 400 euro.',
-    canonicalPath: '/articoli-frontaliere/nuove-regole-centri-estivi-saronno-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-regole-centri-estivi-saronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -237,7 +237,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sede, banca, vendita, varese',
     ogTitle: 'Ex sede Banca d\'Italia in vendita a Varese: quanto costa e perché non si vende',
     ogDescription: 'L\'ex sede della Banca d\'Italia a Varese è in vendita da anni. Scopriamo il prezzo e i motivi per cui non trova acquirenti.',
-    canonicalPath: '/articoli-frontaliere/ex-sede-banca-ditalia-vendita-varese',
+    canonicalPath: '/articoli-frontaliere/ex-sede-banca-ditalia-vendita-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -265,7 +265,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, national, summer, games, special',
     ogTitle: '139 frontalieri del Ticino ai National Summer Games di Special Olympics',
     ogDescription: '139 atleti con disabilità intellettiva dal Ticino partecipano ai National Summer Games di Special Olympics a Zugo dal 28 al 31 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/139-frontalieri-ticino-special-olympics',
+    canonicalPath: '/articoli-frontaliere/139-frontalieri-ticino-special-olympics/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -293,7 +293,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andrea, giuliani, gastrobellinzona, alto',
     ogTitle: 'Andrea Giuliani guida GastroBellinzona Alto Ticino',
     ogDescription: 'Andrea Giuliani è il nuovo presidente di GastroBellinzona Alto Ticino. L\'associazione affronta sfide economiche e speranze per la ristorazione.',
-    canonicalPath: '/articoli-frontaliere/gastrobellinzona-andrea-giuliani',
+    canonicalPath: '/articoli-frontaliere/gastrobellinzona-andrea-giuliani/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -321,7 +321,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, settimana, lavorativa, accorciata',
     ogTitle: 'Infermieri Ticino: settimana lavorativa non accorciata',
     ogDescription: 'Il Consiglio nazionale svizzero ha deciso di mantenere la durata massima della settimana lavorativa degli infermieri a 50 ore, rifiutando la proposta di ridurla',
-    canonicalPath: '/articoli-frontaliere/infermieri-ticino-ore-lavorative-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-ticino-ore-lavorative-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -349,7 +349,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dezonare, terreni, edificabili, emergenza',
     ogTitle: 'Dezonare terreni edificabili: emergenza per la Val di Blenio',
     ogDescription: 'I sindaci di Blenio preoccupati per esuberi del 600-900% e silenzio istituzionale. Quali sono le implicazioni per i frontalieri?',
-    canonicalPath: '/articoli-frontaliere/dezonare-terreni-blenio-2026',
+    canonicalPath: '/articoli-frontaliere/dezonare-terreni-blenio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -377,7 +377,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bankitalia, margini, limitati, debito',
     ogTitle: 'Dfp, Bankitalia: Margini limitati più per debito che per regole Ue',
     ogDescription: 'I margini limitati derivano dall\'esigenza di ridurre il debito, non solo dalle regole Ue. Dal 2027 sentiero discendente.',
-    canonicalPath: '/articoli-frontaliere/dfp-bankitalia-margini-debito-ue-2026',
+    canonicalPath: '/articoli-frontaliere/dfp-bankitalia-margini-debito-ue-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -405,7 +405,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, sfida, carpooling, benefico',
     ogTitle: 'MomòRide: carpooling benefico in Ticino',
     ogDescription: 'La prima sfida collettiva di carpooling a scopo benefico inizia il 1° maggio in Ticino, con l\'obiettivo di raccogliere punti per donare mille franchi.',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -433,7 +433,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borse, europee, flessione, zurigo',
     ogTitle: 'Borse europee in flessione, Zurigo non decolla',
     ogDescription: 'Le borse europee mostrano una linea comune incerta, mentre Zurigo registra un listino primario in flessione.',
-    canonicalPath: '/articoli-frontaliere/borse-zurigo-flessione-2026',
+    canonicalPath: '/articoli-frontaliere/borse-zurigo-flessione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -461,7 +461,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, droga, arresti, estero',
     ogTitle: 'Traffico di droga: sei arresti tra Svizzera ed estero',
     ogDescription: 'Operazione congiunta del Ministero pubblico della Confederazione e della Polizia giudiziaria federale contro un\'organizzazione criminale.',
-    canonicalPath: '/articoli-frontaliere/traffico-droga-arresti-svizzera-estero-2026',
+    canonicalPath: '/articoli-frontaliere/traffico-droga-arresti-svizzera-estero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -489,7 +489,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caslano, ribalta, previsioni, chiude',
     ogTitle: 'Caslano chiude 2025 con 311mila franchi di avanzo',
     ogDescription: 'Il Comune di Caslano ha chiuso il 2025 con un avanzo di 311mila franchi, superando le previsioni di disavanzo di 79mila franchi.',
-    canonicalPath: '/articoli-frontaliere/caslano-2025-bilancio-avanzamento',
+    canonicalPath: '/articoli-frontaliere/caslano-2025-bilancio-avanzamento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -517,7 +517,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, milioni, piano, ciclabile',
     ogTitle: 'Lombardia: 115 milioni per il piano ciclabile',
     ogDescription: 'La Regione Lombardia investe 115 milioni di euro nel piano ciclabile con 25 grandi percorsi',
-    canonicalPath: '/articoli-frontaliere/lombardia-piano-ciclabile-115-milioni',
+    canonicalPath: '/articoli-frontaliere/lombardia-piano-ciclabile-115-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -545,7 +545,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, anni, emergenze, sanitarie, mendrisiotto',
     ogTitle: '25 anni di emergenze sanitarie: il S.A.M. di Mendrisiotto',
     ogDescription: 'Dal 1999 il Servizio Autoambulanze Mendrisiotto risponde alle emergenze. Oggi il direttore Carlo Realini racconta le sfide attuali',
-    canonicalPath: '/articoli-frontaliere/sam-mendrisiotto-25-anni-emergenze',
+    canonicalPath: '/articoli-frontaliere/sam-mendrisiotto-25-anni-emergenze/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -573,7 +573,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nidi, extrascolastico, verso, unico',
     ogTitle: 'Ticino: Nidi ed Extrascolastico verso un Unico Servizio',
     ogDescription: 'Bellinzona affronta la carenza di posti nei nidi con una lista d\'attesa unica e una visione integrata dei servizi (Fonte: laRegione.ch)',
-    canonicalPath: '/articoli-frontaliere/nidi-extrascolastico-ticino-un-servizio',
+    canonicalPath: '/articoli-frontaliere/nidi-extrascolastico-ticino-un-servizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -601,7 +601,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinesi, parigi, roland, garros',
     ogTitle: 'Due ticinesi a Parigi per il Roland Garros',
     ogDescription: 'Rémy Bertola e Susan Bandecchi saranno impegnati nel tabellone delle qualificazioni del Roland Garros. Scopri chi altri svizzeri partecipano.',
-    canonicalPath: '/articoli-frontaliere/ticinesi-parigi-roland-garros',
+    canonicalPath: '/articoli-frontaliere/ticinesi-parigi-roland-garros/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -629,7 +629,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, locarno, smaltisce, rifiuti, landquart',
     ogTitle: 'Locarno smaltisce rifiuti a Landquart: 1000 tonnellate su 156 km',
     ogDescription: 'Locarno smaltisce rifiuti vegetali a Landquart, generando 6,5 tonnellate di CO2 annuali. Interrogazione al Municipio per la mancanza di coerenza ambientale.',
-    canonicalPath: '/articoli-frontaliere/locarno-landquart-rifiuti-1000-tonnellate',
+    canonicalPath: '/articoli-frontaliere/locarno-landquart-rifiuti-1000-tonnellate/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -657,7 +657,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stipendi, svizzeri, crescita, 2025',
     ogTitle: 'Stipendi svizzeri in crescita: +1,6% nel 2025',
     ogDescription: 'I salari reali in Svizzera sono aumentati dell\'1,6% nel 2025, il guadagno più consistente dal 2009. Scopri di più sugli aumenti e le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/stipendi-svizzeri-crescono-2025',
+    canonicalPath: '/articoli-frontaliere/stipendi-svizzeri-crescono-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -685,7 +685,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, traffico, pesante, entrate',
     ogTitle: 'Tassa traffico pesante: entrate mancate e lacune nei controlli',
     ogDescription: 'Lorenzo Quadri denuncia problemi nel nuovo sistema di riscossione della tassa sul traffico pesante, con rischi di frodi e mancati introiti.',
-    canonicalPath: '/articoli-frontaliere/tassa-traffico-pesante-lacune-controlli',
+    canonicalPath: '/articoli-frontaliere/tassa-traffico-pesante-lacune-controlli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -713,7 +713,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, quadri, incalza, consiglio, federale',
     ogTitle: 'Quadri incalza il Consiglio federale su frontiere e tasse sui camion',
     ogDescription: 'Lorenzo Quadri (Lega dei Ticinesi) presenta un\'interpellanza sul nuovo sistema NMTS per la tassa sul traffico pesante.',
-    canonicalPath: '/articoli-frontaliere/quadri-interpella-consiglio-frontiere-tasse',
+    canonicalPath: '/articoli-frontaliere/quadri-interpella-consiglio-frontiere-tasse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -741,7 +741,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, decreto, lavoro, fenealuil, moderatamente',
     ogTitle: 'Decreto Lavoro 2026: FenealUil moderatamente soddisfatta',
     ogDescription: 'Mauro Franzolini, segretario generale FenealUil, commenta la bozza del decreto lavoro in esame al Consiglio dei ministri.',
-    canonicalPath: '/articoli-frontaliere/fenealuil-decreto-lavoro-2026',
+    canonicalPath: '/articoli-frontaliere/fenealuil-decreto-lavoro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -769,7 +769,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mara, bilancio, 2025, avanzo',
     ogTitle: 'Val Mara: bilancio 2025 in avanzo di 616mila franchi',
     ogDescription: 'Il Comune di Val Mara chiude il 2025 con un avanzo di 616mila franchi, superando le previsioni negative. Investimenti mirati e pressione fiscale stabile',
-    canonicalPath: '/articoli-frontaliere/bilancio-val-mara-2025-avanzamento-616mila',
+    canonicalPath: '/articoli-frontaliere/bilancio-val-mara-2025-avanzamento-616mila/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -797,7 +797,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, villa, giuseppe, nuovo, ambulatorio',
     ogTitle: 'Villa San Giuseppe KOS: nuovo ambulatorio cardio-metabolico',
     ogDescription: 'Scopri il nuovo ambulatorio cardio-metabolico presso la Clinica Villa San Giuseppe KOS ad Anzano del Parco. Servizio multidisciplinare per la salute',
-    canonicalPath: '/articoli-frontaliere/ambulatorio-cardio-metabolico-villa-san-giuseppe',
+    canonicalPath: '/articoli-frontaliere/ambulatorio-cardio-metabolico-villa-san-giuseppe/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -825,7 +825,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, disoccupazione, costerà, caro',
     ogTitle: 'Riforma UE: disoccupazione frontalieri costerà caro alla Svizzera',
     ogDescription: 'La revisione europea cambierebbe le regole: oggi paga il Paese di residenza, in futuro quello di lavoro. Un caso che mette alla prova i nuovi accordi tra',
-    canonicalPath: '/articoli-frontaliere/riforma-ue-disoccupazione-frontalieri',
+    canonicalPath: '/articoli-frontaliere/riforma-ue-disoccupazione-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -853,7 +853,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, dadò, propone',
     ogTitle: 'Casse malati, Dadò propone la scissione del dossier',
     ogDescription: 'Fiorenzo Dadò suggerisce di suddividere il dossier sulle casse malati in due rapporti distinti. Possibile votazione popolare.',
-    canonicalPath: '/articoli-frontaliere/casse-malati-dado-scissione-dossier',
+    canonicalPath: '/articoli-frontaliere/casse-malati-dado-scissione-dossier/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -881,7 +881,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iliad, presenta, veloci, piano',
     ogTitle: 'Iliad presenta \'Più veloci\', piano per reti mobili di nuova generazione',
     ogDescription: 'Iliad presenta \'Più Veloci\', un piano per accelerare lo sviluppo delle reti mobili in Italia, con impatto su cittadini, imprese e operatori.',
-    canonicalPath: '/articoli-frontaliere/iliad-piu-veloci-rete-mobili',
+    canonicalPath: '/articoli-frontaliere/iliad-piu-veloci-rete-mobili/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -909,7 +909,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ferrero, ministero, sport, nelle',
     ogTitle: 'Formazione, intesa tra Ministero e Ferrero per promuovere attività sportive nelle scuole',
     ogDescription: 'Ministero dell’Istruzione e del Merito e Ferrero spa firmano protocollo d’intesa per attività educative e formative nelle scuole primarie e secondarie di I',
-    canonicalPath: '/articoli-frontaliere/formazione-ferrero-ministero-2026',
+    canonicalPath: '/articoli-frontaliere/formazione-ferrero-ministero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -937,7 +937,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, condannato, mesi, truffe, online',
     ogTitle: 'Frontaliere condannato a 16 mesi per truffe online',
     ogDescription: 'Un 33enne del Bellinzonese, affetto da ludopatia, è stato condannato a 16 mesi per 82 raggiri online e 65 tentati',
-    canonicalPath: '/articoli-frontaliere/frontalieri-bellinzonese-truffe-16-mesi',
+    canonicalPath: '/articoli-frontaliere/frontalieri-bellinzonese-truffe-16-mesi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -965,7 +965,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, decreto, lavoro, meloni, incentivi',
     ogTitle: 'Decreto Lavoro Meloni: incentivi e salario giusto per i frontalieri',
     ogDescription: 'Via libera del Consiglio dei Ministri al decreto lavoro con incentivi per assunzioni e salario giusto per i lavoratori',
-    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -993,7 +993,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcio, belli, passo, baratro',
     ogTitle: 'Calcio Dnb: Belli a un passo dal baratro dopo la sconfitta',
     ogDescription: 'La squadra di calcio Dnb Belli ha segnato un solo goal in due tiri, ma non è bastato per evitare una situazione critica. Analisi e soluzioni.',
-    canonicalPath: '/articoli-frontaliere/calcio-dnb-belli-crisi',
+    canonicalPath: '/articoli-frontaliere/calcio-dnb-belli-crisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1021,7 +1021,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alain, berset, sostiene, mathias',
     ogTitle: 'Alain Berset sostiene Mathias Reynard dopo la tragedia di Crans-Montana',
     ogDescription: 'L\'ex consigliere federale Alain Berset ha offerto sostegno psicologico e professionale a Mathias Reynard dopo l\'incendio di Capodanno a Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/berset-sostegno-reynard-crans-montana',
+    canonicalPath: '/articoli-frontaliere/berset-sostegno-reynard-crans-montana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1049,7 +1049,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, biasca, rimanda, finale, uttigen',
     ogTitle: 'Biasca rimanda la finale: Uttigen vince ai supplementari',
     ogDescription: 'Il Biasca dovrà attendere ancora per la finale dopo la sconfitta ai supplementari contro l\'Uttigen. La serie va a gara 4.',
-    canonicalPath: '/articoli-frontaliere/biasca-roller-hockey-uttigen-2026',
+    canonicalPath: '/articoli-frontaliere/biasca-roller-hockey-uttigen-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1077,7 +1077,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basket, divario, ginevra, olympic',
     ogTitle: 'Basket: il divario tra Ginevra e Olympic',
     ogDescription: 'Analisi del campionato svizzero di basket con un divario evidente tra le prime e le altre squadre',
-    canonicalPath: '/articoli-frontaliere/vuoto-ginevra-olympic-basket',
+    canonicalPath: '/articoli-frontaliere/vuoto-ginevra-olympic-basket/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1105,7 +1105,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, pista, ciclopedonale, bodio-giornico',
     ogTitle: 'Nuova pista ciclopedonale Bodio-Giornico: 2,1 km di sicurezza e connessione',
     ogDescription: 'Scopri la nuova pista ciclopedonale che collega Bodio e Giornico lungo il fiume Ticino, con un investimento di 3,7 milioni di franchi.',
-    canonicalPath: '/articoli-frontaliere/nuova-pista-ciclopedonale-bodio-giornico-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-pista-ciclopedonale-bodio-giornico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1133,7 +1133,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, hotel, lusso, lago',
     ogTitle: 'Nuovo hotel di lusso sul Lago di Como: The Lake Como EDITION',
     ogDescription: 'Scopri il nuovo hotel di lusso sul Lago di Como, The Lake Como EDITION, con eventi esclusivi e cucina stellata.',
-    canonicalPath: '/articoli-frontaliere/lago-como-edition-hotel-lusso',
+    canonicalPath: '/articoli-frontaliere/lago-como-edition-hotel-lusso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1161,7 +1161,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, lancia, sfida, carpooling',
     ogTitle: 'MomòRide lancia sfida di carpooling per pendolari del Mendrisiotto',
     ogDescription: 'MomòRide lancia una sfida collettiva di carpooling per pendolari del Mendrisiotto. Obiettivo: raccogliere 40.000 punti in un mese per donare 1.000 CHF alla',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-sfida-collettiva',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-sfida-collettiva/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1189,7 +1189,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, scuole, vernate, neggio',
     ogTitle: 'Nuove scuole Vernate Neggio 2026',
     ogDescription: 'Le comunità di Vernate e Neggio hanno inaugurato le nuove scuole intercomunali, un progetto strategico per l\'educazione e l\'aggregazione',
-    canonicalPath: '/articoli-frontaliere/nuove-scuole-vernate-neggio-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-scuole-vernate-neggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1217,7 +1217,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, iniziative, potrebbero',
     ogTitle: 'Casse malati Ticino: le due iniziative potrebbero dividersi',
     ogDescription: 'Il Consiglio di Stato ticinese presenta un piano parziale per le iniziative casse malati, ma i partiti propongono di separarle',
-    canonicalPath: '/articoli-frontaliere/casse-malati-ticino-divise-2026',
+    canonicalPath: '/articoli-frontaliere/casse-malati-ticino-divise-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1245,7 +1245,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, picco, spostamenti, transfrontalieri',
     ogTitle: 'Cina, picco di spostamenti transfrontalieri per il Primo Maggio',
     ogDescription: 'La Cina si prepara a un aumento record di viaggi transfrontalieri durante le vacanze del Primo Maggio, con picchi di oltre 2,4 milioni di passeggeri al giorno.',
-    canonicalPath: '/articoli-frontaliere/cina-spostamenti-frontalieri-primo-maggio',
+    canonicalPath: '/articoli-frontaliere/cina-spostamenti-frontalieri-primo-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1273,7 +1273,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, cultura, rinnova, arriva',
     ogTitle: 'Lugano Cultura digitale: nuovo spazio culturale unico',
     ogDescription: 'Scopri la nuova piattaforma digitale di Lugano Cultura con eventi, operatori e progetti interdisciplinari. Partecipa alla vita culturale di Lugano.',
-    canonicalPath: '/articoli-frontaliere/lugano-cultura-digitale-2024',
+    canonicalPath: '/articoli-frontaliere/lugano-cultura-digitale-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1301,7 +1301,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fondazione, xenia, patto, generazionale',
     ogTitle: 'Fondazione Xenia: il Patto Generazionale per l\'assistenza ai figli disabili',
     ogDescription: 'Scopri il progetto innovativo della Fondazione Xenia per garantire un futuro sereno ai figli disabili, ispirato alla tradizione della casa di corte.',
-    canonicalPath: '/articoli-frontaliere/fondazione-xenia-patto-generazionale',
+    canonicalPath: '/articoli-frontaliere/fondazione-xenia-patto-generazionale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1329,7 +1329,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, podcast, europa, basso, ruolo',
     ogTitle: 'Podcast su \'Un’Europa dal basso\': il ruolo delle regioni con Matteo Bianchi',
     ogDescription: 'Scopri il ruolo delle regioni nelle politiche di coesione dell\'UE nel podcast con Matteo Bianchi, vicepresidente del Comitato delle Regioni.',
-    canonicalPath: '/articoli-frontaliere/europa-dal-basso-regioni-podcast-bianchi',
+    canonicalPath: '/articoli-frontaliere/europa-dal-basso-regioni-podcast-bianchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1357,7 +1357,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, viggiù, bando, giovani, mille',
     ogTitle: 'Bando giovani Viggiù 2026: 1000 euro per progetti comunitari',
     ogDescription: 'Scopri il bando per i giovani di Viggiù: 1000 euro per realizzare progetti per la comunità. Scadenza 10 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/viggi-bando-giovani-comunit-2026',
+    canonicalPath: '/articoli-frontaliere/viggi-bando-giovani-comunit-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1385,7 +1385,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, centro, pacchi, cadenazzo',
     ogTitle: 'Furti al Centro pacchi di Cadenazzo: licenziati due dipendenti',
     ogDescription: 'Due dipendenti della Posta svizzera sono stati licenziati per furti al Centro pacchi di Cadenazzo. Parte della refurtiva è stata recuperata.',
-    canonicalPath: '/articoli-frontaliere/furti-centro-pacchi-cadenazzo',
+    canonicalPath: '/articoli-frontaliere/furti-centro-pacchi-cadenazzo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1413,7 +1413,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, conflitto, medio, oriente, fattura',
     ogTitle: 'Conflitto in Medio Oriente: la fattura energetica per Svizzera e Italia',
     ogDescription: 'Il conflitto in Medio Oriente fa lievitare i prezzi dei carburanti, con costi aggiuntivi di quasi 5 miliardi per la Svizzera e 15 per l\'Italia.',
-    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-medio-oriente',
+    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-medio-oriente/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1441,7 +1441,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, infermieristica, orario, lavoro',
     ogTitle: 'Riforma infermieristica in Ticino: orario di lavoro e reazioni contrastanti',
     ogDescription: 'Il Consiglio nazionale ha deciso di non accorciare l’orario massimo settimanale degli infermieri, che resta fissato a 50 ore. Reazioni contrastanti tra',
-    canonicalPath: '/articoli-frontaliere/riforma-infermieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/riforma-infermieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1469,7 +1469,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, emergenza, casa, como, analisi',
     ogTitle: 'Emergenza casa a Como: analisi e visioni del PD',
     ogDescription: 'Il Partito Democratico di Como organizza un incontro per discutere l\'emergenza abitativa in città, con esperti e relatori.',
-    canonicalPath: '/articoli-frontaliere/emergenza-casa-como-analisi',
+    canonicalPath: '/articoli-frontaliere/emergenza-casa-como-analisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1497,7 +1497,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, annullare, acquisto, f-35',
     ogTitle: 'Iniziativa per annullare l\'acquisto degli F-35',
     ogDescription: 'Un\'associazione civica lancia un\'iniziativa per far annullare il contratto degli F-35, considerati troppo costosi e inadatti. Scopri le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/iniziativa-f-35-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/iniziativa-f-35-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1525,7 +1525,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giro-e, tappa, angera, verbania',
     ogTitle: 'Giro-E 2026: tappa Angera-Verbania sul Lago Maggiore',
     ogDescription: 'Una tappa del Giro-E unisce sport, sostenibilità e promozione turistica lungo il Lago Maggiore, con partenza da Angera il 22 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/giro-e-angera-verbania-2026',
+    canonicalPath: '/articoli-frontaliere/giro-e-angera-verbania-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1553,7 +1553,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziative, casse, malati, spunta',
     ogTitle: 'Iniziative casse malati: spunta il piano Dadò',
     ogDescription: 'Ogni iniziativa sulle casse malati prosegue per la propria strada con misure di finanziamento separate. La proposta di Fiorenzo Dadò.',
-    canonicalPath: '/articoli-frontaliere/iniziative-casse-malati-dado-scissione-dossier',
+    canonicalPath: '/articoli-frontaliere/iniziative-casse-malati-dado-scissione-dossier/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1581,7 +1581,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moschea, pregassona, interroga, municipio',
     ogTitle: 'Moschea Pregassona: UDC interroga Municipio',
     ogDescription: 'L\'UDC chiede garanzie e trasparenza per il progetto di un centro culturale islamico con moschea e appartamenti a Pregassona.',
-    canonicalPath: '/articoli-frontaliere/moschea-pregassona-udc-interroga-municipio',
+    canonicalPath: '/articoli-frontaliere/moschea-pregassona-udc-interroga-municipio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1609,7 +1609,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, lavori, area, camper',
     ogTitle: 'Como, al via i lavori per l\'area camper da 26 posti',
     ogDescription: 'Il cantiere per l\'ampliamento dell\'area camper di Tavernola è iniziato. Ecco quando finiranno i lavori e i dettagli del progetto.',
-    canonicalPath: '/articoli-frontaliere/como-area-camper-26-posti-lavori',
+    canonicalPath: '/articoli-frontaliere/como-area-camper-26-posti-lavori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1637,7 +1637,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caricabatteria, unico, portatili, cosa',
     ogTitle: 'Caricabatteria unico per portatili: cosa cambia dal 28 aprile',
     ogDescription: 'Dal 28 aprile 2024, i computer portatili nell\'UE devono supportare la ricarica via USB-C e i produttori devono offrire versioni senza alimentatore',
-    canonicalPath: '/articoli-frontaliere/caricabatteria-unico-portatili-2024',
+    canonicalPath: '/articoli-frontaliere/caricabatteria-unico-portatili-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1665,7 +1665,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ufficio, open, space, genera',
     ogTitle: 'Ufficio open space genera stress, non comunicazione',
     ogDescription: 'Secondo lo psicoanalista Peter Schneider, gli open space sacrificano il benessere dei dipendenti per ottimizzare gli spazi, causando stress e micro-conflitti',
-    canonicalPath: '/articoli-frontaliere/ufficio-open-space-stress-frontalieri',
+    canonicalPath: '/articoli-frontaliere/ufficio-open-space-stress-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1693,7 +1693,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estival, jazz, pagamento, polemica',
     ogTitle: 'Estival Jazz a pagamento: la polemica a Lugano',
     ogDescription: 'Il consigliere comunale Omar Wicht critica le serate a pagamento dell\'evento musicale Estival Jazz a Lugano, chiedendo chiarimenti all\'Esecutivo',
-    canonicalPath: '/articoli-frontaliere/estival-pagamento-caduta-stile-lugano',
+    canonicalPath: '/articoli-frontaliere/estival-pagamento-caduta-stile-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1721,7 +1721,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giornata, contro, rumore, controlli',
     ogTitle: 'Giornata contro il rumore: controlli a Lugano dal 28 al 30 aprile',
     ogDescription: 'La Polizia comunale di Lugano estende i controlli sul rumore dal 28 al 30 aprile. Focus su veicoli rumorosi e cantieri',
-    canonicalPath: '/articoli-frontaliere/giornata-contro-rumore-lugano-2024',
+    canonicalPath: '/articoli-frontaliere/giornata-contro-rumore-lugano-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1749,7 +1749,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estival, jazz, lugano, introduce',
     ogTitle: 'Estival Jazz Lugano introduce biglietti a pagamento',
     ogDescription: 'Dal 2024 due serate su tre del festival saranno a pagamento per garantire la sostenibilità dell\'evento. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-pagamento-2024',
+    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-pagamento-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1777,7 +1777,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, capitale, sostenibilità, salone',
     ogTitle: 'Varese sostenibilità CSR Camera Commercio',
     ogDescription: 'Il Salone della CSR e dell\'Innovazione Sociale approda a Varese con focus su ecosistema circolare e vantaggi competitivi per le imprese.',
-    canonicalPath: '/articoli-frontaliere/varese-sostenibilita-csr-camera-commercio',
+    canonicalPath: '/articoli-frontaliere/varese-sostenibilita-csr-camera-commercio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1805,7 +1805,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, milioni, quartiere, rivoluziona',
     ogTitle: 'Lombardia: 30 milioni per il quartiere che rivoluziona le bollette',
     ogDescription: 'Scopri come il progetto Livorno Parco a Brescia sta rivoluzionando le bollette energetiche con un investimento di 30 milioni di euro.',
-    canonicalPath: '/articoli-frontaliere/lombardia-30-milioni-quartiere-efficientamento',
+    canonicalPath: '/articoli-frontaliere/lombardia-30-milioni-quartiere-efficientamento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1833,7 +1833,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, moschea, lugano, interrogazioni',
     ogTitle: 'Nuova moschea a Lugano: interrogazioni e dubbi',
     ogDescription: 'Sette consiglieri comunali UDC presentano interrogazione al Municipio di Lugano su progetto moschea a Pregassona',
-    canonicalPath: '/articoli-frontaliere/moschea-lugano-pregassona-2026',
+    canonicalPath: '/articoli-frontaliere/moschea-lugano-pregassona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1861,7 +1861,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, chiasso, causa',
     ogTitle: 'Fuga di ammoniaca a Chiasso: causa individuata',
     ogDescription: 'La fuga di ammoniaca alla pista di ghiaccio di Chiasso è stata causata da una guarnizione difettosa. Tre dipendenti leggermente intossicati.',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-causa-trovata',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-causa-trovata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1889,7 +1889,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, unitas, festeggia, anni, rivista',
     ogTitle: 'Unitas festeggia 80 anni con una rivista audio',
     ogDescription: 'L\'associazione per non vedenti celebra il traguardo con una rivista audio e progetti per il futuro',
-    canonicalPath: '/articoli-frontaliere/unitas-80-anni-innovazione-inclusione',
+    canonicalPath: '/articoli-frontaliere/unitas-80-anni-innovazione-inclusione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1917,7 +1917,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giorgetti, deficit, ridotto, senza',
     ogTitle: 'Dfp, Giorgetti: deficit ridotto senza manovre restrittive',
     ogDescription: 'Il ministro dell\'Economia annuncia una riduzione del deficit senza manovre restrittive grazie a una gestione prudente della finanza pubblica.',
-    canonicalPath: '/articoli-frontaliere/dfp-giorgetti-deficit-ridotto',
+    canonicalPath: '/articoli-frontaliere/dfp-giorgetti-deficit-ridotto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1945,7 +1945,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, castiglione, olona, riaperto, ufficio',
     ogTitle: 'Castiglione Olona: riaperto l\'ufficio postale con nuovi servizi',
     ogDescription: 'L\'ufficio postale di Castiglione Olona è stato riaperto dopo una completa ristrutturazione, offrendo nuovi servizi e migliorando l\'accessibilità.',
-    canonicalPath: '/articoli-frontaliere/castiglione-olona-ufficio-postale-riaperto',
+    canonicalPath: '/articoli-frontaliere/castiglione-olona-ufficio-postale-riaperto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1973,7 +1973,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, programmi, educativi, bellinzona',
     ogTitle: 'Nuovi programmi educativi a Bellinzona: prevenzione e rispetto',
     ogDescription: 'Da settembre 2026, l\'Istituto scolastico comunale di Bellinzona avvia tre programmi educativi per il secondo ciclo della scuola elementare.',
-    canonicalPath: '/articoli-frontaliere/programmi-educativi-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/programmi-educativi-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2001,7 +2001,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aeroporti, milano, boom, fatturato',
     ogTitle: 'Aeroporti Milano: boom fatturato e dividendi 197 milioni',
     ogDescription: 'Malpensa e Linate chiudono il 2025 con ricavi a 876,8 milioni e traffico passeggeri in aumento dell\'8%. Dividendi record per gli azionisti.',
-    canonicalPath: '/articoli-frontaliere/aeroporti-milano-boom-fatturato-197-milioni',
+    canonicalPath: '/articoli-frontaliere/aeroporti-milano-boom-fatturato-197-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2029,7 +2029,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, servizio, clienti, bancario, digitali',
     ogTitle: 'Servizio clienti bancario: UBS al top, le digitali bocciate',
     ogDescription: 'UBS e Banca cantonale di Basilea Campagna garantiscono servizio 24/7, mentre le banche online come Revolut e Neon sono ultime in classifica.',
-    canonicalPath: '/articoli-frontaliere/servizio-clienti-bancario-promossi-bocciati',
+    canonicalPath: '/articoli-frontaliere/servizio-clienti-bancario-promossi-bocciati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2057,7 +2057,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agricoltura, spaziale, primo, centro',
     ogTitle: 'Agricoltura spaziale: primo centro europeo in Svizzera',
     ogDescription: 'Inaugurato il primo centro europeo di ricerca sull\'agricoltura spaziale in Svizzera. Innovazione per il futuro dell\'alimentazione.',
-    canonicalPath: '/articoli-frontaliere/agricoltura-spaziale-svizzera-ricerca',
+    canonicalPath: '/articoli-frontaliere/agricoltura-spaziale-svizzera-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2085,7 +2085,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sotto, accusa, lobbying, aggressivo',
     ogTitle: 'UBS sotto accusa: lobbying aggressivo sul Parlamento svizzero',
     ogDescription: 'La banca UBS esercita pressioni senza precedenti sui parlamentari per ostacolare una legge che la obbligherebbe a rafforzare i capitali.',
-    canonicalPath: '/articoli-frontaliere/ubs-lobbying-parlamento-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-lobbying-parlamento-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2113,7 +2113,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andrea, giuliani, nuovo, presidente',
     ogTitle: 'Andrea Giuliani nuovo presidente di Gastro Bellinzona e Alto Ticino',
     ogDescription: 'Andrea Giuliani è il nuovo presidente di Gastro Bellinzona e Alto Ticino. Scopri le implicazioni per i frontalieri e le strategie per affrontare le sfide',
-    canonicalPath: '/articoli-frontaliere/nuovo-presidente-gastro-bellinzona',
+    canonicalPath: '/articoli-frontaliere/nuovo-presidente-gastro-bellinzona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2141,7 +2141,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, presidio, varese, parcheggi, carenza',
     ogTitle: 'Presidio UIL FP a Varese: parcheggi e carenza di personale all\'ospedale',
     ogDescription: 'La UIL FP protesta davanti all\'ospedale di Varese per parcheggi insufficienti e carenza di personale, con turni massacranti per i lavoratori',
-    canonicalPath: '/articoli-frontaliere/varese-ospedale-parcheggi-personale-2026',
+    canonicalPath: '/articoli-frontaliere/varese-ospedale-parcheggi-personale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2169,7 +2169,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, coalizione, sanitaria, calpestata, volontà',
     ogTitle: 'Coalizione sanitaria: «Calpestata la volontà popolare»',
     ogDescription: 'La Coalizione del personale sanitario critica la decisione del Consiglio nazionale di non ridurre il tempo di lavoro degli infermieri.',
-    canonicalPath: '/articoli-frontaliere/coalizione-sanitario-volonta-calpestata',
+    canonicalPath: '/articoli-frontaliere/coalizione-sanitario-volonta-calpestata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2197,7 +2197,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, volo, swiss, evacuato, passeggeri',
     ogTitle: 'Volo Swiss evacuato: passeggeri non mollano il bagaglio a mano',
     ogDescription: 'Un Airbus A330 della Swiss è stato evacuato a New Delhi dopo un\'interruzione del decollo. Molti passeggeri non hanno seguito le istruzioni di sicurezza.',
-    canonicalPath: '/articoli-frontaliere/volo-swiss-evacuato-passeggeri-bagaglio',
+    canonicalPath: '/articoli-frontaliere/volo-swiss-evacuato-passeggeri-bagaglio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2225,7 +2225,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banche, svizzere, pronte, clienti',
     ogTitle: 'Banche svizzere pronte per i clienti del Golfo',
     ogDescription: 'Trasferimenti di capitali e potenziali trasferimenti di residenza verso la Svizzera a causa del conflitto in Iran',
-    canonicalPath: '/articoli-frontaliere/banche-golfo-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/banche-golfo-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2253,7 +2253,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, saronno, rilanciare, commercio, interventi',
     ogTitle: 'Saronno: rilanciare il commercio con interventi strutturali',
     ogDescription: 'Il Consiglio comunale di Saronno esamina una mozione per rilanciare il commercio cittadino con interventi strutturali e permanenti',
-    canonicalPath: '/articoli-frontaliere/rilanciare-commercio-saronno-2026',
+    canonicalPath: '/articoli-frontaliere/rilanciare-commercio-saronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2281,7 +2281,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, aggressione, donne, casa',
     ogTitle: 'Lugano: aggressione a due donne in casa, arrestato l\'aggressore',
     ogDescription: 'Un uomo ha aggredito due donne nella loro abitazione a Lugano. L\'aggressore è stato preso e interrogato dalle autorità.',
-    canonicalPath: '/articoli-frontaliere/lugano-aggressione-abitazione-2024',
+    canonicalPath: '/articoli-frontaliere/lugano-aggressione-abitazione-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2309,7 +2309,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, chiese, fermati, rumeni',
     ogTitle: 'Furti in chiese: fermati due rumeni in Ticino',
     ogDescription: 'Due cittadini rumeni sono stati fermati per furti in chiese ticinesi. Scopri i dettagli dell\'operazione e le misure di sicurezza.',
-    canonicalPath: '/articoli-frontaliere/furti-chiese-ticino-rumeni-fermati',
+    canonicalPath: '/articoli-frontaliere/furti-chiese-ticino-rumeni-fermati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2337,7 +2337,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attentato, washington, illeso, donald',
     ogTitle: 'Attentato a Washington, illeso Donald Trump',
     ogDescription: 'Donald Trump scampato a un attentato durante una cena di gala a Washington. L\'attentatore arrestato. Implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026',
+    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2365,7 +2365,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, montana, nante, governo',
     ogTitle: 'Casa montana di Nante: il Governo conferma tutto regolare',
     ogDescription: 'Il Consiglio di Stato ticinese ha respinto il ricorso contro il progetto di ristrutturazione della casa montana Madonna delle Nevi a Nante, confermando un',
-    canonicalPath: '/articoli-frontaliere/casa-montana-nante-governo-regolare',
+    canonicalPath: '/articoli-frontaliere/casa-montana-nante-governo-regolare/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2393,7 +2393,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, neuch, vieta, palloncini, lanterne',
     ogTitle: 'Neuchâtel vieta palloncini e lanterne: prima svizzera',
     ogDescription: 'Il Gran Consiglio del Canton Neuchâtel ha approvato il divieto di lancio di palloncini e lanterne volanti, con 55 voti a favore.',
-    canonicalPath: '/articoli-frontaliere/neuchatel-palloncini-lanterne-vietati',
+    canonicalPath: '/articoli-frontaliere/neuchatel-palloncini-lanterne-vietati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2421,7 +2421,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vaud, parlamento, chiede, dimissioni',
     ogTitle: 'Vaud, il Parlamento chiede le dimissioni di Valérie Dittli',
     ogDescription: 'Il Gran Consiglio vodese ha approvato una risoluzione simbolica per chiedere le dimissioni della consigliera di Stato Valérie Dittli.',
-    canonicalPath: '/articoli-frontaliere/vaud-parlamento-dimissioni-dittli',
+    canonicalPath: '/articoli-frontaliere/vaud-parlamento-dimissioni-dittli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2449,7 +2449,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rogo, fermo, battaglia, nessuno',
     ogTitle: 'Rogo a San Fermo della Battaglia, nessuno ferito',
     ogDescription: 'Un incendio è divampato sul Pin Umbrèla a San Fermo della Battaglia, in provincia di Como, senza causare vittime.',
-    canonicalPath: '/articoli-frontaliere/rogo-san-fermo-battaglia-2024',
+    canonicalPath: '/articoli-frontaliere/rogo-san-fermo-battaglia-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2477,7 +2477,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, terremoto, canton, gallo, magnitudo',
     ogTitle: 'Terremoto in Canton San Gallo: magnitudo 3.8, scosse avvertite in tutta la Svizzera',
     ogDescription: 'Un terremoto di magnitudo 3.8 ha colpito il Canton San Gallo il 26 aprile 2026, con epicentro vicino a Walenstadt. Scosse avvertite in tutta la Svizzera.',
-    canonicalPath: '/articoli-frontaliere/terremoto-san-gallo-2026',
+    canonicalPath: '/articoli-frontaliere/terremoto-san-gallo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2505,7 +2505,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, indipendenti, riconoscimento, critiche',
     ogTitle: 'Infermieri indipendenti in Ticino: tra riconoscimento e critiche',
     ogDescription: 'Andrè Brusasco, infermiere indipendente, racconta la realtà del lavoro a domicilio in Ticino e le sfide attuali',
-    canonicalPath: '/articoli-frontaliere/infermieri-indipendenti-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-indipendenti-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2533,7 +2533,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, deposito, sequestrato, como, indagini',
     ogTitle: 'Deposito carrozzeria sequestrato a Como: indagini partite da pezzi d\'auto abbandonati',
     ogDescription: 'La Polizia locale di Como ha sequestrato un deposito di una carrozzeria per violazioni ambientali, scoprendo rifiuti abbandonati e irregolarità nel deposito',
-    canonicalPath: '/articoli-frontaliere/deposito-carrozzeria-sequestrato-como-2026',
+    canonicalPath: '/articoli-frontaliere/deposito-carrozzeria-sequestrato-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2561,7 +2561,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agesp, orari, raccolta, rifiuti',
     ogTitle: 'Agesp: orari raccolta rifiuti primo maggio 2026',
     ogDescription: 'Variazioni nei servizi Agesp il 1° maggio a Busto Arsizio, Fagnano Olona e Venegono Superiore. Info su raccolta rifiuti e chiusure uffici.',
-    canonicalPath: '/articoli-frontaliere/agesp-rifiuti-primo-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/agesp-rifiuti-primo-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2589,7 +2589,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, blocca, acquisizione, manus',
     ogTitle: 'Cina blocca acquisizione Manus: ecco perché',
     ogDescription: 'Pechino ferma l\'acquisto da Meta per 2 miliardi di dollari, temendo perdita di tecnologia strategica',
-    canonicalPath: '/articoli-frontaliere/stop-cinese-acquisizione-manus-implicazioni',
+    canonicalPath: '/articoli-frontaliere/stop-cinese-acquisizione-manus-implicazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2617,7 +2617,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gita, cuore, soncino, sostenere',
     ogTitle: 'Gita del cuore a Soncino per sostenere Saronno Point',
     ogDescription: 'Una giornata tra storia, arte e solidarietà per finanziare le attività di Saronno Point dedicate ai malati oncologici.',
-    canonicalPath: '/articoli-frontaliere/gita-cuore-soncino-saronno-point',
+    canonicalPath: '/articoli-frontaliere/gita-cuore-soncino-saronno-point/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2645,7 +2645,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, decreto, lavoro, meloni, salario',
     ogTitle: 'Decreto lavoro Meloni: salario giusto e stop ai contratti pirata',
     ogDescription: 'Via libera al decreto lavoro con salario giusto e incentivi per le assunzioni. Meloni: patto con imprese e sindacati.',
-    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2673,7 +2673,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, othermovie, lugano, trionfa, witness',
     ogTitle: 'OtherMovie Lugano 2026: trionfa \'God as my Witness\'',
     ogDescription: 'Scopri il vincitore di OtherMovie Lugano 2026 e le implicazioni per i frontalieri che lavorano in Ticino. Partecipa al festival e approfitta delle opportunità',
-    canonicalPath: '/articoli-frontaliere/othermovie-lugano-2026-god-witness',
+    canonicalPath: '/articoli-frontaliere/othermovie-lugano-2026-god-witness/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2701,7 +2701,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nasce, emporio, solidarietà, olgiate',
     ogTitle: 'Nasce l’Emporio della Solidarietà di Olgiate Olona',
     ogDescription: 'Inaugurazione sabato 9 maggio con stand informativi e aperitivo comunitario. Partecipano realtà locali come Mensa del Padre Nostro e CAV di Castellanza.',
-    canonicalPath: '/articoli-frontaliere/emporio-solidarieta-olgiate-olona',
+    canonicalPath: '/articoli-frontaliere/emporio-solidarieta-olgiate-olona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2729,7 +2729,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estival, jazz, lugano, cambia',
     ogTitle: 'Estival Jazz Lugano cambia formula: due serate a pagamento',
     ogDescription: 'Dal 2026 Estival Jazz propone due serate a pagamento con Ernia e Antonello Venditti. Fine dell\'era dei concerti gratuiti.',
-    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-cambia-formula-2026',
+    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-cambia-formula-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2757,7 +2757,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, eurovision, ballad, emozionano, scopri',
     ogTitle: 'Eurovision 2026: le ballad che emozionano',
     ogDescription: 'Scopri le canzoni che emozionano all\'Eurovision 2026, tra ballad e scelte artistiche d\'impatto.',
-    canonicalPath: '/articoli-frontaliere/eurovision-ballad-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/eurovision-ballad-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2785,7 +2785,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, unitas, compie, anni, bilancio',
     ogTitle: 'Unitas compie 80 anni: bilancio e futuro dell\'associazione',
     ogDescription: 'L\'associazione ciechi e ipovedenti della Svizzera italiana festeggia 80 anni. Scopri le sfide e i progetti futuri presentati a Lugano.',
-    canonicalPath: '/articoli-frontaliere/unitas-ottantesimo-futuro-ticino',
+    canonicalPath: '/articoli-frontaliere/unitas-ottantesimo-futuro-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2813,7 +2813,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scaletta, indecente, comune, vuole',
     ogTitle: 'Como, io ho segnalato ma il Comune non ne vuole sapere. Indecente la scaletta che usiamo tutti i giorni',
     ogDescription: 'Segnalazione di una cittadina sul Comune di Como: la scaletta da via Spartaco Cappelletti a via Bellinzona è in una situazione indecente.',
-    canonicalPath: '/articoli-frontaliere/como-io-ho-segnalato-ma-il-comune-non-ne-vuole-sapere',
+    canonicalPath: '/articoli-frontaliere/como-io-ho-segnalato-ma-il-comune-non-ne-vuole-sapere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2841,7 +2841,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ucraina, supera, russia, negli',
     ogTitle: 'Ucraina supera Russia negli attacchi con droni',
     ogDescription: 'Per la prima volta dall\'inizio del conflitto, l\'Ucraina ha lanciato più droni della Russia a marzo 2026, secondo i dati militari analizzati da ABC News.',
-    canonicalPath: '/articoli-frontaliere/ucraina-russia-droni-2026',
+    canonicalPath: '/articoli-frontaliere/ucraina-russia-droni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2869,7 +2869,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, serie, documentari, play',
     ogTitle: 'Nuove serie e documentari su Play Suisse',
     ogDescription: 'Scopri le nuove serie e documentari disponibili su Play Suisse, la piattaforma streaming della SSR. Registrati gratuitamente e inizia a guardare.',
-    canonicalPath: '/articoli-frontaliere/play-suisse-novita-streaming-2026',
+    canonicalPath: '/articoli-frontaliere/play-suisse-novita-streaming-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2897,7 +2897,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dehors, como, ricorso, decisione',
     ogTitle: 'Dehors a Como: ricorso del bar e decisione del Tar',
     ogDescription: 'La rimozione del dehors del bar La Quinta a Como è sospesa. Udienza di merito il 20 maggio 2026. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/dehors-como-ricorso-tar-20-maggio',
+    canonicalPath: '/articoli-frontaliere/dehors-como-ricorso-tar-20-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2925,7 +2925,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bruno, breguet, scomparso, pretore',
     ogTitle: 'Bruno Breguet scomparso: il pretore di Locarno chiude il caso',
     ogDescription: 'La giustizia civile ticinese ha ufficializzato la scomparsa di Bruno Breguet, ex terrorista legato a Carlos e forse agente CIA',
-    canonicalPath: '/articoli-frontaliere/bruno-breguet-scomparsa-ufficializzata',
+    canonicalPath: '/articoli-frontaliere/bruno-breguet-scomparsa-ufficializzata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2953,7 +2953,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, profumo, prato, tagliato, grido',
     ogTitle: 'Il profumo di prato tagliato è un grido d’aiuto delle piante',
     ogDescription: 'Scopri come il profumo dell\'erba tagliata è un segnale di allarme per le piante e attira insetti predatori utili.',
-    canonicalPath: '/articoli-frontaliere/profumo-prato-tagliato-grido-aiuto-piante',
+    canonicalPath: '/articoli-frontaliere/profumo-prato-tagliato-grido-aiuto-piante/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2981,7 +2981,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, novartis, calo, nell, utile',
     ogTitle: 'Novartis: calo del 13% nell\'utile netto nel primo trimestre 2026',
     ogDescription: 'Novartis registra un calo del 13% nell\'utile netto nel primo trimestre 2026, con vendite di Entresto in forte diminuzione.',
-    canonicalPath: '/articoli-frontaliere/novartis-calo-utile-2026',
+    canonicalPath: '/articoli-frontaliere/novartis-calo-utile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3009,7 +3009,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, taglio, accise, energia, proroga',
     ogTitle: 'Taglio accise energia: proroga in arrivo, Meloni chiede coraggio all\'UE',
     ogDescription: 'Il governo italiano lavora a una proroga più breve per il taglio delle accise sull\'energia. Meloni invoca coraggio dall\'Europa per affrontare la crisi',
-    canonicalPath: '/articoli-frontaliere/taglio-accise-proroga-meloni-2026',
+    canonicalPath: '/articoli-frontaliere/taglio-accise-proroga-meloni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3037,7 +3037,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agente, fedpol, arrestato, corruzione',
     ogTitle: 'Agente Fedpol arrestato per corruzione e violazione del segreto d\'ufficio',
     ogDescription: 'Sei persone, tra cui un dipendente di Fedpol, arrestate in un\'operazione contro la criminalità organizzata in Svizzera, Francia e Germania.',
-    canonicalPath: '/articoli-frontaliere/fedpol-arresto-corruzione-2026',
+    canonicalPath: '/articoli-frontaliere/fedpol-arresto-corruzione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3065,7 +3065,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, prima, sfida, benefica',
     ogTitle: 'MomòRide: prima sfida benefica per pendolari ticinesi',
     ogDescription: 'A maggio parte la prima sfida collettiva di MomòRide per promuovere il carpooling e raccogliere fondi per enti benefici del Mendrisiotto.',
-    canonicalPath: '/articoli-frontaliere/momoride-benefico-mendrisiotto-2024',
+    canonicalPath: '/articoli-frontaliere/momoride-benefico-mendrisiotto-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3093,7 +3093,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, uzbekistan, centro, mondo, implicazioni',
     ogTitle: 'Uzbekistan, oro e gas al centro del mondo: implicazioni per il Ticino',
     ogDescription: 'Scopri come l\'apertura economica dell\'Uzbekistan influisce sul Ticino e i frontalieri, con focus su oro, gas e processi finanziari.',
-    canonicalPath: '/articoli-frontaliere/uzbekistan-oro-gas-ticino-implicazioni',
+    canonicalPath: '/articoli-frontaliere/uzbekistan-oro-gas-ticino-implicazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3121,7 +3121,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attentato, trump, aggressore, davanti',
     ogTitle: 'Attentato a Trump: l\'aggressore davanti al giudice',
     ogDescription: 'Cole Allen, 31enne californiano, accusato di aggressione a un agente federale e uso di arma da fuoco, comparirà davanti a un giudice lunedì',
-    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026-analisi',
+    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026-analisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3149,7 +3149,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spese, militari, 2025, miliardi',
     ogTitle: 'Spese militari 2025: +2.9% a 2.900 miliardi',
     ogDescription: 'Il mondo ha destinato quasi 2.900 miliardi di dollari alle spese militari nel 2025, un dato in crescita per l\'undicesimo anno consecutivo',
-    canonicalPath: '/articoli-frontaliere/spese-militari-2025-aumento-2900-miliardi',
+    canonicalPath: '/articoli-frontaliere/spese-militari-2025-aumento-2900-miliardi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3177,7 +3177,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, karimova, bellinzona, accuse',
     ogTitle: 'Processo a Karimova a Bellinzona: accuse di riciclaggio e corruzione',
     ogDescription: 'Gulnara Karimova, figlia dell\'ex presidente uzbeko, è accusata di reati finanziari. Il processo si tiene a Bellinzona.',
-    canonicalPath: '/articoli-frontaliere/karimova-processo-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/karimova-processo-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3205,7 +3205,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, truffe, sentimentali, arresti, milioni',
     ogTitle: 'Truffe sentimentali in Svizzera: 10 arresti per milioni di franchi',
     ogDescription: 'Operazione su larga scala in 6 cantoni svizzeri smantella rete di truffe sentimentali legate al gruppo criminale nigeriano Black Axe.',
-    canonicalPath: '/articoli-frontaliere/truffe-sentimentali-zurigo-2026',
+    canonicalPath: '/articoli-frontaliere/truffe-sentimentali-zurigo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3233,7 +3233,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, esposizione, nazionale, segugi, svizzeri',
     ogTitle: 'Esposizione Nazionale Segugi Svizzeri Malvaglia 2026',
     ogDescription: 'Domenica 3 maggio 2026 a Malvaglia si terrà l\'Esposizione Nazionale dei Segugi Svizzeri, con competizioni e celebrazione delle razze autoctone.',
-    canonicalPath: '/articoli-frontaliere/esposizione-segughi-malvaglia-2026',
+    canonicalPath: '/articoli-frontaliere/esposizione-segughi-malvaglia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3261,7 +3261,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ragazza, 22enne, trovata, morta',
     ogTitle: 'Ragazza 22enne trovata morta in un campo: perquisita la casa di un amico',
     ogDescription: 'Il cadavere di una giovane di 22 anni è stato ritrovato in un campo a Cecima, in Oltrepò Pavese. Le indagini sono in corso.',
-    canonicalPath: '/articoli-frontaliere/ragazza-morta-campo-perquisita-casa-amico',
+    canonicalPath: '/articoli-frontaliere/ragazza-morta-campo-perquisita-casa-amico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3289,7 +3289,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, domestica, nuove, misure',
     ogTitle: 'Violenza domestica: nuove misure urgenti per contrastare il fenomeno',
     ogDescription: 'Il consigliere federale Beat Jans annuncia il numero nazionale 142 e altre iniziative per combattere la violenza domestica in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/violenza-domestica-misure-urgenti',
+    canonicalPath: '/articoli-frontaliere/violenza-domestica-misure-urgenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3317,7 +3317,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, robot, umanoidi, vincono, mezza',
     ogTitle: 'Robot umanoidi vincono maratona: progresso o fascinazione?',
     ogDescription: 'Un robot umanoide ha battuto il record mondiale di mezza maratona a Pechino, suscitando dibattiti sull\'utilità e l\'etica di queste tecnologie',
-    canonicalPath: '/articoli-frontaliere/robot-umanoidi-maratona-fascinazione',
+    canonicalPath: '/articoli-frontaliere/robot-umanoidi-maratona-fascinazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3345,7 +3345,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alla, tutto, quello, devi',
     ogTitle: 'Guida alla Svizzera per frontalieri del Ticino',
     ogDescription: 'Tutto quello che devi sapere per vivere e lavorare in Svizzera, con focus su Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/guida-svizzera-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/guida-svizzera-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3373,7 +3373,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, commesse, pubbliche, servizi, essenziali',
     ogTitle: 'Commesse pubbliche e servizi essenziali: procedure da snellire',
     ogDescription: 'Il Cantone Ticino punta a semplificare le procedure per le commesse pubbliche e i servizi essenziali, con l\'obiettivo di ridurre i ritardi e migliorare',
-    canonicalPath: '/articoli-frontaliere/commesse-pubbliche-servizi-essenziali-2026',
+    canonicalPath: '/articoli-frontaliere/commesse-pubbliche-servizi-essenziali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3401,7 +3401,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sente, criminali, denuncia, dell',
     ogTitle: 'Frontalieri in Ticino: \'Ci si sente come criminali\'',
     ogDescription: 'Denuncia dell\'antropologa Lederrey sui Centri federali d\'asilo in Ticino. La replica della SEM.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-sentono-criminali',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-sentono-criminali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3429,7 +3429,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, esubero, zone, edificabili, leventina',
     ogTitle: 'Esubero zone edificabili in Leventina: il Cantone risponda',
     ogDescription: 'Corrado Nastasi, presidente Acl, chiede chiarimenti sul sovradimensionamento delle zone edificabili in Leventina. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/esubero-leventina-zone-edificabili-2026',
+    canonicalPath: '/articoli-frontaliere/esubero-leventina-zone-edificabili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3457,7 +3457,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, corsi, occasione, fare',
     ogTitle: 'Varese Corsi Net: opportunità per fare rete e sviluppare sinergie',
     ogDescription: 'Un incontro conviviale a Castronno per creare connessioni e sviluppare sinergie con la rete Varese Corsi. Conferma presenza entro il 29 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/varese-corsi-net-opportunita-rete-sinergie-2026',
+    canonicalPath: '/articoli-frontaliere/varese-corsi-net-opportunita-rete-sinergie-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3485,7 +3485,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, centri, responsabilità, sofferenza, richiedenti',
     ogTitle: 'Centri di responsabilità: la sofferenza dei richiedenti asilo',
     ogDescription: 'Analisi delle condizioni nei centri federali d\'asilo in Ticino e le scelte politiche dietro la gestione delle politiche migratorie.',
-    canonicalPath: '/articoli-frontaliere/centri-responsabilita-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/centri-responsabilita-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3513,7 +3513,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incontro, sem-cantone-comuni, annullato, cosa',
     ogTitle: 'Incontro SEM-Cantone-Comuni annullato: cosa cambia per i frontalieri',
     ogDescription: 'L\'incontro tra la SEM e i rappresentanti del Cantone Ticino e dei Comuni di Mendrisiotto è stato annullato. Berna attende i risultati di una sperimentazione.',
-    canonicalPath: '/articoli-frontaliere/incontro-sem-cantone-comuni-annullato',
+    canonicalPath: '/articoli-frontaliere/incontro-sem-cantone-comuni-annullato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3541,7 +3541,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, centrosinistra, varese, patto, città',
     ogTitle: 'Centrosinistra Varese: Patto per la città 2027-2032',
     ogDescription: 'Il centrosinistra di Varese lancia il \'Patto per Varese\', una coalizione aperta con candidato sindaco entro fine anno per le elezioni amministrative del 2027.',
-    canonicalPath: '/articoli-frontaliere/centrosinistra-varese-patto-2027',
+    canonicalPath: '/articoli-frontaliere/centrosinistra-varese-patto-2027/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3569,7 +3569,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, magadino, nuovo, parco, giochi',
     ogTitle: 'Magadino: nuovo parco giochi in riva al lago',
     ogDescription: 'Il Comune di Magadino sostituisce il parco giochi alle Bolle con una nuova area attrezzata in riva al lago, con un investimento di 70mila franchi.',
-    canonicalPath: '/articoli-frontaliere/magadino-parco-giochi-nuova-area-ludica',
+    canonicalPath: '/articoli-frontaliere/magadino-parco-giochi-nuova-area-ludica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3597,7 +3597,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, valle, verzasca, motociclista',
     ogTitle: 'Incidente in Valle Verzasca: motociclista grave',
     ogDescription: 'Un 23enne svizzero ha riportato serie ferite in un incidente in Valle Verzasca. La strada è stata temporaneamente chiusa.',
-    canonicalPath: '/articoli-frontaliere/incidente-valle-verzasca-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-valle-verzasca-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3625,7 +3625,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, affettuosa, separazioni, tutelare, figli',
     ogTitle: 'Guida affettuosa per separazioni in Ticino: supporto giuridico ed economico',
     ogDescription: 'FaMo+ presenta una guida completa per affrontare la separazione con supporto multidisciplinare. Focus su bisogni giuridici, economici e psicologici.',
-    canonicalPath: '/articoli-frontaliere/guida-affettuosa-separazione-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/guida-affettuosa-separazione-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3653,7 +3653,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, tentato, omicidio, chiasso',
     ogTitle: 'Processo tentato omicidio Chiasso: aggressione con manubrio',
     ogDescription: 'Si apre il processo a carico di un cittadino eritreo accusato di aver aggredito la compagna con un manubrio da palestra a Chiasso.',
-    canonicalPath: '/articoli-frontaliere/processo-tentato-omicidio-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/processo-tentato-omicidio-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3681,7 +3681,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, cultura, 2030, costruire',
     ogTitle: 'Varese Cultura 2030: costruire un ecosistema culturale',
     ogDescription: 'Varese Cultura 2030 è un progetto per ridisegnare il futuro culturale della provincia di Varese, con un piano strategico condiviso e una piattaforma digitale di',
-    canonicalPath: '/articoli-frontaliere/varese-cultura-2030-ecosistema-culturale',
+    canonicalPath: '/articoli-frontaliere/varese-cultura-2030-ecosistema-culturale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3709,7 +3709,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, montana, nante, ricorso',
     ogTitle: 'Casa montana Nante, ricorso al Tram | Frontaliere Ticino',
     ogDescription: 'Il comitato referendario evidenzia le discrepanze del Municipio sui costi di ristrutturazione della casa montana Nante-Airolo',
-    canonicalPath: '/articoli-frontaliere/casa-montana-nante-ricorso-tram',
+    canonicalPath: '/articoli-frontaliere/casa-montana-nante-ricorso-tram/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3737,7 +3737,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, atleti, ticinesi, trionfano, arcegno',
     ogTitle: 'Atleti ticinesi trionfano ad Arcegno e Ascona',
     ogDescription: 'Mattia e Tobia Pezzati conquistano le prove di corsa d\'orientamento nel Ticino. Scopri di più sulle loro vittorie e le implicazioni per lo sport regionale.',
-    canonicalPath: '/articoli-frontaliere/atleti-ticinesi-vittoria-arcegno-ascona',
+    canonicalPath: '/articoli-frontaliere/atleti-ticinesi-vittoria-arcegno-ascona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3765,7 +3765,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malnate, parte, lavoro, comitati',
     ogTitle: 'Malnate: parte il lavoro dei Comitati di Quartiere',
     ogDescription: 'I nuovi Comitati di Quartiere di Malnate iniziano il loro mandato con un bilancio partecipativo e progetti mirati per il miglioramento delle aree locali.',
-    canonicalPath: '/articoli-frontaliere/malnate-comitati-quartiere-bilancio-partecipativo',
+    canonicalPath: '/articoli-frontaliere/malnate-comitati-quartiere-bilancio-partecipativo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3793,7 +3793,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, montana, nante, valido',
     ogTitle: 'Casa montana di Nante, valido il voto del Cc di Monteceneri',
     ogDescription: 'Il Consiglio di Stato respinge il ricorso contro la risoluzione adottata dal Legislativo lo scorso giugno',
-    canonicalPath: '/articoli-frontaliere/casa-montana-nante-voto-validato',
+    canonicalPath: '/articoli-frontaliere/casa-montana-nante-voto-validato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3821,7 +3821,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, nelle, cantine, luganese',
     ogTitle: 'Furti nelle cantine del Luganese: condannato 44enne ticinese',
     ogDescription: 'Un 44enne ticinese è stato condannato per furti nelle cantine del Luganese per finanziare la dipendenza da cocaina. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/furti-cantine-luganese-condannato',
+    canonicalPath: '/articoli-frontaliere/furti-cantine-luganese-condannato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3849,7 +3849,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, corsi, corso, intermedio',
     ogTitle: 'Corso intermedio di public speaking a Varese',
     ogDescription: 'Varese Corsi propone un corso intermedio di public speaking per migliorare le tecniche di comunicazione e coinvolgimento del pubblico',
-    canonicalPath: '/articoli-frontaliere/varese-corsi-parlare-pubblico-2026',
+    canonicalPath: '/articoli-frontaliere/varese-corsi-parlare-pubblico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3877,7 +3877,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, sondaggio, tamedia, futuro',
     ogTitle: 'Iniziativa UDC: sondaggio Tamedia sul futuro demografico della Svizzera',
     ogDescription: 'Il 52% degli intervistati sostiene l\'iniziativa UDC \'No a una Svizzera da 10 milioni\' secondo il sondaggio Tamedia del 22-23 aprile 2026',
-    canonicalPath: '/articoli-frontaliere/svizzera-10-milioni-votazione-ticino',
+    canonicalPath: '/articoli-frontaliere/svizzera-10-milioni-votazione-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3905,7 +3905,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, conferma, tassa, sanitaria',
     ogTitle: 'Lombardia conferma tassa sanitaria per frontalieri',
     ogDescription: 'La Lombardia ha respinto la mozione per abolire la tassa sanitaria per i frontalieri, ma promette sconti. Ecco le implicazioni per chi lavora in Svizzera',
-    canonicalPath: '/articoli-frontaliere/lombardia-tassa-sanitaria-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/lombardia-tassa-sanitaria-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3933,7 +3933,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, precompilato, online, aprile, cosa',
     ogTitle: '730 precompilato online dal 30 aprile: cosa cambia per i frontalieri',
     ogDescription: 'Dal 30 aprile 2026 il 730 precompilato è online. Ecco cosa sapere per non sbagliare, con dati e scadenze aggiornati.',
-    canonicalPath: '/articoli-frontaliere/730-precompilato-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/730-precompilato-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3961,7 +3961,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tosatura, pecore, riparazione, vestiti',
     ogTitle: 'Tosatura pecore e riparazione vestiti a Bellinzona',
     ogDescription: 'Evento di sostenibilità a Bellinzona il 9 maggio 2026 con laboratori di upcycling e tosatura pecore. Partecipa e scopri come ridurre l\'impatto ambientale.',
-    canonicalPath: '/articoli-frontaliere/tosatura-pecore-riparazione-vestiti-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/tosatura-pecore-riparazione-vestiti-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3989,7 +3989,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, geopolitica, sindacati, nuovi, equilibri',
     ogTitle: 'Geopolitica e vita quotidiana: il sindacato alla prova dei nuovi equilibri globali',
     ogDescription: 'Il consiglio generale della Fnp Cisl dei Laghi a Varese analizza l\'impatto delle tensioni internazionali su lavoro, pensioni e welfare.',
-    canonicalPath: '/articoli-frontaliere/geopolitica-sindacato-nuovi-equilibri-varese',
+    canonicalPath: '/articoli-frontaliere/geopolitica-sindacato-nuovi-equilibri-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4017,7 +4017,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ferrara, beko, cassinetta, servono',
     ogTitle: 'Ferrara (M5S): Beko a Cassinetta, servono risultati concreti',
     ogDescription: 'Dopo un anno, il Movimento 5 Stelle chiede una verifica sull\'impianto Beko a Cassinetta di Biandronno per valutare l\'impatto sull\'occupazione e lo sviluppo',
-    canonicalPath: '/articoli-frontaliere/ferrara-m5s-beko-cassinetta-verifica',
+    canonicalPath: '/articoli-frontaliere/ferrara-m5s-beko-cassinetta-verifica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4045,7 +4045,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, azienda, comasca, riduce, impianto',
     ogTitle: 'Azienda comasca riduce CO2 con impianto fotovoltaico: 25 tonnellate in meno',
     ogDescription: 'Un impianto fotovoltaico su un tetto industriale a Cucciago riduce le emissioni di 25,71 tonnellate di CO2 all\'anno, con benefici per la comunità locale.',
-    canonicalPath: '/articoli-frontaliere/azienda-comasca-fotovoltaico-25-tonnellate-co2',
+    canonicalPath: '/articoli-frontaliere/azienda-comasca-fotovoltaico-25-tonnellate-co2/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4073,7 +4073,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, città, fiore, balconi, como',
     ogTitle: 'Città in fiore: balconi a Como e Cernobbio omaggiano il Tricolore',
     ogDescription: 'Orticolario lancia l\'iniziativa \'Città in fiore\' per celebrare gli 80 anni della Repubblica Italiana, trasformando balconi e vetrine in opere d\'arte a tema',
-    canonicalPath: '/articoli-frontaliere/citta-fiore-orticolario-tricolore-2026',
+    canonicalPath: '/articoli-frontaliere/citta-fiore-orticolario-tricolore-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4101,7 +4101,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, friborg-gottéron, allo, spareggio, titolo',
     ogTitle: 'Friborg-Gottéron allo spareggio per il titolo di hockey',
     ogDescription: 'La squadra di hockey Friborg-Gottéron si gioca il titolo in uno spareggio cruciale. Tutti i dettagli sulla partita decisiva.',
-    canonicalPath: '/articoli-frontaliere/friborgogotteron-spareggio-titolo-hockey',
+    canonicalPath: '/articoli-frontaliere/friborgogotteron-spareggio-titolo-hockey/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4129,7 +4129,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elogio, verdi, rapinese, così',
     ogTitle: 'Elogio dei Verdi a Rapinese: così si curano gli alberi',
     ogDescription: 'Elisabetta Patelli elogia l\'amministrazione Rapinese per la cura degli alberi a Como, prima del voto di sfiducia all\'assessore al Verde.',
-    canonicalPath: '/articoli-frontaliere/como-verdi-elogio-rapinese-alberi',
+    canonicalPath: '/articoli-frontaliere/como-verdi-elogio-rapinese-alberi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4157,7 +4157,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, approvvigionamento, energetico, sicuro, attacco',
     ogTitle: 'Petrolio e gas in Svizzera, approvvigionamento sicuro nonostante il conflitto in Medio Oriente',
     ogDescription: 'L\'attacco all\'Iran e le rappresaglie hanno aumentato i prezzi di benzina e diesel anche in Svizzera, ma l\'approvvigionamento è sicuro.',
-    canonicalPath: '/articoli-frontaliere/petrolio-gas-svizzera-approvvigionamento-sicuro',
+    canonicalPath: '/articoli-frontaliere/petrolio-gas-svizzera-approvvigionamento-sicuro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4185,7 +4185,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, leyen, guerra, iran, costa',
     ogTitle: 'Von der Leyen: "Guerra in Iran costa all\'Ue 500 milioni al giorno per l\'energia"',
     ogDescription: 'La presidente della Commissione europea avverte che il conflitto in Medio Oriente sta causando gravi ripercussioni economiche, con un costo di 500 milioni al',
-    canonicalPath: '/articoli-frontaliere/von-der-leyen-ue-energia-500-milioni-giorno',
+    canonicalPath: '/articoli-frontaliere/von-der-leyen-ue-energia-500-milioni-giorno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4213,7 +4213,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sempre, cashless, vuole, sistema',
     ogTitle: 'Svizzera sempre più cashless, BNS vuole sistema più equo',
     ogDescription: 'Il contante scende al 30% delle transazioni, le app di pagamento raggiungono il 20%. La BNS avverte sui rischi di concentrazione.',
-    canonicalPath: '/articoli-frontaliere/svizzera-cashless-bns-sistema-equo',
+    canonicalPath: '/articoli-frontaliere/svizzera-cashless-bns-sistema-equo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4241,7 +4241,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dati, consultabili, digitale, 2028',
     ogTitle: 'AVS/AI: dati consultabili in digitale dal 2028',
     ogDescription: 'Via libera del Consiglio nazionale alla nuova legge sui sistemi d\'informazione delle assicurazioni sociali. Risparmi di 35 milioni di franchi',
-    canonicalPath: '/articoli-frontaliere/avs-dati-digitale-frontalieri',
+    canonicalPath: '/articoli-frontaliere/avs-dati-digitale-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4269,7 +4269,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scorte, carburante, approvvigionamento, garantito',
     ogTitle: 'Scorte carburante Svizzera: approvvigionamento garantito fino a maggio 2026',
     ogDescription: 'Le scorte svizzere di carburante sono destinate esclusivamente al fabbisogno nazionale. Approfondiamo la situazione attuale e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/scorte-carburante-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/scorte-carburante-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4297,7 +4297,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, elimina, duty, free',
     ogTitle: 'Swiss elimina il duty free dal 30 settembre 2026',
     ogDescription: 'Swiss International Air Lines ha annunciato l\'eliminazione del servizio duty free a bordo a partire dal 30 settembre 2026.',
-    canonicalPath: '/articoli-frontaliere/swiss-duty-free-addio-30-settembre',
+    canonicalPath: '/articoli-frontaliere/swiss-duty-free-addio-30-settembre/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4325,7 +4325,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carpooling, aziendale, guadagnano, fino',
     ogTitle: 'Carpooling aziendale: frontalieri guadagnano fino a 500 franchi',
     ogDescription: 'Scopri come il progetto MomòRide offre incentivi economici e opportunità di beneficenza per i frontalieri di Balerna, Chiasso e Novazzano',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-frontalieri-benefici',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-frontalieri-benefici/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4353,7 +4353,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, interrompe, vendite, duty-free',
     ogTitle: 'Swiss interrompe vendite duty-free a bordo',
     ogDescription: 'Dal 30 settembre 2026, i prodotti duty-free saranno disponibili solo online. Sconti fino al 50% da giugno.',
-    canonicalPath: '/articoli-frontaliere/swiss-duty-free-fine-vendite-bordo',
+    canonicalPath: '/articoli-frontaliere/swiss-duty-free-fine-vendite-bordo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4381,7 +4381,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, aarau, 18enne, frontaliero',
     ogTitle: 'Incidente ad Aarau: 18enne frontaliero ubriaco causa danni totali',
     ogDescription: 'Un giovane apprendista di 18 anni, residente in Ticino, ha causato un incidente stradale ad Aarau, provocando danni totali all\'auto.',
-    canonicalPath: '/articoli-frontaliere/incidente-aarau-18enne-frontaliere',
+    canonicalPath: '/articoli-frontaliere/incidente-aarau-18enne-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4409,7 +4409,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gallo, vince, ultimo, minuto',
     ogTitle: 'San Gallo vince all\'ultimo minuto, festa rinviata per il Thun',
     ogDescription: 'Il San Gallo segna al 92° minuto e vince contro il Thun, mentre la festa del Thun viene rinviata per la seconda volta',
-    canonicalPath: '/articoli-frontaliere/san-gallo-vince-thun-ritardo-festa',
+    canonicalPath: '/articoli-frontaliere/san-gallo-vince-thun-ritardo-festa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4437,7 +4437,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hupac, cresce, rafforza, busto',
     ogTitle: 'Hupac cresce e rafforza Busto: utile positivo e nuovi collegamenti',
     ogDescription: 'Hupac chiude il 2025 con un utile di 3,5 milioni di franchi e volumi in aumento, nonostante le criticità della rete ferroviaria.',
-    canonicalPath: '/articoli-frontaliere/hupac-busto-utile-positivo-collegamenti',
+    canonicalPath: '/articoli-frontaliere/hupac-busto-utile-positivo-collegamenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4465,7 +4465,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hupac, chiude, 2025, utile',
     ogTitle: 'Hupac chiude 2025 con utile in calo ma bilancio positivo',
     ogDescription: 'Hupac chiude il 2025 con un utile netto di 3,5 milioni di franchi svizzeri, in calo rispetto ai 9,4 milioni del 2024, ma con volumi in crescita del 4,3%.',
-    canonicalPath: '/articoli-frontaliere/hupac-bilancio-positivo-2025',
+    canonicalPath: '/articoli-frontaliere/hupac-bilancio-positivo-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4493,7 +4493,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, riduzione, orario, massimo',
     ogTitle: 'Infermieri, no a riduzione orario massimo settimanale',
     ogDescription: 'Il Consiglio nazionale ha bocciato la proposta di ridurre l\'orario massimo settimanale per infermieri e infermiere, mantenendolo a 50 ore.',
-    canonicalPath: '/articoli-frontaliere/infermieri-orario-lavoro-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-orario-lavoro-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4521,7 +4521,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rumore, traffico, morti, anno',
     ogTitle: 'Rumore traffico Svizzera: 500 morti l\'anno',
     ogDescription: 'In Svizzera 500 morti l\'anno per il rumore del traffico. Le strategie del Canton Ticino per ridurlo: asfalto fonoassorbente e rumorometro.',
-    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-500-morti-anno',
+    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-500-morti-anno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4549,7 +4549,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parchi, vandalizzati, rompe, paga',
     ogTitle: 'Parchi vandalizzati in Ticino: chi rompe non paga',
     ogDescription: 'Bottiglie rotte nei parchi giochi di Azzate, Buguggiate e Daverio. I sindaci denunciano l\'inciviltà e chiedono il rispetto degli spazi pubblici.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-parchi-vandalismo-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-parchi-vandalismo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4577,7 +4577,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, proposto, spacchettamento',
     ogTitle: 'Casse malati, proposto lo spacchettamento delle due iniziative',
     ogDescription: 'Fiorenzo Dadò propone di trattare separatamente le due iniziative sulle casse malati approvate in Ticino per evitare blocchi e offrire risposte rapide ai',
-    canonicalPath: '/articoli-frontaliere/spacchettamento-casse-malati-2026',
+    canonicalPath: '/articoli-frontaliere/spacchettamento-casse-malati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4605,7 +4605,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, athora, over, rimpiange, adesione',
     ogTitle: 'Athora Italia: 30% over 55 rimpiange adesione tardiva',
     ogDescription: 'Studio Athora Italia rivela che il 30% degli over 55 rimpiange di non aver aderito prima alla previdenza complementare. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/athora-italia-previdenza-complementare-2026',
+    canonicalPath: '/articoli-frontaliere/athora-italia-previdenza-complementare-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4633,7 +4633,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, annuario, impresari, ticinesi, sicurezza',
     ogTitle: 'Annuario 2026 impresari ticinesi: sicurezza e trasparenza',
     ogDescription: 'Pubblicato l\'Annuario 2026 degli impresari ticinesi, strumento essenziale per committenti e progettisti. Scopri come orientarti tra le imprese edili',
-    canonicalPath: '/articoli-frontaliere/annuario-impresari-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/annuario-impresari-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4661,7 +4661,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, francisca, lucomagno, anni, turismo',
     ogTitle: 'Via Francisca del Lucomagno: 10 anni di turismo e connessioni',
     ogDescription: 'La Via Francisca del Lucomagno compie dieci anni, unendo Castiglione a Roma e celebrando il turismo e le relazioni tra territori',
-    canonicalPath: '/articoli-frontaliere/via-francisca-10-anni-turismo-ticino',
+    canonicalPath: '/articoli-frontaliere/via-francisca-10-anni-turismo-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4689,7 +4689,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scuola, viganello, gaza, gemellano',
     ogTitle: 'Scuola di Viganello e Gaza si gemellano: scambi culturali e mostre',
     ogDescription: 'Dal 27 aprile al 7 maggio, la scuola media di Viganello ospita una mostra dedicata al gemellaggio con la scuola Al-Salam di Gaza, con scambi di lettere e',
-    canonicalPath: '/articoli-frontaliere/scuola-viganello-gaza-gemellaggio-2026',
+    canonicalPath: '/articoli-frontaliere/scuola-viganello-gaza-gemellaggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4717,7 +4717,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libera, fascicolo, digitale, cosa',
     ogTitle: 'Via libera al fascicolo AVS/AI digitale: cosa cambia per i frontalieri',
     ogDescription: 'Il Consiglio nazionale approva la digitalizzazione dei fascicoli AVS/AI. Dal 2028 accesso online ai dati previdenziali per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/digitalizzazione-avs-ai-frontalieri',
+    canonicalPath: '/articoli-frontaliere/digitalizzazione-avs-ai-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4745,7 +4745,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, domenica, segreti, celti, parco',
     ogTitle: 'Celti a Tradate: evento gratuito al Parco Pineta',
     ogDescription: 'Scopri i segreti dei Celti al Parco Pineta di Tradate con l\'associazione Kaitorikes. Un evento gratuito per immergersi nella storia e nelle usanze del V secolo.',
-    canonicalPath: '/articoli-frontaliere/celti-tradate-parco-pineta-2026',
+    canonicalPath: '/articoli-frontaliere/celti-tradate-parco-pineta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4773,7 +4773,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, canapa, controllata, losanna, bilancio',
     ogTitle: 'Canapa controllata a Losanna: bilancio positivo',
     ogDescription: 'Il progetto pilota per la vendita controllata di cannabis a Losanna ha sottratto 2 milioni di franchi al mercato nero e creato nuovi posti di lavoro',
-    canonicalPath: '/articoli-frontaliere/canapa-losanna-bilancio-positivo-2026',
+    canonicalPath: '/articoli-frontaliere/canapa-losanna-bilancio-positivo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4801,7 +4801,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, jacky, marti, lascia, estival',
     ogTitle: 'Jacky Marti lascia Estival Jazz dopo 47 anni',
     ogDescription: 'Jacky Marti, fondatore e direttore artistico di Estival Jazz, si ritira dopo 47 anni. Presentato il programma della 46esima edizione con due serate a pagamento.',
-    canonicalPath: '/articoli-frontaliere/estival-jazz-marti-ritiro-2026',
+    canonicalPath: '/articoli-frontaliere/estival-jazz-marti-ritiro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4829,7 +4829,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, licata, schengen, euro, aprono',
     ogTitle: 'Licata: Schengen ed euro aprono nuove opportunità per Lombardia e Bulgaria',
     ogDescription: 'Giuseppe Licata, consigliere regionale di Forza Italia, sottolinea l\'importanza di rafforzare l\'asse Lombardia-Bulgaria dopo l\'ingresso del Paese in Schengen ed',
-    canonicalPath: '/articoli-frontaliere/licata-lombardia-bulgaria-opportunita',
+    canonicalPath: '/articoli-frontaliere/licata-lombardia-bulgaria-opportunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4857,7 +4857,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maroggia, posta, riorganizza, servizi',
     ogTitle: 'Maroggia, la Posta riorganizza i servizi dal 2026',
     ogDescription: 'Dal settembre 2026, Maroggia avrà un nuovo servizio postale a domicilio in attesa di una collaborazione con un commercio locale.',
-    canonicalPath: '/articoli-frontaliere/maroggia-servizi-postali-2026',
+    canonicalPath: '/articoli-frontaliere/maroggia-servizi-postali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4885,7 +4885,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gemellaggio, scuole, viganello, gaza',
     ogTitle: 'Gemellaggio scuole Viganello Gaza 2026',
     ogDescription: 'Scopri il gemellaggio tra la scuola di Viganello e la scuola Al-Salam di Gaza, sostenuta da Future in Peace. Mostra dal 27 aprile al 7 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/gemellaggio-scuole-viganello-gaza-2026',
+    canonicalPath: '/articoli-frontaliere/gemellaggio-scuole-viganello-gaza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4913,7 +4913,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, laurent, morel, nuovo, direttore',
     ogTitle: 'Laurent Morel nuovo Direttore Generale di EF Svizzera',
     ogDescription: 'EF Education First nomina Laurent Morel come nuovo Direttore Generale per rafforzare la presenza sul mercato svizzero.',
-    canonicalPath: '/articoli-frontaliere/laurent-morel-nominato-direttore-ef-svizzera',
+    canonicalPath: '/articoli-frontaliere/laurent-morel-nominato-direttore-ef-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4941,7 +4941,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gottardo, caduto, primo, diaframma',
     ogTitle: 'San Gottardo: caduto il primo diaframma a nord',
     ogDescription: 'Importante traguardo nel cantiere del secondo tubo della galleria stradale del San Gottardo. Caduto il primo diaframma sul lato nord.',
-    canonicalPath: '/articoli-frontaliere/san-gottardo-secondo-tubo-caduto-diaframma',
+    canonicalPath: '/articoli-frontaliere/san-gottardo-secondo-tubo-caduto-diaframma/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4969,7 +4969,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, antonello, venditti, lugano, prevendita',
     ogTitle: 'Antonello Venditti a Lugano: concerto del 10 luglio 2026',
     ogDescription: 'Antonello Venditti in concerto a Lugano il 10 luglio 2026 con i brani di \'Cuore\' e \'Notte prima degli esami\'. Posti solo a sedere, prevendita già attiva.',
-    canonicalPath: '/articoli-frontaliere/venditti-estival-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/venditti-estival-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4997,7 +4997,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, syndicom, approva, accordo, editori',
     ogTitle: 'Syndicom approva accordo con editori VSM per Ticino e Svizzera tedesca',
     ogDescription: 'Dopo 20 anni senza intesa, operatori media Ticino e Svizzera tedesca verso regolamentazione condizioni minime lavoro stampa',
-    canonicalPath: '/articoli-frontaliere/accordo-syndicom-vsm-2026',
+    canonicalPath: '/articoli-frontaliere/accordo-syndicom-vsm-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5025,7 +5025,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, philipp, plein, mendrisio, interrogazione',
     ogTitle: 'Philipp Plein a Mendrisio: interrogazione sullo stile controverso',
     ogDescription: 'Il marchio Philipp Plein trasferisce la sede legale a Mendrisio. Interrogazione sul suo stile controverso e impatto sulla città.',
-    canonicalPath: '/articoli-frontaliere/philipp-plein-mendrisio-interrogazione',
+    canonicalPath: '/articoli-frontaliere/philipp-plein-mendrisio-interrogazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5053,7 +5053,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mercatino, primavera, lugano, traffico',
     ogTitle: 'Mercatino di Primavera a Lugano: traffico chiuso sul lungolago',
     ogDescription: 'Venerdì 1 maggio il lungolago di Lugano si trasforma in un\'isola pedonale con bancarelle di artigianato e prodotti locali.',
-    canonicalPath: '/articoli-frontaliere/mercatino-primavera-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/mercatino-primavera-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5081,7 +5081,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, uniscono, forze, nella, ricerca',
     ogTitle: 'Italia e Svizzera uniscono le forze nella ricerca',
     ogDescription: 'La nona Giornata della ricerca italiana nel mondo celebrata a Plan-les-Ouates con focus su scienze della salute e innovazione',
-    canonicalPath: '/articoli-frontaliere/italia-svizzera-ricerca-2026',
+    canonicalPath: '/articoli-frontaliere/italia-svizzera-ricerca-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5109,7 +5109,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ricerca, italiana, focus, scienze',
     ogTitle: 'Ricerca italiana in Svizzera: focus su scienze della vita',
     ogDescription: 'Ginevra ospita la Giornata della ricerca italiana nel mondo, con focus su cooperazione scientifica italo-svizzera e opportunità per frontalieri',
-    canonicalPath: '/articoli-frontaliere/ricerca-italiana-ginevra-2026',
+    canonicalPath: '/articoli-frontaliere/ricerca-italiana-ginevra-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5137,7 +5137,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, programma, cooperazione, svizzera-serbia',
     ogTitle: 'Nuovo programma di cooperazione Svizzera-Serbia 2026-29',
     ogDescription: 'Il presidente Guy Parmelin presenta un nuovo programma di cooperazione con la Serbia, con focus su economia e innovazione.',
-    canonicalPath: '/articoli-frontaliere/svizzera-serbia-cooperazione-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-serbia-cooperazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5165,7 +5165,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, finanzia, politica, oltre, milioni',
     ogTitle: 'Chi finanzia la politica svizzera? Oltre 130 milioni in campagne',
     ogDescription: 'Dall’entrata in vigore delle regole sulla trasparenza, oltre 130 milioni di franchi sono stati investiti nelle campagne politiche svizzere.',
-    canonicalPath: '/articoli-frontaliere/chi-finanzia-politica-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/chi-finanzia-politica-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5193,7 +5193,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, accordo, italia-svizzera',
     ogTitle: 'Lago Maggiore: accordo Italia-Svizzera per più acqua in primavera',
     ogDescription: 'Il livello massimo del Lago Maggiore può ora raggiungere 1,40 metri per contrastare la crisi idrica. Scopri di più sull\'accordo Italia-Svizzera.',
-    canonicalPath: '/articoli-frontaliere/accordo-lago-maggiore-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/accordo-lago-maggiore-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5221,7 +5221,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, webinar, sull, azienda, strategia',
     ogTitle: 'Webinar sull\'AI in azienda: strategia e casi concreti',
     ogDescription: 'Il Gruppo Acinque organizza un webinar sull\'uso strategico dell\'AI in azienda, con un focus sui costi di integrazione e sulle opportunità di innovazione.',
-    canonicalPath: '/articoli-frontaliere/webinar-ai-azienda-strategia-casi-concreti',
+    canonicalPath: '/articoli-frontaliere/webinar-ai-azienda-strategia-casi-concreti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5249,7 +5249,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incontri, cambiamenti, climatici, rancio',
     ogTitle: 'Incontri su cambiamenti climatici a Rancio Valcuvia',
     ogDescription: 'La Comunità Montana Valli del Verbano organizza un ciclo di incontri su biodiversità e cambiamenti climatici da aprile a novembre 2026.',
-    canonicalPath: '/articoli-frontaliere/comunita-montana-valli-verbano-incontri-natura-cambia',
+    canonicalPath: '/articoli-frontaliere/comunita-montana-valli-verbano-incontri-natura-cambia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5277,7 +5277,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libera, innalzamento, lago, maggiore',
     ogTitle: 'Via libera all\'innalzamento del Lago Maggiore fino a 1,40 metri',
     ogDescription: 'Decisivo accordo per aumentare la capacità idrica del lago di 20-30 milioni di metri cubi',
-    canonicalPath: '/articoli-frontaliere/innalzamento-lago-maggiore-140-metri',
+    canonicalPath: '/articoli-frontaliere/innalzamento-lago-maggiore-140-metri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5305,7 +5305,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, guardie, svizzere, giureranno',
     ogTitle: '28 nuove guardie svizzere giureranno al Vaticano',
     ogDescription: 'La cerimonia si terrà il 6 maggio nel Cortile di S. Damaso del Palazzo Apostolico alla presenza del Papa e del presidente della Confederazione Guy Parmelin.',
-    canonicalPath: '/articoli-frontaliere/guardie-svizzere-giuramento-vaticano-2026',
+    canonicalPath: '/articoli-frontaliere/guardie-svizzere-giuramento-vaticano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5333,7 +5333,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, apprendistato, inespresso, varese, solo',
     ogTitle: 'Apprendistato inespresso a Varese: solo il 2,7% degli ingressi al lavoro',
     ogDescription: 'Il progetto Tutor Sapiens punta a rafforzare l\'apprendistato di terzo livello in provincia di Varese, con solo il 2,7% degli ingressi al lavoro nel 2025.',
-    canonicalPath: '/articoli-frontaliere/apprendistato-varese-2-7-ingressi-lavoro',
+    canonicalPath: '/articoli-frontaliere/apprendistato-varese-2-7-ingressi-lavoro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5361,7 +5361,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, dell, hockey, aggiornamenti',
     ogTitle: 'Casa dell\'Hockey: novità e aggiornamenti dal Ticino',
     ogDescription: 'Scopri le ultime novità e aggiornamenti dal mondo dell\'hockey ticinese, con un focus sulle squadre di Lugano e Ambrì Piotta.',
-    canonicalPath: '/articoli-frontaliere/casa-hockey-lugano-ambri-2026',
+    canonicalPath: '/articoli-frontaliere/casa-hockey-lugano-ambri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5389,7 +5389,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, stop, vendita, duty-free',
     ogTitle: 'Swiss: stop vendita duty-free a bordo aerei',
     ogDescription: 'Swiss interrompe la vendita di prodotti duty-free a bordo degli aerei da fine settembre 2026. L\'offerta sarà disponibile solo online sul negozio Worldshop di',
-    canonicalPath: '/articoli-frontaliere/swiss-duty-free-cambia-vendite-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-duty-free-cambia-vendite-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5417,7 +5417,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tutor, sapiens, strumenti, apprendistato',
     ogTitle: 'Tutor Sapiens: strumenti per l’apprendistato di terzo livello',
     ogDescription: 'Camera di Commercio e Provincia di Varese presentano i risultati del percorso formativo Tutor Sapiens per favorire l’inserimento dei giovani talenti.',
-    canonicalPath: '/articoli-frontaliere/tutor-sapiens-apprendistato-terzo-livello',
+    canonicalPath: '/articoli-frontaliere/tutor-sapiens-apprendistato-terzo-livello/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5445,7 +5445,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tunnel, milioni, viabilità, lombardia',
     ogTitle: 'Tunnel Tonale: 16,5 milioni per la viabilità in Lombardia',
     ogDescription: 'Scopri il nuovo tunnel da 16,5 milioni al Passo del Tonale: dettagli, tempi e impatto sulla viabilità in Lombardia.',
-    canonicalPath: '/articoli-frontaliere/tunnel-tonale-viabilita-lombardia',
+    canonicalPath: '/articoli-frontaliere/tunnel-tonale-viabilita-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5473,7 +5473,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, torna, spring, giubiasco, sport',
     ogTitle: 'Spring Giubiasco 2026: sport e convivialità dal 13 al 17 maggio',
     ogDescription: 'Dal 13 al 17 maggio 2026, Giubiasco ospita la Spring Giubiasco con gare di corsa, ciclismo, musica e gastronomia per tutte le età.',
-    canonicalPath: '/articoli-frontaliere/spring-giubiasco-sport-convivialita-2026',
+    canonicalPath: '/articoli-frontaliere/spring-giubiasco-sport-convivialita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5501,7 +5501,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carnago, fratelli, attacca, pendolarismo',
     ogTitle: 'Carnago: Fratelli d\'Italia attacca il pendolarismo di Forza Italia',
     ogDescription: 'Analisi dei costi del consigliere di minoranza Fausto Benzi: oltre 2.400 euro di previsione di spesa fino a fine mandato',
-    canonicalPath: '/articoli-frontaliere/carnago-forza-italia-pendolarismo',
+    canonicalPath: '/articoli-frontaliere/carnago-forza-italia-pendolarismo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5529,7 +5529,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, usa-svizzera, nuove, tensioni, prodotti',
     ogTitle: 'USA-Svizzera: nuove tensioni su prodotti biologici e dazi',
     ogDescription: 'Washington critica Berna per le norme agricole e il predominio di Coop e Migros. Nuovi dazi al 10% fino al 2027',
-    canonicalPath: '/articoli-frontaliere/usa-svizzera-frizioni-commerciali-2026',
+    canonicalPath: '/articoli-frontaliere/usa-svizzera-frizioni-commerciali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5557,7 +5557,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, terremoto, controllato, gottardo, cosa',
     ogTitle: 'Terremoto controllato nel Gottardo: implicazioni per i frontalieri',
     ogDescription: 'Ricercatori provocano terremoto controllato nel massiccio del Gottardo. Cosa sappiamo e quali sono le implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/terremoto-gottardo-frontalieri',
+    canonicalPath: '/articoli-frontaliere/terremoto-gottardo-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5585,7 +5585,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, benzina, record, annuale, mesi',
     ogTitle: 'Benzina in Svizzera a record annuale: +13% in 3 mesi',
     ogDescription: 'Il prezzo della benzina in Svizzera ha raggiunto il record annuale a 1,90 CHF/litro. Il diesel è a 2,17 CHF/litro.',
-    canonicalPath: '/articoli-frontaliere/benzina-record-annuale-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/benzina-record-annuale-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5613,7 +5613,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giovane, gambizzato, colpi, arma',
     ogTitle: 'Giovane gambizzato con tre colpi d\'arma da fuoco a Como',
     ogDescription: 'Un 20enne è stato ferito alla gamba con tre colpi d\'arma da fuoco alla periferia di Como. Gli inquirenti indagano sui motivi del gesto.',
-    canonicalPath: '/articoli-frontaliere/giovane-gambizzato-como-2026',
+    canonicalPath: '/articoli-frontaliere/giovane-gambizzato-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5641,7 +5641,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andré, wyss, nuovo, presidente',
     ogTitle: 'André Wyss nuovo presidente FFS: innovazione e stabilità',
     ogDescription: 'André Wyss è il nuovo presidente delle FFS. Scopri le implicazioni per i frontalieri e le nuove opportunità offerte dalle Ferrovie federali svizzere.',
-    canonicalPath: '/articoli-frontaliere/andre-wyss-nuovo-presidente-ffs',
+    canonicalPath: '/articoli-frontaliere/andre-wyss-nuovo-presidente-ffs/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5669,7 +5669,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moncucco, risultati, positivi, 2025',
     ogTitle: 'Moncucco: risultati positivi nel 2025',
     ogDescription: 'Aumento pazienti, fatturato e utile per il gruppo ospedaliero Moncucco. Preoccupazioni per l\'invecchiamento demografico.',
-    canonicalPath: '/articoli-frontaliere/moncucco-risultati-positivi-2025',
+    canonicalPath: '/articoli-frontaliere/moncucco-risultati-positivi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5697,7 +5697,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, verso, conciliabilità, vita-lavoro',
     ogTitle: 'Bellinzona verso conciliabilità vita-lavoro per dipendenti',
     ogDescription: 'Modifica al regolamento per promuovere equilibrio tra vita privata e professionale. Priorità per benessere e attrattività come datore di lavoro.',
-    canonicalPath: '/articoli-frontaliere/bellinzona-datore-lavoro-conciliabilita',
+    canonicalPath: '/articoli-frontaliere/bellinzona-datore-lavoro-conciliabilita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5725,7 +5725,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, anni, conti, positivo',
     ogTitle: 'Mendrisio: 4 anni di conti in positivo',
     ogDescription: 'Mendrisio chiude il 2025 con un avanzo di 0,8 milioni di franchi, segnando il quarto anno consecutivo di risultati positivi',
-    canonicalPath: '/articoli-frontaliere/mendrisio-conti-positivi-2025',
+    canonicalPath: '/articoli-frontaliere/mendrisio-conti-positivi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5753,7 +5753,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, criminalità, organizzata, arresto, funzionario',
     ogTitle: 'Criminalità organizzata in Svizzera: arresto funzionario fedpol',
     ogDescription: 'Un duro colpo per fedpol: arrestato un funzionario per sospetta corruzione. La criminalità organizzata è ben radicata in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/criminalita-organizzata-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/criminalita-organizzata-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5781,7 +5781,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stazioni, sciistiche, ticinesi, criticità',
     ogTitle: 'Stazioni sciistiche ticinesi: criticità e riforma contributi',
     ogDescription: 'Interrogazione parlamentare per rivedere i finanziamenti alle stazioni sciistiche ticinesi, con 5,6 milioni per la manutenzione fino al 2028.',
-    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-contributi-2026',
+    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-contributi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5809,7 +5809,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, karin, keller-sutter, scontro, lobbismo',
     ogTitle: 'UBS e Karin Keller-Sutter: scontro sul lobbismo',
     ogDescription: 'UBS e Karin Keller-Sutter si scontrano sul lobbismo. Ermotti nega pressioni, Matter lo definisce ridicolo. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ubs-keller-sutter-lobbismo-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-keller-sutter-lobbismo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5837,7 +5837,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, daverio, pazienti, spostano, gazzada',
     ogTitle: 'Daverio: i pazienti si spostano a Gazzada, cambia l\'assistenza sanitaria',
     ogDescription: 'I circa 400 cittadini di Daverio senza medico di base verranno trasferiti alla Casa di Comunità di Gazzada per un\'assistenza più integrata.',
-    canonicalPath: '/articoli-frontaliere/daverio-gazzada-assistenza-medica-2026',
+    canonicalPath: '/articoli-frontaliere/daverio-gazzada-assistenza-medica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5865,7 +5865,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trivella, raggiunge, zona, faglia',
     ogTitle: 'Trivella raggiunge zona di faglia al San Gottardo',
     ogDescription: 'La fresa meccanica \'Alessandra\' ha completato un traguardo cruciale nella costruzione della seconda galleria del tunnel stradale del San Gottardo.',
-    canonicalPath: '/articoli-frontaliere/trivella-san-gottardo-zona-faglia',
+    canonicalPath: '/articoli-frontaliere/trivella-san-gottardo-zona-faglia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5893,7 +5893,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, ambulatori, medici, temporanei',
     ogTitle: 'Varese: ambulatori medici temporanei per oltre 5000 cittadini',
     ogDescription: 'Dal 1° maggio 2026, quattro ambulatori medici temporanei in Varese servono oltre 5000 cittadini senza medico curante.',
-    canonicalPath: '/articoli-frontaliere/ambulatori-medici-temporanei-varese-2026',
+    canonicalPath: '/articoli-frontaliere/ambulatori-medici-temporanei-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5921,7 +5921,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, copernicus, europa, temperature, sopra',
     ogTitle: 'Copernicus: 95% Europa con temperature sopra media nel 2025',
     ogDescription: 'Ondate di calore record in Scandinavia, ghiacciai in calo e incendi boschivi estesi. Ecco i dati chiave del rapporto Copernicus 2025.',
-    canonicalPath: '/articoli-frontaliere/copernicus-clima-2025-europa',
+    canonicalPath: '/articoli-frontaliere/copernicus-clima-2025-europa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5949,7 +5949,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, credinvest, bank, cresce, utili',
     ogTitle: 'Credinvest Bank cresce: utili in aumento e spinta su innovazione',
     ogDescription: 'Credinvest Bank chiude il 2025 con ricavi a 22,80 milioni e utile lordo a 4,93 milioni, investendo in tecnologia e talenti.',
-    canonicalPath: '/articoli-frontaliere/credinvest-bank-crescita-2026',
+    canonicalPath: '/articoli-frontaliere/credinvest-bank-crescita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5977,7 +5977,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, costi, aggiuntivi, approvata',
     ogTitle: 'Riforma frontalieri: costi aggiuntivi per la Svizzera?',
     ogDescription: 'Approvata la riforma UE sull\'assicurazione disoccupazione per i frontalieri. Cosa cambia per la Svizzera?',
-    canonicalPath: '/articoli-frontaliere/riforma-frontalieri-costi-svizzera',
+    canonicalPath: '/articoli-frontaliere/riforma-frontalieri-costi-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6005,7 +6005,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, conciliabilità, vita-lavoro, mozione',
     ogTitle: 'Conciliabilità vita-lavoro Bellinzona 2026',
     ogDescription: 'La mozione per inserire il principio di conciliabilità vita-lavoro nel Rod di Bellinzona e le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/conciliabilita-vita-lavoro-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/conciliabilita-vita-lavoro-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6033,7 +6033,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, anni, carcere, richiesti',
     ogTitle: 'Chiasso: 15 anni di carcere richiesti per tentativo di omicidio',
     ogDescription: 'Il processo a un 34enne per aver aggredito la compagna con attrezzi ginnici il 20 gennaio 2024',
-    canonicalPath: '/articoli-frontaliere/chiasso-assassinio-mancato-15-anni-carcere',
+    canonicalPath: '/articoli-frontaliere/chiasso-assassinio-mancato-15-anni-carcere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6061,7 +6061,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lite, alla, dogana, ponte',
     ogTitle: 'Lite alla dogana di Ponte Chiasso: un ferito, un contuso',
     ogDescription: 'Un incidente alla dogana di Ponte Chiasso ha coinvolto due persone, lasciando un ferito e un contuso. Ecco cosa è successo e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lite-dogana-ponte-chiasso-ferito-contuso',
+    canonicalPath: '/articoli-frontaliere/lite-dogana-ponte-chiasso-ferito-contuso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6089,7 +6089,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intesa, sanpaolo, premia, imprese',
     ogTitle: 'Intesa Sanpaolo premia 10 imprese vincenti: tra queste Lati di Vedano e Pizval di Somma',
     ogDescription: 'Varese prima in Lombardia nel 2025 per crescita di esportazioni. Le due aziende premiate per eccellenza in plastica e moda.',
-    canonicalPath: '/articoli-frontaliere/intesa-sanpaolo-premia-10-imprese-vincenti',
+    canonicalPath: '/articoli-frontaliere/intesa-sanpaolo-premia-10-imprese-vincenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6117,7 +6117,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pillola, giorno, dopo, senza',
     ogTitle: 'Pillola giorno dopo senza consulenza, il Nazionale dice sì',
     ogDescription: 'Il Consiglio nazionale approva mozione per declassare contraccettivi d\'emergenza, rendendoli accessibili senza colloquio obbligatorio.',
-    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-consulenza-nazionale',
+    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-consulenza-nazionale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6145,7 +6145,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sindaci, italiani, contro, innalzamento',
     ogTitle: 'Sindaci italiani contro l\'innalzamento del lago Maggiore',
     ogDescription: 'I sindaci di Verbania, Baveno e Cannobio criticano la decisione di aumentare il livello massimo del lago Maggiore a 1,40 metri.',
-    canonicalPath: '/articoli-frontaliere/sindaci-verbania-baveno-cannobio-opposizione',
+    canonicalPath: '/articoli-frontaliere/sindaci-verbania-baveno-cannobio-opposizione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6173,7 +6173,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, chiude, 2025, quarto',
     ogTitle: 'Mendrisio chiude il 2025 con il quarto bilancio positivo',
     ogDescription: 'Mendrisio annuncia un quarto risultato finanziario positivo consecutivo nel 2025, nonostante le incertezze geopolitiche.',
-    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025',
+    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6201,7 +6201,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tenero, inaugurato, terzo, frigo',
     ogTitle: 'Tenero, terzo frigo anti-spreco inaugurato',
     ogDescription: 'Il 28 aprile 2026 è stato inaugurato a Tenero, in Ticino, il terzo frigo pubblico anti-spreco alimentare promosso dall\'associazione Madame Frigo.',
-    canonicalPath: '/articoli-frontaliere/terzo-frigo-tenero-anti-spreco',
+    canonicalPath: '/articoli-frontaliere/terzo-frigo-tenero-anti-spreco/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6229,7 +6229,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, pagherà, stato, dove',
     ogTitle: 'Frontalieri, la disoccupazione la pagherà lo Stato dove lavoravano',
     ogDescription: 'Riforma UE approvata: cambiamenti significativi per i frontalieri in Svizzera. Ecco cosa cambia e cosa fare',
-    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-stato-lavoro',
+    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-stato-lavoro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6257,7 +6257,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estate, openjobmetis, offre, oltre',
     ogTitle: 'Estate 2026: Openjobmetis offre oltre 2000 opportunità lavorative in Italia',
     ogDescription: 'Openjobmetis registra oltre 2000 posizioni aperte in Italia per l\'estate 2026, con forte domanda nel turismo e nella produzione',
-    canonicalPath: '/articoli-frontaliere/lavoro-openjobmetis-2026-opportunita',
+    canonicalPath: '/articoli-frontaliere/lavoro-openjobmetis-2026-opportunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6285,7 +6285,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, openjobmetis, materia, sportello, ascolto',
     ogTitle: 'Openjobmetis a Materia: sportello di ascolto e orientamento ogni giovedì',
     ogDescription: 'Ogni giovedì pomeriggio, lo sportello Openjobmetis a Materia offre supporto e orientamento per chi cerca lavoro nella provincia di Varese.',
-    canonicalPath: '/articoli-frontaliere/openjobmetis-materia-castronno-2026',
+    canonicalPath: '/articoli-frontaliere/openjobmetis-materia-castronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6313,7 +6313,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, variante, vaiolo, scimmie',
     ogTitle: 'Nuova variante vaiolo scimmie predominante in Svizzera',
     ogDescription: 'La nuova variante di vaiolo delle scimmie è diventata predominante in Svizzera con 32 casi segnalati dall\'inizio dell\'anno, di cui 19 di clade Ib.',
-    canonicalPath: '/articoli-frontaliere/vaiolo-delle-scimmie-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/vaiolo-delle-scimmie-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6341,7 +6341,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maroggia, posta, domicilio, 2024',
     ogTitle: 'Maroggia, la Posta a domicilio dal 2024',
     ogDescription: 'Dal settembre 2024, i residenti di Maroggia potranno usufruire del servizio postale a domicilio in attesa della nuova filiale prevista per il 2027.',
-    canonicalPath: '/articoli-frontaliere/maroggia-postale-domestico-2024',
+    canonicalPath: '/articoli-frontaliere/maroggia-postale-domestico-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6369,7 +6369,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, convegno, milano, sulla, cooperazione',
     ogTitle: 'Convegno Milano mafia Italia Svizzera 2026',
     ogDescription: 'Convegno a Milano sulla cooperazione Italia-Svizzera contro la mafia con Fiorenza Bergomi, giudice del Tribunale penale federale',
-    canonicalPath: '/articoli-frontaliere/convegno-milano-mafia-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/convegno-milano-mafia-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6397,7 +6397,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gruppo, moncucco, 2025, 120mila',
     ogTitle: 'Gruppo Moncucco: 2025 con 120mila ospedalizzazioni e 187 milioni di fatturato',
     ogDescription: 'Il Gruppo Moncucco chiude il 2025 con 120mila ospedalizzazioni e un fatturato di 187 milioni, puntando sulla formazione del personale.',
-    canonicalPath: '/articoli-frontaliere/gruppo-moncucco-2025-risultati',
+    canonicalPath: '/articoli-frontaliere/gruppo-moncucco-2025-risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6425,7 +6425,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, distretto, benessere, ombra, campo',
     ogTitle: 'Distretto del benessere: 2% dei contribuenti ha il 15% del reddito',
     ogDescription: 'Scopri come il 2% dei contribuenti detiene il 15% del reddito nei comuni della collina varesina. Analisi e implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/distretto-benessere-campo-fiori-2026',
+    canonicalPath: '/articoli-frontaliere/distretto-benessere-campo-fiori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6453,7 +6453,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedale, circolo, varese, chiusure',
     ogTitle: 'Chiusure Ospedale Circolo Varese 1° maggio e San Vittore 2026',
     ogDescription: 'Modifiche agli orari dei servizi sanitari per il ponte del 1° maggio e la festività di San Vittore a Varese. Scopri cosa cambia e come organizzarti.',
-    canonicalPath: '/articoli-frontaliere/chiusure-ospedale-circolo-varese-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-ospedale-circolo-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6481,7 +6481,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, overtourism, lucerna, grindelwald, collasso',
     ogTitle: 'Overtourism in Svizzera: Lucerna e Grindelwald al collasso',
     ogDescription: 'Lucerna supera Venezia in pernottamenti turistici. Iniziativa per bloccare nuovi hotel e restrizioni su Airbnb in Ticino, Zurigo, Lucerna e Ginevra.',
-    canonicalPath: '/articoli-frontaliere/svizzera-overtourism-lucerna-grindelwald',
+    canonicalPath: '/articoli-frontaliere/svizzera-overtourism-lucerna-grindelwald/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6509,7 +6509,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alluvione, lavizzara, approvato, piano',
     ogTitle: 'Alluvione Lavizzara: piano zone pericolo approvato',
     ogDescription: 'Il Consiglio di Stato ticinese ha approvato il piano delle zone di pericolo per Lavizzara dopo l\'alluvione del 29-30 giugno 2024',
-    canonicalPath: '/articoli-frontaliere/alluvione-lavizzara-piano-pericoli-approvato',
+    canonicalPath: '/articoli-frontaliere/alluvione-lavizzara-piano-pericoli-approvato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6537,7 +6537,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bedretto, microterremoti, indotti, studiare',
     ogTitle: 'Bedretto Lab: microterremoti indotti per studiare le faglie',
     ogDescription: 'Ricercatori del Politecnico di Zurigo indotti microterremoti in Val Bedretto per studiare il comportamento delle faglie',
-    canonicalPath: '/articoli-frontaliere/bedretto-lab-microterremoti-ricerca',
+    canonicalPath: '/articoli-frontaliere/bedretto-lab-microterremoti-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6565,7 +6565,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, micro, terremoto, controllato, successo',
     ogTitle: 'Micro terremoto controllato in Ticino: un successo per il test',
     ogDescription: 'Ricercatori provocano un sisma nel massiccio del Gottardo. Scosse registrate ma non percepibili in superficie.',
-    canonicalPath: '/articoli-frontaliere/microterremoto-ticino-successo-test',
+    canonicalPath: '/articoli-frontaliere/microterremoto-ticino-successo-test/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6593,7 +6593,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, famiglie, lugano, condivisione',
     ogTitle: 'Festa delle famiglie a Lugano: condivisione e inclusione',
     ogDescription: 'Domenica 26 aprile 2026, il Rotary Club Lugano-Lago e l\'Associazione Amélie hanno organizzato una giornata di condivisione e inclusione per famiglie.',
-    canonicalPath: '/articoli-frontaliere/festa-famiglie-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/festa-famiglie-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6621,7 +6621,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stop, milioni, alle, casse',
     ogTitle: 'Stop ai milioni delle casse malati ai club sportivi: Il Nazionale approva la mozione di Quadri',
     ogDescription: 'Il Consiglio nazionale approva la mozione di Lorenzo Quadri per limitare le sponsorizzazioni delle casse malati ai grandi club sportivi.',
-    canonicalPath: '/articoli-frontaliere/stop-milioni-casse-malati-club-sportivi',
+    canonicalPath: '/articoli-frontaliere/stop-milioni-casse-malati-club-sportivi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6649,7 +6649,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, delusi, dalla, guadagna, poco',
     ogTitle: 'Delusi dalla Svizzera: chi guadagna poco si sente abbandonato',
     ogDescription: 'Un sondaggio rivela che oltre la metà della popolazione svizzera considera il sistema ingiusto, con chi guadagna meno che si sente trattato peggio',
-    canonicalPath: '/articoli-frontaliere/delusi-svizzera-frontalieri-abbandonati',
+    canonicalPath: '/articoli-frontaliere/delusi-svizzera-frontalieri-abbandonati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6677,7 +6677,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, separazioni, rete, supporto, genitori',
     ogTitle: 'Separazioni in Ticino: rete di supporto e guida per genitori',
     ogDescription: 'FaMo+ celebra 40 anni con una nuova guida per famiglie in fase di separazione. Approccio di rete e tavola rotonda a Bellinzona.',
-    canonicalPath: '/articoli-frontaliere/separazioni-ticino-famiglie-monoparentali',
+    canonicalPath: '/articoli-frontaliere/separazioni-ticino-famiglie-monoparentali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6705,7 +6705,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dichiarazione, precompilata, disponibile, oggi',
     ogTitle: 'Dichiarazione precompilata 2026: disponibile da oggi',
     ogDescription: 'Dal 30 aprile 2026 è disponibile la dichiarazione precompilata 2026 per tutti i contribuenti italiani. Ecco cosa cambia.',
-    canonicalPath: '/articoli-frontaliere/dichiarazione-precompilata-2026-disponibile',
+    canonicalPath: '/articoli-frontaliere/dichiarazione-precompilata-2026-disponibile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6733,7 +6733,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gruppo, moncucco, utile, raddoppiato',
     ogTitle: 'Gruppo Moncucco: utile raddoppiato e stipendi aumentati',
     ogDescription: 'Il Gruppo ospedaliero Moncucco chiude il 2025 con un utile di 5,3 milioni di franchi e adeguamenti salariali per i dipendenti',
-    canonicalPath: '/articoli-frontaliere/moncucco-utile-raddoppiato-2026',
+    canonicalPath: '/articoli-frontaliere/moncucco-utile-raddoppiato-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6761,7 +6761,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, domenica, natura, spazio, centro',
     ogTitle: 'Una domenica tra natura e spazio al Centro Didattico Scientifico di Tradate',
     ogDescription: 'Domenica 31 maggio 2026, dalle 14.30 alle 18.00, il Centro Didattico Scientifico di Tradate offre attività tra natura e spazio.',
-    canonicalPath: '/articoli-frontaliere/domenica-natura-spazio-tradate-2026',
+    canonicalPath: '/articoli-frontaliere/domenica-natura-spazio-tradate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6789,7 +6789,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, libera, innalzamento',
     ogTitle: 'Lago Maggiore, via libera all’innalzamento: 20-30 milioni di metri cubi in più',
     ogDescription: 'La decisione aumenterà la disponibilità di acqua di 20-30 milioni di metri cubi. Accordo Italia-Svizzera per l’innalzamento di 15 cm.',
-    canonicalPath: '/articoli-frontaliere/lago-maggiore-innalzamento-2026',
+    canonicalPath: '/articoli-frontaliere/lago-maggiore-innalzamento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6817,7 +6817,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, criticano, regole, duopolio, migros-coop',
     ogTitle: 'USA criticano Svizzera per regole bio e duopolio Migros-Coop',
     ogDescription: 'Norme agricole e predominio di Coop e Migros al centro delle critiche statunitensi. Deficit commerciale in calo, ma tensioni persistono.',
-    canonicalPath: '/articoli-frontaliere/usa-critica-svizzera-bio-duopolio',
+    canonicalPath: '/articoli-frontaliere/usa-critica-svizzera-bio-duopolio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6845,7 +6845,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bollette, novità, consumatori, giugno',
     ogTitle: 'Dl Bollette: novità per i consumatori dal 19 giugno 2026',
     ogDescription: 'Novità per i consumatori: dal 19 giugno 2026 nuove regole su telemarketing e contratti luce-gas. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/dl-bollette-novita-consumatori-2026',
+    canonicalPath: '/articoli-frontaliere/dl-bollette-novita-consumatori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6873,7 +6873,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bonus, sicurezza, ottenere, scopri',
     ogTitle: 'Bonus sicurezza 2026: spese detraibili e come ottenere fino al 50%',
     ogDescription: 'Scopri quali spese per la sicurezza domestica sono detraibili nel 2026 e come evitare errori comuni per ottenere fino al 50% di detrazione.',
-    canonicalPath: '/articoli-frontaliere/bonus-sicurezza-2026-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/bonus-sicurezza-2026-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6901,7 +6901,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, palma, muralto, rinnova, punta',
     ogTitle: 'La Palma di Muralto rinnovata e aperta tutto l\'anno',
     ogDescription: 'L\'hotel La Palma di Muralto ha completato un rinnovamento da 12,7 milioni di franchi e cambia strategia, restando aperto tutto l\'anno.',
-    canonicalPath: '/articoli-frontaliere/palma-muralto-ristrutturazione-strategia-2024',
+    canonicalPath: '/articoli-frontaliere/palma-muralto-ristrutturazione-strategia-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6929,7 +6929,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, insubria, olona, proteggere, ambiente',
     ogTitle: 'GEV Insubria Olona: protezione ambientale in Ticino',
     ogDescription: 'Scopri come le Guardie Ecologiche Volontarie Insubria Olona proteggono l’ambiente in Ticino e offrono opportunità di volontariato',
-    canonicalPath: '/articoli-frontaliere/gev-ticino-ambiente-2026',
+    canonicalPath: '/articoli-frontaliere/gev-ticino-ambiente-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6957,7 +6957,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siccità, lombardia, mancano, riserve',
     ogTitle: 'Siccità in Lombardia: mancano il 37% delle riserve idriche',
     ogDescription: 'Regione Lombardia chiede un uso contenuto dell\'acqua. Accordo tra Piemonte, Lombardia e Canton Ticino per aumentare la disponibilità del Lago Maggiore.',
-    canonicalPath: '/articoli-frontaliere/siccita-lombardia-riserve-idriche-2026',
+    canonicalPath: '/articoli-frontaliere/siccita-lombardia-riserve-idriche-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6985,7 +6985,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, powell, tassi, invariati',
     ogTitle: 'Fed: l\'addio di Powell a tassi invariati',
     ogDescription: 'Jerome Powell lascia la Federal Reserve rivendicando l\'indipendenza dell\'istituzione, mentre i tassi restano tra il 3,50% e il 3,75%.',
-    canonicalPath: '/articoli-frontaliere/fed-powell-addio-tassi-invariati',
+    canonicalPath: '/articoli-frontaliere/fed-powell-addio-tassi-invariati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7013,7 +7013,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, utile, oltre, miliardi, istituto',
     ogTitle: 'UBS, utile oltre i 3 miliardi nel 2026',
     ogDescription: 'UBS registra un utile netto di 3,04 miliardi di dollari nel primo trimestre 2026, superando le aspettative e confermando la propria leadership nel settore',
-    canonicalPath: '/articoli-frontaliere/ubs-utile-3-miliardi-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-utile-3-miliardi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7041,7 +7041,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borse, europee, calo, timori',
     ogTitle: 'Borse europee in calo, timori dalle trimestrali',
     ogDescription: 'Analisi delle flessioni delle Borse europee e impatti per i frontalieri. Zurigo ansima ma poi fa quasi pari.',
-    canonicalPath: '/articoli-frontaliere/borse-europee-zurigo-trimestrali',
+    canonicalPath: '/articoli-frontaliere/borse-europee-zurigo-trimestrali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7069,7 +7069,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, supsi, nomina, nuovi, professori',
     ogTitle: 'SUPSI nomina 20 nuovi professori e professoresse',
     ogDescription: 'La cerimonia di conferimento si è tenuta a Mendrisio il 28 aprile 2026. Assegnate anche 12 nomine a senior.',
-    canonicalPath: '/articoli-frontaliere/supsi-20-nuovi-professori-2026',
+    canonicalPath: '/articoli-frontaliere/supsi-20-nuovi-professori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7097,7 +7097,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morto, italiano, incidente, e-bike',
     ogTitle: 'Incidente e-bike nel Canton Bern: morto italiano',
     ogDescription: 'Tragico incidente a Bätterkinden, nel Canton Bern, il 28 aprile 2026: un uomo di 60 anni ha perso la vita in seguito a una caduta dalla bici elettrica.',
-    canonicalPath: '/articoli-frontaliere/italian-e-bike-tragedy-bern',
+    canonicalPath: '/articoli-frontaliere/italian-e-bike-tragedy-bern/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7125,7 +7125,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, sessuale, conseguenze, sono',
     ogTitle: 'Violenza sessuale, le conseguenze sono tante e durature',
     ogDescription: 'Un nuovo studio romando ha dimostrato che le conseguenze di un\'aggressione sessuale sono indelebili e persistono per mesi con alti tassi di depressione, ansia e',
-    canonicalPath: '/articoli-frontaliere/violenza-sessuale-conseguenze-ticino',
+    canonicalPath: '/articoli-frontaliere/violenza-sessuale-conseguenze-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7153,7 +7153,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, chiude, 2025, avanzo',
     ogTitle: 'Mendrisio chiude 2025 con avanzo di 800mila franchi',
     ogDescription: 'Per il quarto anno consecutivo, Mendrisio presenta un bilancio positivo con un avanzo di 800mila franchi, nonostante un preventivo in rosso.',
-    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025-analisi',
+    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025-analisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7181,7 +7181,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, utile, record, grazie, integrazione',
     ogTitle: 'UBS: utile record grazie all\'integrazione di Credit Suisse',
     ogDescription: 'UBS chiude il primo trimestre 2026 con un utile netto di 3,04 miliardi di dollari, grazie all\'integrazione di Credit Suisse',
-    canonicalPath: '/articoli-frontaliere/ubs-credit-suisse-integrazione-risultati-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-credit-suisse-integrazione-risultati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7209,7 +7209,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, diventa, digitale, visita',
     ogTitle: 'Varese diventa digitale: visita la città in 3D con un click',
     ogDescription: 'Scopri come esplorare Varese in 3D grazie al nuovo portale Varesedigitale.it. Visita la città virtualmente e scopri i suoi luoghi simbolo.',
-    canonicalPath: '/articoli-frontaliere/varese-digitale-3d-visita',
+    canonicalPath: '/articoli-frontaliere/varese-digitale-3d-visita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7237,7 +7237,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, detiene, ricchezza, scoperte',
     ogTitle: 'Varese: il 2% detiene il 15% della ricchezza',
     ogDescription: 'Scoperte sulla concentrazione di ricchezza nel Varesotto e decisioni su Lago Maggiore per l\'estate 2026',
-    canonicalPath: '/articoli-frontaliere/varesotto-paperoni-lago-maggiore-2026',
+    canonicalPath: '/articoli-frontaliere/varesotto-paperoni-lago-maggiore-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7265,7 +7265,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, finanzia, ricerca, insubria',
     ogTitle: 'Regione Lombardia finanzia l\'Università dell\'Insubria con 4,4 milioni per la ricerca',
     ogDescription: 'Regione Lombardia ha assegnato 4,4 milioni di euro all\'Università dell\'Insubria per nuove infrastrutture di ricerca a Varese, Como e Busto Arsizio.',
-    canonicalPath: '/articoli-frontaliere/regione-lombardia-4-4-milioni-insubria',
+    canonicalPath: '/articoli-frontaliere/regione-lombardia-4-4-milioni-insubria/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7293,7 +7293,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luve, sigla, accordo, milioni',
     ogTitle: 'LUVE sigla accordo da 100 milioni con hyperscaler globale',
     ogDescription: 'LUVE, azienda varesina specializzata in sistemi di raffreddamento industriale, firma accordo da oltre 100 milioni con hyperscaler globale per data center ad',
-    canonicalPath: '/articoli-frontaliere/luve-hyperscaler-ai-accordo-100-milioni',
+    canonicalPath: '/articoli-frontaliere/luve-hyperscaler-ai-accordo-100-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7321,7 +7321,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, social, media, lavoro, cosa',
     ogTitle: 'Social media e lavoro: cosa evitare e cosa postare',
     ogDescription: 'Un esperto spiega quali contenuti sui social possono compromettere la carriera dei frontalieri in Ticino',
-    canonicalPath: '/articoli-frontaliere/social-media-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/social-media-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7349,7 +7349,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stazioni, sciistiche, prossimo, credito',
     ogTitle: 'Stazioni sciistiche Ticino: più dati per il prossimo credito',
     ogDescription: 'Interrogazione parlamentare chiede bilancio stagionale e nuovi criteri per valutare le stazioni sciistiche ticinesi',
-    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-credito-dati-2026',
+    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-credito-dati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7377,7 +7377,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavori, notturni, clemente, maraini',
     ogTitle: 'Lavori notturni su via Clemente Maraini a Lugano',
     ogDescription: 'Da domenica 3 maggio a venerdì 22 maggio, lavori notturni su via Clemente Maraini a Lugano per estensione e potenziamento delle sottostrutture AIL.',
-    canonicalPath: '/articoli-frontaliere/lavori-notturni-via-clemente-maraini',
+    canonicalPath: '/articoli-frontaliere/lavori-notturni-via-clemente-maraini/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7405,7 +7405,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parcheggi, viabilità, ospedale, circolo',
     ogTitle: 'Parcheggi e viabilità all’Ospedale di Circolo: confronto costruttivo',
     ogDescription: 'Incontro tra Asst Sette Laghi, Comune di Varese e sindacati per migliorare parcheggi e viabilità all’Ospedale di Circolo.',
-    canonicalPath: '/articoli-frontaliere/parcheggi-ospedale-circolo-varese-2026',
+    canonicalPath: '/articoli-frontaliere/parcheggi-ospedale-circolo-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7433,7 +7433,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mani, pulite, vite, salvate',
     ogTitle: 'Mani pulite, vite salvate: l\'iniziativa di ASST Sette Laghi',
     ogDescription: 'Test pratici per l\'igiene delle mani negli ospedali e case di comunità del Canton Ticino il 5 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/mani-pulite-vite-salvate-asst-iniziativa',
+    canonicalPath: '/articoli-frontaliere/mani-pulite-vite-salvate-asst-iniziativa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7461,7 +7461,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, manager, insubria, rasizza, battioni',
     ogTitle: 'Manager all’Insubria: Rasizza e Battioni in cattedra il 4 maggio',
     ogDescription: 'Rosario Rasizza e Stefano Battioni incontrano gli studenti dell’Università dell’Insubria per discutere di gestione d’impresa e cambiamenti tecnologici.',
-    canonicalPath: '/articoli-frontaliere/manager-insubria-rasizza-battioni-4-maggio',
+    canonicalPath: '/articoli-frontaliere/manager-insubria-rasizza-battioni-4-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7489,7 +7489,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, convegno, liuc, etica, responsabilità',
     ogTitle: 'Convegno LIUC: etica e responsabilità nel lavoro',
     ogDescription: 'Venerdì 8 maggio convegno alla LIUC su etica e responsabilità nel lavoro con UCID. Intervengono il card. Angelo Bagnasco e il vescovo di Lodi.',
-    canonicalPath: '/articoli-frontaliere/lavoro-etico-convegno-liuc-ucid',
+    canonicalPath: '/articoli-frontaliere/lavoro-etico-convegno-liuc-ucid/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7517,7 +7517,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, eremo, monastero, lago',
     ogTitle: '1° maggio tra Eremo e Monastero sul Lago Maggiore e in Valle Olona',
     ogDescription: 'Visite guidate e picnic per la Festa dei Lavoratori all\'Eremo di Santa Caterina del Sasso e al Monastero di Torba il 1° maggio 2026',
-    canonicalPath: '/articoli-frontaliere/1maggio-eremo-monastero-legge-varese',
+    canonicalPath: '/articoli-frontaliere/1maggio-eremo-monastero-legge-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7545,7 +7545,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vergiate, colora, torna, color',
     ogTitle: 'Color Run Vergiate 2026: corsa non competitiva per tutte le età',
     ogDescription: 'Scopri la Color Run di Vergiate 2026, una corsa non competitiva di 4 km aperta a tutte le età. Iscrizioni aperte fino al 10 maggio.',
-    canonicalPath: '/articoli-frontaliere/vergiate-color-run-2026-non-competitiva',
+    canonicalPath: '/articoli-frontaliere/vergiate-color-run-2026-non-competitiva/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7573,7 +7573,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gemellaggio, ticino-gaza, mostra, viganello',
     ogTitle: 'Mostra gemellaggio studenti Ticino Gaza | Frontaliere Ticino',
     ogDescription: 'Scopri la mostra sul gemellaggio tra studenti ticinesi e di Gaza a Viganello. Un progetto di Future in Peace per l\'educazione ai diritti umani.',
-    canonicalPath: '/articoli-frontaliere/due-scuole-due-mondi-un-solo-legame',
+    canonicalPath: '/articoli-frontaliere/due-scuole-due-mondi-un-solo-legame/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7601,7 +7601,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, camion, incastrato, grantola, strada',
     ogTitle: 'Camion incastrato a Grantola: strada bloccata in attesa dell\'autogru',
     ogDescription: 'I vigili del fuoco intervengono per liberare un camion bloccato su un tornante a Grantola, causando interruzioni al traffico.',
-    canonicalPath: '/articoli-frontaliere/camion-incastrato-grantola-2026',
+    canonicalPath: '/articoli-frontaliere/camion-incastrato-grantola-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7629,7 +7629,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vedano, olona, sindaco, denuncia',
     ogTitle: 'Vedano Olona, sindaco scrive ad ASST: «Servizio medici instabile, servono garanzie»',
     ogDescription: 'Il sindaco di Vedano Olona, Sergio Mina, denuncia l\'instabilità del servizio di medicina generale e chiede interventi urgenti per garantire assistenza ai',
-    canonicalPath: '/articoli-frontaliere/vedano-olona-medici-servizio-instabile',
+    canonicalPath: '/articoli-frontaliere/vedano-olona-medici-servizio-instabile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7657,7 +7657,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elmec, innovation, summit, cybersecurity',
     ogTitle: 'Elmec Innovation Summit 2026: AI, Cybersecurity e Infrastrutture IT a Brunello',
     ogDescription: 'Il 14 maggio 2026 torna a Brunello l\'Elmec Innovation Summit, un evento dedicato all\'innovazione IT con workshop, esperienze tecnologiche e confronto su AI',
-    canonicalPath: '/articoli-frontaliere/elmec-innovation-summit-brunello-2026',
+    canonicalPath: '/articoli-frontaliere/elmec-innovation-summit-brunello-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7685,7 +7685,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scuola, austriaca, protagonista, plan',
     ogTitle: 'Scuola austriaca protagonista al Plan ₿ Forum di Lugano',
     ogDescription: 'Saifedean Ammous, Rahim Taghizadegan e Knut Svanholm hanno discusso le radici intellettuali di Bitcoin al Plan ₿ Forum di Lugano.',
-    canonicalPath: '/articoli-frontaliere/scuola-austriaca-bitcoin-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/scuola-austriaca-bitcoin-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7713,7 +7713,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, domus, donato, autonomia, sicura',
     ogTitle: 'Domus San Donato: autonomia sicura per la terza età',
     ogDescription: 'Nuovi appartamenti protetti per anziani a Domus San Donato, realizzati nell\'ex stabile delle Suore. Libertà e servizi assistiti',
-    canonicalPath: '/articoli-frontaliere/domus-san-donato-autonomia-terza-eta',
+    canonicalPath: '/articoli-frontaliere/domus-san-donato-autonomia-terza-eta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7741,7 +7741,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moda, sostenibile, storie, rinascita',
     ogTitle: 'Moda sostenibile e storie di rinascita a Varese',
     ogDescription: 'Scopri come studenti e donne oncologiche hanno unito le forze per una sfilata di moda sostenibile a Varese, con abiti riciclati e messaggi di resilienza.',
-    canonicalPath: '/articoli-frontaliere/moda-sostenibile-varese-2026',
+    canonicalPath: '/articoli-frontaliere/moda-sostenibile-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7769,7 +7769,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sciopero, fame, varese, battaglia',
     ogTitle: 'Sciopero della fame a Varese: la battaglia di Timoc per un terreno conteso',
     ogDescription: 'Timoc, 70 anni, protesta davanti alla caserma dei Carabinieri per accedere a documenti bloccati nella sua abitazione.',
-    canonicalPath: '/articoli-frontaliere/sciopero-fame-timoc-terreno-conteso',
+    canonicalPath: '/articoli-frontaliere/sciopero-fame-timoc-terreno-conteso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7797,7 +7797,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ispra, successo, secondo, pranzo',
     ogTitle: 'Ispra: successo al secondo pranzo solidale in oratorio',
     ogDescription: 'Grande partecipazione a Ispra per il pranzo solidale organizzato dalla Comunità pastorale e dall\'Associazione Volontari ispresi.',
-    canonicalPath: '/articoli-frontaliere/ispra-pranzo-solidale-oratorio-2026',
+    canonicalPath: '/articoli-frontaliere/ispra-pranzo-solidale-oratorio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7825,7 +7825,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malpensa, milioni, contanti, sequestrati',
     ogTitle: 'Malpensa: 6 milioni in contanti sequestrati in 3 mesi',
     ogDescription: 'Controlli della Guardia di Finanza e Dogane rivelano violazioni per oltre 6 milioni di euro in contanti non dichiarati.',
-    canonicalPath: '/articoli-frontaliere/malpensa-contanti-sequestri-370mila-euro',
+    canonicalPath: '/articoli-frontaliere/malpensa-contanti-sequestri-370mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7853,7 +7853,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, stretta, permessi, dopo',
     ogTitle: 'Grigioni, stretta sui permessi dopo infiltrazione mafiosa',
     ogDescription: 'Nuove regole per i permessi di dimora in Grigioni dopo arresti legati alla camorra e \'ndrangheta a Roveredo',
-    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-mafia-roveredo',
+    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-mafia-roveredo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7881,7 +7881,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, intenso, ritardi, oltre',
     ogTitle: 'A2: traffico intenso e ritardi oltre l\'ora',
     ogDescription: 'Restringimento a una corsia sulla A2 causa ritardi fino a 100 minuti tra Chiasso e Grancia. Polizia presente per controlli.',
-    canonicalPath: '/articoli-frontaliere/restringimento-a2-ritardi-2026',
+    canonicalPath: '/articoli-frontaliere/restringimento-a2-ritardi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7909,7 +7909,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, repressione, cinese, criticano, berna',
     ogTitle: 'Repressione cinese in Svizzera: ONG criticano Berna',
     ogDescription: 'ONG denunciano la mancanza di misure concrete per proteggere tibetani e uiguri in Svizzera nonostante il riconoscimento della repressione transnazionale',
-    canonicalPath: '/articoli-frontaliere/repressione-cinese-svizzera-ong-critiche',
+    canonicalPath: '/articoli-frontaliere/repressione-cinese-svizzera-ong-critiche/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7937,7 +7937,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, verso, lugano, traffico, intenso',
     ogTitle: 'Traffico intenso A2 Lugano: ritardi fino a 1h30',
     ogDescription: 'Traffico intenso sull’A2 verso Lugano, con ritardi fino a un’ora e trenta. Scopri le cause e le alternative per evitare i disagi.',
-    canonicalPath: '/articoli-frontaliere/traffico-intenso-a2-lugano-ritardi',
+    canonicalPath: '/articoli-frontaliere/traffico-intenso-a2-lugano-ritardi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7965,7 +7965,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, congestionato, sull, fino',
     ogTitle: 'Traffico congestionato sull\'A2: fino a un\'ora e quaranta di ritardi',
     ogDescription: 'Mattinata da bollino rosso sull\'autostrada A2 tra Chiasso e Lugano, con ritardi fino a 104 minuti a causa di un veicolo in avaria.',
-    canonicalPath: '/articoli-frontaliere/ritardi-a2-tra-chiasso-lugano',
+    canonicalPath: '/articoli-frontaliere/ritardi-a2-tra-chiasso-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7993,7 +7993,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tilt, sola, corsia, ritardi',
     ogTitle: 'A2 in tilt: una sola corsia, ritardi oltre l\'ora',
     ogDescription: 'Traffico intenso tra Chiasso e Grancia, coda da Chiasso/Balerna, ritardi fino a 1h40. Polizia controlla la carreggiata. Cosa fare per evitare ritardi.',
-    canonicalPath: '/articoli-frontaliere/a2-corsia-ritardi-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/a2-corsia-ritardi-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8021,7 +8021,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aquanexa, visita, acquedotto, alfa',
     ogTitle: 'Aquanexa visita acquedotto Alfa a Laveno Mombello',
     ogDescription: 'Una delegazione di Aquanexa ha visitato l\'acquedotto IX Fontane di Laveno Mombello per il progetto Aquamind, esplorando tecnologie avanzate per la gestione del',
-    canonicalPath: '/articoli-frontaliere/aquanexa-visita-acquedotto-alfa-laveno',
+    canonicalPath: '/articoli-frontaliere/aquanexa-visita-acquedotto-alfa-laveno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8049,7 +8049,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bollino, rosso, sull, chiasso',
     ogTitle: 'Bollino rosso sull\'A2 tra Chiasso e Lugano',
     ogDescription: 'Ritardi fino a un\'ora e quaranta minuti sull\'A2 in direzione nord tra Chiasso e Lugano nord a causa di un veicolo in avaria.',
-    canonicalPath: '/articoli-frontaliere/bollino-rosso-a2-chiasso-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/bollino-rosso-a2-chiasso-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8077,7 +8077,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 715mila, euro, pnrr, autonomia',
     ogTitle: '715mila euro PNRR per autonomia disabili Medio Olona',
     ogDescription: 'Scopri come il progetto finanziato dal PNRR sta promuovendo l\'autonomia delle persone con disabilità nel Medio Olona con appartamenti attrezzati e tirocini',
-    canonicalPath: '/articoli-frontaliere/pnrr-disabilita-medio-olona-715mila-euro',
+    canonicalPath: '/articoli-frontaliere/pnrr-disabilita-medio-olona-715mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8105,7 +8105,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, problemi, informatici, casellario, giudiziale',
     ogTitle: 'Problemi informatici al casellario giudiziale di Varese, richieste solo cartacee',
     ogDescription: 'Il sito per prenotare il ritiro del casellario giudiziale di Varese è in tilt. Si accettano solo richieste cartacee con documento d\'identità.',
-    canonicalPath: '/articoli-frontaliere/problemi-casellario-giudiziale-varese-2026',
+    canonicalPath: '/articoli-frontaliere/problemi-casellario-giudiziale-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8133,7 +8133,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, indaga, accordi, illeciti',
     ogTitle: 'COMCO indaga su accordi illeciti nella pubblicità online',
     ogDescription: 'La Commissione della concorrenza svizzera apre due inchieste sui motori di ricerca per presunti accordi illeciti tra aziende di viaggi e casinò online.',
-    canonicalPath: '/articoli-frontaliere/comco-inchieste-pubblicita-online-2026',
+    canonicalPath: '/articoli-frontaliere/comco-inchieste-pubblicita-online-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8161,7 +8161,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, glaciazione, demografica, allarme, futuro',
     ogTitle: 'Glaciazione demografica in Ticino: allarme per il futuro',
     ogDescription: 'Basso tasso di natalità e invecchiamento della popolazione preoccupano il Canton Ticino. Interrogazione parlamentare per una strategia cantonale.',
-    canonicalPath: '/articoli-frontaliere/glaciazione-demografica-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/glaciazione-demografica-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8189,7 +8189,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tilt, ritardi, oltre, chiasso',
     ogTitle: 'A2 in tilt: ritardi oltre l\'ora tra Chiasso e Lugano',
     ogDescription: 'Mattinata da incubo sulla A2 in direzione nord con ritardi fino a un\'ora e quaranta minuti. Incidenti e controlli della polizia complicano il traffico',
-    canonicalPath: '/articoli-frontaliere/a2-traffico-ritardi-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/a2-traffico-ritardi-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8217,7 +8217,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roberto, grassi, nuovo, presidente',
     ogTitle: 'Roberto Grassi nuovo presidente LIUC Castellanza',
     ogDescription: 'Roberto Grassi è il nuovo presidente della LIUC di Castellanza. Scopri le implicazioni per i frontalieri e le nuove opportunità formative.',
-    canonicalPath: '/articoli-frontaliere/roberto-grassi-nuovo-presidente-liuc-castellanza',
+    canonicalPath: '/articoli-frontaliere/roberto-grassi-nuovo-presidente-liuc-castellanza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8245,7 +8245,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assunzioni, nuove, sfide, mercato',
     ogTitle: 'IA e assunzioni: le nuove sfide per il mercato ticinese',
     ogDescription: 'L\'uso dell\'IA nella selezione del personale solleva dubbi su discriminazioni e bias. Analisi dei rischi per i candidati e le aziende in Ticino.',
-    canonicalPath: '/articoli-frontaliere/ia-selezione-personale-rischi-ticino',
+    canonicalPath: '/articoli-frontaliere/ia-selezione-personale-rischi-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8273,7 +8273,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, denatalità, deputato, isabella, chiede',
     ogTitle: 'Denatalità in Ticino: il deputato Isabella chiede azioni concrete',
     ogDescription: 'Claudio Isabella del Centro critica la mancanza di misure efficaci contro il calo delle nascite nel Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/denatalita-ticino-azione-urgente-2026',
+    canonicalPath: '/articoli-frontaliere/denatalita-ticino-azione-urgente-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8301,7 +8301,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beko, cassinetta, superata, crisi',
     ogTitle: 'Beko Cassinetta: superata la crisi, ora contano i risultati',
     ogDescription: 'A un anno dall\'accordo che ha salvato lo stabilimento Beko di Cassinetta, emergono i primi risultati e le sfide future',
-    canonicalPath: '/articoli-frontaliere/beko-cassinetta-risultati-2026',
+    canonicalPath: '/articoli-frontaliere/beko-cassinetta-risultati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8329,7 +8329,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, samantha, bourgoin, nuova, presidente',
     ogTitle: 'Samantha Bourgoin è la nuova presidente di Apisuisse',
     ogDescription: 'La deputata dei Verdi è stata eletta il 18 aprile. Apisuisse rappresenta circa 18\'000 apicoltori in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/samantha-bourgoin-apisuisse-2026',
+    canonicalPath: '/articoli-frontaliere/samantha-bourgoin-apisuisse-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8357,7 +8357,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, birdwatching, monteviasco, escursione, riscoprire',
     ogTitle: 'Birdwatching a Monteviasco: escursione per riscoprire la natura',
     ogDescription: 'Domenica escursione tra sentieri e boschi alla scoperta dell’avifauna locale. Colombo (LIPU): “Un’esperienza per osservare, ascoltare e imparare a proteggere',
-    canonicalPath: '/articoli-frontaliere/birdwatching-monteviasco-2026',
+    canonicalPath: '/articoli-frontaliere/birdwatching-monteviasco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8385,7 +8385,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gallarate, bilancio, cassani, opere',
     ogTitle: 'Gallarate: Bilancio Cassani 2026, opere ma scontro sul debito',
     ogDescription: 'Approvato il decimo bilancio dell\'era Cassani a Gallarate con 92 milioni di entrate e 16 milioni di saldo di cassa. Scopri i dettagli.',
-    canonicalPath: '/articoli-frontaliere/gallarate-bilancio-cassani-2026',
+    canonicalPath: '/articoli-frontaliere/gallarate-bilancio-cassani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8413,7 +8413,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, greco, antico, certificato, lombardia',
     ogTitle: 'Greco antico certificato in Lombardia: prima volta in Italia',
     ogDescription: 'Dal 6 al 7 maggio 2026, studenti dei licei classici lombardi potranno ottenere una certificazione ufficiale in greco antico.',
-    canonicalPath: '/articoli-frontaliere/certificazione-greco-antico-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/certificazione-greco-antico-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8441,7 +8441,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rokj, serata, solidale, maggio',
     ogTitle: 'ROKJ Ticino: serata solidale il 6 maggio a Lugano',
     ogDescription: 'Partecipa alla serata solidale di ROKJ Ticino il 6 maggio a Lugano con Sebalter per sostenere bambini e giovani in difficoltà.',
-    canonicalPath: '/articoli-frontaliere/rokj-lugano-serata-solidale',
+    canonicalPath: '/articoli-frontaliere/rokj-lugano-serata-solidale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8469,7 +8469,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fogliaro, festeggia, giuseppe, lavoratore',
     ogTitle: 'Fogliaro festeggia San Giuseppe lavoratore con messa, gastronomia e mercatino',
     ogDescription: 'Il rione di Fogliaro a Varese celebra San Giuseppe lavoratore con una giornata di eventi tra messa solenne, bancarelle e gastronomia locale',
-    canonicalPath: '/articoli-frontaliere/varese-fogliaro-san-giuseppe-2026',
+    canonicalPath: '/articoli-frontaliere/varese-fogliaro-san-giuseppe-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8497,7 +8497,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, ticinese, conclusa, fase',
     ogTitle: 'Polizia ticinese: conclusa la fase progettuale',
     ogDescription: 'Il Consiglio di Stato ha deciso di non proseguire con il progetto «Polizia ticinese» dopo la consultazione. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticinese-fase-progettuale-conclusa',
+    canonicalPath: '/articoli-frontaliere/polizia-ticinese-fase-progettuale-conclusa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8525,7 +8525,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, melide, chiusure, notturne, lavori',
     ogTitle: 'A2 Melide: chiusure notturne per lavori alla pavimentazione',
     ogDescription: 'Da domenica 3 maggio a venerdì 8 maggio 2026, l\'uscita di Melide sarà chiusa ogni notte dalle 21.30 alle 5.00 per lavori di manutenzione.',
-    canonicalPath: '/articoli-frontaliere/a2-melide-chiusure-notturne-lavori',
+    canonicalPath: '/articoli-frontaliere/a2-melide-chiusure-notturne-lavori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8553,7 +8553,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violare, sanzioni, reato, imprese',
     ogTitle: 'Violare le sanzioni UE è reato: le imprese italiane corrono ai ripari',
     ogDescription: 'Dal 24 gennaio 2026, violare le sanzioni UE può comportare pene fino a 6 anni di reclusione per le persone fisiche e sanzioni fino al 5% del fatturato per le',
-    canonicalPath: '/articoli-frontaliere/sanzioni-ue-imprese-italiane-2026',
+    canonicalPath: '/articoli-frontaliere/sanzioni-ue-imprese-italiane-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8581,7 +8581,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, lavoro, disponibile, mancano',
     ogTitle: 'Varese: lavoro disponibile ma mancano i lavoratori specializzati',
     ogDescription: 'Occupazione in crescita ma difficoltà a trovare profili tecnici e scientifici. Ecco i dati del 2025',
-    canonicalPath: '/articoli-frontaliere/varese-lavoro-specializzato-paradosso-2026',
+    canonicalPath: '/articoli-frontaliere/varese-lavoro-specializzato-paradosso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8609,7 +8609,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, domanda, lavoro, alta',
     ogTitle: 'Varese: domanda di lavoro alta ma competenze sempre più difficili da trovare',
     ogDescription: 'Il mercato del lavoro di Varese mostra un paradosso: alta domanda ma crescente difficoltà nel reperire competenze specializzate, con tassi di occupazione al 70%',
-    canonicalPath: '/articoli-frontaliere/varese-competenze-lavoro-2026',
+    canonicalPath: '/articoli-frontaliere/varese-competenze-lavoro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8637,7 +8637,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, economia, ripresa, prospettive, modeste',
     ogTitle: 'Economia svizzera in ripresa, ma prospettive modeste',
     ogDescription: 'Il barometro del KOF segna 97,9 punti in aprile, con segnali misti dai vari settori economici.',
-    canonicalPath: '/articoli-frontaliere/kof-barometro-ripresa-economica-2026',
+    canonicalPath: '/articoli-frontaliere/kof-barometro-ripresa-economica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8665,7 +8665,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parità, paura, solo, paesi',
     ogTitle: 'La parità che fa paura ai frontalieri del Ticino',
     ogDescription: 'Solo 28 Paesi al mondo sono guidati da una donna. In Ticino, la parità di genere è ancora un obiettivo lontano. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/parita-paura-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/parita-paura-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8693,7 +8693,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, presunti, maltrattamenti, asilo, nido',
     ogTitle: 'Presunti maltrattamenti in asilo nido a Chiasso',
     ogDescription: 'Tre denunce per presunti maltrattamenti in un asilo nido privato di Chiasso. Accertamenti in corso da parte di polizia e Ministero pubblico.',
-    canonicalPath: '/articoli-frontaliere/presunti-maltrattamenti-asilo-chiasso',
+    canonicalPath: '/articoli-frontaliere/presunti-maltrattamenti-asilo-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8721,7 +8721,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, commercio, dettaglio, primo, trimestre',
     ogTitle: 'Commercio al dettaglio in Ticino: +2,7% nel primo trimestre 2026',
     ogDescription: 'Il commercio al dettaglio in Ticino registra un aumento dei ricavi del 2,7% nel primo trimestre 2026, con il segmento alimentare in crescita del 3,2%.',
-    canonicalPath: '/articoli-frontaliere/commercio-dettaglio-ricavi-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/commercio-dettaglio-ricavi-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8749,7 +8749,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, chiude, 2025, rosso',
     ogTitle: 'Bellinzona chiude 2025 con un rosso più contenuto',
     ogDescription: 'Il consuntivo 2025 della Città di Bellinzona mostra un disavanzo di 2,7 milioni, molto inferiore ai 13,4 milioni previsti.',
-    canonicalPath: '/articoli-frontaliere/contibellinzona-2025-risultati',
+    canonicalPath: '/articoli-frontaliere/contibellinzona-2025-risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8777,7 +8777,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inadempiente, crediti, sanitari, quadri',
     ogTitle: 'Italia inadempiente sui crediti sanitari: Quadri chiede chiarezza',
     ogDescription: 'Il consigliere nazionale Lorenzo Quadri interroga il Consiglio federale sui ritardi italiani nei rimborsi sanitari alla Svizzera',
-    canonicalPath: '/articoli-frontaliere/italia-inadempiente-crediti-sanitari',
+    canonicalPath: '/articoli-frontaliere/italia-inadempiente-crediti-sanitari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8805,7 +8805,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ricavi, alberghieri, crescita, 2025',
     ogTitle: 'Ricavi alberghieri in crescita: +3,9% nel 2025',
     ogDescription: 'Il settore alberghiero svizzero registra un aumento del 3,9% nel fatturato 2025, con picchi estivi e differenze tra categorie e zone turistiche.',
-    canonicalPath: '/articoli-frontaliere/settore-alberghiero-ricavi-2025',
+    canonicalPath: '/articoli-frontaliere/settore-alberghiero-ricavi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8833,7 +8833,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, skopje, rafforzano, scambi',
     ogTitle: 'Berna e Skopje rafforzano scambi economici e cooperazione',
     ogDescription: 'Il presidente della Confederazione Guy Parmelin visita la Macedonia del Nord per rafforzare le relazioni economiche e la cooperazione internazionale.',
-    canonicalPath: '/articoli-frontaliere/berna-skopje-scambi-economici-2026',
+    canonicalPath: '/articoli-frontaliere/berna-skopje-scambi-economici-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8861,7 +8861,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, conti, bellinzona, 2025, balzo',
     ogTitle: 'Conti Bellinzona 2025: balzo in avanti di 11 milioni',
     ogDescription: 'I conti 2025 di Bellinzona chiudono con un rosso di 2,7 milioni, migliorando di 10,7 milioni rispetto al preventivo. Analisi e implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/conti-bellinzona-2025-balzo-11-milioni',
+    canonicalPath: '/articoli-frontaliere/conti-bellinzona-2025-balzo-11-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8889,7 +8889,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, 2025, conti, migliori',
     ogTitle: 'Bellinzona 2025: conti migliori del previsto, disavanzo ridotto',
     ogDescription: 'Il consuntivo 2025 di Bellinzona chiude con un disavanzo di 2,7 milioni, migliorando di 10,7 milioni rispetto al preventivo. Investimenti per 25 milioni.',
-    canonicalPath: '/articoli-frontaliere/contibellinzona2025risultati',
+    canonicalPath: '/articoli-frontaliere/contibellinzona2025risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8917,7 +8917,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, calo, previsioni, dell',
     ogTitle: 'Disoccupazione in calo in Ticino: le previsioni dell\'USI',
     ogDescription: 'L\'Istituto di ricerche economiche dell\'USI prevede un ribasso del tasso di disoccupazione in Ticino nei prossimi trimestri.',
-    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-usi-2026',
+    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-usi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8945,7 +8945,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cessione, bper-bcc, filiali, interessate',
     ogTitle: 'Cessione Bper-BCC: le sei filiali interessate in provincia di Varese',
     ogDescription: 'BPER Banca cede sei filiali al Gruppo BCC Iccrea nelle province di Varese e Como. Ecco cosa cambia per i clienti e i dipendenti.',
-    canonicalPath: '/articoli-frontaliere/cessione-bper-bcc-varese-2026',
+    canonicalPath: '/articoli-frontaliere/cessione-bper-bcc-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8973,7 +8973,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, innalzamento, lago, maggiore, impatti',
     ogTitle: 'Innalzamento Lago Maggiore: impatti economici e ambientali',
     ogDescription: 'L\'Autorità di Bacino del Po fissa il livello massimo a 140 cm, ma il territorio teme danni irreversibili all\'economia e alla biodiversità.',
-    canonicalPath: '/articoli-frontaliere/innalzamento-livello-verbano-impatti-economici',
+    canonicalPath: '/articoli-frontaliere/innalzamento-livello-verbano-impatti-economici/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9001,7 +9001,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, barometro, ripresa, modesta, economia',
     ogTitle: 'Barometro KOF: ripresa modesta per l\'economia svizzera',
     ogDescription: 'Il barometro del KOF segnala un leggero miglioramento in aprile, ma le prospettive economiche restano modeste sotto la media pluriennale.',
-    canonicalPath: '/articoli-frontaliere/barometro-kof-ripresa-modesta-2026',
+    canonicalPath: '/articoli-frontaliere/barometro-kof-ripresa-modesta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9029,7 +9029,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inflazione, aprile, carrello, spesa',
     ogTitle: 'Inflazione Italia aprile 2026: +2,8% e carrello della spesa in aumento',
     ogDescription: 'Ad aprile 2026 l\'inflazione in Italia sale al +2,8%, con un aumento del carrello della spesa al +2,5%. Scopri l\'impatto per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/inflazione-aprile-2026-italia',
+    canonicalPath: '/articoli-frontaliere/inflazione-aprile-2026-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9057,7 +9057,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, azienda, bardello, cerca, operatore',
     ogTitle: 'Azienda Bardello cerca operatore CNC: esperienza richiesta',
     ogDescription: 'Onostampi Srl, azienda certificata ISO 9001:2015, cerca operatore CNC con almeno 5 anni di esperienza per lavorazioni su 3, 4 e 5 assi.',
-    canonicalPath: '/articoli-frontaliere/azienda-bardello-cerca-operatore-cnc',
+    canonicalPath: '/articoli-frontaliere/azienda-bardello-cerca-operatore-cnc/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9085,7 +9085,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensionati, penalizzati, fino, euro',
     ogTitle: 'Pensionati penalizzati: fino a 2.400 euro in più di Irpef',
     ogDescription: 'Una simulazione del Caf Cgil evidenzia un divario fiscale tra lavoratori dipendenti e pensionati sotto i 50mila euro annui',
-    canonicalPath: '/articoli-frontaliere/divario-irpef-pensionati-2026',
+    canonicalPath: '/articoli-frontaliere/divario-irpef-pensionati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9113,7 +9113,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, indaga, accordi, illeciti',
     ogTitle: 'COMCO indaga su accordi illeciti nel keyword bidding',
     ogDescription: 'Due inchieste aperte dalla COMCO nel settore dei viaggi e dei casinò online per presunti accordi illeciti nel keyword bidding.',
-    canonicalPath: '/articoli-frontaliere/comco-inchieste-keyword-bidding-2026',
+    canonicalPath: '/articoli-frontaliere/comco-inchieste-keyword-bidding-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9141,7 +9141,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dezonamenti, serve, dialogo, diretto',
     ogTitle: 'Dezonamenti in Ticino: serve dialogo diretto con il Dipartimento',
     ogDescription: 'L\'Associazione dei Comuni Ticino chiede confronto diretto con il Dipartimento del Territorio per risolvere problemi di dezonamento',
-    canonicalPath: '/articoli-frontaliere/dezonamenti-ticino-2026-confronti',
+    canonicalPath: '/articoli-frontaliere/dezonamenti-ticino-2026-confronti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9169,7 +9169,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pizza, bibita, sempre, care',
     ogTitle: 'Pizza e bibita sempre più care: la classifica delle 30 città più costose',
     ogDescription: 'Scopri la classifica delle 30 città italiane più costose per pizza e bibita. Bolzano in testa con 15 euro di media. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/pizza-bibita-costi-citta',
+    canonicalPath: '/articoli-frontaliere/pizza-bibita-costi-citta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9197,7 +9197,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, strategia, cambio, chf-eur, simulazione',
     ogTitle: 'Frontalieri: strategia cambio CHF-EUR 2026',
     ogDescription: 'Simulazione pratica per gestire al meglio il cambio CHF-EUR nel 2026 con checklist operativa e confronto scenari',
-    canonicalPath: '/articoli-frontaliere/frontaliere-cambio-chf-eur-strategia-2026-simulazione-pratica',
+    canonicalPath: '/articoli-frontaliere/frontaliere-cambio-chf-eur-strategia-2026-simulazione-pratica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9230,7 +9230,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, laghi, lombardi, inizio, estate',
     ogTitle: 'Laghi lombardi, inizio estate tragico: sicurezza e consapevolezza',
     ogDescription: 'Un morto nel Comasco e un giovane in condizioni gravissime a Desenzano riaccendono l\'allarme sicurezza sui laghi lombardi. ANAB Lombardia lancia un appello.',
-    canonicalPath: '/articoli-frontaliere/laghi-lombardi-sicurezza-estate-2026',
+    canonicalPath: '/articoli-frontaliere/laghi-lombardi-sicurezza-estate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9263,7 +9263,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piogge, intense, ceresio, sfide',
     ogTitle: 'Piogge intense sul Ceresio: sfide per la gestione del lago',
     ogDescription: 'Il Consorzio pulizia rive e Lago Ceresio affronta nuove sfide con piogge meno frequenti ma più intense. Rimossi 2.000 tonnellate di materiale nel 2025.',
-    canonicalPath: '/articoli-frontaliere/piogge-intense-ceresio-2026',
+    canonicalPath: '/articoli-frontaliere/piogge-intense-ceresio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9296,7 +9296,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, langnau, case, garage',
     ogTitle: 'Incendio a Langnau: due case e un garage distrutti',
     ogDescription: 'Un incendio ha distrutto due case e un garage a Bärau, nel comune di Langnau (BE). Nessun ferito, ma vasta operazione di soccorso.',
-    canonicalPath: '/articoli-frontaliere/incendio-langnau-due-case-garage',
+    canonicalPath: '/articoli-frontaliere/incendio-langnau-due-case-garage/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9329,7 +9329,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dalla, rotta, piccaluga, lavoro',
     ogTitle: 'Dalla rotta di Piccaluga a lavoro, salari ed economia',
     ogDescription: 'Intervista a Daniele Piccaluga e dibattito su lavoro, salari ed economia con Cristina Maderni e Giangiorgio Gargantini',
-    canonicalPath: '/articoli-frontaliere/domenica-corriere-piccaluga-lavoro-salari-economia',
+    canonicalPath: '/articoli-frontaliere/domenica-corriere-piccaluga-lavoro-salari-economia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9362,7 +9362,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sacrificate, vostra, vita, campagna',
     ogTitle: '«Sacrificate la vostra vita»: la campagna iraniana allarma la Svizzera',
     ogDescription: 'L\'ambasciata iraniana a Berna diffonde un appello che invita i cittadini iraniani a sacrificarsi per la patria, generando preoccupazione in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/campagna-iraniana-allarma-svizzera',
+    canonicalPath: '/articoli-frontaliere/campagna-iraniana-allarma-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9395,7 +9395,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, area, sosta, fantasma, sull',
     ogTitle: 'Area di sosta fantasma sull\'A3: pericolo per i frontalieri',
     ogDescription: 'Edificio abbandonato sull\'autostrada fra Coira e Zurigo mette a rischio la sicurezza del traffico. La Confederazione offre 800\'000 CHF, ma il proprietario ne',
-    canonicalPath: '/articoli-frontaliere/area-sosta-fantasma-sicurezza-autostrada',
+    canonicalPath: '/articoli-frontaliere/area-sosta-fantasma-sicurezza-autostrada/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9428,7 +9428,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro, carburanti, benzina, euro',
     ogTitle: 'Caro carburanti: benzina a 1,9 euro al litro',
     ogDescription: 'Prezzi benzina e diesel in aumento, self service sfiora 1,9 euro al litro. Analisi su impatto frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/aumento-prezzi-carburanti-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/aumento-prezzi-carburanti-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9461,7 +9461,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, bellinzona, evacuato, stabile',
     ogTitle: 'Incendio a Bellinzona: evacuato lo stabile in via Borromini',
     ogDescription: 'Domenica mattina un incendio è divampato in un appartamento al pian terreno di via Borromini a Bellinzona, causando l\'evacuazione di una decina di persone.',
-    canonicalPath: '/articoli-frontaliere/incendio-bellinzona-appartamento-evacuato',
+    canonicalPath: '/articoli-frontaliere/incendio-bellinzona-appartamento-evacuato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9494,7 +9494,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, permesso, conviene, cambiare, famiglia',
     ogTitle: 'Permesso G vs B 2026: conviene cambiare per una famiglia con figli?',
     ogDescription: 'Confronto tecnico tra Permesso G e B nel 2026 per frontalieri con famiglia. Checklist operativa e scenari pratici per il Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/permesso-g-vs-b-2026-famiglia-figli',
+    canonicalPath: '/articoli-frontaliere/permesso-g-vs-b-2026-famiglia-figli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9527,7 +9527,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, borromini, evacuate, dieci',
     ogTitle: 'Incendio in via Borromini: evacuate dieci persone',
     ogDescription: 'Un incendio in un appartamento al pian terreno ha causato l\'evacuazione di dieci persone a Bellinzona. Una persona è rimasta lievemente intossicata.',
-    canonicalPath: '/articoli-frontaliere/incendio-bellinzona-via-borromini-evacuati',
+    canonicalPath: '/articoli-frontaliere/incendio-bellinzona-via-borromini-evacuati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9560,7 +9560,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, nuovi, bandi, oltre',
     ogTitle: 'Polizia, due nuovi bandi per oltre 4.500 posti',
     ogDescription: 'La Polizia di Stato cerca 220 commissari e 4.400 allievi agenti. Scadenze e procedure per partecipare.',
-    canonicalPath: '/articoli-frontaliere/polizia-bandi-4500-posti-2026',
+    canonicalPath: '/articoli-frontaliere/polizia-bandi-4500-posti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9593,7 +9593,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, landsgemeinde, glarona, cosa, cambia',
     ogTitle: 'Landsgemeinde Glarona: cosa cambia per frontalieri e residenti',
     ogDescription: 'Scopri le decisioni prese durante la Landsgemeinde di Glarona e come influenzano frontalieri e residenti. Deduzioni pendolari, sussidi casse malati e politica',
-    canonicalPath: '/articoli-frontaliere/casse-malati-alloggi-landsgemeinde-2026',
+    canonicalPath: '/articoli-frontaliere/casse-malati-alloggi-landsgemeinde-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9626,7 +9626,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, albertoni, cinelli, brothers, dancing',
     ogTitle: 'Albertoni e i Cinelli Brothers in \'Dancing Shoes\'',
     ogDescription: 'Scopri il nuovo singolo di Freddie & The Cannonballs con i Cinelli Brothers, ispirato alle \'Scarpette Ricamate\'',
-    canonicalPath: '/articoli-frontaliere/dancing-shoes-albertoni-cinelli-collaboration',
+    canonicalPath: '/articoli-frontaliere/dancing-shoes-albertoni-cinelli-collaboration/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9659,7 +9659,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, landsgemeinde, glarona, aliquota, fiscale',
     ogTitle: 'Landsgemeinde Glarona 2026: aliquota fiscale e alloggi al centro dei dibattiti',
     ogDescription: 'La Landsgemeinde del canton Glarona ha votato su temi finanziari e abitativi. Aliquota fiscale confermata al 58%, nuove detrazioni per pendolari e sussidi per',
-    canonicalPath: '/articoli-frontaliere/landsgemeinde-glarona-2026-finanze-alloggi',
+    canonicalPath: '/articoli-frontaliere/landsgemeinde-glarona-2026-finanze-alloggi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9692,7 +9692,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, vivibile, lettera, vuole',
     ogTitle: 'Como vivibile: la lettera di un frontaliere che non vuole essere espulso',
     ogDescription: 'Un comasco d\'adozione denuncia la pressione immobiliare e chiede politiche per i residenti',
-    canonicalPath: '/articoli-frontaliere/como-vivibile-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/como-vivibile-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9725,7 +9725,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, verso, ultimo, appello',
     ogTitle: 'Calcio Dnb: Bellinzona verso l\'ultimo appello dopo la sconfitta dello StadeNyonnais',
     ogDescription: 'Lo StadeNyonnais perde 0-1 contro il Wil, complicando la situazione del Bellinzona nella lotta per la salvezza in Dnb.',
-    canonicalPath: '/articoli-frontaliere/calcio-dnb-bellinzona-ultimo-appello',
+    canonicalPath: '/articoli-frontaliere/calcio-dnb-bellinzona-ultimo-appello/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9758,7 +9758,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parcheggi, folli, cernobbio, auto',
     ogTitle: 'Parcheggi folli a Cernobbio: auto ticinese occupa due posti per residenti',
     ogDescription: 'Un\'auto con targa ticinese occupa due posti auto riservati ai residenti a Cernobbio, causando disagi e interventi della polizia locale.',
-    canonicalPath: '/articoli-frontaliere/parcheggi-cernobbio-ticino-residenti',
+    canonicalPath: '/articoli-frontaliere/parcheggi-cernobbio-ticino-residenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9791,7 +9791,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vandalismo, bellinzona, danni, galleria',
     ogTitle: 'Vandalismo a Bellinzona: danni al bar Galleria',
     ogDescription: 'Atti vandalici notturni all\'esterno del bar Galleria Bellinzona. Danni in corso di valutazione, indagini in corso grazie alle telecamere di sorveglianza.',
-    canonicalPath: '/articoli-frontaliere/vandalismo-bar-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/vandalismo-bar-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9824,7 +9824,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, brebbia, 19enne, precipita, tetto',
     ogTitle: 'Brebbia: 19enne precipita dal tetto di una fabbrica',
     ogDescription: 'Un giovane di 19 anni è caduto dal tetto di una fabbrica a Brebbia, in provincia di Varese. Grave ma fuori pericolo.',
-    canonicalPath: '/articoli-frontaliere/brebbia-19enne-grave-incidente-fabbrica',
+    canonicalPath: '/articoli-frontaliere/brebbia-19enne-grave-incidente-fabbrica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9857,7 +9857,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aeroporto, lugano, costi, aumento',
     ogTitle: 'Aeroporto di Lugano: costi in aumento, 25 domande al Municipio',
     ogDescription: 'Le consigliere comunali Sara Beretta-Piccoli e Carola Barchi chiedono chiarimenti sui costi e la gestione dell\'aeroporto di Lugano-Agno',
-    canonicalPath: '/articoli-frontaliere/aeroporto-lugano-costi-interpellanza-2025',
+    canonicalPath: '/articoli-frontaliere/aeroporto-lugano-costi-interpellanza-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9890,7 +9890,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, terminal, malpensa, problema',
     ogTitle: 'Incendio Malpensa Terminal 1 risolto',
     ogDescription: 'Un incendio è divampato al Terminal 1 dell\'Aeroporto di Malpensa, ma il problema è stato rapidamente risolto. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incendio-malpensa-terminal-1-risolto',
+    canonicalPath: '/articoli-frontaliere/incendio-malpensa-terminal-1-risolto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9923,7 +9923,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maillard, attacca, iniziativa, rischi',
     ogTitle: 'Maillard (USS) attacca iniziativa UDC: rischi per salari e posti di lavoro',
     ogDescription: 'Il presidente dell\'USS critica l\'iniziativa UDC \'No a una Svizzera da 10 milioni!\' per i rischi su salari, pensioni e occupazione.',
-    canonicalPath: '/articoli-frontaliere/maillard-uss-udc-iniziativa-1-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/maillard-uss-udc-iniziativa-1-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9956,7 +9956,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cervelat, salsiccia, nazionale, scopri',
     ogTitle: 'Cervelat, la salsiccia nazionale svizzera',
     ogDescription: 'Scopri la storia e le curiosità del cervelat, la salsiccia nazionale svizzera, amata in tutto il Paese e simbolo di identità nazionale.',
-    canonicalPath: '/articoli-frontaliere/cervelat-salsiccia-nazionale-svizzera',
+    canonicalPath: '/articoli-frontaliere/cervelat-salsiccia-nazionale-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9989,7 +9989,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, incontro, amare, politica',
     ogTitle: 'Luino: incontro su \'Amare la politica\' tra giovani e istituzioni',
     ogDescription: 'Sabato 2 maggio a Luino presentato il libro \'Amare la Politica\' con dibattito su ruolo della politica nella società contemporanea',
-    canonicalPath: '/articoli-frontaliere/amare-politica-luino-2026',
+    canonicalPath: '/articoli-frontaliere/amare-politica-luino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10022,7 +10022,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassis, araghchi, parlano, colloquio',
     ogTitle: 'Cassis e Araghchi si parlano: colloquio diplomatico Svizzera-Iran',
     ogDescription: 'Il consigliere federale Ignazio Cassis ha avuto un colloquio telefonico con il ministro degli affari esteri iraniano Abbas Araghchi.',
-    canonicalPath: '/articoli-frontaliere/cassis-araghchi-colloquio-2026',
+    canonicalPath: '/articoli-frontaliere/cassis-araghchi-colloquio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10055,7 +10055,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, tornano, corsi, vela',
     ogTitle: 'Luino: tornano i corsi di vela per adulti dell\'AVAV',
     ogDescription: 'L\'Associazione Velica Alto Verbano rilancia per il 2026 i corsi su cabinato, aperti anche ai principianti sul Lago Maggiore',
-    canonicalPath: '/articoli-frontaliere/corsi-vela-adulti-luino-avav-2026',
+    canonicalPath: '/articoli-frontaliere/corsi-vela-adulti-luino-avav-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10088,7 +10088,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, palazzina, bellinzona, evacuati',
     ogTitle: 'Incendio Bellinzona: evacuati 10 inquilini',
     ogDescription: 'Un incendio è divampato questa mattina in una palazzina di Bellinzona, causando l\'evacuazione di 10 persone e un\'intossicazione lieve.',
-    canonicalPath: '/articoli-frontaliere/incendio-bellinzona-via-borromini-evacuati-10-persone',
+    canonicalPath: '/articoli-frontaliere/incendio-bellinzona-via-borromini-evacuati-10-persone/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10121,7 +10121,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agricoltura, ticinese, chiede, prodotti',
     ogTitle: 'Agricoltura ticinese chiede più prodotti locali agli eventi',
     ogDescription: 'I delegati dell\'Unione contadini ticinesi chiedono maggiore presenza di prodotti locali agli eventi, preoccupati da costi e predatori',
-    canonicalPath: '/articoli-frontaliere/agricoltura-ticino-prodotti-locali-eventi-2026',
+    canonicalPath: '/articoli-frontaliere/agricoltura-ticino-prodotti-locali-eventi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10154,7 +10154,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, turismo, como, senza, precedenti',
     ogTitle: 'Turismo a Como senza precedenti: quartieri in difficoltà e frontalieri esclusi',
     ogDescription: 'Incontro allo Yacht Club su turismo e periferie: crescita senza precedenti ma quartieri in difficoltà e senza benefici',
-    canonicalPath: '/articoli-frontaliere/turismo-como-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/turismo-como-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10187,7 +10187,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, omegna, ciclista, precipita, scarpata',
     ogTitle: 'Omegna: ciclista precipita in scarpata, ricovero in codice rosso',
     ogDescription: 'Gravi le condizioni di un ciclista precipitato in un dirupo vicino a Omegna. Ricovero in codice rosso all\'ospedale di Novara.',
-    canonicalPath: '/articoli-frontaliere/omegna-ciclista-precipita-scarpata-ricovero-rosso',
+    canonicalPath: '/articoli-frontaliere/omegna-ciclista-precipita-scarpata-ricovero-rosso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10220,7 +10220,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ritirano, missili, lungo, raggio',
     ogTitle: 'USA ritirano missili a lungo raggio dalla Germania',
     ogDescription: 'Le tensioni tra Berlino e Washington influenzano la strategia NATO e i piani di deterrenza in Europa. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/usa-missili-germania-2026',
+    canonicalPath: '/articoli-frontaliere/usa-missili-germania-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10253,7 +10253,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, degrado, mancanza, sicurezza',
     ogTitle: 'Como: degrado e mancanza di sicurezza alla mensa di solidarietà',
     ogDescription: 'Una lettrice segnala forte degrado e mancanza di sicurezza presso la mensa di via Don Guanella a Como, nonostante il valore sociale dell\'iniziativa.',
-    canonicalPath: '/articoli-frontaliere/mensa-solidarieta-degrado-sicurezza-2026',
+    canonicalPath: '/articoli-frontaliere/mensa-solidarieta-degrado-sicurezza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10286,7 +10286,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, laboratorio, estivo, museo, moesano',
     ogTitle: 'Laboratorio estivo al Museo Moesano: archeologia per ragazzi',
     ogDescription: 'Dal 3 al 7 agosto 2026, bambini e ragazzi di 7-12 anni scoprono i massi cuppellari con un laboratorio teatrale al Museo Moesano di San Vittore',
-    canonicalPath: '/articoli-frontaliere/laboratorio-estivo-museo-moesano-2026',
+    canonicalPath: '/articoli-frontaliere/laboratorio-estivo-museo-moesano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10319,7 +10319,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, lago, perduto, memoria',
     ogTitle: 'Varese: “Il lago perduto”, memoria viva di una comunità',
     ogDescription: 'La mostra fotografica di Mario Chiodetti alle Ghiacciaie di Cazzago Brabbia celebra la tradizione dei pescatori del lago di Varese.',
-    canonicalPath: '/articoli-frontaliere/varese-lago-perduto-memoria-comunita',
+    canonicalPath: '/articoli-frontaliere/varese-lago-perduto-memoria-comunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10352,7 +10352,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, marcia, lenta, lugano, contro',
     ogTitle: 'Marcia lenta a Lugano contro i rischi del petrolio',
     ogDescription: 'Cinque attivisti di \'act now!\' hanno organizzato una marcia lenta a Lugano per denunciare i pericoli del petrolio.',
-    canonicalPath: '/articoli-frontaliere/rischi-petrolio-lugano-3-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/rischi-petrolio-lugano-3-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10385,7 +10385,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusa, notte, percorso, alternativo',
     ogTitle: 'A9 chiusa notte: percorso alternativo Lomazzo-Saronno',
     ogDescription: 'Lomazzo Nord-Saronno chiusa 6-7 maggio per manutenzione verde. Percorso alternativo su viabilità ordinaria per frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lavori-a9-lomazzo-saronno-chiusura-notte',
+    canonicalPath: '/articoli-frontaliere/lavori-a9-lomazzo-saronno-chiusura-notte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10418,7 +10418,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, protesta, vezia, petrolio, uccide',
     ogTitle: 'Protesta a Vezia: «Il petrolio uccide»',
     ogDescription: 'Attivisti di Act Now dipingono una tela davanti al distributore Eni di Vezia per sensibilizzare sull\'impatto ambientale e sanitario dei combustibili fossili',
-    canonicalPath: '/articoli-frontaliere/petrolio-uccide-protesta-vezia-2026',
+    canonicalPath: '/articoli-frontaliere/petrolio-uccide-protesta-vezia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10451,7 +10451,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, valley, festival, malvaglia, giorni',
     ogTitle: 'Sun Valley Festival a Malvaglia: tre giorni di musica e divertimento',
     ogDescription: 'Dal 22 al 24 maggio 2026, Malvaglia ospita il Sun Valley Festival con artisti internazionali e attività per tutte le età.',
-    canonicalPath: '/articoli-frontaliere/sun-valley-festival-malvaglia-2026',
+    canonicalPath: '/articoli-frontaliere/sun-valley-festival-malvaglia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10484,7 +10484,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pulizia, lago, lemano, tonnellate',
     ogTitle: 'Pulizia Lago Lemano 2026: 2,5 tonnellate di rifiuti raccolti in due giorni',
     ogDescription: 'Oltre 1.000 volontari, tra cui 300 sommozzatori, hanno partecipato alla 13esima edizione di Net\'Léman, raccogliendo 2.592 kg di rifiuti',
-    canonicalPath: '/articoli-frontaliere/pulizia-lago-lemano-2026',
+    canonicalPath: '/articoli-frontaliere/pulizia-lago-lemano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10517,7 +10517,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, verso, taglio, fondi',
     ogTitle: 'Crans-Montana, taglio fondi avvocati vittime',
     ogDescription: 'Le risorse del Cantone Vallese per gli avvocati delle vittime della tragedia di Crans-Montana sono insufficienti, con fondi già esauriti.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-fondi-avvocati-vittime',
+    canonicalPath: '/articoli-frontaliere/crans-montana-fondi-avvocati-vittime/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10550,7 +10550,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disordini, alla, pensilina, botta',
     ogTitle: 'Disordini alla pensilina Botta a Lugano: pista politica e rivalità tra tifoserie',
     ogDescription: 'Forze dell\'ordine e soccorsi sono intervenuti per sedare gli scontri e identificare i responsabili. Due feriti leggeri e ostacoli all\'operato degli agenti.',
-    canonicalPath: '/articoli-frontaliere/disordini-pensilina-botta-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/disordini-pensilina-botta-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10583,7 +10583,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scontri, pensilina, lugano, feriti',
     ogTitle: 'Scontri in pensilina a Lugano: feriti e tensioni crescenti',
     ogDescription: 'La municipale di Lugano commenta gli scontri del 1° maggio che hanno portato al ferimento di due persone. La situazione resta critica.',
-    canonicalPath: '/articoli-frontaliere/scontri-pensilina-lugano-violenza',
+    canonicalPath: '/articoli-frontaliere/scontri-pensilina-lugano-violenza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10616,7 +10616,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, neutalia, bilancio, 2025, supera',
     ogTitle: 'Neutalia: bilancio 2025 supera le attese, ricavi e utile in crescita',
     ogDescription: 'Neutalia chiude il 2025 con un fatturato di 22,5 milioni di euro e un utile netto di 3,17 milioni, con investimenti per 12,2 milioni nel revamping d',
-    canonicalPath: '/articoli-frontaliere/neutalia-bilancio-2025-crescita-ricavi',
+    canonicalPath: '/articoli-frontaliere/neutalia-bilancio-2025-crescita-ricavi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10649,7 +10649,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, life, podisti, gallarate, benessere',
     ogTitle: 'Life Run 2026: 550 podisti a Gallarate per il benessere',
     ogDescription: 'Oltre 550 podisti hanno partecipato alla Life Run 2026 a Gallarate, con vittorie di Mattia Grifa e Federica Cerruti nella gara Fidal.',
-    canonicalPath: '/articoli-frontaliere/life-run-gallarate-2026-successo',
+    canonicalPath: '/articoli-frontaliere/life-run-gallarate-2026-successo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10682,7 +10682,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petrolio, export, record, chiusura',
     ogTitle: 'Petrolio USA: export record con chiusura Hormuz',
     ogDescription: 'Le esportazioni di petrolio USA raggiungono livelli record con la chiusura dello Stretto di Hormuz, impattando le scorte globali e i mercati energetici',
-    canonicalPath: '/articoli-frontaliere/usa-petrolio-export-hormuz-impatti-ticino',
+    canonicalPath: '/articoli-frontaliere/usa-petrolio-export-hormuz-impatti-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10715,7 +10715,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, marchirolo, celebra, primo, maggio',
     ogTitle: 'Marchirolo celebra il Primo Maggio con corteo, musica e riconoscimenti',
     ogDescription: 'La Festa del lavoro a Marchirolo con corteo, musica e consegna di benemerenze. Tutti i dettagli dell\'evento.',
-    canonicalPath: '/articoli-frontaliere/marchirolo-primo-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/marchirolo-primo-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10748,7 +10748,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, schianto, sulla, turate, quattro',
     ogTitle: 'Schianto A9 Turate: 4 feriti tra frontalieri',
     ogDescription: 'Incidente sulla A9 direzione Milano a Turate, quattro persone tra feriti e contusi. Implicazioni per i frontalieri in transito.',
-    canonicalPath: '/articoli-frontaliere/schianto-a9-turate-feriti-frontalieri',
+    canonicalPath: '/articoli-frontaliere/schianto-a9-turate-feriti-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10781,7 +10781,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inter, campione, cavalcata-scudetto, nerazzurri',
     ogTitle: 'Inter campione d\'Italia: la cavalcata-scudetto dei nerazzurri di Chivu',
     ogDescription: 'L\'Inter vince il ventunesimo scudetto con 3 giornate d\'anticipo, festeggiato dopo il 2-0 contro il Parma',
-    canonicalPath: '/articoli-frontaliere/inter-scudetto-chivu-2026',
+    canonicalPath: '/articoli-frontaliere/inter-scudetto-chivu-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10814,7 +10814,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, lago, como, morto',
     ogTitle: 'Tragedia al lago di Como: morto un 15enne',
     ogDescription: 'Un quindicenne perde la vita nel lago di Como. Gli amici danno l\'allarme, ma i soccorsi non riescono a salvarlo.',
-    canonicalPath: '/articoli-frontaliere/tragedia-lago-como-frontalieri',
+    canonicalPath: '/articoli-frontaliere/tragedia-lago-como-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10847,7 +10847,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, sull, autolaghi, donna',
     ogTitle: 'Incidente Autolaghi: donna ferita in codice giallo',
     ogDescription: 'Una 77enne ha perso il controllo dell\'auto e ha urtato il guardrail. Trasportata in ospedale, non in gravi condizioni.',
-    canonicalPath: '/articoli-frontaliere/incidente-autolaghi-donna-ferita',
+    canonicalPath: '/articoli-frontaliere/incidente-autolaghi-donna-ferita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10880,7 +10880,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, sull, turate, feriti',
     ogTitle: 'Incidente A9 Turate: due feriti all\'alba',
     ogDescription: 'Incidente sull\'autostrada A9 prima dell\'uscita di Turate con due feriti. Intervento vigili del fuoco, 118 e polizia stradale. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incidente-a9-turate-feriti-frontalieri',
+    canonicalPath: '/articoli-frontaliere/incidente-a9-turate-feriti-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10913,7 +10913,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese-trento, playoff, battaglia, ottavo',
     ogTitle: 'Varese-Trento playoff: la battaglia per l\'ottavo posto',
     ogDescription: 'Varese e Trento si giocano l\'ottavo posto nei playoff. Ecco cosa succede e le implicazioni per i tifosi',
-    canonicalPath: '/articoli-frontaliere/varese-trento-playoff-basket-2026',
+    canonicalPath: '/articoli-frontaliere/varese-trento-playoff-basket-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10946,7 +10946,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, perde, zona, boschiva',
     ogTitle: 'Varese, si perde in zona boschiva e cade in un canale: ferita e recuperata',
     ogDescription: 'Una persona si è persa in una zona boschiva vicino a Varese ed è caduta in un canale, rimanendo ferita. È stata recuperata dai soccorritori.',
-    canonicalPath: '/articoli-frontaliere/varese-caduta-canale-frontaliere',
+    canonicalPath: '/articoli-frontaliere/varese-caduta-canale-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10979,7 +10979,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, sull, direzione, chiusura',
     ogTitle: 'Incidente A2 Lodrino: chiusura e soccorsi',
     ogDescription: 'Incidente sull\'autostrada A2 in direzione sud all\'altezza di Lodrino. Chiusura autostrada e soccorsi in corso. Aggiornamenti per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incidente-a2-lodrino-frontalieri',
+    canonicalPath: '/articoli-frontaliere/incidente-a2-lodrino-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11012,7 +11012,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lega, propone, chiusura, confini',
     ogTitle: 'Lega Ticino propone chiusura confini con Italia per una settimana',
     ogDescription: 'La Lega dei Ticinesi propone di chiudere i confini con l\'Italia per una settimana per vedere l\'effetto che fa, citando Jannacci.',
-    canonicalPath: '/articoli-frontaliere/league-ticino-border-closure-proposal-2026',
+    canonicalPath: '/articoli-frontaliere/league-ticino-border-closure-proposal-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11045,7 +11045,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petrolio, approvvigionamento, sicuro, attacco',
     ogTitle: 'Petrolio e gas in Ticino, approvvigionamento sicuro nonostante il conflitto in Medio Oriente',
     ogDescription: 'L\'attacco all\'Iran e le rappresaglie hanno aumentato i prezzi di benzina e diesel anche in Svizzera, ma l\'approvvigionamento rimane stabile.',
-    canonicalPath: '/articoli-frontaliere/petrolio-gas-sicuro-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/petrolio-gas-sicuro-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11078,7 +11078,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, negoziati, stallo, iran, tensioni',
     ogTitle: 'Negoziati in stallo tra USA e Iran: tensioni crescenti',
     ogDescription: 'Le distanze tra Stati Uniti e Iran si fanno sempre più marcate, con nuove proposte e minacce che alimentano le tensioni internazionali.',
-    canonicalPath: '/articoli-frontaliere/negoziati-stallo-iran-usa-2026',
+    canonicalPath: '/articoli-frontaliere/negoziati-stallo-iran-usa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11111,7 +11111,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inter, campione, cosa, cambia',
     ogTitle: 'Inter campione d\'Italia: impatti per i frontalieri',
     ogDescription: 'L\'Inter vince lo scudetto numero 21. Impatti per i frontalieri che lavorano in Ticino e vivono in Italia.',
-    canonicalPath: '/articoli-frontaliere/inter-scudetto-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/inter-scudetto-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11144,7 +11144,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, austriaci, fuggono, auto, movimento',
     ogTitle: 'Due austriaci fuggono da auto in movimento: inseguimento finisce contro un muro',
     ogDescription: 'Un inseguimento della polizia in Ticino si conclude con due austriaci che saltano da un\'auto in movimento e si schiantano contro un muro di sostegno.',
-    canonicalPath: '/articoli-frontaliere/austriaci-ferma-verifica-2026',
+    canonicalPath: '/articoli-frontaliere/austriaci-ferma-verifica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11177,7 +11177,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, statua, volta, como, invasa',
     ogTitle: 'Statua di Volta a Como invasa dalle erbacce',
     ogDescription: 'La statua di Alessandro Volta a Como è di nuovo invasa dalle erbacce, a pochi mesi dal bicentenario della sua nascita. Scopri cosa fare.',
-    canonicalPath: '/articoli-frontaliere/statua-volta-como-2026',
+    canonicalPath: '/articoli-frontaliere/statua-volta-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11210,7 +11210,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scia, luminosa, cosa, sappiamo',
     ogTitle: 'Scia luminosa in Ticino: cosa sappiamo',
     ogDescription: 'La scia luminosa avvistata in Ticino era attesa e non rappresenta un mistero. Ecco i dettagli',
-    canonicalPath: '/articoli-frontaliere/scia-luminosa-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/scia-luminosa-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11243,7 +11243,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fiaccola, sacconago, arriva, carica',
     ogTitle: 'La Fiaccola di Sacconago arriva carica di speranza e amicizia',
     ogDescription: 'Domenica 3 maggio 2026, la Fiaccola di Sacconago ha illuminato la Madonna in Campagna, portando fede, speranza e amicizia alla comunità.',
-    canonicalPath: '/articoli-frontaliere/fiaccola-sacconago-speranza-amicizia',
+    canonicalPath: '/articoli-frontaliere/fiaccola-sacconago-speranza-amicizia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11276,7 +11276,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, caos, taxi, boat',
     ogTitle: 'Como, caos taxi boat: 600 imbarcazioni in un solo molo',
     ogDescription: 'Il molo di Sant\'Agostino a Como è insostenibile con 600 barche in attesa. Operatori chiedono più pontili per ridurre il caos.',
-    canonicalPath: '/articoli-frontaliere/ingorgo-taxi-boat-como-2026',
+    canonicalPath: '/articoli-frontaliere/ingorgo-taxi-boat-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11309,7 +11309,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantù, controlli, locali, trovato',
     ogTitle: 'Cantù, controlli nei locali: trovato un lavoratore in nero',
     ogDescription: 'Operazione congiunta dei Carabinieri e Polizia Locale a Cantù, sospesa un\'attività per lavoro irregolare',
-    canonicalPath: '/articoli-frontaliere/controlli-cantu-movida-nero-2026',
+    canonicalPath: '/articoli-frontaliere/controlli-cantu-movida-nero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11342,7 +11342,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como-napoli, nico, brilla, douvikas',
     ogTitle: 'Como-Napoli 0-0: Nico Paz brilla, ma Douvikas e Diao non concretizzano',
     ogDescription: 'Il Como pareggia 0-0 contro il Napoli. Nico Paz è il migliore in campo con due assist, ma Douvikas e Diao sprecano occasioni da gol.',
-    canonicalPath: '/articoli-frontaliere/como-napoli-pareggio-2026',
+    canonicalPath: '/articoli-frontaliere/como-napoli-pareggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11375,7 +11375,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, incontro, violenza, psicologica',
     ogTitle: 'Varese: incontro su violenza psicologica e disturbi alimentari',
     ogDescription: 'Venerdì 8 maggio a Varese un evento per riflettere sul legame tra maltrattamento psicologico e disagio alimentare.',
-    canonicalPath: '/articoli-frontaliere/varese-incontro-violenza-psicologica-disturbi-alimentari',
+    canonicalPath: '/articoli-frontaliere/varese-incontro-violenza-psicologica-disturbi-alimentari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11408,7 +11408,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, automobilisti, stranieri, rischiano, faido-chiggiogna',
     ogTitle: 'Automobilisti stranieri rischiano la sicurezza all\'entrata autostradale di Faido-Chiggiogna',
     ogDescription: 'Automobilisti con targa straniera rischiano multe e incidenti per evitare code sull\'A2 in Ticino.',
-    canonicalPath: '/articoli-frontaliere/retromarcia-contromano-faido-chiggiogna-2026',
+    canonicalPath: '/articoli-frontaliere/retromarcia-contromano-faido-chiggiogna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11441,7 +11441,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano-yb, cornaredo, terzultima, sfida',
     ogTitle: 'Lugano-YB a Cornaredo: la terzultima sfida prima del trasloco',
     ogDescription: 'Il Lugano ospita lo Young Boys in una partita cruciale per l\'accesso alle coppe europee. Ultime gare al Cornaredo prima del trasferimento nell\'Ail Arena.',
-    canonicalPath: '/articoli-frontaliere/lugano-young-boys-cornaredo-2026',
+    canonicalPath: '/articoli-frontaliere/lugano-young-boys-cornaredo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11474,7 +11474,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, alla, fallätsche, 69enne',
     ogTitle: 'Tragedia alla Fallätsche: 69enne precipita mortalmente',
     ogDescription: 'Un uomo di 69 anni è precipitato mortalmente alla Fallätsche, un\'area di svago vicino a Zurigo. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/tragedia-falleatsche-frontalieri',
+    canonicalPath: '/articoli-frontaliere/tragedia-falleatsche-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11507,7 +11507,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, clandestino, tenta, fuga, verbania',
     ogTitle: 'Clandestino tenta la fuga a Verbania, fermato e poi espulso',
     ogDescription: 'Un clandestino è stato fermato mentre tentava la fuga a Verbania e successivamente espulso. Ecco i dettagli dell\'accaduto e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/verbania-clandestino-espulsione-2026',
+    canonicalPath: '/articoli-frontaliere/verbania-clandestino-espulsione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11540,7 +11540,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lanzo, aderisce, alla, campagna',
     ogTitle: 'COF Lanzo aderisce alla Campagna mondiale per l’igiene delle mani',
     ogDescription: 'Il COF Lanzo Hospital aderisce alla Campagna mondiale per l’igiene delle mani, promossa dall’OMS e dal Ministero della Salute.',
-    canonicalPath: '/articoli-frontaliere/cof-lanzo-igiene-mani-2026',
+    canonicalPath: '/articoli-frontaliere/cof-lanzo-igiene-mani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11573,7 +11573,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, peter, zeidler, nuovo, tecnico',
     ogTitle: 'Peter Zeidler nuovo tecnico del Grasshopper',
     ogDescription: 'Peter Zeidler è stato nominato nuovo allenatore del Grasshopper, con l\'obiettivo di mantenere la squadra in Super League.',
-    canonicalPath: '/articoli-frontaliere/grasshopper-zeidler-allenatore-2026',
+    canonicalPath: '/articoli-frontaliere/grasshopper-zeidler-allenatore-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11606,7 +11606,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disordini, lugano, intervento, veloce',
     ogTitle: 'Disordini a Lugano: intervento veloce grazie al presidio accresciuto',
     ogDescription: 'La capodicastero Sicurezza Karin Valenzano Rossi commenta gli scontri in Pensilina e l\'importanza di abbassare i toni politici',
-    canonicalPath: '/articoli-frontaliere/disordini-pensilina-lugano-intervento-veloce',
+    canonicalPath: '/articoli-frontaliere/disordini-pensilina-lugano-intervento-veloce/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11639,7 +11639,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disordini, lugano, pensilina, feriti',
     ogTitle: 'Disordini a Lugano Pensilina: due feriti leggeri',
     ogDescription: 'Intervento massiccio della polizia a Lugano Pensilina con due feriti leggeri e uso di spray urticante',
-    canonicalPath: '/articoli-frontaliere/disordini-pensilina-lugano-intervento-veloce-2026',
+    canonicalPath: '/articoli-frontaliere/disordini-pensilina-lugano-intervento-veloce-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11672,7 +11672,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, teresina, cerini, festeggia, anni',
     ogTitle: 'Teresina Cerini festeggia 100 anni a Coglio',
     ogDescription: 'Celebrazione con famiglia e autorità per i 100 anni di Teresina Cerini, nata a Lodano nel 1926',
-    canonicalPath: '/articoli-frontaliere/teresina-cerini-100-anni-coglio',
+    canonicalPath: '/articoli-frontaliere/teresina-cerini-100-anni-coglio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11705,7 +11705,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, batte, cechia, rigori, raddrizzando',
     ogTitle: 'Svizzera batte Cechia ai rigori, raddrizzando il weekend',
     ogDescription: 'La nazionale svizzera di hockey vince ai rigori contro la Repubblica Ceca, chiudendo in positivo il weekend dopo due sconfitte.',
-    canonicalPath: '/articoli-frontaliere/svizzera-cechia-rigori-4-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-cechia-rigori-4-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11738,7 +11738,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, orso, ripreso, valposchiavo, cosa',
     ogTitle: 'Orso ripreso in Valposchiavo: cosa cambia per i frontalieri',
     ogDescription: 'Un orso è stato avvistato in Valposchiavo dopo anni di assenza. Ecco cosa sapere per chi lavora in Svizzera e vive in Italia.',
-    canonicalPath: '/articoli-frontaliere/orso-valposchiavo-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/orso-valposchiavo-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11771,7 +11771,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, thun, campione, svizzero, calcio',
     ogTitle: 'Thun campione svizzero di calcio per la prima volta',
     ogDescription: 'Dopo 128 anni, il Thun vince il campionato svizzero. L\'allenatore ticinese Mauro Lustrinelli è uno degli artefici del successo',
-    canonicalPath: '/articoli-frontaliere/thun-campionato-calcio-2026',
+    canonicalPath: '/articoli-frontaliere/thun-campionato-calcio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11804,7 +11804,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scudetto, nerazzurro, varesotto, festeggia',
     ogTitle: 'Scudetto nerazzurro, il Varesotto festeggia: caroselli in piazza Montegrappa e alla fontana di Gallarate',
     ogDescription: 'I tifosi dell\'Inter celebrano il 21° titolo con festeggiamenti nelle piazze di Varese e Gallarate. Ecco come è andata la notte del 3 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/scudetto-varese-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/scudetto-varese-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11837,7 +11837,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pannelli, ignifughi, semi, anguria',
     ogTitle: 'Pannelli ignifughi con semi di anguria: rivoluzione per la sicurezza antincendio',
     ogDescription: 'Scoperta del Politecnico di Zurigo: pannelli resistenti al fuoco realizzati con semi di anguria. Possibili applicazioni in Ticino.',
-    canonicalPath: '/articoli-frontaliere/anguria-pannelli-incendio-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/anguria-pannelli-incendio-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11870,7 +11870,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ilvo, junghi, vince, tiro',
     ogTitle: 'Ilvo Junghi vince il tiro a 50 metri categoria Veterani',
     ogDescription: 'Ilvo Junghi si aggiudica la vittoria nel tiro sportivo a 50 metri categoria Veterani. Scopri i dettagli della competizione e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/tiro-sportivo-veterani-junghi-2026',
+    canonicalPath: '/articoli-frontaliere/tiro-sportivo-veterani-junghi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11903,7 +11903,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, thun, campione, svizzero, festa',
     ogTitle: 'FC Thun campione svizzero: festa a Thun',
     ogDescription: 'Il FC Thun, guidato dall\'allenatore ticinese Mauro Lustrinelli, vince il campionato svizzero per la prima volta nella sua storia.',
-    canonicalPath: '/articoli-frontaliere/fc-thun-campionato-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/fc-thun-campionato-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11936,7 +11936,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, motociclista, ferito, sulla, strada',
     ogTitle: 'Motociclista ferito sulla strada del Maloja',
     ogDescription: 'Un motociclista di 63 anni si è ferito in un incidente sulla strada del Maloja, trasportato in ospedale a Samedan. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incidente-maloja-frontaliere-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-maloja-frontaliere-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11969,7 +11969,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, thun, campione, super, league',
     ogTitle: 'FC Thun campione di Super League: festa a Thun dopo la vittoria storica',
     ogDescription: 'La neopromossa FC Thun conquista il primo titolo della sua storia. Festa alla Stockhorn Arena dopo il ko del San Gallo contro il Sion.',
-    canonicalPath: '/articoli-frontaliere/thun-campionato-calcio-2026-festa-thun',
+    canonicalPath: '/articoli-frontaliere/thun-campionato-calcio-2026-festa-thun/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12002,7 +12002,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, playoff, vittoria, sofferta',
     ogTitle: 'Varese ai playoff: vittoria sofferta contro la Lavagnese',
     ogDescription: 'Il Varese batte 3-2 la Lavagnese e accede ai playoff, con un rigore decisivo nel recupero. La squadra di mister Ciceri affronterà la Biellese nel primo turno.',
-    canonicalPath: '/articoli-frontaliere/varese-playoff-lavagnese-2026',
+    canonicalPath: '/articoli-frontaliere/varese-playoff-lavagnese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12035,7 +12035,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, dell, hockey, novità',
     ogTitle: 'La Casa dell\'Hockey: novità e sviluppi nel mondo dell\'hockey ticinese',
     ogDescription: 'Scopri le ultime novità e gli sviluppi nel mondo dell\'hockey ticinese, con focus sugli eventi recenti e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/casa-hockey-ticino-novita',
+    canonicalPath: '/articoli-frontaliere/casa-hockey-ticino-novita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12068,7 +12068,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tessile, diventa, arte, evento',
     ogTitle: 'Tessile diventa arte: evento a Como con oltre 150 partecipanti',
     ogDescription: 'Scopri come il tessile diventa arte nell\'evento \'Trame in Trasformazione\' a Como, con la partecipazione di giovani talenti e professionisti del settore.',
-    canonicalPath: '/articoli-frontaliere/tessile-arte-giovani-generazioni-como',
+    canonicalPath: '/articoli-frontaliere/tessile-arte-giovani-generazioni-como/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12101,7 +12101,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, riciclaggio, incendio, restano',
     ogTitle: 'Crans-Montana: riciclaggio e incendio restano uniti',
     ogDescription: 'Le procuratrici respingono la richiesta di separare l\'inchiesta sul rogo mortale dal sospetto di riciclaggio',
-    canonicalPath: '/articoli-frontaliere/crans-montana-incendio-riciclaggio-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-incendio-riciclaggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12134,7 +12134,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, antonelli, vince, miami, ordine',
     ogTitle: 'Antonelli vince GP Miami 2026: ordine d\'arrivo e classifica mondiale',
     ogDescription: 'Andrea Kimi Antonelli trionfa a Miami e resta leader del Mondiale di Formula 1. Ecco l\'ordine d\'arrivo e la classifica aggiornata.',
-    canonicalPath: '/articoli-frontaliere/antonelli-vince-gp-miami-2026',
+    canonicalPath: '/articoli-frontaliere/antonelli-vince-gp-miami-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12167,7 +12167,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, nave, morti, nell',
     ogTitle: 'Tre morti hantavirus nave Atlantico | Frontaliere Ticino',
     ogDescription: 'L\'OMS conferma tre decessi legati a un possibile focolaio di hantavirus su una nave da crociera nell\'Atlantico. Ecco cosa sappiamo.',
-    canonicalPath: '/articoli-frontaliere/tre-morti-hantavirus-nave-atlantico',
+    canonicalPath: '/articoli-frontaliere/tre-morti-hantavirus-nave-atlantico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12200,7 +12200,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, juve, pareggia, verona, retrocesso',
     ogTitle: 'Juve pareggia 1-1 con il Verona già retrocesso',
     ogDescription: 'La Juventus pareggia 1-1 contro il Verona già retrocesso, fallendo l\'aggancio al Milan nella corsa alla Champions.',
-    canonicalPath: '/articoli-frontaliere/juve-verona-1-1-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/juve-verona-1-1-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12233,7 +12233,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, immigrazione, perché, modello, demografico',
     ogTitle: 'Immigrazione: perché la Svizzera è un modello demografico',
     ogDescription: 'Il professor Philippe Wanner spiega il ruolo cruciale dell\'immigrazione nel successo demografico svizzero. Focus su Ticino e frontalieri.',
-    canonicalPath: '/articoli-frontaliere/immigrazione-modello-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/immigrazione-modello-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12266,7 +12266,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, csoa, molino, inizia',
     ogTitle: 'Addio Csoa Il Molino: inizia la rimozione delle macerie',
     ogDescription: 'La Città di Lugano avvia i lavori di riqualificazione dell\'area dell\'ex Macello. Durata stimata tra un mese e mezzo e due mesi.',
-    canonicalPath: '/articoli-frontaliere/csoa-molino-rimozione-macerie-lugano',
+    canonicalPath: '/articoli-frontaliere/csoa-molino-rimozione-macerie-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12299,7 +12299,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, condanna, omicidio, colposo, mesi',
     ogTitle: 'Condanna per omicidio colposo: 6 mesi per il camionista',
     ogDescription: 'Il camionista che investì un ciclista a Riazzino nel gennaio 2025 è stato condannato a 6 mesi per omicidio colposo.',
-    canonicalPath: '/articoli-frontaliere/incidente-riazzino-ciclista-condanna',
+    canonicalPath: '/articoli-frontaliere/incidente-riazzino-ciclista-condanna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12332,7 +12332,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sergi, punta, nuovo, alla',
     ogTitle: 'Sergi punta di nuovo alla presidenza del basket ticinese',
     ogDescription: 'Giancarlo Sergi sfida Andrea Siviero per la presidenza del basket in Ticino. Elezioni previste per maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/sergi-presidenza-basket-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/sergi-presidenza-basket-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12365,7 +12365,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ginnastica, artistica, giovani, talenti',
     ogTitle: 'Ginnastica artistica: giovani talenti brillano ai Campionati ticinesi',
     ogDescription: 'Scopri i risultati dei Campionati ticinesi di ginnastica artistica 2026 e le opportunità per i giovani talenti e i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ginnastica-artistica-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ginnastica-artistica-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12398,7 +12398,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sospetti, scandali, minetti, tensioni',
     ogTitle: 'Italia dei sospetti: scandali VAR, Minetti e tensioni italo-svizzere',
     ogDescription: 'Scandali nel calcio italiano e dubbi sulla grazia a Nicole Minetti dominano la cronaca elvetica. Ecco cosa succede.',
-    canonicalPath: '/articoli-frontaliere/italia-sospetti-var-minetti-quirinale',
+    canonicalPath: '/articoli-frontaliere/italia-sospetti-var-minetti-quirinale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12431,7 +12431,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, azzate, festeggia, koningsdag, console',
     ogTitle: 'Azzate si tinge d’arancione: il Koningsdag compie tredici anni e ospita la Console olandese',
     ogDescription: 'Domenica 3 maggio, Azzate ha celebrato il Koningsdag con mercatini, musica e la presenza della Console olandese Mascha Baak.',
-    canonicalPath: '/articoli-frontaliere/azzate-koningsdag-console-olandese-2026',
+    canonicalPath: '/articoli-frontaliere/azzate-koningsdag-console-olandese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12464,7 +12464,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confine, vacallo, clandestini, passano',
     ogTitle: 'Confine Vacallo: clandestini passano da buco nella ramina',
     ogDescription: 'Tiziano Pasta, consigliere UDC a Mendrisio, denuncia passaggi illegali di clandestini da un varco nella ramina a Vacallo. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/confine-vacallo-clandestini-2026',
+    canonicalPath: '/articoli-frontaliere/confine-vacallo-clandestini-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12497,7 +12497,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morte, alex, zanardi, simbolo',
     ogTitle: 'Morte Alex Zanardi: un simbolo per lo sport italiano',
     ogDescription: 'Alex Zanardi, ex pilota di Formula 1 e atleta paralimpico, è morto a 59 anni. La sua vita e carriera sono un esempio di resilienza e passione.',
-    canonicalPath: '/articoli-frontaliere/morte-alex-zanardi-impatti-frontalieri',
+    canonicalPath: '/articoli-frontaliere/morte-alex-zanardi-impatti-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12530,7 +12530,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premio, walo, hecht, stephan',
     ogTitle: 'Premio Walo 2026: Hecht e Stephan Eicher trionfano',
     ogDescription: 'La 50ma edizione del Prix Walo ha insignito gli Hecht come miglior gruppo e Stephan Eicher nella categoria Canto Pop/Rock.',
-    canonicalPath: '/articoli-frontaliere/premio-walo-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/premio-walo-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12563,7 +12563,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stresa, espulso, cittadino, egiziano',
     ogTitle: 'Stresa: espulso cittadino egiziano, nessun diritto all\'asilo politico',
     ogDescription: 'Un cittadino egiziano è stato espulso da Stresa dopo il rifiuto della richiesta di asilo politico. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/stresa-espulsione-egiziano-2026',
+    canonicalPath: '/articoli-frontaliere/stresa-espulsione-egiziano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12596,7 +12596,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stati, canaglia, lista, aggiorna',
     ogTitle: 'Stati canaglia 2026: la lista si aggiorna',
     ogDescription: 'Gli Stati Uniti e Israele tra i paesi \'infrequentabili\' secondo un\'analisi che ridefinisce la geopolitica contemporanea',
-    canonicalPath: '/articoli-frontaliere/stati-canaglia-2026-aggiornamento-lista',
+    canonicalPath: '/articoli-frontaliere/stati-canaglia-2026-aggiornamento-lista/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12629,7 +12629,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mélenchon, candida, alle, presidenziali',
     ogTitle: 'Mélenchon si candida alle presidenziali: «Sono l’uomo giusto contro la destra»',
     ogDescription: 'Il leader di La France Insoumise punta sull’esperienza per contrastare la minaccia della destra alle urne. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/melenchon-candidatura-presidenziali-2027',
+    canonicalPath: '/articoli-frontaliere/melenchon-candidatura-presidenziali-2027/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12662,7 +12662,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, trionfa, goal, renato',
     ogTitle: 'Lugano trionfa con il goal di Renato Steffen',
     ogDescription: 'Renato Steffen segna il goal decisivo per il Lugano contro il Thun, assicurando la vittoria finale.',
-    canonicalPath: '/articoli-frontaliere/lugano-renato-steffen-goal-staffa',
+    canonicalPath: '/articoli-frontaliere/lugano-renato-steffen-goal-staffa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12695,7 +12695,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giudici, tribunale, federale, conviventi',
     ogTitle: 'Giudici del Tribunale federale conviventi: la Corte dovrà chiarire',
     ogDescription: 'Due giudici del Tribunale federale potrebbero aver violato la legge sulla composizione della suprema corte. La Corte dovrà decidere se riaprire le sentenze.',
-    canonicalPath: '/articoli-frontaliere/tribunale-federale-giudici-conviventi-2026',
+    canonicalPath: '/articoli-frontaliere/tribunale-federale-giudici-conviventi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12728,7 +12728,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, celebra, vittore, girometta',
     ogTitle: 'Varese celebra San Vittore con la Girometta d’oro ad Andrea Chiodi',
     ogDescription: 'Varese celebra San Vittore con la Girometta d’oro ad Andrea Chiodi, Mera & Longhi e la \'super nonna\' di 102 anni',
-    canonicalPath: '/articoli-frontaliere/varese-celebra-san-vittore-girometta-oro-2026',
+    canonicalPath: '/articoli-frontaliere/varese-celebra-san-vittore-girometta-oro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12761,7 +12761,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iran, invita, sacrificio, cosa',
     ogTitle: 'Iran invita frontalieri al sacrificio: cosa cambia in Ticino',
     ogDescription: 'L\'ambasciata iraniana a Berna promuove la campagna Janfada. Preoccupazione tra la diaspora e autorità svizzere. Implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/iran-invita-sacrificio-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/iran-invita-sacrificio-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12794,7 +12794,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piccaluga, dialogo, aperto, norman',
     ogTitle: 'Piccaluga: «Con l\'UDC dialogo aperto, Norman e Claudio due anime diverse»',
     ogDescription: 'Daniele Piccaluga, coordinatore della Lega dei Ticinesi, parla del movimento in crescita e delle differenze tra Norman Gobbi e Claudio Zali.',
-    canonicalPath: '/articoli-frontaliere/piccaluga-udc-dialogo-apertura',
+    canonicalPath: '/articoli-frontaliere/piccaluga-udc-dialogo-apertura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12827,7 +12827,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bonifici, ritardo, cosa, fare',
     ogTitle: 'Bonifici in ritardo: guida pratica per i frontalieri',
     ogDescription: 'Scopri cosa fare se il tuo bonifico tra Svizzera e Italia è in ritardo. Guida pratica per i frontalieri con tempi e regole specifiche.',
-    canonicalPath: '/articoli-frontaliere/bonifici-ritardo-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/bonifici-ritardo-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12860,7 +12860,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, noleggio, auto, consigli, confronta',
     ogTitle: 'Noleggio auto: consigli per frontalieri',
     ogDescription: 'Scopri come noleggiare un\'auto in modo sicuro e conveniente. Confronta le tariffe, verifica le condizioni del veicolo e controlla le coperture assicurative.',
-    canonicalPath: '/articoli-frontaliere/noleggio-auto-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/noleggio-auto-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12893,7 +12893,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresti, notte, nell, aargau',
     ogTitle: 'Due arresti in una notte nell\'Aargau: un tunesino e un marocchino',
     ogDescription: 'La polizia cantonale dell\'Aargau ha arrestato due uomini in due diversi comuni nella notte tra venerdì e sabato. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/aargau-festnahmen-2-mag-2026',
+    canonicalPath: '/articoli-frontaliere/aargau-festnahmen-2-mag-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12926,7 +12926,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gambarogno, vince, battaglia, cittadini',
     ogTitle: 'Gambarogno: vince la battaglia dei cittadini sui contributi di costruzione',
     ogDescription: 'Il Tribunale di espropriazione ha deciso sui prelievi per opere di canalizzazione e depurazione a Contone. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/gambarogno-contributi-costruzione-ricorrenti',
+    canonicalPath: '/articoli-frontaliere/gambarogno-contributi-costruzione-ricorrenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12959,7 +12959,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavena, ponte, tresa, brano',
     ogTitle: 'Da Lavena Ponte Tresa un brano musicale in onore di Leone XIV',
     ogDescription: 'Un brano musicale dedicato a Papa Leone XIV sarà eseguito per la prima volta l\'8 maggio a Cremenaga. Scopri di più su questo evento speciale.',
-    canonicalPath: '/articoli-frontaliere/lavena-brano-musicale-leone-xiv',
+    canonicalPath: '/articoli-frontaliere/lavena-brano-musicale-leone-xiv/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12992,7 +12992,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, unesco, lancia, allarme, minacce',
     ogTitle: 'UNESCO lancia l\'allarme: minacce e autocensura minano la libertà di stampa',
     ogDescription: 'Il 3 maggio si celebra la Giornata mondiale della libertà di stampa. L\'UNESCO segnala un preoccupante arretramento globale tra violenze, pressioni e crisi',
-    canonicalPath: '/articoli-frontaliere/giornata-liberta-stampa-unesco-minacce-autocensura',
+    canonicalPath: '/articoli-frontaliere/giornata-liberta-stampa-unesco-minacce-autocensura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13025,7 +13025,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, russotto, bellinzona, scelta, forse',
     ogTitle: 'Russotto a Bellinzona: «Una scelta che forse non rifarei»',
     ogDescription: 'Andrea Russotto ricorda gli anni in Ticino tra sacrifici familiari e il peso di essere indicato come il nuovo Del Piero.',
-    canonicalPath: '/articoli-frontaliere/russotto-bellinzona-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/russotto-bellinzona-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13058,7 +13058,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, quando, democrazia, smette, essere',
     ogTitle: 'Quando una democrazia smette di essere tale',
     ogDescription: 'Esperti discutono i segnali di declino democratico e le sfide nel definirne la fine, con implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/democrazia-finisce-quando-ticino',
+    canonicalPath: '/articoli-frontaliere/democrazia-finisce-quando-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13091,7 +13091,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, test, gratuito, scarpe, trail-running',
     ogTitle: 'Test gratuito scarpe trail-running Monte Verità 2026',
     ogDescription: 'Belotti Sport organizza un test gratuito di scarpe da trail-running al Monte Verità di Ascona il 9 maggio 2026. Iscrizioni aperte.',
-    canonicalPath: '/articoli-frontaliere/belotti-sport-test-scarpe-trail-running-2026',
+    canonicalPath: '/articoli-frontaliere/belotti-sport-test-scarpe-trail-running-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13124,7 +13124,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, milioni, pericoli, minori',
     ogTitle: 'Iniziativa 10 milioni: i pericoli per i minori',
     ogDescription: 'Un\'alleanza di organizzazioni avverte sui rischi per i diritti dei bambini se l\'iniziativa verrà approvata il 14 giugno',
-    canonicalPath: '/articoli-frontaliere/pericoli-minori-iniziativa-10-milioni',
+    canonicalPath: '/articoli-frontaliere/pericoli-minori-iniziativa-10-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13157,7 +13157,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agrinatura, sold, degustazioni, show',
     ogTitle: 'Agrinatura sold out: degustazioni, show cooking e laboratori',
     ogDescription: 'Agrinatura 2026 è sold out con laboratori e cooking show. Scopri il programma e i protagonisti della manifestazione.',
-    canonicalPath: '/articoli-frontaliere/agrinatura-sold-out-2026',
+    canonicalPath: '/articoli-frontaliere/agrinatura-sold-out-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13190,7 +13190,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mezzo, milione, sviluppo, luganese',
     ogTitle: 'Mezzo milione per lo sviluppo del Luganese nel 2026',
     ogDescription: 'L\'ERSL mette a disposizione 500mila franchi per progetti locali nel Luganese, con un effetto leva di 8 franchi per ogni franco investito.',
-    canonicalPath: '/articoli-frontaliere/mezzo-milione-luganese-sviluppo-2026',
+    canonicalPath: '/articoli-frontaliere/mezzo-milione-luganese-sviluppo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13223,7 +13223,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, raccolti, quasi, 2000, euro',
     ogTitle: 'Raccolti quasi 2000 euro per il parco giochi in memoria di Matteo',
     ogDescription: 'Quasi 2000 euro raccolti per un nuovo parco giochi in memoria del piccolo Matteo a Busto Arsizio. Scopri come contribuire.',
-    canonicalPath: '/articoli-frontaliere/raccolti-2000-euro-parco-matteo',
+    canonicalPath: '/articoli-frontaliere/raccolti-2000-euro-parco-matteo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13256,7 +13256,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moleno, arriva, piazza, green',
     ogTitle: 'Moleno: piazza green e chiesa migliorata',
     ogDescription: 'Il Municipio di Bellinzona presenta i progetti per la nuova piazza verde e il restauro della chiesa a Moleno. Ecco i dettagli e l\'impatto sui frontalieri.',
-    canonicalPath: '/articoli-frontaliere/moleno-piazza-green-chiesa-migliorata',
+    canonicalPath: '/articoli-frontaliere/moleno-piazza-green-chiesa-migliorata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13289,7 +13289,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, armato, barrica, casa, arrestato',
     ogTitle: 'Armato si barrica in casa: arrestato 30enne a Frauenfeld',
     ogDescription: 'Un uomo di 30 anni si è barricato nel suo appartamento a Frauenfeld, in condizioni psichiche alterate. La polizia lo ha arrestato dopo un intervento di diverse',
-    canonicalPath: '/articoli-frontaliere/arresto-frauenfeld-30enne-barricato',
+    canonicalPath: '/articoli-frontaliere/arresto-frauenfeld-30enne-barricato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13322,7 +13322,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mercato, lavoro, svizzero, conferma',
     ogTitle: 'Mercato del lavoro svizzero: KOF conferma la ripresa',
     ogDescription: 'Le nuove cifre KOF segnalano una ripresa del mercato del lavoro elvetico, con prospettive positive per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/mercato-lavoro-kof-ripresa-2026',
+    canonicalPath: '/articoli-frontaliere/mercato-lavoro-kof-ripresa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13355,7 +13355,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vendite, auto, stabili, cresce',
     ogTitle: 'Vendite auto stabili in Ticino, cresce l\'elettrico',
     ogDescription: 'In aprile 2026 vendite auto stabili in Svizzera, elettriche +35%. Focus su impatto frontalieri e mercato ticinese.',
-    canonicalPath: '/articoli-frontaliere/vendite-auto-ticino-2026-stabili-elettrico',
+    canonicalPath: '/articoli-frontaliere/vendite-auto-ticino-2026-stabili-elettrico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13388,7 +13388,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, indice, svizzero, ottimismo, oltre',
     ogTitle: 'Indice PMI svizzero: ottimismo oltre le stime',
     ogDescription: 'L\'indice PMI svizzero sale a 54,5 punti per il manifatturiero e 54,8 per i servizi, superando le previsioni degli analisti',
-    canonicalPath: '/articoli-frontaliere/indice-pmi-svizzera-ottimismo-2026',
+    canonicalPath: '/articoli-frontaliere/indice-pmi-svizzera-ottimismo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13421,7 +13421,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tenero, festeggia, anni, campo',
     ogTitle: 'Tenero festeggia 25 anni con il campo 3T per giovani atleti',
     ogDescription: 'Dal 10 al 15 maggio, il Centro Sportivo di Tenero ospita 500 giovani talenti per il campo 3T, organizzato da Swiss Olympic',
-    canonicalPath: '/articoli-frontaliere/campo-talenti-tenero-25-anni',
+    canonicalPath: '/articoli-frontaliere/campo-talenti-tenero-25-anni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13454,7 +13454,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aeroporto, zurigo, traffico, aereo',
     ogTitle: 'Aeroporto Zurigo: traffico aereo in crescita del 5% ad aprile',
     ogDescription: 'Superati i livelli pre-pandemici con 23\'300 movimenti aerei, primo aumento annuale dal 2019. Dati Awp su regole IFR.',
-    canonicalPath: '/articoli-frontaliere/aeroporto-zurigo-traffico-crescita-2026',
+    canonicalPath: '/articoli-frontaliere/aeroporto-zurigo-traffico-crescita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13487,7 +13487,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, treni, extra, ascensione, pentecoste',
     ogTitle: 'FFS: 58 treni extra per Ascensione e Pentecoste',
     ogDescription: 'Le FFS potenziano l\'offerta con 58 treni speciali e 130.000 posti aggiuntivi tra Svizzera tedesca e Ticino',
-    canonicalPath: '/articoli-frontaliere/ffs-ascensione-pentecoste-2026',
+    canonicalPath: '/articoli-frontaliere/ffs-ascensione-pentecoste-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13520,7 +13520,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stralugano, percorsi, tutti, livelli',
     ogTitle: 'StraLugano 2026: percorsi per tutti i livelli',
     ogDescription: 'Scopri i percorsi disponibili alla StraLugano 2026, dalla 5 km alla mezza maratona, con tariffe agevolate per gli Over 65.',
-    canonicalPath: '/articoli-frontaliere/stralugano-percorsi-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/stralugano-percorsi-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13553,7 +13553,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, camelie, locarno, record, visitatori',
     ogTitle: 'Camelie Locarno 2026: record di visitatori e incassi',
     ogDescription: 'L\'edizione 2026 di Camelie Locarno ha registrato 14.000 visitatori e un aumento del 10% degli incassi rispetto al 2022.',
-    canonicalPath: '/articoli-frontaliere/camelie-locarno-record-visitatori-2026',
+    canonicalPath: '/articoli-frontaliere/camelie-locarno-record-visitatori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13586,7 +13586,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, museo, leventina, disastri, diventano',
     ogTitle: 'Al Museo di Leventina i disastri diventano un gioco dell\'oca',
     ogDescription: 'Nuova mostra interattiva dal Medioevo a oggi su come le comunità del Ticino hanno affrontato frane, epidemie e incendi',
-    canonicalPath: '/articoli-frontaliere/disastri-museo-leventina-gioco-oca',
+    canonicalPath: '/articoli-frontaliere/disastri-museo-leventina-gioco-oca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13619,7 +13619,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ndrangheta, sfuggire, antimafia, italiana',
     ogTitle: 'La ’ndrangheta usa il Ticino per sfuggire all’antimafia italiana',
     ogDescription: 'Sentenze svizzere e italiane rivelano come la cosca di Isola Capo Rizzuto abbia usato società ticinesi per aggirare interdittive antimafia',
-    canonicalPath: '/articoli-frontaliere/ndrangheta-ticino-antimafia-italiana',
+    canonicalPath: '/articoli-frontaliere/ndrangheta-ticino-antimafia-italiana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13652,7 +13652,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, accise, carburanti, cambiano',
     ogTitle: 'Nuove accise carburanti 2026: impatto sui frontalieri Ticino',
     ogDescription: 'Dai 2 maggio 2026 le accise sulla benzina e sul GPL sono aumentate, mentre il diesel è in lieve calo. Ecco come cambia il costo del carburante per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/nuove-accise-carburanti-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-accise-carburanti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13685,7 +13685,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponti, primaverili, traffico, intenso',
     ogTitle: 'Ponti primaverili: traffico intenso su autostrade e valichi',
     ogDescription: 'L\'Ufficio federale delle strade prevede disagi su A2, A13 e valichi di frontiera durante i ponti di Ascensione, Pentecoste e Corpus Domini.',
-    canonicalPath: '/articoli-frontaliere/ponti-primaverili-traffico-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ponti-primaverili-traffico-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13718,7 +13718,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lidl, avrà, elvetico, prima',
     ogTitle: 'Lidl Svizzera avrà un CEO elvetico: è la prima volta',
     ogDescription: 'Michael Kunz, attuale CEO di Lidl Austria, prenderà il posto di Nicholas Pennanen a fine estate 2026. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lidl-svizzera-ceo-elvetico',
+    canonicalPath: '/articoli-frontaliere/lidl-svizzera-ceo-elvetico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13751,7 +13751,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, torneo, alge, sport, calcio',
     ogTitle: 'Torneo Alge Alp Sport: calcio alpino in Ticino dal 14 al 17 maggio',
     ogDescription: 'Dal 14 al 17 maggio, Bellinzona, Tenero e Gambarogno ospiteranno il torneo Alge Alp Sport, un evento internazionale di calcio giovanile e inclusivo',
-    canonicalPath: '/articoli-frontaliere/calcio-alpino-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/calcio-alpino-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13784,7 +13784,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponti, primaverili, traffico, strada',
     ogTitle: 'Ponti primaverili: più traffico su strada e rotaia',
     ogDescription: 'FFS potenziano l\'offerta con 58 treni speciali e 130.000 posti aggiuntivi. USTRA consiglia alternative per evitare ingorghi.',
-    canonicalPath: '/articoli-frontaliere/ponti-primaverili-traffico-2026',
+    canonicalPath: '/articoli-frontaliere/ponti-primaverili-traffico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13817,7 +13817,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, perbacco, bianchi, bellinzona, giorni',
     ogTitle: 'PerBacco! che Bianchi! a Bellinzona: degustazioni e musica',
     ogDescription: 'Dal 8 al 10 maggio 2026, Bellinzona celebra i vini bianchi ticinesi con degustazioni, musica e tour tra i vigneti. Scopri il programma e come partecipare.',
-    canonicalPath: '/articoli-frontaliere/perbacco-bianchi-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/perbacco-bianchi-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13850,7 +13850,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bianconeri, amano, corto, muso',
     ogTitle: 'I bianconeri amano il corto muso: quattro vittorie consecutive',
     ogDescription: 'I bianconeri del FC Lugano vincono il quarto 1-0 consecutivo, agganciando il San Gallo in seconda posizione nella Super League.',
-    canonicalPath: '/articoli-frontaliere/bianconeri-corto-muso-2026',
+    canonicalPath: '/articoli-frontaliere/bianconeri-corto-muso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13883,7 +13883,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tasse, sugli, immobili, rischio',
     ogTitle: 'Tasse sugli immobili: il rischio di una stangata nascosta',
     ogDescription: 'Famiglie e imprese in allarme per la revisione dei valori di stima immobiliari in Ticino. Ecco cosa cambia e come difendersi.',
-    canonicalPath: '/articoli-frontaliere/stangata-nascosta-tasse-immobiliari',
+    canonicalPath: '/articoli-frontaliere/stangata-nascosta-tasse-immobiliari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13916,7 +13916,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro, benzina, benzinai, varesini',
     ogTitle: 'Caro benzina: benzinai varesini tra accise e incertezze',
     ogDescription: 'Dopo il ponte del 1° maggio, i distributori di carburante della provincia di Varese si sono trovati a secco. Ecco come le accise stanno complicando la vita ai',
-    canonicalPath: '/articoli-frontaliere/caro-benzina-varese-accise-2026',
+    canonicalPath: '/articoli-frontaliere/caro-benzina-varese-accise-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13949,7 +13949,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, meloni, cooperazione, mediterraneo, gestire',
     ogTitle: 'Meloni: cooperazione Mediterraneo per immigrazione',
     ogDescription: 'La premier italiana sottolinea l\'importanza della cooperazione internazionale per affrontare le sfide migratorie e le loro implicazioni economiche e sociali.',
-    canonicalPath: '/articoli-frontaliere/meloni-cooperazione-mediterraneo-immigrazione',
+    canonicalPath: '/articoli-frontaliere/meloni-cooperazione-mediterraneo-immigrazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13982,7 +13982,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, paolo, iodice, nuovo, questore',
     ogTitle: 'Paolo Iodice nuovo questore di Varese: sicurezza e continuità',
     ogDescription: 'Paolo Iodice è il nuovo questore di Varese. Ecco cosa cambia per la sicurezza e i frontalieri che lavorano in Svizzera e risiedono in Italia.',
-    canonicalPath: '/articoli-frontaliere/nuovo-questore-varese-sicurezza-frontalieri',
+    canonicalPath: '/articoli-frontaliere/nuovo-questore-varese-sicurezza-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14015,7 +14015,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, questore, varese, priorità',
     ogTitle: 'Nuovo questore Varese: priorità a truffe, furti e rapine',
     ogDescription: 'Paolo Iodice si presenta come nuovo questore di Varese, con focus su sicurezza e lotta alla criminalità transfrontaliera',
-    canonicalPath: '/articoli-frontaliere/nuovo-questore-varese-sicurezza-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-questore-varese-sicurezza-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14048,7 +14048,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, franzolini, fenealuil, serve, piano',
     ogTitle: 'Franzolini (FenealUil): Piano strutturale casa',
     ogDescription: 'Il segretario generale della FenealUil, Mauro Franzolini, sottolinea l\'importanza di un piano strutturale per affrontare il caro affitti e riqualificare il',
-    canonicalPath: '/articoli-frontaliere/franzolini-fenealuil-piano-casa',
+    canonicalPath: '/articoli-frontaliere/franzolini-fenealuil-piano-casa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14081,7 +14081,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inaugurazione, parco, biumo, sabato',
     ogTitle: 'Inaugurazione parco Biumo: sabato 9 maggio',
     ogDescription: 'Nuovo parco a Biumo con campo da basket, pingpong e teqball. Inaugurazione sabato 9 maggio alle 15 con tornei e musica',
-    canonicalPath: '/articoli-frontaliere/parco-biumo-inaugurazione-2026',
+    canonicalPath: '/articoli-frontaliere/parco-biumo-inaugurazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14114,7 +14114,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parcheggi, como, residenti, beffati',
     ogTitle: 'Parcheggi blu a Como: residenti beffati, vie vuote nonostante le promesse',
     ogDescription: 'I parcheggi blu a Como centro restano vuoti nonostante le promesse. La consigliera Paola Ceriello denuncia la situazione.',
-    canonicalPath: '/articoli-frontaliere/parcheggi-blu-como-residenti',
+    canonicalPath: '/articoli-frontaliere/parcheggi-blu-como-residenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14147,7 +14147,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, proposte, cernobbio, mercato, tessile',
     ogTitle: 'Proposte 2026 a Cernobbio: mercato tessile da 1,3 miliardi di euro',
     ogDescription: 'La 33ª edizione di Proposte, la fiera del tessuto d’arredamento, si apre a Villa Erba con 87 espositori internazionali e un focus su sostenibilità e',
-    canonicalPath: '/articoli-frontaliere/proposte-cernobbio-2026-tessile',
+    canonicalPath: '/articoli-frontaliere/proposte-cernobbio-2026-tessile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14180,7 +14180,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confisca, preventiva, cappa, propone',
     ogTitle: 'Confisca preventiva: Cappa propone modello italiano per la Svizzera',
     ogDescription: 'Rosa Maria Cappa, ex procuratrice federale, propone di introdurre in Svizzera il sequestro preventivo dei beni delle mafie, come in Italia',
-    canonicalPath: '/articoli-frontaliere/confisca-preventiva-mafie-svizzera',
+    canonicalPath: '/articoli-frontaliere/confisca-preventiva-mafie-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14213,7 +14213,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedale, erba, massaggi, make-up',
     ogTitle: 'Ospedale Erba: massaggi e make-up per pazienti oncologiche',
     ogDescription: 'Nuovo progetto per il benessere psicofisico delle pazienti oncologiche con massaggi e consulenze make-up. Iniziativa a partire da settembre 2026.',
-    canonicalPath: '/articoli-frontaliere/ospedale-erba-cura-oncologiche-2026',
+    canonicalPath: '/articoli-frontaliere/ospedale-erba-cura-oncologiche-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14246,7 +14246,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mezzo, milione, progetti, luganese',
     ogTitle: 'Mezzo milione per progetti nel Luganese: come partecipare',
     ogDescription: 'L\'Ersl mette a disposizione 500\'000 franchi per progetti nel Luganese. Scopri come richiedere i contributi e i criteri di selezione.',
-    canonicalPath: '/articoli-frontaliere/mezzo-milione-franchi-progetti-luganese-2026',
+    canonicalPath: '/articoli-frontaliere/mezzo-milione-franchi-progetti-luganese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14279,7 +14279,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, alla, stazione, bellinzona',
     ogTitle: 'Tragedia alla stazione di Bellinzona: muore folgorato dalla linea ferroviaria',
     ogDescription: 'Un uomo è morto folgorato dalla linea ferroviaria alla stazione di Bellinzona. Le indagini sono in corso.',
-    canonicalPath: '/articoli-frontaliere/tragedia-bellinzona-folgorazione-2026',
+    canonicalPath: '/articoli-frontaliere/tragedia-bellinzona-folgorazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14312,7 +14312,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, monti, angei, lega',
     ogTitle: 'Varese: Monti e Angei (Lega) chiedono intervento urgente per via Monte Santo',
     ogDescription: 'I consiglieri comunali Monti e Angei denunciano degrado e insicurezza nell\'ex sede dei Lavori Pubblici a Varese, chiedendo un intervento urgente',
-    canonicalPath: '/articoli-frontaliere/sicurezza-varese-monte-santo-intervento-comune',
+    canonicalPath: '/articoli-frontaliere/sicurezza-varese-monte-santo-intervento-comune/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14345,7 +14345,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arrestato, albanese, grammi, cocaina',
     ogTitle: 'Arrestato albanese con 54 grammi di cocaina a Capolago',
     ogDescription: 'Un 24enne albanese è stato arrestato con 54 grammi di cocaina in auto sull\'A2 a Capolago. Ecco i dettagli dell\'operazione.',
-    canonicalPath: '/articoli-frontaliere/arresto-albanese-cocaina-capolago',
+    canonicalPath: '/articoli-frontaliere/arresto-albanese-cocaina-capolago/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14378,7 +14378,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banca, cantonale, grigionese, denunciata',
     ogTitle: 'Banca cantonale grigionese denunciata per centinaia di milioni',
     ogDescription: 'Una causa milionaria è stata intentata contro la Banca cantonale grigionese e la sua affiliata BZ Bank per presunte violazioni degli obblighi contrattuali.',
-    canonicalPath: '/articoli-frontaliere/banca-grigionese-denuncia-centinaia-milioni',
+    canonicalPath: '/articoli-frontaliere/banca-grigionese-denuncia-centinaia-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14411,7 +14411,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, posti, vuoti, residenti',
     ogTitle: 'Como: posti blu vuoti e residenti in difficoltà a parcheggiare',
     ogDescription: 'Residenti di Como segnalano posti blu pieni e difficoltà a trovare parcheggio, nonostante i posti blu non ASA liberi. Cosa fare?',
-    canonicalPath: '/articoli-frontaliere/parcheggi-blu-como-residenti-difficolta',
+    canonicalPath: '/articoli-frontaliere/parcheggi-blu-como-residenti-difficolta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14444,7 +14444,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 2027, presidio, security, alla',
     ogTitle: 'Dal 2027 presidio Fs Security a Gallarate',
     ogDescription: 'Nuovo presidio di sicurezza alla stazione di Gallarate dal 2027, con operatori attivi 24 ore su 24.',
-    canonicalPath: '/articoli-frontaliere/gallarate-fs-security-2027',
+    canonicalPath: '/articoli-frontaliere/gallarate-fs-security-2027/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14477,7 +14477,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, chiasso, evacuati, residenti',
     ogTitle: 'Incendio a Chiasso: evacuati 30 residenti',
     ogDescription: 'Un incendio sul tetto di una palazzina a Chiasso ha portato all\'evacuazione di 30 persone. Due operai sono rimasti leggermente feriti.',
-    canonicalPath: '/articoli-frontaliere/incendio-chiasso-palazzina-evacuati-30',
+    canonicalPath: '/articoli-frontaliere/incendio-chiasso-palazzina-evacuati-30/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14510,7 +14510,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aperto, nuovo, mcdonald, lamone',
     ogTitle: 'Aperto il nuovo McDonald\'s di Lamone',
     ogDescription: 'Il nuovo McDonald\'s di Lamone è ufficialmente aperto. Scopri le implicazioni per i frontalieri e le procedure da seguire.',
-    canonicalPath: '/articoli-frontaliere/mcdonalds-lamone-apertura-2026',
+    canonicalPath: '/articoli-frontaliere/mcdonalds-lamone-apertura-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14543,7 +14543,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maxi, piano, traffico, sulla',
     ogTitle: 'Maxi piano per il traffico sulla statale del Lago di Como: soluzioni chirurgiche',
     ogDescription: 'Interventi mirati per migliorare la sicurezza e fluidità della viabilità lungo la SS 340 Regina, con finanziamenti ANAS e coordinamento provinciale',
-    canonicalPath: '/articoli-frontaliere/maxi-piano-traffico-lago-como-2026',
+    canonicalPath: '/articoli-frontaliere/maxi-piano-traffico-lago-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14576,7 +14576,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, tetto, chiasso, evacuati',
     ogTitle: 'Incendio sul tetto a Chiasso, evacuati una trentina di persone',
     ogDescription: 'Un incendio è scoppiato sul tetto di una palazzina in Piazza Indipendenza a Chiasso, causando l\'evacuazione di circa trenta persone.',
-    canonicalPath: '/articoli-frontaliere/incendio-chiasso-evacuati-trentina-persone',
+    canonicalPath: '/articoli-frontaliere/incendio-chiasso-evacuati-trentina-persone/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14609,7 +14609,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lotta, alla, zanzara, tigre',
     ogTitle: 'Lotta alla zanzara tigre a Mendrisio',
     ogDescription: 'Mendrisio in prima linea nel 2026 contro la zanzara tigre con un progetto basato sulla tecnica del maschio sterile',
-    canonicalPath: '/articoli-frontaliere/lotta-zanzara-tigre-mendrisio',
+    canonicalPath: '/articoli-frontaliere/lotta-zanzara-tigre-mendrisio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14642,7 +14642,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inaugurato, nuovo, cardiocentro, offre',
     ogTitle: 'Inaugurato il nuovo Cardiocentro Ticino',
     ogDescription: 'Il nuovo Cardiocentro Ticino offre servizi integrati e migliorata assistenza specialistica per il territorio. Inaugurato a Lugano il 4 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/inaugurato-nuovo-cardiocentro-ticino',
+    canonicalPath: '/articoli-frontaliere/inaugurato-nuovo-cardiocentro-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14675,7 +14675,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guardia, finanza, controlli, carburanti',
     ogTitle: 'Guardia di Finanza: controlli sui carburanti a Como',
     ogDescription: 'Quattro distributori multati per violazioni sui prezzi della benzina. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/guardia-finanza-carburanti-como-2026',
+    canonicalPath: '/articoli-frontaliere/guardia-finanza-carburanti-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14708,7 +14708,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luciano, bordignon, festeggia, anni',
     ogTitle: 'Luciano Bordignon festeggia 100 anni a Chiasso',
     ogDescription: 'Il signor Luciano Bordignon ha spento 100 candeline lo scorso 30 aprile, festeggiando con il sindaco Bruno Arrigoni a Chiasso.',
-    canonicalPath: '/articoli-frontaliere/nuovo-centenario-chiasso-luciano-bordignon',
+    canonicalPath: '/articoli-frontaliere/nuovo-centenario-chiasso-luciano-bordignon/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14741,7 +14741,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, evian, possibili, chiusure, frontiere',
     ogTitle: 'G7 Evian: chiusure frontiere, cosa cambia per i frontalieri',
     ogDescription: 'Manifestazioni anti-G7 e possibili chiusure parziali dei valichi con la Francia. Ecco cosa sapere se vivi in Italia e lavori in Svizzera',
-    canonicalPath: '/articoli-frontaliere/g7-evian-frontiere-chiuse-2026',
+    canonicalPath: '/articoli-frontaliere/g7-evian-frontiere-chiuse-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14774,7 +14774,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, quattro, distributori, guai, prezzi',
     ogTitle: 'Quattro distributori nei guai: prezzi esposti diversi da quelli praticati',
     ogDescription: 'La Guardia di Finanza di Como ha scoperto irregolarità in quattro distributori di carburante nel Ticino. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/distributori-carburante-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/distributori-carburante-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14807,7 +14807,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dona, spesa, nova, coop',
     ogTitle: 'Dona la Spesa 2026: Nova Coop raccoglie beni per associazioni locali',
     ogDescription: 'Sabato 9 maggio torna l\'iniziativa solidale nei supermercati di Tradate, Luino e Castano Primo. Raccolta per Caritas, Croce Rossa e altre associazioni',
-    canonicalPath: '/articoli-frontaliere/dona-spesa-nova-coop-2026',
+    canonicalPath: '/articoli-frontaliere/dona-spesa-nova-coop-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14840,7 +14840,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, littizzetto, critica, fatture, feriti',
     ogTitle: 'Littizzetto critica la Svizzera per le fatture ai feriti di Crans Montana',
     ogDescription: 'La comica italiana Luciana Littizzetto critica la Svizzera per le fatture ospedaliere ai feriti dell\'incendio di Crans Montana, sollevando polemiche e luoghi',
-    canonicalPath: '/articoli-frontaliere/littizzetto-critica-svizzera-crans-montana',
+    canonicalPath: '/articoli-frontaliere/littizzetto-critica-svizzera-crans-montana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14873,7 +14873,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fondazione, cariplo, milioni, varese',
     ogTitle: 'Fondazione Cariplo: 5 milioni a Varese per 48 progetti nel 2025',
     ogDescription: 'La Fondazione Cariplo ha approvato il bilancio 2025, assegnando quasi 5 milioni di euro a 48 progetti nella provincia di Varese.',
-    canonicalPath: '/articoli-frontaliere/fondazione-cariplo-varese-5-milioni-2025',
+    canonicalPath: '/articoli-frontaliere/fondazione-cariplo-varese-5-milioni-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14906,7 +14906,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese-milano, rallentamenti, treni, maggio',
     ogTitle: 'Varese-Milano, rallentamenti treni 5-11 maggio 2026',
     ogDescription: 'Trenord annuncia rallentamenti sui treni Varese-Milano dal 5 all’11 maggio 2026. Ritardi fino a 3 minuti su diverse linee. Consigli per i pendolari.',
-    canonicalPath: '/articoli-frontaliere/varese-milano-rallentamenti-treni-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/varese-milano-rallentamenti-treni-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14939,7 +14939,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, rafforzati, carburanti, provincia',
     ogTitle: 'Controlli rafforzati sui carburanti in provincia di Como',
     ogDescription: 'La Guardia di Finanza di Como ha intensificato i controlli sui distributori di carburante, elevando quattro sanzioni per irregolarità sui prezzi.',
-    canonicalPath: '/articoli-frontaliere/controlli-carburanti-como-guardia-finanza',
+    canonicalPath: '/articoli-frontaliere/controlli-carburanti-como-guardia-finanza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14972,7 +14972,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piazza, finanziaria, ticinese, solida',
     ogTitle: 'ABT: piazza finanziaria ticinese più solida che mai',
     ogDescription: 'Rinnovate le cariche dell\'Associazione Bancaria Ticinese per il triennio 2026-2029. Petruzzella confermato presidente.',
-    canonicalPath: '/articoli-frontaliere/banca-piazza-petruzzella-abt-2026',
+    canonicalPath: '/articoli-frontaliere/banca-piazza-petruzzella-abt-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15005,7 +15005,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, market, index, crescita',
     ogTitle: 'Swiss Market Index in crescita, ma con timori per le trimestrali',
     ogDescription: 'L\'indice Swiss Market Index chiude in positivo, ma le Borse europee mostrano preoccupazione per i risultati delle aziende.',
-    canonicalPath: '/articoli-frontaliere/swiss-market-index-crescita-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-market-index-crescita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15038,7 +15038,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, apre, inchieste, keyword',
     ogTitle: 'COMCO apre inchieste su keyword bidding: viaggi e casinò online nel mirino',
     ogDescription: 'La Commissione della concorrenza indaga su accordi illeciti tra aziende di viaggi e casinò online per il keyword bidding',
-    canonicalPath: '/articoli-frontaliere/comco-keyword-bidding-inchieste',
+    canonicalPath: '/articoli-frontaliere/comco-keyword-bidding-inchieste/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15071,7 +15071,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, autolaghi, chiusura, notturna, lavori',
     ogTitle: 'Autolaghi chiusura barriere antirumore',
     ogDescription: 'L\'autostrada A8 Milano-Varese sarà chiusa per due notti tra Busto Arsizio e Gallarate verso Varese per lavori alle barriere antirumore.',
-    canonicalPath: '/articoli-frontaliere/autolaghi-chiusura-barriere-antirumore-2026',
+    canonicalPath: '/articoli-frontaliere/autolaghi-chiusura-barriere-antirumore-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15104,7 +15104,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, mamma, solidale, buoni',
     ogTitle: 'Festa della mamma solidale: buoni per ristoranti a famiglie monoparentali',
     ogDescription: 'Soccorso d\'Inverno e GastroTicino regalano buoni per la Festa della mamma a 26 famiglie monoparentali in difficoltà economica',
-    canonicalPath: '/articoli-frontaliere/festa-mamma-solidarieta-2026',
+    canonicalPath: '/articoli-frontaliere/festa-mamma-solidarieta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15137,7 +15137,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cambiano, chiusure, notturne, solbiate',
     ogTitle: 'A8, cambiano le chiusure notturne tra Solbiate Arno e Gallarate',
     ogDescription: 'Nuove restrizioni notturne sull\'autostrada A8 tra Solbiate Arno e Gallarate dal 6 al 8 maggio 2026. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/a8-chiusure-gallarate-frontalieri',
+    canonicalPath: '/articoli-frontaliere/a8-chiusure-gallarate-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15170,7 +15170,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costi, aeroporto, lugano, milioni',
     ogTitle: 'Costi aeroporto Lugano: 4 milioni in spese non autorizzate',
     ogDescription: 'Interpellanza al Municipio: 2,7 milioni per carburante, IVA non inclusa. Strategia e tempistiche ancora sfocate. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/costi-aeroporto-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/costi-aeroporto-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15203,7 +15203,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ladies, torna, corsa, femminile',
     ogTitle: 'Ladies Run Ticino 2026: corsa femminile a Lugano',
     ogDescription: 'Sabato 9 maggio 2026 a Lugano torna la Ladies Run Ticino con percorsi di 2.5 km, 5 km e 10 km. Iscrizioni ancora aperte online fino al 7 maggio.',
-    canonicalPath: '/articoli-frontaliere/ladies-run-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/ladies-run-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15236,7 +15236,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, distensione, meloni, parmelin',
     ogTitle: 'Crans-Montana, distensione tra Meloni e Parmelin',
     ogDescription: 'Incontro tra i due leader per risolvere la questione delle spese sanitarie per le vittime italiane dell\'incendio',
-    canonicalPath: '/articoli-frontaliere/crans-montana-meloni-parmelin-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-meloni-parmelin-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15269,7 +15269,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gabbiano, bonaparte, avvistato, prima',
     ogTitle: 'Gabbiano di Bonaparte avvistato in Svizzera: prima volta in Ticino',
     ogDescription: 'Un gabbiano di Bonaparte, raro esemplare americano, è stato avvistato per la prima volta in Svizzera, creando scalpore tra gli appassionati.',
-    canonicalPath: '/articoli-frontaliere/gabbiano-bonaparte-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/gabbiano-bonaparte-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15302,7 +15302,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, buoni, ristoranti, mamme, monoparentali',
     ogTitle: 'Buoni per ristoranti a mamme monoparentali in Ticino',
     ogDescription: 'Soccorso d’inverno Ticino e GastroTicino regalano buoni per ristoranti a 74 persone, tra cui 50 bambini, per la Festa della mamma 2026',
-    canonicalPath: '/articoli-frontaliere/buoni-ristorante-mamme-monoparentali-ticino',
+    canonicalPath: '/articoli-frontaliere/buoni-ristorante-mamme-monoparentali-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15335,7 +15335,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, chiasso, operai, ricoverati',
     ogTitle: 'Incendio a Chiasso: due operai ricoverati dopo un rogo su un tetto',
     ogDescription: 'Un incendio causato da fiamme libere ha coinvolto un tetto a Chiasso, con due operai ricoverati in ospedale. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/incendio-chiasso-operai-ricoverati',
+    canonicalPath: '/articoli-frontaliere/incendio-chiasso-operai-ricoverati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15368,7 +15368,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hodler, restituito, storia, dipinto',
     ogTitle: 'Hodler restituito: storia di un dipinto e di una frontaliere',
     ogDescription: 'Un dipinto di Hodler, venduto sotto coercizione durante il regime nazista, torna agli eredi. La storia di Martha Nathan, cittadina svizzera e frontaliere',
-    canonicalPath: '/articoli-frontaliere/hodler-dipinto-eredita-frontalieri',
+    canonicalPath: '/articoli-frontaliere/hodler-dipinto-eredita-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15401,7 +15401,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, solo, staffetta, qualificata, pechino',
     ogTitle: 'Solo una staffetta svizzera qualificata per Pechino 2027',
     ogDescription: 'La staffetta 4x100 m mista svizzera si qualifica per i Mondiali di Pechino 2027, mentre le altre squadre svizzere sono state eliminate',
-    canonicalPath: '/articoli-frontaliere/staffette-rossocrociate-pechino-2027',
+    canonicalPath: '/articoli-frontaliere/staffette-rossocrociate-pechino-2027/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15434,7 +15434,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, walter, camarda, riconfermato, presidente',
     ogTitle: 'Walter Camarda riconfermato presidente del Consorzio Ecolight',
     ogDescription: 'L\'assemblea annuale del Consorzio Ecolight ha confermato Walter Camarda alla presidenza per il triennio 2026-2028. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ecolight-camarda-presidente-2026-2028',
+    canonicalPath: '/articoli-frontaliere/ecolight-camarda-presidente-2026-2028/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15467,7 +15467,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, boom, viaggiatori, treni, elvetici',
     ogTitle: 'Boom di viaggiatori sui treni elvetici',
     ogDescription: 'Record di passeggeri nel primo trimestre 2026, ma calo del trasporto merci. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/boom-viaggiatori-treni-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/boom-viaggiatori-treni-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15500,7 +15500,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, neutralizzazione, stime, immobiliari, difesa',
     ogTitle: 'Neutralizzazione stime immobiliari: difesa dei sacrifici di una vita',
     ogDescription: 'Iniziativa popolare per neutralizzare le stime immobiliari in Ticino. Implicazioni per i frontalieri e l\'economia locale.',
-    canonicalPath: '/articoli-frontaliere/neutralizzazione-stime-immobiliari-2026',
+    canonicalPath: '/articoli-frontaliere/neutralizzazione-stime-immobiliari-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15533,7 +15533,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, neutralizzazione, stime, immobiliari, perché',
     ogTitle: 'Neutralizzazione stime immobiliari: perché il Ticino vota SÌ',
     ogDescription: '430 milioni di franchi annui in gioco: il Ticino decide se adeguare automaticamente le imposte o lasciare la scelta al Gran Consiglio',
-    canonicalPath: '/articoli-frontaliere/neutralizzazione-stime-immobiliari-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/neutralizzazione-stime-immobiliari-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15566,7 +15566,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, barometro, economia, leggero, miglioramento',
     ogTitle: 'Barometro KOF: economia svizzera in leggero miglioramento ma prospettive modeste',
     ogDescription: 'Il barometro del KOF segna 97,9 punti in aprile, ma l\'economia elvetica resta sotto la media pluriennale di 100. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/barometro-kof-aprile-2026-prospettive-modeste',
+    canonicalPath: '/articoli-frontaliere/barometro-kof-aprile-2026-prospettive-modeste/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15599,7 +15599,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elicottero, precipita, mezzovico, feriti',
     ogTitle: 'Elicottero precipita a Mezzovico: sei feriti, uno grave',
     ogDescription: 'Un elicottero precipita durante l\'atterraggio a Mezzovico-Vira, sei persone ferite, una in gravi condizioni. Indagini in corso sulle cause.',
-    canonicalPath: '/articoli-frontaliere/elicottero-mezzovico-frontalieri',
+    canonicalPath: '/articoli-frontaliere/elicottero-mezzovico-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15632,7 +15632,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sogna, ospedale, universitario, diffuso',
     ogTitle: 'Ticino sogna un ospedale universitario diffuso',
     ogDescription: 'Il progetto è sul tavolo del Consiglio di Stato. Sanvido (Eoc): \'Speriamo di ricevere presto il via libera\'',
-    canonicalPath: '/articoli-frontaliere/ospedale-universitario-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ospedale-universitario-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15665,7 +15665,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, legge, quadro, florovivaismo, libera',
     ogTitle: 'Legge Quadro Florovivaismo: via libera, Confagricoltura Varese soddisfatta',
     ogDescription: 'Approvata la Legge Quadro sul Florovivaismo. Confagricoltura Varese: un traguardo storico per il settore, che vale il 10% dell\'agricoltura provinciale.',
-    canonicalPath: '/articoli-frontaliere/legge-quadro-florovivaismo-varese-2026',
+    canonicalPath: '/articoli-frontaliere/legge-quadro-florovivaismo-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15698,7 +15698,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, policonsumo, droga, rapporto, 2025',
     ogTitle: 'Policonsumo droga Ticino 2026: rapporto Ingrado',
     ogDescription: 'Il rapporto 2025 di Ingrado conferma il policonsumo come tendenza prevalente in Ticino, con un aumento del 16,4% nei consultori sostanze.',
-    canonicalPath: '/articoli-frontaliere/policonsumo-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/policonsumo-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15731,7 +15731,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crack, house, aumento, persone',
     ogTitle: 'Crack house in aumento in Ticino: 8 persone al giorno chiedono aiuto a Ingrado',
     ogDescription: 'Oltre 3.200 persone seguite nel 2025 per dipendenze da alcol, droghe, videogiochi e scommesse online. Ingrado lancia allarme sulle crack house',
-    canonicalPath: '/articoli-frontaliere/crack-house-ingrado-2026',
+    canonicalPath: '/articoli-frontaliere/crack-house-ingrado-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15764,7 +15764,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, jashari, bocciato, esordio, milan',
     ogTitle: 'Jashari bocciato all\'esordio con il Milan',
     ogDescription: 'Critiche dall\'Italia per il rendimento di Jashari, protagonista di un errore costato l\'1-0 al Milan contro il Sassuolo',
-    canonicalPath: '/articoli-frontaliere/jashari-milan-bocciatura',
+    canonicalPath: '/articoli-frontaliere/jashari-milan-bocciatura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15797,7 +15797,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, nuova, sindaca, rossini',
     ogTitle: 'Mendrisio: la nuova sindaca Rossini punta sul senso di città',
     ogDescription: 'La neo sindaca Simona Rossini (Lega) prende il testimone da Lucio Lorenzon e rilancia il tema dei campanilismi a Mendrisio',
-    canonicalPath: '/articoli-frontaliere/mendrisio-senso-citta-rossini-lorenzon',
+    canonicalPath: '/articoli-frontaliere/mendrisio-senso-citta-rossini-lorenzon/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15830,7 +15830,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, chiasso, operai, feriti',
     ogTitle: 'Incendio a Chiasso: operai feriti e evacuati',
     ogDescription: 'Un incendio sul tetto di una palazzina a Chiasso ha causato feriti e l\'evacuazione di una trentina di persone. Scopri di più sull\'accaduto e le implicazioni per',
-    canonicalPath: '/articoli-frontaliere/incendio-chiasso-operai-feriti',
+    canonicalPath: '/articoli-frontaliere/incendio-chiasso-operai-feriti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15863,7 +15863,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, chiude, 2025, avanzo',
     ogTitle: 'Luino chiude il 2025 con un avanzo di 2,6 milioni',
     ogDescription: 'Il bilancio consuntivo 2025 del Comune di Luino mostra un avanzo di 2,6 milioni di euro, con entrate per oltre 31,5 milioni.',
-    canonicalPath: '/articoli-frontaliere/luino-bilancio-2025-avanzo-26-milioni',
+    canonicalPath: '/articoli-frontaliere/luino-bilancio-2025-avanzo-26-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15896,7 +15896,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, cardiocentro, lugano, inaugurati',
     ogTitle: 'Nuovo Cardiocentro Lugano: inaugurati tre piani aggiuntivi',
     ogDescription: 'Inaugurati tre piani aggiuntivi al Cardiocentro di Lugano, con miglioramenti per pazienti e operatori. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nuovo-cardiocentro-lugano-realta',
+    canonicalPath: '/articoli-frontaliere/nuovo-cardiocentro-lugano-realta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15929,7 +15929,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spazi, autogestione, lugano, ghisletta',
     ogTitle: 'Spazi per l\'autogestione a Lugano: Ghisletta, «Il tema non è sul tavolo»',
     ogDescription: 'Inizio lavori per la riqualificazione dell\'ex Macello di Lugano, mentre si discute la futura ex scuola di sartoria di Viganello per la cultura indipendente.',
-    canonicalPath: '/articoli-frontaliere/spazi-autogestione-lugano-ghisletta',
+    canonicalPath: '/articoli-frontaliere/spazi-autogestione-lugano-ghisletta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15962,7 +15962,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aviazione, civile, svizzeri, favorevole',
     ogTitle: 'Svizzera e aviazione civile: il 61% degli svizzeri favorevole',
     ogDescription: 'Secondo uno studio commissionato da Aviationsuisse, la maggioranza degli svizzeri riconosce l\'importanza strategica ed economica degli aeroporti.',
-    canonicalPath: '/articoli-frontaliere/svizzera-volare-aviazione-civile',
+    canonicalPath: '/articoli-frontaliere/svizzera-volare-aviazione-civile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15995,7 +15995,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inaugurato, grande, anello, verde',
     ogTitle: 'Inaugurato il Grande Anello Verde di Somma Lombardo: 25 km di natura e storia',
     ogDescription: 'Scopri il nuovo Grande Anello Verde di Somma Lombardo, un percorso di 25 km tra natura e storia, inaugurato il 16 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/tangenziale-verde-somma-lombardo-2026',
+    canonicalPath: '/articoli-frontaliere/tangenziale-verde-somma-lombardo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16028,7 +16028,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inaugurazione, parchetto, biumo, nuovo',
     ogTitle: 'Inaugurazione parchetto Biumo: nuovo spazio sportivo e sociale',
     ogDescription: 'Sabato 9 maggio inaugurazione del nuovo parchetto di via Arconati a Biumo, Varese, con tornei di basket, musica e picnic.',
-    canonicalPath: '/articoli-frontaliere/inaugurazione-parchetto-biumo-via-arconati',
+    canonicalPath: '/articoli-frontaliere/inaugurazione-parchetto-biumo-via-arconati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16061,7 +16061,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, candida, capitale, culturale',
     ogTitle: 'Mendrisio si candida a Capitale Culturale Svizzera',
     ogDescription: 'Mendrisio ha presentato la sua candidatura per diventare Capitale Culturale Svizzera nel 2026. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/mendrisio-capitale-culturale-2026',
+    canonicalPath: '/articoli-frontaliere/mendrisio-capitale-culturale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16094,7 +16094,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, falsi, preti, barasso, allerta',
     ogTitle: 'Falsi preti a Barasso: l’allerta del Comune contro le truffe agli anziani',
     ogDescription: 'Il Comune di Barasso avverte: falsi preti truffano gli anziani. Ecco cosa fare per proteggersi.',
-    canonicalPath: '/articoli-frontaliere/falsi-preti-barasso-truffe-anziani',
+    canonicalPath: '/articoli-frontaliere/falsi-preti-barasso-truffe-anziani/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16127,7 +16127,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, milioni, restauro, beni, culturali',
     ogTitle: '21,5 milioni per il restauro dei beni culturali lombardi',
     ogDescription: 'Regione Lombardia e Fondazione Cariplo finanziano progetti per trasformare immobili pubblici in hub culturali. Domande entro il 24 giugno 2026.',
-    canonicalPath: '/articoli-frontaliere/bando-restauro-beni-culturali-lombardia',
+    canonicalPath: '/articoli-frontaliere/bando-restauro-beni-culturali-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16160,7 +16160,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andrea, lotta, contro, leucemie',
     ogTitle: 'Insieme ad Andrea si può: ricerca contro leucemie infantili',
     ogDescription: 'La storia di Andrea ha ispirato la nascita di un\'associazione che sostiene la ricerca contro le leucemie infantili. Scopri come sostenere la causa.',
-    canonicalPath: '/articoli-frontaliere/insieme-ad-andrea-si-puo-ricerca-leucemie-infantili',
+    canonicalPath: '/articoli-frontaliere/insieme-ad-andrea-si-puo-ricerca-leucemie-infantili/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16193,7 +16193,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scuola, chiude, fino, mornasco',
     ogTitle: 'Scuola chiude a Fino Mornasco: calo nascite e proteste',
     ogDescription: 'Il sindaco di Fino Mornasco conferma la chiusura della scuola Rodari a Socco a causa del calo delle nascite. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/scuola-chiude-fino-mornasco-2026',
+    canonicalPath: '/articoli-frontaliere/scuola-chiude-fino-mornasco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16226,7 +16226,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, turismo, sostenibile, futuro',
     ogTitle: 'Como tra turismo sostenibile e futuro del territorio',
     ogDescription: 'Il 10 maggio a Como si discute di turismo sostenibile e futuro del territorio con laboratori e dibattiti.',
-    canonicalPath: '/articoli-frontaliere/como-turismo-sostenibile-10-maggio',
+    canonicalPath: '/articoli-frontaliere/como-turismo-sostenibile-10-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16259,7 +16259,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, serge, aubin, nuovo, allenatore',
     ogTitle: 'Serge Aubin nuovo allenatore del Berna',
     ogDescription: 'Il tecnico canadese ha firmato un contratto triennale con gli Orsi di Berna. Scopri di più sulle sue ambizioni e strategie.',
-    canonicalPath: '/articoli-frontaliere/nuovo-allenatore-orsi-serge-aubin',
+    canonicalPath: '/articoli-frontaliere/nuovo-allenatore-orsi-serge-aubin/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16292,7 +16292,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, villa, geno, como, asta',
     ogTitle: 'Villa Geno a Como all\'asta: servono quasi 400mila euro',
     ogDescription: 'Il Comune di Como mette all\'asta Villa Geno e l\'area verde annessa. La concessione ha un canone annuo di quasi 400mila euro.',
-    canonicalPath: '/articoli-frontaliere/asta-villa-geno-como-400mila-euro',
+    canonicalPath: '/articoli-frontaliere/asta-villa-geno-como-400mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16325,7 +16325,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, besozzo, superiore, nasce, mercato',
     ogTitle: 'Mercato agricolo a Besozzo Superiore: date e prodotti',
     ogDescription: 'Scopri il nuovo mercato agricolo a Besozzo Superiore con prodotti locali e filiera corta. Date e dettagli.',
-    canonicalPath: '/articoli-frontaliere/mercato-agricolo-besozzo-superiore',
+    canonicalPath: '/articoli-frontaliere/mercato-agricolo-besozzo-superiore/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16358,7 +16358,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confcommercio, convegno, robotica, varese',
     ogTitle: 'Intelligenza artificiale e robotica in azienda: il convegno di Confcommercio a Varese',
     ogDescription: 'L\'intelligenza artificiale e la robotica avanzata entrano nelle PMI, con casi studio di VHIT Spa e opportunità per le aziende varesine.',
-    canonicalPath: '/articoli-frontaliere/intelligenza-artificiale-robotica-varese-2026',
+    canonicalPath: '/articoli-frontaliere/intelligenza-artificiale-robotica-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16391,7 +16391,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lemano, pescati, oltre, tonnellate',
     ogTitle: 'Dal Lemano pescati oltre 2,5 tonnellate di rifiuti in due giorni',
     ogDescription: 'L\'iniziativa Net\'Léman ha rimosso 2.592 kg di rifiuti dal lago Lemano in due giorni, coinvolgendo oltre 1.000 volontari.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-rifiuti-lac-lemano',
+    canonicalPath: '/articoli-frontaliere/frontalieri-rifiuti-lac-lemano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16424,7 +16424,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, camminata, enogastronomica, cazzago, brabbia',
     ogTitle: 'Camminan Mangiando a Cazzago Brabbia: gusto, cultura e natura domenica 17 maggio 2026',
     ogDescription: 'Una passeggiata di 5 km tra sapori locali, eventi culturali e scorci del territorio a Cazzago Brabbia domenica 17 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/cazzago-brabbia-camminan-mangiando-2026',
+    canonicalPath: '/articoli-frontaliere/cazzago-brabbia-camminan-mangiando-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16457,7 +16457,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polish, airlines, festeggia, anni',
     ogTitle: 'Lot Polish Airlines festeggia 60 anni di voli tra Malpensa e Varsavia',
     ogDescription: 'LOT Polish Airlines celebra 60 anni di collegamenti tra Milano Malpensa e Varsavia con oltre 2,2 milioni di passeggeri trasportati',
-    canonicalPath: '/articoli-frontaliere/lot-polish-60-anni-malpensa-varsavia',
+    canonicalPath: '/articoli-frontaliere/lot-polish-60-anni-malpensa-varsavia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16490,7 +16490,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, auto, truccate, mirino, polizia',
     ogTitle: 'Auto truccate nel mirino della polizia a Zugo',
     ogDescription: 'Controlli alla Stierenmarkt: 4 auto con scarichi modificati, 5 sequestrate per tuning software non autorizzato. Ecco cosa rischiano i proprietari',
-    canonicalPath: '/articoli-frontaliere/auto-truccate-polizia-zugo-2026',
+    canonicalPath: '/articoli-frontaliere/auto-truccate-polizia-zugo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16523,7 +16523,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spirometrie, gratuite, bambini, varese',
     ogTitle: 'Spirometrie gratuite per i bambini a Varese per la Giornata Mondiale dell’Asma 2026',
     ogDescription: 'In occasione della Giornata Mondiale dell’Asma 2026, l’Ambulatorio di Pneumologia e Allergologia Pediatrica dell’Ospedale F. Del Ponte di Varese offre',
-    canonicalPath: '/articoli-frontaliere/spirometrie-gratuite-bambini-varese-2026',
+    canonicalPath: '/articoli-frontaliere/spirometrie-gratuite-bambini-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16556,7 +16556,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blackdamp, memoria, sacrificio, emigrazione',
     ogTitle: 'Blackdamp: memoria, sacrificio ed emigrazione nel nuovo romanzo storico di Lucia Tiziani',
     ogDescription: 'Il nuovo romanzo storico di Lucia Tiziani, \'Blackdamp\', esplora l\'emigrazione italiana e il sacrificio di Ferdinando Tiziani.',
-    canonicalPath: '/articoli-frontaliere/blackdamp-memoria-sacrificio-ed-emigrazione-nuovo-romanzo-storico-lucia-tiziani',
+    canonicalPath: '/articoli-frontaliere/blackdamp-memoria-sacrificio-ed-emigrazione-nuovo-romanzo-storico-lucia-tiziani/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16589,7 +16589,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, castellanza, busto, arsizio',
     ogTitle: 'Incidente in A8 tra Castellanza e Busto Arsizio: lunghe code verso Varese',
     ogDescription: 'Incidente in A8 tra Castellanza e Busto Arsizio causa code fino a 4 km verso Varese. Due feriti soccorsi dal 118. Impatto sui frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incidente-a8-castellanza-busto-arsizio-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-a8-castellanza-busto-arsizio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16622,7 +16622,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elicottero, precipita, mezzovico, diversi',
     ogTitle: 'Elicottero precipita a Mezzovico: diversi feriti',
     ogDescription: 'Incidente a Mezzovico-Vira: elicottero privato precipita, diversi feriti. Intervengono pompieri, ambulanze, Rega e Polizia cantonale.',
-    canonicalPath: '/articoli-frontaliere/elicottero-mezzovico-incidente-2026',
+    canonicalPath: '/articoli-frontaliere/elicottero-mezzovico-incidente-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16655,7 +16655,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inarzo, natura, favole, drag',
     ogTitle: 'Festa Oasi Palude Brabbia 2026: natura, favole e drag queen a Inarzo',
     ogDescription: 'Scopri il programma della Festa Oasi della Palude Brabbia 2026 a Inarzo: laboratori, visite guidate e spettacoli per tutte le età.',
-    canonicalPath: '/articoli-frontaliere/inarzo-festa-oasi-palude-brabbia-2026',
+    canonicalPath: '/articoli-frontaliere/inarzo-festa-oasi-palude-brabbia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16688,7 +16688,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, josi, niederreiter, hischier, meier',
     ogTitle: 'Josi, Niederreiter, Hischier e Meier ai Mondiali 2026',
     ogDescription: 'Quattro stelle NHL si aggiungono alla squadra svizzera per i Mondiali di hockey 2026 a Zurigo e Friburgo. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/mondiali-hockey-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/mondiali-hockey-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16721,7 +16721,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comanorun, record, iscritti, nuovi',
     ogTitle: 'ComanoRun 2026: record di 801 iscritti e nuovi primati',
     ogDescription: 'Scopri i dettagli della sesta edizione della ComanoRun con 801 iscritti e i nuovi primati nelle categorie maschile e femminile.',
-    canonicalPath: '/articoli-frontaliere/comanorun-record-801-iscritti',
+    canonicalPath: '/articoli-frontaliere/comanorun-record-801-iscritti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16754,7 +16754,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comano, record, partecipanti, nuovo',
     ogTitle: 'Comano Run 2026: record di partecipanti e nuovo percorso',
     ogDescription: 'Oltre 800 partecipanti alla sesta edizione della Comano Run, con nuovi record nel percorso e nelle categorie giovanili.',
-    canonicalPath: '/articoli-frontaliere/comano-run-record-2026',
+    canonicalPath: '/articoli-frontaliere/comano-run-record-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16787,7 +16787,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moria, pesci, berneck, liquame',
     ogTitle: 'Moria di pesci a Berneck: liquame in torrente',
     ogDescription: 'Una ventina di pesci morti a causa di liquame in un torrente a Berneck, Canton San Gallo. L\'agricoltore responsabile sarà denunciato.',
-    canonicalPath: '/articoli-frontaliere/moria-pesci-berneck-2026',
+    canonicalPath: '/articoli-frontaliere/moria-pesci-berneck-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16820,7 +16820,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festival, meraviglia, arte, musica',
     ogTitle: 'Festival della Meraviglia: arte, musica e incontri tra Laveno e Luino',
     ogDescription: 'Dal 8 al 15 maggio, cinque serate di arte, musica e filosofia con ospiti internazionali. Scopri il programma completo.',
-    canonicalPath: '/articoli-frontaliere/festival-meraviglia-laveno-luino-2026',
+    canonicalPath: '/articoli-frontaliere/festival-meraviglia-laveno-luino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16853,7 +16853,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festival, meraviglia, storie, costruiscono',
     ogTitle: 'Festival Meraviglia 2026: storie che costruiscono il presente',
     ogDescription: 'Dal 8 al 24 maggio, Laveno Mombello e Luino ospitano il Festival della Meraviglia con eventi culturali e incontri su storia, scienza e arte.',
-    canonicalPath: '/articoli-frontaliere/meraviglia-festival-laveno-luino-2026',
+    canonicalPath: '/articoli-frontaliere/meraviglia-festival-laveno-luino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16886,7 +16886,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incalza, spesa, cultura, indipendente',
     ogTitle: 'UDC incalza su spesa cultura indipendente: «Giustificata?»',
     ogDescription: 'Interpellanza UDC sul finanziamento cantonale per spazi culturali indipendenti. Dubbi su efficacia e sostenibilità finanziaria',
-    canonicalPath: '/articoli-frontaliere/udc-cultura-indipendente-spesa-giustificata',
+    canonicalPath: '/articoli-frontaliere/udc-cultura-indipendente-spesa-giustificata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16919,7 +16919,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scontri, pensilina, lugano, politica',
     ogTitle: 'Scontri in pensilina a Lugano, la politica deve abbassare i toni',
     ogDescription: 'Karin Valenzano Rossi, capodicastero sicurezza di Lugano, commenta gli scontri avvenuti in pensilina che hanno portato al ferimento di due persone.',
-    canonicalPath: '/articoli-frontaliere/scontri-lugano-politica-toni',
+    canonicalPath: '/articoli-frontaliere/scontri-lugano-politica-toni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16952,7 +16952,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, istruzioni, cosa, cambia, dalla',
     ogTitle: 'Svizzera, istruzioni per l\'uso: cosa cambia per i frontalieri',
     ogDescription: 'Scopri le novità che impattano i frontalieri in Ticino, dalla perequazione finanziaria ai tagli universitari, e come affrontarle.',
-    canonicalPath: '/articoli-frontaliere/svizzera-istruzioni-uso-frontalieri',
+    canonicalPath: '/articoli-frontaliere/svizzera-istruzioni-uso-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16985,7 +16985,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, prigioni, sovraffollate, marcato, peggioramento',
     ogTitle: 'Prigioni Ticino sovraffollate: marcato peggioramento',
     ogDescription: 'Le strutture carcerarie ticinesi segnalano livelli di occupazione estremamente elevati, con margini di manovra pressoché nulli.',
-    canonicalPath: '/articoli-frontaliere/prigioni-ticino-sovraffollate-2026',
+    canonicalPath: '/articoli-frontaliere/prigioni-ticino-sovraffollate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17018,7 +17018,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, folgorato, alla, stazione, bellinzona',
     ogTitle: 'Folgorato alla stazione di Bellinzona, morto un uomo',
     ogDescription: 'Incidente mortale alla stazione di Bellinzona: un uomo folgorato da una scarica elettrica. Le cause sono in fase di accertamento.',
-    canonicalPath: '/articoli-frontaliere/folgorato-stazione-bellinzona-morto-uomo',
+    canonicalPath: '/articoli-frontaliere/folgorato-stazione-bellinzona-morto-uomo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17051,7 +17051,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lupo, tempo, dell, attesa',
     ogTitle: 'Lupo in Ticino: il tempo dell\'attesa è finito, occorre agire',
     ogDescription: 'Il Municipio di Onsernone lancia un allarme: le comunità di montagna rischiano di perdere la loro identità a causa della presenza del lupo.',
-    canonicalPath: '/articoli-frontaliere/lupo-tempo-attesa-finito-agire',
+    canonicalPath: '/articoli-frontaliere/lupo-tempo-attesa-finito-agire/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17084,7 +17084,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, binningen, morte, moglie',
     ogTitle: 'Processo a Binningen per la morte della moglie: l\'imputato invoca l\'autodifesa',
     ogDescription: 'Un 43enne svizzero è accusato di aver ucciso la moglie nel febbraio 2024. Il processo è iniziato il 4 maggio 2026. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/processo-binningen-morte-moglie-2026',
+    canonicalPath: '/articoli-frontaliere/processo-binningen-morte-moglie-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17117,7 +17117,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gianni, morandi, locarno, concerto',
     ogTitle: 'Gianni Morandi a Locarno: concerto al Palexpo FEVI il 4 ottobre 2026',
     ogDescription: 'Gianni Morandi celebra 60 anni di \'C\'era un ragazzo\' con un concerto a Locarno il 4 ottobre 2026. Biglietti in prevendita su biglietteria.ch.',
-    canonicalPath: '/articoli-frontaliere/gianni-morandi-locarno-2026',
+    canonicalPath: '/articoli-frontaliere/gianni-morandi-locarno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17150,7 +17150,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tensioni, geopolitiche, spingono, verso',
     ogTitle: 'Tensioni geopolitiche spingono verso l\'elettrico in Ticino',
     ogDescription: 'Le vendite di auto elettriche in Ticino crescono, ma con ritmi più lenti rispetto al resto della Svizzera. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/tensioni-geopolitiche-elettrico-ticino',
+    canonicalPath: '/articoli-frontaliere/tensioni-geopolitiche-elettrico-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17183,7 +17183,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, disgelo, dopo, mesi',
     ogTitle: 'Crans-Montana, disgelo tra Italia e Svizzera | Frontaliere Ticino',
     ogDescription: 'Dopo mesi di tensioni, l\'ambasciatore Cornado smorza i toni. Gianini: alcune uscite sono state controproducenti.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-disgelo-italia-svizzera',
+    canonicalPath: '/articoli-frontaliere/crans-montana-disgelo-italia-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17216,7 +17216,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, thun, vince, campionato, lezione',
     ogTitle: 'Thun vince il campionato: la lezione di programmazione per il calcio svizzero',
     ogDescription: 'Livio Bordoli commenta la vittoria del Thun: «Hanno dato concretezza alla frase \'lasciamo lavorare l’allenatore\'»',
-    canonicalPath: '/articoli-frontaliere/thun-vince-calcio-programmazione',
+    canonicalPath: '/articoli-frontaliere/thun-vince-calcio-programmazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17250,7 +17250,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cliché, politici, cosa, pensano',
     ogTitle: 'Cliché politici: cosa pensano i giovani di destra e sinistra',
     ogDescription: 'I giovani del Ticino hanno idee ben precise su cosa rappresenti la destra e la sinistra, dai vestiti alle abitudini quotidiane.',
-    canonicalPath: '/articoli-frontaliere/cliche-politici-giovani-ticino',
+    canonicalPath: '/articoli-frontaliere/cliche-politici-giovani-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17284,7 +17284,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, ingaggia, olle, lycksell',
     ogTitle: 'Lugano ingaggia Olle Lycksell fino al 2029',
     ogDescription: 'Il centro-ala svedese firma con l\'HC Lugano un contratto triennale. Ecco cosa cambia per i tifosi bianconeri',
-    canonicalPath: '/articoli-frontaliere/lugano-ingaggia-olle-lycksell-2026',
+    canonicalPath: '/articoli-frontaliere/lugano-ingaggia-olle-lycksell-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17318,7 +17318,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, questionario, allievi, docenti, strumento',
     ogTitle: 'Questionario scuole Ticino 2026: strumento utile e dissuasivo',
     ogDescription: 'Il Decs ha testato un questionario per allievi e docenti in una scuola professionale ticinese per migliorare il benessere scolastico.',
-    canonicalPath: '/articoli-frontaliere/questionario-scuole-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/questionario-scuole-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17352,7 +17352,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scuola, como, chiusura, plesso',
     ogTitle: 'Scuola Como chiusura plesso Socco genitori in rivolta',
     ogDescription: 'Genitori e comitato cittadino protestano contro la chiusura della scuola primaria di Socco a Fino Mornasco',
-    canonicalPath: '/articoli-frontaliere/scuola-como-chiusura-socco',
+    canonicalPath: '/articoli-frontaliere/scuola-como-chiusura-socco/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17386,7 +17386,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rischio, benzina, varcare, confine',
     ogTitle: 'Rischio benzina in Svizzera: varcare il confine potrebbe non bastare',
     ogDescription: 'La Svizzera rischia una carenza di carburante. Florence Schurch di Suissenégoce avverte di un rischio elevato e di possibili ripercussioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/rischio-benzina-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/rischio-benzina-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17420,7 +17420,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mense, scolastiche, prezzi, popolari',
     ogTitle: 'Mense scolastiche a prezzi popolari: studenti in attesa di risposte',
     ogDescription: 'Il SISA denuncia l\'immobilismo del governo ticinese sull\'aumento dei prezzi delle mense scolastiche. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/mense-scolastiche-ticino-prezzi-2026',
+    canonicalPath: '/articoli-frontaliere/mense-scolastiche-ticino-prezzi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17454,7 +17454,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inflazione, aprile, sale, allo',
     ogTitle: 'Inflazione Svizzera: +0,6% ad aprile 2026',
     ogDescription: 'L\'inflazione in Svizzera sale allo 0,6% ad aprile 2026, trainata dai prezzi dei beni importati. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/inflazione-ticino-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/inflazione-ticino-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17488,7 +17488,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pubblicità, impatto, ambientale, dibattito',
     ogTitle: 'Pubblicità e impatto ambientale: il dibattito in Svizzera',
     ogDescription: 'Amsterdam vieta pubblicità di carne e combustibili fossili. In Svizzera, il dibattito è acceso tra ambientalisti e sostenitori della libertà di mercato.',
-    canonicalPath: '/articoli-frontaliere/pubblicita-ambiente-amsterdam-svizzera',
+    canonicalPath: '/articoli-frontaliere/pubblicita-ambiente-amsterdam-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17522,7 +17522,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, tunisino, aggredisce, giovane',
     ogTitle: 'Como: tunisino aggredisce un giovane, si ferisce e si ritrova denunciato',
     ogDescription: 'Un cittadino tunisino ha aggredito un giovane a Como, ferendosi e finendo per essere denunciato dalle autorità locali.',
-    canonicalPath: '/articoli-frontaliere/como-tunisino-denunciato-aggressione',
+    canonicalPath: '/articoli-frontaliere/como-tunisino-denunciato-aggressione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17556,7 +17556,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, internazionali, programma, dove, vederli',
     ogTitle: 'Internazionali d\'Italia 2026: programma e dove vederli in tv',
     ogDescription: 'Inizia oggi il torneo di tennis a Roma. Ecco il programma della prima giornata e dove seguirlo in tv',
-    canonicalPath: '/articoli-frontaliere/internazionali-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/internazionali-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17590,7 +17590,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, valore, vicino, ciclo, incontri',
     ogTitle: 'Il valore del vicino: ciclo di incontri sull\'economia della prossimità',
     ogDescription: 'Confartigianato Imprese Varese e Materia Impresa Lab organizzano cinque incontri da maggio a dicembre per valorizzare le filiere locali',
-    canonicalPath: '/articoli-frontaliere/il-valore-del-vicino-ciclo-incontri-economia-prossimita',
+    canonicalPath: '/articoli-frontaliere/il-valore-del-vicino-ciclo-incontri-economia-prossimita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17624,7 +17624,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carburante, scorte, critiche, cherosene',
     ogTitle: 'Carburante Svizzera: scorte critiche per il cherosene',
     ogDescription: 'Le scorte di cherosene in Svizzera coprono solo 72 giorni. Ecco cosa cambia per i frontalieri e come prepararsi alle eventuali carenze.',
-    canonicalPath: '/articoli-frontaliere/carburante-svizzera-scorte-2026',
+    canonicalPath: '/articoli-frontaliere/carburante-svizzera-scorte-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17658,7 +17658,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, nuoto, 750mila, euro',
     ogTitle: 'Como Nuoto, 750mila euro in tribunale: esposto delle minoranze',
     ogDescription: 'I consiglieri di minoranza del Comune di Como hanno depositato un esposto alla Procura per la gestione di 750mila euro per la piscina di viale Geno.',
-    canonicalPath: '/articoli-frontaliere/como-nuoto-750mila-euro-tribunale',
+    canonicalPath: '/articoli-frontaliere/como-nuoto-750mila-euro-tribunale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17692,7 +17692,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arrestato, 24enne, albanese, cocaina',
     ogTitle: 'Arrestato 24enne albanese con cocaina a Mendrisio',
     ogDescription: 'Un giovane albanese è stato arrestato a Mendrisio con cocaina a bordo dell\'auto. Ecco i dettagli dell\'operazione e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/arresto-cocaina-mendrisio-albanese',
+    canonicalPath: '/articoli-frontaliere/arresto-cocaina-mendrisio-albanese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17726,7 +17726,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guerra, frena, viaggi, estero',
     ogTitle: 'Guerra frena viaggi all\'estero: un terzo degli svizzeri rinuncia',
     ogDescription: 'Secondo il TCS, un terzo degli svizzeri non si sente sicuro per le vacanze fuori dai confini. Spagna e Portogallo sono le mete preferite.',
-    canonicalPath: '/articoli-frontaliere/guerra-frena-viaggi-estero-2026',
+    canonicalPath: '/articoli-frontaliere/guerra-frena-viaggi-estero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17760,7 +17760,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavori, danno, soddisfazione, dati',
     ogTitle: 'Lavori che danno più soddisfazione in Svizzera: i dati del Ticino',
     ogDescription: 'Scopri quali sono i lavori che danno più soddisfazione in Svizzera e come questo influisce sui frontalieri del Ticino. Dati e analisi dello studio Sotomo.',
-    canonicalPath: '/articoli-frontaliere/lavori-soddisfazione-svizzeri-ticino',
+    canonicalPath: '/articoli-frontaliere/lavori-soddisfazione-svizzeri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17794,7 +17794,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, benzina, supera, euro, litro',
     ogTitle: 'Benzina supera 1,9 euro al litro: prima volta in due anni',
     ogDescription: 'Il prezzo della benzina tocca quota 1,926 euro al litro in modalità self service, mentre il gasolio scende leggermente.',
-    canonicalPath: '/articoli-frontaliere/benzina-19-euro-5-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/benzina-19-euro-5-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17828,7 +17828,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passo, gottardo, riaperto, venerdì',
     ogTitle: 'Passo del San Gottardo riaperto da venerdì',
     ogDescription: 'Il passo del San Gottardo riapre al traffico venerdì alle 11, in tempo per le festività dell\'Ascensione e di Pentecoste, alleggerendo l\'autostrada A2.',
-    canonicalPath: '/articoli-frontaliere/passo-gottardo-riaperto-ascensione',
+    canonicalPath: '/articoli-frontaliere/passo-gottardo-riaperto-ascensione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17866,7 +17866,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passo, gottardo, riapre, anticipo',
     ogTitle: 'Passo del Gottardo riapre in anticipo l\'8 maggio',
     ogDescription: 'Grazie alle condizioni meteo favorevoli, il Passo del Gottardo riapre già venerdì 8 maggio, alleggerendo il traffico in vista delle festività',
-    canonicalPath: '/articoli-frontaliere/passo-gottardo-riapre-anticipo-8-maggio',
+    canonicalPath: '/articoli-frontaliere/passo-gottardo-riapre-anticipo-8-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17904,7 +17904,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, auto, land, rover',
     ogTitle: 'Furti d\'auto in Ticino: Land Rover, Alfa Romeo e Porsche le più colpite',
     ogDescription: 'Aumentano i furti d\'auto in Ticino. Land Rover, Alfa Romeo e Porsche le più colpite. Ecco cosa sapere e come proteggersi.',
-    canonicalPath: '/articoli-frontaliere/furti-auto-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/furti-auto-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17942,7 +17942,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lamone, nono, mcdonald, ticinese',
     ogTitle: 'A Lamone il nono McDonald\'s ticinese',
     ogDescription: 'Nuova apertura a Lamone, 35 posti di lavoro e 85% ingredienti locali. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/lamone-nono-mcdonalds-ticino',
+    canonicalPath: '/articoli-frontaliere/lamone-nono-mcdonalds-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17980,7 +17980,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stagflazione, allarme, imprese, varesine',
     ogTitle: 'Stagflazione: allarme per le imprese varesine',
     ogDescription: 'Le imprese varesine affrontano una fase complessa tra inflazione e rallentamento produttivo. Ecco cosa cambia e come adattarsi',
-    canonicalPath: '/articoli-frontaliere/stagflazione-imprese-varesine-2026',
+    canonicalPath: '/articoli-frontaliere/stagflazione-imprese-varesine-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18018,7 +18018,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, nuove, regole, permessi',
     ogTitle: 'Nuove regole permessi Grigioni 2026',
     ogDescription: 'Il Canton Grigioni modifica le regole sui permessi di dimora dopo arresti per infiltrazioni mafiose a Roveredo.',
-    canonicalPath: '/articoli-frontaliere/permessi-dimora-grigioni-mafie',
+    canonicalPath: '/articoli-frontaliere/permessi-dimora-grigioni-mafie/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18056,7 +18056,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caseifici, aperti, aziende, visitare',
     ogTitle: 'Caseifici aperti in Ticino: 18 aziende da visitare',
     ogDescription: 'Scopri la 13esima edizione di Caseifici Aperti in Ticino: 18 caseifici aprono le porte al pubblico il 9 e 10 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/caseifici-aperti-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/caseifici-aperti-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18094,7 +18094,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lancia, campagna, prestazioni, sanitarie',
     ogTitle: 'DSS lancia campagna per prestazioni sanitarie consapevoli',
     ogDescription: 'Il DSS promuove un utilizzo più consapevole delle prestazioni sanitarie con una nuova campagna digitale ispirata a Choosing Wisely',
-    canonicalPath: '/articoli-frontaliere/campagna-dss-appropriatezza-sanitaria',
+    canonicalPath: '/articoli-frontaliere/campagna-dss-appropriatezza-sanitaria/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18132,7 +18132,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parco, controlli, intensificati, weekend',
     ogTitle: 'Parco del Ticino: controlli intensificati per il weekend del Primo maggio',
     ogDescription: 'Grazie ai controlli e alla sensibilizzazione, i comportamenti incivili sono diminuiti nel Parco del Ticino durante il weekend del Primo maggio.',
-    canonicalPath: '/articoli-frontaliere/parco-ticino-controlli-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/parco-ticino-controlli-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18170,7 +18170,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pasto, vegetale, gratis, tutto',
     ogTitle: 'Un pasto 100% vegetale (gratis) tutto da scoprire a Lugano',
     ogDescription: 'Greenpeace offre un pasto vegetale gratuito a Lugano per promuovere un\'alimentazione sostenibile. Scopri i dettagli dell\'iniziativa.',
-    canonicalPath: '/articoli-frontaliere/pasto-vegetale-gratis-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/pasto-vegetale-gratis-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18208,7 +18208,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rancate, nasce, mercatino, quartiere',
     ogTitle: 'Mercatino di quartiere a Rancate: appuntamento mensile',
     ogDescription: 'A Rancate, Mendrisio, è nato il Mercatino di quartiere, un\'iniziativa promossa dalla Città di Mendrisio e Pro Senectute Ticino e Moesano',
-    canonicalPath: '/articoli-frontaliere/mercatino-rancate-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/mercatino-rancate-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18246,7 +18246,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, migliorano, prospettive, impiego, oltre',
     ogTitle: 'KOF: migliorano le prospettive d’impiego in Ticino, oltre la media pluriennale',
     ogDescription: 'L’indicatore dell’occupazione del KOF sale a 2,2 punti nel secondo trimestre 2026, segnando un miglioramento rispetto al periodo gennaio-marzo.',
-    canonicalPath: '/articoli-frontaliere/kof-prospettive-lavoro-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/kof-prospettive-lavoro-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18284,7 +18284,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cornaredo, miliardo, promesse, milione',
     ogTitle: 'Cornaredo: un miliardo di promesse e un milione di metri cubi di cemento',
     ogDescription: 'Discussioni sul rilancio del comparto di Cornaredo a Lugano, con critiche alla densificazione estrema e alle promesse non mantenute',
-    canonicalPath: '/articoli-frontaliere/cornaredo-miliardo-promesse-cemento',
+    canonicalPath: '/articoli-frontaliere/cornaredo-miliardo-promesse-cemento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18322,7 +18322,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ladies, chiusure, stradali, lugano',
     ogTitle: 'Ladies Run 2026: chiusure stradali a Lugano',
     ogDescription: 'Modifiche alla viabilità per la manifestazione podistica del 9 maggio 2026. Ecco cosa cambia per automobilisti e frontalieri',
-    canonicalPath: '/articoli-frontaliere/ladies-run-lugano-chiusure-stradali-2026',
+    canonicalPath: '/articoli-frontaliere/ladies-run-lugano-chiusure-stradali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18360,7 +18360,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, auto, dati, rivelano',
     ogTitle: 'Furti d\'auto in Ticino: dati AXA rivelano impennata',
     ogDescription: 'I furti d\'auto in Ticino sono in aumento, con il Cantone sopra la media svizzera. AXA segnala casi quasi raddoppiati rispetto al pre-pandemia.',
-    canonicalPath: '/articoli-frontaliere/furti-auto-ticino-2026-axa',
+    canonicalPath: '/articoli-frontaliere/furti-auto-ticino-2026-axa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18398,7 +18398,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, focus, nuove, imprese, malpensafiere',
     ogTitle: 'Focus Day Nuove Imprese 2026 a MalpensaFiere: guida pratica',
     ogDescription: 'Giovedì 14 maggio 2026 a MalpensaFiere: assistenza per avviare un\'impresa, focus su agricoltura e home food. Partecipazione gratuita.',
-    canonicalPath: '/articoli-frontaliere/malpensafiere-hub-imprese-2026',
+    canonicalPath: '/articoli-frontaliere/malpensafiere-hub-imprese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18436,7 +18436,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, olgiate, olona, nuovo, alloggio',
     ogTitle: 'Nuovo alloggio domotico per disabili a Olgiate Olona con fondi Pnrr',
     ogDescription: 'Inaugurato a Olgiate Olona un appartamento domotico per persone con disabilità, finanziato dal Pnrr. Obiettivo: autonomia abitativa e lavorativa.',
-    canonicalPath: '/articoli-frontaliere/olgiate-olona-alloggio-domotico-disabili-2026',
+    canonicalPath: '/articoli-frontaliere/olgiate-olona-alloggio-domotico-disabili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18474,7 +18474,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, voice, tour, torna',
     ogTitle: 'Swiss Voice Tour torna a Tenero: concorso canoro al Centro commerciale',
     ogDescription: 'Dal 12 al 16 maggio 2026, giovani talenti e adulti si sfideranno per accedere alle fasi finali del concorso con Paolo Meneguzzi come giurato.',
-    canonicalPath: '/articoli-frontaliere/swiss-voice-tour-tenero-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-voice-tour-tenero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18512,7 +18512,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alla, cosa, sapere, lavorare',
     ogTitle: 'Guida alla Svizzera: cosa sapere per lavorare in Ticino',
     ogDescription: 'Scopri come trovare lavoro, quali mezzi di trasporto usare e chi paga le spese mediche in Svizzera',
-    canonicalPath: '/articoli-frontaliere/guida-svizzera-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/guida-svizzera-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18550,7 +18550,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, caos, comitato, ticinese',
     ogTitle: 'Iniziativa del caos: il comitato ticinese si oppone',
     ogDescription: 'Il comitato unitario ticinese contro l\'iniziativa \'No a una Svizzera da 10 milioni\' si è riunito per contrastare il progetto',
-    canonicalPath: '/articoli-frontaliere/iniziativa-caos-comitato-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/iniziativa-caos-comitato-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18588,7 +18588,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedale, universitario, zurigo, gravi',
     ogTitle: 'Ospedale universitario di Zurigo, gravi mancanze in cardiochirurgia',
     ogDescription: 'L’Ospedale universitario di Zurigo ammette gravi mancanze nella cardiochirurgia tra il 2016 e il 2020, con decine di decessi inattesi e casi segnalati alla',
-    canonicalPath: '/articoli-frontaliere/ospedale-zurigo-mancanze-cardiochirurgia',
+    canonicalPath: '/articoli-frontaliere/ospedale-zurigo-mancanze-cardiochirurgia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18626,7 +18626,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libretto, servizio, digitale, cosa',
     ogTitle: 'Libretto di servizio digitale: cosa cambia per i militari',
     ogDescription: 'Dal 1° giugno 2026 il libretto di servizio diventa digitale. Ecco cosa cambia per i militari e la protezione civile in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/libretto-digitale-militare-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/libretto-digitale-militare-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18664,7 +18664,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, valli, punta, sulla',
     ogTitle: 'Bellinzona e Valli punta sulla bici: percorsi, eventi e collaborazioni',
     ogDescription: 'Nuova strategia per attrarre ciclisti di ogni livello con 13 percorsi di mountain bike e eventi internazionali',
-    canonicalPath: '/articoli-frontaliere/bici-bellinzona-valli-strategia',
+    canonicalPath: '/articoli-frontaliere/bici-bellinzona-valli-strategia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18702,7 +18702,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dipendenti, statali, dati, soddisfazione',
     ogTitle: 'Dipendenti statali Ticino: dati soddisfazione 2026',
     ogDescription: 'Il Comitato ErreDiPi contesta i dati del sondaggio ISMAT 2025 sulla soddisfazione dei dipendenti cantonali del Ticino',
-    canonicalPath: '/articoli-frontaliere/dipendenti-statali-ticino-soddisfazione-2026',
+    canonicalPath: '/articoli-frontaliere/dipendenti-statali-ticino-soddisfazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18740,7 +18740,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fitness, record, adulto, iscritto',
     ogTitle: 'Fitness in Ticino: record 2026, 1 adulto su 5 iscritto',
     ogDescription: 'Nel 2025, 1,45 milioni di svizzeri iscritti a centri fitness. Ticino 6° per densità palestre. Giovani 20-29 anni la fascia più attiva.',
-    canonicalPath: '/articoli-frontaliere/fitness-ticino-record-2026',
+    canonicalPath: '/articoli-frontaliere/fitness-ticino-record-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18778,7 +18778,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, education, studenti, protagonisti, varese',
     ogTitle: 'Education Day: 300 studenti protagonisti a Varese',
     ogDescription: 'Oltre 300 studenti delle scuole primarie e secondarie hanno partecipato alla terza edizione dell\'Education Day di Confindustria Varese.',
-    canonicalPath: '/articoli-frontaliere/education-day-varese-studenti',
+    canonicalPath: '/articoli-frontaliere/education-day-varese-studenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18816,7 +18816,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, truck, lavoro, etico, sicuro',
     ogTitle: 'Truck lavoro etico Varese studenti visori 3D',
     ogDescription: 'Lunedì 11 maggio in piazza Monte Grappa a Varese, il Truck del lavoro etico e sicuro offre orientamento e opportunità per studenti e disoccupati.',
-    canonicalPath: '/articoli-frontaliere/truck-lavoro-etico-varese-studenti-visori-3d',
+    canonicalPath: '/articoli-frontaliere/truck-lavoro-etico-varese-studenti-visori-3d/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18854,7 +18854,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bici, miliardi, percorsi, ciclabili',
     ogTitle: 'La bici vale miliardi: sei percorsi ciclabili attraversano la provincia di Varese',
     ogDescription: 'La Regione Lombardia investe decine di milioni di euro in percorsi ciclabili, con sei itinerari che attraversano la provincia di Varese, un crocevia strategico',
-    canonicalPath: '/articoli-frontaliere/bici-miliardi-varese-percorsi-ciclabili',
+    canonicalPath: '/articoli-frontaliere/bici-miliardi-varese-percorsi-ciclabili/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18892,7 +18892,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assicurazione, dentaria, obbligatoria, doppia',
     ogTitle: 'Assicurazione dentaria obbligatoria: doppia tassa per i ticinesi',
     ogDescription: 'Il comitato No all\'iniziativa sulle cure dentarie spiega perché la proposta è costosa e sproporzionata per i cittadini e le imprese ticinesi.',
-    canonicalPath: '/articoli-frontaliere/assicurazione-dentaria-obbligatoria-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/assicurazione-dentaria-obbligatoria-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18930,7 +18930,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, auto, ribaltata, valico, fornasette',
     ogTitle: 'Auto ribaltata al valico di Fornasette: intervento di polizia e soccorritori',
     ogDescription: 'Un incidente stradale ha coinvolto un\'auto con targhe italiane al valico di Fornasette, nel territorio comunale di Tresa. Sul posto polizia, pompieri e',
-    canonicalPath: '/articoli-frontaliere/incidente-fornasette-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-fornasette-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18968,7 +18968,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, tramite, agenzia, lombardia',
     ogTitle: '1 su 3 lavoratori tramite agenzia in Lombardia è frontaliere',
     ogDescription: 'Dati Assolavoro rivelano che un terzo dei lavoratori tramite agenzia in Lombardia sono frontalieri. Impatto su AVS, LPP e imposta alla fonte.',
-    canonicalPath: '/articoli-frontaliere/lavoro-agenzia-lombardia-frontalieri',
+    canonicalPath: '/articoli-frontaliere/lavoro-agenzia-lombardia-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19006,7 +19006,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, regole, commenti, sito',
     ogTitle: 'TV Svizzera: nuove regole per i commenti e l\'uso del sito',
     ogDescription: 'TV Svizzera introduce nuove linee guida per i commenti e l\'uso del sito web e delle pagine social. Scopri cosa è incoraggiato e cosa non è tollerato.',
-    canonicalPath: '/articoli-frontaliere/condizioni-utilizzo-tvsvizzera',
+    canonicalPath: '/articoli-frontaliere/condizioni-utilizzo-tvsvizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19044,7 +19044,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, baroni, assolavoro, nuovo, ccnl',
     ogTitle: 'Baroni (Assolavoro): Nuovo Ccnl innovativo, più welfare e servizi',
     ogDescription: 'Il nuovo Contratto Collettivo Nazionale di Lavoro per i lavoratori in somministrazione introduce misure innovative in welfare e servizi.',
-    canonicalPath: '/articoli-frontaliere/nuovo-ccnl-assolavoro-welfare-lavoratori',
+    canonicalPath: '/articoli-frontaliere/nuovo-ccnl-assolavoro-welfare-lavoratori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19082,7 +19082,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dipendenti, cantonali, erredipi, richiede',
     ogTitle: 'Dipendenti cantonali in Ticino: ErreDiPi richiede analisi più approfondita',
     ogDescription: 'Il comitato ErreDiPi analizza il rapporto sulla soddisfazione del personale cantonale, evidenziando limiti metodologici e temi critici come stress e',
-    canonicalPath: '/articoli-frontaliere/dipendenti-cantonali-soddisfazione-erre-dipi',
+    canonicalPath: '/articoli-frontaliere/dipendenti-cantonali-soddisfazione-erre-dipi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19120,7 +19120,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupati, potrebbero, ricevere, indennità',
     ogTitle: 'I frontalieri disoccupati potrebbero ricevere le indennità dalla Svizzera',
     ogDescription: 'Una riforma europea vuole cambiare le regole sulla disoccupazione dei frontalieri: in futuro l\'indennità verrebbe pagata dal Paese dell\'ultimo impiego e non più',
-    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupati-svizzera-indennita',
+    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupati-svizzera-indennita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19158,7 +19158,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bottini, somministrazione, crea, occupazione',
     ogTitle: 'Bottini: Somministrazione crea occupazione di qualità',
     ogDescription: 'Il nuovo Ccnl per i lavoratori in somministrazione, rinnovato a luglio 2025, garantisce occupazione di qualità con formazione e welfare.',
-    canonicalPath: '/articoli-frontaliere/somministrazione-occupazione-qualita-bottini',
+    canonicalPath: '/articoli-frontaliere/somministrazione-occupazione-qualita-bottini/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19196,7 +19196,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, misoxperience, 2024, festival, sport',
     ogTitle: 'MisoXperience 2024: il festival degli sport all\'aperto in Mesolcina',
     ogDescription: 'Dal 9 al 17 maggio, la valle Mesolcina ospita il MisoXperience Festival con kayak, bouldering e parapendio. Scopri il programma completo',
-    canonicalPath: '/articoli-frontaliere/misoexperience-festival-sport-2024',
+    canonicalPath: '/articoli-frontaliere/misoexperience-festival-sport-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19234,7 +19234,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, servizio, civile, alleanza, avverte',
     ogTitle: 'Servizio civile: alleanza del no avverte sui rischi',
     ogDescription: 'Riduzione del 40% degli effettivi metterebbe a rischio case anziani, scuole e ambiente. Voto il 14 giugno',
-    canonicalPath: '/articoli-frontaliere/servizio-civile-legge-nefasta-frontalieri',
+    canonicalPath: '/articoli-frontaliere/servizio-civile-legge-nefasta-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19272,7 +19272,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, arrestati, marocchini, furto',
     ogTitle: 'Arrestati due marocchini per furto al Carrefour di Como',
     ogDescription: 'Due cittadini marocchini senza fissa dimora sono stati arrestati per tentata rapina e furto aggravato dopo un episodio al Carrefour di via Recchi.',
-    canonicalPath: '/articoli-frontaliere/furto-carrefour-como-marocchini-arrestati',
+    canonicalPath: '/articoli-frontaliere/furto-carrefour-como-marocchini-arrestati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19310,7 +19310,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzera-italia, nuova, fase, nelle',
     ogTitle: 'Nuova fase nelle relazioni Svizzera-Italia dopo Crans-Montana',
     ogDescription: 'Guy Parmelin a Roma per discutere delle cure ai feriti italiani. Possibile soluzione con deroga UE. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/svizzera-italia-nuova-fase-relazioni',
+    canonicalPath: '/articoli-frontaliere/svizzera-italia-nuova-fase-relazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19348,7 +19348,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moschea, cantù, vittoria, assalam',
     ogTitle: 'Moschea a Cantù: vittoria per Assalam dopo 12 anni',
     ogDescription: 'Il Consiglio di Stato ha riconosciuto il diritto di Assalam a costruire una moschea a Cantù, condannando il Comune a pagare le spese del giudizio.',
-    canonicalPath: '/articoli-frontaliere/moschea-cantu-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/moschea-cantu-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19386,7 +19386,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, como, monte, salvare',
     ogTitle: 'Lago di Como, il monte meraviglioso da salvare: no impianti da sci e opere da 5 milioni',
     ogDescription: 'Il Coordinamento Salviamo il Monte San Primo si batte contro nuovi impianti sciistici a bassa quota. Interrogazione in Regione per riqualificazione ambientale.',
-    canonicalPath: '/articoli-frontaliere/lago-como-monte-san-primo-5-milioni',
+    canonicalPath: '/articoli-frontaliere/lago-como-monte-san-primo-5-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19424,7 +19424,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mistero, milioni, comprato, palazzo',
     ogTitle: 'Mistero da 7 milioni: chi ha comprato il palazzo comunale di Como?',
     ogDescription: 'Dopo 20 giorni dalla vendita, l\'identità dell\'acquirente dell\'ex orfanotrofio di via Tommaso Grossi a Como rimane sconosciuta.',
-    canonicalPath: '/articoli-frontaliere/mistero-palazzo-como-7-milioni',
+    canonicalPath: '/articoli-frontaliere/mistero-palazzo-como-7-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19462,7 +19462,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, palestre, record, iscritti, adulto',
     ogTitle: 'Palestre in Svizzera: record di iscritti nel 2026',
     ogDescription: 'Un adulto su cinque in Svizzera ha un abbonamento fitness. Il Ticino è sesto per densità di strutture con 17 centri ogni 100.000 abitanti',
-    canonicalPath: '/articoli-frontaliere/palestre-svizzera-record-2026',
+    canonicalPath: '/articoli-frontaliere/palestre-svizzera-record-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19500,7 +19500,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aarau, 23enne, somalo, arrestato',
     ogTitle: 'Aarau: 23enne somalo arrestato con auto rubata e refurtiva',
     ogDescription: 'La polizia di Aarau ha arrestato un 23enne somalo trovato alla guida di un\'auto rubata con presunta refurtiva all\'interno. Scopri di più su questo episodio.',
-    canonicalPath: '/articoli-frontaliere/aarau-arresto-somalier-auto-delitto',
+    canonicalPath: '/articoli-frontaliere/aarau-arresto-somalier-auto-delitto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19538,7 +19538,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, expat, ticinese, sventa, truffa',
     ogTitle: 'Expat ticinese sventa truffa: «Hackerato, ma avevo l\'arma segreta»',
     ogDescription: 'Un expat ticinese ha evitato una truffa online grazie a un codice segreto. Scopri come proteggerti dalle truffe online.',
-    canonicalPath: '/articoli-frontaliere/expat-ticino-sventa-truffa-hacker',
+    canonicalPath: '/articoli-frontaliere/expat-ticino-sventa-truffa-hacker/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19576,7 +19576,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, braunwald, camminatore, disperso',
     ogTitle: 'Tragedia a Braunwald: camminatore disperso dopo un incidente',
     ogDescription: 'Un camminatore è scomparso dopo un incidente a Braunwald. Le autorità sono ancora alla ricerca del disperso. Scopri di più su questa tragica vicenda.',
-    canonicalPath: '/articoli-frontaliere/tragedia-braunwald-camminatore-disperso',
+    canonicalPath: '/articoli-frontaliere/tragedia-braunwald-camminatore-disperso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19614,7 +19614,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 20mila, firme, contro, autostrada',
     ogTitle: '20mila firme contro l\'autostrada a pagamento in Lombardia',
     ogDescription: 'Angelo Orsenigo e Gigi Ponti, consiglieri regionali del Pd, hanno raccolto 20mila firme contro il pedaggio sulla Pedemontana Milano-Meda',
-    canonicalPath: '/articoli-frontaliere/20mila-firme-autostrada-pedaggio',
+    canonicalPath: '/articoli-frontaliere/20mila-firme-autostrada-pedaggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19652,7 +19652,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, casciago, varese, situazione',
     ogTitle: 'Incendio a Casciago, Varese: situazione sotto controllo',
     ogDescription: 'Un edificio va a fuoco a Casciago, Varese. La situazione è sotto controllo. Nessun ferito segnalato. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incendio-casciago-varese-2026',
+    canonicalPath: '/articoli-frontaliere/incendio-casciago-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19690,7 +19690,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, spacciatore, arrestato, lavoro',
     ogTitle: 'Varese: spacciatore arrestato, lavoro serio perso',
     ogDescription: 'Un giovane albanese è stato arrestato a Mendrisio con cocaina in auto. Un caso che coinvolge i frontalieri e le dinamiche del lavoro transfrontaliero.',
-    canonicalPath: '/articoli-frontaliere/varese-spacciatore-arresto-frontalieri',
+    canonicalPath: '/articoli-frontaliere/varese-spacciatore-arresto-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19728,7 +19728,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassano, magnago, balcone, fiamme',
     ogTitle: 'Cassano Magnago: balcone in fiamme, sgombero forzato',
     ogDescription: 'Un incendio ha colpito un balcone a Cassano Magnago, Varese, costringendo allo sgombero forzato degli abitanti. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/incendio-cassano-magnago-sgombero',
+    canonicalPath: '/articoli-frontaliere/incendio-cassano-magnago-sgombero/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19766,7 +19766,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, auto, segnala, aumento',
     ogTitle: 'Furti auto in Ticino: AXA segnala un aumento',
     ogDescription: 'AXA segnala un aumento dei furti di auto in Svizzera, soprattutto nei cantoni di confine come il Ticino. Ecco cosa sapere e come proteggersi.',
-    canonicalPath: '/articoli-frontaliere/furti-auto-ticino-2026-axa-segnalazioni',
+    canonicalPath: '/articoli-frontaliere/furti-auto-ticino-2026-axa-segnalazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19804,7 +19804,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, minoteries, chiude, sito, zollbrück',
     ogTitle: 'Minoteries chiude sito a Zollbrück, 28 dipendenti interessati',
     ogDescription: 'Il Gruppo Minoteries chiude il mulino Steiner a Zollbrück nel primo semestre 2027, interessando 28 dipendenti. Scopri le implicazioni e le opportunità.',
-    canonicalPath: '/articoli-frontaliere/minoteries-chiude-zollbruck-28-dipendenti',
+    canonicalPath: '/articoli-frontaliere/minoteries-chiude-zollbruck-28-dipendenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19842,7 +19842,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passo, gottardo, riapre, maggio',
     ogTitle: 'Passo del Gottardo riapre l’8 maggio 2026: traffico agevolato per frontalieri',
     ogDescription: 'Il passo del Gottardo riapre l’8 maggio 2026, due settimane prima del previsto. Corsie speciali per Airolo e passi del Gottardo e della Novena.',
-    canonicalPath: '/articoli-frontaliere/gottardo-riapre-8-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/gottardo-riapre-8-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19880,7 +19880,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agricoltura, precisione, meno, pesticidi',
     ogTitle: 'Agricoltura di precisione: meno pesticidi in Svizzera',
     ogDescription: 'Un progetto pilota riduce del 25% l\'uso di pesticidi grazie alla tecnologia. Scopri come cambia l\'agricoltura in Ticino e Grigioni',
-    canonicalPath: '/articoli-frontaliere/agricoltura-precisione-pesticidi-2026',
+    canonicalPath: '/articoli-frontaliere/agricoltura-precisione-pesticidi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19918,7 +19918,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, sulla, hondius, trasmissione',
     ogTitle: 'Hantavirus sulla Hondius: trasmissione uomo-uomo confermata',
     ogDescription: 'L\'OMS conferma la trasmissione da uomo a uomo dell\'hantavirus sulla nave da crociera Hondius. Tre morti e cinque casi sospetti. Scopri le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/hondius-hantavirus-frontalieri',
+    canonicalPath: '/articoli-frontaliere/hondius-hantavirus-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19956,7 +19956,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tajani, parmelin, rimborsi, sanitari',
     ogTitle: 'Tajani e Parmelin su rimborsi sanitari e cooperazione transfrontaliera',
     ogDescription: 'Incontro tra Tajani e Parmelin a Roma: rimborsi sanitari per la tragedia di Crans-Montana e cooperazione transfrontaliera',
-    canonicalPath: '/articoli-frontaliere/tajani-parmelin-crans-montana-2026',
+    canonicalPath: '/articoli-frontaliere/tajani-parmelin-crans-montana-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19994,7 +19994,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carburante, nessuna, penuria, prezzo',
     ogTitle: 'Carburante in Ticino: nessuna penuria, ma prezzo alto',
     ogDescription: 'Ad oggi non manca il carburante in Ticino, ma i prezzi restano elevati. Il futuro dipende dall\'andamento della guerra e dai flussi energetici europei.',
-    canonicalPath: '/articoli-frontaliere/carburante-ticino-guerra-2026',
+    canonicalPath: '/articoli-frontaliere/carburante-ticino-guerra-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20032,7 +20032,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, ticinesi, saranno, sacrificati',
     ogTitle: 'UDC: «I lavoratori ticinesi non saranno sacrificati»',
     ogDescription: 'Il Comitato cantonale UDC raccomanda il sì all\'iniziativa «No a una Svizzera da 10 milioni» e critica la libera circolazione.',
-    canonicalPath: '/articoli-frontaliere/udc-sostenibilita-lavoro-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/udc-sostenibilita-lavoro-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20070,7 +20070,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lumino-san, vittore, porte, aperte',
     ogTitle: 'A13 Lumino-San Vittore: porte aperte alla compensazione ambientale',
     ogDescription: 'Scopri le opere di compensazione ambientale lungo l\'A13 tra Lumino e San Vittore. Visita guidata sabato 9 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/a13-lumino-san-vittore-compensazione-ambientale',
+    canonicalPath: '/articoli-frontaliere/a13-lumino-san-vittore-compensazione-ambientale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20108,7 +20108,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, divieto, petardi, cosa, cambia',
     ogTitle: 'Divieto petardi Svizzera: cosa cambia per i frontalieri',
     ogDescription: 'La Commissione della scienza, educazione e cultura approva il divieto di petardi in Svizzera. Ecco le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/divieto-petardi-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/divieto-petardi-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20146,7 +20146,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salotto, accende, asilo, ciani',
     ogTitle: 'Il Salotto accende l\'Asilo Ciani a Lugano',
     ogDescription: 'Sabato 9 maggio 2026, l\'Asilo Ciani di Lugano ospita \'Il Salotto\', un evento che unisce arte e musica con giovani artisti locali.',
-    canonicalPath: '/articoli-frontaliere/salotto-ciani-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/salotto-ciani-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20184,7 +20184,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hockey, lugano, nuovi, giocatori',
     ogTitle: 'Hockey Lugano: nuovi giocatori svedesi 2026',
     ogDescription: 'Scopri i nuovi giocatori dell\'HC Lugano per la stagione 2026: Jere Innala e Olle Lycksell. Tutte le novità e le aspettative.',
-    canonicalPath: '/articoli-frontaliere/hockey-lugano-nuovi-giocatori-2026',
+    canonicalPath: '/articoli-frontaliere/hockey-lugano-nuovi-giocatori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20222,7 +20222,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tresa, auto, ribalta, prima',
     ogTitle: 'Tresa: auto si ribalta prima del valico di Fornasette, ferita una persona',
     ogDescription: 'Incidente stradale con auto ribaltata vicino al valico di Fornasette, ferito il conducente italiano. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incidente-fornasette-2026-ribaltamento-auto',
+    canonicalPath: '/articoli-frontaliere/incidente-fornasette-2026-ribaltamento-auto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20260,7 +20260,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accesso, dossier, mengele, cosa',
     ogTitle: 'Accesso al dossier Mengele: novità per i frontalieri',
     ogDescription: 'Il Servizio delle attività informative svizzero consente l\'accesso ai documenti di Mengele presso l\'Archivio federale, con modalità in fase di definizione.',
-    canonicalPath: '/articoli-frontaliere/accesso-dossier-mengele',
+    canonicalPath: '/articoli-frontaliere/accesso-dossier-mengele/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20298,7 +20298,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, stazione, bellinzona, identificata',
     ogTitle: 'Tragedia in stazione a Bellinzona: identificata la vittima',
     ogDescription: 'Identificata la vittima della tragedia in stazione a Bellinzona: aveva 33 anni',
-    canonicalPath: '/articoli-frontaliere/tragedia-stazione-bellinzona-frontalieri',
+    canonicalPath: '/articoli-frontaliere/tragedia-stazione-bellinzona-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20336,7 +20336,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pompieri, lugano, operativi, record',
     ogTitle: 'Pompieri Lugano operativi 24/7: record interventi 2025',
     ogDescription: 'Record di interventi per i pompieri di Lugano nel 2025. Operatività 24 ore su 24 dal 2026.',
-    canonicalPath: '/articoli-frontaliere/pompieri-lugano-24-ore-2026',
+    canonicalPath: '/articoli-frontaliere/pompieri-lugano-24-ore-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20374,7 +20374,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nathan, borradori, rinnovo, ambrì',
     ogTitle: 'Nathan Borradori rinnova con l\'Ambrì Piotta fino al 2030',
     ogDescription: 'L\'attaccante classe 2006 resterà in biancoblù fino al termine della stagione 2029/30 con opzione per un ulteriore anno',
-    canonicalPath: '/articoli-frontaliere/nathan-borradori-ambri-2030',
+    canonicalPath: '/articoli-frontaliere/nathan-borradori-ambri-2030/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20412,7 +20412,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, conducente, falcia, folla, lipsia',
     ogTitle: 'Conducente falcia folla a Lipsia, ricoverato in psichiatria',
     ogDescription: 'L\'uomo di 33 anni, già ricoverato in aprile, è stato arrestato dopo aver investito due persone a Lipsia. Le autorità escludono motivazioni politiche.',
-    canonicalPath: '/articoli-frontaliere/conducente-folla-ricoverato-psichiatria-2026',
+    canonicalPath: '/articoli-frontaliere/conducente-folla-ricoverato-psichiatria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20450,7 +20450,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dipendenti, cantonali, dati, ismat',
     ogTitle: 'Dipendenti cantonali: dati ISMAT 2025 svelano malcontento',
     ogDescription: 'Comitato ErreDiPi critica rapporto ISMAT: solo il 44% vede possibilità di crescita, 55% si sente non riconosciuto',
-    canonicalPath: '/articoli-frontaliere/dipendenti-cantonali-soddisfazione-2026',
+    canonicalPath: '/articoli-frontaliere/dipendenti-cantonali-soddisfazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20488,7 +20488,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, proposta, leghista',
     ogTitle: 'Casse malati in Ticino: la proposta leghista avanza',
     ogDescription: 'La Commissione della gestione del Canton Ticino discute la divisione delle iniziative sulle casse malati, con la proposta leghista in vantaggio.',
-    canonicalPath: '/articoli-frontaliere/casse-malati-ticino-leghista-socialista',
+    canonicalPath: '/articoli-frontaliere/casse-malati-ticino-leghista-socialista/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20526,7 +20526,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morto, rené, groebli, fotografo',
     ogTitle: 'Morto René Groebli, fotografo svizzero di fama internazionale',
     ogDescription: 'Il fotografo zurighese René Groebli è deceduto all\'età di 98 anni. Innovatore della fotografia di guerra e autore di celebri serie fotografiche.',
-    canonicalPath: '/articoli-frontaliere/morto-rene-groebli-fotografo-98-anni',
+    canonicalPath: '/articoli-frontaliere/morto-rene-groebli-fotografo-98-anni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20564,7 +20564,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, food, truck, festival, locarno',
     ogTitle: 'Food Truck Festival Locarno 2026: 5\'000 visitatori in Piazza Grande',
     ogDescription: 'Oltre 5\'000 visitatori hanno partecipato all\'8ª edizione del Food Truck Festival Locarno, con street food, concerti gratuiti e tanto sole.',
-    canonicalPath: '/articoli-frontaliere/food-truck-festival-locarno-2026',
+    canonicalPath: '/articoli-frontaliere/food-truck-festival-locarno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20602,7 +20602,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hendschiken, arrestato, 19enne, francese',
     ogTitle: 'Hendschiken: arrestato 19enne francese per furto d\'auto e fuga',
     ogDescription: 'Un giovane francese di 19 anni è stato arrestato a Hendschiken dopo un furto d\'auto e una fuga. Ecco i dettagli dell\'accaduto.',
-    canonicalPath: '/articoli-frontaliere/hendsichen-arresto-francese-autodiebstahl',
+    canonicalPath: '/articoli-frontaliere/hendsichen-arresto-francese-autodiebstahl/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20640,7 +20640,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bper, lupi, risiko, bancario',
     ogTitle: 'Bper e i lupi del risiko bancario: crescita e mercato come difesa',
     ogDescription: 'Gianni Franco Papa, AD di Bper, parla di crescita e capitalizzazione di mercato come difesa contro possibili scalate. Focus su bancassurance e aggregazioni.',
-    canonicalPath: '/articoli-frontaliere/bper-risiko-bancario-crescita-mercato',
+    canonicalPath: '/articoli-frontaliere/bper-risiko-bancario-crescita-mercato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20678,7 +20678,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salute, mentale, costa, sempre',
     ogTitle: 'Svizzera: salute mentale costa sempre di più',
     ogDescription: 'Aumento delle spese per la salute mentale in Svizzera, con costi in crescita e maggiori ricorsi alle cure tra i giovani e le donne.',
-    canonicalPath: '/articoli-frontaliere/svizzeri-felici-salute-mentale-costi',
+    canonicalPath: '/articoli-frontaliere/svizzeri-felici-salute-mentale-costi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20716,7 +20716,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, liuc, settimana, dell, innovazione',
     ogTitle: 'LIUC: Settimana dell\'Innovazione 2026 con focus su IA e startup',
     ogDescription: 'Dal 12 al 15 maggio 2026, la LIUC di Castellanza ospita la Settimana dell\'Innovazione con workshop su IA, startup e nuove competenze richieste dal mercato.',
-    canonicalPath: '/articoli-frontaliere/liuc-innovazione-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/liuc-innovazione-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20754,7 +20754,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alessandro, colombi, lascia, gruppo',
     ogTitle: 'Alessandro Colombi lascia il Gruppo Corriere del Ticino',
     ogDescription: 'Dopo dodici anni di collaborazione, Alessandro Colombi lascia il Gruppo Corriere del Ticino. Il Consiglio di Fondazione e il Consiglio d\'Amministrazione',
-    canonicalPath: '/articoli-frontaliere/colombi-addio-corriere-ticino',
+    canonicalPath: '/articoli-frontaliere/colombi-addio-corriere-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20792,7 +20792,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scandalo, cardiochirurgia, zurigo, pazienti',
     ogTitle: 'Scandalo cardiochirurgia Zurigo: 70 pazienti sarebbero sopravvissuti',
     ogDescription: 'Un\'inchiesta rivela gravi mancanze nella cardiochirurgia dell\'Ospedale universitario di Zurigo. 70 pazienti potrebbero essere sopravvissuti altrove.',
-    canonicalPath: '/articoli-frontaliere/ospedale-zurigo-cardiochirurgia-scandalo',
+    canonicalPath: '/articoli-frontaliere/ospedale-zurigo-cardiochirurgia-scandalo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20830,7 +20830,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, locarno, record, abitanti, domiciliati',
     ogTitle: 'Locarno: record abitanti, ma domiciliati in calo',
     ogDescription: 'La Gestione del Consiglio comunale di Locarno invita a usare toni meno trionfalistici nonostante l\'aumento degli abitanti.',
-    canonicalPath: '/articoli-frontaliere/locarno-abitanti-domiciliati-2026',
+    canonicalPath: '/articoli-frontaliere/locarno-abitanti-domiciliati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20868,7 +20868,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, dentarie, milioni, senza',
     ogTitle: 'Cure dentarie in Ticino: 150 milioni in più, ma senza miglioramenti',
     ogDescription: 'Si vota il 14 giugno 2026 sull\'iniziativa per le cure dentarie. Un comitato denuncia un doppio colpo: più prelievi e imposte',
-    canonicalPath: '/articoli-frontaliere/cure-dentarie-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cure-dentarie-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20906,7 +20906,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bilancio, dopo, voto, canone',
     ogTitle: 'Bilancio dopo il voto sul canone SSR: impatto sui frontalieri',
     ogDescription: 'L\'Assemblea generale della SSR Svizzera italiana del 9 maggio fa il punto sul voto del canone dell\'8 marzo. Focus su Enavant e autonomia editoriale.',
-    canonicalPath: '/articoli-frontaliere/bilancio-voto-canone-ssr-2026',
+    canonicalPath: '/articoli-frontaliere/bilancio-voto-canone-ssr-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20944,7 +20944,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, cure, dentarie, proposta',
     ogTitle: 'Iniziativa cure dentarie: «No a una proposta ingannevole e costosa»',
     ogDescription: 'Comitato contrario all\'assicurazione obbligatoria per le cure odontoiatriche di base: costi elevati e problemi irrisolti',
-    canonicalPath: '/articoli-frontaliere/votazioni-cure-dentarie-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/votazioni-cure-dentarie-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20982,7 +20982,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, dell, artigianato, cerca',
     ogTitle: 'Casa dell\'artigianato Dongio cerca sostegno',
     ogDescription: 'Raccolta fondi per garantire il futuro del negozio di Dongio e preservare il patrimonio artigianale della Valle di Blenio',
-    canonicalPath: '/articoli-frontaliere/casa-artigianato-dongio-sostegno',
+    canonicalPath: '/articoli-frontaliere/casa-artigianato-dongio-sostegno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21020,7 +21020,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cnhi, potrebbe, lasciare, mendrisio',
     ogTitle: 'CNHI potrebbe lasciare Mendrisio: dipendenti in allarme',
     ogDescription: 'La CNHI International SA valuta un trasferimento della sede ticinese, con possibili ripercussioni per gli 80-100 dipendenti. Valutazioni in corso.',
-    canonicalPath: '/articoli-frontaliere/cnhi-mendrisio-dipendenti-allarme',
+    canonicalPath: '/articoli-frontaliere/cnhi-mendrisio-dipendenti-allarme/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21058,7 +21058,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, made, cosa, cambia',
     ogTitle: 'Swiss Made: cosa cambia per i frontalieri con le nuove regole',
     ogDescription: 'Nuove regole per l\'uso del marchio Swiss Made: cosa significa per i frontalieri in Ticino e quali prodotti possono ora fregiarsi della croce svizzera',
-    canonicalPath: '/articoli-frontaliere/swiss-made-regole-frontalieri',
+    canonicalPath: '/articoli-frontaliere/swiss-made-regole-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21096,7 +21096,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cucina, tipica, lombarda, passi',
     ogTitle: 'Cucina tipica lombarda: passi avanti per il progetto di legge in Regione',
     ogDescription: 'Il progetto di legge per la valorizzazione della cucina tipica lombarda avanza in Regione Lombardia con un primo stanziamento di 600mila euro.',
-    canonicalPath: '/articoli-frontaliere/cucina-tipica-lombarda-legge-2026',
+    canonicalPath: '/articoli-frontaliere/cucina-tipica-lombarda-legge-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21134,7 +21134,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estate, chiasso, evento, giorno',
     ogTitle: 'Estate 2026 a Chiasso: un evento al giorno',
     ogDescription: 'Oltre un centinaio di eventi animeranno l\'estate di Chiasso dal maggio al settembre 2026. Scopri il programma e cosa aspettarti.',
-    canonicalPath: '/articoli-frontaliere/estate-chiasso-2026-eventi',
+    canonicalPath: '/articoli-frontaliere/estate-chiasso-2026-eventi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21172,7 +21172,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inflazione, balzo, petrolio, rialzo',
     ogTitle: 'Inflazione Svizzera: balzo a +0,6% per il petrolio',
     ogDescription: 'Il rialzo del prezzo del petrolio fa salire l\'inflazione in Svizzera a +0,6% in aprile. Gli esperti rassicurano: per ora non si teme il contagio ad altri',
-    canonicalPath: '/articoli-frontaliere/petrolio-inflazione-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/petrolio-inflazione-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21210,7 +21210,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, negozi, vicinato, persi',
     ogTitle: 'Varese: 1.602 negozi di vicinato persi in 10 anni, ma cresce l\'occupazione',
     ogDescription: 'In provincia di Varese, tra il 2015 e il 2025, sono stati persi 1.602 negozi di vicinato, ma l\'occupazione è aumentata del 18,3%.',
-    canonicalPath: '/articoli-frontaliere/negozi-varese-frontalieri-occupazione',
+    canonicalPath: '/articoli-frontaliere/negozi-varese-frontalieri-occupazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21248,7 +21248,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinese, punta, alla, silicon',
     ogTitle: 'App ticinese per la guida punta alla Silicon Valley',
     ogDescription: 'Scopri SteerBudd, l\'app ticinese che punta alla Silicon Valley per ottimizzare le lezioni di guida con GPS e dati di apprendimento.',
-    canonicalPath: '/articoli-frontaliere/app-guida-ticino-silicon-valley-2026',
+    canonicalPath: '/articoli-frontaliere/app-guida-ticino-silicon-valley-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21286,7 +21286,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, torna, festival, sport, aperto',
     ogTitle: 'Torna il festival degli sport all\'aperto in Mesolcina',
     ogDescription: 'Dal 9 al 17 maggio 2026, la Mesolcina ospita la sesta edizione di MisoXperience con kayak, bouldering e parapendio.',
-    canonicalPath: '/articoli-frontaliere/mesolcina-festival-sport-2026',
+    canonicalPath: '/articoli-frontaliere/mesolcina-festival-sport-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21324,7 +21324,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, goldbarren, falsi, dalla, cina',
     ogTitle: 'Goldbarren falsi dalla Cina sequestrati a Zurigo: il Zoll interviene',
     ogDescription: 'Le autorità svizzere hanno scoperto e sequestrato goldbarren contraffatti provenienti dalla Cina a Zurigo. Ecco i dettagli dell\'operazione.',
-    canonicalPath: '/articoli-frontaliere/goldbarren-zurigo-zoll-confiscati',
+    canonicalPath: '/articoli-frontaliere/goldbarren-zurigo-zoll-confiscati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21362,7 +21362,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arese, apre, nuovo, negozio',
     ogTitle: 'Arese: apre il nuovo negozio danese Normal con prezzi bassi e caccia al tesoro',
     ogDescription: 'Il famoso negozio danese Normal inaugura il suo nuovo store ad Arese con prezzi fissi e un\'esperienza di shopping unica.',
-    canonicalPath: '/articoli-frontaliere/negozio-danese-arese-2026',
+    canonicalPath: '/articoli-frontaliere/negozio-danese-arese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21400,7 +21400,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, estate, aperto, summer',
     ogTitle: 'Varese: estate all\'aperto con le Summer Experience 2026',
     ogDescription: 'Varese Corsi lancia le Summer Experience: corsi all\'aperto in ville storiche e parchi per benessere e movimento. Scopri le attività e i luoghi',
-    canonicalPath: '/articoli-frontaliere/varese-summer-experience-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/varese-summer-experience-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21438,7 +21438,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malpensa, picchi, rumore, casorate',
     ogTitle: 'Malpensa, picchi di rumore a Casorate Sempione. Sindaco: situazione temporanea',
     ogDescription: 'Gli ambientalisti denunciano picchi di rumore fino a 90.5 dBA. Il sindaco Cassani conferma il disagio ma rassicura: la situazione è temporanea.',
-    canonicalPath: '/articoli-frontaliere/malpensa-rumore-casorate-sempione-2026',
+    canonicalPath: '/articoli-frontaliere/malpensa-rumore-casorate-sempione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21476,7 +21476,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, migliaia, piazza, contro',
     ogTitle: '1° maggio: migliaia in piazza contro l\'iniziativa UDC',
     ogDescription: 'Mobilitazione nazionale per difendere i diritti dei lavoratori e contrastare l\'iniziativa UDC \'No a una Svizzera da 10 milioni!\'',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-monito-svizzera-10-milioni',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-monito-svizzera-10-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21514,7 +21514,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bambini, tecnologia, incontro, gratuito',
     ogTitle: 'Bambini e tecnologia: incontro gratuito a Varese',
     ogDescription: 'Incontro gratuito a Varese con la psicologa Cristiana De Porcellinis per guidare i genitori nell\'uso consapevole di smartphone e tablet per i bambini.',
-    canonicalPath: '/articoli-frontaliere/bambini-tecnologia-varese-2026',
+    canonicalPath: '/articoli-frontaliere/bambini-tecnologia-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21552,7 +21552,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, benzina, ticinese, rifornimento, rincaro',
     ogTitle: 'Benzina: un ticinese su tre fa rifornimento in Italia',
     ogDescription: 'Il rincaro della benzina in Italia spinge i frontalieri a fare rifornimento in Ticino. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/ticino-benzina-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/ticino-benzina-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21590,7 +21590,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, meloni, vertice, consob, antitrust',
     ogTitle: 'Meloni al vertice su Consob e Antitrust: nomine in gioco',
     ogDescription: 'Vertice a Palazzo Chigi per le nomine alle autorità indipendenti. Meloni cerca sintesi tra alleati. Impatto sui frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nomine-meloni-consob-antitrust-2026',
+    canonicalPath: '/articoli-frontaliere/nomine-meloni-consob-antitrust-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21628,7 +21628,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, francia, fiumi, estate, rodano',
     ogTitle: 'Francia sui fiumi: estate sul Rodano e autunno sulla Senna',
     ogDescription: 'Scopri le crociere fluviali in Francia con partenza dal Ticino, esplorando il Rodano in estate e la Senna in autunno con le navi Excellence.',
-    canonicalPath: '/articoli-frontaliere/crociere-ticino-rodano-senna-2026',
+    canonicalPath: '/articoli-frontaliere/crociere-ticino-rodano-senna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21666,7 +21666,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tunisini, algerini, arrestati, furti',
     ogTitle: 'Tunisini e algerini arrestati per furti d\'auto a Würenlos',
     ogDescription: 'Due individui sono stati arrestati per furti d\'auto a Würenlos. Scopri i dettagli dell\'operazione e le misure preventive per proteggere il tuo veicolo.',
-    canonicalPath: '/articoli-frontaliere/tunesier-algerier-autoknacker-wuerenlos',
+    canonicalPath: '/articoli-frontaliere/tunesier-algerier-autoknacker-wuerenlos/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21704,7 +21704,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, servizio, civile, errore, nelle',
     ogTitle: 'Servizio civile: errore nelle spiegazioni di voto',
     ogDescription: 'Un errore nell\'opuscolo informativo del Consiglio federale per le votazioni del 14 giugno 2026 riguarda le domande di ammissione al servizio civile.',
-    canonicalPath: '/articoli-frontaliere/servizio-civile-errore-voto-2026',
+    canonicalPath: '/articoli-frontaliere/servizio-civile-errore-voto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21742,7 +21742,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parità, salariale, ancora, traguardo',
     ogTitle: 'Parità salariale in Ticino: ancora un traguardo lontano',
     ogDescription: 'In Ticino, la parità salariale tra uomini e donne rimane un traguardo lontano. Scopri le implicazioni per i frontalieri e cosa fare in caso di discriminazione.',
-    canonicalPath: '/articoli-frontaliere/parita-salariale-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/parita-salariale-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21780,7 +21780,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavori, chiasso, nuove, chiusure',
     ogTitle: 'Lavori a Chiasso: nuove chiusure in via Franscini',
     ogDescription: 'Da lunedì 11 maggio chiusura parziale in via Franscini, deviazioni per auto e mezzi pubblici, durata stimata 4 settimane.',
-    canonicalPath: '/articoli-frontaliere/lavori-chiasso-franscini-2026',
+    canonicalPath: '/articoli-frontaliere/lavori-chiasso-franscini-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21818,7 +21818,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, posta, trasferisce, negozio, alimentari',
     ogTitle: 'La Posta si trasferisce al negozio di alimentari a Castel San Pietro',
     ogDescription: 'A partire dall\'8 giugno, i servizi postali saranno ospitati presso il negozio di alimentari in Largo Bernasconi. Orari estesi e servizi a domicilio.',
-    canonicalPath: '/articoli-frontaliere/posta-castel-san-pietro-negozio-alimentari',
+    canonicalPath: '/articoli-frontaliere/posta-castel-san-pietro-negozio-alimentari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21856,7 +21856,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicuritalia, assume, guardie, giurate',
     ogTitle: 'Sicuritalia assume 150 guardie giurate in Lombardia e Veneto',
     ogDescription: 'Sicuritalia, gruppo leader nella sicurezza in Italia, assume 150 guardie giurate in Lombardia e Veneto. Scopri le opportunità di lavoro e come candidarti.',
-    canonicalPath: '/articoli-frontaliere/sicuritalia-assunzioni-lombardia-veneto-2026',
+    canonicalPath: '/articoli-frontaliere/sicuritalia-assunzioni-lombardia-veneto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21894,7 +21894,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, volandia, record, presenze, ponte',
     ogTitle: 'Volandia: record di presenze nel ponte di maggio',
     ogDescription: 'Oltre 2.200 visitatori in tre giorni, 400 battesimi del volo in elicottero. Il museo del volo a Somma Lombardo conferma il suo successo',
-    canonicalPath: '/articoli-frontaliere/volandia-record-presenze-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/volandia-record-presenze-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21932,7 +21932,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swissquote, trading, lugano, esperti',
     ogTitle: 'Swissquote Trading Day a Lugano: esperti e strategie finanziarie',
     ogDescription: 'Il 13 maggio al LAC di Lugano, Swissquote organizza il Trading Day con esperti del settore finanziario. Focus su volatilità, criptovalute e strategie di',
-    canonicalPath: '/articoli-frontaliere/swissquote-trading-day-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/swissquote-trading-day-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21970,7 +21970,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, liberalizzazione, cannabis, minori, tutelare',
     ogTitle: 'Liberalizzazione cannabis: minori da tutelare «fin dall\'inizio»',
     ogDescription: 'La Commissione della sanità del Consiglio nazionale svizzero esamina il progetto di legge sulla liberalizzazione della cannabis, con misure per proteggere i',
-    canonicalPath: '/articoli-frontaliere/liberalizzazione-cannabis-minori-tutelati',
+    canonicalPath: '/articoli-frontaliere/liberalizzazione-cannabis-minori-tutelati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22008,7 +22008,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, afghano, aggredisce, donna, treno',
     ogTitle: 'Afghano aggredisce donna in treno a Chiasso: arrestato',
     ogDescription: 'Un afghano ha aggredito una donna in un treno a Chiasso, spingendola contro una siepe. L\'uomo è stato arrestato. Scopri di più sull\'incidente e le implicazioni',
-    canonicalPath: '/articoli-frontaliere/afghano-arresto-zug-chiasso',
+    canonicalPath: '/articoli-frontaliere/afghano-arresto-zug-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22046,7 +22046,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, nelle, attività, commerciali',
     ogTitle: 'Sicurezza nelle attività commerciali: serata informativa a Locarno',
     ogDescription: 'Mercoledì 27 maggio 2026 a Locarno si terrà una serata informativa sulla sicurezza nelle attività commerciali, con interventi di Polizia e Pompieri.',
-    canonicalPath: '/articoli-frontaliere/sicurezza-commerciali-locarno-2026',
+    canonicalPath: '/articoli-frontaliere/sicurezza-commerciali-locarno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22084,7 +22084,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roveredo, iniziativa, popolare, carnevale',
     ogTitle: 'Roveredo, iniziativa per un Carnevale accessibile a tutti',
     ogDescription: 'Un gruppo di cittadini di Roveredo lancia un\'iniziativa per rendere il Carnevale Lingera più inclusivo e trasparente',
-    canonicalPath: '/articoli-frontaliere/roveredo-carnevale-tutti-2026',
+    canonicalPath: '/articoli-frontaliere/roveredo-carnevale-tutti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22122,7 +22122,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fnma, cerca, autisti, meccanici',
     ogTitle: 'FNMA cerca autisti e meccanici: appuntamento il 12 maggio a Saronno',
     ogDescription: 'FNMA organizza un Recruiting Day a Saronno il 12 maggio per assumere autisti e meccanici. Colloqui diretti e presentazione aziendale.',
-    canonicalPath: '/articoli-frontaliere/fnma-recruiting-day-saronno-2026',
+    canonicalPath: '/articoli-frontaliere/fnma-recruiting-day-saronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22160,7 +22160,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sportello, energetico, gratuito, cittadini',
     ogTitle: 'Sportello energetico gratuito per i cittadini delle Valli del Verbano',
     ogDescription: 'Scopri come risparmiare in bolletta e migliorare l\'efficienza energetica della tua abitazione grazie allo sportello gratuito di Bosco Clima.',
-    canonicalPath: '/articoli-frontaliere/sportello-energetico-verbano-2026',
+    canonicalPath: '/articoli-frontaliere/sportello-energetico-verbano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22198,7 +22198,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vittima, folgorata, bellinzona, 33enne',
     ogTitle: 'Vittima folgorata a Bellinzona: chi era il 33enne del Bellinzonese',
     ogDescription: 'Un 33enne svizzero del Bellinzonese è la vittima dell\'infortunio mortale alla stazione di Bellinzona. L\'inchiesta è ancora in corso.',
-    canonicalPath: '/articoli-frontaliere/vittima-folgorata-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/vittima-folgorata-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22236,7 +22236,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bilaterali, richiesta, doppia, maggioranza',
     ogTitle: 'Bilaterali III: richiesta doppia maggioranza per l\'approvazione',
     ogDescription: 'La commissione degli Stati chiede l\'inserimento del pacchetto Bilaterali III nella Costituzione federale, richiedendo doppia maggioranza',
-    canonicalPath: '/articoli-frontaliere/bilaterali-iii-doppia-maggioranza',
+    canonicalPath: '/articoli-frontaliere/bilaterali-iii-doppia-maggioranza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22274,7 +22274,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, immigrazione, possibile, pochi',
     ogTitle: 'Tassa immigrazione: possibile ma con pochi benefici',
     ogDescription: 'Il Consiglio federale ha adottato un rapporto che analizza la fattibilità di una tassa d\'immigrazione in Svizzera, con implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/tassa-immigrazione-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/tassa-immigrazione-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22312,7 +22312,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bilaterali, necessaria, modifica, costituzionale',
     ogTitle: 'Bilaterali III: necessaria modifica costituzionale',
     ogDescription: 'La Commissione delle istituzioni politiche del Consiglio degli Stati propone una modifica costituzionale per l\'approvazione degli accordi con l\'UE.',
-    canonicalPath: '/articoli-frontaliere/bilaterali-iii-modifica-costituzionale',
+    canonicalPath: '/articoli-frontaliere/bilaterali-iii-modifica-costituzionale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22350,7 +22350,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, screening, mammografico, anni, cosa',
     ogTitle: 'Screening mammografico a 45 anni in Ticino',
     ogDescription: 'Tre società svizzere raccomandano di anticipare lo screening del tumore al seno a 45 anni. Ecco cosa cambia per le donne in Ticino.',
-    canonicalPath: '/articoli-frontaliere/screening-senologico-45-anni-ticino',
+    canonicalPath: '/articoli-frontaliere/screening-senologico-45-anni-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22388,7 +22388,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, evian, controlli, alle, frontiere',
     ogTitle: 'G7 Evian: controlli frontiere Svizzera-Francia dal 10 giugno',
     ogDescription: 'Dal 10 al 19 giugno controlli rafforzati ai valichi con la Francia per il vertice del G7 a Evian-les-Bains. Impatto sui frontalieri',
-    canonicalPath: '/articoli-frontaliere/g7-evian-controlli-frontiere-ticino',
+    canonicalPath: '/articoli-frontaliere/g7-evian-controlli-frontiere-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22426,7 +22426,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, menaggio, dice, test, automobilisti',
     ogTitle: 'Menaggio dice no ai test: sei automobilisti nei guai',
     ogDescription: 'Sei automobilisti nei guai per rifiuto test a Menaggio, vicino al confine con il Ticino. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/menaggio-test-automobilisti-guai',
+    canonicalPath: '/articoli-frontaliere/menaggio-test-automobilisti-guai/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22464,7 +22464,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, votazioni, giugno, esito, incerto',
     ogTitle: 'Votazioni Ticino 14 giugno: esito incerto per entrambi gli oggetti',
     ogDescription: 'Sondaggio YouGov Svizzera rivela un testa a testa tra favorevoli e contrari per l\'iniziativa UDC e la modifica della legge sul servizio civile',
-    canonicalPath: '/articoli-frontaliere/votazioni-ticino-14-giugno-2024',
+    canonicalPath: '/articoli-frontaliere/votazioni-ticino-14-giugno-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22502,7 +22502,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borse, rialzo, eccetto, londra',
     ogTitle: 'Borse in rialzo, eccetto Londra: cosa cambia per i frontalieri',
     ogDescription: 'Scopri le implicazioni del rialzo delle Borse europee, tranne Londra, per i frontalieri del Ticino.',
-    canonicalPath: '/articoli-frontaliere/borse-ticino-londra-verde',
+    canonicalPath: '/articoli-frontaliere/borse-ticino-londra-verde/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22540,7 +22540,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bagni, pubblici, bellinzona, riaprono',
     ogTitle: 'Bagni Bellinzona riaprono: novità 2026',
     ogDescription: 'Scopri le novità per la stagione estiva 2026 dei Bagni pubblici di Bellinzona, inclusa la prenotazione online e il nuovo concept ristorativo.',
-    canonicalPath: '/articoli-frontaliere/bagni-bellinzona-riaprono-novita-2026',
+    canonicalPath: '/articoli-frontaliere/bagni-bellinzona-riaprono-novita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22578,7 +22578,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, market, index, rialzo',
     ogTitle: 'Swiss Market Index in rialzo: +2.3% a Zurigo',
     ogDescription: 'Il Swiss Market Index vola a 13\'352 punti circa, con progresso del 2.30%. Podio occupato da Richemont, Amrize e Holcim.',
-    canonicalPath: '/articoli-frontaliere/swiss-market-index-entusiasmo-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-market-index-entusiasmo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22616,7 +22616,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, valuta, limiti, alle',
     ogTitle: 'Trump valuta limiti alle esportazioni di petrolio USA',
     ogDescription: 'I prezzi dei carburanti negli USA sono aumentati del 50% da inizio guerra in Iran, aprendo alla possibilità di limitare le esportazioni.',
-    canonicalPath: '/articoli-frontaliere/trump-export-limits-petrol-2026',
+    canonicalPath: '/articoli-frontaliere/trump-export-limits-petrol-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22654,7 +22654,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bagno, pubblico, bellinzona, riapre',
     ogTitle: 'Bagno pubblico Bellinzona riapre 9 maggio 2026',
     ogDescription: 'Novità per la stagione 2026: pagamento online, ristorazione rinnovata e orari aggiornati. Tariffe invariate dopo l\'aumento del 20% del 2025',
-    canonicalPath: '/articoli-frontaliere/riapertura-bagno-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/riapertura-bagno-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22692,7 +22692,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, partita, cornaredo, blocchi, stradali',
     ogTitle: 'Partita a Cornaredo: blocchi stradali e deviazioni previste',
     ogDescription: 'Domenica 10 maggio 2026, la partita tra FC Lugano e FC San Gallo causerà blocchi stradali a Cornaredo/Molino Nuovo. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/partita-cornaredo-blocchi-stradali-2026',
+    canonicalPath: '/articoli-frontaliere/partita-cornaredo-blocchi-stradali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22730,7 +22730,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fondi, europei, fesr, pnrr',
     ogTitle: 'Fondi europei in Ticino: FSE, FESR, PNRR e Horizon',
     ogDescription: 'Scopri come i fondi europei FSE, FESR, PNRR e Horizon finanziano progetti in Ticino e Lombardia, con esempi concreti e opportunità per imprese e cittadini.',
-    canonicalPath: '/articoli-frontaliere/fondi-europei-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/fondi-europei-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22768,7 +22768,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, friborgo, vive, hockey, mondiale',
     ogTitle: 'Friborgo vive di hockey come il Ticino: Mondiale 2026 alla BCF Arena',
     ogDescription: 'Friborgo ospiterà il Mondiale di hockey 2026 alla BCF Arena. John Gobbi: "80mila persone per la festa del titolo del Gottéron"',
-    canonicalPath: '/articoli-frontaliere/friborgo-hockey-mondiale-2026',
+    canonicalPath: '/articoli-frontaliere/friborgo-hockey-mondiale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22806,7 +22806,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, accordo, risarcimento, vittime',
     ogTitle: 'Pagare per le vittime italiane di Crans-Montana? A Berna l\'idea non piace a tutti',
     ogDescription: 'La Svizzera valuta di coprire le spese sanitarie per le vittime italiane del rogo di Crans-Montana, ma l\'idea divide a Berna.',
-    canonicalPath: '/articoli-frontaliere/pagare-vittime-crans-montana-2026',
+    canonicalPath: '/articoli-frontaliere/pagare-vittime-crans-montana-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22844,7 +22844,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, losanna, introduce, parcheggi, sicuri',
     ogTitle: 'Losanna introduce parcheggi sicuri per e-bike',
     ogDescription: 'La città di Losanna installa Vélobox per contrastare l\'aumento dei furti di biciclette elettriche. Pro Vélo Losanna accoglie positivamente l\'iniziativa.',
-    canonicalPath: '/articoli-frontaliere/e-bike-parcheggi-sicuri-losanna-2026',
+    canonicalPath: '/articoli-frontaliere/e-bike-parcheggi-sicuri-losanna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22882,7 +22882,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, serie, auto, arrestato',
     ogTitle: 'Furti in serie in auto: arrestato un 40enne del Luganese',
     ogDescription: 'Un 40enne del Luganese è stato arrestato per furti in auto. Scoperti oggetti di dubbia provenienza e migliaia di franchi in contanti.',
-    canonicalPath: '/articoli-frontaliere/furti-serie-automobili-luganese-arrestato',
+    canonicalPath: '/articoli-frontaliere/furti-serie-automobili-luganese-arrestato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22920,7 +22920,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, taccheggio, supermercato, trasforma',
     ogTitle: 'Como, taccheggio al supermercato si trasforma in rapina: doppio arresto',
     ogDescription: 'Due individui sono stati arrestati a Como dopo che un tentativo di taccheggio si è trasformato in rapina con minaccia di arma.',
-    canonicalPath: '/articoli-frontaliere/como-taccheggio-rapina-doppio-arresto',
+    canonicalPath: '/articoli-frontaliere/como-taccheggio-rapina-doppio-arresto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22958,7 +22958,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, riapre, bagno, pubblico',
     ogTitle: 'Bellinzona: riapre il Bagno Pubblico con nuove attrazioni',
     ogDescription: 'Il Bagno Pubblico di Bellinzona riapre il 9 maggio con pagamento online, nuovo ristorante e intrattenimento. Orari e tariffe aggiornati.',
-    canonicalPath: '/articoli-frontaliere/bellinzona-bagno-pubblico-riapre-2026',
+    canonicalPath: '/articoli-frontaliere/bellinzona-bagno-pubblico-riapre-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22996,7 +22996,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, minaccia, accordi, bilaterali',
     ogTitle: 'NO all\'iniziativa UDC che minaccia gli accordi bilaterali con l\'UE',
     ogDescription: 'Il 14 giugno votazione sull\'iniziativa UDC che potrebbe isolare la Svizzera e colpire i diritti dei frontalieri',
-    canonicalPath: '/articoli-frontaliere/udc-bilaterali-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/udc-bilaterali-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23034,7 +23034,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nessun, esperimento, richiedenti, asilo',
     ogTitle: 'Nessun esperimento con richiedenti asilo problematici a Pasture',
     ogDescription: 'La mozione Marchesi-Fonio-Gianini richiede il consenso di Cantone e Comuni per progetti pilota della SEM a Balerna.',
-    canonicalPath: '/articoli-frontaliere/centro-pasture-balerna-asilo',
+    canonicalPath: '/articoli-frontaliere/centro-pasture-balerna-asilo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23072,7 +23072,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, persone, fila, pasto, vegetale',
     ogTitle: '300 persone in fila per un pasto vegetale a Lugano',
     ogDescription: 'Un\'iniziativa di Greenpeace Svizzera per promuovere un\'alimentazione sostenibile. 300 bowl vegetali servite al Campus Est USI-SUPSI.',
-    canonicalPath: '/articoli-frontaliere/300-persone-pasto-vegetale-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/300-persone-pasto-vegetale-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23110,7 +23110,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 20mila, franchi, multa, viaggio',
     ogTitle: 'Svizzera, 20mila franchi di multa per viaggio senza biglietto',
     ogDescription: 'Un uomo di 40 anni del Canton Svitto è stato condannato a 20mila franchi per aver viaggiato senza biglietto e falsificato documenti.',
-    canonicalPath: '/articoli-frontaliere/svizzera-treno-multa-20000-franchi',
+    canonicalPath: '/articoli-frontaliere/svizzera-treno-multa-20000-franchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23148,7 +23148,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, decreto, lavoro, coldiretti, varese',
     ogTitle: 'Decreto Lavoro, Coldiretti Varese: misure per la stabilità dell\'occupazione',
     ogDescription: 'Coldiretti Varese promuove il Decreto Lavoro, ritenendo le misure adottate un passo importante per rafforzare la stabilità e la qualità dell\'occupazione nel',
-    canonicalPath: '/articoli-frontaliere/decreto-lavoro-coldiretti-varese-2026',
+    canonicalPath: '/articoli-frontaliere/decreto-lavoro-coldiretti-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23186,7 +23186,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, elimina, posti, lavoro',
     ogTitle: 'Swiss elimina 300 posti di lavoro con uscite volontarie',
     ogDescription: 'Swiss ha eliminato 300 posti di lavoro nel personale di cabina attraverso uscite volontarie, offrendo incentivi economici per favorire le partenze senza',
-    canonicalPath: '/articoli-frontaliere/swiss-300-uscite-volontarie-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-300-uscite-volontarie-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23224,7 +23224,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parmelin, conferma, stop, alle',
     ogTitle: 'Parmelin conferma stop alle fatture mediche per le vittime di Crans-Montana',
     ogDescription: 'Il presidente svizzero Guy Parmelin ha ribadito che non saranno più inviate fatture per le spese sanitarie ai familiari delle vittime dell\'incendio di Capodanno',
-    canonicalPath: '/articoli-frontaliere/parmelin-stop-fatture-mediche-crans-montana',
+    canonicalPath: '/articoli-frontaliere/parmelin-stop-fatture-mediche-crans-montana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23262,7 +23262,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, massarenti, denuncia, trucco',
     ogTitle: 'Luino: Massarenti denuncia il trucco delle percentuali nella sanità pubblica',
     ogDescription: 'Marco Massarenti, candidato di \'La nostra Luino\', critica i dati presentati dalla Regione Lombardia sulla sanità, evidenziando disparità e problemi strutturali.',
-    canonicalPath: '/articoli-frontaliere/luino-sanita-massarenti-2026',
+    canonicalPath: '/articoli-frontaliere/luino-sanita-massarenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23300,7 +23300,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siss, lombardia, astuti, denuncia',
     ogTitle: 'SISS Lombardia: Astuti denuncia problemi cronici e inazione',
     ogDescription: 'Il consigliere regionale PD Samuele Astuti attacca la giunta lombarda per i malfunzionamenti del sistema informativo socio-sanitario',
-    canonicalPath: '/articoli-frontaliere/siss-problemi-lombardia-frontalieri',
+    canonicalPath: '/articoli-frontaliere/siss-problemi-lombardia-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23338,7 +23338,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, utili, crescita, primo',
     ogTitle: 'Swiss: utili in crescita nel primo trimestre ma rischi in vista',
     ogDescription: 'Swiss chiude il primo trimestre con utili in crescita, ma i costi del carburante potrebbero erodere i guadagni. Impatto sui frontalieri.',
-    canonicalPath: '/articoli-frontaliere/swiss-risultati-trimestre-frontalieri',
+    canonicalPath: '/articoli-frontaliere/swiss-risultati-trimestre-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23376,7 +23376,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, poliani, riconfermato, digital, innovation',
     ogTitle: 'Stefano Poliani riconfermato alla guida del Digital Innovation Hub di Confindustria Lombardia',
     ogDescription: 'L\'imprenditore guiderà l\'organismo per il triennio 2026-2028 con l\'obiettivo di accompagnare le PMI verso l\'intelligenza artificiale',
-    canonicalPath: '/articoli-frontaliere/poliani-digital-innovation-hub-2026',
+    canonicalPath: '/articoli-frontaliere/poliani-digital-innovation-hub-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23414,7 +23414,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nespresso, resta, malgrado, dazi',
     ogTitle: 'Nespresso resta in Svizzera malgrado i dazi USA',
     ogDescription: 'Nestlé conferma la produzione Nespresso in Svizzera nonostante i dazi americani. Tagli di 16\'000 posti entro 2027. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nespresso-svizzera-dazi-2026',
+    canonicalPath: '/articoli-frontaliere/nespresso-svizzera-dazi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23452,7 +23452,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fondazione, giuliano, bignasca, oltre',
     ogTitle: 'Fondazione Bignasca: 20 mila franchi di aiuti nel 2025',
     ogDescription: 'La Fondazione Giuliano Bignasca ha erogato oltre 20 mila franchi in aiuti diretti nel 2025, tra buoni spesa e sostegno per pigioni e premi di cassa malati.',
-    canonicalPath: '/articoli-frontaliere/fondazione-bignasca-aiuti-2025',
+    canonicalPath: '/articoli-frontaliere/fondazione-bignasca-aiuti-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23490,7 +23490,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assegni, figli, problemi, inps',
     ogTitle: 'Assegni figli frontalieri: problemi con l\'INPS ma i pagamenti continuano',
     ogDescription: 'Il Consiglio federale respinge la proposta di Lorenzo Quadri di sospendere i versamenti agli italiani che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/assegni-figli-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/assegni-figli-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23528,7 +23528,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, studenti, gaza, nelle, scuole',
     ogTitle: 'Studenti da Gaza nelle scuole italiane: 1,5 milioni per l\'integrazione',
     ogDescription: 'Il Ministero dell\'Istruzione stanzia 1,5 milioni per l\'integrazione degli studenti provenienti da Gaza nelle scuole italiane. Scadenza per l\'adesione: 26 maggio',
-    canonicalPath: '/articoli-frontaliere/integrazione-studenti-gaza-italia-2026',
+    canonicalPath: '/articoli-frontaliere/integrazione-studenti-gaza-italia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23566,7 +23566,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ladro, seriale, luganese, intero',
     ogTitle: 'Ladro seriale dal Luganese all\'intero Ticino: incastrato dalle carte di credito',
     ogDescription: 'Un ladro seriale attivo tra Lugano e Bellinzona è stato arrestato grazie alle carte di credito rubate. Ecco i dettagli dell\'operazione.',
-    canonicalPath: '/articoli-frontaliere/ladro-seriale-ticino-arresto-carte-credito',
+    canonicalPath: '/articoli-frontaliere/ladro-seriale-ticino-arresto-carte-credito/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23604,7 +23604,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, solidale, convegno, sulla',
     ogTitle: 'Varese Solidale: convegno povertà sanitaria e alimentare 2026',
     ogDescription: 'Varese Solidale presenta il convegno sulla povertà sanitaria e alimentare il 15 maggio 2026. Esperti e istituzioni si confrontano su strategie e strumenti per',
-    canonicalPath: '/articoli-frontaliere/varese-solidale-convegno-poverta-sanitaria-alimentare-2026',
+    canonicalPath: '/articoli-frontaliere/varese-solidale-convegno-poverta-sanitaria-alimentare-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23642,7 +23642,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, centri, famiglia, alto, varesotto',
     ogTitle: 'Centri famiglia Alto Varesotto: supporto alle famiglie in difficoltà',
     ogDescription: 'Scopri come i Centri per la famiglia in Alto Varesotto offrono supporto alle famiglie con nuove emergenze e disorientamento, con servizi di ascolto, consulenze',
-    canonicalPath: '/articoli-frontaliere/centri-famiglia-altovaresotto-2026',
+    canonicalPath: '/articoli-frontaliere/centri-famiglia-altovaresotto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23680,7 +23680,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, senza, immigrazione, invecchierebbe, rapidamente',
     ogTitle: 'Senza immigrazione, la Svizzera invecchierebbe rapidamente',
     ogDescription: 'L\'immigrazione rallenta l\'invecchiamento demografico della Svizzera, con effetti diretti su AVS e premi assicurativi',
-    canonicalPath: '/articoli-frontaliere/immigrazione-svizzera-invecchiamento-2026',
+    canonicalPath: '/articoli-frontaliere/immigrazione-svizzera-invecchiamento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23718,7 +23718,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bocconi, avvelenati, segnalazioni, anno',
     ogTitle: 'Bocconi avvelenati in Ticino: 18 segnalazioni in un anno',
     ogDescription: 'L\'app Amico Fido ha raccolto 18 segnalazioni di bocconi avvelenati in Ticino, con un picco nel mese di maggio 2025. Scopri come proteggere il tuo cane.',
-    canonicalPath: '/articoli-frontaliere/bocconi-avvelenati-ticino-segnalazioni',
+    canonicalPath: '/articoli-frontaliere/bocconi-avvelenati-ticino-segnalazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23756,7 +23756,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, vita, albergo, corecco',
     ogTitle: 'Nuova vita per l’ex Albergo Corecco di Quinto',
     ogDescription: 'Recupero e valorizzazione dell\'ex Albergo Corecco a Lurengo, Quinto, con la realizzazione di una struttura ricettiva dedicata al benessere.',
-    canonicalPath: '/articoli-frontaliere/nuova-vita-albergo-corecco-quinto',
+    canonicalPath: '/articoli-frontaliere/nuova-vita-albergo-corecco-quinto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23794,7 +23794,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dalla, logistica, agli, swissskills',
     ogTitle: 'Dalla logistica agli SwissSkills 2025: il percorso di Alessandro',
     ogDescription: 'Scopri il viaggio lavorativo e di studio di Alessandro, 19enne impiegato in logistica al Cardiocentro di Lugano e partecipante agli SwissSkills 2025.',
-    canonicalPath: '/articoli-frontaliere/alessandro-logistica-swissskills-2025',
+    canonicalPath: '/articoli-frontaliere/alessandro-logistica-swissskills-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23832,7 +23832,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ladri, reclutati, rubare, auto',
     ogTitle: 'Ladri reclutati per rubare auto di lusso in Svizzera',
     ogDescription: 'Scopri come i cantoni svizzeri stanno creando una task force per contrastare i furti di auto di lusso e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ladri-auto-lusso-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ladri-auto-lusso-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23870,7 +23870,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tuberkulosefall, primarschule, saint-maurice, caso',
     ogTitle: 'Tuberkulosefall an Primarschule in Saint-Maurice',
     ogDescription: 'Un caso di tubercolosi segnalato in una scuola primaria a Saint-Maurice, Canton Vallese. Le autorità sanitarie intervengono.',
-    canonicalPath: '/articoli-frontaliere/tuberkulose-caso-saint-maurice-2024',
+    canonicalPath: '/articoli-frontaliere/tuberkulose-caso-saint-maurice-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23908,7 +23908,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fondazione, bignasca, oltre, franchi',
     ogTitle: 'Fondazione Bignasca: oltre 20.000 franchi in aiuti per i più bisognosi',
     ogDescription: 'La Fondazione Giuliano Bignasca ha erogato oltre 20.000 franchi nel 2025 per sostenere famiglie e persone in difficoltà economica nel Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/fondazione-bignasca-aiuti-2026',
+    canonicalPath: '/articoli-frontaliere/fondazione-bignasca-aiuti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23946,7 +23946,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, case, lusso, prezzi, record',
     ogTitle: 'Case lusso Svizzera: prezzi record nel 2026',
     ogDescription: 'Studio UBS: immobili di pregio +3% annuo, Alpi +6%. St. Moritz la più cara (52.000 CHF/mq). Ticino stagnante ma stabile grazie a investitori italiani e finanza.',
-    canonicalPath: '/articoli-frontaliere/lusso-immobiliare-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/lusso-immobiliare-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23984,7 +23984,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, rivaluta, valore, economico',
     ogTitle: 'Chiasso rivaluta il suo valore economico con l\'aggregazione',
     ogDescription: 'L\'operazione contabile straordinaria restituisce un risultato positivo da 23 milioni, ma l\'ordinario resta nelle cifre rosse.',
-    canonicalPath: '/articoli-frontaliere/chiasso-valore-economico-aggregazione',
+    canonicalPath: '/articoli-frontaliere/chiasso-valore-economico-aggregazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24022,7 +24022,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, governance, partecipativa, presentato, consensus',
     ogTitle: 'Governance partecipativa, presentato consensus paper per Ssn equo e sostenibile',
     ogDescription: 'Presentato al Senato il Consensus Paper per una sanità partecipata, equa e sostenibile. Coinvolgimento attivo di cittadini e pazienti.',
-    canonicalPath: '/articoli-frontaliere/governance-partecipativa-ssn-2026',
+    canonicalPath: '/articoli-frontaliere/governance-partecipativa-ssn-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24060,7 +24060,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accessibile, tutti, novità, guido',
     ogTitle: 'SSN accessibile a tutti: le novità per i frontalieri del Ticino',
     ogDescription: 'Guido Quintino Liris (Fdi) annuncia riforme per rendere il Servizio Sanitario Nazionale accessibile a tutti, con focus su prevenzione e assistenza territoriale',
-    canonicalPath: '/articoli-frontaliere/ssn-accessibile-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ssn-accessibile-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24098,7 +24098,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, isolamento, contenere, epidemia',
     ogTitle: 'Hantavirus: isolamento per contenere l\'epidemia',
     ogDescription: 'Pietro Antonini, consulente malattie infettive, spiega come si trasmette l\'hantavirus e quali misure adottare per contenerlo.',
-    canonicalPath: '/articoli-frontaliere/hantavirus-crociera-isolamento',
+    canonicalPath: '/articoli-frontaliere/hantavirus-crociera-isolamento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24136,7 +24136,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, tunnel, lukmanier, sicurezza',
     ogTitle: 'Nuovo tunnel al Lukmanier per più sicurezza',
     ogDescription: 'Un nuovo tunnel verrà costruito al Lukmanier per migliorare la sicurezza stradale.',
-    canonicalPath: '/articoli-frontaliere/nuovo-tunnel-lukmanier-sicurezza',
+    canonicalPath: '/articoli-frontaliere/nuovo-tunnel-lukmanier-sicurezza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24174,7 +24174,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, cerca, passeggeri, volo',
     ogTitle: 'Hantavirus, l\'OMS cerca passeggeri di un volo per il Sudafrica',
     ogDescription: 'L\'OMS cerca passeggeri di un volo per il Sudafrica dopo la morte di una donna olandese affetta da hantavirus.',
-    canonicalPath: '/articoli-frontaliere/hantavirus-oms-passeggeri-sudafrica',
+    canonicalPath: '/articoli-frontaliere/hantavirus-oms-passeggeri-sudafrica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24212,7 +24212,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, contrabbandiera, ciclismo, vintage, domenica',
     ogTitle: 'La Contrabbandiera 2026: ciclismo vintage tra Italia e Svizzera',
     ogDescription: 'Domenica 24 maggio 2026, a Uggiate con Ronago, si terrà la ciclostorica La Contrabbandiera, un evento che unisce passione per il ciclismo d\'epoca e paesaggi di',
-    canonicalPath: '/articoli-frontaliere/contrabbandiera-ciclostorica-2026',
+    canonicalPath: '/articoli-frontaliere/contrabbandiera-ciclostorica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24250,7 +24250,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libertà, doveri, autocensura, bocciata',
     ogTitle: 'Libertà, doveri e autocensura: bocciata a Mendrisio la risoluzione',
     ogDescription: 'La maggioranza del Consiglio comunale di Mendrisio ha bocciato una risoluzione sulla tutela dei politici locali, con divisioni nell\'area progressista.',
-    canonicalPath: '/articoli-frontaliere/liberta-dovery-autocensura-mendrisio',
+    canonicalPath: '/articoli-frontaliere/liberta-dovery-autocensura-mendrisio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24288,7 +24288,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, case, lusso, prezzi, ancora',
     ogTitle: 'Case di lusso in Svizzera: prezzi ancora alti ma trend in rallentamento',
     ogDescription: 'I prezzi degli immobili di lusso in Svizzera sono aumentati del 3% nel 2025, ma il mercato mostra segni di indebolimento. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/case-lusso-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/case-lusso-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24326,7 +24326,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, 2025, disavanzo, ordinario',
     ogTitle: 'Chiasso 2025: disavanzo ordinario ridotto e avanzo eccezionale',
     ogDescription: 'I conti 2025 di Chiasso mostrano un disavanzo ordinario ridotto a 2,8 milioni e un avanzo eccezionale di 23,1 milioni grazie a rivalutazioni',
-    canonicalPath: '/articoli-frontaliere/chiasso-conti-2025-disavanzo-avanzo',
+    canonicalPath: '/articoli-frontaliere/chiasso-conti-2025-disavanzo-avanzo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24364,7 +24364,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, quartiere, gera, iragna',
     ogTitle: 'Nuovo quartiere Gera a Iragna: pianificazione conforme alle normative',
     ogDescription: 'Il Municipio di Riviera conferma che la pianificazione del nuovo quartiere Gera a Iragna rispetta i valori limite di elettromagnetismo.',
-    canonicalPath: '/articoli-frontaliere/quartiere-gera-iragna-pianificazione',
+    canonicalPath: '/articoli-frontaliere/quartiere-gera-iragna-pianificazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24402,7 +24402,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, chiede, risarcimento, almeno',
     ogTitle: 'Crans-Montana, l\'Italia chiede un risarcimento di almeno 300.000 euro',
     ogDescription: 'La Repubblica italiana ha depositato una richiesta di costituirsi parte civile per un risarcimento di almeno 300.000 euro nel procedimento penale relativo',
-    canonicalPath: '/articoli-frontaliere/crans-montana-italia-risarcimento-300000-euro',
+    canonicalPath: '/articoli-frontaliere/crans-montana-italia-risarcimento-300000-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24440,7 +24440,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mariano, comense, como, assale',
     ogTitle: 'Mariano Comense (Como): assale e ferisce il barista, 24enne denunciato',
     ogDescription: 'Mariano Comense (Como): assale e ferisce il barista, 24enne denunciato',
-    canonicalPath: '/articoli-frontaliere/mariano-comense-assale-ferisce-barista-denunciato',
+    canonicalPath: '/articoli-frontaliere/mariano-comense-assale-ferisce-barista-denunciato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24478,7 +24478,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roveredo, patriziato, sciopera, contro',
     ogTitle: 'Roveredo: il patriziato sciopera contro la gestione della',
     ogDescription: 'Il Patriziato di Roveredo protesta da oltre un mese contro l\'assenza di interventi concreti del Cantone sui controlli dei permessi di soggiorno, limitando le na',
-    canonicalPath: '/articoli-frontaliere/roveredo-patriziato-sciopera-gestione-criminalit',
+    canonicalPath: '/articoli-frontaliere/roveredo-patriziato-sciopera-gestione-criminalit/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24516,7 +24516,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, friuli, anni, solidarietà',
     ogTitle: 'Varese e il Friuli: 50 anni di solidarietà e ricostruzione',
     ogDescription: 'Un reportage su come i volontari del Varesotto hanno aiutato il Friuli dopo il terremoto del 1976, con testimonianze e celebrazioni del 2026',
-    canonicalPath: '/articoli-frontaliere/varese-friuli-solidarieta-2026',
+    canonicalPath: '/articoli-frontaliere/varese-friuli-solidarieta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24554,7 +24554,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, natura, tavola, cucina, vegetale',
     ogTitle: 'Natura a tavola: cucina vegetale a Lugano con Greenpeace',
     ogDescription: 'Greenpeace Svizzera promuove un\'iniziativa di cucina vegetale a Lugano con un pasto gratuito per 300 persone. Scopri come e perché.',
-    canonicalPath: '/articoli-frontaliere/natura-tavola-cucina-vegetale-lugano-2024',
+    canonicalPath: '/articoli-frontaliere/natura-tavola-cucina-vegetale-lugano-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24592,7 +24592,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cambio, vertici, commissione, magistrati',
     ogTitle: 'Cambio vertici commissione magistrati Ticino',
     ogDescription: 'Emanuela Colombo Epiney si dimette. Il Gran Consiglio nominerà il successore. Luca Marazzi proposto come nuovo membro.',
-    canonicalPath: '/articoli-frontaliere/cambiamenti-commissione-magistrati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cambiamenti-commissione-magistrati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24630,7 +24630,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, filippo, armati, ticinese, alla',
     ogTitle: 'Filippo Armati: un ticinese alla guida di Afro-Pfingsten',
     ogDescription: 'Scopri chi è Filippo Armati e come sta contribuendo a portare cultura e sostenibilità a Winterthur con Afro-Pfingsten.',
-    canonicalPath: '/articoli-frontaliere/ticinese-timone-afro-pfingsten',
+    canonicalPath: '/articoli-frontaliere/ticinese-timone-afro-pfingsten/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24668,7 +24668,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, corsi, iscrizioni, nuovi',
     ogTitle: 'Varese Corsi: 6.327 iscrizioni e nuovi corsi per il 2026',
     ogDescription: 'Varese Corsi Net registra 6.327 iscrizioni e introduce simulazioni di volo e Vocal Fitness per l\'inglese. Nuove sinergie tra docenti, istituzioni e imprese.',
-    canonicalPath: '/articoli-frontaliere/varese-corsi-nuovi-orizzonti-2026',
+    canonicalPath: '/articoli-frontaliere/varese-corsi-nuovi-orizzonti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24706,7 +24706,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinesi, nuove, guardie, svizzere',
     ogTitle: 'Due ticinesi tra le nuove Guardie Svizzere',
     ogDescription: 'Davide Iannalfo e Mattia Canonica giurano come Guardie Svizzere Pontificie. Il Ticino è il secondo cantone per numero di guardie',
-    canonicalPath: '/articoli-frontaliere/due-ticinesi-guardie-svizzere-2026',
+    canonicalPath: '/articoli-frontaliere/due-ticinesi-guardie-svizzere-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24744,7 +24744,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, zurigo, crocerista, ricoverato',
     ogTitle: 'Hantavirus a Zurigo: crocerista ricoverato, UFSP rassicura',
     ogDescription: 'Passeggero positivo al virus delle Ande dopo crociera, isolato all\'USZ. Popolazione svizzera non in pericolo, dice l\'Ufficio federale della sanità pubblica.',
-    canonicalPath: '/articoli-frontaliere/hantavirus-zurigo-ricovero-crocerista',
+    canonicalPath: '/articoli-frontaliere/hantavirus-zurigo-ricovero-crocerista/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24782,7 +24782,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, valli, punta, sulle',
     ogTitle: 'L\'Otr Bellinzona e Valli punta sulle due ruote',
     ogDescription: 'Scopri la strategia \'Tutti in sella\' per il turismo ciclistico nella regione di Bellinzona e Valli e come impatterà i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/bellinzona-valli-bici-velocita',
+    canonicalPath: '/articoli-frontaliere/bellinzona-valli-bici-velocita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24820,7 +24820,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, riapre, mulini, grassi',
     ogTitle: 'Varese, riapre via Mulini Grassi: terminati i lavori di messa in sicurezza',
     ogDescription: 'La strada che collega Sant\'Ambrogio con la Valle Olona è tornata percorribile dopo i lavori di consolidamento strutturale.',
-    canonicalPath: '/articoli-frontaliere/varese-riapre-via-mulini-grassi',
+    canonicalPath: '/articoli-frontaliere/varese-riapre-via-mulini-grassi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24858,7 +24858,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, passaporto, passa, berna',
     ogTitle: 'L’addio al passaporto Usa passa da Berna: cosa cambia per i frontalieri',
     ogDescription: 'Migliaia di americani rinunciano al passaporto USA. Ecco cosa sapere se vivi in Ticino e lavori in Svizzera',
-    canonicalPath: '/articoli-frontaliere/addio-passaporto-usa-berna',
+    canonicalPath: '/articoli-frontaliere/addio-passaporto-usa-berna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24896,7 +24896,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, marco, odermatt, riceve, dottorato',
     ogTitle: 'Marco Odermatt riceve dottorato honoris causa dal Politecnico di Losanna',
     ogDescription: 'Marco Odermatt, campione svizzero di sci alpino, insignito del dottorato honoris causa dal Politecnico federale di Losanna.',
-    canonicalPath: '/articoli-frontaliere/odermatt-dottorato-honoris-causa',
+    canonicalPath: '/articoli-frontaliere/odermatt-dottorato-honoris-causa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24934,7 +24934,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cottarelli, liceo, manzoni, geopolitica',
     ogTitle: 'Cottarelli al Liceo Manzoni: geopolitica e futuro globale',
     ogDescription: 'L\'economista Carlo Cottarelli incontra gli studenti del Liceo Manzoni di Varese per parlare di tensioni globali e scenari economici',
-    canonicalPath: '/articoli-frontaliere/cottarelli-liceo-manzoni-geopolitica',
+    canonicalPath: '/articoli-frontaliere/cottarelli-liceo-manzoni-geopolitica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24972,7 +24972,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, teletext, fuori, niente, aggiornamenti',
     ogTitle: 'Teletext fuori uso in Ticino: niente aggiornamenti, servizi o accesso',
     ogDescription: 'Il servizio Teletext è attualmente fuori uso in Ticino, causando disagi per i frontalieri che lo utilizzano per informazioni aggiornate.',
-    canonicalPath: '/articoli-frontaliere/teletext-ticino-fuori-uso-2024',
+    canonicalPath: '/articoli-frontaliere/teletext-ticino-fuori-uso-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25010,7 +25010,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bayern, bayer, differenze, confusione',
     ogTitle: 'Bayern e Bayer: differenze e confusione nella Champions League',
     ogDescription: 'La stampa italiana confonde Bayern Monaco e Bayer Leverkusen, due realtà sportive e geografiche distinte durante la Champions League 2026.',
-    canonicalPath: '/articoli-frontaliere/bayern-bayer-differenze-champions-2026',
+    canonicalPath: '/articoli-frontaliere/bayern-bayer-differenze-champions-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25048,7 +25048,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, esponiamo, bandiera, dell',
     ogTitle: '9 maggio: esponiamo la bandiera dell\'Unione Europea',
     ogDescription: 'Il Movimento Federalista Europeo invita a esporre la bandiera europea in occasione del 9 maggio, Giorno dell\'Europa.',
-    canonicalPath: '/articoli-frontaliere/9-maggio-europa-bandiera-unione',
+    canonicalPath: '/articoli-frontaliere/9-maggio-europa-bandiera-unione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25086,7 +25086,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scuole, materne, gallarate, crisi',
     ogTitle: 'Scuole Materne Gallarate: crisi non è fatalità, piano entro giugno',
     ogDescription: 'Anna Zambon del Pd Gallarate chiede al nuovo presidente Agostini certezze per famiglie e personale. Critiche all\'amministrazione per gestioni passate.',
-    canonicalPath: '/articoli-frontaliere/scuole-materne-gallarate-crisi-piano-2026',
+    canonicalPath: '/articoli-frontaliere/scuole-materne-gallarate-crisi-piano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25124,7 +25124,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, regazzi, rieletto, usam, burocrazia',
     ogTitle: 'Regazzi rieletto USAM: burocrazia e iniziativa UDC',
     ogDescription: 'Fabio Regazzi rieletto presidente USAM. Critica burocrazia e iniziativa UDC su immigrazione. Impatto economico per frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/regazzi-rieletto-usam-burocrazia-udc',
+    canonicalPath: '/articoli-frontaliere/regazzi-rieletto-usam-burocrazia-udc/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25162,7 +25162,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, comunale, lopagno, vendita',
     ogTitle: 'Ex casa comunale Lopagno in vendita: prezzo e scadenze',
     ogDescription: 'Il Municipio di Capriasca mette in vendita l\'ex casa comunale di Lopagno a un prezzo minimo di 315.000 franchi. Scadenza offerte: 31 luglio.',
-    canonicalPath: '/articoli-frontaliere/ex-casa-comunale-lopagno-vendita',
+    canonicalPath: '/articoli-frontaliere/ex-casa-comunale-lopagno-vendita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25200,7 +25200,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ascensione, pentecoste, mete, viaggi',
     ogTitle: 'Ascensione e Pentecoste: mete e viaggi 2026',
     ogDescription: 'Scopri le destinazioni più gettonate per le festività 2026 e come raggiungerle in treno o aereo',
-    canonicalPath: '/articoli-frontaliere/ascensione-pentecoste-viaggi-2026',
+    canonicalPath: '/articoli-frontaliere/ascensione-pentecoste-viaggi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25238,7 +25238,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, veglia, preghiera, contro, omofobia',
     ogTitle: 'Veglia di preghiera contro omofobia, bifobia e transfobia a Lugano',
     ogDescription: 'In occasione della Giornata internazionale contro l’omofobia, una veglia di preghiera a Lugano per contrastare discriminazione e violenza.',
-    canonicalPath: '/articoli-frontaliere/veglia-preghiera-omofobia-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/veglia-preghiera-omofobia-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25276,7 +25276,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parcheggi, digitali, lugano, funziona',
     ogTitle: 'Parcheggi digitali a Lugano: come funziona il nuovo sistema',
     ogDescription: 'Scopri come funziona il nuovo sistema digitale per i parcheggi a Lugano e come può influenzare i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/parcheggi-digitali-lugano-2024',
+    canonicalPath: '/articoli-frontaliere/parcheggi-digitali-lugano-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25314,7 +25314,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rimpatrio, forzato, turchia, famiglia',
     ogTitle: 'Rimpatrio forzato in Turchia: famiglia curda di Riazzino sotto shock',
     ogDescription: 'La famiglia Pokerce, di etnia curda, è stata rimpatriata in Turchia dopo il rigetto della domanda d\'asilo. I due figli maggiorenni restano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/rimpatrio-famiglia-curda-riazzino',
+    canonicalPath: '/articoli-frontaliere/rimpatrio-famiglia-curda-riazzino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25352,7 +25352,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, strisce, pedonali, invisibili',
     ogTitle: 'Varese: strisce pedonali invisibili, MAV chiede interventi urgenti',
     ogDescription: 'Il Movimento Angelo Vidoletti denuncia lo stato di degrado delle strisce pedonali a Varese, chiedendo un piano di manutenzione strutturato',
-    canonicalPath: '/articoli-frontaliere/varese-strisce-pedonali-invisibili-2026',
+    canonicalPath: '/articoli-frontaliere/varese-strisce-pedonali-invisibili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25391,7 +25391,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, negozi, self-service, situazione',
     ogTitle: 'Furti nei negozi self-service in Ticino: cosa sapere',
     ogDescription: 'Scopri cosa sta succedendo nei negozi self-service del Ticino e come i frontalieri possono contribuire a prevenire i furti.',
-    canonicalPath: '/articoli-frontaliere/furti-self-service-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/furti-self-service-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25430,7 +25430,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, arrestato, spacciatore, droga',
     ogTitle: 'Varese: arrestato spacciatore, droga nascosta nel bosco',
     ogDescription: 'Un 20enne italiano è stato arrestato a Varese con 40 panetti di hascisc. La droga è stata trovata in una borsa lanciata nel bosco.',
-    canonicalPath: '/articoli-frontaliere/varese-arresto-spacciatore-frontaliere',
+    canonicalPath: '/articoli-frontaliere/varese-arresto-spacciatore-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25469,7 +25469,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, uboldo, maltempo, scoperchia, tetto',
     ogTitle: 'Uboldo: maltempo scoperchia tetto, nessun ferito',
     ogDescription: 'Il maltempo del 6 maggio 2026 ha causato gravi danni a un edificio residenziale a Uboldo, Varese, senza però feriti. Ecco cosa è successo e cosa fare in caso di',
-    canonicalPath: '/articoli-frontaliere/uboldo-tetto-scoperchiato-maltempo-2026',
+    canonicalPath: '/articoli-frontaliere/uboldo-tetto-scoperchiato-maltempo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25508,7 +25508,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spreco, alimentare, social, fondamentali',
     ogTitle: 'Spreco alimentare: social fondamentali per coinvolgere i giovani',
     ogDescription: 'La deputata Maria Chiara Gadda promuove l\'uso dei social network per combattere lo spreco alimentare e coinvolgere i giovani.',
-    canonicalPath: '/articoli-frontaliere/spreco-alimentare-giovani-social',
+    canonicalPath: '/articoli-frontaliere/spreco-alimentare-giovani-social/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25547,7 +25547,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, axenstrasse, canton, svitto',
     ogTitle: 'Nuova Axenstrasse in Canton Svitto: lavori iniziati',
     ogDescription: 'La nuova galleria di 3 km sostituirà la strada attuale, esposta a frane. Completamento previsto per il 2033 con un costo di 1,2 miliardi di franchi.',
-    canonicalPath: '/articoli-frontaliere/nuova-axenstrasse-svitto-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-axenstrasse-svitto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25586,7 +25586,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spreco, alimentare, obiettivo, intermedio',
     ogTitle: 'Spreco alimentare in Svizzera: obiettivo intermedio fallito',
     ogDescription: 'Il piano d\'azione contro lo spreco alimentare in Svizzera ha fallito l\'obiettivo intermedio del 25% di riduzione. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/spreco-alimentare-svizzera-obiettivo-fallito',
+    canonicalPath: '/articoli-frontaliere/spreco-alimentare-svizzera-obiettivo-fallito/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25625,7 +25625,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elon, musk, svizzero, processo',
     ogTitle: 'Elon Musk svizzero a processo per truffa e reati economici',
     ogDescription: 'Pascal Jaussi, fondatore di Swiss Space Systems, a processo a Friburgo per un buco di 30 milioni di franchi. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/elon-musk-svizzero-processo-friburgo',
+    canonicalPath: '/articoli-frontaliere/elon-musk-svizzero-processo-friburgo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25664,7 +25664,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fedpol, talpa, aveva, accesso',
     ogTitle: 'Fedpol, la talpa aveva accesso a dossier di inchiesta',
     ogDescription: 'Nuovi dettagli sul funzionario arrestato per aver venduto informazioni a un\'organizzazione criminale. Accesso a dossier internazionali e misure immediate prese',
-    canonicalPath: '/articoli-frontaliere/fedpol-talpa-accesso-dossier-inchiesta',
+    canonicalPath: '/articoli-frontaliere/fedpol-talpa-accesso-dossier-inchiesta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25703,7 +25703,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, otto, frodi, reddito, cittadinanza',
     ogTitle: 'Otto frodi al reddito di cittadinanza scoperti dalla Guardia di Finanza',
     ogDescription: 'La Guardia di Finanza di Varese ha scoperto otto casi di frode al reddito di cittadinanza e assegno di inclusione, con un danno di oltre 140mila euro.',
-    canonicalPath: '/articoli-frontaliere/frode-reddito-cittadinanza-varese-2026',
+    canonicalPath: '/articoli-frontaliere/frode-reddito-cittadinanza-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25742,7 +25742,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calo, anno, primi, mesi',
     ogTitle: 'Frontalieri in Ticino in calo nel 2026: -0,5% in un anno',
     ogDescription: 'Nei primi tre mesi del 2026 i frontalieri in Ticino sono 78.562, in calo dello 0,5% rispetto al 2025. Scopri le implicazioni per chi lavora in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-calo-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-calo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25781,7 +25781,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, allerta, grado, temporali, traffico',
     ogTitle: 'Allerta grado 3 per temporali in Ticino: traffico rallentato dalla grandine',
     ogDescription: 'MeteoSvizzera ha diramato un\'allerta di grado 3 per temporali nel Luganese, con rischio di frane, allagamenti e traffico rallentato.',
-    canonicalPath: '/articoli-frontaliere/temporali-ticino-traffico-2024',
+    canonicalPath: '/articoli-frontaliere/temporali-ticino-traffico-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25820,7 +25820,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, progetto, prossimità, locarno, cosa',
     ogTitle: 'Progetto di Prossimità Locarno: cosa cambia per i frontalieri',
     ogDescription: 'Scopri le novità del Progetto di Prossimità a Locarno e le opportunità per i frontalieri fino al 2029. Implicazioni pratiche e come partecipare.',
-    canonicalPath: '/articoli-frontaliere/progetto-prossimita-locarno-2026',
+    canonicalPath: '/articoli-frontaliere/progetto-prossimita-locarno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25859,7 +25859,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, media, svizzeri, adottano, codice',
     ogTitle: 'Media svizzeri adottano codice etico sull\'IA',
     ogDescription: 'Un nuovo codice di condotta per l\'uso responsabile dell\'intelligenza artificiale nei media svizzeri, ispirato al Consiglio d\'Europa, mira a rafforzare la',
-    canonicalPath: '/articoli-frontaliere/media-svizzera-codice-condotta-ia',
+    canonicalPath: '/articoli-frontaliere/media-svizzera-codice-condotta-ia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25898,7 +25898,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassis, cornado, tensione, fatture',
     ogTitle: 'Cassis e Cornado: tensione su fatture ospedaliere per feriti di Crans-Montana',
     ogDescription: 'L\'ambasciatore italiano Gian Lorenzo Cornado replica a Cassis: «Parlo senza mezzi termini». La questione riguarda le fatture ospedaliere per i feriti di',
-    canonicalPath: '/articoli-frontaliere/cassis-italia-cornado-risarcimento',
+    canonicalPath: '/articoli-frontaliere/cassis-italia-cornado-risarcimento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25937,7 +25937,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, calo, aprile, tasso',
     ogTitle: 'Disoccupazione in calo al 3% in aprile in Ticino',
     ogDescription: 'Il tasso di disoccupazione in Ticino è sceso al 2,8% ad aprile 2026. Ecco cosa cambia per i frontalieri che lavorano in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25976,7 +25976,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controtendenza, pernottamenti, marzo, mentre',
     ogTitle: 'Ticino +3,8% pernottamenti marzo 2026',
     ogDescription: 'Mentre la Svizzera registra un calo del 5,2%, il Ticino cresce con 133.800 pernottamenti. Ecco i dettagli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ticino-pernottamenti-controtendenza-2026',
+    canonicalPath: '/articoli-frontaliere/ticino-pernottamenti-controtendenza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26015,7 +26015,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lonza, cede, micro, macinazione',
     ogTitle: 'Lonza cede Micro Macinazione SA: cosa cambia per il Canton Ticino',
     ogDescription: 'Lonza ha ceduto Micro Macinazione SA a Schedio Group Holding e Microsize. Nuove sinergie per il polo farmaceutico ticinese.',
-    canonicalPath: '/articoli-frontaliere/lonza-cede-micro-macinazione-stabio',
+    canonicalPath: '/articoli-frontaliere/lonza-cede-micro-macinazione-stabio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26054,7 +26054,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agricoltura, sociale, strategie, inclusione',
     ogTitle: 'Agricoltura sociale in Ticino: strategie e inclusione',
     ogDescription: 'Il progetto Curare Cura conclude i focus group con strategie per l\'agricoltura sociale in Ticino, coinvolgendo operatori e beneficiari.',
-    canonicalPath: '/articoli-frontaliere/agricoltura-sociale-ticino-strategie-2026',
+    canonicalPath: '/articoli-frontaliere/agricoltura-sociale-ticino-strategie-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26093,7 +26093,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresto, droga, capolago, grammi',
     ogTitle: 'Arresto per droga a Capolago: 54 grammi di cocaina sequestrati',
     ogDescription: 'La Polizia cantonale ha arrestato un cittadino albanese con 54 grammi di cocaina sull\'autostrada A2. Ecco cosa è successo e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/arresto-droga-capolago-2026',
+    canonicalPath: '/articoli-frontaliere/arresto-droga-capolago-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26132,7 +26132,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, saluta, stadio, cornaredo',
     ogTitle: 'Lugano saluta lo stadio di Cornaredo: evento il 4 giugno',
     ogDescription: 'Festa aperta al pubblico per celebrare 75 anni dello stadio di Cornaredo prima della sostituzione con la nuova AIL Arena nel 2026',
-    canonicalPath: '/articoli-frontaliere/lugano-saluta-stadio-cornaredo-2024',
+    canonicalPath: '/articoli-frontaliere/lugano-saluta-stadio-cornaredo-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26171,7 +26171,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giro, ecco, strade, chiuse',
     ogTitle: 'Giro d\'Italia in Ticino: strade chiuse al traffico',
     ogDescription: 'Il 26 maggio il Giro d\'Italia passa in Ticino. Ecco le strade chiuse al traffico e gli orari delle chiusure.',
-    canonicalPath: '/articoli-frontaliere/giro-ditalia-ticino-strade-chiuse',
+    canonicalPath: '/articoli-frontaliere/giro-ditalia-ticino-strade-chiuse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26210,7 +26210,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passo, novena, montagne, neve',
     ogTitle: 'Passo della Novena: montagne di neve da spostare per la riapertura',
     ogDescription: 'Operazioni di pulizia in corso per riaprire il Passo della Novena. Video delle operazioni pubblicato dal consigliere di Stato Norman Gobbi.',
-    canonicalPath: '/articoli-frontaliere/montagne-neve-riapertura-passo-novena',
+    canonicalPath: '/articoli-frontaliere/montagne-neve-riapertura-passo-novena/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26249,7 +26249,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lucerna, supera, zugo, nuovo',
     ogTitle: 'Lucerna supera Zugo: nuovo paradiso fiscale per le imprese',
     ogDescription: 'Lucerna riduce l\'imposta sugli utili all\'11,66%, superando Zugo. Impatto sui frontalieri e confronto con l\'UE.',
-    canonicalPath: '/articoli-frontaliere/lucerna-paradiso-fiscale-frontalieri',
+    canonicalPath: '/articoli-frontaliere/lucerna-paradiso-fiscale-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26288,7 +26288,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spring, pride, inclusione, diritti',
     ogTitle: 'Spring Pride 2026: inclusione e diritti a Saronno, Caronno, Ceriano e Solaro',
     ogDescription: 'Dal 12 al 17 maggio eventi culturali e momenti di confronto per promuovere diritti e partecipazione in vista della Giornata contro l’omolesbobitransfobia',
-    canonicalPath: '/articoli-frontaliere/spring-pride-saronno-2026',
+    canonicalPath: '/articoli-frontaliere/spring-pride-saronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26327,7 +26327,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, josef, mengele, 1961, dossier',
     ogTitle: 'Josef Mengele in Svizzera nel 1961: il dossier segreto',
     ogDescription: 'Josef Mengele potrebbe aver soggiornato a Kloten nel 1961. Il dossier secretato fino al 2071 potrebbe chiarire il mistero',
-    canonicalPath: '/articoli-frontaliere/mengele-svizzera-1961-verifica',
+    canonicalPath: '/articoli-frontaliere/mengele-svizzera-1961-verifica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26366,7 +26366,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, zurigo, crocerista, isolamento',
     ogTitle: 'Hantavirus a Zurigo: crocerista in isolamento',
     ogDescription: 'Un uomo positivo all\'hantavirus è in cura a Zurigo dopo un viaggio in America del Sud. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/hantavirus-zurigo-crocerista-frontalieri',
+    canonicalPath: '/articoli-frontaliere/hantavirus-zurigo-crocerista-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26405,7 +26405,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassis, cornado, tensioni, risarcimento',
     ogTitle: 'Cassis e Cornado: tensioni sul risarcimento per le vittime di Crans-Montana',
     ogDescription: 'L\'ambasciatore italiano Cornado risponde alle critiche di Cassis sulle fatture ospedaliere per le vittime italiane dell\'incendio di Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/cassis-cornado-crans-montana-risarcimento',
+    canonicalPath: '/articoli-frontaliere/cassis-cornado-crans-montana-risarcimento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26444,7 +26444,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cedu, condanna, violazione, libertà',
     ogTitle: 'CEDU condanna Svizzera per violazione libertà di riunione',
     ogDescription: 'La Corte europea dei diritti dell\'uomo ha condannato la Svizzera per aver violato la libertà di riunione durante una manifestazione a Ginevra nel 2019.',
-    canonicalPath: '/articoli-frontaliere/liberta-riunione-cedu-condanna-svizzera',
+    canonicalPath: '/articoli-frontaliere/liberta-riunione-cedu-condanna-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26483,7 +26483,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colpo, stiletto, alla, galleria',
     ogTitle: 'Difficoltà alla Galleria Italo-Svizzera',
     ogDescription: 'Scopri le recenti sfide affrontate dalla Galleria Italo-Svizzera.',
-    canonicalPath: '/articoli-frontaliere/galleria-italo-svizzera-enigmista',
+    canonicalPath: '/articoli-frontaliere/galleria-italo-svizzera-enigmista/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26522,7 +26522,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costi, sanitari, crans-montana, marchesi',
     ogTitle: 'Deroghe costi sanitari Crans-Montana: Marchesi chiede chiarimenti',
     ogDescription: 'Il consigliere nazionale Piero Marchesi presenta un\'interpellanza sul trattamento dei costi sanitari legati al dramma di Crans-Montana, sollevando p',
-    canonicalPath: '/articoli-frontaliere/svizzera-deroghe-costi-sanitari-crans-montana',
+    canonicalPath: '/articoli-frontaliere/svizzera-deroghe-costi-sanitari-crans-montana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26561,7 +26561,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 2100, scenari, futuro, studio',
     ogTitle: 'Svizzera 2100: 5 scenari per il futuro dei frontalieri',
     ogDescription: 'Uno studio delinea cinque possibili scenari per la Svizzera nel 2100, con implicazioni per i frontalieri del Ticino.',
-    canonicalPath: '/articoli-frontaliere/svizzera-2100-scenari-frontalieri',
+    canonicalPath: '/articoli-frontaliere/svizzera-2100-scenari-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26600,7 +26600,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controllers, getting, bonuses, fines',
     ogTitle: 'SBB controllers getting bonuses for fines? What frontalieri need to know',
     ogDescription: 'SBB controllers may receive bonuses based on fines collected. Impact on Ticino cross-border workers and how to navigate the new system.',
-    canonicalPath: '/articoli-frontaliere/sbb-controllers-bonuses-fines-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/sbb-controllers-bonuses-fines-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26639,7 +26639,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, farmaco, leucemia, linfatica',
     ogTitle: 'Nuovo farmaco per leucemia linfatica cronica approvato in Italia',
     ogDescription: 'L\'AIFA approva pirtobrutinib per trattare pazienti con leucemia linfatica cronica recidivante o refrattaria. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nuovo-farmaco-leucemia-linfatica-cronica',
+    canonicalPath: '/articoli-frontaliere/nuovo-farmaco-leucemia-linfatica-cronica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26678,7 +26678,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, registro, imprese, varese, anni',
     ogTitle: 'Registro Imprese Varese: 30 anni di innovazione digitale',
     ogDescription: 'La Camera di Commercio di Varese celebra 30 anni del Registro Imprese, un pilastro digitale per imprese e istituzioni',
-    canonicalPath: '/articoli-frontaliere/registro-imprese-varese-30-anni',
+    canonicalPath: '/articoli-frontaliere/registro-imprese-varese-30-anni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26717,7 +26717,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, castellanza, milioni, investimenti, 2025',
     ogTitle: 'Castellanza: 1,8 milioni in investimenti per il 2025',
     ogDescription: 'Il Comune di Castellanza ha approvato un bilancio 2025 con 1,8 milioni di euro in investimenti per strade, scuole e impianti sportivi',
-    canonicalPath: '/articoli-frontaliere/castellanza-investimenti-2025',
+    canonicalPath: '/articoli-frontaliere/castellanza-investimenti-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26756,7 +26756,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rischio, blackout, cosa, cambia',
     ogTitle: 'Svizzera a rischio blackout: cosa cambia per i frontalieri',
     ogDescription: 'La Svizzera rischia carenze elettriche nel 2026. Ecco le implicazioni per chi lavora in Ticino e vive in Italia',
-    canonicalPath: '/articoli-frontaliere/svizzera-elettricita-inverno-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-elettricita-inverno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26795,7 +26795,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, casi, rari, basso',
     ogTitle: 'Hantavirus in Svizzera: casi rari, basso rischio di epidemia',
     ogDescription: 'Gli esperti rassicurano: i casi di hantavirus in Svizzera sono rari e il rischio di epidemia è basso. Ecco cosa sapere per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/hantavirus-svizzera-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/hantavirus-svizzera-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26834,7 +26834,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cedu, condanna, violazione, diritti',
     ogTitle: 'CEDU condanna la Svizzera per violazione diritti manifestante',
     ogDescription: 'La Corte europea dei diritti dell\'uomo ha condannato la Svizzera per aver violato la libertà di riunione e associazione di un\'organizzatrice di manifestazione.',
-    canonicalPath: '/articoli-frontaliere/cedu-condanna-svizzera-diritti-manifestante',
+    canonicalPath: '/articoli-frontaliere/cedu-condanna-svizzera-diritti-manifestante/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26873,7 +26873,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fabio, giorgianni, autista, amato',
     ogTitle: 'Fabio Giorgianni vince premio Autista Stellato',
     ogDescription: 'Fabio Giorgianni, conducente varesino di Autoservizi Morandi, vince il premio Autista Stellato per le recensioni più alte tra i passeggeri FlixBus',
-    canonicalPath: '/articoli-frontaliere/autista-stellato-fabio-giorgianni-premio',
+    canonicalPath: '/articoli-frontaliere/autista-stellato-fabio-giorgianni-premio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26912,7 +26912,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accordo, editori-sindacati, tedesca, cosa',
     ogTitle: 'Accordo editori-sindacati in Svizzera tedesca: cosa cambia',
     ogDescription: 'Dopo 20 anni, Svizzera tedesca ha un accordo su salari minimi per giornalisti. Il Ticino lo esaminerà presto.',
-    canonicalPath: '/articoli-frontaliere/accordo-editori-sindacati-svizzera-tedesca',
+    canonicalPath: '/articoli-frontaliere/accordo-editori-sindacati-svizzera-tedesca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26951,7 +26951,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sotto, pressione, cresce, minaccia',
     ogTitle: 'Svizzera sotto pressione: minaccia ibrida russa',
     ogDescription: 'Rapporto del Consiglio federale allarma: spionaggio, ciberattacchi e sabotaggi russi minacciano la sicurezza svizzera. Impatto sui frontalieri.',
-    canonicalPath: '/articoli-frontaliere/svizzera-minaccia-ibrida-russa-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-minaccia-ibrida-russa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26990,7 +26990,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nottambuli, convivere, orari, sociali',
     ogTitle: 'Nottambuli di r/Italy, come fate a convivere con gli orari imposti dalla società odierna?',
     ogDescription: 'Scopri come i frontalieri del Ticino gestiscono gli orari di lavoro svizzeri e italiani, con consigli pratici e scenari concreti.',
-    canonicalPath: '/articoli-frontaliere/nottambuli-ticino-orari-societa',
+    canonicalPath: '/articoli-frontaliere/nottambuli-ticino-orari-societa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27029,7 +27029,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, economia, circolare, ripara, vite',
     ogTitle: 'Economia circolare ripara vite: due storie di lavoro in carcere',
     ogDescription: 'Due progetti in carcere a Varese e Busto Arsizio trasformano scarti in opportunità lavorative per detenuti, riducendo la recidiva e creando valore sociale.',
-    canonicalPath: '/articoli-frontaliere/economia-circolare-lavoro-carcere-varese',
+    canonicalPath: '/articoli-frontaliere/economia-circolare-lavoro-carcere-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27068,7 +27068,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gavirate, scontro, auto, zona',
     ogTitle: 'Gavirate: scontro tra auto in zona nordlacuale, uomo ferito',
     ogDescription: 'Un incidente stradale a Gavirate, Varese, coinvolge un frontaliero. Ecco cosa sapere su assistenza e procedure.',
-    canonicalPath: '/articoli-frontaliere/gavirate-incidente-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/gavirate-incidente-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27107,7 +27107,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cedu, condanna, libertà, manifestazione',
     ogTitle: 'CEDU condanna la Svizzera per libertà di manifestazione',
     ogDescription: 'La Corte europea dei diritti dell\'uomo ha condannato la Svizzera per aver violato la libertà di riunione e associazione di un\'organizzatrice di una',
-    canonicalPath: '/articoli-frontaliere/cedu-condanna-svizzera-liberta-manifestazione',
+    canonicalPath: '/articoli-frontaliere/cedu-condanna-svizzera-liberta-manifestazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27146,7 +27146,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spaccio, droga, busto, sequestrati',
     ogTitle: 'Spaccio di droga a Busto: sequestrati 18mila euro in contanti',
     ogDescription: 'La Polizia di Stato di Busto Arsizio ha arrestato due cittadini stranieri con 18.617,60 euro in contanti e droga nascosta in casa.',
-    canonicalPath: '/articoli-frontaliere/spaccio-droga-busto-18mila-euro',
+    canonicalPath: '/articoli-frontaliere/spaccio-droga-busto-18mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27185,7 +27185,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, auto, sull, zona',
     ogTitle: 'Incendio auto A2 Camorino: rallentamenti per frontalieri',
     ogDescription: 'Un\'auto in fiamme ha causato rallentamenti sull\'autostrada A2 in direzione nord tra Lugano Nord e la galleria del Monte Ceneri.',
-    canonicalPath: '/articoli-frontaliere/incendio-auto-a2-camorino',
+    canonicalPath: '/articoli-frontaliere/incendio-auto-a2-camorino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27224,7 +27224,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, convegno, sulle, pari, opportunità',
     ogTitle: 'Convegno sulle pari opportunità in Ticino: cultura e inclusione',
     ogDescription: 'Folto convegno a Lugano su squilibri nel settore artistico e culturale. Focus su finanziamenti, visibilità e ruoli decisionali.',
-    canonicalPath: '/articoli-frontaliere/cultura-pari-opportunita-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/cultura-pari-opportunita-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27263,7 +27263,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confisca, patrimoni, mafiosi, proposta',
     ogTitle: 'Confisca patrimoni mafiosi in Svizzera: proposta radicale',
     ogDescription: 'Proposta di confisca preventiva dei beni mafiosi in Svizzera, come in Italia. Arresto di un funzionario della Polizia federale.',
-    canonicalPath: '/articoli-frontaliere/confisca-patrimoni-mafiosi-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/confisca-patrimoni-mafiosi-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27302,7 +27302,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, oltre, terzo, adulti, utilizza',
     ogTitle: 'IA in Svizzera: oltre un terzo degli adulti la usa',
     ogDescription: 'In Svizzera, il 37,8% degli adulti utilizza strumenti di intelligenza artificiale, superando la media mondiale del 17,8%.',
-    canonicalPath: '/articoli-frontaliere/ia-svizzera-uso-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/ia-svizzera-uso-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27341,7 +27341,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, suini, compenso, allevatori, ridurre',
     ogTitle: 'Suini in Svizzera: compenso per allevatori per ridurre produzione',
     ogDescription: 'La Svizzera offre compensi per ridurre la sovrapproduzione di carne suina. Ecco cosa cambia per i frontalieri e gli allevatori.',
-    canonicalPath: '/articoli-frontaliere/suini-svizzera-compenso-allevatori',
+    canonicalPath: '/articoli-frontaliere/suini-svizzera-compenso-allevatori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27380,7 +27380,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, inseguire, scopriamo, insieme',
     ogTitle: 'Polizia svizzera inseguimento Italia: cosa sapere',
     ogDescription: 'Scopri se la polizia svizzera può inseguire persone in Italia e le implicazioni per i frontalieri del Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/polizia-svizzera-inseguimento-italia',
+    canonicalPath: '/articoli-frontaliere/polizia-svizzera-inseguimento-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27419,7 +27419,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, seco, troppo, presto',
     ogTitle: 'Disoccupazione Ticino: Seco, troppo presto per vedere effetti guerra',
     ogDescription: 'La SECO afferma che è troppo presto per valutare l\'impatto della guerra in Iran sul mercato del lavoro ticinese. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-2026-effetti-guerra',
+    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-2026-effetti-guerra/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27458,7 +27458,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, record, organi, importati, 2025',
     ogTitle: 'Record di organi importati in Svizzera nel 2025',
     ogDescription: 'Nel 2025 la Svizzera ha importato un record di organi, con 69 trapianti da donatori esteri.',
-    canonicalPath: '/articoli-frontaliere/record-organi-importati-2025',
+    canonicalPath: '/articoli-frontaliere/record-organi-importati-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27497,7 +27497,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, batte, finlandia, crescita, incoraggiante',
     ogTitle: 'Svizzera batte Finlandia: crescita incoraggiante prima dei Mondiali',
     ogDescription: 'La Svizzera vince contro la Finlandia in un\'amichevole pre-Mondiali, con una prestazione convincente.',
-    canonicalPath: '/articoli-frontaliere/svizzera-hockey-finlandia-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-hockey-finlandia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27536,7 +27536,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, frontiera, dirinella, orari, ridotti',
     ogTitle: 'Frontiera su Dirinella: orari ridotti per il tax-free',
     ogDescription: 'Orari ridotti per il tax-free al valico di Dirinella, attenzione agli acquisti per i frontalieri. Ecco cosa cambia per il rimborso delle tasse',
-    canonicalPath: '/articoli-frontaliere/tax-free-dirinella-orari-ridotti',
+    canonicalPath: '/articoli-frontaliere/tax-free-dirinella-orari-ridotti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27575,7 +27575,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, chiede, completamento, alptransit',
     ogTitle: 'La Lombardia chiede il completamento di AlpTransit',
     ogDescription: 'Il Consiglio della Regione Lombardia approva all\'unanimità la mozione per il potenziamento delle linee di accesso alle gallerie di base del Ceneri, del Gottardo',
-    canonicalPath: '/articoli-frontaliere/lombardia-chiede-completamento-alptransit',
+    canonicalPath: '/articoli-frontaliere/lombardia-chiede-completamento-alptransit/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27614,7 +27614,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, milioni, franchi, campagna, record',
     ogTitle: '15 milioni di franchi per la campagna \'No a una Svizzera da 10 milioni\'',
     ogDescription: 'Record di finanziamenti per la campagna politica sull\'iniziativa UDC. Ecco chi sono i principali finanziatori e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/campagna-politica-frontalieri-15-milioni-franchi',
+    canonicalPath: '/articoli-frontaliere/campagna-politica-frontalieri-15-milioni-franchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27653,7 +27653,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colf, badanti, mila, anni',
     ogTitle: 'Colf e badanti in Ticino: +122 mila in tre anni',
     ogDescription: 'Nel 2029 serviranno 2,2 milioni di colf e badanti in Italia. Opportunità per i frontalieri del Ticino e nuove prospettive lavorative.',
-    canonicalPath: '/articoli-frontaliere/colf-badanti-ticino-2029',
+    canonicalPath: '/articoli-frontaliere/colf-badanti-ticino-2029/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27692,7 +27692,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, turismo, varesotto, numeri, opportunità',
     ogTitle: 'Turismo nel Varesotto 2026: numeri e opportunità per frontalieri',
     ogDescription: 'Scopri i numeri del turismo nel Varesotto nel 2026 e le opportunità per i frontalieri. Dati, analisi e consigli pratici.',
-    canonicalPath: '/articoli-frontaliere/turismo-varesotto-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/turismo-varesotto-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27731,7 +27731,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, antonino, nuovi, filtri, pfas',
     ogTitle: 'San Antonino: nuovi filtri PFAS in funzione',
     ogDescription: 'Il Comune di San Antonino ha attivato un innovativo sistema di filtrazione a carbone attivo per eliminare le sostanze PFAS dall\'acqua potabile.',
-    canonicalPath: '/articoli-frontaliere/filtri-pfas-san-antonino-2024',
+    canonicalPath: '/articoli-frontaliere/filtri-pfas-san-antonino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27770,7 +27770,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traduzione, documenti, finanziari, visto',
     ogTitle: 'Traduzione documenti finanziari per visto',
     ogDescription: 'Guida pratica per i frontalieri su come tradurre i documenti finanziari per il visto in Svizzera',
-    canonicalPath: '/articoli-frontaliere/traduzione-documenti-finanziari-visto',
+    canonicalPath: '/articoli-frontaliere/traduzione-documenti-finanziari-visto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27809,7 +27809,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pfas, nell, acqua, sant',
     ogTitle: 'Pfas nell’acqua: Sant’Antonino attiva filtrazione a carbone attivo',
     ogDescription: 'Il nuovo sistema riduce i Pfas a valori inferiori ai 2 ng/l, finanziato interamente dalla Confederazione. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/filtrazione-carbone-attivo-san-antonino',
+    canonicalPath: '/articoli-frontaliere/filtrazione-carbone-attivo-san-antonino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27848,7 +27848,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, edilizia, resiste, sfide, investimenti',
     ogTitle: 'Edilizia Ticino resiste a sfide investimenti e geopolitica',
     ogDescription: 'Il settore edilizio ticinese mostra resilienza nonostante le sfide, con 3 miliardi di cifre d\'affari e 5.500 lavoratori. Le riserve di lavoro sono a 5 mesi.',
-    canonicalPath: '/articoli-frontaliere/edilizia-ticino-resiste-investimenti-geopolitica',
+    canonicalPath: '/articoli-frontaliere/edilizia-ticino-resiste-investimenti-geopolitica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27887,7 +27887,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, adeguati, assetti, obbligo, opportunità',
     ogTitle: 'Adeguati assetti: obbligo e opportunità per l’impresa',
     ogDescription: 'Gli adeguati assetti organizzativi, amministrativi e contabili sono un obbligo di legge ma anche un\'opportunità di crescita per le imprese in Ticino.',
-    canonicalPath: '/articoli-frontaliere/adeguati-assetti-imprese-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/adeguati-assetti-imprese-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27926,7 +27926,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accuse, alla, prime, crepe',
     ogTitle: 'Accuse alla Svizzera, prime crepe sul fronte italiano',
     ogDescription: 'L\'editoriale-bonsai del Giornale del Ticino segnala tensioni tra Italia e Svizzera, con possibili ripercussioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/accuse-svizzera-italia-2026',
+    canonicalPath: '/articoli-frontaliere/accuse-svizzera-italia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27965,7 +27965,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elcom, avverte, rischio, approvvigionamento',
     ogTitle: 'ElCom avverte: rischio approvvigionamento elettrico per l\'inverno 2026',
     ogDescription: 'La guerra in Iran e il blocco dello Stretto di Hormuz minacciano la sicurezza energetica svizzera. L\'ElCom sottolinea l\'importanza di un accordo con l\'UE.',
-    canonicalPath: '/articoli-frontaliere/elcom-preoccupata-inverno-2026',
+    canonicalPath: '/articoli-frontaliere/elcom-preoccupata-inverno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28004,7 +28004,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, balerna, ribalta, previsioni, 2025',
     ogTitle: 'Balerna 2025: cifre nere e implicazioni per i frontalieri',
     ogDescription: 'Balerna chiude il 2025 nelle cifre nere grazie a entrate fiscali straordinarie. Ecco cosa cambia per i frontalieri e come pianificare di conseguenza.',
-    canonicalPath: '/articoli-frontaliere/balerna-2025-cifre-nere-frontalieri',
+    canonicalPath: '/articoli-frontaliere/balerna-2025-cifre-nere-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28043,7 +28043,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, regole, scambio, informazioni',
     ogTitle: 'Nuove regole scambio informazioni AdER enti creditori',
     ogDescription: 'Dal 6 maggio 2026 nuove norme per la trasmissione telematica dei dati tra Agenzia delle Entrate-Riscossione e enti creditori',
-    canonicalPath: '/articoli-frontaliere/nuove-regole-scambio-informazioni-ader-enti-creditori',
+    canonicalPath: '/articoli-frontaliere/nuove-regole-scambio-informazioni-ader-enti-creditori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28082,7 +28082,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, solidale, giorni, contro',
     ogTitle: 'Varese Solidale 2026: due giorni contro la povertà sanitaria',
     ogDescription: 'Dal 15 al 16 maggio, 42 associazioni varesine si mobilitano per combattere la povertà sanitaria con convegni, screening e una cena solidale',
-    canonicalPath: '/articoli-frontaliere/varese-solidale-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/varese-solidale-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28121,7 +28121,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, mamma, metri, palazzo',
     ogTitle: 'Festa della Mamma a 161 metri: Palazzo Lombardia apre il Belvedere',
     ogDescription: 'Domenica 10 maggio apertura straordinaria del 39esimo piano di Palazzo Lombardia per la Festa della Mamma. Visite gratuite e attività per famiglie.',
-    canonicalPath: '/articoli-frontaliere/festa-mamma-palazzo-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/festa-mamma-palazzo-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28160,7 +28160,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, anche, quelli, cassa, malati',
     ogTitle: 'Anche a voi quelli della cassa malati sembrano arroganti?',
     ogDescription: 'Scopri come i frontalieri del Ticino possono affrontare le sfide con le casse malati svizzere e quali sono i loro diritti.',
-    canonicalPath: '/articoli-frontaliere/casse-malati-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/casse-malati-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28199,7 +28199,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, open, days, artekrea, varese',
     ogTitle: 'Open Days ArteKrea a Varese: benessere e creatività dal 15 al 17 maggio',
     ogDescription: 'Scopri il programma degli Open Days ArteKrea a Varese: yoga, tai chi, trattamenti olistici e laboratori creativi. Prenotazione obbligatoria.',
-    canonicalPath: '/articoli-frontaliere/artekrea-open-days-varese-2026',
+    canonicalPath: '/articoli-frontaliere/artekrea-open-days-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28238,7 +28238,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sanremo, eurovision, campione, vinci',
     ogTitle: 'Sanremo, l\'Eurovision e poi Campione: Sal Da Vinci in concerto',
     ogDescription: 'Il vincitore di Sanremo 2026 incanterà Campione d’Italia con un concerto al Casinò il 18 maggio. Scopri tutti i dettagli.',
-    canonicalPath: '/articoli-frontaliere/sanremo-eurovision-campione-2026',
+    canonicalPath: '/articoli-frontaliere/sanremo-eurovision-campione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28277,7 +28277,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morbio, inferiore, raccolta, vegetali',
     ogTitle: 'Morbio Inferiore: raccolta vegetali meno frequente e più cara',
     ogDescription: 'Il PLR di Morbio Inferiore denuncia un servizio di raccolta scarti vegetali meno frequente e più costoso rispetto ai comuni vicini',
-    canonicalPath: '/articoli-frontaliere/morbio-inferiore-raccolta-vegetali-2026',
+    canonicalPath: '/articoli-frontaliere/morbio-inferiore-raccolta-vegetali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28316,7 +28316,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, centromedico, bellinzona, operazioni, ritorno',
     ogTitle: 'Centromedico Bellinzona: operazioni e ritorno a casa lo stesso giorno',
     ogDescription: 'Nuova struttura sanitaria a Bellinzona per interventi ambulatoriali. Apertura al pubblico il 9 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/centromedico-bellinzona-frontalieri',
+    canonicalPath: '/articoli-frontaliere/centromedico-bellinzona-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28355,7 +28355,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, passteggia, iscrizioni, aperte',
     ogTitle: 'Lugano Passteggia 2026: iscrizioni aperte',
     ogDescription: 'Scopri come partecipare a Lugano Passteggia 2026, l\'evento enogastronomico e di camminata più atteso della tarda estate ticinese.',
-    canonicalPath: '/articoli-frontaliere/lugano-passteggia-iscrizioni-aperte',
+    canonicalPath: '/articoli-frontaliere/lugano-passteggia-iscrizioni-aperte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28394,7 +28394,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pfas, nell, acqua, potabile',
     ogTitle: 'PFAS nell\'acqua potabile: San Antonino attiva filtrazione avanzata',
     ogDescription: 'Il Municipio di San Antonino ha installato un sistema di filtrazione a carbone attivo per rimuovere i PFAS dall\'acqua potabile, con un investimento di 1,8',
-    canonicalPath: '/articoli-frontaliere/pfas-filtrazione-san-antonino-2026',
+    canonicalPath: '/articoli-frontaliere/pfas-filtrazione-san-antonino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28433,7 +28433,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, auto, fiamme, bellinzona-sud, riaperta',
     ogTitle: 'Auto in fiamme a Bellinzona-Sud, A2 riaperta',
     ogDescription: 'Incendio di un\'auto sull\'autostrada A2 a Bellinzona-Sud, traffico bloccato per 40 minuti. Pompiere e polizia sul posto',
-    canonicalPath: '/articoli-frontaliere/incendio-auto-bellinzona-sud-2026',
+    canonicalPath: '/articoli-frontaliere/incendio-auto-bellinzona-sud-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28472,7 +28472,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pari, opportunità, nella, cultura',
     ogTitle: 'Pari opportunità nella cultura: a Lugano una prima ticinese',
     ogDescription: 'Il primo convegno «Che genere di cultura?» a Lugano ha evidenziato sfide e opportunità per le pari opportunità nel settore artistico e culturale.',
-    canonicalPath: '/articoli-frontaliere/pari-opportunita-cultura-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/pari-opportunita-cultura-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28511,7 +28511,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mari, froes, middea, concerto',
     ogTitle: 'Mari Froes e Leo Middea in concerto a Lugano',
     ogDescription: 'Serata brasiliana al Lugano LongLake Festival con Mari Froes e Leo Middea, 14 luglio 2026 al Parco Ciani',
-    canonicalPath: '/articoli-frontaliere/brasile-mari-froes-leo-middea-lugano',
+    canonicalPath: '/articoli-frontaliere/brasile-mari-froes-leo-middea-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28550,7 +28550,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, telelavoro, cosa, cambia',
     ogTitle: 'Lavoratori frontalieri e telelavoro: cosa cambia nel 2026',
     ogDescription: 'Nuove regole per i frontalieri che lavorano da casa in Italia. Scopri cosa cambia e come adeguarsi',
-    canonicalPath: '/articoli-frontaliere/cross-border-teleworking-2026',
+    canonicalPath: '/articoli-frontaliere/cross-border-teleworking-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28589,7 +28589,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fiera, dell, antiquariato, mendrisio',
     ogTitle: 'Fiera dell\'antiquariato a Mendrisio: 160 espositori e oltre 10.000 visitatori',
     ogDescription: 'La 42esima edizione della Fiera dell\'Antiquariato, Arte e Collezionismo si terrà domenica 10 maggio a Mendrisio, con oltre 160 espositori e un\'ampia offerta di',
-    canonicalPath: '/articoli-frontaliere/fiera-antiquariato-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/fiera-antiquariato-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28628,7 +28628,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, dentarie, accessibili, battaglia',
     ogTitle: 'Cure dentarie accessibili in Ticino: la battaglia per il rimborso',
     ogDescription: 'Il Comitato referendario lancia l\'allarme: le famiglie del ceto medio rinunciano sempre più spesso alle cure dentarie per i costi elevati.',
-    canonicalPath: '/articoli-frontaliere/cure-dentarie-accessibili-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cure-dentarie-accessibili-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28667,7 +28667,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dolores, poretti, anni, trovo',
     ogTitle: 'Dolores Poretti, 91 anni: «Trovo qualcosa di bello in ogni momento»',
     ogDescription: 'La storia di Dolores Poretti, 91 anni, residente alla Casa anziani Polis di Pregassona, e i suoi consigli per i giovani',
-    canonicalPath: '/articoli-frontaliere/dolores-poretti-91-anni-frontalieri',
+    canonicalPath: '/articoli-frontaliere/dolores-poretti-91-anni-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28706,7 +28706,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costruzioni, impresari, chiedono, investimenti',
     ogTitle: 'Costruzioni in Ticino: impresari chiedono investimenti e decisioni rapide',
     ogDescription: 'Il settore edilizio ticinese richiede accelerazione degli investimenti pubblici e semplificazioni burocratiche per evitare rallentamenti.',
-    canonicalPath: '/articoli-frontaliere/costruzioni-ticino-impresari-investimenti-rapidi',
+    canonicalPath: '/articoli-frontaliere/costruzioni-ticino-impresari-investimenti-rapidi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28745,7 +28745,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pazienti, oncologici, aiutano, malati',
     ogTitle: 'Ex pazienti oncologici aiutano i malati in Ticino',
     ogDescription: 'Un progetto innovativo all\'Ospedale Civico di Lugano trasforma i pazienti in protagonisti attivi nella revisione delle cure e dei servizi sanitari',
-    canonicalPath: '/articoli-frontaliere/ex-pazienti-oncologici-aiutano-malati-ticino',
+    canonicalPath: '/articoli-frontaliere/ex-pazienti-oncologici-aiutano-malati-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28784,7 +28784,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grande, festa, popolare, cornaredo',
     ogTitle: 'Grande festa popolare al Cornaredo: il 4 giugno in scena',
     ogDescription: 'Il 4 giugno, lo Stadio di Cornaredo ospiterà un grande evento per salutare la struttura a 75 anni dalla sua inaugurazione, con attività e musica.',
-    canonicalPath: '/articoli-frontaliere/picnic-stadio-cornaredo',
+    canonicalPath: '/articoli-frontaliere/picnic-stadio-cornaredo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28823,7 +28823,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malessere, nella, polizia, cantonale',
     ogTitle: 'Malessere nella Polizia cantonale: audit in arrivo',
     ogDescription: 'Audit indipendente per migliorare il clima di lavoro nella Polizia cantonale.',
-    canonicalPath: '/articoli-frontaliere/malessere-polizia-cantonale-audit',
+    canonicalPath: '/articoli-frontaliere/malessere-polizia-cantonale-audit/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28862,7 +28862,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, desiderio, chiede, permesso, bufera',
     ogTitle: 'Il desiderio non chiede permesso: bufera sui cartelloni di un locale erotico',
     ogDescription: 'Il slogan del locale erotico a Vallese ha scatenato critiche. Collettivo Femminista del Vallese: \'È un messaggio che può essere percepito come un incitamento',
-    canonicalPath: '/articoli-frontaliere/desiderio-non-chiede-permesso-bufera-sui-cartelloni-di-un-locale-erotico',
+    canonicalPath: '/articoli-frontaliere/desiderio-non-chiede-permesso-bufera-sui-cartelloni-di-un-locale-erotico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28901,7 +28901,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, friburgo, finale, europa, league',
     ogTitle: 'Friburgo in finale di Europa League: Manzambi decide',
     ogDescription: 'Il gol del nazionale elvetico Johan Manzambi manda il Friburgo in finale di Europa League. Il 20 maggio a Istanbul contro l\'Aston Villa.',
-    canonicalPath: '/articoli-frontaliere/friburgo-finale-europa-manzambi',
+    canonicalPath: '/articoli-frontaliere/friburgo-finale-europa-manzambi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28940,7 +28940,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assicurazione, legale, davvero, utile',
     ogTitle: 'Assicurazione legale in Svizzera: è davvero utile?',
     ogDescription: 'Tutela legale e sicurezza per i frontalieri in Svizzera. Scopri utilità e limiti delle assicurazioni legali.',
-    canonicalPath: '/articoli-frontaliere/legal-insurance-utilita-sicurezza',
+    canonicalPath: '/articoli-frontaliere/legal-insurance-utilita-sicurezza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28979,7 +28979,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dazi, trump, bocciati, corte',
     ogTitle: 'Dazi Trump bocciati: Corte per il commercio USA li dichiara illegali',
     ogDescription: 'La Corte per il commercio americana ha dichiarato illegali i dazi globali al 10% imposti da Donald Trump. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/trump-dazi-corte-commercio-2026',
+    canonicalPath: '/articoli-frontaliere/trump-dazi-corte-commercio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29018,7 +29018,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pirata, strada, lipsia, preannunciato',
     ogTitle: 'Pirata della strada a Lipsia: preannunciato il gesto',
     ogDescription: 'Un uomo di 33 anni ha investito diverse persone a Lipsia, causando due morti e sei feriti. Il gesto era stato preannunciato in un messaggio alla moglie.',
-    canonicalPath: '/articoli-frontaliere/lipsia-pirata-strada-frontalieri',
+    canonicalPath: '/articoli-frontaliere/lipsia-pirata-strada-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29057,7 +29057,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lula, trump, difendono, democrazia',
     ogTitle: 'Lula e Trump difendono democrazia e sovranità',
     ogDescription: 'Il presidente brasiliano Lula incontra Trump alla Casa Bianca, sottolineando l\'importanza dei rapporti economici e della cooperazione geopolitica.',
-    canonicalPath: '/articoli-frontaliere/lula-trump-riunione-democrazia-sovranita',
+    canonicalPath: '/articoli-frontaliere/lula-trump-riunione-democrazia-sovranita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29096,7 +29096,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, delitto, garlasco, chiara, uccisa',
     ogTitle: 'Delitto di Garlasco: Chiara uccisa con odio e crudeltà',
     ogDescription: 'Nuove rivelazioni sull\'omicidio di Chiara Poggi: Andrea Sempio accusato di omicidio con aggravanti. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/delitto-garlasco-chiara-omicidio-2026',
+    canonicalPath: '/articoli-frontaliere/delitto-garlasco-chiara-omicidio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29135,7 +29135,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hondius, cosa, cambia, nave',
     ogTitle: 'Hondius: cosa cambia per i frontalieri del Ticino',
     ogDescription: 'La nave crociera con focolaio di hantavirus resterà in rada. Ecco cosa succede e come potrebbe influenzare i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/hondius-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/hondius-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29174,7 +29174,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, harrods, risarcirà, decine, vittime',
     ogTitle: 'Harrods risarcirà decine di vittime dello scandalo Al-Fayed',
     ogDescription: 'Harrods annuncia risarcimenti per più di 75 donne vittime di presunti abusi sessuali da parte del defunto magnate Mohamed Al-Fayed.',
-    canonicalPath: '/articoli-frontaliere/harrods-risarcimenti-vittime-al-fayed',
+    canonicalPath: '/articoli-frontaliere/harrods-risarcimenti-vittime-al-fayed/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29213,7 +29213,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, tempo, fino, luglio',
     ogTitle: 'Trump all\'Ue: tempo fino al 4 luglio per l\'accordo commerciale',
     ogDescription: 'Il presidente USA concede una scadenza all\'Unione europea per rispettare l\'intesa siglata a Turnberry, in Scozia. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/trump-ue-accordo-commerciale-4-luglio',
+    canonicalPath: '/articoli-frontaliere/trump-ue-accordo-commerciale-4-luglio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29252,7 +29252,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, funzionari, manifestano, contro, misure',
     ogTitle: '3\'000 funzionari manifestano contro misure di risparmio a Ginevra',
     ogDescription: 'Tra le 2\'500 e le 3\'000 persone hanno manifestato a Ginevra contro le misure di austerità previste dal Cantone, con blocco degli scatti salariali e congelamento',
-    canonicalPath: '/articoli-frontaliere/ginevra-manifestazione-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/ginevra-manifestazione-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29291,7 +29291,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, josi, scrive, alla, federazione',
     ogTitle: 'Josi scrive alla federazione: «Per Fischer, non contro Cadieux»',
     ogDescription: 'Roman Josi spiega la sua lettera alla federazione dopo il licenziamento di Patrick Fischer, in vista dei Mondiali di hockey 2026',
-    canonicalPath: '/articoli-frontaliere/josi-fischer-lettera-cuore',
+    canonicalPath: '/articoli-frontaliere/josi-fischer-lettera-cuore/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29330,7 +29330,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, votazione, popolare, sulla, lamal',
     ogTitle: 'Votazione LAMal: impatto sui frontalieri in Ticino',
     ogDescription: 'Scopri cosa cambia con la votazione popolare sulla modifica della LAMal e come potrebbe influenzare i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/votazione-popolare-lamal-frontalieri',
+    canonicalPath: '/articoli-frontaliere/votazione-popolare-lamal-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29369,7 +29369,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maxi, blitz, nell, atlantico',
     ogTitle: 'Maxi blitz nell\'Atlantico: sequestrate 30 tonnellate di cocaina',
     ogDescription: 'La Guardia Civil spagnola ha intercettato 30,2 tonnellate di cocaina a bordo del mercantile Arconian, il più grande sequestro in Spagna in una sola operazione.',
-    canonicalPath: '/articoli-frontaliere/maxi-blitz-cocaina-atlantico-30-tonnellate',
+    canonicalPath: '/articoli-frontaliere/maxi-blitz-cocaina-atlantico-30-tonnellate/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29408,7 +29408,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, indagine, giudici, federali, implicazioni',
     ogTitle: 'Indagine su due giudici federali: implicazioni per il Ticino',
     ogDescription: 'Due esperti esterni indagano sulla relazione tra Beatrice van de Graaf e Yves Donzallaz del Tribunale federale. Scopri le implicazioni per i frontalieri del',
-    canonicalPath: '/articoli-frontaliere/giudici-federali-indagine-2026',
+    canonicalPath: '/articoli-frontaliere/giudici-federali-indagine-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29447,7 +29447,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, centromedico, castello, ecco, regno',
     ogTitle: 'Centromedico Castello: chirurgia ambulatoriale a Bellinzona',
     ogDescription: 'Nuova struttura per chirurgia ambulatoriale a Bellinzona, con centro oftalmologico Swiss Visio. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/centromedico-castello-chirurgia-ambulatoriale',
+    canonicalPath: '/articoli-frontaliere/centromedico-castello-chirurgia-ambulatoriale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29486,7 +29486,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresto, commissario, fedpol, informazioni',
     ogTitle: 'Arresto commissario Fedpol: informazioni alla mafia per 100mila franchi',
     ogDescription: 'Un commissario del Servizio Federale di Sicurezza svizzero arrestato per aver trasmesso informazioni riservate a un\'organizzazione mafiosa.',
-    canonicalPath: '/articoli-frontaliere/arresto-commissario-fedpol-mafia',
+    canonicalPath: '/articoli-frontaliere/arresto-commissario-fedpol-mafia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29525,7 +29525,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, broker, scontro, retrocessioni',
     ogTitle: 'Processo al broker dei VIP: scontro su retrocessioni e conflitto d’interessi',
     ogDescription: 'Seconda giornata di dibattimento per un 53enne accusato di danno millionario. Oltre 5 anni d’inchiesta',
-    canonicalPath: '/articoli-frontaliere/processo-broker-vip-retrocessioni',
+    canonicalPath: '/articoli-frontaliere/processo-broker-vip-retrocessioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29564,7 +29564,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, durisch, blocco, vede, solo',
     ogTitle: 'Durisch risponde a Dadò sul blocco del Tribunale amministrativo',
     ogDescription: 'Il capogruppo socialista Ivo Durisch risponde alle accuse di Fiorenzo Dadò sul blocco del Tribunale amministrativo in Ticino. Scopri le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/durisch-dado-blocco-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/durisch-dado-blocco-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29603,7 +29603,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dipendenti, affitto, privilegi, città',
     ogTitle: 'Ex dipendenti in affitto con privilegi? La Città faccia chiarezza',
     ogDescription: 'Interrogazione della Lega al Municipio di Lugano per maggiore trasparenza su immobili comunali e ex dipendenti',
-    canonicalPath: '/articoli-frontaliere/frontalieri-lugano-chiarezza-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-lugano-chiarezza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29642,7 +29642,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sgombero, macerie, macello, lugano',
     ogTitle: 'Sgombero macerie Ex Macello Lugano: attenzione all\'amianto',
     ogDescription: 'Iniziati i lavori di sgombero delle macerie dell\'ex Macello di Lugano. Possibile presenza di polveri di amianto. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/sgombero-macerie-lugano-amianto',
+    canonicalPath: '/articoli-frontaliere/sgombero-macerie-lugano-amianto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29681,7 +29681,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lamanotesa, trasforma, dolore, bene',
     ogTitle: 'Lamanotesa.ch trasforma il dolore in un bene condiviso',
     ogDescription: 'La Fondazione Lamanotesa.ch organizza un incontro sulla giustizia riparativa a 15 anni dall\'attentato di Marrakech',
-    canonicalPath: '/articoli-frontaliere/lamanotesa-ch-dolore-bene-condiviso',
+    canonicalPath: '/articoli-frontaliere/lamanotesa-ch-dolore-bene-condiviso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29720,7 +29720,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elizabeth, baume-schneider, lamal, cost',
     ogTitle: 'Elizabeth Baume-Schneider: No a una LAMal low cost con premi più bassi',
     ogDescription: 'La Consigliera federale Elizabeth Baume-Schneider si oppone alla proposta di una LAMal low cost con premi più bassi, difendendo il sistema attuale.',
-    canonicalPath: '/articoli-frontaliere/lamal-low-cost-premi-bassi-2026',
+    canonicalPath: '/articoli-frontaliere/lamal-low-cost-premi-bassi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29759,7 +29759,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, inviano, fattura, costi',
     ogTitle: 'Grigioni inviano fattura all\'Italia per i costi del traffico olimpico',
     ogDescription: 'Il cantone dei Grigioni ha inviato una fattura da 2,6 milioni di franchi all\'Italia per coprire i costi del piano trasporti durante le Olimpiadi di',
-    canonicalPath: '/articoli-frontaliere/grigioni-fattura-italia-olimpiadi',
+    canonicalPath: '/articoli-frontaliere/grigioni-fattura-italia-olimpiadi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29798,7 +29798,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, untersander, lascia, berna, ginevra',
     ogTitle: 'Untersander lascia il Berna per il Ginevra Servette',
     ogDescription: 'Ramon Untersander, ex capitano del Berna, si trasferisce al Ginevra Servette. Ecco cosa cambia per i tifosi e gli appassionati di hockey.',
-    canonicalPath: '/articoli-frontaliere/untersander-ginevra-2026',
+    canonicalPath: '/articoli-frontaliere/untersander-ginevra-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29837,7 +29837,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, richiedere, dati, precalcolati, gestire',
     ogTitle: 'ISA 2026: dati precalcolati e delega unica',
     ogDescription: 'Scopri come richiedere i dati precalcolati ISA 2026 e gestire la delega unica. Impatto operativo per frontalieri e intermediari.',
-    canonicalPath: '/articoli-frontaliere/dati-precalcolati-isa-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/dati-precalcolati-isa-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29876,7 +29876,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stabili, 2026-q1, dati, indicano',
     ogTitle: 'Frontalieri Ticino stabili nel 2026-Q1',
     ogDescription: 'I dati BFS indicano che il numero di frontalieri in Ticino è rimasto stabile nel primo trimestre del 2026, con una variazione dello -0.16% rispetto al trimestre',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-stabili-2026-q1',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-stabili-2026-q1/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29915,7 +29915,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ricorso, patente, lavoro, bilico',
     ogTitle: 'Ricorso patente: lavoro in bilico per i tempi della giustizia',
     ogDescription: 'Una professionista di Varese racconta l\'attesa di un ricorso per patente ritirata: 1500 euro spesi e ancora nessuna risposta. Cosa fare se il lavoro dipende',
-    canonicalPath: '/articoli-frontaliere/ricorso-patente-lavoro-varese-2026',
+    canonicalPath: '/articoli-frontaliere/ricorso-patente-lavoro-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29954,7 +29954,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aggregazione, comuni, vedeggio, primo',
     ogTitle: 'Aggregazione Comuni Vedeggio: primo passo verso la fusione',
     ogDescription: 'Bedano, Cadempino, Gravesano e Lamone presentano istanza formale al Consiglio di Stato per uno studio aggregativo. Obiettivo: progetto condiviso entro primavera',
-    canonicalPath: '/articoli-frontaliere/aggregazione-comuni-vedeggio-2026',
+    canonicalPath: '/articoli-frontaliere/aggregazione-comuni-vedeggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29993,7 +29993,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giardino, ferroviario, balerna, nuovo',
     ogTitle: 'Giardino ferroviario Balerna: inaugurazione e opportunità per frontalieri',
     ogDescription: 'Scopri il nuovo Giardino ferroviario di Balerna, un\'area sostenibile unica in Svizzera con orti urbani e spazi di aggregazione. Inaugurazione il 9 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/giardino-ferroviario-balerna-2026',
+    canonicalPath: '/articoli-frontaliere/giardino-ferroviario-balerna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30032,7 +30032,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vertigini, montagna, rischio, sottovalutato',
     ogTitle: 'Vertigini in montagna: rischio sottovalutato per i frontalieri',
     ogDescription: 'Quasi un terzo degli escursionisti in Svizzera soffre di vertigini, aumentando il rischio di cadute. Ecco come affrontare il problema per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/vertigini-montagna-frontalieri',
+    canonicalPath: '/articoli-frontaliere/vertigini-montagna-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30071,7 +30071,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, real, madrid, caos, rissa',
     ogTitle: 'Real Madrid nel caos: rissa fra Tchouaméni e Valverde',
     ogDescription: 'Nervi tesi al Real Madrid dopo una violenta rissa tra Tchouaméni e Valverde, con il giocatore uruguaiano finito in ospedale per un trauma cranico.',
-    canonicalPath: '/articoli-frontaliere/real-madrid-caos-rissa-tchouameni-valverde',
+    canonicalPath: '/articoli-frontaliere/real-madrid-caos-rissa-tchouameni-valverde/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30110,7 +30110,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bioblitz, lombardia, giorni, natura',
     ogTitle: 'BioBlitz Lombardia 2026: natura e scienza al Parco delle Groane',
     ogDescription: 'Dal 15 al 17 maggio 2026, il Parco delle Groane ospita il BioBlitz Lombardia, un evento di citizen science per scoprire la biodiversità locale.',
-    canonicalPath: '/articoli-frontaliere/bioblitz-groane-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/bioblitz-groane-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30149,7 +30149,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intervista, joris, begevoord, presidente',
     ogTitle: 'Intervista a Joris Begevoord - Presidente AEBR',
     ogDescription: 'Joris Begevoord, Presidente dell\'AEBR, discute delle sfide e opportunità per i frontalieri in Ticino nel 2026.',
-    canonicalPath: '/articoli-frontaliere/joris-begevoord-intervista-aebr-2026',
+    canonicalPath: '/articoli-frontaliere/joris-begevoord-intervista-aebr-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30188,7 +30188,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pokerce, dimezzati, cosa, cambia',
     ogTitle: 'Pokerce dimezzati: cosa cambia per i frontalieri | Frontaliere Ticino',
     ogDescription: 'Il Consiglio di Stato del Canton Ticino può decidere il destino di due fratelli curdi rimasti in Svizzera. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-pokerce-dimezzati',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-pokerce-dimezzati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30227,7 +30227,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, orari, flessibili, residenzialità, nuove',
     ogTitle: 'Orari flessibili e residenzialità: nuove proposte per i frontalieri',
     ogDescription: 'Lea propone orari lavorativi più flessibili e residenzialità per i frontalieri per alleggerire il traffico e migliorare la qualità della vita in Ticino.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-orari-lavorativi-residenzialita',
+    canonicalPath: '/articoli-frontaliere/frontalieri-orari-lavorativi-residenzialita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30266,7 +30266,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lumen, claro, premiati, 1989',
     ogTitle: 'Lumen Claro: i premiati dal 1989 a Varese',
     ogDescription: 'Scopri i premiati del Lumen Claro dal 1989 a Varese, un riconoscimento del Lions Club Varese Prealpi per le eccellenze del territorio.',
-    canonicalPath: '/articoli-frontaliere/lumen-claro-premiati-varese-1989',
+    canonicalPath: '/articoli-frontaliere/lumen-claro-premiati-varese-1989/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30305,7 +30305,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grandine, cislago, protezione, civile',
     ogTitle: 'Grandine a Cislago: Protezione Civile in azione tutta la notte',
     ogDescription: 'Il maltempo del 7 maggio 2026 ha causato disagi a Cislago. Il Comune ringrazia i volontari per l\'intervento tempestivo.',
-    canonicalPath: '/articoli-frontaliere/grandine-cislago-protezione-civile-2026',
+    canonicalPath: '/articoli-frontaliere/grandine-cislago-protezione-civile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30344,7 +30344,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, edoardo, conquista, teatro, intred',
     ogTitle: 'Edoardo Leo conquista il Teatro Intred di Varese con parole, risate e poesia',
     ogDescription: 'Edoardo Leo ha portato in scena \'Ti racconto una storia\' al Teatro Intred di Varese il 6 maggio 2026, coinvolgendo il pubblico con aneddoti, barzellette e',
-    canonicalPath: '/articoli-frontaliere/edoardo-leo-teatro-intred-varese-2026',
+    canonicalPath: '/articoli-frontaliere/edoardo-leo-teatro-intred-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30383,7 +30383,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, locarno, rilancia, campagna, contro',
     ogTitle: 'Locarno rilancia la campagna contro la zanzara tigre',
     ogDescription: 'Locarno distribuisce gratuitamente Vectobac® G per contrastare la diffusione della zanzara tigre. Scopri come partecipare.',
-    canonicalPath: '/articoli-frontaliere/locarno-zanzara-tigre-campagna-rilancia-2026',
+    canonicalPath: '/articoli-frontaliere/locarno-zanzara-tigre-campagna-rilancia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30422,7 +30422,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, legge, foti, sotto, accusa',
     ogTitle: 'Legge Foti sotto accusa: obiettivi solo sulla carta',
     ogDescription: 'Esperti criticano la legge Foti per inefficienze e distorsioni, con impatti su burocrazia e pubblica amministrazione. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/legge-foti-critica-economia-ticino',
+    canonicalPath: '/articoli-frontaliere/legge-foti-critica-economia-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30461,7 +30461,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, progetto, eiger, palace, lugano',
     ogTitle: 'Progetto Eiger Palace a Lugano: demolizioni e tre anni di lavori',
     ogDescription: 'La licenza edilizia per il progetto Eiger Palace a Besso, Lugano, è entrata in giudicato. Ecco le prossime tappe del progetto.',
-    canonicalPath: '/articoli-frontaliere/progetto-eiger-palace-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/progetto-eiger-palace-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30500,7 +30500,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cartelle, pagamento, cassazione, fissa',
     ogTitle: 'Cartelle di pagamento: Cassazione fissa termine di decadenza',
     ogDescription: 'La Cassazione stabilisce che il termine per la notifica delle cartelle di pagamento decorre dalla scadenza ordinaria della dichiarazione, non dalla',
-    canonicalPath: '/articoli-frontaliere/cartelle-pagamento-cassazione-2026',
+    canonicalPath: '/articoli-frontaliere/cartelle-pagamento-cassazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30539,7 +30539,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, interazione, output, floor, requisiti',
     ogTitle: 'CRD: interazione tra output floor e requisiti del II pilastro',
     ogDescription: 'Analisi delle implicazioni per i frontalieri Ticino: cosa cambia con l\'interazione tra output floor e requisiti del II pilastro',
-    canonicalPath: '/articoli-frontaliere/crd-output-floor-ii-pilastro',
+    canonicalPath: '/articoli-frontaliere/crd-output-floor-ii-pilastro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30578,7 +30578,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ultimo, svizzero, ricoverato, estero',
     ogTitle: 'Ultimo svizzero ricoverato torna in Svizzera dopo incendio Crans-Montana',
     ogDescription: 'L\'ultimo cittadino svizzero ricoverato all\'estero dopo l\'incendio di Capodanno a Crans-Montana torna in Svizzera. Tre nuove audizioni in programma',
-    canonicalPath: '/articoli-frontaliere/ultimo-svizzero-rientra-incendio-crans-montana',
+    canonicalPath: '/articoli-frontaliere/ultimo-svizzero-rientra-incendio-crans-montana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30617,7 +30617,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, università, insubria, premia, neolaureato',
     ogTitle: 'Università Insubria premia neolaureato in Infermieristica',
     ogDescription: 'Mattia Giussani, neolaureato in Infermieristica, vince il terzo posto nazionale per la miglior presentazione orale al Congresso SIAN.',
-    canonicalPath: '/articoli-frontaliere/universita-insubria-premia-frontalieri',
+    canonicalPath: '/articoli-frontaliere/universita-insubria-premia-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30656,7 +30656,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, gallarate, denunciato, uomo',
     ogTitle: 'Identificato e denunciato un uomo per l\'incendio a Gallarate: cosa cambia per i frontalieri',
     ogDescription: 'La polizia ha identificato e denunciato un uomo per l\'incendio alla centralina di via Cavour a Gallarate. Ecco le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incendio-gallarate-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/incendio-gallarate-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30695,7 +30695,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cardada, cimetta, riapre, bikers',
     ogTitle: 'Cardada Cimetta riapre ai bikers: ecco cosa cambia',
     ogDescription: 'Dopo la chiusura per manutenzione straordinaria, il trail 397 a Cardada Cimetta è nuovamente percorribile. Ecco le novità per gli appassionati di mountain bike',
-    canonicalPath: '/articoli-frontaliere/cardada-cimetta-riapre-bikers-2024',
+    canonicalPath: '/articoli-frontaliere/cardada-cimetta-riapre-bikers-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30734,7 +30734,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, graudio, edizione, dell, maggio',
     ogTitle: 'GrAudio edizione delle 10:30 dell\'8 maggio: notizie per i frontalieri',
     ogDescription: 'Le ultime notizie dall\'edizione delle 10:30 dell\'8 maggio su Varesenoi.it, con focus su eventi e novità per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-8-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-8-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30773,7 +30773,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, adam, walder, vince, titolo',
     ogTitle: 'Adam Walder vince il titolo nazionale Under 14',
     ogDescription: 'Il giovane atleta del Circolo Scherma Locarno si aggiudica il titolo nazionale Under 14 ai Campionati svizzeri di Morges.',
-    canonicalPath: '/articoli-frontaliere/adam-walder-titolo-nazionale-under-14',
+    canonicalPath: '/articoli-frontaliere/adam-walder-titolo-nazionale-under-14/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30812,7 +30812,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fart, 2025, boom, utenti',
     ogTitle: 'FART 2025: boom di utenti sui bus e nuovi treni in crescita',
     ogDescription: 'Le Ferrovie Autolinee Regionali Ticinesi (FART) registrano un aumento del 10% di passeggeri sui bus e miglioramenti con i nuovi treni.',
-    canonicalPath: '/articoli-frontaliere/fart-2025-frontalieri-transporti',
+    canonicalPath: '/articoli-frontaliere/fart-2025-frontalieri-transporti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30851,7 +30851,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rimborso, cure, dentarie, beneficia',
     ogTitle: 'Rimborso cure dentarie in Ticino: chi ne beneficia e come funziona',
     ogDescription: 'Scopri chi può accedere al rimborso delle cure dentarie in Ticino e come funziona il sistema di finanziamento ispirato all\'AVS',
-    canonicalPath: '/articoli-frontaliere/rimborso-cure-dentarie-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/rimborso-cure-dentarie-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30890,7 +30890,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bolla, immobiliare, rischio, aumento',
     ogTitle: 'Bolla immobiliare Svizzera 2026: rischio in aumento per i frontalieri',
     ogDescription: 'L\'UBS Swiss Real Estate Bubble Index sale a 0,69 punti nel primo trimestre 2026, segnalando un rischio moderato di bolla immobiliare in Svizzera. Cosa significa',
-    canonicalPath: '/articoli-frontaliere/bolla-immobiliare-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/bolla-immobiliare-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30929,7 +30929,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, imprinting, antonino, saggio, architettura',
     ogTitle: 'L’Imprinting di Antonino Saggio: architettura italiana in Ticino',
     ogDescription: 'Esplora come l\'architettura italiana influisce sul design urbano del Ticino con l\'imprinting di Antonino Saggio.',
-    canonicalPath: '/articoli-frontaliere/imprinting-saggio-architettura-italiana',
+    canonicalPath: '/articoli-frontaliere/imprinting-saggio-architettura-italiana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30968,7 +30968,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pagaiate, internazionali, grigioni, tutto',
     ogTitle: 'Pagaiate internazionali fra Grigioni e Ticino 2026',
     ogDescription: 'Sabato 9 e domenica 10 maggio 2026, gare di canoa sui fiumi Moesa e Ticino. Over 110 atleti da 7 nazioni, tra cui l\'Australia.',
-    canonicalPath: '/articoli-frontaliere/pagaiate-internazionali-grigioni-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/pagaiate-internazionali-grigioni-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31007,7 +31007,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aquile, mannheim, alla, coppa',
     ogTitle: 'Le Aquile di Mannheim alla Coppa Spengler 2026',
     ogDescription: 'Le Aquile di Mannheim partecipano alla 98esima Coppa Spengler. Scopri le implicazioni per gli appassionati di hockey su ghiaccio.',
-    canonicalPath: '/articoli-frontaliere/aquile-mannheim-coppa-spengler-2026',
+    canonicalPath: '/articoli-frontaliere/aquile-mannheim-coppa-spengler-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31046,7 +31046,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incentivi, assunzioni, sgravi, contributivi',
     ogTitle: 'Incentivi assunzioni 2026: tre sgravi contributivi poco utilizzati',
     ogDescription: 'Scopri i tre sgravi contributivi per le assunzioni nel 2026, tra cui NASpI, ADI e donne vittime di violenza, con esoneri fino al 100%.',
-    canonicalPath: '/articoli-frontaliere/incentivi-assunzioni-2026-sgravi-contributivi',
+    canonicalPath: '/articoli-frontaliere/incentivi-assunzioni-2026-sgravi-contributivi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31085,7 +31085,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caregiver, serve, coraggio, nelle',
     ogTitle: 'Ddl caregiver: confronto tra Aila e parlamentari, serve più coraggio nelle riforme',
     ogDescription: 'Il 6 maggio 2026 Aila incontra la Commissione Affari Sociali per modifiche al disegno di legge sui caregiver familiari. Tre milioni di italiani assistono',
-    canonicalPath: '/articoli-frontaliere/ddl-caregiver-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ddl-caregiver-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31124,7 +31124,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, simona, waltert, avanza, secondo',
     ogTitle: 'Simona Waltert avanza al secondo turno a Roma',
     ogDescription: 'La tennista grigionese si qualifica per il secondo turno del WTA 1\'000 di Roma, raggiungendo altre tre svizzere',
-    canonicalPath: '/articoli-frontaliere/simona-waltert-ticino-frontalieri',
+    canonicalPath: '/articoli-frontaliere/simona-waltert-ticino-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31163,7 +31163,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bonnie, tyler, coma, farmacologico',
     ogTitle: 'Bonnie Tyler in coma farmacologico dopo intervento d\'urgenza',
     ogDescription: 'La cantante britannica Bonnie Tyler, 74 anni, è in coma farmacologico in Portogallo dopo un intervento per perforazione intestinale.',
-    canonicalPath: '/articoli-frontaliere/bonnie-tyler-coma-farmacologico-2026',
+    canonicalPath: '/articoli-frontaliere/bonnie-tyler-coma-farmacologico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31202,7 +31202,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scambio, automatico, informazioni, immobili',
     ogTitle: 'Scambio automatico informazioni immobili: nuovo accordo multilaterale',
     ogDescription: 'Nuovo accordo per lo scambio automatico di informazioni sugli immobili tra Svizzera e Italia. Cosa cambia per i frontalieri?',
-    canonicalPath: '/articoli-frontaliere/nuovo-accordo-immobili-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-accordo-immobili-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31241,7 +31241,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, riforma, 2024, cosa',
     ogTitle: 'Nuova riforma AVS 2024: cosa cambia per i frontalieri',
     ogDescription: 'Dal 1° gennaio 2024 entrano in vigore nuove regole AVS. Ecco le novità per chi lavora in Svizzera e risiede in Italia',
-    canonicalPath: '/articoli-frontaliere/nuova-riforma-avs-2024-frontalieri',
+    canonicalPath: '/articoli-frontaliere/nuova-riforma-avs-2024-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31280,7 +31280,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lohnausweis, funziona, pratica, certificato',
     ogTitle: 'Lohnausweis: cos\'è e come funziona per i frontalieri del Ticino',
     ogDescription: 'Guida pratica al certificato di stipendio svizzero per i lavoratori transfrontalieri: cosa cambia e come ottenerlo',
-    canonicalPath: '/articoli-frontaliere/lohnausweis-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/lohnausweis-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31319,7 +31319,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, emigrazione, cassa, pensione, risparmiare',
     ogTitle: 'Emigrazione e cassa pensione: come risparmiare sulle imposte',
     ogDescription: 'Scopri come i frontalieri del Ticino possono risparmiare sulle imposte con la cassa pensione svizzera. Guida pratica con dati e procedure.',
-    canonicalPath: '/articoli-frontaliere/emigrazione-cassa-pensione-risparmio-imposte',
+    canonicalPath: '/articoli-frontaliere/emigrazione-cassa-pensione-risparmio-imposte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31358,7 +31358,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, accordo, riforma, secondo',
     ogTitle: 'Nuovo accordo frontalieri: riforma del secondo pilastro in votazione',
     ogDescription: 'Scopri cosa cambia con la riforma del secondo pilastro per i frontalieri in Ticino e come prepararti ai possibili cambiamenti',
-    canonicalPath: '/articoli-frontaliere/nuovo-accordo-frontalieri-pilastro-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-accordo-frontalieri-pilastro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31397,7 +31397,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tempi, attesa, alla, dogana',
     ogTitle: 'Tempi di attesa alla dogana di Chiasso: cosa sapere',
     ogDescription: 'Scopri i tempi di attesa alla dogana di Chiasso e come organizzare al meglio i tuoi spostamenti transfrontalieri.',
-    canonicalPath: '/articoli-frontaliere/chiasso-dogana-tempi-attesa',
+    canonicalPath: '/articoli-frontaliere/chiasso-dogana-tempi-attesa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31436,7 +31436,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stipendi, neo-laureati, austria, germania',
     ogTitle: 'Stipendi neo-laureati: Svizzera, Austria e Germania in testa',
     ogDescription: 'Confronto salariale per i neo-laureati in Svizzera, Austria, Germania, Italia, Polonia e Spagna. Chi paga di più?',
-    canonicalPath: '/articoli-frontaliere/stipendi-neolaureati-svizzera-austria-germania',
+    canonicalPath: '/articoli-frontaliere/stipendi-neolaureati-svizzera-austria-germania/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31475,7 +31475,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, basi, tecniche, 2025',
     ogTitle: 'Nuove basi tecniche LPP 2025: impatto su aspettativa di vita e invalidità',
     ogDescription: 'Scopri come le nuove basi tecniche LPP 2025 influenzano l\'aspettativa di vita e l\'invalidità per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/nuove-basi-lpp-2025-frontalieri',
+    canonicalPath: '/articoli-frontaliere/nuove-basi-lpp-2025-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31514,7 +31514,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumenti, stipendi, cosa, cambia',
     ogTitle: 'Aumenti stipendi Svizzera 2026: impatto sui frontalieri',
     ogDescription: 'Scopri come gli aumenti salariali in Svizzera influenzano i frontalieri del Ticino e cosa fare per massimizzare i benefici.',
-    canonicalPath: '/articoli-frontaliere/aumenti-stipendi-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/aumenti-stipendi-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31553,7 +31553,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lista, morosi, cassa, malati',
     ogTitle: 'Lista morosi cassa malati Ticino: cosa sapere',
     ogDescription: 'Scopri cosa succede se non paghi i premi assicurativi sanitari in Ticino e come evitare di finire nella lista dei morosi',
-    canonicalPath: '/articoli-frontaliere/lista-morosi-cassa-malati-ticino',
+    canonicalPath: '/articoli-frontaliere/lista-morosi-cassa-malati-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31592,7 +31592,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, falegnami, aumento, stipendi, busta',
     ogTitle: 'Aumento stipendi falegnami Ticino 2025',
     ogDescription: 'Dal 2025 gli stipendi dei falegnami in Ticino aumenteranno. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/falegnami-stipendi-2025',
+    canonicalPath: '/articoli-frontaliere/falegnami-stipendi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31631,7 +31631,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tasse, sulle, mance, cosa',
     ogTitle: 'Tasse sulle mance: cosa cambia per i frontalieri del Ticino',
     ogDescription: 'Scopri le ultime novità sulla tassazione delle mance per i frontalieri del Ticino e le implicazioni per i lavoratori e i datori di lavoro.',
-    canonicalPath: '/articoli-frontaliere/tasse-mance-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/tasse-mance-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31670,7 +31670,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tasse, biglietti, aerei, kerosene',
     ogTitle: 'No a tasse su biglietti aerei e kerosene in Ticino',
     ogDescription: 'La Svizzera rinuncia a tassare biglietti aerei e kerosene. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/tasse-aeree-kerosene-2026',
+    canonicalPath: '/articoli-frontaliere/tasse-aeree-kerosene-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31709,7 +31709,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cremona, nuovo, accordo, agenzia',
     ogTitle: 'Cremona, nuovo accordo tra Agenzia, Gdf e Procura - Fisco Oggi',
     ogDescription: 'Nuovo accordo per contrastare l\'evasione fiscale tra Agenzia delle Entrate, Guardia di Finanza e Procura di Cremona. Ecco le novità per i frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/nuovo-accordo-cremona-fisco-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-accordo-cremona-fisco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31748,7 +31748,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lapo, elkann, trasferisce, lucerna',
     ogTitle: 'Lapo Elkann si trasferisce a Lucerna: perché la Svizzera',
     ogDescription: 'Lapo Elkann spiega il suo trasferimento a Lucerna: sicurezza e neutralità svizzera al centro della scelta',
-    canonicalPath: '/articoli-frontaliere/lapo-elkann-lucerna-2024',
+    canonicalPath: '/articoli-frontaliere/lapo-elkann-lucerna-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31787,7 +31787,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, impatriati, passato, preclude, agevolazioni',
     ogTitle: 'Impatriati: il passato da frontaliere non preclude le agevolazioni fiscali',
     ogDescription: 'Scopri come il passato da frontaliere non preclude le agevolazioni fiscali per impatriati in Canton Ticino. Guida pratica per il trasferimento.',
-    canonicalPath: '/articoli-frontaliere/impatriati-fiscalita-frontalieri',
+    canonicalPath: '/articoli-frontaliere/impatriati-fiscalita-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31826,7 +31826,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzeri, ottimisti, sulla, situazione',
     ogTitle: 'Svizzeri ottimisti sulla situazione finanziaria per il 2026',
     ogDescription: 'Un sondaggio rivela che i residenti svizzeri, inclusi i frontalieri, sono fiduciosi per il futuro finanziario',
-    canonicalPath: '/articoli-frontaliere/svizzeri-ottimisti-finanze-2026',
+    canonicalPath: '/articoli-frontaliere/svizzeri-ottimisti-finanze-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31865,7 +31865,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, emolumenti, svizzeri, tassazione, dichiarazione',
     ogTitle: 'Emolumenti svizzeri: tassazione e dichiarazione in Italia',
     ogDescription: 'Guida pratica per i frontalieri: come dichiarare gli emolumenti svizzeri in Italia e evitare la doppia imposizione.',
-    canonicalPath: '/articoli-frontaliere/emolumenti-svizzera-tassazione-italia',
+    canonicalPath: '/articoli-frontaliere/emolumenti-svizzera-tassazione-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31904,7 +31904,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piloti, assicurazione, malattie, cosa',
     ogTitle: 'Piloti per l\'assicurazione malattie in Ticino: cosa cambia per i frontalieri',
     ogDescription: 'Il BAG lancia progetti pilota per contenere i costi dell\'assicurazione malattie. Ecco cosa sapere se lavori in Ticino',
-    canonicalPath: '/articoli-frontaliere/assicurazione-malattie-pilota-ticino',
+    canonicalPath: '/articoli-frontaliere/assicurazione-malattie-pilota-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31943,7 +31943,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, revoca, permesso, direttore, steiner',
     ogTitle: 'Revoca permesso G a direttore Steiner: implicazioni per i frontalieri',
     ogDescription: 'Il direttore della Steiner ha perso il permesso G. Ecco le implicazioni per i frontalieri e cosa fare per evitare problemi.',
-    canonicalPath: '/articoli-frontaliere/revoca-permesso-g-steiner-ticino',
+    canonicalPath: '/articoli-frontaliere/revoca-permesso-g-steiner-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31982,7 +31982,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rientro, lento, sulla, minuti',
     ogTitle: 'Rientro lento sulla A2: 40 minuti di ritardo per i frontalieri',
     ogDescription: 'Traffico intenso e pioggia rendono il rientro da sud sulla A2 particolarmente lento. Ritardi fino a 40 minuti tra Rivera e Chiasso.',
-    canonicalPath: '/articoli-frontaliere/rientro-lento-a2-frontalieri',
+    canonicalPath: '/articoli-frontaliere/rientro-lento-a2-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32021,7 +32021,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, costi, fissi, ecco',
     ogTitle: 'Addio ai costi fissi per l\'AI: ecco le nuove tariffe a consumo',
     ogDescription: 'Le aziende che utilizzano l\'intelligenza artificiale dovranno ora pagare in base all\'uso effettivo, con un impatto significativo sui costi operativi.',
-    canonicalPath: '/articoli-frontaliere/addio-tutto-compreso-ai-costi',
+    canonicalPath: '/articoli-frontaliere/addio-tutto-compreso-ai-costi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32060,7 +32060,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andrea, arcidiacono, nuovo, addetto',
     ogTitle: 'Andrea Arcidiacono nuovo addetto stampa della Curia di Lugano',
     ogDescription: 'Andrea Arcidiacono, ex vicecancelliere del Consiglio federale, è il nuovo addetto stampa della Curia vescovile di Lugano dal 1° giugno 2026.',
-    canonicalPath: '/articoli-frontaliere/arcidiacono-curia-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/arcidiacono-curia-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32099,7 +32099,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morto, visp, simone, grossi',
     ogTitle: 'Frontaliere morto a Visp: è Simone Grossi',
     ogDescription: 'Simone Grossi, frontaliere italiano, è deceduto questa mattina a Visp. Le autorità stanno indagando sulle cause dell\'incidente.',
-    canonicalPath: '/articoli-frontaliere/simone-grossi-frontaliere-visp',
+    canonicalPath: '/articoli-frontaliere/simone-grossi-frontaliere-visp/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32138,7 +32138,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blackout, internet, iran, giorni',
     ogTitle: 'Blackout internet Iran: 70 giorni di disconnessione',
     ogDescription: 'Il blackout di internet in Iran ha raggiunto il 70esimo giorno, uno dei blocchi più lunghi mai registrati. Scopri l\'impatto e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/blackout-internet-iran-70-giorni',
+    canonicalPath: '/articoli-frontaliere/blackout-internet-iran-70-giorni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32177,7 +32177,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, bellinzona, mozione, migliorare',
     ogTitle: 'Sicurezza a Bellinzona: mozione per migliorare la qualità della vita',
     ogDescription: 'Karim Spinelli (Plr) presenta mozione per rafforzare sicurezza e presenza istituzionale in zone sensibili di Bellinzona',
-    canonicalPath: '/articoli-frontaliere/rafforzare-sicurezza-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/rafforzare-sicurezza-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32216,7 +32216,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, austria, vicini, grazie, ambasciatori',
     ogTitle: 'Austria e Ticino più vicini grazie a due ambasciatori',
     ogDescription: 'Onorificenze a Helga Martinelli e Giuseppe Perale per il loro impegno nelle relazioni tra Austria e Ticino',
-    canonicalPath: '/articoli-frontaliere/austria-ticino-ambasciatori-2026',
+    canonicalPath: '/articoli-frontaliere/austria-ticino-ambasciatori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32255,7 +32255,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, professionisti, esclusione, fase, liquidazione',
     ogTitle: 'ISA e professionisti: esclusione in fase di liquidazione',
     ogDescription: 'Professionisti in liquidazione potrebbero essere esclusi dagli ISA. Scopri cosa cambia e come prepararti',
-    canonicalPath: '/articoli-frontaliere/isa-liquidazione-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/isa-liquidazione-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32294,7 +32294,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malattie, renali, rare, parte',
     ogTitle: 'Malattie renali rare: parte da Milano la campagna CL3AR',
     ogDescription: 'La campagna itinerante CL3AR mira a sensibilizzare sulla salute dei reni, con focus su malattie croniche rare come la C3G e la IC-MPGN primaria.',
-    canonicalPath: '/articoli-frontaliere/malattie-renali-campagna-cl3ar-milano',
+    canonicalPath: '/articoli-frontaliere/malattie-renali-campagna-cl3ar-milano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32333,7 +32333,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hantavirus, ginevrino, isolamento, basso',
     ogTitle: 'Hantavirus: ginevrino in isolamento, basso rischio per frontalieri',
     ogDescription: 'Un ginevrino è in isolamento dopo un volo con un malato di hantavirus. L\'UFSP rassicura: basso rischio per la popolazione.',
-    canonicalPath: '/articoli-frontaliere/hantavirus-ginevrino-isolamento-frontalieri',
+    canonicalPath: '/articoli-frontaliere/hantavirus-ginevrino-isolamento-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32372,7 +32372,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pentagono, pubblica, documenti, immagini',
     ogTitle: 'Pentagono pubblica documenti e immagini inedite sugli Ufo',
     ogDescription: 'Il Pentagono ha reso pubblici 162 documenti inediti su fenomeni anomali non identificati, nell\'ambito di un programma voluto da Donald Trump.',
-    canonicalPath: '/articoli-frontaliere/pentagono-ufo-documenti-inediti-2026',
+    canonicalPath: '/articoli-frontaliere/pentagono-ufo-documenti-inediti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32411,7 +32411,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, croce, rossa, festeggia, anni',
     ogTitle: 'Croce Rossa Svizzera festeggia 160 anni, ma restano i tagli agli educatori',
     ogDescription: 'Celebrazione al boschetto Ciani di Lugano per i 160 anni di Croce Rossa Svizzera, ma persistono le preoccupazioni per la riduzione del personale educativo',
-    canonicalPath: '/articoli-frontaliere/croce-rossa-160-anni-tagli-educatori',
+    canonicalPath: '/articoli-frontaliere/croce-rossa-160-anni-tagli-educatori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32450,7 +32450,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, servizi, dentari, scolastici, governo',
     ogTitle: 'Servizi dentari scolastici: il governo interviene sui conflitti d\'interesse',
     ogDescription: 'La Lega dei Ticinesi interroga il Consiglio di Stato su trasparenza e conflitti d\'interesse nell\'assegnazione dei servizi dentari scolastici',
-    canonicalPath: '/articoli-frontaliere/servizi-dentari-scolastici-conflitti-interesse',
+    canonicalPath: '/articoli-frontaliere/servizi-dentari-scolastici-conflitti-interesse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32489,7 +32489,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensioni, questo, importo, svantaggiato',
     ogTitle: 'Pensioni, con questo importo sei svantaggiato. Paghi più tasse',
     ogDescription: 'Scopri come i frontalieri del Ticino possono essere svantaggiati con le pensioni e pagare più tasse. Analisi dettagliata e soluzioni pratiche.',
-    canonicalPath: '/articoli-frontaliere/pensioni-svantaggio-tasse-frontalieri',
+    canonicalPath: '/articoli-frontaliere/pensioni-svantaggio-tasse-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32528,7 +32528,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, takahashia, japonica, proteggere, alberi',
     ogTitle: 'Takahashia japonica in Ticino: come proteggere gli alberi',
     ogDescription: 'Le autorità cantonali rassicurano: la situazione non è allarmante, ma è necessario agire per contenere la diffusione della cocciniglia.',
-    canonicalPath: '/articoli-frontaliere/takahashia-japonica-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/takahashia-japonica-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32567,7 +32567,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, onorificenze, austriache, lugano, riconoscimenti',
     ogTitle: 'Onorificenze austriache a Lugano: riconoscimenti per il dialogo italo-svizzero',
     ogDescription: 'Helga Martinelli e Giuseppe Perale premiati per il contributo alle relazioni tra Austria e Ticino',
-    canonicalPath: '/articoli-frontaliere/onorificenze-austriache-lugano-2024',
+    canonicalPath: '/articoli-frontaliere/onorificenze-austriache-lugano-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32606,7 +32606,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, divisa, sull, iniziativa, milioni',
     ogTitle: 'Svizzera divisa sull\'iniziativa per 10 milioni di abitanti',
     ogDescription: 'Sondaggio SSR: 47% a favore, 47% contro l\'iniziativa UDC. Frontalieri: cosa cambia?',
-    canonicalPath: '/articoli-frontaliere/votazioni-svizzera-10-milioni-frontalieri',
+    canonicalPath: '/articoli-frontaliere/votazioni-svizzera-10-milioni-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32645,7 +32645,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, protezione, antincendio, modifiche, regolamento',
     ogTitle: 'Modifiche regolamento antincendio Ticino 2026',
     ogDescription: 'L\'Associazione dei Comuni Ticinesi ricorre al Tribunale Federale contro le modifiche governative al regolamento sulla protezione antincendio',
-    canonicalPath: '/articoli-frontaliere/modifiche-regolamento-antincendio-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/modifiche-regolamento-antincendio-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32684,7 +32684,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans, montana, straordinarie, pagate',
     ogTitle: 'Crans Montana: ore straordinarie non pagate ai soccorritori',
     ogDescription: 'A quattro mesi dall\'incendio, i soccorritori dell\'Ospedale del Vallese attendono ancora il pagamento delle ore straordinarie.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-ore-straordinarie-non-pagate',
+    canonicalPath: '/articoli-frontaliere/crans-montana-ore-straordinarie-non-pagate/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32723,7 +32723,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, quattro, giocatori, lasciano',
     ogTitle: 'FC Lugano: quattro giocatori lasciano la squadra',
     ogDescription: 'Mohamed Belhadj Mahmoud, Hicham Mahou, Zachary Brault-Guillard e Serif Berbic non rinnovano il contratto con il FC Lugano.',
-    canonicalPath: '/articoli-frontaliere/lugano-calcio-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/lugano-calcio-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32762,7 +32762,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premiate, classi, vincitrici, concorso',
     ogTitle: 'Premiate le classi vincitrici del concorso \'L\'acqua è vita\'',
     ogDescription: 'Le classi 5B di Bellinzona Nord, 2B di Gambarogno e 3/4 di Brissago si aggiudicano il concorso creativo promosso dall\'Associazione Fontanieri Ticinesi',
-    canonicalPath: '/articoli-frontaliere/premiate-classi-acqua-vita-2026',
+    canonicalPath: '/articoli-frontaliere/premiate-classi-acqua-vita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32801,7 +32801,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, biasca, ucraina, volontari, missione',
     ogTitle: 'Da Biasca all\'Ucraina: sei volontari in missione umanitaria',
     ogDescription: 'Sei volontari della Hunpa partono da Biasca per portare aiuto medico in Ucraina, con due squadre che si divideranno per coprire il nord-est e il sud del Paese.',
-    canonicalPath: '/articoli-frontaliere/biasca-ucraina-aiuto-medico-2026',
+    canonicalPath: '/articoli-frontaliere/biasca-ucraina-aiuto-medico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32840,7 +32840,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, criptovalute, esperto, consiglia, evitare',
     ogTitle: 'Criptovalute: l\'esperto consiglia di evitare il timing perfetto',
     ogDescription: 'Mathias Imbach, CEO di Sygnum Bank, spiega come investire in criptovalute senza cercare il momento ideale. Strategie e consigli per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/criptovalute-frontalieri-timing-perfetto',
+    canonicalPath: '/articoli-frontaliere/criptovalute-frontalieri-timing-perfetto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32879,7 +32879,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, super-ricco, svizzero, vuole, pagare',
     ogTitle: 'Super-ricco svizzero vuole pagare più tasse, ma è l’unico',
     ogDescription: 'Un cittadino svizzero benestante desidera pagare più tasse, un caso unico in Svizzera. Ecco cosa cambia per i frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/super-ricco-tasse-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/super-ricco-tasse-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32918,7 +32918,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, interroll, acquisisce, royal, apollo',
     ogTitle: 'Interroll acquisisce Royal Apollo Group: implicazioni per i frontalieri',
     ogDescription: 'Interroll, azienda ticinese leader nell\'automazione logistica, acquisisce Royal Apollo Group. Scopri le implicazioni per i frontalieri e il mercato del lavoro.',
-    canonicalPath: '/articoli-frontaliere/interroll-acquisisce-royal-apollo-group',
+    canonicalPath: '/articoli-frontaliere/interroll-acquisisce-royal-apollo-group/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32957,7 +32957,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alpini, paracadutisti, genova, adunata',
     ogTitle: 'Alpini paracadutisti a Genova per l\'Adunata nazionale: il video',
     ogDescription: 'Migliaia di Alpini in arrivo a Genova per la 97esima Adunata nazionale. Video dell\'atterraggio dei paracadutisti sulla spiaggia.',
-    canonicalPath: '/articoli-frontaliere/alpini-paracadutisti-genova-2026',
+    canonicalPath: '/articoli-frontaliere/alpini-paracadutisti-genova-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32996,7 +32996,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, hockey, novità, nuovi',
     ogTitle: 'Lugano Hockey: novità per i frontalieri',
     ogDescription: 'Nuovi giocatori e strategie per la stagione 2024-2025. Cosa cambia per i tifosi frontalieri',
-    canonicalPath: '/articoli-frontaliere/casa-hockey-lugano-frontalieri',
+    canonicalPath: '/articoli-frontaliere/casa-hockey-lugano-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33035,7 +33035,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, papa, leone, incontra, napoli',
     ogTitle: 'Papa Leone incontra a Napoli la madre di un frontaliere',
     ogDescription: 'Papa Leone XIV ha incontrato Patrizia Mercolino, madre di Domenico Caliendo, un bambino di due anni deceduto dopo un trapianto di cuore.',
-    canonicalPath: '/articoli-frontaliere/papa-leone-incontra-madre-frontaliere',
+    canonicalPath: '/articoli-frontaliere/papa-leone-incontra-madre-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33074,7 +33074,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sconfitta, dalla, svezia, implicazioni',
     ogTitle: 'Svizzera sconfitta dalla Svezia: implicazioni per i frontalieri',
     ogDescription: 'Analisi della sconfitta della Svizzera contro la Svezia e delle implicazioni per i frontalieri che lavorano in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/svizzera-sconfitta-svezia-frontalieri',
+    canonicalPath: '/articoli-frontaliere/svizzera-sconfitta-svezia-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33113,7 +33113,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cremlino, tregua, ucraina, lunga',
     ogTitle: 'Cremlino: tregua Ucraina più lunga improbabile',
     ogDescription: 'Il consigliere presidenziale russo Yuri Ushakov ha dichiarato che l\'estensione del cessate il fuoco è improbabile. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/tregua-ucraina-improbabile-cremlino',
+    canonicalPath: '/articoli-frontaliere/tregua-ucraina-improbabile-cremlino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33152,7 +33152,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, tuta, alare, 32enne',
     ogTitle: 'Incidente in tuta alare: 32enne svizzera gravemente ferita in Austria',
     ogDescription: 'Una cittadina svizzera di 32 anni è rimasta gravemente ferita in un incidente di tuta alare a Hohenems, Austria, durante un volo con 15 saltatori.',
-    canonicalPath: '/articoli-frontaliere/incidente-tuta-alare-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-tuta-alare-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33191,7 +33191,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ghiacciai, svizzeri, senza, scudo',
     ogTitle: 'Ghiacciai svizzeri senza scudo protettivo: cosa cambia per i frontalieri',
     ogDescription: 'Scopri le implicazioni per i frontalieri del Ticino dopo un inverno secco che ha lasciato i ghiacciai svizzeri senza scudo protettivo.',
-    canonicalPath: '/articoli-frontaliere/ghiacciai-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/ghiacciai-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33230,7 +33230,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, niente, centro, migranti, fornasette',
     ogTitle: 'Niente centro migranti a Fornasette: la caserma ai pompieri',
     ogDescription: 'La ex caserma dei carabinieri di Fornasette a Luino sarà destinata ai vigili del fuoco, non ai migranti. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/frontalieri-luino-caserma-fornasette',
+    canonicalPath: '/articoli-frontaliere/frontalieri-luino-caserma-fornasette/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33269,7 +33269,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, black, list, morosi, cassa',
     ogTitle: 'Black list morosi cassa malati: cosa cambia per i frontalieri',
     ogDescription: 'Nuove regole per i morosi della cassa malati in Ticino. Ecco cosa sapere e come evitare di finire nella black list',
-    canonicalPath: '/articoli-frontaliere/black-list-morosi-cassa-malati-ticino',
+    canonicalPath: '/articoli-frontaliere/black-list-morosi-cassa-malati-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33308,7 +33308,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, documentario, claire, ghiringhelli, lugano',
     ogTitle: 'Documentario Claire Ghiringhelli Lugano | Frontaliere Ticino',
     ogDescription: 'Scopri il documentario su Claire Ghiringhelli, atleta paralimpica di canottaggio, in proiezione a Lugano. Una storia di resilienza e determinazione.',
-    canonicalPath: '/articoli-frontaliere/documentario-claire-ghiringhelli-lugano',
+    canonicalPath: '/articoli-frontaliere/documentario-claire-ghiringhelli-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33347,7 +33347,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malpensa, pista, riapre, cosa',
     ogTitle: 'Malpensa: pista 35L riapre, cosa cambia per i frontalieri',
     ogDescription: 'I lavori alla pista 35L di Malpensa sono terminati. La riapertura è prevista per domenica 10 maggio. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/malpensa-pista-riapre-frontalieri',
+    canonicalPath: '/articoli-frontaliere/malpensa-pista-riapre-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33386,7 +33386,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, peter, magyar, giurato, ungheria',
     ogTitle: 'Peter Magyar giurato: l\'Ungheria cambia pagina',
     ogDescription: 'Dopo 16 anni, finisce l\'era di Viktor Orban. Peter Magyar è il nuovo primo ministro ungherese. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/peter-magyar-ungheria-volta-pagina',
+    canonicalPath: '/articoli-frontaliere/peter-magyar-ungheria-volta-pagina/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33425,7 +33425,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, potere, acquisto, calo, acsi',
     ogTitle: 'Potere d\'acquisto in calo: ACSI allarma su povertà crescente in Ticino',
     ogDescription: 'La fiducia dei consumatori resta bassa, premi cassa malati e inflazione pesano sulle famiglie ticinesi. Antonella Crüzer: \'Situazione preoccupante\'',
-    canonicalPath: '/articoli-frontaliere/potere-dacquisto-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/potere-dacquisto-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33464,7 +33464,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, minivan, canale, chioggia, vittime',
     ogTitle: 'Minivan nel canale a Chioggia: tre vittime tra i frontalieri',
     ogDescription: 'Un incidente mortale a Chioggia coinvolge frontalieri marocchini diretti al lavoro nei campi del radicchio. Tre vittime, tra cui il conducente.',
-    canonicalPath: '/articoli-frontaliere/minivan-chioggia-frontalieri-incidente',
+    canonicalPath: '/articoli-frontaliere/minivan-chioggia-frontalieri-incidente/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33503,7 +33503,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, curiosità, svizzere, tradizioni, usanze',
     ogTitle: 'Curiosità svizzere: tradizioni e usanze uniche in Ticino',
     ogDescription: 'Scopri le tradizioni più insolite della Svizzera e del Ticino, dalle mucche che combattono ai riti primaverili con le uova.',
-    canonicalPath: '/articoli-frontaliere/curiosita-rossocrociate-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/curiosita-rossocrociate-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33542,7 +33542,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malcontento, dipendenti, dell, aeroporto',
     ogTitle: 'Malcontento tra i dipendenti dell\'aeroporto di Lugano',
     ogDescription: 'Lettera anonima al Municipio di Lugano segna tensioni tra il personale e il direttore Christian Castelli',
-    canonicalPath: '/articoli-frontaliere/malcontento-aeroporto-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/malcontento-aeroporto-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33581,7 +33581,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chippis, demolisce, ponte, storico',
     ogTitle: 'Chippis demolisce ponte storico per sicurezza | Frontaliere Ticino',
     ogDescription: 'Il Comune di Chippis ha demolito un ponte del 1880 per prevenire rischi legati alla faglia dei Fios. Lavori di sicurezza costano 1,8 milioni di franchi.',
-    canonicalPath: '/articoli-frontaliere/chippis-ponte-demolito-sicurezza',
+    canonicalPath: '/articoli-frontaliere/chippis-ponte-demolito-sicurezza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33620,7 +33620,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, stradale, cittiglio, laveno',
     ogTitle: 'Incidente stradale tra Cittiglio e Laveno: auto e moto coinvolte',
     ogDescription: 'Due persone ferite in un incidente tra un\'auto e una moto sulla provinciale tra Cittiglio e Laveno Mombello la sera dell\'8 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/incidente-stradale-cittiglio-laveno',
+    canonicalPath: '/articoli-frontaliere/incidente-stradale-cittiglio-laveno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33659,7 +33659,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ossolano, morto, visp, procura',
     ogTitle: 'Frontaliere ossolano morto a Visp: autopsia disposta',
     ogDescription: 'La procura elvetica ha disposto l\'autopsia sul corpo di un frontaliere ossolano trovato morto a Visp. Ecco cosa sappiamo finora.',
-    canonicalPath: '/articoli-frontaliere/frontaliero-ossolano-morto-visp-autopsia',
+    canonicalPath: '/articoli-frontaliere/frontaliero-ossolano-morto-visp-autopsia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33698,7 +33698,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, putin, conflitto, ucraino, volgendo',
     ogTitle: 'Putin: «Il conflitto ucraino sta volgendo al termine»',
     ogDescription: 'Il presidente russo annuncia una svolta nel conflitto ucraino e si dice pronto a negoziare con l\'UE. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/putin-ucraina-termine-frontalieri',
+    canonicalPath: '/articoli-frontaliere/putin-ucraina-termine-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33737,7 +33737,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassa, malati, spacchettare, doveroso',
     ogTitle: 'Cassa malati: spacchettare è doveroso per i frontalieri',
     ogDescription: 'Le due iniziative popolari sui premi di cassa malati in Ticino vengono separate. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/cassa-malati-spacchettamento-ticino',
+    canonicalPath: '/articoli-frontaliere/cassa-malati-spacchettamento-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33776,7 +33776,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fedeli, chiedono, chiarezza, alla',
     ogTitle: 'Fedeli chiedono chiarezza alla Diocesi di Lugano',
     ogDescription: 'Il gruppo promotore della petizione 2025 chiede all\'Amministratore Apostolico di intervenire sull\'Azione Cattolica Ticinese per chiarezza sulla veglia del 22',
-    canonicalPath: '/articoli-frontaliere/fedeli-chiedono-chiarezza-diocesi-2026',
+    canonicalPath: '/articoli-frontaliere/fedeli-chiedono-chiarezza-diocesi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33815,7 +33815,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, ispra, soccorso, giovane',
     ogTitle: 'Incidente a Ispra: soccorso un giovane di 19 anni',
     ogDescription: 'Un incidente stradale a Ispra coinvolge un giovane frontaliero. Ecco cosa è successo e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incidente-ispra-frontaliere-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-ispra-frontaliere-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33854,7 +33854,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, openjobmetis, bologna, partita, decisiva',
     ogTitle: 'Openjobmetis a Bologna: la partita decisiva per i playoff',
     ogDescription: 'La Pallacanestro Varese gioca a Bologna il 10 maggio 2026 per i playoff. La Virtus non farà sconti.',
-    canonicalPath: '/articoli-frontaliere/basket-openjobmetis-bologna-2026',
+    canonicalPath: '/articoli-frontaliere/basket-openjobmetis-bologna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33893,7 +33893,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blitz, boschi, droga, arrestati',
     ogTitle: 'Blitz nei boschi della droga: tre arrestati a Turate',
     ogDescription: 'La polizia di Como ha arrestato tre marocchini irregolari per spaccio di stupefacenti nel territorio di Turate. Sequestrati droga e un machete.',
-    canonicalPath: '/articoli-frontaliere/blitz-droga-turate-frontalieri',
+    canonicalPath: '/articoli-frontaliere/blitz-droga-turate-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33932,7 +33932,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, nuove, audizioni, incendio',
     ogTitle: 'Crans-Montana: tre nuove audizioni per l\'incendio di Capodanno',
     ogDescription: 'Tre nuove audizioni previste la settimana prossima per l\'incendio di Capodanno a Crans-Montana, tra cui due figure politiche. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-audizioni-frontalieri',
+    canonicalPath: '/articoli-frontaliere/crans-montana-audizioni-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33971,7 +33971,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sommer, bocciato, dall, inter',
     ogTitle: 'Sommer bocciato dall\'Inter: cosa cambia per i frontalieri',
     ogDescription: 'Emiliano Viviano critica il portiere svizzero: «Quest\'anno non ha dato quasi niente all\'Inter». Analisi delle implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/sommer-bocciato-inter-frontalieri',
+    canonicalPath: '/articoli-frontaliere/sommer-bocciato-inter-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34010,7 +34010,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, precompilata, accesso, novità, controlli',
     ogTitle: 'Precompilata 2026: guida su accesso, novità, controlli e invio',
     ogDescription: 'Guida completa alla dichiarazione precompilata 2026 per frontalieri in Ticino: accesso, novità, controlli e invio del modello 730 o Redditi PF',
-    canonicalPath: '/articoli-frontaliere/precompilata-2026-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/precompilata-2026-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34049,7 +34049,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arlotti, chiede, franchigia, presidente',
     ogTitle: 'Arlotti scrive a Letta, Saccomanni e Fassina: ripristinate la franchigia per i frontalieri',
     ogDescription: 'Il presidente di San Marino chiede il ripristino della franchigia per i frontalieri in Ticino. Ecco cosa cambia e cosa fare.',
-    canonicalPath: '/articoli-frontaliere/arlotti-franchigia-frontalieri-letta',
+    canonicalPath: '/articoli-frontaliere/arlotti-franchigia-frontalieri-letta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34088,7 +34088,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, maggio, notizie, ultime',
     ogTitle: 'Varese, 10 maggio 2026: notizie per i frontalieri',
     ogDescription: 'Le ultime notizie dal confine italo-svizzero: incidenti, eventi sportivi e altro per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-varese-10-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-varese-10-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34127,7 +34127,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, riduce, personale, amministrativo',
     ogTitle: 'Swiss riduce del 10% il personale amministrativo: cosa cambia per i frontalieri',
     ogDescription: 'Swiss intende ridurre il personale amministrativo del 10% con partenze volontarie e incentivi finanziari. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/swiss-riduce-personale-amministrativo',
+    canonicalPath: '/articoli-frontaliere/swiss-riduce-personale-amministrativo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34166,7 +34166,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, palacinema, locarno, servono, risposte',
     ogTitle: 'Palacinema di Locarno: servono risposte urgenti',
     ogDescription: 'Yvonne Ballestra Cotti e Barbara Angelini Piva presentano un\'interpellanza urgente per il Palacinema di Locarno. Scopri le implicazioni e come partecipare.',
-    canonicalPath: '/articoli-frontaliere/palacinema-locarno-urgenti-2026',
+    canonicalPath: '/articoli-frontaliere/palacinema-locarno-urgenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34205,7 +34205,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, venezia, esperienza, sonora, ispirata',
     ogTitle: 'Venezia: esperienza sonora ispirata a Ildegarda di Bingen',
     ogDescription: 'Scopri l\'esperienza sonora ispirata a Santa Ildegarda di Bingen a Venezia, un\'opportunità unica di riflessione e connessione spirituale.',
-    canonicalPath: '/articoli-frontaliere/venezia-ildegarda-frontalieri',
+    canonicalPath: '/articoli-frontaliere/venezia-ildegarda-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34244,7 +34244,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, altri, arresti, rissa, morì',
     ogTitle: 'Altri tre arresti per la rissa in cui morì Enzo Ambrosino',
     ogDescription: 'Nuovi sviluppi nelle indagini sull\'omicidio di Enzo Ambrosino a Induno Olona. Tre persone arrestate e una cavalla abbattuta a Castelveccana.',
-    canonicalPath: '/articoli-frontaliere/tre-arresti-rissa-ambrosino-cavalla',
+    canonicalPath: '/articoli-frontaliere/tre-arresti-rissa-ambrosino-cavalla/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34283,7 +34283,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scioperi, aerei, lunedì, maggio',
     ogTitle: 'Scioperi aerei Italia 11 maggio 2026: voli a rischio',
     ogDescription: 'Lunedì 11 maggio 2026 scioperi nel trasporto aereo italiano. Voli a rischio cancellazione o ritardo. Cosa fare?',
-    canonicalPath: '/articoli-frontaliere/scioperi-aerei-italia-11-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/scioperi-aerei-italia-11-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34322,7 +34322,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, difficoltà, oltre, milioni, franchi',
     ogTitle: 'Acb in difficoltà: oltre 2 milioni di franchi di debiti',
     ogDescription: 'La società Acb di Bellinzona deve saldare debiti per oltre 2 milioni di franchi. Martedì attesi chiarimenti dalla società.',
-    canonicalPath: '/articoli-frontaliere/acb-debito-futuro-2026',
+    canonicalPath: '/articoli-frontaliere/acb-debito-futuro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34361,7 +34361,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sciopero, easyjet, malpensa, voli',
     ogTitle: 'Sciopero Easyjet Malpensa 11 maggio 2026',
     ogDescription: 'Sciopero nazionale Easyjet l\'11 maggio 2026, coinvolgendo anche Malpensa. Fasce orarie garantite e voli a rischio. Informazioni e consigli per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/sciopero-easyjet-malpensa-11-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/sciopero-easyjet-malpensa-11-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34400,7 +34400,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, secondo, pilastro, divisione, anche',
     ogTitle: 'Secondo pilastro: divisione anche dopo lunga separazione',
     ogDescription: 'Scopri come la divisione del secondo pilastro AVS/LPP influisce sui frontalieri del Ticino, anche dopo una lunga separazione.',
-    canonicalPath: '/articoli-frontaliere/secondo-pilastro-diviso-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/secondo-pilastro-diviso-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34439,7 +34439,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 15enne, rompe, vetri, ospedale',
     ogTitle: '15enne rompe vetri ospedale Como: denunciato dalla polizia',
     ogDescription: 'Un 15enne ha danneggiato il box office dell\'Ospedale Sant\'Anna a San Fermo della Battaglia, Como, dopo aver preteso una visita senza prenotazione.',
-    canonicalPath: '/articoli-frontaliere/ospedale-como-frontalieri-15-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/ospedale-como-frontalieri-15-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34478,7 +34478,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, direttrice, ringrazia, whistleblower, licenziato',
     ogTitle: 'Direttrice USZ ringrazia whistleblower licenziato',
     ogDescription: 'La direttrice dell\'Ospedale universitario di Zurigo esprime gratitudine al whistleblower licenziato che ha denunciato irregolarità nella clinica di',
-    canonicalPath: '/articoli-frontaliere/whistleblower-zurigo-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/whistleblower-zurigo-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34517,7 +34517,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, newsletter, restare, aggiornati, sulle',
     ogTitle: 'Newsletter Ticino: come restare aggiornati sulle novità',
     ogDescription: 'Scopri come iscriverti alla newsletter gratuita di TVS per ricevere aggiornamenti su lavoro, economia e vita in Ticino',
-    canonicalPath: '/articoli-frontaliere/abbonamento-newsletter-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/abbonamento-newsletter-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34556,7 +34556,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, balerna, diventa, zona, pianificazione',
     ogTitle: 'Balerna zona di pianificazione: cosa cambia per i frontalieri',
     ogDescription: 'Il Municipio di Balerna ha elaborato una scheda che designa il comune come zona di pianificazione. Ecco cosa cambia per chi vive e lavora in Ticino.',
-    canonicalPath: '/articoli-frontaliere/balerna-zona-pianificazione-2026',
+    canonicalPath: '/articoli-frontaliere/balerna-zona-pianificazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34595,7 +34595,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guillermo, silva, vince, tappa',
     ogTitle: 'Guillermo Silva vince la tappa e indossa la maglia rosa del Giro d\'Italia',
     ogDescription: 'L\'uruguaiano trionfa nella seconda tappa del Giro d\'Italia, diventando il primo uruguaiano a vincere una tappa di un grande giro.',
-    canonicalPath: '/articoli-frontaliere/giro-ditalia-silva-maglia-rosa',
+    canonicalPath: '/articoli-frontaliere/giro-ditalia-silva-maglia-rosa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34634,7 +34634,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rogo, crans-montana, convocati, nuovi',
     ogTitle: 'Rogo di Crans-Montana: convocati tre nuovi indagati',
     ogDescription: 'Tre nuovi indagati, tra cui due figure politiche, saranno interrogati la prossima settimana per l\'incendio al bar Le Constellation.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-audizioni-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-audizioni-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34673,7 +34673,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giugno, quel, sapere, iniziativa',
     ogTitle: '14 giugno: quel che c’è da sapere',
     ogDescription: 'Iniziativa per la sostenibilità e modifica della legge sul servizio civile: ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/votazioni-federali-14-giugno-2026',
+    canonicalPath: '/articoli-frontaliere/votazioni-federali-14-giugno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34712,7 +34712,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, locarno, lugano, mendrisio, capitale',
     ogTitle: 'Locarno approva alleanza con Lugano e Mendrisio per Capitale Culturale Svizzera 2030',
     ogDescription: 'La Gestione di Locarno dice sì alla candidatura congiunta, ma chiede misure per evitare una posizione marginale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/locarno-lugano-mendrisio-alleanza-2026',
+    canonicalPath: '/articoli-frontaliere/locarno-lugano-mendrisio-alleanza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34751,7 +34751,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, chiusure, notturne, sull',
     ogTitle: 'Chiusure notturne A9: tratti coinvolti e percorsi alternativi',
     ogDescription: 'Da lunedì 11 a venerdì 15 maggio 2026, chiusure notturne sull\'A9 tra Lainate, Como e Chiasso per manutenzione del verde. Ecco i tratti coinvolti e i percorsi',
-    canonicalPath: '/articoli-frontaliere/autostrada-a9-chiusure-11-15-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/autostrada-a9-chiusure-11-15-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34790,7 +34790,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, minimo, secondo, pilastro, rimane',
     ogTitle: 'LPP: il minimo del secondo pilastro rimane al 1,25%',
     ogDescription: 'La LPP conferma il minimo del secondo pilastro al 1,25% per il 2026, con implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/lpp-minimo-secondo-pilastro-2026',
+    canonicalPath: '/articoli-frontaliere/lpp-minimo-secondo-pilastro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34829,7 +34829,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, esplosione, miniera, colombia, morti',
     ogTitle: 'Esplosione in miniera in Colombia: 4 morti',
     ogDescription: 'Un\'esplosione in una miniera di carbone in Colombia ha causato la morte di quattro minatori. Le autorità indagano sulle cause del disastro.',
-    canonicalPath: '/articoli-frontaliere/esplosione-miniera-colombia-4-morti',
+    canonicalPath: '/articoli-frontaliere/esplosione-miniera-colombia-4-morti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34868,7 +34868,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, referendum, castelli, bellinzona, popolo',
     ogTitle: 'Referendum sui Castelli di Bellinzona: il popolo decide',
     ogDescription: 'Oltre 4.600 firme raccolte contro il credito per il progetto Fortezza. Il referendum è riuscito, ora la parola passa ai cittadini',
-    canonicalPath: '/articoli-frontaliere/referendum-castelli-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/referendum-castelli-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34907,7 +34907,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fabienne, schlumpf, seconda, ginevra',
     ogTitle: 'Fabienne Schlumpf seconda a Ginevra: ritorno in maratona senza deludere',
     ogDescription: 'Fabienne Schlumpf torna a correre la maratona dopo due anni e si piazza seconda a Ginevra con un tempo di 2:31:15',
-    canonicalPath: '/articoli-frontaliere/maratona-schlumpf-ginevra-2026',
+    canonicalPath: '/articoli-frontaliere/maratona-schlumpf-ginevra-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34946,7 +34946,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siviero, rieletto, presidente, swiss',
     ogTitle: 'Siviero rieletto presidente Swiss Basketball',
     ogDescription: 'Andrea Siviero confermato alla guida della federazione svizzera di basket con 31 voti contro 24 del rivale Sergi',
-    canonicalPath: '/articoli-frontaliere/siviero-rieletto-swiss-basketball',
+    canonicalPath: '/articoli-frontaliere/siviero-rieletto-swiss-basketball/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34985,7 +34985,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blocco, ristorni, discussione, tensione',
     ogTitle: 'Ticino: blocco ristorni in discussione per tensione con Italia',
     ogDescription: 'Il presidente del Consiglio di Stato Claudio Zali propone di bloccare i ristorni come risposta alle richieste italiane sulla tassa salute per i vecchi',
-    canonicalPath: '/articoli-frontaliere/ristorni-bloccati-ticino-italia',
+    canonicalPath: '/articoli-frontaliere/ristorni-bloccati-ticino-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35024,7 +35024,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, paul, magnier, trionfa, ancora',
     ogTitle: 'Paul Magnier trionfa ancora al Giro d\'Italia: Froidevaux dodicesimo',
     ogDescription: 'Il francese Paul Magnier vince la terza tappa del Giro d\'Italia a Sofia, mentre il vodese Robin Froidevaux si piazza dodicesimo.',
-    canonicalPath: '/articoli-frontaliere/giro-ditalia-magnier-froidevaux-2026',
+    canonicalPath: '/articoli-frontaliere/giro-ditalia-magnier-froidevaux-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35063,7 +35063,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comprare, casa, svizzero, svuota',
     ogTitle: 'Comprare casa? Uno svizzero su due svuota il secondo pilastro',
     ogDescription: 'Scopri come gli svizzeri utilizzano il secondo pilastro per l\'acquisto della casa e le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/svizzeri-secondo-pilastro-casa',
+    canonicalPath: '/articoli-frontaliere/svizzeri-secondo-pilastro-casa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35102,7 +35102,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, stesse, regole, residenti',
     ogTitle: 'Disoccupazione: stesse regole per frontalieri e residenti in Ticino',
     ogDescription: 'Nuove norme per la disoccupazione in Ticino: frontalieri e residenti ora hanno gli stessi diritti e obblighi. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/disoccupazione-frontalieri-residenti',
+    canonicalPath: '/articoli-frontaliere/disoccupazione-frontalieri-residenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35141,7 +35141,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, opportunità, lavoro, insegnanti, canton',
     ogTitle: 'Opportunità di lavoro per insegnanti nel Canton Ticino',
     ogDescription: 'Scopri le nuove opportunità di lavoro per insegnanti nel Canton Ticino e come i frontalieri possono approfittarne',
-    canonicalPath: '/articoli-frontaliere/lavoro-insegnanti-ticino-opportunita',
+    canonicalPath: '/articoli-frontaliere/lavoro-insegnanti-ticino-opportunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35180,7 +35180,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, utili, fatturato, analisi, dettagliata',
     ogTitle: 'Utili e fatturato LPP S.A. – GPW:LPP',
     ogDescription: 'Analisi dettagliata degli utili e del fatturato di LPP S.A. e il suo impatto sui frontalieri del Ticino',
-    canonicalPath: '/articoli-frontaliere/utilifatturatolppsa-gpw',
+    canonicalPath: '/articoli-frontaliere/utilifatturatolppsa-gpw/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35219,7 +35219,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, questore, bimbo, caduto, pilastro',
     ogTitle: 'Questore su bimbo caduto dal Pilastro: responsabilità da valutare',
     ogDescription: 'Il questore di Bologna commenta l\'incidente al Pilastro, ribadendo che le responsabilità saranno valutate dall\'autorità giudiziaria.',
-    canonicalPath: '/articoli-frontaliere/questore-bimbo-pilastro-responsabilita',
+    canonicalPath: '/articoli-frontaliere/questore-bimbo-pilastro-responsabilita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35258,7 +35258,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tasse, confermato, regime, attuale',
     ogTitle: 'Tasse frontalieri Ticino: confermato il regime attuale',
     ogDescription: 'Nessun cambiamento per i frontalieri \'vecchi\' in Ticino. Ecco cosa sapere sulle tasse e i ristorni',
-    canonicalPath: '/articoli-frontaliere/tasse-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/tasse-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35297,7 +35297,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, professioni, sanitarie, lamal, decisioni',
     ogTitle: 'Professioni sanitarie e LaMal: decisioni del Canton Ticino',
     ogDescription: 'Il Canton Ticino ha preso decisioni importanti riguardo l\'accesso alla LaMal per i professionisti sanitari frontalieri. Scopri le implicazioni e le nuove',
-    canonicalPath: '/articoli-frontaliere/professioni-sanitarie-lamal-cantone-ticino',
+    canonicalPath: '/articoli-frontaliere/professioni-sanitarie-lamal-cantone-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35336,7 +35336,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lamal, verso, rilevazione, unica',
     ogTitle: 'LAMal: rilevazione unica dati in Ticino',
     ogDescription: 'Nuova procedura per la raccolta dei dati assicurativi in Ticino. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/lamal-rilevazione-dati-unica-ticino',
+    canonicalPath: '/articoli-frontaliere/lamal-rilevazione-dati-unica-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35375,7 +35375,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nigri, diventa, country, manager',
     ogTitle: 'LPP: Nigri Country Manager Italia',
     ogDescription: 'LPP nomina Nigri Country Manager per l\'Italia, puntando sul value-for-money di Sinsay retail&food. Opportunità per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/lpp-nigri-country-manager-italia',
+    canonicalPath: '/articoli-frontaliere/lpp-nigri-country-manager-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35414,7 +35414,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stipendi, aumento, inflazione, erode',
     ogTitle: 'Stipendi frontalieri in aumento, ma l\'inflazione li erode',
     ogDescription: 'Aumento degli stipendi per i frontalieri, ma l\'inflazione potrebbe annullare i benefici. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/stipendi-frontalieri-inflazione-ticino',
+    canonicalPath: '/articoli-frontaliere/stipendi-frontalieri-inflazione-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35453,7 +35453,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, successione, confronto, ocse',
     ogTitle: 'Tassa successione Svizzera: confronto OCSE',
     ogDescription: 'La tassa sulla successione in Svizzera non è così leggera rispetto al resto dell\'OCSE. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/tassa-successione-svizzera-ocse',
+    canonicalPath: '/articoli-frontaliere/tassa-successione-svizzera-ocse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35492,7 +35492,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumento, salariale, personale, domestico',
     ogTitle: 'Aumento salariale per il personale domestico in Ticino',
     ogDescription: 'Scopri come l\'aumento del salario orario per il personale domestico in Ticino influenzerà i frontalieri e cosa fare per prepararsi.',
-    canonicalPath: '/articoli-frontaliere/salario-domestico-ticino-aumento',
+    canonicalPath: '/articoli-frontaliere/salario-domestico-ticino-aumento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35531,7 +35531,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensione, inps, oltre, pratica',
     ogTitle: 'Frontaliere pensione AVS/INPS 2026: oltre 20 km',
     ogDescription: 'Guida pratica per frontalieri Ticino: coordinamento pensioni AVS/INPS, finestre temporali e pianificazione per distanze oltre 20 km',
-    canonicalPath: '/articoli-frontaliere/frontaliere-pensione-avs-inps-2026',
+    canonicalPath: '/articoli-frontaliere/frontaliere-pensione-avs-inps-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35570,7 +35570,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, quanto, costa, vivere, lugano',
     ogTitle: 'Quanto costa vivere a Lugano da frontaliere',
     ogDescription: 'Analisi dettagliata dei costi reali per un frontaliere che valuta il trasferimento a Lugano: affitto, trasporti, assicurazione e spesa alimentare.',
-    canonicalPath: '/articoli-frontaliere/costo-vivere-lugano-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/costo-vivere-lugano-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35609,7 +35609,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lamal, confronto, analisi, dettagliata',
     ogTitle: 'LAMal o CMI frontalieri: quale conviene nel 2026?',
     ogDescription: 'Confronto aggiornato LAMal vs CMI per frontalieri Ticino. Premi, coperture e franchigie 2026. Esempi pratici per famiglie e single.',
-    canonicalPath: '/articoli-frontaliere/lamal-cmi-frontalieri-conviene-2026',
+    canonicalPath: '/articoli-frontaliere/lamal-cmi-frontalieri-conviene-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35648,7 +35648,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcolo, pensione, italiana, funziona',
     ogTitle: 'Calcolo pensione frontaliere AVS italiana: come funziona',
     ogDescription: 'Guida pratica per frontalieri Ticino: contributi AVS svizzeri, INPS italiana, totalizzazione e tempistiche per la pensione.',
-    canonicalPath: '/articoli-frontaliere/calcolo-pensione-frontaliere-avs-italiana',
+    canonicalPath: '/articoli-frontaliere/calcolo-pensione-frontaliere-avs-italiana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35687,7 +35687,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costo, auto, pendolare, benzina',
     ogTitle: 'Costo auto pendolare frontalieri Ticino: benzina, vignette, parcheggio e usura',
     ogDescription: 'Analisi dettagliata dei costi per chi lavora in Ticino e usa l\'auto per pendolare: benzina, vignette, parcheggio, usura e confronto con treno e bus.',
-    canonicalPath: '/articoli-frontaliere/costo-auto-pendolare-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/costo-auto-pendolare-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35726,7 +35726,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dichiarazione, andreoli, marino, suscitato',
     ogTitle: 'Dichiarazione Andreoli San Marino RTV',
     ogDescription: 'La dichiarazione di Andreoli su San Marino RTV ha suscitato interesse tra i frontalieri. Scopri le implicazioni pratiche.',
-    canonicalPath: '/articoli-frontaliere/dichiarazione-andreoli-san-marino-rtv',
+    canonicalPath: '/articoli-frontaliere/dichiarazione-andreoli-san-marino-rtv/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35765,7 +35765,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calo, potere, acquisto, lamal',
     ogTitle: 'Calo potere d\'acquisto e LAMal: contromisure per il Ticino',
     ogDescription: 'La Regione Ticino annuncia contromisure per contrastare il calo del potere d\'acquisto e supportare LAMal, l\'iniziativa per la rilevazione dati unica.',
-    canonicalPath: '/articoli-frontaliere/calo-potere-acquisto-lamal-contromisure-ticino',
+    canonicalPath: '/articoli-frontaliere/calo-potere-acquisto-lamal-contromisure-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35804,7 +35804,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, temporali, grandine, luganese, allerta',
     ogTitle: 'Temporali e grandine nel Luganese: allerta livello 3',
     ogDescription: 'MeteoSvizzera ha diramato un\'allerta maltempo livello 3 per il Luganese e il Bellinzonese. Grandine a Capriasca, rischio frane e allagamenti',
-    canonicalPath: '/articoli-frontaliere/temporali-grandine-luganese-11-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/temporali-grandine-luganese-11-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35843,7 +35843,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, direttrice, unispital, zurigo, ringrazia',
     ogTitle: 'Direttrice Unispital Zurigo ringrazia il whistleblower licenziato',
     ogDescription: 'Monika Jänicke, direttrice dell\'USZ, esprime gratitudine verso l\'ex cardiochirurgo che ha denunciato irregolarità nella clinica di cardiochirurgia.',
-    canonicalPath: '/articoli-frontaliere/direttrice-unispital-zurigo-whistleblower',
+    canonicalPath: '/articoli-frontaliere/direttrice-unispital-zurigo-whistleblower/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35882,7 +35882,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, allerta, meteo, temporali, grandine',
     ogTitle: 'Allerta meteo per temporali e grandine',
     ogDescription: 'Allerta meteo nel varesotto: cosa fare per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/temporali-grandine-varesotto-allerta-meteo',
+    canonicalPath: '/articoli-frontaliere/temporali-grandine-varesotto-allerta-meteo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35921,7 +35921,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, orchestra, nove, concerti, lugano',
     ogTitle: 'Orchestra Le Nove: concerti a Lugano e Bellinzona a maggio',
     ogDescription: 'L\'Orchestra Le Nove porta Tchaikovsky a Lugano e Bellinzona il 16 e 18 maggio 2026. Dettagli su date, sedi e programma.',
-    canonicalPath: '/articoli-frontaliere/orchestra-le-nove-lugano-bellinzona',
+    canonicalPath: '/articoli-frontaliere/orchestra-le-nove-lugano-bellinzona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35960,7 +35960,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, destra, accanisce, critica',
     ogTitle: 'Luino, il Pd: «La destra si accanisce sui frontalieri». Bianchi replica a Sertori',
     ogDescription: 'Il Pd critica le politiche fiscali e sanitarie del centrodestra per i frontalieri. Il sindaco di Luino Enrico Bianchi replica alle parole dell’assessore',
-    canonicalPath: '/articoli-frontaliere/luino-pd-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/luino-pd-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35999,7 +35999,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stop, alla, tassa, salute',
     ogTitle: 'Frontalieri: stop alla tassa salute. Licata difende i lavoratori storici',
     ogDescription: 'La battaglia contro la tassa sanitaria per i frontalieri pre-2026. Licata chiede un tavolo nazionale e fondi per la sanità di confine.',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-licata-2026',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-licata-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36038,7 +36038,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, esseri, umani, valico',
     ogTitle: 'Allerta frontalieri: controlli intensificati al valico di Tresa dopo traffici illeciti',
     ogDescription: 'Smantellata rete criminale curdo-turca. Rischio code e controlli severi per chi lavora in Ticino. Misure di sicurezza e diritti dei frontalieri.',
-    canonicalPath: '/articoli-frontaliere/traffico-umani-valico-tresa-impatto-frontalieri',
+    canonicalPath: '/articoli-frontaliere/traffico-umani-valico-tresa-impatto-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36077,7 +36077,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziative, cassa, malati, date',
     ogTitle: 'Ticino: date implementazione iniziative cassa malati 2026',
     ogDescription: 'A giugno il Gran Consiglio decide le tempistiche. Impatti per i frontalieri su assicurazione, costi e controlli ai valichi.',
-    canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36116,7 +36116,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, tasse, salate, shock',
     ogTitle: 'Tasse frontalieri Ticino',
     ogDescription: 'Informazioni sulle tasse per i frontalieri in Ticino e come gestirle.',
-    canonicalPath: '/articoli-frontaliere/nuovi-frontalieri-tasse-salate',
+    canonicalPath: '/articoli-frontaliere/nuovi-frontalieri-tasse-salate/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36155,7 +36155,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, disoccupazione, pressioni, dalla',
     ogTitle: 'Riforma disoccupazione frontalieri, pressioni dalla Francia sulla Svizzera',
     ogDescription: 'Il ministro francese del lavoro, Jean-Pierre Farandou, intende fare pressione sulla Svizzera per applicare il nuovo accordo europeo sulle indennità di',
-    canonicalPath: '/articoli-frontaliere/riforma-disoccupazione-frontalieri-francia-svizzera',
+    canonicalPath: '/articoli-frontaliere/riforma-disoccupazione-frontalieri-francia-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36194,7 +36194,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, artoni, chiede, abolizione',
     ogTitle: 'Luino: Artoni chiede l\'abolizione della tassa sulla salute per i frontalieri',
     ogDescription: 'Il candidato sindaco Furio Artoni denuncia la doppia imposizione sui lavoratori frontalieri e chiede l\'abolizione della tassa sulla salute.',
-    canonicalPath: '/articoli-frontaliere/abolire-tassa-salute-frontalieri',
+    canonicalPath: '/articoli-frontaliere/abolire-tassa-salute-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36233,7 +36233,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, caos, luino',
     ogTitle: 'Tassa salute frontalieri: caos tra Luino e Verbania',
     ogDescription: 'Il Pd denuncia disparità tra lavoratori frontalieri di Luino e Verbania, con possibili ricorsi sindacali e dubbi di costituzionalità.',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-luino-verbania',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-luino-verbania/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36272,7 +36272,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blocco, ristorni, ticino-italia, cosa',
     ogTitle: 'Blocco ristorni Ticino-Italia: cosa cambia per i frontalieri',
     ogDescription: 'Il Canton Ticino minaccia di bloccare i ristorni ai comuni italiani a causa della nuova tassa sulla salute per i frontalieri. Scopri cosa cambia.',
-    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-italia-2026',
+    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-italia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36311,7 +36311,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rischio, pagamenti, doppi, nuova',
     ogTitle: 'Scontro Svizzera-Italia su assegni familiari: rischio pagamenti doppi per i frontalieri',
     ogDescription: 'Nuova diatriba tra Svizzera e Italia sugli assegni familiari dei frontalieri. Il Consiglio federale esclude la sospensione dei versamenti.',
-    canonicalPath: '/articoli-frontaliere/assegni-familiari-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/assegni-familiari-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36350,7 +36350,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blocco, ristorni, lega, ticinesi',
     ogTitle: 'Blocco ristorni: Lega Ticinesi propone fondo sanità per frontalieri',
     ogDescription: 'La Lega dei Ticinesi propone di bloccare i ristorni per finanziare un fondo di emergenza sanità per i residenti del Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36389,7 +36389,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blocco, ristorni, politica, ticinese',
     ogTitle: 'Blocco ristorni: la politica ticinese è possibilista',
     ogDescription: 'Il Consiglio di Stato ha tempo fino a fine giugno per decidere se trattenere i 120 milioni di imposta alla fonte dei frontalieri',
-    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-politica-2026',
+    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-politica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36428,7 +36428,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, blocco, ristorni',
     ogTitle: 'Tassa salute frontalieri: blocco ristorni, cosa cambia',
     ogDescription: 'Il governo ticinese valuta il blocco dei ristorni all\'Italia. Ecco cosa sappiamo e come potrebbe influire sui frontalieri.',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36467,7 +36467,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, documenti, necessari, iniziare, lavorare',
     ogTitle: 'Documenti necessari per iniziare a lavorare in Svizzera: la checklist completa',
     ogDescription: 'Scopri tutti i documenti necessari per iniziare a lavorare in Svizzera come frontaliere: permesso G, contratto, assicurazione e molto altro.',
-    canonicalPath: '/articoli-frontaliere/documenti-frontalieri-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/documenti-frontalieri-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36506,7 +36506,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, contro, depressione, rimborsata, dalla',
     ogTitle: 'App contro la depressione rimborsata dalla cassa malati: ecco come funziona',
     ogDescription: 'Dal primo luglio 2026, l\'app Deprexis sarà rimborsata dalle casse malati svizzere. Ecco cosa cambia per i frontalieri del Ticino',
-    canonicalPath: '/articoli-frontaliere/app-depressione-cassa-malati-2026',
+    canonicalPath: '/articoli-frontaliere/app-depressione-cassa-malati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36545,7 +36545,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensione, senza, intermediario, soggetta',
     ogTitle: 'Pensione LPP: senza intermediario è soggetta a tassazione separata',
     ogDescription: 'Scopri come la tassazione separata della pensione LPP senza intermediario impatta i frontalieri Ticino. Guida pratica 2026.',
-    canonicalPath: '/articoli-frontaliere/pensione-lpp-tassazione-senza-intermediario',
+    canonicalPath: '/articoli-frontaliere/pensione-lpp-tassazione-senza-intermediario/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36584,7 +36584,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premi, cassa, malati, intesa',
     ogTitle: 'Premi di cassa malati: intesa politica per applicare le iniziative',
     ogDescription: 'La commissione parlamentare decide di applicare le iniziative sui premi di cassa malati senza attendere la definizione delle coperture finanziarie',
-    canonicalPath: '/articoli-frontaliere/premi-cassa-malati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/premi-cassa-malati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36623,7 +36623,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, dell, ascensione, chiusa',
     ogTitle: 'Festa dell\'Ascensione in Svizzera: chiusa la dogana di Brogeda e modifiche alla viabilità sulla A9',
     ogDescription: 'Modifiche alla viabilità sulla A9 e chiusura della dogana di Brogeda per la Festa dell\'Ascensione in Svizzera. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/ascensione-svizzera-viabilit-2026',
+    canonicalPath: '/articoli-frontaliere/ascensione-svizzera-viabilit-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36662,7 +36662,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, astuti, nessun, vero, confronto',
     ogTitle: 'Frontalieri, Astuti: “Nessun vero confronto sui territori”',
     ogDescription: 'Il consigliere regionale del PD Samuele Astuti critica la gestione della tassa sanitaria per i frontalieri e l\'incertezza nei rapporti con la Svizzera.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-astuti-confronto-territori',
+    canonicalPath: '/articoli-frontaliere/frontalieri-astuti-confronto-territori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36701,7 +36701,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, confronto, corso',
     ogTitle: 'Tassa salute frontalieri: confronto in corso tra Forza Italia e PD',
     ogDescription: 'Il consigliere regionale del PD Samuele Astuti è disponibile a discutere con Forza Italia sulla tassa salute dei frontalieri',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-confronto-2026',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-confronto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36740,7 +36740,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ascensione, traffico, paralizzato, gottardo',
     ogTitle: 'Ascensione: traffico paralizzato dal Gottardo a Chiasso',
     ogDescription: 'Code di 8 km al San Gottardo e oltre un\'ora di attesa sull\'A2 verso Chiasso. Le autorità consigliano alternative per alleggerire il traffico.',
-    canonicalPath: '/articoli-frontaliere/ascensione-traffico-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ascensione-traffico-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36779,7 +36779,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spese, casa, trovare, equilibrio',
     ogTitle: 'Frontalieri: spese in Svizzera e casa in Italia, come trovare l\'equilibrio',
     ogDescription: 'Guida pratica per i frontalieri che lavorano in Svizzera e vivono in Italia: come gestire al meglio le spese tra i due Paesi dopo il nuovo accordo fiscale',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-spese-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-spese-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36818,7 +36818,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, città, laghi, innovazione, sostenibilità',
     ogTitle: 'Città dei Laghi: innovazione e sostenibilità transfrontaliera',
     ogDescription: 'Sei classi premiate per progetti su sviluppo sostenibile e mobilità transfrontaliera nella \'Città dei Laghi\' insubrica.',
-    canonicalPath: '/articoli-frontaliere/citta-laghi-innovativa-transfrontaliera',
+    canonicalPath: '/articoli-frontaliere/citta-laghi-innovativa-transfrontaliera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36857,7 +36857,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, combattiamo, mostruosità, premi, cassa',
     ogTitle: 'Combattiamo mostruosità come i premi di cassa malati',
     ogDescription: 'Giuseppe Sergi, coordinatore del Movimento per il socialismo, parla di premi di cassa malati e condizioni dei frontalieri',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-premi-cassa-malati',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-premi-cassa-malati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36896,7 +36896,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzero, multato, abbandono, rifiuti',
     ogTitle: 'Frontaliere svizzero multato per abbandono di rifiuti in Italia',
     ogDescription: 'Un cittadino svizzero è stato multato per aver abbandonato rifiuti in un paese italiano di confine. Scopri i dettagli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/frontaliere-immondizia-cantello-multa',
+    canonicalPath: '/articoli-frontaliere/frontaliere-immondizia-cantello-multa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36935,7 +36935,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cooperazione, materia, fiscale, direttiva',
     ogTitle: 'Cooperazione in materia fiscale. Direttiva Dac9 al traguardo',
     ogDescription: 'La Direttiva Dac9 entrerà in vigore nel 2026, rafforzando la cooperazione fiscale tra Svizzera e Italia. Scopri come cambia la fiscalità per i frontalieri del',
-    canonicalPath: '/articoli-frontaliere/cooperazione-fiscale-dac9-traguardo',
+    canonicalPath: '/articoli-frontaliere/cooperazione-fiscale-dac9-traguardo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36974,7 +36974,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, equipara, residenti, lavoratori',
     ogTitle: 'Disoccupazione frontalieri: l\'UE equipara residenti e lavoratori svizzeri',
     ogDescription: 'Nuove regole UE per i sussidi di disoccupazione: il Paese di lavoro paga, non quello di residenza. Cosa cambia per i frontalieri Ticino-Italia.',
-    canonicalPath: '/articoli-frontaliere/disoccupazione-frontalieri-ue-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/disoccupazione-frontalieri-ue-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37013,7 +37013,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, multato, dell, immondizia, cantello',
     ogTitle: 'Multato un frontaliere dell\'immondizia a Cantello',
     ogDescription: 'Un cittadino svizzero è stato sanzionato per aver abbandonato rifiuti in Italia. Aumentano le segnalazioni di frontalieri che scaricano immondizia oltreconfine.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-immondizia-cantello-multa',
+    canonicalPath: '/articoli-frontaliere/frontalieri-immondizia-cantello-multa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37052,7 +37052,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dirigenza, annuncia, cambiamenti, deposito',
     ogTitle: 'FFS in Ticino: dirigenza annuncia cambiamenti, deposito di Chiasso resta aperto',
     ogDescription: 'La dirigenza delle FFS scenderà in Ticino il 19 maggio per annunciare nuovi tagli e cambiamenti nella gestione del trasporto merci. Il deposito di Chiasso non',
-    canonicalPath: '/articoli-frontaliere/ffs-dirigenza-ticino-deposito-chiasso',
+    canonicalPath: '/articoli-frontaliere/ffs-dirigenza-ticino-deposito-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37091,7 +37091,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, documenti, necessari, checklist, completa',
     ogTitle: 'Documenti necessari per frontalieri',
     ogDescription: 'Checklist completa per iniziare a lavorare in Svizzera come frontaliere',
-    canonicalPath: '/articoli-frontaliere/documenti-necessari-frontaliere',
+    canonicalPath: '/articoli-frontaliere/documenti-necessari-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37130,7 +37130,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, parigi, pressione, berna',
     ogTitle: 'Disoccupazione frontalieri, Parigi fa pressione su Berna',
     ogDescription: 'La Francia esercita pressione sulla Svizzera per l\'applicazione del nuovo accordo europeo sulle indennità di disoccupazione dei frontalieri.',
-    canonicalPath: '/articoli-frontaliere/disoccupazione-frontalieri-parigi-berna',
+    canonicalPath: '/articoli-frontaliere/disoccupazione-frontalieri-parigi-berna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37169,7 +37169,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, paradosso, tassa, salute, disparità',
     ogTitle: 'Tassa Salute Frontalieri: Il Paradosso al Confine',
     ogDescription: 'La tassa salute applicata in modo differente in regioni adiacenti: come si riflette sui frontalieri?',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-paradosso-luino-verbania',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-paradosso-luino-verbania/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37208,7 +37208,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cargo, conferma, attività, chiasso',
     ogTitle: 'FFS Cargo conferma sede a Chiasso e riorganizza personale',
     ogDescription: 'FFS Cargo resterà a Chiasso con modifiche al personale e possibile chiusura posticipata al 2027.',
-    canonicalPath: '/articoli-frontaliere/ffs-cargo-chiasso-personale-2026',
+    canonicalPath: '/articoli-frontaliere/ffs-cargo-chiasso-personale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37247,7 +37247,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, permessi, errori, comuni, cambiarne',
     ogTitle: 'Permessi G e B per i frontalieri: errori comuni e come cambiarne status',
     ogDescription: 'I frontalieri devono cambiare status da permesso G a permesso B entro il 2026. Questo cambio di status comporta errori comuni, come la mancata presentazione dei',
-    canonicalPath: '/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-errori-comuni',
+    canonicalPath: '/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-errori-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37286,7 +37286,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confronto, permesso, quando, conviene',
     ogTitle: 'Confronto tra Permesso G e B nel 2026: quando conviene davvero cambiare status?',
     ogDescription: 'Il nuovo accordo fiscale 2026 potrebbe avere un impatto maggiore sui frontalieri che risiedono oltre 20 km dal confine italo-svizzero.',
-    canonicalPath: '/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km',
+    canonicalPath: '/articoli-frontaliere/permesso-g-vs-b-frontalieri-2026-oltre-20-km/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37325,7 +37325,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cambio, alla, dell, ambasciata',
     ogTitle: 'Cambio alla guida dell\'ambasciata italiana in Svizzera',
     ogDescription: 'L\'ambasciatore Gian Lorenzo Cornado lascia la sede diplomatica di Berna a fine giugno 2026 dopo aver gestito la crisi del rogo di Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/cambio-ambasciatore-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/cambio-ambasciatore-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37364,7 +37364,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varesino, salvato, dalla, polizia',
     ogTitle: 'Varesino salvato dalla Polizia di Frontiera di Domodossola',
     ogDescription: 'Un uomo di 57 anni, residente in provincia di Varese, è stato salvato dalla Polizia di Frontiera di Domodossola dopo aver manifestato l\'intenzione di togliersi',
-    canonicalPath: '/articoli-frontaliere/varesino-salvato-polizia-frontiera-domodossola',
+    canonicalPath: '/articoli-frontaliere/varesino-salvato-polizia-frontiera-domodossola/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37403,7 +37403,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costo, benzina, perché, pagano',
     ogTitle: 'Costo benzina in Ticino: perché i frontalieri pagano di più',
     ogDescription: 'I prezzi della benzina in Ticino rimangono elevati, con differenze di oltre 20 centesimi al litro tra le diverse zone. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/costo-benzina-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/costo-benzina-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37442,7 +37442,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crédit, agricole, secondo, pilastro',
     ogTitle: 'Crédit Agricole secondo pilastro Italia',
     ogDescription: 'Crédit Agricole rafforza la sua presenza in Italia con il secondo pilastro della sua strategia. Scopri cosa significa per i frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/credit-agricole-second-pilastro-italia',
+    canonicalPath: '/articoli-frontaliere/credit-agricole-second-pilastro-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37481,7 +37481,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, mobilitazione, contro, tagli',
     ogTitle: 'Tagli al deposito FFS Cargo Chiasso: assemblea e mobilitazione',
     ogDescription: 'Deposito macchinisti FFS Cargo Chiasso: annunciati ulteriori tagli, assemblea pubblica e mobilitazione.',
-    canonicalPath: '/articoli-frontaliere/mobilitazione-deposito-macchinisti-chiasso',
+    canonicalPath: '/articoli-frontaliere/mobilitazione-deposito-macchinisti-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37520,7 +37520,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, checklist, documenti, lavorare, scopri',
     ogTitle: 'Documenti necessari per lavorare in Svizzera | Frontaliere Ticino',
     ogDescription: 'Scopri quali documenti sono necessari per lavorare in Svizzera come frontaliere e come ottenerli',
-    canonicalPath: '/articoli-frontaliere/frontaliere-documenti-necessari-inizio-lavoro-svizzera',
+    canonicalPath: '/articoli-frontaliere/frontaliere-documenti-necessari-inizio-lavoro-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37559,7 +37559,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petizione, contro, tagli, supsi',
     ogTitle: 'Petizione contro i tagli a USI e SUPSI',
     ogDescription: 'La petizione si oppone ai risparmi proposti dal Consiglio di Stato per finanziare le due iniziative sulle casse malati.',
-    canonicalPath: '/articoli-frontaliere/petizione-usi-supsi-500-firme',
+    canonicalPath: '/articoli-frontaliere/petizione-usi-supsi-500-firme/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37598,7 +37598,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libera, circolazione, ue-svizzera, effetti',
     ogTitle: 'Libera circolazione UE-Svizzera: effetti sull\'economia elvetica',
     ogDescription: 'Scopri gli effetti della libera circolazione UE-Svizzera sull\'economia elvetica e le implicazioni per i frontalieri. Leggi ora!',
-    canonicalPath: '/articoli-frontaliere/libera-circolazione-ue-svizzera-impatti',
+    canonicalPath: '/articoli-frontaliere/libera-circolazione-ue-svizzera-impatti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37637,7 +37637,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, milioni, torna, alla',
     ogTitle: 'Iniziativa 10 milioni: la situazione è insostenibile o è la solita battaglia dell\'UDC?',
     ogDescription: 'Traffico, penuria di alloggi, cementificazione e criminalità alle stelle. L\'iniziativa \'No a una Svizzera da 10 milioni!\' sarà votata il 14 giugno. Scopri di',
-    canonicalPath: '/articoli-frontaliere/iniziativa-10-milioni-votazione-14-giugno',
+    canonicalPath: '/articoli-frontaliere/iniziativa-10-milioni-votazione-14-giugno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37676,7 +37676,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, terza, mondo, negli, investimenti',
     ogTitle: 'Svizzera terza al mondo negli investimenti aziendali nella ricerca',
     ogDescription: 'La Svizzera si conferma ai vertici mondiali per l\'innovazione con il terzo posto per intensità di ricerca e sviluppo.',
-    canonicalPath: '/articoli-frontaliere/svizzera-investimenti-ricerca-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-investimenti-ricerca-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37715,7 +37715,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantonale, interna, ascona, porto',
     ogTitle: 'Cantonale \'interna\' da Ascona a Porto Ronco, lavori (e disagi) in vista | Frontaliere Ticino',
     ogDescription: 'Iniziati i lavori per la nuova strada cantonale \'interna\' da Ascona a Porto Ronco. I frontalieri potrebbero riscontrare disagi nella viabilità.',
-    canonicalPath: '/articoli-frontaliere/cantonale-interna-ascona-porto-ronco-lavori-disagi-vista',
+    canonicalPath: '/articoli-frontaliere/cantonale-interna-ascona-porto-ronco-lavori-disagi-vista/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37754,7 +37754,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, migranti, varese, operazione',
     ogTitle: 'Traffico di migranti tra Varese e il Ticino | Frontaliere Ticino',
     ogDescription: 'Operazione congiunta tra Italia e Svizzera porta all\'arresto di otto persone accusate di gestire un\'associazione criminale che favoriva l\'immigrazione',
-    canonicalPath: '/articoli-frontaliere/traffico-migranti-tra-varese-e-il-ticino',
+    canonicalPath: '/articoli-frontaliere/traffico-migranti-tra-varese-e-il-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37793,7 +37793,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, molestie, lavoro, oltre, alle',
     ogTitle: 'Molestie sul lavoro: oltre alle segnalazioni servono strumenti nelle aziende',
     ogDescription: 'Il caso dell\'Ospedale Civico di Lugano ha evidenziato la necessità di canali sicuri e formazione regolare per prevenire e gestire le molestie sul lavoro.',
-    canonicalPath: '/articoli-frontaliere/molestie-sul-lavoro-oltre-alle-segnalazioni',
+    canonicalPath: '/articoli-frontaliere/molestie-sul-lavoro-oltre-alle-segnalazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37832,7 +37832,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, sulla, disoccupazione, gobbi',
     ogTitle: 'Riforma sulla disoccupazione dei frontalieri: Gobbi Stoppa derive pericolose',
     ogDescription: 'Il consigliere di Stato Norman Gobbi ha invitato il Consiglio federale a tutelare gli interessi del nostro Paese per non pagare un conto salatissimo. La riforma',
-    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-ue-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-ue-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37871,7 +37871,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assemblea, generale, novembre, marino',
     ogTitle: 'Frontalieri: assemblea generale il 26 novembre - San Marino Rtv',
     ogDescription: 'L\'assemblea generale dei frontalieri si terrà il 26 novembre, come annunciato da San Marino Rtv.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-assemblea-generale-2023',
+    canonicalPath: '/articoli-frontaliere/frontalieri-assemblea-generale-2023/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37910,7 +37910,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pasta, quanto, pesa, produce',
     ogTitle: 'Pasta: l\'Italia al top, ma quanto pesa la Svizzera? | Frontaliere Ticino',
     ogDescription: 'La Svizzera produce circa 40\'000 tonnellate di pasta all\'anno, ma rappresenta solo una piccola parte del mercato mondiale della pasta. Scopri le sfide per i',
-    canonicalPath: '/articoli-frontaliere/pasta-svizzera-italia-2026',
+    canonicalPath: '/articoli-frontaliere/pasta-svizzera-italia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37949,7 +37949,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, code, solo, autostrada, rientro',
     ogTitle: 'Code, e non solo in autostrada | Frontaliere Ticino',
     ogDescription: 'Rientro difficile dopo il ponte dell\'Ascensione: disagi sull\'A2 in direzione nord e traffico intenso anche sulle strade cantonali. Scopri le cause e come',
-    canonicalPath: '/articoli-frontaliere/code-e-non-solo-in-autostrada',
+    canonicalPath: '/articoli-frontaliere/code-e-non-solo-in-autostrada/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -37988,7 +37988,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ascensione, aumento, traffico, rientro',
     ogTitle: 'Ascensione, in aumento il traffico del rientro in Ticino',
     ogDescription: 'Il rientro dal lungo ponte dell\'Ascensione sta entrando nel vivo, soprattutto per quanto concerne il traffico sulla A2, direzione Nord.',
-    canonicalPath: '/articoli-frontaliere/traffico-rientro-ascensione-ticino',
+    canonicalPath: '/articoli-frontaliere/traffico-rientro-ascensione-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38027,7 +38027,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, verso, nuovi, tagli, cosa',
     ogTitle: 'FFS verso nuovi tagli in Ticino: cosa cambia per i frontalieri',
     ogDescription: 'Le Ferrovie federali svizzere annunciano nuovi tagli di posti di lavoro in Ticino, sollevando preoccupazioni tra i lavoratori e le autorità locali',
-    canonicalPath: '/articoli-frontaliere/ffs-tagli-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/ffs-tagli-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38066,7 +38066,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, terapia, complementare, attestati, cantonali',
     ogTitle: 'Terapia complementare: 16 attestati cantonali a Lugano',
     ogDescription: '16 partecipanti hanno ottenuto l’attestato cantonale Tronco comune OmL Terapia complementare al CPS di Lugano',
-    canonicalPath: '/articoli-frontaliere/terapia-complementare-attestati-lugano',
+    canonicalPath: '/articoli-frontaliere/terapia-complementare-attestati-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38105,7 +38105,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, blocco, ristorni, rosa, dice',
     ogTitle: 'Blocco dei ristorni. De Rosa si dice aperto a valutare',
     ogDescription: 'Il direttore del DSS Raffaele De Rosa si dice aperto a valutare l\'opzione di un blocco o di una decurtazione dei ristorni.',
-    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-de-rosa-aperto-a-valutare',
+    canonicalPath: '/articoli-frontaliere/blocco-ristorni-ticino-de-rosa-aperto-a-valutare/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38144,7 +38144,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giovani, assistenza, sociale, lugano',
     ogTitle: 'Giovani e assistenza sociale a Lugano: i dati preoccupanti',
     ogDescription: 'Il consigliere comunale Omar Wicht solleva preoccupazioni sui giovani beneficiari di assistenza sociale a Lugano, con dati allarmanti da Locarno',
-    canonicalPath: '/articoli-frontaliere/giovani-assistenza-lugano-preoccupazione',
+    canonicalPath: '/articoli-frontaliere/giovani-assistenza-lugano-preoccupazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38183,7 +38183,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, statuto, centrale, permesso, direttori',
     ogTitle: 'Statuto S: no della Svizzera centrale a permesso B',
     ogDescription: 'La Svizzera centrale si oppone alla trasformazione dello statuto S in permesso B, con impatti sui costi sociali per frontaliere e Cantoni.',
-    canonicalPath: '/articoli-frontaliere/statuto-svizzera-centrale-permesso-b',
+    canonicalPath: '/articoli-frontaliere/statuto-svizzera-centrale-permesso-b/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38222,7 +38222,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassis, blocco, ristorni, reazione',
     ogTitle: 'Cassis: ‘Blocco ristorni dal Ticino? La reazione più pesante sarebbe con Berna’',
     ogDescription: 'Il Consiglio di Stato del Cantone Ticino si riunisce per discutere la proposta di bloccare i ristorni dal Ticino, con possibili implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/cassis-blocco-ristorni-ticino-la-reazione-piu-pesante-sarebbe-con-berna',
+    canonicalPath: '/articoli-frontaliere/cassis-blocco-ristorni-ticino-la-reazione-piu-pesante-sarebbe-con-berna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38261,7 +38261,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumento, premi, lamal, assicuratore',
     ogTitle: 'Aumento premi LAMal: assicuratore deve mostrare contabilità',
     ogDescription: 'L\'aumento dei premi LAMal richiede agli assicuratori di dimostrare la loro contabilità.',
-    canonicalPath: '/articoli-frontaliere/aumento-premi-lamal-assicuratore-deve-mostrare-contabilita',
+    canonicalPath: '/articoli-frontaliere/aumento-premi-lamal-assicuratore-deve-mostrare-contabilita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38300,7 +38300,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, economia, registrato, buon, inizio',
     ogTitle: 'L\'economia svizzera ha registrato un buon inizio di anno',
     ogDescription: 'L\'economia svizzera ha mostrato una crescita inaspettata dello 0,5% nel primo trimestre 2026, superando le previsioni degli esperti nonostante le incertezze',
-    canonicalPath: '/articoli-frontaliere/svizzera-economia-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-economia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38339,7 +38339,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disagi, arrivo, lavori, autostradali',
     ogTitle: 'Inizia un\'altra settimana di disagi per i lavori autostradali alle barriere antirumore sull\'Autolaghi',
     ogDescription: 'Chiusure notturne sulla A8 Milano-Varese per lavori di riqualifica delle barriere antirumore. Deviazioni e alternative per i pendolari.',
-    canonicalPath: '/articoli-frontaliere/autostrada-chiusure-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/autostrada-chiusure-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38378,7 +38378,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoro, discriminazioni, sondaggio, persone',
     ogTitle: 'Lavoro e discriminazioni, un sondaggio per le persone LGBTQIA+',
     ogDescription: 'UNIA e Imbarco Immediato lanciano un sondaggio per indagare le discriminazioni sul posto di lavoro verso le persone LGBTQIA+. Pubblicato online domenica, il',
-    canonicalPath: '/articoli-frontaliere/lgbtqia-lavoro-sondaggio-unia-imbarco-immediato',
+    canonicalPath: '/articoli-frontaliere/lgbtqia-lavoro-sondaggio-unia-imbarco-immediato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38417,7 +38417,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tensioni, tassa, lombarda, ipotesi',
     ogTitle: 'Tensioni su tassa lombarda e ipotesi blocco ristorni, Cassis in Ticino',
     ogDescription: 'Il Consiglio di Stato del Ticino esprime preoccupazione per le tensioni sulla tassa lombarda e l\'ipotesi di blocco dei ristorni',
-    canonicalPath: '/articoli-frontaliere/tensioni-tassa-lombarda-ipotesi-blocco-ristorni-cassis-ticino',
+    canonicalPath: '/articoli-frontaliere/tensioni-tassa-lombarda-ipotesi-blocco-ristorni-cassis-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38456,7 +38456,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riorganizza, traffico, carri, isolati',
     ogTitle: 'FFS riorganizza il traffico a carri isolati, 40 collaboratori toccati in Ticino',
     ogDescription: 'Le FFS riorganizzano il traffico a carri isolati, con conseguenze per 40 collaboratori in Ticino. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/ffs-riorganizza-traffico-a-carri-isolati-40-collaboratori-toccati-in-ticino',
+    canonicalPath: '/articoli-frontaliere/ffs-riorganizza-traffico-a-carri-isolati-40-collaboratori-toccati-in-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38495,7 +38495,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lega, chiede, garanzie, chiasso',
     ogTitle: 'Riorganizzazione FFS Cargo: la Lega chiede garanzie per Chiasso e i posti di lavoro',
     ogDescription: 'La Lega/UDC/Indipendenti ha presentato un\'interrogazione al Municipio di Chiasso esprimendo forte preoccupazione per il futuro della presenza ferroviaria',
-    canonicalPath: '/articoli-frontaliere/ffs-cargo-chiasso-riorganizzazione',
+    canonicalPath: '/articoli-frontaliere/ffs-cargo-chiasso-riorganizzazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38534,7 +38534,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, securini, sono, consiglio, stato',
     ogTitle: 'Il Ticino ha 1.200 \'securini\', 4 su 10 sono frontalieri',
     ogDescription: 'Il Consiglio di Stato del Ticino ha fornito i dati aggiornati sul numero di agenti di sicurezza privata autorizzati e il loro status di frontalieri. Scopri di',
-    canonicalPath: '/articoli-frontaliere/il-ticino-ha-1200-securini-4-su-10-sono-frontalieri-434090',
+    canonicalPath: '/articoli-frontaliere/il-ticino-ha-1200-securini-4-su-10-sono-frontalieri-434090/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38573,7 +38573,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, doppia, imposizione, preoccupazioni, grigioni',
     ogTitle: 'Doppia imposizione dei frontalieri, le preoccupazioni a sud dei Grigioni',
     ogDescription: 'Le nuove regole fiscali per i frontalieri creano preoccupazione e difficoltà di reclutamento in specifici settori del Grigioni italiano, come l\'edilizia e la',
-    canonicalPath: '/articoli-frontaliere/doppia-imposizione-frontalieri-sud-grigion',
+    canonicalPath: '/articoli-frontaliere/doppia-imposizione-frontalieri-sud-grigion/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38612,7 +38612,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casanova, tanta, pressione, sulle',
     ogTitle: 'Casanova: «C\'è tanta pressione sulle aziende, serve collaborazione»',
     ogDescription: 'Le aziende ticinesi affrontano sfide come geopolitica, dazi e carenza di manodopera. La collaborazione è fondamentale per influenzare le condizioni quadro',
-    canonicalPath: '/articoli-frontaliere/casanova-pressione-aziende',
+    canonicalPath: '/articoli-frontaliere/casanova-pressione-aziende/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38651,7 +38651,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensioni, svizzere, versate, estero',
     ogTitle: 'Le pensioni svizzere versate all’estero sono numerose, ma modeste',
     ogDescription: 'Le pensioni svizzere versate all’estero ammontano a circa 1 miliardo di franchi svizzeri all’anno, ma sono in media piuttosto basse',
-    canonicalPath: '/articoli-frontaliere/pensioni-svizzere-all-estero-numerose-ma-modeste',
+    canonicalPath: '/articoli-frontaliere/pensioni-svizzere-all-estero-numerose-ma-modeste/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38690,7 +38690,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ucraini, permesso, quello, timori',
     ogTitle: 'Ucraini in Svizzera: dal permesso S a quello B, i timori dei cantoni',
     ogDescription: 'Il Cantone del Ticino esprime preoccupazione per il cambiamento di status degli ucraini in Svizzera dal permesso S a quello B. Ecco cosa cambia per i',
-    canonicalPath: '/articoli-frontaliere/ucraini-in-svizzera-permesso-s-b-timori-dei-cantoni',
+    canonicalPath: '/articoli-frontaliere/ucraini-in-svizzera-permesso-s-b-timori-dei-cantoni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38729,7 +38729,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 2027, novità, nuovi, collegamenti',
     ogTitle: 'FFS 2027: novità per i frontalieri del Ticino',
     ogDescription: 'Scopri le novità dell\'orario FFS 2027 che riguardano i frontalieri del Ticino, con nuovi collegamenti e miglioramenti per i pendolari e i turisti.',
-    canonicalPath: '/articoli-frontaliere/ffs-2027-ticino',
+    canonicalPath: '/articoli-frontaliere/ffs-2027-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38768,7 +38768,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fisco, richiami, inviati, errore',
     ogTitle: 'Fisco, richiami inviati per errore a chi ha già dichiarato',
     ogDescription: 'Centinaia di contribuenti ticinesi hanno ricevuto un richiamo dalle autorità cantonali per non aver inviato la dichiarazione d\'imposta entro i termini previsti',
-    canonicalPath: '/articoli-frontaliere/richiami-fiscali-errati-ticino',
+    canonicalPath: '/articoli-frontaliere/richiami-fiscali-errati-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38807,7 +38807,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assegno, inclusione, date, lavorazioni',
     ogTitle: 'Assegno di Inclusione, ricarica ordinaria maggio 2026: date lavorazioni e pagamenti di fine mese',
     ogDescription: 'Le lavorazioni e la ricarica ordinaria dell’Assegno di Inclusione di fine maggio 2026 sono vicine. Scopri le date delle lavorazioni e dei pagamenti e come',
-    canonicalPath: '/articoli-frontaliere/assegno-inclusione-maggio-2026-ricarica-ordinaria',
+    canonicalPath: '/articoli-frontaliere/assegno-inclusione-maggio-2026-ricarica-ordinaria/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38846,7 +38846,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, municipio, aziende, conoscersi, meglio',
     ogTitle: 'Il municipio e le aziende, per conoscersi meglio',
     ogDescription: 'Il municipio di Vezia organizza un evento per rafforzare il dialogo con le realtà aziendali attive sul territorio. L\'incontro ha visto la partecipazione di una',
-    canonicalPath: '/articoli-frontaliere/il-municipio-e-le-aziende-per-conoscersi-meglio',
+    canonicalPath: '/articoli-frontaliere/il-municipio-e-le-aziende-per-conoscersi-meglio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38885,7 +38885,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, orario, lavoro, settimanale, minuti',
     ogTitle: 'Orario di lavoro settimanale in Svizzera: 40 ore e 3 minuti nel 2025',
     ogDescription: 'L\'orario di lavoro settimanale in Svizzera si è mantenuto stabile nel 2025 a 40 ore e 3 minuti, segnando però un forte aumento rispetto al 2020. Scopri le',
-    canonicalPath: '/articoli-frontaliere/orario-lavoro-settimanale-svizzera-2025',
+    canonicalPath: '/articoli-frontaliere/orario-lavoro-settimanale-svizzera-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38924,7 +38924,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, regime, fiscale, approfondimento, focus',
     ogTitle: 'Regime fiscale frontalieri in Svizzera 2026',
     ogDescription: 'Novità fiscali per i frontalieri in Svizzera dal 2026, con focus su aliquote, ristorni e procedure.',
-    canonicalPath: '/articoli-frontaliere/regime-fiscale-frontaliere-svizzera',
+    canonicalPath: '/articoli-frontaliere/regime-fiscale-frontaliere-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -38963,7 +38963,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoro, chiasso, opportunità, scopri',
     ogTitle: 'Lavoro a Chiasso: Opportunità per Frontalieri',
     ogDescription: 'Scopri le opportunità di lavoro a Chiasso per i frontalieri, con dettagli su permessi, fiscalità e vantaggi del lavorare in Ticino.',
-    canonicalPath: '/articoli-frontaliere/lavoro-chiasso-opportunita-frontalieri',
+    canonicalPath: '/articoli-frontaliere/lavoro-chiasso-opportunita-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39002,7 +39002,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, cosa, cambia',
     ogTitle: 'Salario minimo in Ticino: cosa cambia per i frontalieri dal 2029',
     ogDescription: 'Dal 2029 il salario minimo in Ticino salirà a 21,75-22,25 franchi l\'ora. Ecco cosa cambia per i frontalieri e i residenti.',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-frontalieri-2029',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-frontalieri-2029/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39041,7 +39041,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, modifica, lamal, finanziamento, uniforme',
     ogTitle: 'Modifica LAMal: Finanziamento uniforme delle prestazioni',
     ogDescription: 'Scopri le novità sulla modifica LAMal e il finanziamento uniforme delle prestazioni sanitarie in Svizzera, con focus sui frontalieri',
-    canonicalPath: '/articoli-frontaliere/modifica-lamal-finaziamento-uniforme',
+    canonicalPath: '/articoli-frontaliere/modifica-lamal-finaziamento-uniforme/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39080,7 +39080,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcolo, salario, netto, funziona',
     ogTitle: 'Calcolo Salario Netto Svizzera: Come Funziona per i Frontalieri',
     ogDescription: 'Scopri come calcolare il tuo salario netto in Svizzera, con dettagli su imposte, contributi e ristorni per i frontalieri del Ticino.',
-    canonicalPath: '/articoli-frontaliere/calcolo-salario-netto-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/calcolo-salario-netto-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39119,7 +39119,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, documenti, primo, giorno, lavoro',
     ogTitle: 'Documenti per il primo giorno di lavoro in Ticino: checklist 2026',
     ogDescription: 'Scopri quali documenti sono necessari per il tuo primo giorno di lavoro in Ticino nel 2026 e come prepararti al meglio',
-    canonicalPath: '/articoli-frontaliere/documenti-primo-giorno-lavoro-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/documenti-primo-giorno-lavoro-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39158,7 +39158,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, residenza, valutazione, costi, tempi',
     ogTitle: 'Frontalieri: residenza Italia o Svizzera nel 2026',
     ogDescription: 'Valutazione dei costi, tempi di viaggio, sanità e fiscalità per frontalieri oltre 20 km dal confine',
-    canonicalPath: '/articoli-frontaliere/frontaliere-residenza-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/frontaliere-residenza-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39197,7 +39197,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trasporti, chiasso-lugano, pratica, scopri',
     ogTitle: 'Trasporti Chiasso-Lugano: guida pratica per frontalieri',
     ogDescription: 'Scopri come muoverti tra Chiasso e Lugano con treno, auto e abbonamenti. Guida pratica con costi e consigli per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/trasporti-chiasso-lugano-frontalieri',
+    canonicalPath: '/articoli-frontaliere/trasporti-chiasso-lugano-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39236,7 +39236,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trasporti, chiasso-lugano, pratica, chiasso',
     ogTitle: 'Frontalieri: trasporti Chiasso-Lugano 2026',
     ogDescription: 'Guida pratica ai trasporti per i frontalieri tra Chiasso e Lugano, con focus su abbonamenti, costi e simulazione pratica.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-transporti-chiasso-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-transporti-chiasso-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39275,7 +39275,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, figli, agli, asili, nido',
     ogTitle: 'Frontaliere con figli: guida agli asili nido in Svizzera',
     ogDescription: 'Scopri costi, liste d\'attesa e alternative per i frontalieri con figli in Ticino. Guida pratica con dati aggiornati.',
-    canonicalPath: '/articoli-frontaliere/frontaliere-asilo-nido-svizzera',
+    canonicalPath: '/articoli-frontaliere/frontaliere-asilo-nido-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39314,7 +39314,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cambio, euro, franco, conviene',
     ogTitle: 'Frontalieri: cambio euro franco conviene',
     ogDescription: 'Scopri le migliori strategie di cambio CHF-EUR per i frontalieri, le piattaforme di cambio valuta e l\'impatto sullo stipendio',
-    canonicalPath: '/articoli-frontaliere/cambio-euro-franco-frontalieri',
+    canonicalPath: '/articoli-frontaliere/cambio-euro-franco-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39353,7 +39353,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, diritti, maternità, paternità, congedo',
     ogTitle: 'Diritti di maternità e paternità per frontalieri: congedo svizzero vs italiano',
     ogDescription: 'Confronta le indennità giornaliere, come richiedere le prestazioni e casi pratici per neo-genitori frontalieri.',
-    canonicalPath: '/articoli-frontaliere/congedo-parentale-frontalieri-svizzera-italia',
+    canonicalPath: '/articoli-frontaliere/congedo-parentale-frontalieri-svizzera-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39392,7 +39392,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assicurazione, auto, confronto, costi',
     ogTitle: 'Frontaliere: Assicurazione Auto Svizzera vs Italia',
     ogDescription: 'Confronto tra costi, coperture e sinistri per chi lavora in Svizzera e risiede in Italia',
-    canonicalPath: '/articoli-frontaliere/frontaliere-assicurazione-auto-svizzera-italia',
+    canonicalPath: '/articoli-frontaliere/frontaliere-assicurazione-auto-svizzera-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39431,7 +39431,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ottenere, mutuo, casa, pratica',
     ogTitle: 'Frontaliere: come ottenere un mutuo per la casa in Svizzera',
     ogDescription: 'Guida pratica per i frontalieri che vogliono acquistare casa in Svizzera: requisiti, banche e procedure da seguire',
-    canonicalPath: '/articoli-frontaliere/frontaliere-mutuo-casa-svizzera-requisiti',
+    canonicalPath: '/articoli-frontaliere/frontaliere-mutuo-casa-svizzera-requisiti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39470,7 +39470,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoro, stagionale, regole, diritti',
     ogTitle: 'Lavoro stagionale in Ticino: regole, diritti e opportunità',
     ogDescription: 'Guida pratica per frontalieri stagionali: permessi, contratti, fiscalità e opportunità di lavoro in Ticino',
-    canonicalPath: '/articoli-frontaliere/lavoro-stagionale-ticino-regole',
+    canonicalPath: '/articoli-frontaliere/lavoro-stagionale-ticino-regole/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39509,7 +39509,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alle, detrazioni, fiscali, scopri',
     ogTitle: 'Frontalieri: Guida alle detrazioni fiscali in Italia 2026',
     ogDescription: 'Scopri quali spese possono essere scaricate e i documenti necessari per le detrazioni fiscali dei frontalieri in Italia nel 2026.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-detrazioni-fiscali-italia-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-detrazioni-fiscali-italia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39548,7 +39548,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, abbonamenti, sconti, trasporti, pubblici',
     ogTitle: 'Abbonamenti sconti frontalieri trasporti Ticino-Lombardia',
     ogDescription: 'Guida completa agli abbonamenti e sconti per frontalieri sui trasporti pubblici tra Ticino e Lombardia, con dettagli su treni, bus e agevolazioni.',
-    canonicalPath: '/articoli-frontaliere/abbonamenti-sconti-frontalieri-transporti',
+    canonicalPath: '/articoli-frontaliere/abbonamenti-sconti-frontalieri-transporti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39587,7 +39587,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, educatore, dell, infanzia, stipendio',
     ogTitle: 'Educatore infanzia Ticino stipendio requisiti',
     ogDescription: 'Scopri quanto guadagna un educatore dell\'infanzia in Ticino, i requisiti per lavorare e come ottenere il Permesso G',
-    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendio-requisiti',
+    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendio-requisiti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39626,7 +39626,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, residenza, scelta, migliore, famiglia',
     ogTitle: 'Residenza Italia o Svizzera: la scelta migliore per una famiglia con figli nel 2026',
     ogDescription: 'Confronto tra costi, tempi di viaggio, sanità e fiscalità per aiutare le famiglie con figli a decidere dove risiedere nel 2026.',
-    canonicalPath: '/articoli-frontaliere/scelta-residenza-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/scelta-residenza-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39665,7 +39665,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, laivin, studenti, festival, teatro',
     ogTitle: 'LaivIn 2026 a Cassano Valcuvia: 300 studenti per un festival di teatro e crescita',
     ogDescription: 'Dal 26 al 28 maggio, il Festival LaivIn Plus porterà 300 ragazzi a Cassano Valcuvia per 12 spettacoli e laboratori teatrali diffusi.',
-    canonicalPath: '/articoli-frontaliere/laivin-festival-cassano-valcuvia-2026',
+    canonicalPath: '/articoli-frontaliere/laivin-festival-cassano-valcuvia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39704,7 +39704,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 2030, cosa, cambia, consiglio',
     ogTitle: 'AVS 2030: cosa cambia per i frontalieri del Ticino',
     ogDescription: 'Scopri le novità della riforma AVS 2030 e come influenzerà i frontalieri del Ticino.',
-    canonicalPath: '/articoli-frontaliere/avs-2030-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/avs-2030-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39743,7 +39743,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, frontiera, svizzera-francia, cosa',
     ogTitle: 'Controlli frontiera Svizzera-Francia: cosa cambia per i frontalieri',
     ogDescription: 'Dal 10 al 19 giugno 2024, la Svizzera reintrodurrà i controlli alle frontiere con la Francia per il G7 di Evian-les-Bains. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/controlli-frontiere-svizzera-francia-2024',
+    canonicalPath: '/articoli-frontaliere/controlli-frontiere-svizzera-francia-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39782,7 +39782,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, keller-sutter, alle, banche, tutti',
     ogTitle: 'Keller-Sutter alle banche: "Tutti devono contribuire alla stabilità"',
     ogDescription: 'La ministra delle finanze elvetica avverte il settore bancario: la stabilità della Svizzera non è scontata e richiede responsabilità anche dalle grandi banche.',
-    canonicalPath: '/articoli-frontaliere/keller-sutter-banche-stabilita-2026',
+    canonicalPath: '/articoli-frontaliere/keller-sutter-banche-stabilita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39821,7 +39821,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavorare, educatore, dell, infanzia',
     ogTitle: 'Lavorare come educatore dell\'infanzia in Ticino: stipendi e requisiti',
     ogDescription: 'Guida completa per diventare educatore dell\'infanzia in Ticino: diploma SSS richiesto, stipendio CHF 73K–97K, LIS e altri datori di lavoro, processo per',
-    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendi-2026',
+    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39860,7 +39860,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pentecoste, traffico, rientro, verso',
     ogTitle: 'Pentecoste 2026: traffico in rientro verso il Ticino',
     ogDescription: 'Dopo il weekend lungo di Pentecoste, il rientro verso il Ticino promette meno code rispetto agli anni precedenti. Ecco cosa aspettarsi.',
-    canonicalPath: '/articoli-frontaliere/rientro-pentecoste-traffico-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/rientro-pentecoste-traffico-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39899,7 +39899,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, meccanici, manutentori, edili, introvabili',
     ogTitle: 'Meccanici, manutentori ed edili introvabili in Ticino',
     ogDescription: 'L\'analisi di Openjobmetis rivela oltre 1.200 posizioni aperte in Italia, con forte richiesta in Lombardia, Veneto e Toscana.',
-    canonicalPath: '/articoli-frontaliere/meccanici-manutentori-edili-introvabili-ticino',
+    canonicalPath: '/articoli-frontaliere/meccanici-manutentori-edili-introvabili-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39938,7 +39938,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavorare, educatore, dell, infanzia',
     ogTitle: 'Lavorare come educatore dell\'infanzia in Ticino: stipendio e requisiti',
     ogDescription: 'Guida completa su come diventare educatore dell\'infanzia in Ticino: stipendio tra CHF 73K e CHF 97K, requisiti, datori di lavoro e confronto salariale con',
-    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendi',
+    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -39977,7 +39977,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, educatore, dell, infanzia, stipendi',
     ogTitle: 'Educatore infanzia Ticino stipendi requisiti',
     ogDescription: 'Scopri stipendi, requisiti e procedure per lavorare come educatore dell\'infanzia in Ticino, con confronto salariale Italia-Svizzera',
-    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendi-requisiti',
+    canonicalPath: '/articoli-frontaliere/educatore-infanzia-ticino-stipendi-requisiti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40016,7 +40016,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, contributi, fino, euro, prevenzione',
     ogTitle: 'Prevenzione sanitaria lavoro 2026',
     ogDescription: 'Contributi fino a 3000 euro per le imprese che investono nella prevenzione sanitaria dei lavoratori.',
-    canonicalPath: '/articoli-frontaliere/prevenzione-sanitaria-lavoro-2026',
+    canonicalPath: '/articoli-frontaliere/prevenzione-sanitaria-lavoro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40055,7 +40055,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, treni, tilo, presi, assalto',
     ogTitle: 'Treni FFS e TILO presi d’assalto: viaggi infernali per i frontalieri',
     ogDescription: 'Affollamento record sui treni FFS e TILO durante il ponte di Pentecoste: passeggeri esasperati e disagi per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/treni-ffs-tilo-affollamento-pentecoste',
+    canonicalPath: '/articoli-frontaliere/treni-ffs-tilo-affollamento-pentecoste/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40094,7 +40094,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, marcello, guido, decostruttivismo, italiano',
     ogTitle: 'Marcello Guido e il decostruttivismo in Italia',
     ogDescription: 'La storia dimenticata di Marcello Guido, precursore del decostruttivismo nell\'architettura italiana.',
-    canonicalPath: '/articoli-frontaliere/marcello-guido-decostruttivismo-architettura',
+    canonicalPath: '/articoli-frontaliere/marcello-guido-decostruttivismo-architettura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40133,7 +40133,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elisoccorso, azione, brinzio, infortunio',
     ogTitle: 'Elisoccorso in azione per infortunio sul lavoro al Brinzio',
     ogDescription: 'Un intervento di elisoccorso al Brinzio ha soccorso un lavoratore infortunato, con rilevanza per frontalieri e regole assicurative in Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/elisoccorso-infortunio-brinzio-2026',
+    canonicalPath: '/articoli-frontaliere/elisoccorso-infortunio-brinzio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40172,7 +40172,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aziende, svizzere, risultati, trimestrali',
     ogTitle: 'Aziende svizzere: risultati trimestrali migliori del previsto',
     ogDescription: 'Le società quotate in Svizzera superano le attese degli analisti nel primo trimestre 2026, nonostante il contesto difficile.',
-    canonicalPath: '/articoli-frontaliere/aziende-svizzere-trimestrali-migliori-previsto',
+    canonicalPath: '/articoli-frontaliere/aziende-svizzere-trimestrali-migliori-previsto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40211,7 +40211,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ristorni, propone, soluzione, concreta',
     ogTitle: 'Ristorni frontalieri: l\'UDC Ticino propone una soluzione concreta',
     ogDescription: 'L\'UDC Ticino chiede di portare all\'ordine del giorno del Gran Consiglio l\'iniziativa 507, che prevede deduzioni sociali solo per figli residenti in Svizzera',
-    canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-udc-ticino',
+    canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-udc-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40250,7 +40250,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asili, nido, costi, liste',
     ogTitle: 'Asili nido in Ticino per frontalieri: costi, liste d\'attesa e sussidi',
     ogDescription: 'Guida pratica per i frontalieri con figli: come iscrivere i bambini agli asili nido in Ticino, costi, tempi d\'attesa e sussidi disponibili.',
-    canonicalPath: '/articoli-frontaliere/frontaliere-asilo-nido-guida-2026',
+    canonicalPath: '/articoli-frontaliere/frontaliere-asilo-nido-guida-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40289,7 +40289,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sciopero, treni, collegamenti, tilo',
     ogTitle: 'Sciopero treni TILO: tratte coinvolte e alternative per frontalieri',
     ogDescription: 'Sciopero nazionale Italia 28-29 maggio 2025: 5 tratte TILO bloccate. Guida con alternative, bus sostitutivi e consigli per frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/sciopero-train-tilo-28-29-maggio-2025',
+    canonicalPath: '/articoli-frontaliere/sciopero-train-tilo-28-29-maggio-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40328,7 +40328,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, nuove, opportunità, lavoro',
     ogTitle: 'Opportunità lavoro Varese per frontalieri Ticino',
     ogDescription: 'Nuove opportunità lavorative in provincia di Varese per frontalieri Ticino. Accordi con agenzie per il lavoro e settori in maggiore richiesta.',
-    canonicalPath: '/articoli-frontaliere/varese-camera-commercio-lavoro-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/varese-camera-commercio-lavoro-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40367,7 +40367,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, figli, funziona, asilo, nido',
     ogTitle: 'Frontalieri con figli: asilo nido Svizzera | Frontaliere Ticino',
     ogDescription: 'Guida pratica per i frontalieri con figli: asili nido ticinesi, costi, lista d\'attesa, sussidi, alternative italiane',
-    canonicalPath: '/articoli-frontaliere/frontaliere-con-figli-asilo-nido-svizzera',
+    canonicalPath: '/articoli-frontaliere/frontaliere-con-figli-asilo-nido-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40406,7 +40406,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumento, beneficiari, rendite, 2025',
     ogTitle: 'Aumento beneficiari rendite AVS in Ticino: +40.400 nel 2025',
     ogDescription: 'L\'AVS ha erogato 2,64 milioni di rendite nel 2025, con +1,6% rispetto al 2024. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/aumento-beneficiari-rendite-avs-ticino',
+    canonicalPath: '/articoli-frontaliere/aumento-beneficiari-rendite-avs-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40445,7 +40445,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ucraini, permesso, preoccupazione, lugano',
     ogTitle: 'Ucraini con permesso B a Lugano: cosa cambia',
     ogDescription: 'Il passaggio a un permesso B per i rifugiati ucraini a Lugano potrebbe avere importanti implicazioni sociali ed economiche.',
-    canonicalPath: '/articoli-frontaliere/ucraini-con-permesso-b-preoccupazione',
+    canonicalPath: '/articoli-frontaliere/ucraini-con-permesso-b-preoccupazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40484,7 +40484,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, porrentruy, piscina, comunale, pagano',
     ogTitle: 'Porrentruy: piscina comunale, tariffe doppie per frontalieri',
     ogDescription: 'Frontalieri e non residenti pagano il doppio per entrare in piscina a Porrentruy. Abbonamenti vietati, biglietti solo online.',
-    canonicalPath: '/articoli-frontaliere/porrentruy-piscina-frontaliere-tariffe',
+    canonicalPath: '/articoli-frontaliere/porrentruy-piscina-frontaliere-tariffe/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40523,7 +40523,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresto, ponte, tresa, chili',
     ogTitle: 'Arresto Ponte Tresa 100 kg hashish 22 maggio',
     ogDescription: '44enne ucraino arrestato il 22 maggio con 100 kg di hashish al valico di Ponte Tresa. UDSC e Procuratrice Lanzillo al caso.',
-    canonicalPath: '/articoli-frontaliere/arresto-ponte-tresa-100-chili-hashish',
+    canonicalPath: '/articoli-frontaliere/arresto-ponte-tresa-100-chili-hashish/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -40562,7 +40562,7 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mostre, libere, padiglione, italiano',
     ogTitle: 'Un nuovo modo di fare mostre: meno rigore scientifico, curatori animatori e più libertà interpretativa al pubblico. Virtù e limiti del Padiglione italiano di Guendalina Salimei',
     ogDescription: 'Le mostre d\'arte stanno cambiando il loro approccio, con meno rigore scientifico e più libertà per il pubblico. Il Padiglione italiano di Guendalina Salimei ne',
-    canonicalPath: '/articoli-frontaliere/mostre-nuove-virtu-e-limit-padiglione-italiano-guendalina-salimei',
+    canonicalPath: '/articoli-frontaliere/mostre-nuove-virtu-e-limit-padiglione-italiano-guendalina-salimei/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",

--- a/services/seo/seo-blog-6.ts
+++ b/services/seo/seo-blog-6.ts
@@ -13,7 +13,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, federviti, lancia, risoluzione, vino',
     ogTitle: 'Federviti lancia risoluzione: vino ticinese prima scelta,',
     ogDescription: 'L’Assemblea annuale di Federviti a Biasca, il 2025 con le rese più basse degli ultimi 25 anni e consumi in calo. Il presidente Cadenazzi chiede priorità al vino',
-    canonicalPath: '/articoli-frontaliere/risoluzione-federviti-vino-ticinese-2025',
+    canonicalPath: '/articoli-frontaliere/risoluzione-federviti-vino-ticinese-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -41,7 +41,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziative, cassa, malati, piano',
     ogTitle: 'Iniziative cassa malati: il piano da 51 milioni bocciato',
     ogDescription: 'Il Consiglio di Stato ticinese propone un piano da 51 milioni l’anno per le iniziative sulla cassa malati. La Lega bolla la proposta come inaccettabile e chiede',
-    canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-piano-lega-ticino',
+    canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-piano-lega-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -69,7 +69,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, a8-a9, verso, chiasso, chiusa',
     ogTitle: 'A8-A9 verso Chiasso chiusa di notte: percorsi alternativi',
     ogDescription: 'Da mercoledì 22 a giovedì 23 aprile 2026 stop al ramo A8-A9 verso Chiasso per manutenzione. Percorsi alternativi via Lainate Arese, Origgio e Saronno per chi vi',
-    canonicalPath: '/articoli-frontaliere/chiusura-ramo-a8-a9-notte-lavori-2026',
+    canonicalPath: '/articoli-frontaliere/chiusura-ramo-a8-a9-notte-lavori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -97,7 +97,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riduce, tempi, determinazione, prezzi',
     ogTitle: 'L’IA riduce i tempi di determinazione dei prezzi del 75%',
     ogDescription: 'L’intelligenza artificiale di Swiss Re accelera i processi assicurativi fino all’80% e libera tempo per i collaboratori. Il CEO Andreas Berger illustra l’impatt',
-    canonicalPath: '/articoli-frontaliere/ia-swiss-re-produttivita-ceo-berger',
+    canonicalPath: '/articoli-frontaliere/ia-swiss-re-produttivita-ceo-berger/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -125,7 +125,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, progetto, echo, praterie, sommerse',
     ogTitle: 'Progetto Echo: praterie sommerse per salvare i laghi di L',
     ogDescription: 'Il progetto Interreg Echo (2025-2027) sperimenta il restauro delle praterie sommerse con biochar per combattere il cambiamento climatico nei laghi di Lugano e C',
-    canonicalPath: '/articoli-frontaliere/rinascita-praterie-sommerse-laghi-ticino',
+    canonicalPath: '/articoli-frontaliere/rinascita-praterie-sommerse-laghi-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -153,7 +153,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, stabio, cosa',
     ogTitle: 'Fuga di ammoniaca a Stabio: cosa sapere e come reagire',
     ogDescription: 'Giovedì 16 aprile 2026, fuga di ammoniaca nella fabbrica alimentare Rapelli a Stabio. Autorità chiedono di chiudere porte e finestre in un raggio di 1 km. Nessu',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-stabio-rapelli-allerta-ticino',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-stabio-rapelli-allerta-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -181,7 +181,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arena, lugano, porte, aperte',
     ogTitle: 'AIL Arena a Lugano: porte aperte il 30 e 31 maggio per sc',
     ogDescription: 'Il 30 e 31 maggio 2025 il FC Lugano apre la nuova AIL Arena con due giornate di eventi gratuiti: tour guidati, Fan Village e concorso con una Renault Clio in pa',
-    canonicalPath: '/articoli-frontaliere/inaugurazione-ail-arena-lugano-30-31-maggio',
+    canonicalPath: '/articoli-frontaliere/inaugurazione-ail-arena-lugano-30-31-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -209,7 +209,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ritardi, negli, assegni, cassa',
     ogTitle: 'Ritardi negli assegni cassa malati a Mendrisio: cosa risc',
     ogDescription: 'Mendrisio chiede al Canton Ticino di sbloccare i pagamenti dei sussidi cassa malati ritardati da mesi. Frontalieri e residenti rischiano di non pagare i premi a',
-    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi-2026',
+    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -237,7 +237,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mercato, immobiliare, alloggi, anni',
     ogTitle: 'Mercato immobiliare Ticino 2025: la crisi degli alloggi in',
     ogDescription: 'Calo del 33% degli alloggi in affitto in Ticino. Analisi dei dati federali e consigli pratici per i frontalieri che cercano casa in Ticino.',
-    canonicalPath: '/articoli-frontaliere/alloggi-frontalieri-ticino-crisi-2025',
+    canonicalPath: '/articoli-frontaliere/alloggi-frontalieri-ticino-crisi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -265,7 +265,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grandine, bellinzona, allerta, meteo',
     ogTitle: 'Grandine Ticino: allerta Lugano e Chiasso 19 aprile 2026',
     ogDescription: 'Allerta meteo grado 3 per grandine a Lugano e Chiasso. Procedure per frontalieri, danni ai veicoli e consigli per spostamenti. Aggiornamenti in tempo reale.',
-    canonicalPath: '/articoli-frontaliere/grandine-bellinzonese-allerta-lugano-chiasso-19-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/grandine-bellinzonese-allerta-lugano-chiasso-19-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -293,7 +293,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, apertura, sportello, didi, dipendenze',
     ogTitle: 'Ticino: apertura sportello DIDI per dipendenze digitali',
     ogDescription: 'OSC lancia sportello dedicato alle dipendenze digitali. 6,8% ticinesi a rischio, 22% under 15. Servizio operativo a Lugano e Bellinzona',
-    canonicalPath: '/articoli-frontaliere/sportello-dipendenze-digitali-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/sportello-dipendenze-digitali-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -321,7 +321,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, paradiso, fiscale, milionari, fuga',
     ogTitle: 'Ticino, paradiso fiscale per milionari in fuga dal Golfo',
     ogDescription: 'Dallo scoppio della guerra in Iran, le richieste di immobili nel Ticino sono aumentate del 15%. Agevolazioni fiscali forfettarie e case vacanza senza permesso d',
-    canonicalPath: '/articoli-frontaliere/tasse-agevolate-milionari-ticino-golfo',
+    canonicalPath: '/articoli-frontaliere/tasse-agevolate-milionari-ticino-golfo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -349,7 +349,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermiere, pratiche, avanzate, nuovo',
     ogTitle: 'APN Ticino: formazione, ruoli e vantaggi per frontalieri',
     ogDescription: 'Scopri come la figura dell\'Infermiere di Pratiche Avanzate (APN) sta rivoluzionando il sistema sanitario ticinese e quali vantaggi offre ai frontalieri.',
-    canonicalPath: '/articoli-frontaliere/infermiere-pratiche-avanzate-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/infermiere-pratiche-avanzate-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -377,7 +377,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, medio, oriente, fiamme, costi',
     ogTitle: 'Medio Oriente in fiamme: costi e rischi per imprese ticin',
     ogDescription: 'Materie prime in aumento del 30-50% a causa del conflitto. Direttore SSIC Bagnovini chiede interventi urgenti per salvare cantieri edili.',
-    canonicalPath: '/articoli-frontaliere/caos-medioriente-e-impatti-costruzione-ticino',
+    canonicalPath: '/articoli-frontaliere/caos-medioriente-e-impatti-costruzione-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -405,7 +405,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dazi, parmelin, washington, rilanciare',
     ogTitle: 'Dazi USA: Parmelin a Washington per rilanciare accordo co',
     ogDescription: 'Il presidente della Confederazione Guy Parmelin incontra il rappresentante USA per i dazi Jamieson Greer. Volontà di accordo, ma senza certezze su tempistiche e',
-    canonicalPath: '/articoli-frontaliere/parmelin-washington-dazi-usa-2026',
+    canonicalPath: '/articoli-frontaliere/parmelin-washington-dazi-usa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -433,7 +433,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colombiani, arrestati, furto, verbano',
     ogTitle: 'Tre colombiani arrestati per furto sul Verbano: uno in Ti',
     ogDescription: 'Tre membri di una banda colombiana hanno rubato gioielli per 50mila franchi a un orafo sul Lago Maggiore. Uno dei ladri è stato arrestato in Ticino dopo 10 mesi',
-    canonicalPath: '/articoli-frontaliere/gang-colombiani-verbano-arresti-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/gang-colombiani-verbano-arresti-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -461,7 +461,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parmelin, firma, accordo, bahrein',
     ogTitle: 'Parmelin firma accordo con Bahrein per proteggere gli inv',
     ogDescription: 'Guy Parmelin ha firmato a Washington un accordo bilaterale per proteggere gli investimenti tra Svizzera e Bahrein. L’intesa entra in vigore dopo le approvazioni',
-    canonicalPath: '/articoli-frontaliere/parmelin-accordo-investimenti-bahrein-2026',
+    canonicalPath: '/articoli-frontaliere/parmelin-accordo-investimenti-bahrein-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -489,7 +489,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, palazzo, civico, collegiata, bellinzona',
     ogTitle: 'Palazzo civico e Collegiata di Bellinzona più accessibili',
     ogDescription: 'Il Municipio di Bellinzona stanzia 1,385 milioni per eliminare barriere architettoniche a Palazzo Civico e Collegiata. Ascensori rifatti, piattaforme elevatrici',
-    canonicalPath: '/articoli-frontaliere/palazzo-civico-collegiata-accessibilita-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/palazzo-civico-collegiata-accessibilita-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -517,7 +517,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roche, investe, miliardi, farmaci',
     ogTitle: 'Roche investe su farmaci anti-obesità: cosa cambia per i',
     ogDescription: 'Petrelintide di Roche promette perdita di peso del 10,7% in 42 settimane. Analisi su costi, copertura e opportunità per frontalieri Ticino-Lombardia.',
-    canonicalPath: '/articoli-frontaliere/roche-farmaci-obesita-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/roche-farmaci-obesita-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -545,7 +545,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, chiusure, sull, autostrada',
     ogTitle: 'Chiusure autostrada A9: cosa cambia per i frontalieri |',
     ogDescription: 'Autostrade per l\'Italia annuncia chiusure notturne sull\'A9 tra Como e Chiasso per lavori di manutenzione. Ecco gli itinerari alternativi e le implicazioni per',
-    canonicalPath: '/articoli-frontaliere/chiusure-autostrada-a9-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-autostrada-a9-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -573,7 +573,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, capre, alla, dogana, gandria',
     ogTitle: 'Capre alla dogana di Gandria: rischio incidente |',
     ogDescription: 'Quattro capre hanno attirato l\'attenzione delle autorità doganali, rischiando di causare due incidenti. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-incidenti-2026',
+    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-incidenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -601,7 +601,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavori, autostrade, chiusure, notturne',
     ogTitle: 'Lavori autostrade Ticino: chiusure notturne | Frontaliere',
     ogDescription: 'Autostrade per l\'Italia programma interventi notturni dal 20 al 24 aprile 2026. Chiusure a Besnate, Turate e sulla A9 Lainate-Como-Chiasso',
-    canonicalPath: '/articoli-frontaliere/lavori-autostrade-ticino-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/lavori-autostrade-ticino-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -629,7 +629,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, militari, treni, trenord, euro',
     ogTitle: 'Militari sui treni Trenord: 20 euro all\'anno per maggiore',
     ogDescription: 'Dal 1° maggio 2026, i militari potranno viaggiare su Trenord in Lombardia con un abbonamento agevolato di 20 euro annui per incrementare la sicurezza sui',
-    canonicalPath: '/articoli-frontaliere/militari-treni-ticino-20-euro',
+    canonicalPath: '/articoli-frontaliere/militari-treni-ticino-20-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -657,7 +657,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, just, consegna, prodotti, migros',
     ogTitle: 'Just Eat consegna Migros in Ticino | Frontaliere Ticino',
     ogDescription: 'Dal 4 maggio 2026, Just Eat consegna prodotti Migros in Ticino, Vallese e Ginevra con consegna in meno di un\'ora. Prezzi identici a quelli dei negozi.',
-    canonicalPath: '/articoli-frontaliere/just-eat-migros-ticino-consegna-2026',
+    canonicalPath: '/articoli-frontaliere/just-eat-migros-ticino-consegna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -685,7 +685,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intervento, alla, dogana, gandria',
     ogTitle: 'Intervento alla dogana di Gandria: salvate quattro capre |',
     ogDescription: 'L\'Ufficio federale della dogana e della sicurezza dei confini ha salvato quattro capre che mettevano a rischio la circolazione.',
-    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-intervento-30-marzo',
+    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-intervento-30-marzo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -713,7 +713,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, fatture, continuano',
     ogTitle: 'Cure a domicilio: costi in Ticino | Frontaliere Ticino',
     ogDescription: 'Il Parlamento ticinese ha bocciato la richiesta di urgenza per abolire la partecipazione ai costi delle cure a domicilio. Scopri cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/costi-cure-domocilio-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/costi-cure-domocilio-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -741,7 +741,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, ecco, cambia',
     ogTitle: 'Salario minimo Ticino 2027-2029 | Frontaliere Ticino',
     ogDescription: 'Il Gran Consiglio ha approvato il compromesso sul salario minimo in Ticino: da 20,50 a 21,75-22,25 franchi l\'ora entro il 2029',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -769,7 +769,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, palla, tribuna',
     ogTitle: 'Cure a domicilio, palla in tribuna | Frontaliere Ticino',
     ogDescription: 'Il Gran Consiglio del Ticino ha respinto la richiesta d\'urgenza sull\'iniziativa che chiedeva di stralciare la partecipazione ai costi per le cure a domicilio.',
-    canonicalPath: '/articoli-frontaliere/cure-domocilio-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cure-domocilio-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -797,7 +797,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asili, nido, bellinzona, polemiche',
     ogTitle: 'Asili nido Bellinzona: polemiche sussidi | Frontaliere',
     ogDescription: 'Scopri le ultime novità sul sistema di sussidi per gli asili nido a Bellinzona e come questo potrebbe influenzare i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-sussidi-2026',
+    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-sussidi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -825,7 +825,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sette, cantoni, stanno, scomparendo',
     ogTitle: 'Giovani in calo in 7 cantoni svizzeri: il caso Ticino',
     ogDescription: 'Nel 2024, i dati ufficiali mostrano una diminuzione della popolazione under 65 in sette cantoni, con gravi conseguenze per l\'economia e la previdenza nel',
-    canonicalPath: '/articoli-frontaliere/giovani-scomparsi-7-cantoni',
+    canonicalPath: '/articoli-frontaliere/giovani-scomparsi-7-cantoni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -853,7 +853,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzeri, italiani, cucina, italiana',
     ogTitle: 'Cucina italiana preferita dagli svizzeri | Frontaliere',
     ogDescription: 'Un sondaggio rivela che il 79% degli svizzeri preferisce la cucina italiana quando mangia fuori, seguita dalla cucina elvetica al 71%.',
-    canonicalPath: '/articoli-frontaliere/svizzeri-italiani-cucina-preferita',
+    canonicalPath: '/articoli-frontaliere/svizzeri-italiani-cucina-preferita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -881,7 +881,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, restrizioni, investitori, immobiliari',
     ogTitle: 'Nuove restrizioni per investitori immobiliari stranieri in',
     ogDescription: 'Il Consiglio federale svizzero propone modifiche alla Lex Koller per limitare gli acquisti di immobili da parte di stranieri non residenti.',
-    canonicalPath: '/articoli-frontaliere/svizzera-chiude-investitori-immobiliari-stranieri',
+    canonicalPath: '/articoli-frontaliere/svizzera-chiude-investitori-immobiliari-stranieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -909,7 +909,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, nuove, regole',
     ogTitle: 'Nuovo salario minimo in Ticino dal 2027',
     ogDescription: 'Dal 2027 il salario minimo in Ticino sarà tra i 20,50 e i 21 franchi all\'ora. Scopri le nuove regole e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029-nuove-regole',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029-nuove-regole/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -937,7 +937,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cybercrimepolice, disponibile, italiano, maggiore',
     ogTitle: 'Cybercrimepolice.ch ora in italiano | Frontaliere Ticino',
     ogDescription: 'La piattaforma nazionale di prevenzione Cybercrimepolice.ch è ora disponibile anche in italiano, grazie al contributo della Polizia cantonale ticinese.',
-    canonicalPath: '/articoli-frontaliere/cybercrimepolice-ticino-italiano-2026',
+    canonicalPath: '/articoli-frontaliere/cybercrimepolice-ticino-italiano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -965,7 +965,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, azienda, assume, autisti, lombardia',
     ogTitle: 'Azienda assume autisti in Lombardia | Frontaliere Ticino',
     ogDescription: 'FNM Autoservizi cerca nuovi autisti con un percorso formativo retribuito e un premio di ingresso di 3000 euro',
-    canonicalPath: '/articoli-frontaliere/azienda-assume-autisti-lombardia-800-euro',
+    canonicalPath: '/articoli-frontaliere/azienda-assume-autisti-lombardia-800-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -993,7 +993,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bancastato, walking, mendrisio, percorsi',
     ogTitle: 'BancaStato Walking Mendrisio 2026 | Frontaliere Ticino',
     ogDescription: 'Domenica 26 aprile 2026 a Mendrisio tre percorsi di diversa difficoltà, pranzo offerto e animazioni per la nuova edizione di BancaStato Walking Mendrisio.',
-    canonicalPath: '/articoli-frontaliere/bancastato-walking-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/bancastato-walking-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1021,7 +1021,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premia, aziende, salute, lavoro',
     ogTitle: 'WHP premia 90 aziende del Ticino | Frontaliere Ticino',
     ogDescription: 'ATS Insubria e Confindustria Varese premiano quasi 90 aziende del territorio per la loro adesione al programma WHP, promuovendo la salute nei luoghi di lavoro.',
-    canonicalPath: '/articoli-frontaliere/whp-premia-aziende-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/whp-premia-aziende-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1049,7 +1049,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rapina, milano, frontaliero, ticinese',
     ogTitle: 'Rapina a Milano: frontaliero ticinese derubato | Frontaliere',
     ogDescription: 'Tre arresti per la rapina ai danni di un cittadino svizzero domiciliato in Canton Lucerna, pedinato e derubato a Milano dopo un viaggio in treno da Lugano.',
-    canonicalPath: '/articoli-frontaliere/rapina-milano-frontaliere-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/rapina-milano-frontaliere-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1077,7 +1077,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, approvata, mozione, contributo, sanitario',
     ogTitle: 'Frontalieri: mozione per contributo sanitario equo',
     ogDescription: 'Scopri come la mozione approvata da Zocchi (FdI) mira a rendere il contributo sanitario meno gravoso per i frontalieri e a distribuire le risorse nei territori',
-    canonicalPath: '/articoli-frontaliere/frontalieri-contributo-sanitario-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-contributo-sanitario-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1105,7 +1105,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcio, licenza, negata, bellinzona',
     ogTitle: 'Bellinzona: licenza negata, dubbi sulle finanze |',
     ogDescription: 'Il Bellinzona non ottiene la licenza Dnb a causa di dubbi sulle finanze, sollevando nuove preoccupazioni sul futuro del club.',
-    canonicalPath: '/articoli-frontaliere/bellinzona-calcio-licenza-negata-finanze',
+    canonicalPath: '/articoli-frontaliere/bellinzona-calcio-licenza-negata-finanze/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1133,7 +1133,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, approvata, unanimità, mozione, salute',
     ogTitle: 'Mozione salute vigili fuoco | Frontaliere Ticino',
     ogDescription: 'Regione Lombardia approva mozione per screening e studi epidemiologici sui vigili del fuoco, classificati a rischio cancerogeno.',
-    canonicalPath: '/articoli-frontaliere/mozione-salute-vigili-fuoco-lombardia',
+    canonicalPath: '/articoli-frontaliere/mozione-salute-vigili-fuoco-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1161,7 +1161,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cuasso, monte, chiusura, definitiva',
     ogTitle: 'Cuasso al Monte: chiusura ospedale frontalieri | Frontaliere',
     ogDescription: 'Dopo vent\'anni di dibattiti, l\'ospedale dei frontalieri di Cuasso al Monte chiude definitivamente. Servizi trasferiti nel palazzo comunale.',
-    canonicalPath: '/articoli-frontaliere/cuasso-monte-ospedale-frontalieri-chiusura',
+    canonicalPath: '/articoli-frontaliere/cuasso-monte-ospedale-frontalieri-chiusura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1189,7 +1189,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, bocciata, abrogazione',
     ogTitle: 'Tassa salute frontalieri: cosa cambia nel 2026',
     ogDescription: 'La Regione Lombardia ha bocciato la mozione del Pd per abolire la tassa salute per i frontalieri, ma punta a detrazioni e aliquote minime.',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1217,7 +1217,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dalla, vita, alla, tela',
     ogTitle: 'Donna in arte a Chiasso | Frontaliere Ticino',
     ogDescription: 'Una mostra a Chiasso celebra l\'arte di sette donne, portando cultura e inclusione nel Centro diurno OSC',
-    canonicalPath: '/articoli-frontaliere/donne-arte-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/donne-arte-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1245,7 +1245,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, nuovi, bandi, camera',
     ogTitle: 'Varese: Nuovi bandi 2026 della Camera di Commercio per l’',
     ogDescription: 'La Camera di Commercio di Varese investe 150mila euro in due bandi per il 2026, focalizzati su formazione e mobilità, per favorire l’integrazione professionale',
-    canonicalPath: '/articoli-frontaliere/cameradi-commercio-2026-integrazione',
+    canonicalPath: '/articoli-frontaliere/cameradi-commercio-2026-integrazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1273,7 +1273,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basiletti, accede, main, draw',
     ogTitle: 'Basiletti accede al main draw: vittoria a Chiasso',
     ogDescription: 'La giovane tennista italiana Noemi Basiletti supera l\'ex numero 60 del mondo Cagla Buyukakcay all\'Axion Open di Chiasso, conquistando l\'accesso al main draw.',
-    canonicalPath: '/articoli-frontaliere/basiletti-main-draw-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/basiletti-main-draw-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1301,7 +1301,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trasporto, pubblico, sfida, nils',
     ogTitle: 'Trasporto pubblico: la sfida per il Ticino',
     ogDescription: 'Nils Planzer, CEO di un\'azienda di trasporti, sottolinea l\'importanza di investire nel trasporto pubblico per affrontare le sfide del traffico in Ticino.',
-    canonicalPath: '/articoli-frontaliere/ticino-trasporto-pubblico-priorita',
+    canonicalPath: '/articoli-frontaliere/ticino-trasporto-pubblico-priorita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1329,7 +1329,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, omaggio, agli, angeli',
     ogTitle: 'Omaggio agli Angeli di Ponte Chiasso | Frontaliere Ticino',
     ogDescription: 'Finalmente a Ponte Chiasso viene posata la targa in onore degli Angeli che salvarono vite durante la Seconda Guerra Mondiale. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso',
+    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1357,7 +1357,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dogana, chiasso, limitazioni, traffico',
     ogTitle: 'Dogana Chiasso: limitazioni traffico 2026 | Frontaliere',
     ogDescription: 'Venerdì 24 aprile 2026, dalle 9:20 alle 10:00, traffico deviato verso Maslianico/Pizzamiglio per cerimonia in onore degli Angeli di Ponte Chiasso',
-    canonicalPath: '/articoli-frontaliere/dogana-chiasso-traffico-2026',
+    canonicalPath: '/articoli-frontaliere/dogana-chiasso-traffico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1385,7 +1385,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, spinge, integrazione, lavorativa',
     ogTitle: 'Integrazione lavorativa stranieri Ticino 2026',
     ogDescription: 'Scopri le nuove misure per l\'integrazione lavorativa degli stranieri in Ticino. Supporto nella formazione e nella ricerca di un impiego.',
-    canonicalPath: '/articoli-frontaliere/integrazione-lavoro-stranieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/integrazione-lavoro-stranieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1413,7 +1413,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, franchi, lordi',
     ogTitle: 'Salario minimo Ticino 2029: 4.000 franchi | Frontaliere',
     ogDescription: 'Il Parlamento cantonale ticinese ha approvato l\'aumento del salario minimo a 4.000 franchi lordi al mese dal 2029, beneficiando 23.000 lavoratori, di cui 15.000',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2029-4000-franchi',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2029-4000-franchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1441,7 +1441,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guasti, trenord, ritardi, cancellazioni',
     ogTitle: 'Guasti Trenord: ritardi e cancellazioni in Lombardia il 21',
     ogDescription: 'Doppio guasto tecnico ad Albizzate e Milano Certosa causa disagi diffusi sulla rete ferroviaria lombarda nella giornata di martedì 21 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/guasti-trenord-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/guasti-trenord-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1469,7 +1469,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponte, chiasso, prelievi, parrocchia',
     ogTitle: 'Ponte Chiasso: prelievi in parrocchia | Frontaliere Ticino',
     ogDescription: 'A Ponte Chiasso, un infermiere volontario offre servizi di prelievo nella parrocchia locale, mentre il Comitato Obiettivo Salute chiede un presidio sanitario',
-    canonicalPath: '/articoli-frontaliere/ponte-chiasso-sanita-2026',
+    canonicalPath: '/articoli-frontaliere/ponte-chiasso-sanita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1497,7 +1497,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, soloaffitti, como, partner, ideale',
     ogTitle: 'SoloAffitti Como: il partner ideale per affitti senza',
     ogDescription: 'Scopri come SoloAffitti Como offre un servizio completo per affitti di abitazioni e locali commerciali, garantendo sicurezza e professionalità.',
-    canonicalPath: '/articoli-frontaliere/soloaffitti-como-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/soloaffitti-como-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1525,7 +1525,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumenti, medici, infermieri, confine',
     ogTitle: 'Aumenti del 20% per medici e infermieri al confine',
     ogDescription: 'Lombardia stanzia 10.000 euro per medici e 5.400 euro per infermieri che operano nelle zone di confine con la Svizzera',
-    canonicalPath: '/articoli-frontaliere/aumenti-stipendi-medici-infermieri-lombardia',
+    canonicalPath: '/articoli-frontaliere/aumenti-stipendi-medici-infermieri-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1553,7 +1553,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svincolo, sigirino, ritardo, possibile',
     ogTitle: 'Svincolo A2 Sigirino: ritardo possibile',
     ogDescription: 'Lo svincolo A2 di Sigirino potrebbe slittare a dopo il 2030. Scopri le implicazioni per i frontalieri e come seguire l\'evoluzione del progetto',
-    canonicalPath: '/articoli-frontaliere/svincolo-a2-sigirino-ritardo',
+    canonicalPath: '/articoli-frontaliere/svincolo-a2-sigirino-ritardo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1581,7 +1581,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salari, aumentati, 2025, media',
     ogTitle: 'Salari in Svizzera aumentati nel 2025: +1,8% in media',
     ogDescription: 'Scopri come i salari in Svizzera sono aumentati del 1,8% nel 2025 e quali sono le implicazioni per i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/salari-svizzera-aumentati-2025',
+    canonicalPath: '/articoli-frontaliere/salari-svizzera-aumentati-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1609,7 +1609,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, diventare, autista, costo, zero',
     ogTitle: 'Academy FNMA: autisti bus a costo zero | Frontaliere Ticino',
     ogDescription: 'Scopri come diventare autista di bus con l’Academy di FNM Autoservizi. Formazione gratuita, assunzione a tempo indeterminato e bonus di 3.000 euro.',
-    canonicalPath: '/articoli-frontaliere/academy-fnma-autisti-bus-2026',
+    canonicalPath: '/articoli-frontaliere/academy-fnma-autisti-bus-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1637,7 +1637,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, patentino, digitale, libera, lombardia',
     ogTitle: 'Patentino Digitale: via libera in Lombardia',
     ogDescription: 'Approvato il primo progetto di legge regionale per l\'istituzione del Patentino Digitale per contrastare bullismo e dipendenza tecnologica tra i giovani',
-    canonicalPath: '/articoli-frontaliere/patentino-digitale-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/patentino-digitale-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1665,7 +1665,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, truffe, agli, anziani, arresti',
     ogTitle: 'Truffe agli anziani: due arresti nel Locarnese | Frontaliere',
     ogDescription: 'Due cittadini cechi arrestati per truffe telefoniche ai danni di anziani a Gordola. Recuperata la refurtiva. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/chiamate-shock-arresti-locarnese-2024',
+    canonicalPath: '/articoli-frontaliere/chiamate-shock-arresti-locarnese-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1693,7 +1693,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, valbianca, forti, difficoltà, airolo',
     ogTitle: 'Valbianca in forti difficoltà: Airolo mette 1,5 milioni e',
     ogDescription: 'Il comune di Airolo investe 1,5 milioni di franchi per salvare Valbianca, un\'azienda in difficoltà. Scopri le implicazioni per i frontalieri e come monitorare',
-    canonicalPath: '/articoli-frontaliere/valbianca-in-forti-difficolta-airolo-mette-1-5-milioni-e-aumenta-il-moltiplicatore',
+    canonicalPath: '/articoli-frontaliere/valbianca-in-forti-difficolta-airolo-mette-1-5-milioni-e-aumenta-il-moltiplicatore/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1721,7 +1721,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumento, medici, infermieri, frontiera',
     ogTitle: 'Aumento stipendi medici e infermieri | Frontaliere Ticino',
     ogDescription: 'La Lombardia introduce un aumento del 20% per medici e infermieri di frontiera per contrastare la fuga verso la Svizzera.',
-    canonicalPath: '/articoli-frontaliere/aumento-stipendi-frontalieri-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/aumento-stipendi-frontalieri-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1749,7 +1749,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantieri, situazione, sottoceneri, estate',
     ogTitle: 'Cantieri Sottoceneri | Frontaliere Ticino',
     ogDescription: '11 cantieri attivi nel Sottoceneri, tra cui il Tunnel di Genzana a Lugano. Lavori notturni e viabilità modificata fino al 2027',
-    canonicalPath: '/articoli-frontaliere/cantieri-sottoceneri-estate-2024',
+    canonicalPath: '/articoli-frontaliere/cantieri-sottoceneri-estate-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1777,7 +1777,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, stazioni, ricarica, ultraveloci',
     ogTitle: 'Nuove stazioni di ricarica a Campione d\'Italia',
     ogDescription: 'Ewiva attiva colonnine ultraveloci a Campione d\'Italia per frontalieri e turisti. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/ricarica-auto-elettriche-campione-2026',
+    canonicalPath: '/articoli-frontaliere/ricarica-auto-elettriche-campione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1805,7 +1805,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cena, primavera, libano, avsi',
     ogTitle: 'Cena di primavera per il Libano | Frontaliere Ticino',
     ogDescription: 'Sabato 9 maggio 2026 a Castiglione Olona, la Fondazione AVSI organizza una cena benefica per le comunità libanesi colpite dalla guerra.',
-    canonicalPath: '/articoli-frontaliere/cena-spring-avsi-libano-castiglione',
+    canonicalPath: '/articoli-frontaliere/cena-spring-avsi-libano-castiglione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1833,7 +1833,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, cambia, prassi, permessi',
     ogTitle: 'Grigioni cambia prassi per i permessi di dimora |',
     ogDescription: 'Nuove regole per i permessi di dimora nel Canton Grigioni: dichiarazione obbligatoria di precedenti penali e procedimenti in corso.',
-    canonicalPath: '/articoli-frontaliere/permessi-dimora-grigioni-cambia-prassi',
+    canonicalPath: '/articoli-frontaliere/permessi-dimora-grigioni-cambia-prassi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1861,7 +1861,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, divario, salariale, residenti, studio',
     ogTitle: 'Divario salariale frontalieri Ticino 2026',
     ogDescription: 'Scopri il divario salariale tra frontalieri e residenti in Ticino nel 2026, con dati e analisi dell\'Ufficio di statistica del Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/divario-salariale-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/divario-salariale-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1889,7 +1889,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bandecchi, quarti, chiasso, sento',
     ogTitle: 'Bandecchi ai quarti a Chiasso | Frontaliere Ticino',
     ogDescription: 'Susan Bandecchi raggiunge i quarti di finale dell\'Axion Open di Chiasso, sconfiggendo la croata Lucija Ciric Bagaric in due set.',
-    canonicalPath: '/articoli-frontaliere/bandecchi-quarti-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/bandecchi-quarti-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1917,7 +1917,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantello, amministrazione, legambiente, unite',
     ogTitle: 'Cantello: Amministrazione e Legambiente contro il \'peduncolo',
     ogDescription: 'Amministrazione comunale e Legambiente Cantello chiedono lo stralcio del progetto della superstrada a quattro corsie tra Italia e Svizzera.',
-    canonicalPath: '/articoli-frontaliere/cantello-peduncolo-gaggiolo-2026',
+    canonicalPath: '/articoli-frontaliere/cantello-peduncolo-gaggiolo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1945,7 +1945,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assegno, educativo, mendrisio, scadenza',
     ogTitle: 'Assegno educativo Mendrisio 2026: scadenza 30 giugno',
     ogDescription: 'Scadenza 30 giugno 2026 per richiedere l\'Assegno educativo, Contributo per colonie e Sussidio all\'alloggio a Mendrisio. Requisiti e procedure.',
-    canonicalPath: '/articoli-frontaliere/assegno-educativo-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/assegno-educativo-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1973,7 +1973,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, autocertificazione, penali, permessi',
     ogTitle: 'Grigioni: autocertificazione penali per permessi di dimora',
     ogDescription: 'Da maggio 2026, chi richiede un permesso di dimora nei Grigioni dovrà dichiarare eventuali precedenti penali o procedimenti in corso.',
-    canonicalPath: '/articoli-frontaliere/grigioni-permessi-dimora-2026',
+    canonicalPath: '/articoli-frontaliere/grigioni-permessi-dimora-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2001,7 +2001,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, aumenta, stipendi, medici',
     ogTitle: 'Aumento stipendi medici e infermieri Lombardia 2026',
     ogDescription: 'Dal settembre 2026, medici e infermieri delle zone di confine con la Svizzera vedranno aumenti fino a 10.000 euro lordi annui. La Lombardia investe 45 milioni',
-    canonicalPath: '/articoli-frontaliere/aumento-stipendi-medici-infermieri-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/aumento-stipendi-medici-infermieri-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2029,7 +2029,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dividere, lavoratori, significa, abbassare',
     ogTitle: 'Dividere i lavoratori significa abbassare i salari |',
     ogDescription: 'Il Primo Maggio torna a Lugano con un focus sui diritti dei lavoratori, indipendentemente dall\'origine, dal contratto o dal settore economico.',
-    canonicalPath: '/articoli-frontaliere/dividere-lavoratori-salari-2026',
+    canonicalPath: '/articoli-frontaliere/dividere-lavoratori-salari-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2057,7 +2057,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lufthansa, elimina, bagaglio, mano',
     ogTitle: 'Lufthansa elimina il bagaglio a mano gratuito | Frontaliere',
     ogDescription: 'Dal 19 maggio 2026, solo un oggetto personale incluso nella tariffa base. Ecco cosa cambia per i passeggeri e i frontalieri',
-    canonicalPath: '/articoli-frontaliere/lufthansa-bagaglio-gratuito-eliminato',
+    canonicalPath: '/articoli-frontaliere/lufthansa-bagaglio-gratuito-eliminato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2085,7 +2085,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banditi, assaltano, gioielleria, tavernola',
     ogTitle: 'Banditi assaltano gioielleria a Tavernola: l\'assalto e le',
     ogDescription: 'Rapina a mano armata a Tavernola: tre banditi hanno seminato il panico e hanno prelevato gioielli dal centro commerciale Lario.',
-    canonicalPath: '/articoli-frontaliere/como-frazione-tavernola-banditi-assaltano-gioielleria-e-si-dileguano',
+    canonicalPath: '/articoli-frontaliere/como-frazione-tavernola-banditi-assaltano-gioielleria-e-si-dileguano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2113,7 +2113,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, regione, lombardia, aumento, stipendi',
     ogTitle: 'Regione Lombardia: aumento stipendi medici e infermieri',
     ogDescription: 'La Regione Lombardia introduce una norma per aumentare lo stipendio dei medici e infermieri nelle zone al confine con la Svizzera. La misura mira a trattenere',
-    canonicalPath: '/articoli-frontaliere/regione-lombardia-aumento-stipendi-medici-infermieri',
+    canonicalPath: '/articoli-frontaliere/regione-lombardia-aumento-stipendi-medici-infermieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2141,7 +2141,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, divario, salariale, residenti, guadagnano',
     ogTitle: 'Divario salariale in Ticino: residenti guadagnano 1.157',
     ogDescription: 'L\'Ufficio cantonale di statistica rivela che i residenti in Ticino guadagnano mediamente 5.957 franchi, mentre i frontalieri 4.800 franchi. Il divario è del',
-    canonicalPath: '/articoli-frontaliere/divario-salari-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/divario-salari-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2169,7 +2169,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'permesso g, frontalieri, ticino, 2026, rientro settimanale, 25 telelavoro, 45 giorni, imposta alla fonte, guida permesso g, permesso g vs permesso b',
     ogTitle: 'Permesso G 2026: la guida definitiva per frontalieri',
     ogDescription: 'Tutto quello che serve al frontaliere sul Permesso G: procedura, costi, rinnovo, rientro settimanale, telelavoro e fiscalità nel 2026.',
-    canonicalPath: '/articoli-frontaliere/permesso-g-guida-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/permesso-g-guida-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -2199,7 +2199,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'imposta alla fonte svizzera, quellensteuer 2026, confronto cantoni, nov 120000, pilastro 3a frontalieri, imposta fonte ticino grigioni vallese berna zurigo',
     ogTitle: 'Imposta alla fonte Svizzera 2026: dove pagare meno',
     ogDescription: 'Confronto completo dell\'imposta alla fonte 2026 nei principali cantoni frontalieri: aliquote, NOV, deduzioni e pilastro 3a.',
-    canonicalPath: '/articoli-frontaliere/imposta-fonte-svizzera-2026-confronto-cantoni',
+    canonicalPath: '/articoli-frontaliere/imposta-fonte-svizzera-2026-confronto-cantoni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -2229,7 +2229,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'permesso b, imposta alla fonte 2026, ticino, tassazione ordinaria ulteriore, tou, nov, frontalieri, svizzera, tasse, pilastro 3a, deduzioni',
     ogTitle: 'Permesso B e imposta alla fonte 2026: guida fiscale',
     ogDescription: 'Guida fiscale completa ai titolari di permesso B in Ticino: aliquote imposta alla fonte 2026, deduzioni, soglia TOU e confronto con il permesso G.',
-    canonicalPath: '/articoli-frontaliere/permesso-b-imposta-fonte-2026',
+    canonicalPath: '/articoli-frontaliere/permesso-b-imposta-fonte-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -2259,7 +2259,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'ai frontalieri, assistente ai frontalieri, chatbot frontaliere, intelligenza artificiale frontalieri, gemini frontaliere, chatbot gratis frontalieri, ai ticino',
     ogTitle: 'Assistente AI per frontalieri: la guida completa 2026',
     ogDescription: 'Chatbot gratuito per frontalieri: permesso G, imposta alla fonte, job search, privacy e 15 FAQ reali.',
-    canonicalPath: '/articoli-frontaliere/assistente-ai-frontalieri',
+    canonicalPath: '/articoli-frontaliere/assistente-ai-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -2289,7 +2289,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, economia, rischio, burocrazia, divisioni',
     ogTitle: 'Economia svizzera a rischio: burocrazia e divisioni interne',
     ogDescription: 'L\'economista Rudolf Walser lancia l\'allarme: la Svizzera rischia di perdere competitività a causa della burocrazia federale e delle divisioni interne.',
-    canonicalPath: '/articoli-frontaliere/economia-svizzera-rischio-burocrazia',
+    canonicalPath: '/articoli-frontaliere/economia-svizzera-rischio-burocrazia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2317,7 +2317,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, samira, stefano, semifinale, chiasso',
     ogTitle: 'Samira De Stefano in semifinale a Chiasso | Frontaliere',
     ogDescription: 'La tennista varesina Samira De Stefano raggiunge la semifinale a Chiasso e migliora il suo best ranking. Scopri di più su questa promessa del tennis italiano.',
-    canonicalPath: '/articoli-frontaliere/samira-de-stefano-semifinale-chiasso',
+    canonicalPath: '/articoli-frontaliere/samira-de-stefano-semifinale-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2345,7 +2345,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, omaggio, agli, angeli, ponte',
     ogTitle: 'Omaggio agli Angeli di Ponte Chiasso | Frontaliere Ticino',
     ogDescription: 'Scoperta targa commemorativa per Giuseppina Panzìca, Giovanni Gavino Tolis e Paolo Boetti, eroi che salvarono ebrei dai nazifascisti al confine italo-svizzero',
-    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2373,7 +2373,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, comunale, stabio, futuro',
     ogTitle: 'Polizia Stabio: futuro incerto, presenza costante |',
     ogDescription: 'Il futuro della polizia comunale di Stabio è incerto, ma la sua presenza rimane costante. Scopri di più sulle attività 2025 e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-stabio-futuro-incerto',
+    canonicalPath: '/articoli-frontaliere/polizia-stabio-futuro-incerto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2401,7 +2401,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, settimana, giorni, esperimento, rivoluziona',
     ogTitle: 'Settimana di 4 giorni in Ticino | Frontaliere Ticino',
     ogDescription: 'Scopri come la settimana di 4 giorni sta rivoluzionando il lavoro in Ticino e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/settimana-corta-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/settimana-corta-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2429,7 +2429,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, mancano, criteri, chiari',
     ogTitle: 'COMCO usa l’IA: ma mancano criteri chiari',
     ogDescription: 'La Commissione della concorrenza svizzera utilizza l’intelligenza artificiale per combattere i cartelli, ma il CdF critica la mancanza di una strategia chiara',
-    canonicalPath: '/articoli-frontaliere/comco-ia-criteri-2026',
+    canonicalPath: '/articoli-frontaliere/comco-ia-criteri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2457,7 +2457,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, autista, belga, fila, polizia',
     ogTitle: 'Autista belga guida 20 ore: polizia Thurgau interviene',
     ogDescription: 'Un autista belga è stato fermato dopo aver guidato quasi 20 ore consecutive. La polizia del Canton Thurgau ha preso provvedimenti.',
-    canonicalPath: '/articoli-frontaliere/autista-belga-20-ore-thurgau-intervento',
+    canonicalPath: '/articoli-frontaliere/autista-belga-20-ore-thurgau-intervento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2485,7 +2485,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, neuch, dipendenti, telelavoro, guasto',
     ogTitle: 'UST Neuchâtel: 300 dipendenti in telelavoro | Frontaliere',
     ogDescription: 'Circa 300 dipendenti dell’Ufficio federale di statistica di Neuchâtel sono in telelavoro a causa di un malfunzionamento del sistema antincendio.',
-    canonicalPath: '/articoli-frontaliere/ust-neuchatel-telelavoro-300-dipendenti',
+    canonicalPath: '/articoli-frontaliere/ust-neuchatel-telelavoro-300-dipendenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2513,7 +2513,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, alla, carta, identità',
     ogTitle: 'Addio alla carta d\'identità cartacea | Frontaliere Ticino',
     ogDescription: 'Dal 3 agosto 2026, la carta d\'identità cartacea non sarà più valida. Ecco cosa cambia e come richiedere la CIE',
-    canonicalPath: '/articoli-frontaliere/cartaelettronica-varese-2026',
+    canonicalPath: '/articoli-frontaliere/cartaelettronica-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2541,7 +2541,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, frode, crediti, covid, 3334',
     ogTitle: 'Frode crediti Covid: 3334 casi aperti in Ticino',
     ogDescription: 'Le autorità svizzere affrontano 3334 procedimenti per frodi sui crediti Covid, per un valore di oltre 406 milioni di franchi.',
-    canonicalPath: '/articoli-frontaliere/frode-crediti-covid-ticino-3334-casi',
+    canonicalPath: '/articoli-frontaliere/frode-crediti-covid-ticino-3334-casi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2569,7 +2569,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, sulla, salute, entro',
     ogTitle: 'Frontalieri, “tassa sulla salute” al via entro settembre',
     ogDescription: 'Regione Lombardia conferma il cronoprogramma per il contributo economico che servirà a sostenere gli stipendi del personale sanitario nelle zone al confine con',
-    canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-lombardia',
+    canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2597,7 +2597,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trovare, casa, mercato, immobiliare',
     ogTitle: 'Trovare casa in Ticino: il mercato immobiliare nel 2026',
     ogDescription: 'Scopri come trovare casa in Ticino nel 2026: analisi del mercato immobiliare, implicazioni per i frontalieri e azioni concrete per trovare un alloggio.',
-    canonicalPath: '/articoli-frontaliere/casa-ticino-2026-piu-difficile',
+    canonicalPath: '/articoli-frontaliere/casa-ticino-2026-piu-difficile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2625,7 +2625,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, quadranti, chiede, controlli',
     ogTitle: 'Sicurezza frontalieri Ticino: Quadranti chiede più controlli',
     ogDescription: 'Il capogruppo PLR Matteo Quadranti chiede al Consiglio di Stato misure per aumentare la sicurezza, soprattutto nel sottoceneri e nelle aree frontaliere',
-    canonicalPath: '/articoli-frontaliere/sicurezza-frontalieri-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/sicurezza-frontalieri-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2653,7 +2653,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vacanze, estive, costi, aumento',
     ogTitle: 'Vacanze estive 2026: costi in aumento per la guerra |',
     ogDescription: 'Un\'analisi di HolidayCheck rivela che i prezzi delle vacanze estive 2026 sono superiori del 10-20% rispetto all\'anno scorso, ma alcune destinazioni registrano',
-    canonicalPath: '/articoli-frontaliere/vacanze-estive-2026-costi-guerra',
+    canonicalPath: '/articoli-frontaliere/vacanze-estive-2026-costi-guerra/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2681,7 +2681,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, anni, ricerca, biomedica',
     ogTitle: 'IRB Bellinzona: 25 anni di ricerca biomedica | Frontaliere',
     ogDescription: 'L\'Istituto di Ricerca in Biomedicina di Bellinzona festeggia 25 anni di attività con 160 collaboratori e quasi 1000 pubblicazioni scientifiche.',
-    canonicalPath: '/articoli-frontaliere/irb-bellinzona-valore-aggiunto-ticino',
+    canonicalPath: '/articoli-frontaliere/irb-bellinzona-valore-aggiunto-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2709,7 +2709,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incentivo, alla, remigrazione, cosa',
     ogTitle: 'Incentivo alla remigrazione: cosa cambia per i frontalieri',
     ogDescription: 'Il governo italiano introduce un bonus di 615 euro per avvocati che convincono richiedenti asilo a tornare in patria. La misura solleva critiche in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/incentivo-remigrazione-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/incentivo-remigrazione-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2737,7 +2737,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confederazione, cantoni, ridiscutono, compiti',
     ogTitle: 'Confederazione e Cantoni ridiscutono i compiti | Frontaliere',
     ogDescription: 'Il progetto Dissociazione 27 propone modifiche in 14 settori, tra cui trasporti e formazione. Ecco le implicazioni per chi lavora in Ticino.',
-    canonicalPath: '/articoli-frontaliere/confederazione-cantoni-ridiscutono-compiti-2026',
+    canonicalPath: '/articoli-frontaliere/confederazione-cantoni-ridiscutono-compiti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2765,7 +2765,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asili, nido, pubblici, bellinzona',
     ogTitle: 'Asili nido pubblici Bellinzona: l\'Asp sostiene l\'iniziativa',
     ogDescription: 'L\'Associazione per la difesa del servizio pubblico sostiene l\'iniziativa per più asili nido pubblici a Bellinzona, evidenziando l\'importanza dell\'equità sociale',
-    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-asp-2026',
+    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-asp-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2793,7 +2793,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavena, ponte, tresa, celebra',
     ogTitle: 'Lavena Ponte Tresa celebra la Libertà: successo del',
     ogDescription: 'La comunità di Lavena Ponte Tresa ha festeggiato l\'81° anniversario della Liberazione con una partecipata cerimonia che ha visto protagonisti i giovani del',
-    canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-battesimo-civico-2026',
+    canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-battesimo-civico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2821,7 +2821,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tilo, fermo, fino, alle',
     ogTitle: 'Tilo S40 fermo fino alle 21: manca personale in Italia',
     ogDescription: 'La linea S40 tra Mendrisio e Como San Giovanni e Varese è limitata fino alle 21 per mancanza di personale in Italia. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ferrovia-tilo-s40-fermi-italia-personale',
+    canonicalPath: '/articoli-frontaliere/ferrovia-tilo-s40-fermi-italia-personale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2849,7 +2849,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, stretta, permessi, dimora',
     ogTitle: 'Grigioni: stretta sui permessi di dimora | Frontaliere',
     ogDescription: 'Nuove regole per i permessi di dimora nei Grigioni: dichiarazione obbligatoria di precedenti penali e procedimenti in corso. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-dimora-2026',
+    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-dimora-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2877,7 +2877,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spese, cura, ufas, chiarisce',
     ogTitle: 'Spese di cura frontalieri: UFAS chiarisce la procedura',
     ogDescription: 'L\'Ufficio federale delle assicurazioni sociali spiega come vengono gestite le spese mediche per i frontalieri italiani infortunati in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/spese-cura-frontalieri-ufas-2026',
+    canonicalPath: '/articoli-frontaliere/spese-cura-frontalieri-ufas-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2905,7 +2905,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, miliardari, dubai, alla, lugano',
     ogTitle: 'Miliardari da Dubai alla Svizzera: Lugano nel mirino',
     ogDescription: 'L\'incertezza geopolitica spinge i miliardari di Dubai a trasferirsi in Svizzera, con Lugano come meta preferita. Decine di miliardi in arrivo.',
-    canonicalPath: '/articoli-frontaliere/miliardari-dubai-svizzera-lugano',
+    canonicalPath: '/articoli-frontaliere/miliardari-dubai-svizzera-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2933,7 +2933,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, ufas, chiarisce, spese',
     ogTitle: 'Crans-Montana: UFAS chiarisce le spese di cura per i',
     ogDescription: 'L\'Ufficio federale delle assicurazioni sociali spiega la procedura per il rimborso delle spese mediche per i pazienti italiani infortunati in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-ufas-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-ufas-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2961,7 +2961,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantone, comuni, uniti, contro',
     ogTitle: 'Alleanza clima Ticino Comuni | Frontaliere Ticino',
     ogDescription: 'Cantone e Comuni uniti contro i cambiamenti climatici. Scopri le implicazioni per i frontalieri e come contribuire alla sostenibilità.',
-    canonicalPath: '/articoli-frontaliere/alleanza-clima-ticino-comuni',
+    canonicalPath: '/articoli-frontaliere/alleanza-clima-ticino-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2989,7 +2989,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, riceve, euro, valorizzare',
     ogTitle: 'Varese riceve 35.000 euro per valorizzare le sue bellezze |',
     ogDescription: 'Regione Lombardia finanzia il marketing territoriale: Varese ottiene 35.000 euro per promuovere le sue eccellenze culturali e turistiche.',
-    canonicalPath: '/articoli-frontaliere/marketing-territoriale-varese-35000-euro',
+    canonicalPath: '/articoli-frontaliere/marketing-territoriale-varese-35000-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3017,7 +3017,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, tassa, finanziare, stipendi',
     ogTitle: 'Nuova tassa sui frontalieri: 3% in più per finanziare gli',
     ogDescription: 'Dal settembre 2026, i frontalieri in Lombardia pagheranno una tassa del 3% per finanziare aumenti salariali per medici e infermieri',
-    canonicalPath: '/articoli-frontaliere/nuova-tassa-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-tassa-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3045,7 +3045,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, fatture, cure, pazienti',
     ogTitle: 'Crans-Montana: fatture cure italiani | Frontaliere Ticino',
     ogDescription: 'L\'Italia ribadisce che non pagherà le fatture delle cure per i pazienti italiani ricoverati in Svizzera dopo il rogo di Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-cure-italiani-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-cure-italiani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3073,7 +3073,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, shopping, milioni, svizzeri, preferiscono',
     ogTitle: 'Shopping in Italia per 700 milioni: svizzeri preferiscono',
     ogDescription: 'Scopri come gli svizzeri spendono 700 milioni all\'anno in Italia, con il 67% degli acquisti nei supermercati comaschi. Implicazioni per i frontalieri e',
-    canonicalPath: '/articoli-frontaliere/svizzeri-shopping-como-700-milioni',
+    canonicalPath: '/articoli-frontaliere/svizzeri-shopping-como-700-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3101,7 +3101,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, apprendisti, cifre, allarmanti, sugli',
     ogTitle: 'Apprendisti in Ticino: cifre allarmanti sugli incidenti',
     ogDescription: 'Quasi 23.000 apprendisti svizzeri sono vittime di incidenti ogni anno, con tre casi mortali in media. Unia chiede misure urgenti.',
-    canonicalPath: '/articoli-frontaliere/apprendisti-ticino-incidenti-2026',
+    canonicalPath: '/articoli-frontaliere/apprendisti-ticino-incidenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3129,7 +3129,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fiorenzo, dadò, statali, nella',
     ogTitle: 'Fiorenzo Dadò, le sue tre «P» e gli statali nella morsa p',
     ogDescription: 'Fiorenzo Dadò, presidente dell\'OCST, discute con Alain Buehler, capogruppo UDC, sulle iniziative statali.',
-    canonicalPath: '/articoli-frontaliere/fiorenzo-dado-le-sue-tre-p-e-gli-statali-nella-morsa-politica',
+    canonicalPath: '/articoli-frontaliere/fiorenzo-dado-le-sue-tre-p-e-gli-statali-nella-morsa-politica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3157,7 +3157,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, medici, senza, permesso, fenomeno',
     ogTitle: 'Medici senza permesso in Svizzera | Frontaliere Ticino',
     ogDescription: 'Scopri il fenomeno preoccupante dei medici che esercitano senza permesso in Svizzera e le implicazioni per i frontalieri del Ticino.',
-    canonicalPath: '/articoli-frontaliere/medici-senza-permesso-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/medici-senza-permesso-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3185,7 +3185,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, spese, mediche, respinge',
     ogTitle: 'Crans-Montana, spese mediche: Italia respinge richiesta',
     ogDescription: 'La premier Meloni annuncia che l\'Italia non pagherà le spese mediche per i feriti di Crans-Montana, nonostante la Svizzera intenda chiedere il rimborso',
-    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3213,7 +3213,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, aumenta, stipendi, sanitari',
     ogTitle: 'Lombardia aumenta stipendi sanitari al confine | Frontaliere',
     ogDescription: 'La Lombardia introduce un aumento del 20% per medici e infermieri al confine con la Svizzera, finanziato da un contributo sui salari dei frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lombardia-aumenta-stipendi-sanitari-2026',
+    canonicalPath: '/articoli-frontaliere/lombardia-aumenta-stipendi-sanitari-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3241,7 +3241,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petizione, contro, tassa, esenzione',
     ogTitle: 'Petizione contro tassa esenzione militare | Frontaliere',
     ogDescription: 'La Gioventù comunista lancia una petizione per abolire la tassa d\'esenzione dall\'obbligo militare in Ticino, accusando il governo di privilegiare l\'esercito.',
-    canonicalPath: '/articoli-frontaliere/petizione-gioventu-comunista-tassa-esenzione-militare',
+    canonicalPath: '/articoli-frontaliere/petizione-gioventu-comunista-tassa-esenzione-militare/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3269,7 +3269,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petizione, abolire, tassa, esenzione',
     ogTitle: 'Petizione per abolire la tassa di esenzione dal servizio',
     ogDescription: 'La Gioventù Comunista lancia una petizione per abolire la tassa di esenzione dal servizio militare, definita ingiusta e discriminatoria.',
-    canonicalPath: '/articoli-frontaliere/petizione-tassa-esenzione-militare-ticino',
+    canonicalPath: '/articoli-frontaliere/petizione-tassa-esenzione-militare-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3297,7 +3297,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, immigrazione, anni, dibattito, iniziative',
     ogTitle: 'Immigrazione in Svizzera: 60 anni di dibattito',
     ogDescription: 'Scopri come l\'immigrazione ha plasmato la Svizzera in 60 anni e le implicazioni per i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/immigrazione-svizzera-60-anni-2026',
+    canonicalPath: '/articoli-frontaliere/immigrazione-svizzera-60-anni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3325,7 +3325,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, supermercati, migros, coop, aldi',
     ogTitle: 'Supermercati Ticino: Nessun rincaro immediato | Frontaliere',
     ogDescription: 'Migros, Coop e Aldi rassicurano: con la crisi in Medio Oriente nessun rincaro immediato per i prodotti di largo consumo in Ticino',
-    canonicalPath: '/articoli-frontaliere/supermercati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/supermercati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3353,7 +3353,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, latte, ticinese, situazione, urgente',
     ogTitle: 'Latte ticinese, la situazione è urgente e la politica è già',
     ogDescription: 'Il Partito comunista interpella il governo sul prezzo del latte in Ticino, ai minimi storici. Urge una risposta politica alla crisi della filiera la',
-    canonicalPath: '/articoli-frontaliere/latte-ticino-crisi-politica-ritardo',
+    canonicalPath: '/articoli-frontaliere/latte-ticino-crisi-politica-ritardo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3381,7 +3381,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maria, timofeeva, trionfa, torneo',
     ogTitle: 'Maria Timofeeva trionfa al torneo di Chiasso | Frontaliere',
     ogDescription: 'La ventiduenne uzbeka Maria Timofeeva ha vinto l\'Axion Open di Chiasso sconfiggendo Lisa Pigato in finale. Scopri di più su questa vittoria storica.',
-    canonicalPath: '/articoli-frontaliere/maria-timofeeva-trionfa-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/maria-timofeeva-trionfa-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3409,7 +3409,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, paga, cure, italiani',
     ogTitle: 'Crans-Montana: chi paga le cure per gli italiani? |',
     ogDescription: 'Le fatture delle cure per i tre italiani feriti a Crans-Montana hanno scatenato polemiche. Ecco chi deve pagare e come funziona il sistema.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-cure-italiani-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-cure-italiani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3437,7 +3437,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costi, salute, esperto, avverte',
     ogTitle: 'Costi salute Svizzera: esperto avverte, «Sistema al',
     ogDescription: 'Nel 2025 i costi sanitari svizzeri toccheranno i 100 miliardi, con una spesa pro capite di 900 CHF al mese. L\'esperto Igor Francetic della SUPSI avverte: il',
-    canonicalPath: '/articoli-frontaliere/costi-salute-svizzera-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/costi-salute-svizzera-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3465,7 +3465,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, imposta, ocse, sulle, multinazionali',
     ogTitle: 'Imposta OCSE Multinazionali: Obiettivi Lontani | Frontaliere',
     ogDescription: 'L\'imposta minima del 15% per le multinazionali in Svizzera ha incassato 564 milioni nel 2025, ben al di sotto degli obiettivi miliardari del Consiglio federale.',
-    canonicalPath: '/articoli-frontaliere/imposta-ocse-multinazionali-obiettivi-lontani',
+    canonicalPath: '/articoli-frontaliere/imposta-ocse-multinazionali-obiettivi-lontani/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3493,7 +3493,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, settimana, corta, meno, produttività',
     ogTitle: 'Settimana corta in Svizzera: meno ore, più produttività',
     ogDescription: 'Un esperimento svizzero mostra che lavorare meno ore a parità di salario riduce assenze e aumenta la motivazione dei dipendenti',
-    canonicalPath: '/articoli-frontaliere/settimana-corta-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/settimana-corta-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3521,7 +3521,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, adulti, ricevono, soldi, genitori',
     ogTitle: 'Adulti che ricevono soldi dai genitori | Frontaliere Ticino',
     ogDescription: 'Scopri come il sostegno finanziario all’interno delle famiglie sta aumentando in Ticino e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/adulti-genitori-sostegno-finanziario-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/adulti-genitori-sostegno-finanziario-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3549,7 +3549,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, lufthansa, lanciano, economy',
     ogTitle: 'Swiss e Lufthansa Economy Basic | Frontaliere Ticino',
     ogDescription: 'Scopri la nuova tariffa Economy Basic di Swiss e Lufthansa per voli europei con bagaglio a mano piccolo. Disponibile dal 28 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/swiss-lufthansa-economy-basic-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-lufthansa-economy-basic-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3577,7 +3577,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, frode, twint, proteggere, account',
     ogTitle: 'Frode TWINT: come proteggere il tuo account',
     ogDescription: 'Scopri come i criminali rubano gli account TWINT e come proteggere il tuo. Consigli pratici e cosa fare se sei vittima di frode.',
-    canonicalPath: '/articoli-frontaliere/twint-account-frode-frontalieri',
+    canonicalPath: '/articoli-frontaliere/twint-account-frode-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3605,7 +3605,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costi, sanitari, 2024, famiglie',
     ogTitle: 'Costi sanitari Ticino 2024: +4% | Frontaliere Ticino',
     ogDescription: 'Scopri l\'aumento dei costi sanitari in Ticino nel 2024 e le implicazioni per i frontalieri. Confronta i premi delle assicurazioni malattie e pianifica le tue',
-    canonicalPath: '/articoli-frontaliere/costi-sanitari-ticino-2024-4-percento',
+    canonicalPath: '/articoli-frontaliere/costi-sanitari-ticino-2024-4-percento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3633,7 +3633,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cybersicurezza, industriale, proteggere, produzione',
     ogTitle: 'Cybersicurezza industriale: proteggere produzione e',
     ogDescription: 'Le imprese del Canton Ticino devono adottare un approccio integrato per la sicurezza informatica industriale, secondo un webinar promosso da ANIMA C',
-    canonicalPath: '/articoli-frontaliere/cybersicurezza-industriale-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cybersicurezza-industriale-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3661,7 +3661,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, redditi, 2024, luvinate, comune',
     ogTitle: 'Redditi 2024: Luvinate è il comune più ricco della provincia',
     ogDescription: 'Luvinate supera Galliate Lombardo con un reddito medio di 37.654 euro. I dati dei frontalieri non sono inclusi.',
-    canonicalPath: '/articoli-frontaliere/redditi-varesotti-2024-luvinate',
+    canonicalPath: '/articoli-frontaliere/redditi-varesotti-2024-luvinate/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3689,7 +3689,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, autostrade, cosa',
     ogTitle: 'Chiusure notturne autostrade: cosa cambia per i frontalieri',
     ogDescription: 'Dalla notte tra il 28 e il 29 aprile, chiusure notturne tra A8, Raccordo Fiera e Diramazione Gallarate-Gattico. Ecco le alternative',
-    canonicalPath: '/articoli-frontaliere/chiusure-autostrade-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-autostrade-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3717,7 +3717,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accordo, storico, navigazione, tedesca',
     ogTitle: 'Accordo navigazione Lago di Costanza | Frontaliere Ticino',
     ogDescription: 'Biglietti validi reciprocamente dal 2026 e ripresa degli scali a Costanza. Cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/accordo-navigazione-costanza-2026',
+    canonicalPath: '/articoli-frontaliere/accordo-navigazione-costanza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3745,7 +3745,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, germignaga, comunità, energetica, rinnovabile',
     ogTitle: 'Germignaga: Comunità Energetica Rinnovabile del Luinese',
     ogDescription: 'La Comunità Energetica Rinnovabile del Luinese raggiunge 400 kW di potenza e punta a 1000 kW entro fine 2026. 17 Comuni e 287 soci coinvolti.',
-    canonicalPath: '/articoli-frontaliere/comunita-energetica-rinnovabile-luinese-400-kw',
+    canonicalPath: '/articoli-frontaliere/comunita-energetica-rinnovabile-luinese-400-kw/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3773,7 +3773,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusura, notturna, uscita, gallarate',
     ogTitle: 'Chiusura notturna uscita A8 Gallarate: cosa cambia per i',
     ogDescription: 'L\'uscita di Gallarate sulla A8 Milano-Varese sarà chiusa nella notte tra mercoledì 29 e giovedì 30 aprile per lavori di manutenzione. Ecco le alternative',
-    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a8-gallarate-29-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a8-gallarate-29-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3801,7 +3801,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sovranità, alimentare, latte, ticinese',
     ogTitle: 'Sovranità alimentare e latte in Ticino: crisi e soluzioni',
     ogDescription: 'Il Partito Comunista segnala il rischio di smantellamento della filiera del latte in Ticino. Analisi, scenari e azioni concrete.',
-    canonicalPath: '/articoli-frontaliere/sovranita-latte-ticino',
+    canonicalPath: '/articoli-frontaliere/sovranita-latte-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3829,7 +3829,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, giornata, alla, scoperta',
     ogTitle: 'Chiasso: Una giornata alla scoperta degli enti di primo',
     ogDescription: 'Scopri chi sono gli enti di primo intervento a Chiasso e partecipa alla Missione Emergenza.',
-    canonicalPath: '/articoli-frontaliere/chiasso-scoperta-enti-primo-intervento',
+    canonicalPath: '/articoli-frontaliere/chiasso-scoperta-enti-primo-intervento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3857,7 +3857,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tennis, donne, open, chiasso',
     ogTitle: 'Tennis donne / “Open” di Chiasso, a Marija Glebovna',
     ogDescription: 'La russa Marija Glebovna Timofeeva ha vinto il titolo dell\'“Open” di Chiasso, una delle competizioni più prestigiose in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/tennis-donne-open-di-chiasso-a-marija-glebovna-timofeeva-il-titolo',
+    canonicalPath: '/articoli-frontaliere/tennis-donne-open-di-chiasso-a-marija-glebovna-timofeeva-il-titolo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3885,7 +3885,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, foreste, sommerse, salvare, laghi',
     ogTitle: 'Foreste sommerse per salvare i laghi di Como e Lugano',
     ogDescription: 'Scopri come il progetto Echo utilizza piante acquatiche per ripristinare gli ecosistemi lacustri e combattere il cambiamento climatico nei laghi di Como e',
-    canonicalPath: '/articoli-frontaliere/foreste-sommerse-lago-como-lugano',
+    canonicalPath: '/articoli-frontaliere/foreste-sommerse-lago-como-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3913,7 +3913,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, viabilità, olimpica, grigioni, risparmiano',
     ogTitle: 'Viabilità olimpica: Grigioni risparmiano, Lombardia tace',
     ogDescription: 'I costi per la gestione del traffico olimpico sono inferiori alle previsioni, ma la Lombardia non ha ancora confermato il suo contributo.',
-    canonicalPath: '/articoli-frontaliere/grigioni-viabilita-olimpica-2026',
+    canonicalPath: '/articoli-frontaliere/grigioni-viabilita-olimpica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3941,7 +3941,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mobilità, sostenibile, città, vivibili',
     ogTitle: 'Mobilità sostenibile e città vivibili | Frontaliere Ticino',
     ogDescription: 'Scopri come Barcellona, Parigi e Singapore stanno ridisegnando lo spazio urbano per ridurre inquinamento e migliorare la qualità della vita per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/mobilita-sostenibile-citta-vivibili-2026',
+    canonicalPath: '/articoli-frontaliere/mobilita-sostenibile-citta-vivibili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3969,7 +3969,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, relazioni, italo-svizzere, novità, sviluppi',
     ogTitle: 'Relazioni italo-svizzere: novità e sviluppi',
     ogDescription: 'Scoperte geologiche, controversie su cure mediche e design svizzero al Fuorisalone milanese. Ecco gli ultimi aggiornamenti.',
-    canonicalPath: '/articoli-frontaliere/relazioni-italo-svizzere-2026',
+    canonicalPath: '/articoli-frontaliere/relazioni-italo-svizzere-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3997,7 +3997,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, integrazione, inclusione, dibattito, futuro',
     ogTitle: 'Integrazione o inclusione? Il dibattito sul futuro in Ticino',
     ogDescription: 'Esperti si riuniscono a Bellinzona per discutere il futuro dell\'integrazione e dell\'inclusione in Ticino, con progetti partecipativi e culturali in corso.',
-    canonicalPath: '/articoli-frontaliere/integrazione-inclusione-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/integrazione-inclusione-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4025,7 +4025,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, provincia, como, ricca, cresce',
     ogTitle: 'Provincia di Como più ricca: cresce il reddito | Frontaliere',
     ogDescription: 'Scopri come il reddito pro capite della provincia di Como è aumentato e le implicazioni per i frontalieri che lavorano in questa zona.',
-    canonicalPath: '/articoli-frontaliere/reddito-como-2024-frontalieri',
+    canonicalPath: '/articoli-frontaliere/reddito-como-2024-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4053,7 +4053,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moritz, costruisce, case, prezzi',
     ogTitle: 'St. Moritz costruisce case con prezzi basati sul reddito |',
     ogDescription: 'Il Comune di St. Moritz avvia la costruzione di 19 appartamenti a prezzi accessibili basati sul reddito, con altri progetti per 150-200 unità abitative in fase',
-    canonicalPath: '/articoli-frontaliere/st-moritz-case-accessibili-2026',
+    canonicalPath: '/articoli-frontaliere/st-moritz-case-accessibili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4081,7 +4081,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, macello, residenze, secondarie, quota',
     ogTitle: 'Ex Gas ex Macello: residenze secondarie, quota inefficace |',
     ogDescription: 'Locarno non aggiorna il piano per il comparto dopo la decisione dell\'Are. La quota di residenze secondarie risulta inefficace.',
-    canonicalPath: '/articoli-frontaliere/ex-gas-macello-residenze-secondarie',
+    canonicalPath: '/articoli-frontaliere/ex-gas-macello-residenze-secondarie/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4109,7 +4109,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, contratto, lago, lands, lake',
     ogTitle: 'Contratto di Lago: Lands Lake chiama a confronto i candidati',
     ogDescription: 'L\'associazione Lands Lake organizza incontri pubblici con i candidati sindaco di Baveno, Stresa, Luino e Laveno Mombello per discutere il futuro del Lago',
-    canonicalPath: '/articoli-frontaliere/contratto-lago-lands-lake-2026',
+    canonicalPath: '/articoli-frontaliere/contratto-lago-lands-lake-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4137,7 +4137,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, radar, controlli, aprile, maggio',
     ogTitle: 'Radar in Ticino: controlli dal 27 aprile al 3 maggio |',
     ogDescription: 'La Polizia cantonale e le polizie comunali annunciano i controlli della velocità in Ticino per la settimana dal 27 aprile al 3 maggio.',
-    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-aprile-maggio',
+    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-aprile-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4165,7 +4165,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, finanze, pubbliche, allarme, commercialisti',
     ogTitle: 'Finanze pubbliche Ticino: allarme commercialisti',
     ogDescription: 'L\'Ordine dei commercialisti del Canton Ticino esprime preoccupazione per le finanze pubbliche e il rischio di delocalizzazioni.',
-    canonicalPath: '/articoli-frontaliere/finanze-pubbliche-ticino-2026-preoccupazioni',
+    canonicalPath: '/articoli-frontaliere/finanze-pubbliche-ticino-2026-preoccupazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4193,7 +4193,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premi, oltre, dato, dimezza',
     ogTitle: 'Premi non oltre il 10%, il dato che dimezza i costi',
     ogDescription: 'Il governo ticinese riduce i costi dell\'iniziativa a 130 milioni. De Pietro (SUPSI): \'Più impegno nel socio-sanitario\'',
-    canonicalPath: '/articoli-frontaliere/premi-non-oltre-10-percento',
+    canonicalPath: '/articoli-frontaliere/premi-non-oltre-10-percento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4221,7 +4221,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guerra, iran, pressione, sull',
     ogTitle: 'Guerra in Iran: pressione sull\'industria alimentare svizzera',
     ogDescription: 'La guerra in Iran sta mettendo sotto pressione l\'industria alimentare svizzera, con possibili ripercussioni sui consumatori e sui lavoratori del settore.',
-    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-svizzera',
+    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4249,7 +4249,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bollini, rossi, gottardo, caos',
     ogTitle: 'Bollini rossi al San Gottardo: caos traffico in maggio |',
     ogDescription: 'Maggio 2026: previsti giorni neri per il traffico al tunnel del San Gottardo, con code fino a 20 km e ritardi fino a 2 ore. Scopri le previsioni del TCS e cosa',
-    canonicalPath: '/articoli-frontaliere/bollini-rossi-traffico-san-gottardo-2026',
+    canonicalPath: '/articoli-frontaliere/bollini-rossi-traffico-san-gottardo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4277,7 +4277,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, treno, lugano-zurigo, panne, passeggeri',
     ogTitle: 'Treno Lugano-Zurigo in panne: passeggeri a piedi da',
     ogDescription: 'Guasto tecnico sopprime il treno delle 19:00, nessun sostitutivo. Passeggeri in attesa alla stazione di Bellinzona',
-    canonicalPath: '/articoli-frontaliere/treno-guasto-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/treno-guasto-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4305,7 +4305,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elezioni, comuni, provincia, como',
     ogTitle: 'Elezioni Como 2026: 10 comuni al voto | Frontaliere Ticino',
     ogDescription: 'Si vota il 24 e 25 maggio 2026 in 10 comuni della Provincia di Como. Ecco i candidati e le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/elezioni-como-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/elezioni-como-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4333,7 +4333,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, teatro, dell, architettura, stagione',
     ogTitle: 'Teatro dell\'Architettura: stagione espositiva 2026',
     ogDescription: 'Scopri la stagione espositiva 2026 del Teatro dell\'Architettura di Mendrisio con tre mostre distinte su architettura e design.',
-    canonicalPath: '/articoli-frontaliere/teatro-architettura-mendrisio-stagione-2026',
+    canonicalPath: '/articoli-frontaliere/teatro-architettura-mendrisio-stagione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4361,7 +4361,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arrestato, truffatore, maggia, frode',
     ogTitle: 'Arrestato truffatore a Maggia: frode con schockanruf',
     ogDescription: 'Un truffatore è stato arrestato a Maggia dopo essere stato colto in flagrante durante una frode telefonica. Scopri i dettagli dell\'operazione e come',
-    canonicalPath: '/articoli-frontaliere/frontalieri-arresto-maggia-truffa',
+    canonicalPath: '/articoli-frontaliere/frontalieri-arresto-maggia-truffa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4389,7 +4389,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, study, china, opportunità, oltre',
     ogTitle: 'Study in China: opportunità per frontalieri Ticino',
     ogDescription: 'Scopri le opportunità di studio in Cina per i frontalieri del Ticino. Oltre 380.000 studenti internazionali nel 2024-2025, con un aumento del 15%.',
-    canonicalPath: '/articoli-frontaliere/study-china-ticino-frontalieri',
+    canonicalPath: '/articoli-frontaliere/study-china-ticino-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4417,7 +4417,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, treno, senza, biglietto, sperimenta',
     ogTitle: 'Treno senza biglietto: la Svizzera sperimenta il futuro',
     ogDescription: 'La Svizzera introduce il sistema Bibo per viaggiare senza biglietti. Test nazionale dal 27 aprile con 3000 utenti, tra cui frontalieri ticinesi.',
-    canonicalPath: '/articoli-frontaliere/treno-senza-biglietto-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/treno-senza-biglietto-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4445,7 +4445,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, stradale, oltre, patenti',
     ogTitle: 'Polizia Stradale: 1.600 patenti ritirate | Frontaliere',
     ogDescription: 'Nel 2025, la Polizia Stradale di Varese ha ritirato oltre 1.600 patenti, con un calo del 42% per eccesso di velocità e del 25% per guida in stato di ebbrezza.',
-    canonicalPath: '/articoli-frontaliere/polizia-stradale-varese-1600-patenti',
+    canonicalPath: '/articoli-frontaliere/polizia-stradale-varese-1600-patenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4473,7 +4473,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lupo, cinghiali, burocrazia, sfide',
     ogTitle: 'Lupo, cinghiali e burocrazia: le sfide degli agricoltori',
     ogDescription: 'La 79ª assemblea di Confagricoltura Varese evidenzia le criticità del settore agricolo, tra fauna selvatica, costi elevati e Green Deal.',
-    canonicalPath: '/articoli-frontaliere/agricoltori-varesini-sfide-burocrazia',
+    canonicalPath: '/articoli-frontaliere/agricoltori-varesini-sfide-burocrazia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4501,7 +4501,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, banconote, euro, temi',
     ogTitle: 'Nuove banconote in euro: restyling e temi in gara',
     ogDescription: 'Scopri i due temi proposti per le nuove banconote in euro: cultura europea e natura. Decisione finale entro fine 2026.',
-    canonicalPath: '/articoli-frontaliere/nuove-banconote-euro-restyling-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-banconote-euro-restyling-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4529,7 +4529,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, amazon, made, italy, days',
     ogTitle: 'Amazon Made in Italy Days 2026: 5.500 eccellenze italiane in',
     ogDescription: 'Dal 13 al 19 maggio 2026, Amazon ospita 5.500 prodotti Made in Italy su 11 mercati internazionali. Collaborazione con Agenzia Ice.',
-    canonicalPath: '/articoli-frontaliere/amazon-made-in-italy-days-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/amazon-made-in-italy-days-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4557,7 +4557,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro-carburanti, dove, fare, pieno',
     ogTitle: 'Caro-carburanti: dove fare il pieno in Ticino | Frontaliere',
     ogDescription: 'Confronta i prezzi della benzina e del diesel in Ticino e risparmia con i nostri consigli pratici',
-    canonicalPath: '/articoli-frontaliere/carburanti-ticino-confronto-2024',
+    canonicalPath: '/articoli-frontaliere/carburanti-ticino-confronto-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4585,7 +4585,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, contratto, collettivo, edilizia',
     ogTitle: 'Nuovo CCL-Ti 2026-2031: cosa cambia per i lavoratori',
     ogDescription: 'Scopri le novità del nuovo Contratto Collettivo di Lavoro per l’edilizia e il genio civile in Ticino, valido dal 1° maggio 2026 al 31 dicembre 2031.',
-    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026-2031',
+    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026-2031/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4613,7 +4613,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, varese, sindacati',
     ogTitle: 'Primo Maggio Varese 2026: sindacati in corteo per un lavoro',
     ogDescription: 'Scopri di più sulla manifestazione del Primo Maggio 2026 a Varese, organizzata dai sindacati CGIL, CISL e UIL per un lavoro dignitoso.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-dignitoso',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-dignitoso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4641,7 +4641,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallimenti, fotovoltaico, clienti, rischio',
     ogTitle: 'Fallimenti fotovoltaico: clienti a rischio | Frontaliere',
     ogDescription: 'Diverse aziende fotovoltaiche fallite in Ticino, clienti con impianti incompleti e acconti a rischio. Swissolar consiglia verifiche e garanzie.',
-    canonicalPath: '/articoli-frontaliere/fallimenti-fotovoltaico-clienti-ticino',
+    canonicalPath: '/articoli-frontaliere/fallimenti-fotovoltaico-clienti-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4669,7 +4669,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, coop, ritira, insetti, commestibili',
     ogTitle: 'Coop Svizzera ritira insetti commestibili | Frontaliere',
     ogDescription: 'Coop Svizzera ritira insetti commestibili dagli scaffali. Scopri le implicazioni per i frontalieri e le alternative disponibili.',
-    canonicalPath: '/articoli-frontaliere/coop-svizzera-insetti-commestibili-2026',
+    canonicalPath: '/articoli-frontaliere/coop-svizzera-insetti-commestibili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4697,7 +4697,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, rafforzati, airolo, doppia',
     ogTitle: 'Controlli rafforzati a Airolo: doppia verifica per i',
     ogDescription: 'Nuovi controlli radar in arrivo per chi entra in Svizzera da Airolo. Doppia verifica per i frontalieri, tempi di attesa più lunghi. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/controlli-frontalieri-airolo-2026',
+    canonicalPath: '/articoli-frontaliere/controlli-frontalieri-airolo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4725,7 +4725,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallimenti, startup, boom, insolito',
     ogTitle: 'Fallimenti e startup in Svizzera 2026 | Frontaliere Ticino',
     ogDescription: 'Analisi del boom di fallimenti e startup in Svizzera nel 2026 e le implicazioni per i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/fallimenti-startup-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/fallimenti-startup-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4753,7 +4753,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, limite, dimezzare, inquinamento, acustico',
     ogTitle: 'Limite a 30 km/h per dimezzare l\'inquinamento acustico in',
     ogDescription: 'L\'ATA chiede maggiore autonomia per introdurre zone a 30 km/h nelle aree più esposte al rumore, migliorando la qualità della vita e la sicurezza stradale in',
-    canonicalPath: '/articoli-frontaliere/limite-velocita-30-ticino-inquinamento-acustico',
+    canonicalPath: '/articoli-frontaliere/limite-velocita-30-ticino-inquinamento-acustico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4781,7 +4781,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, tavolo, tecnico, risolvere',
     ogTitle: 'Varese: tavolo tecnico per parcheggi ospedale Sette Laghi |',
     ogDescription: 'Comune di Varese e ASST Sette Laghi si incontrano per risolvere problemi parcheggi lavoratori sanitari. Incontro fissato per il 28 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/varese-parcheggi-ospedale-sette-laghi-2026',
+    canonicalPath: '/articoli-frontaliere/varese-parcheggi-ospedale-sette-laghi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4809,7 +4809,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zecche, punture, 2025, ecco',
     ogTitle: 'Zecche in Ticino: 18.000 punture nel 2025 | Frontaliere',
     ogDescription: 'Nel 2025 in Svizzera sono state registrate 18.000 punture di zecche. La dottoressa Luisa Carnino dell\'EOC spiega sintomi e prevenzione',
-    canonicalPath: '/articoli-frontaliere/zecche-ticino-2026-18000-punture',
+    canonicalPath: '/articoli-frontaliere/zecche-ticino-2026-18000-punture/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4837,7 +4837,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, over, raddoppiati, anni',
     ogTitle: 'Lavoratori over 65: raddoppiati in 20 anni | Frontaliere',
     ogDescription: 'Nel 2025, 220\'000 persone continuano a lavorare dopo i 65 anni, più del doppio rispetto al 2005. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4865,7 +4865,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcio, bellinzona, batte, stade',
     ogTitle: 'Calcio Dnb: Bellinzona batte Stade Nyonnais | Frontaliere',
     ogDescription: 'Il Bellinzona ha sconfitto lo Stade Nyonnais negli anticipi del campionato di calcio Dnb, approfittando della vittoria ottenuta grazie agli errori degli',
-    canonicalPath: '/articoli-frontaliere/calcio-dnb-bellinzona-vittoria-stade-nyonnais',
+    canonicalPath: '/articoli-frontaliere/calcio-dnb-bellinzona-vittoria-stade-nyonnais/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4893,7 +4893,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, senza, indipendenza, energetica, oggi',
     ogTitle: 'Svizzera senza indipendenza energetica | Frontaliere Ticino',
     ogDescription: 'Dal 27 aprile 2026 la Svizzera non è più autosufficiente energeticamente. Ecco cosa cambia per i frontalieri e il Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/svizzera-indipendenza-energetica-importazioni-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-indipendenza-energetica-importazioni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4921,7 +4921,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, misure, contro, violenza',
     ogTitle: 'Nuove misure contro violenza domestica in Svizzera |',
     ogDescription: 'Scopri le nuove misure introdotte dal Dipartimento federale di giustizia e polizia per contrastare la violenza domestica in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/nuove-misure-violenza-domestica-svizzera',
+    canonicalPath: '/articoli-frontaliere/nuove-misure-violenza-domestica-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4949,7 +4949,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ruag, giotto, creano, dati',
     ogTitle: 'RUAG e Giotto.AI creano IA svizzera per dati militari',
     ogDescription: 'La RUAG collabora con Giotto.AI per sviluppare un\'IA nazionale per dati sensibili, presentando LLARA a Thun.',
-    canonicalPath: '/articoli-frontaliere/ruag-ia-svizzera-difesa-2026',
+    canonicalPath: '/articoli-frontaliere/ruag-ia-svizzera-difesa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4977,7 +4977,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, leggi, strategia, nazionale',
     ogTitle: 'Nuove leggi e strategia nazionale contro la violenza',
     ogDescription: 'Confederazione e Cantoni annunciano progressi ma servono strumenti più efficaci. Nuove leggi in arrivo per il 2027.',
-    canonicalPath: '/articoli-frontaliere/nuove-leggi-violenza-domestica-2027',
+    canonicalPath: '/articoli-frontaliere/nuove-leggi-violenza-domestica-2027/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5005,7 +5005,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, regione, lombardia, stanzia, milioni',
     ogTitle: 'Regione Lombardia stanzia 6,4 milioni per case popolari |',
     ogDescription: 'Regione Lombardia ha stanziato oltre 6,4 milioni di euro per il recupero di alloggi sfitti e l\'accessibilità in Lombardia. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/regione-lombardia-casa-popolari-6-4-milioni',
+    canonicalPath: '/articoli-frontaliere/regione-lombardia-casa-popolari-6-4-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5033,7 +5033,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, domestica, gallo, prevenzione',
     ogTitle: 'Violenza domestica: prevenzione a San Gallo | Frontaliere',
     ogDescription: 'Scopri come la polizia di San Gallo previene la violenza domestica attraverso colloqui preventivi con un tasso di successo del 90%.',
-    canonicalPath: '/articoli-frontaliere/prevenzione-violenza-domestica-san-gallo-2026',
+    canonicalPath: '/articoli-frontaliere/prevenzione-violenza-domestica-san-gallo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5061,7 +5061,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zurigo, economia, cresce, meno',
     ogTitle: 'Zurigo guida l\'economia svizzera, ma cresce meno della media',
     ogDescription: 'Zurigo contribuisce al 21% del PIL svizzero, ma cresce solo dell\'1,3% contro il 1,7% nazionale. Scopri perché e cosa significa per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita-media-2026',
+    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita-media-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5089,7 +5089,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swisscom, avverte, minacce, informatiche',
     ogTitle: 'Swisscom avverte: minacce informatiche in aumento nel 2026 |',
     ogDescription: 'Swisscom segnala un forte aumento delle minacce informatiche, con rischi legati all\'IA e alle tensioni geopolitiche. Scopri come proteggere la tua azienda.',
-    canonicalPath: '/articoli-frontaliere/swisscom-minacce-cyber-2026',
+    canonicalPath: '/articoli-frontaliere/swisscom-minacce-cyber-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5117,7 +5117,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, istruzioni, sfide, dall, immigrazione',
     ogTitle: 'Svizzera, istruzioni per l\'uso: le sfide del 2026',
     ogDescription: 'Dall\'immigrazione alla casa, ecco i temi caldi che stanno cambiando il Paese e le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/svizzera-istruzioni-uso-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-istruzioni-uso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5145,7 +5145,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, reparto, securizzato, pasture, solo',
     ogTitle: 'Reparto securizzato a Pasture: consenso Cantone e Comuni |',
     ogDescription: 'La Commissione delle Istituzioni politiche della Camera bassa ha trovato una via mediana per il progetto pilota a Pasture, coinvolgendo gli enti locali.',
-    canonicalPath: '/articoli-frontaliere/reparto-securizzato-pasture-consenso-cantone-comuni',
+    canonicalPath: '/articoli-frontaliere/reparto-securizzato-pasture-consenso-cantone-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5173,7 +5173,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, edilizia, firmato, nuovo, ticinese',
     ogTitle: 'Nuovo CCL edilizia Ticino 2026-2031 | Frontaliere Ticino',
     ogDescription: 'Il nuovo contratto collettivo di lavoro per l\'edilizia e il genio civile in Ticino è stato firmato, valido dal 1° maggio 2026 al 2031. Scopri le novità e le',
-    canonicalPath: '/articoli-frontaliere/nuovo-ccnl-edilizia-ticino-2026-2031',
+    canonicalPath: '/articoli-frontaliere/nuovo-ccnl-edilizia-ticino-2026-2031/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5201,7 +5201,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morcote, apre, stagione, eventi',
     ogTitle: 'Morcote 2026: Scalinata di Corsa e Caccia al Tesoro |',
     ogDescription: 'Scopri gli eventi di Morcote 2026: la Morcote Scal il 2 maggio e la Caccia al Tesoro il 9 maggio. Iscrizioni aperte fino al 30 aprile.',
-    canonicalPath: '/articoli-frontaliere/morcote-eventi-2026-scalinata-caccia-tesoro',
+    canonicalPath: '/articoli-frontaliere/morcote-eventi-2026-scalinata-caccia-tesoro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5229,7 +5229,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, credito, energetico, cosa, cambia',
     ogTitle: 'Svizzera a credito energetico: cosa cambia per i frontalieri',
     ogDescription: 'Dal 27 aprile 2026 la Svizzera dipende dalle importazioni per il 68% del suo fabbisogno energetico. Ecco le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/svizzera-credito-energetico-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-credito-energetico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5257,7 +5257,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, oftalmologi, ticinesi, messico, operazioni',
     ogTitle: 'Oftalmologi ticinesi in Messico: operazioni gratuite',
     ogDescription: 'Un\'équipe di medici svizzeri, in gran parte ticinesi, opera gratuitamente pazienti nel Quintana Roo, Messico, per curare la cataratta.',
-    canonicalPath: '/articoli-frontaliere/oftalmologi-svizzeri-messico-vista',
+    canonicalPath: '/articoli-frontaliere/oftalmologi-svizzeri-messico-vista/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5285,7 +5285,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rumore, traffico, morti, anno',
     ogTitle: 'Rumore traffico Svizzera: 2.000 morti l\'anno | Frontaliere',
     ogDescription: 'Il rumore del traffico stradale causa fino a 2.000 decessi prematuri l\'anno in Svizzera, con 850.000 persone esposte a rumori nocivi',
-    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5313,7 +5313,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controversia, sull, bandiera, sulle',
     ogTitle: 'Controversia bandiera svizzera su scarpe On | Frontaliere',
     ogDescription: 'Scopri le polemiche sull\'uso della bandiera svizzera sulle scarpe On prodotte all\'estero e le implicazioni per il mercato elvetico.',
-    canonicalPath: '/articoli-frontaliere/bandiera-svizzera-scarpe-on-controversia',
+    canonicalPath: '/articoli-frontaliere/bandiera-svizzera-scarpe-on-controversia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5341,7 +5341,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incontro, solidarietà, sicurezza, bioggio',
     ogTitle: 'Incontro tra solidarietà e sicurezza a Bioggio',
     ogDescription: 'Volontari di City Angels Svizzera condividono esperienze dirette il 16 maggio al Centro Faressere di Bioggio',
-    canonicalPath: '/articoli-frontaliere/incontro-solidarieta-sicurezza-bioggio',
+    canonicalPath: '/articoli-frontaliere/incontro-solidarieta-sicurezza-bioggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5369,7 +5369,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, introvabili, boom, arrivi',
     ogTitle: 'Infermieri introvabili: boom di arrivi da Tunisia, India e',
     ogDescription: 'Scopri come la carenza di infermieri in Italia spinge le aziende a reclutare all\'estero, con oltre 1.000 professionisti selezionati negli ultimi tre anni.',
-    canonicalPath: '/articoli-frontaliere/infermieri-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5397,7 +5397,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, deepfake, pornografici, cosa, dice',
     ogTitle: 'Deepfake pornografici: cosa dice la legge svizzera |',
     ogDescription: 'Scopri cosa dice la legge svizzera sui deepfake pornografici e cosa fare se sei vittima di questi contenuti illegali.',
-    canonicalPath: '/articoli-frontaliere/deepfake-legge-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/deepfake-legge-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5425,7 +5425,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinesi, missione, umanitaria, ucraina',
     ogTitle: 'Ticinesi in missione umanitaria in Ucraina | Frontaliere',
     ogDescription: 'Volontari ticinesi si preparano per portare assistenza medica e conforto alla popolazione ucraina colpita dalla guerra. Scopri di più su questa missione',
-    canonicalPath: '/articoli-frontaliere/ticinesi-missione-ucraina-2026',
+    canonicalPath: '/articoli-frontaliere/ticinesi-missione-ucraina-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5453,7 +5453,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, posto, lavoro, solo, basta',
     ogTitle: 'Frontalieri e lavoro in Ticino: annuncio scandaloso |',
     ogDescription: 'Fabrizio Sirica denuncia un annuncio di lavoro a Massagno riservato esclusivamente ai frontalieri con uno stipendio di 2.900 franchi lordi al mese.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-massagno-salario-scandaloso',
+    canonicalPath: '/articoli-frontaliere/frontalieri-massagno-salario-scandaloso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5481,7 +5481,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, infermieristiche, 190mila, firme',
     ogTitle: 'Cure infermieristiche: 190mila firme per l\'applicazione',
     ogDescription: '190mila firme consegnate a Berna per l\'applicazione immediata dell\'iniziativa sulle cure infermieristiche. Il Consiglio nazionale discute la nuova legge.',
-    canonicalPath: '/articoli-frontaliere/cure-infermieristiche-190mila-firme-2026',
+    canonicalPath: '/articoli-frontaliere/cure-infermieristiche-190mila-firme-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5509,7 +5509,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maxi, spiegamento, fiamme, gialle',
     ogTitle: 'Maxi spiegamento Fiamme Gialle Comasco | Frontaliere Ticino',
     ogDescription: 'Controlli intensi nel Comasco: scoperti lavoratori in nero e sequestrati stupefacenti. Ecco i dettagli dell\'operazione.',
-    canonicalPath: '/articoli-frontaliere/maxi-spiegamento-fiamme-gialle-comasco-2026',
+    canonicalPath: '/articoli-frontaliere/maxi-spiegamento-fiamme-gialle-comasco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5537,7 +5537,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, medici, famiglia, sumai',
     ogTitle: 'Riforma medici famiglia: Sumai, il nodo è organizzazione |',
     ogDescription: 'Antonio Magi, segretario generale del Sumai-Assoprof, contesta l\'idea di dipendenza dei medici di base, evidenziando problemi organizzativi e carenza di',
-    canonicalPath: '/articoli-frontaliere/riforma-medici-famiglia-sumai-organizzazione',
+    canonicalPath: '/articoli-frontaliere/riforma-medici-famiglia-sumai-organizzazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5565,7 +5565,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, pensionabile, anni, 2025',
     ogTitle: 'Lavoratori in età pensionabile in Ticino: +220% in 20 anni',
     ogDescription: 'Nel 2025, 220.000 persone in Svizzera lavoravano oltre l\'età pensionabile. Ecco cosa cambia per i frontalieri del Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026-2046',
+    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026-2046/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5593,7 +5593,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intelligenza, artificiale, università, varese',
     ogTitle: 'Intelligenza artificiale all\'Università di Varese |',
     ogDescription: 'L\'Università dell\'Insubria organizza un evento sull\'intelligenza artificiale il 6 maggio 2026 a Varese, con interventi di esperti e nuove linee guida per',
-    canonicalPath: '/articoli-frontaliere/universita-varese-intelligenza-artificiale-2026',
+    canonicalPath: '/articoli-frontaliere/universita-varese-intelligenza-artificiale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5621,7 +5621,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, visite, gratuite, prevenzione, tumore',
     ogTitle: 'Visite Gratuite Prevenzione Tumore Seno Gallarate |',
     ogDescription: 'Due giornate di visite senologiche gratuite con ecografia a Gallarate in piazza Libertà nel mese di maggio. Prenotazione obbligatoria al numero 380 8644677.',
-    canonicalPath: '/articoli-frontaliere/visite-gratuite-prevenzione-tumore-seno-gallarate-lilt',
+    canonicalPath: '/articoli-frontaliere/visite-gratuite-prevenzione-tumore-seno-gallarate-lilt/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5649,7 +5649,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mozione, contro, discriminazione, lavorativa',
     ogTitle: 'Frontalieri: mozione contro discriminazione lavorativa in',
     ogDescription: 'Fabrizio Sirica presenta mozione per contrastare il dumping salariale e favorire l\'occupazione dei residenti nel Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-mozione-sirica-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/frontalieri-mozione-sirica-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5677,7 +5677,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aiutare, altri, corsi, gratuiti',
     ogTitle: 'Corsi gratuiti Varese sociale | Frontaliere Ticino',
     ogDescription: 'Your Self Company offre corsi gratuiti per ASA, OSS e ASACOM a Varese. Finanziati da Regione Lombardia, posti limitati. Iscrizioni aperte.',
-    canonicalPath: '/articoli-frontaliere/corsi-gratuiti-varese-sociale-2026',
+    canonicalPath: '/articoli-frontaliere/corsi-gratuiti-varese-sociale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5705,7 +5705,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, solaro, incontri, pubblici, rifiuti',
     ogTitle: 'Solaro: incontri su rifiuti e tariffazione puntuale |',
     ogDescription: 'Il Comune di Solaro organizza due serate informative su raccolta differenziata e tariffazione puntuale per chiarire dubbi ai cittadini.',
-    canonicalPath: '/articoli-frontaliere/solaro-rifiuti-differenziata-tariffazione-puntuale',
+    canonicalPath: '/articoli-frontaliere/solaro-rifiuti-differenziata-tariffazione-puntuale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5733,7 +5733,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, quadri, deve, pagare',
     ogTitle: 'Disoccupazione frontalieri: Quadri, «La Svizzera non deve',
     ogDescription: 'Il consigliere nazionale ticinese Lorenzo Quadri (Lega) presenta una mozione per evitare che la Svizzera versi le indennità di disoccupazione ai frontalieri.',
-    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri',
+    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5761,7 +5761,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, lugano, strade, chiuse',
     ogTitle: '1° maggio a Lugano: strade chiuse per corteo sindacale',
     ogDescription: 'Dalle 16:00 alle 17:00 saranno chiuse le vie centrali di Lugano per il corteo sindacale. Mercatini sul lungolago dalle 09:00 alle 20:00.',
-    canonicalPath: '/articoli-frontaliere/corteo-maggio-lugano-traffico-2024',
+    canonicalPath: '/articoli-frontaliere/corteo-maggio-lugano-traffico-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5789,7 +5789,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, suva, incidenti, mortali, lavoro',
     ogTitle: 'SUVA: incidenti mortali sul lavoro -80% | Frontaliere Ticino',
     ogDescription: 'Dati SUVA: infortuni mortali sul lavoro ridotti dell\'80% dal 1986-1990 al 2020-2024, nonostante aumento occupati. Innovazione e formazione chiave.',
-    canonicalPath: '/articoli-frontaliere/incidenti-mortali-lavoro-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/incidenti-mortali-lavoro-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5817,7 +5817,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, coldiretti, brennero, stop, falso',
     ogTitle: 'Coldiretti al Brennero: Stop al falso Made in Italy |',
     ogDescription: 'Agricoltori varesini si uniscono alla protesta per modificare il codice doganale e contrastare il falso Made in Italy. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/coldiretti-brennero-made-italy-2026',
+    canonicalPath: '/articoli-frontaliere/coldiretti-brennero-made-italy-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5845,7 +5845,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sempre, amato, tedeschi, record',
     ogTitle: 'Ticino sempre più amato dai tedeschi | Frontaliere Ticino',
     ogDescription: 'Scopri come il Ticino attira i turisti tedeschi con oltre 450.000 pernottamenti nel 2025 e una crescita dell\'8,2% rispetto al 2024.',
-    canonicalPath: '/articoli-frontaliere/ticino-tedeschi-turismo-2026',
+    canonicalPath: '/articoli-frontaliere/ticino-tedeschi-turismo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5873,7 +5873,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tagli, contributi, numero, chiuso',
     ogTitle: 'Tagli USI 2026: rette raddoppiate e numero chiuso |',
     ogDescription: 'L\'USI taglia i posti per studenti esteri e raddoppia le rette. Dal 2027 tagli federali alle università. Cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/universita-ticino-tagli-contributi-2026',
+    canonicalPath: '/articoli-frontaliere/universita-ticino-tagli-contributi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5901,7 +5901,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, arrestati, uomini, furto',
     ogTitle: 'Chiasso: arrestati per furto di biciclette',
     ogDescription: 'Due cittadini rumeni arrestati a Chiasso per furto di biciclette. Scoperti attrezzi da scasso e biciclette rubate. Consigli per la sicurezza delle biciclette.',
-    canonicalPath: '/articoli-frontaliere/chiasso-arresti-furto-biciclette-2026',
+    canonicalPath: '/articoli-frontaliere/chiasso-arresti-furto-biciclette-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5929,7 +5929,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, lavoro, impegno, insubria',
     ogTitle: 'Sicurezza sul lavoro: l’impegno di ATS Insubria |',
     ogDescription: 'ATS Insubria presenta i dati del Servizio di Prevenzione e Sicurezza negli Ambienti di Lavoro (PSAL) per il 2025. Scopri di più su vigilanza e prevenzione.',
-    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-2026',
+    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5957,7 +5957,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furto, biciclette, giubiasco, arrestati',
     ogTitle: 'Furto biciclette Giubiasco: arrestati per mancato pagamento',
     ogDescription: 'Tre biciclette elettriche rubate a Giubiasco, due arrestati per mancato pagamento del carburante. Scopri i dettagli dell\'operazione e le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/furto-biciclette-giubiasco-2026',
+    canonicalPath: '/articoli-frontaliere/furto-biciclette-giubiasco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5985,7 +5985,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, osservatori, traffico, attivi, anche',
     ogTitle: 'Osservatori traffico Lago di Como | Frontaliere Ticino',
     ogDescription: 'Dal 2 maggio 2026, gli osservatori del traffico saranno attivi anche il sabato sulla Statale Regina tra Colonno e Ossuccio.',
-    canonicalPath: '/articoli-frontaliere/osservatori-traffico-lago-como-2026',
+    canonicalPath: '/articoli-frontaliere/osservatori-traffico-lago-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6013,7 +6013,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, prevenzione, varese, como',
     ogTitle: 'Sicurezza sul lavoro: ATS Insubria aumenta controlli |',
     ogDescription: 'ATS Insubria presenta i dati delle attività ispettive e dei progetti di prevenzione tra Varese e Como, con oltre 8.125 interventi nel 2025.',
-    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-varese-como-2026',
+    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-varese-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6041,7 +6041,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, biciclette, benzina, chiasso',
     ogTitle: 'Furti di biciclette e benzina a Chiasso | Frontaliere Ticino',
     ogDescription: 'Due individui sono stati arrestati a Chiasso per furti di biciclette e benzina. Scopri di più su questo episodio e le misure preventive da adottare.',
-    canonicalPath: '/articoli-frontaliere/furto-biciclette-benzina-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/furto-biciclette-benzina-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6069,7 +6069,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bando, direzione, formazione, professionale',
     ogTitle: 'Bando Formazione Professionale | Critiche PLR | Frontaliere',
     ogDescription: 'Il PLR critica i requisiti del bando per la direzione della Formazione professionale in Ticino, sollevando perplessità sulla gestione procedurale.',
-    canonicalPath: '/articoli-frontaliere/bando-formazione-professionale-plr-2026',
+    canonicalPath: '/articoli-frontaliere/bando-formazione-professionale-plr-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6097,7 +6097,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, pensionati, 220mila, 2025',
     ogTitle: 'Lavoratori pensionati in Svizzera: +220mila nel 2025',
     ogDescription: 'Nel 2025, 220mila persone continuano a lavorare dopo i 65 anni in Svizzera. Scopri le implicazioni per i frontalieri e come pianificare il futuro.',
-    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6125,7 +6125,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, metà, percepisce, sistema, ingiusto',
     ogTitle: 'Metà della Svizzera percepisce il sistema come ingiusto',
     ogDescription: 'Un sondaggio rivela che oltre la metà della popolazione svizzera considera il sistema sociale ingiusto, con un aumento dell\'insoddisfazione rispetto al 2024.',
-    canonicalPath: '/articoli-frontaliere/met-svizzera-insoddisfatta-sistema-2026',
+    canonicalPath: '/articoli-frontaliere/met-svizzera-insoddisfatta-sistema-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6153,7 +6153,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, esperti, gestione, dell',
     ogTitle: 'Nuovi EGE a Varese | Frontaliere Ticino',
     ogDescription: 'Scopri i nuovi Esperti in Gestione dell’Energia certificati a Varese e le opportunità per i frontalieri nel settore energetico.',
-    canonicalPath: '/articoli-frontaliere/nuovi-esperti-gestione-energia-varese',
+    canonicalPath: '/articoli-frontaliere/nuovi-esperti-gestione-energia-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6181,7 +6181,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, negoziati, falliti, sullo, stretto',
     ogTitle: 'Negoziati falliti sullo Stretto di Hormuz | Frontaliere',
     ogDescription: 'Il ministro degli Esteri iraniano Abbas Araghchi ha dichiarato che le richieste eccessive degli USA hanno fatto fallire i negoziati sullo Stretto di Hormuz.',
-    canonicalPath: '/articoli-frontaliere/negoziati-falliti-stretto-hormuz-2026',
+    canonicalPath: '/articoli-frontaliere/negoziati-falliti-stretto-hormuz-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6209,7 +6209,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roadmap, violenza, domestica, jans',
     ogTitle: 'Roadmap violenza domestica: Jans traccia un bilancio',
     ogDescription: 'La roadmap contro la violenza domestica e sessuale ha dimostrato efficacia, ma servono ulteriori misure per contrastare i femminicidi. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/roadmap-violenza-domestica-bilancio-positivo',
+    canonicalPath: '/articoli-frontaliere/roadmap-violenza-domestica-bilancio-positivo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6237,7 +6237,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beneessere, integrità, allievi, nuovi',
     ogTitle: 'Nuovi programmi educativi a Bellinzona | Frontaliere Ticino',
     ogDescription: 'Scopri i nuovi programmi educativi per il benessere e l’integrità degli allievi a Bellinzona, in collaborazione con la Fondazione ASPI.',
-    canonicalPath: '/articoli-frontaliere/benessere-integrita-allievi-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/benessere-integrita-allievi-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6265,7 +6265,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, made, switzerland, cosa, cambia',
     ogTitle: 'Made in Switzerland: cosa cambia | Frontaliere Ticino',
     ogDescription: 'Scopri le nuove regole per l\'uso del marchio Swiss Made e il suo impatto economico. L\'Istituto federale della proprietà intellettuale ha modificato le norme.',
-    canonicalPath: '/articoli-frontaliere/cosa-significa-made-switzerland',
+    canonicalPath: '/articoli-frontaliere/cosa-significa-made-switzerland/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6293,7 +6293,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, equans, licenzia, dipendenti, monteceneri',
     ogTitle: 'Equans licenzia 19 dipendenti a Monteceneri | Frontaliere',
     ogDescription: 'Equans ha annunciato 19 licenziamenti nella sua sede di Monteceneri, colpendo i settori delle fibre ottiche e della gestione impianti. Scopri le implicazioni',
-    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-19-dipendenti',
+    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-19-dipendenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6321,7 +6321,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, verdi, strategia, cantonali, esplorano',
     ogTitle: 'Verdi Ticino: strategia per le cantonali 2026 | Frontaliere',
     ogDescription: 'I Verdi del Ticino esplorano alleanze per le elezioni cantonali del 2026, puntando a un fronte progressista più ampio con MPS e PS.',
-    canonicalPath: '/articoli-frontaliere/verdi-ticino-cantonali-2026',
+    canonicalPath: '/articoli-frontaliere/verdi-ticino-cantonali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6349,7 +6349,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borse, studio, bracco, opportunità',
     ogTitle: 'Borse di studio Bracco: 11 opportunità per studenti di sei',
     ogDescription: 'La Fondazione Bracco ha aperto il bando per 11 borse di studio, con contributi fino a 4mila euro, per studenti meritevoli di Bovisio Masciago, Ceriano Laghetto',
-    canonicalPath: '/articoli-frontaliere/borse-studio-bracco-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/borse-studio-bracco-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6377,7 +6377,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sportello, incontri, gratuiti, cunardo',
     ogTitle: 'Sportello ME-TE a Cunardo e Marchirolo | Frontaliere Ticino',
     ogDescription: 'Incontri gratuiti per genitori a Cunardo e Marchirolo con il progetto ME-TE. Scopri come partecipare e le date degli eventi.',
-    canonicalPath: '/articoli-frontaliere/sportello-me-te-cunardo-marchirolo-2026',
+    canonicalPath: '/articoli-frontaliere/sportello-me-te-cunardo-marchirolo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6405,7 +6405,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accordo, record, edilizia, ticinese',
     ogTitle: 'Accordo record edilizia Ticino 2026-2031',
     ogDescription: 'Firmato il nuovo contratto collettivo cantonale per l\'edilizia ticinese, valido fino al 2031. Stabilità e opportunità di formazione per lavoratori e imprese.',
-    canonicalPath: '/articoli-frontaliere/accordo-edilizia-ticino-2026-2031',
+    canonicalPath: '/articoli-frontaliere/accordo-edilizia-ticino-2026-2031/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6433,7 +6433,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, equans, rivera, taglia, posti',
     ogTitle: 'Equans Rivera taglia 19 posti di lavoro, rifiuta piano',
     ogDescription: 'La multinazionale Equans di Rivera licenzia 19 dipendenti senza accordo sociale. Jelmini: \'Dispiace per la mancanza di riguardo\'',
-    canonicalPath: '/articoli-frontaliere/equans-rivera-19-licenziamenti',
+    canonicalPath: '/articoli-frontaliere/equans-rivera-19-licenziamenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6461,7 +6461,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, finanza, persone, identificate',
     ogTitle: 'Controlli Finanza Comasco: 226 persone identificate',
     ogDescription: 'La Guardia di Finanza ha condotto controlli in provincia di Como, identificando 226 persone e scoprendo 3 lavoratori in nero e sostanze stupefacenti.',
-    canonicalPath: '/articoli-frontaliere/controlli-finanza-comasco-226-persone',
+    canonicalPath: '/articoli-frontaliere/controlli-finanza-comasco-226-persone/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6489,7 +6489,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, auto, cinesi, quota, mercato',
     ogTitle: 'Auto cinesi in Svizzera: quota di mercato al 3,7% nel 2026',
     ogDescription: 'BYD, MG e Leapmotor dominano le vendite di auto cinesi in Svizzera, con una quota di mercato del 3,7% nel primo trimestre 2026. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/auto-cinesi-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/auto-cinesi-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6517,7 +6517,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dengue, verso, sistema, rapido',
     ogTitle: 'Dengue: sistema rapido per individuarla in Ticino |',
     ogDescription: 'Nuove misure per la diagnosi precoce della dengue in Canton Ticino. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/dengue-sistema-rapido-individuazione',
+    canonicalPath: '/articoli-frontaliere/dengue-sistema-rapido-individuazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6545,7 +6545,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aprile, secco, allarme, siccità',
     ogTitle: 'Aprile secco: allarme siccità in Ticino',
     ogDescription: 'MeteoSvizzera lancia l\'allarme: aprile 2026 è il più secco dalla rilevazione, con gravi carenze di pioggia in Ticino e altre regioni.',
-    canonicalPath: '/articoli-frontaliere/aprile-secco-siccita-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/aprile-secco-siccita-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6573,7 +6573,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, multa, fino, franchi, svapa',
     ogTitle: 'Multa fino a 500 franchi per chi svapa in stazione |',
     ogDescription: 'L\'Associazione svizzera per la prevenzione del tabagismo propone multe fino a 500 franchi per chi viola il divieto di fumo e svapo nei binari delle stazioni',
-    canonicalPath: '/articoli-frontaliere/multa-svapo-stazioni-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/multa-svapo-stazioni-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6601,7 +6601,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, pagherà, spesa, fino',
     ogTitle: 'Disoccupazione frontalieri: la Svizzera non pagherà |',
     ogDescription: 'La Svizzera respinge la proposta UE di pagare le indennità di disoccupazione ai frontalieri, con costi fino a un miliardo di franchi all\'anno.',
-    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6629,7 +6629,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, allerta, gialla, temporali, tutta',
     ogTitle: 'Allerta gialla per temporali su Varese | Frontaliere Ticino',
     ogDescription: 'La Protezione Civile della Regione Lombardia ha emesso un\'allerta meteo gialla per temporali su tutta la provincia di Varese. Scopri cosa fare e come',
-    canonicalPath: '/articoli-frontaliere/allerta-gialla-temporali-varese-2026',
+    canonicalPath: '/articoli-frontaliere/allerta-gialla-temporali-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6657,7 +6657,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ostetriche, conferenza, parto, fisiologico',
     ogTitle: 'Conferenza ostetriche EOC Mendrisio 2026 | Frontaliere',
     ogDescription: 'Scopri la conferenza sull\'assistenza ostetrica organizzata dall\'EOC a Mendrisio il 6 maggio 2026. Focus su parto fisiologico e continuità assistenziale.',
-    canonicalPath: '/articoli-frontaliere/ostetriche-eoc-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/ostetriche-eoc-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6685,7 +6685,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, domestica, convince, modello',
     ogTitle: 'Violenza domestica: convince il modello Zurigo',
     ogDescription: 'Il progetto pilota di sorveglianza elettronica in tempo reale per contrastare la violenza domestica ha dato risultati positivi. L\'obiettivo è estenderlo a',
-    canonicalPath: '/articoli-frontaliere/modello-zurigo-violenza-domestica',
+    canonicalPath: '/articoli-frontaliere/modello-zurigo-violenza-domestica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6713,7 +6713,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, approva, sepoltura, animali',
     ogTitle: 'Berna approva sepoltura con animali domestici | Frontaliere',
     ogDescription: 'Dal 2026 a Berna sarà possibile essere sepolti con il proprio animale domestico in aree dedicate. Ecco cosa cambia e come funziona',
-    canonicalPath: '/articoli-frontaliere/sepolti-con-animali-domestici-berna-2026',
+    canonicalPath: '/articoli-frontaliere/sepolti-con-animali-domestici-berna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6741,7 +6741,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guasti, swiss, cosa, cambia',
     ogTitle: 'Due guasti in 48 ore per Swiss: implicazioni per i',
     ogDescription: 'Due incidenti tecnici in meno di 48 ore per la compagnia aerea Swiss. Ecco cosa cambia per i frontalieri che viaggiano tra Ticino e Svizzera.',
-    canonicalPath: '/articoli-frontaliere/swiss-guasti-voli-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-guasti-voli-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6769,7 +6769,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banca, varese, anni, dopo',
     ogTitle: 'Banca d\'Italia Varese: 10 anni dopo | Frontaliere Ticino',
     ogDescription: 'L\'ex sede della Banca d\'Italia a Varese è in vendita dal 2018 ma non trova acquirenti. Scopri perché e cosa fare per acquistarla.',
-    canonicalPath: '/articoli-frontaliere/banca-ditalia-varese-10-anni-dopo',
+    canonicalPath: '/articoli-frontaliere/banca-ditalia-varese-10-anni-dopo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6797,7 +6797,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sempre, meno, svizzeri, pagano',
     ogTitle: 'Contributo clima online | Frontaliere Ticino',
     ogDescription: 'Dati Galaxus: nel 2026 solo il 9% degli ordini online in Svizzera include il contributo volontario per il clima, contro l\'11% del 2024 e il 12% del 2022.',
-    canonicalPath: '/articoli-frontaliere/svizzeri-contributo-clima-acquisti-online-2026',
+    canonicalPath: '/articoli-frontaliere/svizzeri-contributo-clima-acquisti-online-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6825,7 +6825,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passeggiata, lago, inverno, lido',
     ogTitle: 'Passeggiata a lago in inverno al lido di Ascona, test',
     ogDescription: 'La stagione di prova della passeggiata invernale al lido di Ascona ha avuto successo. La presidente del Patriziato annuncia che l\'iniziativa sarà riproposta.',
-    canonicalPath: '/articoli-frontaliere/passeggiata-lago-inverno-ascona-2026',
+    canonicalPath: '/articoli-frontaliere/passeggiata-lago-inverno-ascona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6853,7 +6853,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, notifiche, 2025, controlli, diminuiscono',
     ogTitle: 'Notifiche frontalieri Ticino: -16% nel 2025',
     ogDescription: 'Diminuiscono le notifiche irregolari per i frontalieri in Ticino, ma le autorità avvertono: non si può abbassare la guardia. Ecco i dati 2025.',
-    canonicalPath: '/articoli-frontaliere/notifiche-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/notifiche-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6881,7 +6881,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, minacce, informatiche, swisscom, lancia',
     ogTitle: 'Minacce informatiche in Svizzera: Swisscom lancia l\'allarme',
     ogDescription: 'Swisscom rileva un aumento significativo delle minacce informatiche in Svizzera, con rischi crescenti per le imprese a causa dell\'IA e delle tensioni',
-    canonicalPath: '/articoli-frontaliere/minacce-informatiche-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/minacce-informatiche-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6909,7 +6909,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gamberetti, avariati, torneo, madrid',
     ogTitle: 'Gamberetti avariati al torneo di Madrid: intossicazioni e',
     ogDescription: 'Intossicazioni alimentari colpiscono i giocatori al Masters 1000 di Madrid, con Jim Courier che accusa i gamberetti serviti alla mensa',
-    canonicalPath: '/articoli-frontaliere/gamberetti-torneo-madrid-2026',
+    canonicalPath: '/articoli-frontaliere/gamberetti-torneo-madrid-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6937,7 +6937,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro, carburanti, rischio, stop',
     ogTitle: 'Caro carburanti, rischio stop trasporto pubblico in Ticino',
     ogDescription: 'Il caro carburanti minaccia il trasporto pubblico locale, con costi aggiuntivi stimati in 0,54 milioni di euro al giorno per il diesel. Scopri l\'impatto sui',
-    canonicalPath: '/articoli-frontaliere/carburanti-tpl-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/carburanti-tpl-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6965,7 +6965,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alla, scoperta, dell, africa',
     ogTitle: 'Alla scoperta dell’Africa a Materia: dialogo su opportunità',
     ogDescription: 'Martedì 28 aprile 2026 a Castronno, un incontro con Martino Ghielmi e Alfie Nze per esplorare un nuovo rapporto culturale con l\'Africa.',
-    canonicalPath: '/articoli-frontaliere/scoperta-africa-materia-castronno-2026',
+    canonicalPath: '/articoli-frontaliere/scoperta-africa-materia-castronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6993,7 +6993,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, università, numero, chiuso, rette',
     ogTitle: 'Università Ticino: numero chiuso e rette in aumento',
     ogDescription: 'Dal 2026 l\'Università della Svizzera italiana introduce il numero chiuso e le rette aumentano, soprattutto per gli studenti stranieri',
-    canonicalPath: '/articoli-frontaliere/universita-ticino-numero-chiuso-2026',
+    canonicalPath: '/articoli-frontaliere/universita-ticino-numero-chiuso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7021,7 +7021,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pedaggi, autostrada, lombardia, addio',
     ogTitle: 'Pedaggi autostrada Lombardia: addio viaggi gratis per frontalieri',
     ogDescription: 'Dal 1° maggio 2026 pedaggio obbligatorio sulla Corda Molle con sconti del 50% per residenti di 22 comuni. Agevolazioni in arrivo per pendolari',
-    canonicalPath: '/articoli-frontaliere/pedaggi-autostrada-lombardia-frontalieri',
+    canonicalPath: '/articoli-frontaliere/pedaggi-autostrada-lombardia-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7049,7 +7049,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, semaforo, melide, venti, paradiso-melide',
     ogTitle: 'Semaforo Melide: un\'ora e venti per Paradiso-Melide',
     ogDescription: 'Un automobilista racconta di un\'odissea di un\'ora e venti per andare da Paradiso a Melide a causa di un semaforo malfunzionante.',
-    canonicalPath: '/articoli-frontaliere/semaforo-paradiso-melide-2026',
+    canonicalPath: '/articoli-frontaliere/semaforo-paradiso-melide-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7077,7 +7077,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zurigo, economia, cresce, meno',
     ogTitle: 'Zurigo guida l\'economia svizzera ma cresce meno della media',
     ogDescription: 'Zurigo genera il 21% del PIL svizzero ma cresce solo dell\'1,3% annuo, meno della media nazionale dell\'1,7%. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita',
+    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7105,7 +7105,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 58enne, fugge, trottinetti, viene',
     ogTitle: '58enne fugge in trottinetti a 127 km/h e viene fermato dalla polizia',
     ogDescription: 'Un 58enne è stato fermato dalla polizia dopo aver raggiunto i 127 km/h su un trottinetti elettrico a Lugano. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-trottinetti-velocita-polizia',
+    canonicalPath: '/articoli-frontaliere/frontalieri-trottinetti-velocita-polizia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7133,7 +7133,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, insubria, sperimenta, diffusa, blocker',
     ogTitle: 'ATS Insubria sperimenta RSA diffusa e bed blocker per liberare gli ospedali',
     ogDescription: 'Due progetti pilota per ridurre i tempi di degenza e liberare letti ospedalieri in Lombardia, con finanziamenti regionali',
-    canonicalPath: '/articoli-frontaliere/ats-insubria-soluzioni-ospedali-2026',
+    canonicalPath: '/articoli-frontaliere/ats-insubria-soluzioni-ospedali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7161,7 +7161,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, avis, lombardia, lancia, allarme',
     ogTitle: 'Avis Lombardia lancia l\'allarme: il dono del sangue sotto attacco dei privati',
     ogDescription: 'I dati del 2025 mostrano un aumento dell\'8,24% nella raccolta di plasma, ma l\'Avis Lombardia avverte del rischio di speculazioni commerciali',
-    canonicalPath: '/articoli-frontaliere/avis-lombardia-dono-sangue-privati-2026',
+    canonicalPath: '/articoli-frontaliere/avis-lombardia-dono-sangue-privati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7189,7 +7189,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, raduno, moto, storiche, varese',
     ogTitle: 'Raduno moto storiche Varese 2026',
     ogDescription: 'Domenica 26 aprile 2026, raduno di moto storiche tra Varese e il Lago Maggiore. Circa 100 motociclette iconiche in mostra.',
-    canonicalPath: '/articoli-frontaliere/varese-moto-storiche-2026',
+    canonicalPath: '/articoli-frontaliere/varese-moto-storiche-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7217,7 +7217,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, contratto, edilizia, giornate',
     ogTitle: 'Nuovo contratto edilizia Ticino: giornate più corte e tutela dalle intemperie',
     ogDescription: 'Accordo fino al 2031 con nuove regole su orari e condizioni di lavoro. Focus su sicurezza e ricambio generazionale nel settore edile ticinese',
-    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7245,7 +7245,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusura, parziale, raccordo, varese-a8',
     ogTitle: 'Chiusura parziale raccordo Varese-A8 lunedì sera',
     ogDescription: 'Dalle 22:00 alle 24:00 di lunedì 27 aprile 2026 chiuso il ramo di immissione sulla A8 Milano-Varese, verso Varese.',
-    canonicalPath: '/articoli-frontaliere/viabilita-varese-racordo-chiuso-2026',
+    canonicalPath: '/articoli-frontaliere/viabilita-varese-racordo-chiuso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7273,7 +7273,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresti, furti, biciclette, mendrisiotto',
     ogTitle: 'Due arresti per furti di biciclette nel Mendrisiotto',
     ogDescription: 'Due cittadini rumeni arrestati con tre biciclette smontate e attrezzi da scasso. Polizia ricorda consigli per prevenire furti.',
-    canonicalPath: '/articoli-frontaliere/furti-biciclette-mendrisiotto-2026',
+    canonicalPath: '/articoli-frontaliere/furti-biciclette-mendrisiotto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7301,7 +7301,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giümai, acquista, ultimi, edifici',
     ogTitle: 'Per Giümai acquista gli ultimi tre edifici del Monte Piaroi',
     ogDescription: 'L\'associazione Per Giümai ha completato l\'acquisto degli ultimi tre edifici sul Monte Piaroi, grazie al contributo di privati e alla collaborazione con la',
-    canonicalPath: '/articoli-frontaliere/per-giumai-acquisti-monte-piaroi-2026',
+    canonicalPath: '/articoli-frontaliere/per-giumai-acquisti-monte-piaroi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7329,7 +7329,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scoperte, rovine, romane, magliaso',
     ogTitle: 'Rovine romane Magliaso: nuove scuole e patrimonio storico',
     ogDescription: 'Scoperte rovine dell\'epoca tardo romana durante la costruzione delle nuove scuole elementari a Magliaso. Archeologi al lavoro per documentazione.',
-    canonicalPath: '/articoli-frontaliere/rovine-magliaso-scuole-nuove-2026',
+    canonicalPath: '/articoli-frontaliere/rovine-magliaso-scuole-nuove-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7357,7 +7357,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, misure, sono, estreme, presidente',
     ogTitle: 'BNS: Le misure per UBS non sono estreme',
     ogDescription: 'Il presidente della BNS, Martin Schlegel, difende le nuove regole per UBS, minimizzando il rischio di una partenza dell\'istituto.',
-    canonicalPath: '/articoli-frontaliere/bns-ubs-misure-non-estreme-2026',
+    canonicalPath: '/articoli-frontaliere/bns-ubs-misure-non-estreme-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7385,7 +7385,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, maestri, lavoro, leonardo',
     ogTitle: 'Nuovi Maestri del Lavoro 2026: Leonardo primeggia in provincia di Varese',
     ogDescription: 'Celebrati a Milano i nuovi Maestri del Lavoro 2026. Leonardo S.p.A. è l\'azienda con il maggior numero di premiati nella provincia di Varese.',
-    canonicalPath: '/articoli-frontaliere/nuovi-maestri-lavoro-varese-leonardo-2026',
+    canonicalPath: '/articoli-frontaliere/nuovi-maestri-lavoro-varese-leonardo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7413,7 +7413,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cambio, guardia, velo, sabbadini',
     ogTitle: 'Cambio di guardia a Pro Velo Ticino: Sabbadini succede a Vitali',
     ogDescription: 'Claudio Sabbadini è il nuovo presidente di Pro Velo Ticino, sostituendo Marco Vitali. Discussione su progetti per migliorare la mobilità ciclistica nelle valli',
-    canonicalPath: '/articoli-frontaliere/cambio-guardia-pro-velo-ticino-sabbadini-vitali',
+    canonicalPath: '/articoli-frontaliere/cambio-guardia-pro-velo-ticino-sabbadini-vitali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7441,7 +7441,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, ambulatorio, ecocardiografia, busto',
     ogTitle: 'Nuovo ambulatorio di ecocardiografia a Busto Arsizio: apertura il 7 maggio',
     ogDescription: 'Dal 7 maggio 2026, un nuovo servizio di ecocardiografia sarà disponibile presso la Casa di Comunità di Busto Arsizio, su prenotazione con impegnativa medica.',
-    canonicalPath: '/articoli-frontaliere/nuovo-ambulatorio-ecocardiografia-busto-arsizio',
+    canonicalPath: '/articoli-frontaliere/nuovo-ambulatorio-ecocardiografia-busto-arsizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7469,7 +7469,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, velafrica, torna, luganese, seconda',
     ogTitle: 'Velafrica torna nel Luganese: seconda vita per le bici usate',
     ogDescription: 'Il progetto Velafrica ritorna nel Luganese per dare una seconda vita alle biciclette usate. Un\'iniziativa che coinvolge la comunità e promuove la sostenibilità',
-    canonicalPath: '/articoli-frontaliere/velafrica-bici-usate-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/velafrica-bici-usate-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7497,7 +7497,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedale, varese, senza, acqua',
     ogTitle: 'Ospedale Varese senza acqua calda in oncologia',
     ogDescription: 'Disservizi segnalati nel reparto di oncologia e pneumologia. La Sette Laghi: soluzione in tempi brevi.',
-    canonicalPath: '/articoli-frontaliere/ospedale-varese-acqua-calda-oncologia',
+    canonicalPath: '/articoli-frontaliere/ospedale-varese-acqua-calda-oncologia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7525,7 +7525,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, nordafricani, arrestati, furti',
     ogTitle: 'Cinque nordafricani arrestati per furti d\'auto',
     ogDescription: 'Notte di arresti ad Aarau: cinque uomini nordafricani fermati per sospetti furti d\'auto. Scopri cosa è successo e come proteggere i tuoi veicoli.',
-    canonicalPath: '/articoli-frontaliere/cinque-nordafricani-festnati-auto-aarau',
+    canonicalPath: '/articoli-frontaliere/cinque-nordafricani-festnati-auto-aarau/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7553,7 +7553,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, discariche, abusive, doppio, sequestro',
     ogTitle: 'Discariche abusive: doppio sequestro tra Varese e cintura',
     ogDescription: 'Tre indagati e due siti sequestrati per smaltimento illecito di rifiuti speciali in provincia di Varese',
-    canonicalPath: '/articoli-frontaliere/doppio-sequestro-discariche-abusive-varese',
+    canonicalPath: '/articoli-frontaliere/doppio-sequestro-discariche-abusive-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7581,7 +7581,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sfida, comuni, coop, sarà',
     ogTitle: 'Sfida tra comuni Coop 2026: chi sarà il più attivo?',
     ogDescription: 'Dal 1° al 31 maggio 2026, oltre 200 comuni svizzeri, tra cui diversi in Ticino, si sfidano per promuovere l\'attività fisica. Scopri come partecipare e',
-    canonicalPath: '/articoli-frontaliere/sfida-comuni-coop-2026-attivita-fisica',
+    canonicalPath: '/articoli-frontaliere/sfida-comuni-coop-2026-attivita-fisica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7609,7 +7609,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, rafforza, tutela, lavoratori',
     ogTitle: 'La Cina rafforza la tutela dei lavoratori nelle nuove occupazioni',
     ogDescription: 'Nuove linee guida per proteggere i lavoratori delle piattaforme digitali, con focus su compensi e algoritmi.',
-    canonicalPath: '/articoli-frontaliere/cina-tutela-lavoratori-nuove-occupazioni',
+    canonicalPath: '/articoli-frontaliere/cina-tutela-lavoratori-nuove-occupazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7637,7 +7637,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dovremo, tagliare, vivo, misure',
     ogTitle: 'USI: tagli strutturali e revisione piano strategico',
     ogDescription: 'Monica Duca Widmer annuncia tagli strutturali per l’USI a causa dei ridotti finanziamenti. Scopri le implicazioni per studenti e personale.',
-    canonicalPath: '/articoli-frontaliere/usi-ticino-tagli-bilancio-2026',
+    canonicalPath: '/articoli-frontaliere/usi-ticino-tagli-bilancio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7665,7 +7665,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, campione, sfida, poltrona, sindaco',
     ogTitle: 'Campione d’Italia, sfida a tre per la poltrona di sindaco',
     ogDescription: 'Tre candidati in lizza per la carica di sindaco a Campione d’Italia. Scopri chi sono e cosa propongono.',
-    canonicalPath: '/articoli-frontaliere/campione-ditalia-elezioni-sindaco-2026',
+    canonicalPath: '/articoli-frontaliere/campione-ditalia-elezioni-sindaco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7693,7 +7693,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gioventù, dibatte, studenti, gara',
     ogTitle: 'La gioventù dibatte: 500 studenti in gara a Bellinzona',
     ogDescription: '500 studenti si sfidano nella finale de \'La gioventù dibatte\' a Bellinzona, difendendo tesi su temi di attualità davanti a una giuria.',
-    canonicalPath: '/articoli-frontaliere/gioventu-dibatte-500-studenti-gara',
+    canonicalPath: '/articoli-frontaliere/gioventu-dibatte-500-studenti-gara/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7721,7 +7721,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tallero, anni, nuovo, design',
     ogTitle: 'Tallero d\'oro: 80 anni e nuovo design',
     ogDescription: 'Il Tallero d\'oro compie 80 anni e si rinnova nel design. Il prezzo aumenta a 8 franchi per la prima volta dal 1998.',
-    canonicalPath: '/articoli-frontaliere/tallero-doro-80-anni-nuovo-design',
+    canonicalPath: '/articoli-frontaliere/tallero-doro-80-anni-nuovo-design/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7749,7 +7749,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inaugurata, nuova, sede, conservatorio',
     ogTitle: 'Inaugurata nuova sede Conservatorio Svizzera italiana Bellinzona',
     ogDescription: 'Il direttore Luca Medici sottolinea l\'importanza della formazione musicale per trasmettere valori fondamentali nella nuova sede del Conservatorio a Bellinzona.',
-    canonicalPath: '/articoli-frontaliere/conservatorio-bellinzona-valori-musicali',
+    canonicalPath: '/articoli-frontaliere/conservatorio-bellinzona-valori-musicali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7777,7 +7777,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, national, geographic, scuola, sergio',
     ogTitle: 'National Geographic a scuola: Sergio Pitamitz incontra gli studenti dell\'Einaudi',
     ogDescription: 'Il celebre fotografo ha parlato di conservazione ambientale e fotografia naturalistica con gli studenti di Varese.',
-    canonicalPath: '/articoli-frontaliere/national-geographic-scuola-einaudi-varese',
+    canonicalPath: '/articoli-frontaliere/national-geographic-scuola-einaudi-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7805,7 +7805,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, nuovi, programmi, benessere',
     ogTitle: 'Nuovi programmi educativi a Bellinzona per il benessere scolastico',
     ogDescription: 'Scopri i nuovi programmi educativi introdotti a Bellinzona per il benessere degli studenti dal 2026',
-    canonicalPath: '/articoli-frontaliere/benessere-scolastico-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/benessere-scolastico-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7833,7 +7833,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, capitale, culturale, opportunità',
     ogTitle: 'Mendrisio Capitale Culturale: Opportunità da Cogliere',
     ogDescription: 'La maggioranza della Gestione di Mendrisio rassicura sui costi e allontana il rischio di sudditanza verso Lugano',
-    canonicalPath: '/articoli-frontaliere/mendrisio-capitale-culturale-opportunita',
+    canonicalPath: '/articoli-frontaliere/mendrisio-capitale-culturale-opportunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7861,7 +7861,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, velo, marco, vitali, lascia',
     ogTitle: 'Pro Velo Ticino: Marco Vitali lascia la presidenza',
     ogDescription: 'Marco Vitali lascia la presidenza di Pro Velo Ticino dopo aver trasferito il domicilio in Alsazia. Claudio Sabbadini è il nuovo presidente.',
-    canonicalPath: '/articoli-frontaliere/pro-velo-ticino-cambiamento-presidenza-2026',
+    canonicalPath: '/articoli-frontaliere/pro-velo-ticino-cambiamento-presidenza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7889,7 +7889,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallimento, nomine, sims, posizione',
     ogTitle: 'Fallimento nomine SIMS in Ticino',
     ogDescription: 'La vicenda delle nomine SIMS mette in discussione la gestione dei concorsi pubblici nel Canton Ticino, con ripercussioni sulla credibilità istituzionale.',
-    canonicalPath: '/articoli-frontaliere/nomine-sims-fallimento',
+    canonicalPath: '/articoli-frontaliere/nomine-sims-fallimento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7917,7 +7917,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, fatture, riaprono, scontro',
     ogTitle: 'Crans-Montana, le fatture riaprono lo scontro con Roma',
     ogDescription: 'Le fatture per le cure prestate in Svizzera alle vittime italiane della tragedia di Crans-Montana hanno riacceso le tensioni tra Roma e Berna.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-scontro-roma-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-scontro-roma-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7945,7 +7945,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basta, lamentele, addio, alla',
     ogTitle: 'Ticino, basta lamentele: addio alla sindrome di Calimero',
     ogDescription: 'Nicoletta Casanova, presidente Aiti, critica il dibattito economico ticinese e invita a cambiare atteggiamento per migliorare le opportunità per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ticino-calimero-sindrome-2026',
+    canonicalPath: '/articoli-frontaliere/ticino-calimero-sindrome-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7973,7 +7973,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, mediano, mette',
     ogTitle: 'Salario minimo e mediano: il mix che mette a rischio il Ticino',
     ogDescription: 'Analisi delle tensioni salariali tra frontalieri e residenti, con impatti sul mercato del lavoro ticinese.',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-mediano-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-mediano-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8001,7 +8001,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, padroncini, lavoratori, distaccati, stabili',
     ogTitle: 'Padroncini e lavoratori distaccati stabili su livelli bassi',
     ogDescription: 'Il numero di ditte notificate in Ticino rimane stabile su livelli bassi, ma l\'AIC avverte: non abbassare la guardia',
-    canonicalPath: '/articoli-frontaliere/padroncini-lavoratori-stabili-bassi-2025',
+    canonicalPath: '/articoli-frontaliere/padroncini-lavoratori-stabili-bassi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8029,7 +8029,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, busto, garolfo, milioni, utile',
     ogTitle: 'Bcc Busto Garolfo: 14,4 milioni di utile e 2 milioni per il territorio',
     ogDescription: 'L\'assemblea dei soci approva il bilancio 2025 con un utile netto di 14,4 milioni e 2 milioni destinati al territorio',
-    canonicalPath: '/articoli-frontaliere/bcc-busto-garolfo-2-milioni-territorio',
+    canonicalPath: '/articoli-frontaliere/bcc-busto-garolfo-2-milioni-territorio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8057,7 +8057,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, legge, polizia, controllo',
     ogTitle: 'Nuova legge polizia Ticino: controllo periodico obbligatorio',
     ogDescription: 'Padlina e Rigamonti propongono rapporto annuale per la polizia cantonale. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nuova-legge-polizia-ticino-controllo-periodico',
+    canonicalPath: '/articoli-frontaliere/nuova-legge-polizia-ticino-controllo-periodico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8085,7 +8085,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malpensa, parigi, galline, complessità',
     ogTitle: 'Malpensa, Parigi e due galline: la complessità del vivere semplice',
     ogDescription: 'Un viaggio tra lavoro transfrontaliero e regolamentazioni svizzere sugli animali domestici',
-    canonicalPath: '/articoli-frontaliere/malpensa-parigi-galline-frontalieri',
+    canonicalPath: '/articoli-frontaliere/malpensa-parigi-galline-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8113,7 +8113,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borsa, zurigo, giornata, altalenante',
     ogTitle: 'Borsa di Zurigo: giornata altalenante per i frontalieri',
     ogDescription: 'Lo Swiss market index chiude a 13\'165.23 punti, con Lonza Group e UBS Group in positivo',
-    canonicalPath: '/articoli-frontaliere/borsa-zurigo-frontalieri-27-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/borsa-zurigo-frontalieri-27-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8141,7 +8141,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colpi, arma, fuoco, como',
     ogTitle: 'Colpi d\'arma da fuoco a Como: ferito giovane straniero',
     ogDescription: 'Un giovane straniero è stato ferito da colpi d\'arma da fuoco sparati da un\'auto a San Fermo della Battaglia, vicino a Como. Scopri di più sull\'incidente e le',
-    canonicalPath: '/articoli-frontaliere/colpi-arma-da-fuoco-como-ferito-frontaliere',
+    canonicalPath: '/articoli-frontaliere/colpi-arma-da-fuoco-como-ferito-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8169,7 +8169,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disagi, linea, tilo, errore',
     ogTitle: 'Disagi linea TiLo S40: errore nella programmazione del personale',
     ogDescription: 'Trenord spiega i disagi del 25 aprile: problema nella programmazione dei turni del personale. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/disagi-trenord-tilo-s40-25-aprile-2024',
+    canonicalPath: '/articoli-frontaliere/disagi-trenord-tilo-s40-25-aprile-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8197,7 +8197,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scommesse, guerra, trump, boom',
     ogTitle: 'Scommesse su guerra e Trump: il boom dei prediction market',
     ogDescription: 'Scopri come le piattaforme di prediction market stanno diventando popolari, permettendo scommesse su eventi globali con rischi etici e finanziari.',
-    canonicalPath: '/articoli-frontaliere/scommesse-guerra-trump-prediction-market',
+    canonicalPath: '/articoli-frontaliere/scommesse-guerra-trump-prediction-market/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8225,7 +8225,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, lusso, auto, rubate',
     ogTitle: 'Furti di lusso in Ticino: 5 auto rubate in un weekend',
     ogDescription: 'Due furti in una sola garage a Murten: 5 auto di lusso rubate in un weekend. Scopri le implicazioni per i frontalieri e le misure di sicurezza.',
-    canonicalPath: '/articoli-frontaliere/furti-lusso-murten-2026',
+    canonicalPath: '/articoli-frontaliere/furti-lusso-murten-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8253,7 +8253,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gestione, illecita, rifiuti, varese',
     ogTitle: 'Gestione illecita rifiuti Varese Arcisate',
     ogDescription: 'Operazione Carabinieri Forestali per smaltimento illegale rifiuti tra Varese e Arcisate. Tre denunciati e sequestri di capannone e mezzi.',
-    canonicalPath: '/articoli-frontaliere/gestione-illecita-rifiuti-varese-arcisate-2026',
+    canonicalPath: '/articoli-frontaliere/gestione-illecita-rifiuti-varese-arcisate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8281,7 +8281,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, anni, superati, dall, ufficio',
     ogTitle: 'Frontalieri Ticino: +30% in 10 anni, superati i 91.000',
     ogDescription: 'Dall\'Ufficio federale di statistica: frontalieri italiani in Svizzera cresciuti del 30% in 10 anni, con il Ticino che resta il polo principale',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-crescita-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-crescita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8309,7 +8309,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trasparenza, nelle, iniziative, popolari',
     ogTitle: 'Trasparenza iniziative popolari Ticino 2026',
     ogDescription: 'Una nuova iniziativa parlamentare mira a rafforzare la trasparenza finanziaria nelle iniziative popolari in Ticino, con soglie ben definite per la s',
-    canonicalPath: '/articoli-frontaliere/trasparenza-iniziative-popolari-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/trasparenza-iniziative-popolari-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8337,7 +8337,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tristan, brenn, difende, decisione',
     ogTitle: 'Tristan Brenn difende la decisione sul caso Fischer',
     ogDescription: 'Tristan Brenn, direttore del DFE, spiega le ragioni della decisione sul caso Fischer e le implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/tristan-brenn-fischer-decisione',
+    canonicalPath: '/articoli-frontaliere/tristan-brenn-fischer-decisione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8365,7 +8365,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, leader, brevetti, curiosità, roche',
     ogTitle: 'Svizzera leader in brevetti: 5 curiosità 2026',
     ogDescription: 'Roche supera Novartis, sigarette elettroniche e seggiolini per bambini: ecco i dati EPO su brevetti svizzeri',
-    canonicalPath: '/articoli-frontaliere/svizzera-brevetti-innovazione-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-brevetti-innovazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8393,7 +8393,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intervento, rega, boglia, soccorso',
     ogTitle: 'Intervento Rega sul Boglia: soccorso in montagna',
     ogDescription: 'Un elicottero della Rega è intervenuto sul Monte Boglia per soccorrere un escursionista in difficoltà. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-rega-boglia-intervento',
+    canonicalPath: '/articoli-frontaliere/frontalieri-rega-boglia-intervento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8421,7 +8421,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, equans, licenziamenti, confermati, posti',
     ogTitle: 'Equans licenzia 19 dipendenti a Monteceneri',
     ogDescription: 'Equans procederà con 19 licenziamenti presso la sua sede di Monteceneri. I lavoratori interessati sono liberi da subito. Scopri le implicazioni e le',
-    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-2026',
+    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8449,7 +8449,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momenti, paura, velivolo, swiss',
     ogTitle: 'Momenti di paura su un velivolo Swiss',
     ogDescription: 'Un incidente tecnico su un velivolo Swiss ha causato momenti di tensione. Ecco cosa è successo e le implicazioni per i passeggeri.',
-    canonicalPath: '/articoli-frontaliere/momenti-paura-velivolo-swiss-2026',
+    canonicalPath: '/articoli-frontaliere/momenti-paura-velivolo-swiss-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8477,7 +8477,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, allerta, meteo, lombardia, piogge',
     ogTitle: 'Allerta meteo in Ticino e Lombardia: piogge e temporali',
     ogDescription: 'La Protezione civile lombarda ha emesso un\'allerta per piogge e temporali in Ticino e nord Lombardia, con rischio di vento forte in Valtellina.',
-    canonicalPath: '/articoli-frontaliere/allerta-meteo-ticino-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/allerta-meteo-ticino-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8505,7 +8505,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rottamazione-quinquies, domande, entro, aprile',
     ogTitle: 'Rottamazione-quinquies: domande entro il 30 aprile',
     ogDescription: 'Scade il 30 aprile il termine per aderire alla rottamazione-quinquies. Ecco cosa sapere e come fare la domanda per regolarizzare i debiti senza sanzioni e',
-    canonicalPath: '/articoli-frontaliere/rottamazione-quinquies-scadenza-30-aprile',
+    canonicalPath: '/articoli-frontaliere/rottamazione-quinquies-scadenza-30-aprile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8533,7 +8533,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, architettura, sostenibile, nuovo, iast',
     ogTitle: 'Architettura sostenibile in Ticino: il nuovo IAST dell\'USI',
     ogDescription: 'Scopri come il nuovo Istituto per l\'architettura sostenibile e la tecnologia dell\'USI promuove il riuso e la conservazione degli edifici esistenti.',
-    canonicalPath: '/articoli-frontaliere/architettura-sostenibile-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/architettura-sostenibile-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8561,7 +8561,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sisa, attacca, piano, governo',
     ogTitle: 'SISA attacca il piano del Governo sulle casse malati',
     ogDescription: 'Il sindacato studentesco critica i tagli ai servizi essenziali e l’aumento delle tasse universitarie in Ticino',
-    canonicalPath: '/articoli-frontaliere/sisa-contro-tagli-governo-2024',
+    canonicalPath: '/articoli-frontaliere/sisa-contro-tagli-governo-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8589,7 +8589,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pista, ciclopedonale, bodio-giornico, mobilità',
     ogTitle: 'Pista ciclopedonale Bodio-Giornico: mobilità lenta e sostenibile',
     ogDescription: 'Scopri la nuova pista ciclopedonale tra Bodio e Giornico, un progetto per la mobilità sostenibile nella regione del Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/pista-ciclopedonale-bodio-giornico-2026',
+    canonicalPath: '/articoli-frontaliere/pista-ciclopedonale-bodio-giornico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8617,7 +8617,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, sfida, carpooling, benefica',
     ogTitle: 'MomòRide: carpooling benefico Chiasso Balerna Novazzano',
     ogDescription: 'Dal 1° maggio parte MomòRide, iniziativa biennale di carpooling per aziende e pendolari di Chiasso, Balerna e Novazzano. Obiettivo: 40.000 punti in un mese per',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8645,7 +8645,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, escursionisti, lasciare, traccia, montagna',
     ogTitle: 'Kit per escursionisti: come non lasciare traccia in montagna',
     ogDescription: 'Scopri il kit \'Non lascio traccia\' per escursionisti e impara a rispettare l\'ambiente montano con pratiche sostenibili.',
-    canonicalPath: '/articoli-frontaliere/kit-escursionisti-montagna-pulita',
+    canonicalPath: '/articoli-frontaliere/kit-escursionisti-montagna-pulita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8673,7 +8673,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moda, sostenibile, bellinzona, giornata',
     ogTitle: 'Moda sostenibile a Bellinzona: giornata dedicata al riuso e alla riparazione',
     ogDescription: 'Sabato 9 maggio a Bellinzona laboratori, upcycling e tosatura delle pecore per sensibilizzare contro la fast fashion',
-    canonicalPath: '/articoli-frontaliere/moda-sostenibile-bellinzona-9-maggio',
+    canonicalPath: '/articoli-frontaliere/moda-sostenibile-bellinzona-9-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8701,7 +8701,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, chiasso, situazione',
     ogTitle: 'Fuga di ammoniaca a Chiasso, situazione sotto controllo',
     ogDescription: 'Incidente alla pista di ghiaccio di Chiasso, tre persone intossicate ma nessuna grave. La popolazione non è in pericolo.',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-controllo',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-controllo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8729,7 +8729,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, perdita, ammoniaca, allo, stadio',
     ogTitle: 'Perdita di ammoniaca a Chiasso: tre intossicati',
     ogDescription: 'Tre persone intossicate a causa di una perdita di ammoniaca allo stadio del ghiaccio di Chiasso. Intervento dei pompieri e dei sanitari.',
-    canonicalPath: '/articoli-frontaliere/chiasso-ammoniaca-stadio-ghiaccio',
+    canonicalPath: '/articoli-frontaliere/chiasso-ammoniaca-stadio-ghiaccio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8757,7 +8757,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, alla, pista',
     ogTitle: 'Fuga di ammoniaca alla pista di ghiaccio di Chiasso',
     ogDescription: 'Tre addetti alla manutenzione visitati dai soccorritori, ma nessuno ha bisogno di ricovero ospedaliero',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-pista-ghiaccio',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-pista-ghiaccio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8785,7 +8785,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, biglietti, trenord, whatsapp, funziona',
     ogTitle: 'Biglietti Trenord su WhatsApp: come funziona',
     ogDescription: 'Scopri come acquistare biglietti Trenord su WhatsApp, disponibili alle self-service e ai Digital Gate di Milano e Malpensa T1',
-    canonicalPath: '/articoli-frontaliere/biglietto-trenord-whatsapp-ticino',
+    canonicalPath: '/articoli-frontaliere/biglietto-trenord-whatsapp-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8813,7 +8813,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, aerei, finanziare, treni',
     ogTitle: 'Tassa su aerei per finanziare i treni in Ticino',
     ogDescription: 'Un comitato propone di tassare i biglietti aerei per sostenere i trasporti pubblici in Svizzera, con un contributo minimo di 30 franchi.',
-    canonicalPath: '/articoli-frontaliere/tassa-aerei-sostegno-treni',
+    canonicalPath: '/articoli-frontaliere/tassa-aerei-sostegno-treni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8841,7 +8841,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comune, como, maggio, solo',
     ogTitle: 'Comune di Como: appuntamenti obbligatori per 12 servizi dal 4 maggio 2026',
     ogDescription: 'Dal 4 maggio 2026, 12 servizi del Comune di Como saranno disponibili solo su appuntamento, tra cui il rilascio della Carta d\'Identità Elettronica (CIE).',
-    canonicalPath: '/articoli-frontaliere/comune-como-appuntamenti-cie-2026',
+    canonicalPath: '/articoli-frontaliere/comune-como-appuntamenti-cie-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8869,7 +8869,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, auto, elettriche, momento, ricarica',
     ogTitle: 'Auto elettriche: il momento della ricarica è il più delicato',
     ogDescription: 'Un incendio in un\'autorimessa di Breganzona ha riacceso i riflettori sui rischi legati alla ricarica delle auto elettriche. Scopri cosa fare per garantire la',
-    canonicalPath: '/articoli-frontaliere/auto-elettriche-ricarica-breganzona',
+    canonicalPath: '/articoli-frontaliere/auto-elettriche-ricarica-breganzona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8897,7 +8897,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, università, insubria, milioni, ricerca',
     ogTitle: 'Università Insubria: 4,4 milioni per ricerca a Como e Varese',
     ogDescription: 'Regione Lombardia finanzia progetti IMPACTT e SustAA per potenziare infrastrutture di ricerca e innovazione sostenibile.',
-    canonicalPath: '/articoli-frontaliere/universita-insubria-4-4-milioni-ricerca',
+    canonicalPath: '/articoli-frontaliere/universita-insubria-4-4-milioni-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8925,7 +8925,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, airpack, lombardia, lavoratori, rischio',
     ogTitle: 'Airpack Lombardia: 41 lavoratori a rischio licenziamento',
     ogDescription: 'La proprietà belga Abriso insiste sulla chiusura dello stabilimento di Ossago Lodigiano, nonostante le offerte di acquisto.',
-    canonicalPath: '/articoli-frontaliere/airpack-lombardia-41-lavoratori',
+    canonicalPath: '/articoli-frontaliere/airpack-lombardia-41-lavoratori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8953,7 +8953,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, tassa, aerei, miliardi',
     ogTitle: 'Iniziativa tassa aerei: 1,5 miliardi per treni e buoni mobilità',
     ogDescription: 'Un\'iniziativa popolare svizzera vuole tassare i biglietti aerei per finanziare trasporti pubblici e buoni mobilità. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/tassa-aerei-trasporto-pubblico',
+    canonicalPath: '/articoli-frontaliere/tassa-aerei-trasporto-pubblico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8981,7 +8981,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, settimana, formazione, professionale, eventi',
     ogTitle: 'Settimana formazione professionale Ticino 2024',
     ogDescription: 'Dal 4 all’8 maggio, oltre 30 eventi tra radio, TV e sul territorio per scoprire le professioni in Ticino. Scopri come partecipare.',
-    canonicalPath: '/articoli-frontaliere/settimanaprofessionale-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/settimanaprofessionale-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9009,7 +9009,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colazione, equa, eventi, giornata',
     ogTitle: 'Colazione equa in Ticino: eventi per la Giornata mondiale del commercio equo',
     ogDescription: 'Il 9 maggio 2026 il Ticino celebra la Giornata mondiale del commercio equo con colazioni, degustazioni e promozioni in varie Botteghe del Mondo.',
-    canonicalPath: '/articoli-frontaliere/colazione-equo-ticino-9-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/colazione-equo-ticino-9-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9037,7 +9037,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro, energia, provincia, varese',
     ogTitle: 'Caro energia in provincia di Varese: impatti su imprese e frontalieri',
     ogDescription: 'Analisi dell\'impatto del caro energia in provincia di Varese, con focus su imprese metalmeccaniche e lavoratori frontalieri.',
-    canonicalPath: '/articoli-frontaliere/costo-energia-varese-impatti-frontalieri',
+    canonicalPath: '/articoli-frontaliere/costo-energia-varese-impatti-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9065,7 +9065,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedali, varesini, meno, letti',
     ogTitle: 'Ospedali varesini: meno letti, più specializzazione in 20 anni',
     ogDescription: 'Negli ultimi vent\'anni i posti letto negli ospedali del Varesotto si sono ridotti del 30-40%, con un modello di cura più efficiente ma anche più fragile.',
-    canonicalPath: '/articoli-frontaliere/ospedali-varesini-cambiamenti-20-anni',
+    canonicalPath: '/articoli-frontaliere/ospedali-varesini-cambiamenti-20-anni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9093,7 +9093,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sunrise, dovrà, integrare, offerta',
     ogTitle: 'Sunrise dovrà integrare l’offerta HBB della SSR',
     ogDescription: 'Il Tribunale amministrativo federale ha sancito che Sunrise deve includere l’offerta HBB della SSR, con funzionalità per disabili sensoriali.',
-    canonicalPath: '/articoli-frontaliere/sunrise-integra-hbb-ssr-2026',
+    canonicalPath: '/articoli-frontaliere/sunrise-integra-hbb-ssr-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9121,7 +9121,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, alla, riduzione, settimanali',
     ogTitle: 'Infermieri: no alla riduzione delle ore settimanali',
     ogDescription: 'Il Consiglio nazionale ha deciso di mantenere a 50 ore la durata massima settimanale del lavoro per gli infermieri, nonostante l\'iniziativa popolare approvata',
-    canonicalPath: '/articoli-frontaliere/infermieri-lavoro-ore-settimanali',
+    canonicalPath: '/articoli-frontaliere/infermieri-lavoro-ore-settimanali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9149,7 +9149,7 @@ const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sorveglianza, telecomunicazioni, rallenta, tempo',
     ogTitle: 'Sorveglianza telecomunicazioni: +40% in Svizzera, ma rallenta in tempo reale',
     ogDescription: 'Nel 2025, le ricerche tramite antenna sono aumentate del 69%, mentre la sorveglianza in tempo reale è cresciuta solo del 3%.',
-    canonicalPath: '/articoli-frontaliere/sorveglianza-telecomunicazioni-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/sorveglianza-telecomunicazioni-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",

--- a/services/seo/seo-blog-7.ts
+++ b/services/seo/seo-blog-7.ts
@@ -13,7 +13,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, education, scuole, imprese, confronto',
     ogTitle: 'Education Day 2026: scuole e imprese a confronto',
     ogDescription: 'La terza edizione dell\'Education Day di Confindustria Varese si terrà il 5 maggio 2026 alle Ville Ponti con centinaia di studenti.',
-    canonicalPath: '/articoli-frontaliere/education-day-confindustria-varese-2026',
+    canonicalPath: '/articoli-frontaliere/education-day-confindustria-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -41,7 +41,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, polizia, progetto, fermo',
     ogTitle: 'Riforma polizia Ticino: progetto fermo',
     ogDescription: 'Il Consiglio di Stato non attua la riorganizzazione tra polizia cantonale e comunale. Zali: \'Decisione politica non ancora presa\'',
-    canonicalPath: '/articoli-frontaliere/riforma-polizia-ticino-progetto-fermo',
+    canonicalPath: '/articoli-frontaliere/riforma-polizia-ticino-progetto-fermo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -69,7 +69,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siemens, firmano, contratto, nuovi',
     ogTitle: 'FFS e Siemens firmano contratto per 116 nuovi treni',
     ogDescription: 'Le FFS e Siemens Mobility Svizzera hanno firmato il contratto per 116 nuovi treni a due piani per la S-Bahn, con un investimento di fino a 2 miliardi di',
-    canonicalPath: '/articoli-frontaliere/ffs-siemens-nuovi-treni-ticino',
+    canonicalPath: '/articoli-frontaliere/ffs-siemens-nuovi-treni-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -97,7 +97,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passaporto, uffici, postali, italiani',
     ogTitle: 'Passaporto in 7.500 uffici postali italiani',
     ogDescription: 'Scopri come richiedere il passaporto in 7.500 uffici postali italiani, inclusi quelli del progetto Polis. Vantaggi e procedure per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/passaporto-poste-italiane-uffici',
+    canonicalPath: '/articoli-frontaliere/passaporto-poste-italiane-uffici/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -125,7 +125,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, indaga, pubblicità, motori',
     ogTitle: 'COMCO indaga su pubblicità via motori di ricerca: viaggi e casinò online',
     ogDescription: 'La Commissione della Concorrenza svizzera apre due indagini su accordi illeciti tra aziende del settore viaggi e casinò online',
-    canonicalPath: '/articoli-frontaliere/comco-indaga-pubblicita-motori-ricerca',
+    canonicalPath: '/articoli-frontaliere/comco-indaga-pubblicita-motori-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -153,7 +153,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, record, passeggeri, treni, svizzeri',
     ogTitle: 'Record di passeggeri sui treni svizzeri nel 2026',
     ogDescription: 'Le principali compagnie ferroviarie svizzere registrano un aumento del 5% nel primo trimestre 2026, mentre il trasporto merci cala del 4%.',
-    canonicalPath: '/articoli-frontaliere/record-passeggeri-treni-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/record-passeggeri-treni-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -181,7 +181,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ferrovia, passi, avanti, nell',
     ogTitle: 'Ferrovia: passi avanti nell\'estensione dell\'infrastruttura',
     ogDescription: '300 progetti in corso per l\'ampliamento della rete ferroviaria svizzera entro il 2035, con lavori in corso a Losanna e Friburgo.',
-    canonicalPath: '/articoli-frontaliere/ferrovia-svizzera-300-progetti-2026',
+    canonicalPath: '/articoli-frontaliere/ferrovia-svizzera-300-progetti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -209,7 +209,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassi, invariati, impatto, canton',
     ogTitle: 'Bce: tassi invariati, impatto sul Canton Ticino',
     ogDescription: 'La Bce mantiene i tassi di interesse invariati, con implicazioni per i frontalieri e l\'economia ticinese.',
-    canonicalPath: '/articoli-frontaliere/bce-tassi-invariati-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/bce-tassi-invariati-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -237,7 +237,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, telefonare, navigare, costerà, sunrise',
     ogTitle: 'Aumenti tariffe Sunrise 2026: cosa cambia per i frontalieri',
     ogDescription: 'Scopri gli aumenti delle tariffe di Sunrise, Yallo e Lebara dal 2026 e come influenzano i frontalieri in Ticino. Confronta le offerte e pianifica il tuo budget.',
-    canonicalPath: '/articoli-frontaliere/aumenti-tariffe-sunrise-2026',
+    canonicalPath: '/articoli-frontaliere/aumenti-tariffe-sunrise-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -265,7 +265,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 18mila, lavoratori, cercano, riconoscimento',
     ogTitle: 'ICT Ticino: 18mila lavoratori cercano riconoscimento',
     ogDescription: 'Il settore ICT in Ticino, con 18mila addetti, chiede di essere rappresentato nella Commissione Tripartita. Il Consiglio di Stato riconosce l\'importanza',
-    canonicalPath: '/articoli-frontaliere/settore-ict-ticino-riconoscimento-istituzioni',
+    canonicalPath: '/articoli-frontaliere/settore-ict-ticino-riconoscimento-istituzioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -293,7 +293,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassi, fermi, rischi, inflazione',
     ogTitle: 'Bce tassi fermi ma rischi inflazione aumentati',
     ogDescription: 'La Bce mantiene i tassi invariati ma avverte su rischi inflazione per conflitto Medio Oriente. Impatti per frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/bce-tassi-inflazione-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/bce-tassi-inflazione-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -321,7 +321,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, microterremoto, artificiale, esperimento, storico',
     ogTitle: 'Microterremoto artificiale in Ticino: esperimento storico nel San Gottardo',
     ogDescription: 'Ricercatori svizzeri, italiani e tedeschi innescano un terremoto controllato nel massiccio del San Gottardo per studiare la prevedibilità dei sismi',
-    canonicalPath: '/articoli-frontaliere/microterremoto-artificiale-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/microterremoto-artificiale-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -349,7 +349,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, flottila, gaza, otto, svizzeri',
     ogTitle: 'Flottila Svizzera a Gaza: Otto Svizzeri Sani e Salvi',
     ogDescription: 'Gli otto svizzeri partiti con la Global Sumud Flotilla sono sani e salvi dopo l\'intervento della marina israeliana. Greenpeace chiede protezione.',
-    canonicalPath: '/articoli-frontaliere/flotilla-svizzera-gaza-2026',
+    canonicalPath: '/articoli-frontaliere/flotilla-svizzera-gaza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -377,7 +377,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vittoria, consumatori, illegittime, clausole',
     ogTitle: 'Vittoria consumatori: illegittime le clausole Sunrise',
     ogDescription: 'Il tribunale di Zurigo accoglie la causa contro Sunrise, giudicando illegittime le clausole su disdette e aumenti tariffari',
-    canonicalPath: '/articoli-frontaliere/clausole-sunrise-illegittime-2026',
+    canonicalPath: '/articoli-frontaliere/clausole-sunrise-illegittime-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -405,7 +405,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lidl, introduce, formazione, duale',
     ogTitle: 'Lidl introduce formazione duale in Ticino',
     ogDescription: 'Lidl Italia porta il modello di formazione duale nella grande distribuzione organizzata, con oltre 23.000 candidature in quattro anni.',
-    canonicalPath: '/articoli-frontaliere/lidl-formazione-duale-gdo-ticino',
+    canonicalPath: '/articoli-frontaliere/lidl-formazione-duale-gdo-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -433,7 +433,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, rafforza, attrattiva, grandi',
     ogTitle: 'Lugano rafforza l\'attrattiva per grandi contribuenti',
     ogDescription: 'Il Municipio di Lugano conferma un piano d\'azione per attrarre contribuenti facoltosi e investitori internazionali. Scopri le implicazioni pratiche.',
-    canonicalPath: '/articoli-frontaliere/lugano-red-carpet-contribuenti-2026',
+    canonicalPath: '/articoli-frontaliere/lugano-red-carpet-contribuenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -461,7 +461,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trenord, linee, indennizzo, inizio',
     ogTitle: 'Trenord: 25 linee con indennizzo, inizio 2026 disastroso',
     ogDescription: 'Dati allarmanti per Trenord: 25 linee con indennizzo a gennaio 2026, 17 a febbraio. Il Pd chiede chiarezza su disservizi e indennizzi.',
-    canonicalPath: '/articoli-frontaliere/trenord-disservizi-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/trenord-disservizi-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -489,7 +489,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pulmino, elettrico, granello, cislago',
     ogTitle: 'Pulmino elettrico per Il Granello di Cislago: viaggi più sostenibili',
     ogDescription: 'Un pulmino elettrico messo a disposizione gratuitamente per alcuni mesi da un concessionario di Gallarate supporta le attività quotidiane e gli spostamenti dei',
-    canonicalPath: '/articoli-frontaliere/pulmino-elettrico-granello-cislago-2026',
+    canonicalPath: '/articoli-frontaliere/pulmino-elettrico-granello-cislago-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -517,7 +517,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ambrogio, castiglioni, nuovo, presidente',
     ogTitle: 'Ambrogio Castiglioni nuovo presidente di Digital Industries World',
     ogDescription: 'Ambrogio Castiglioni, originario di Carnago, è stato nominato nuovo presidente di Digital Industries World. Scopri le implicazioni per i frontalieri e le',
-    canonicalPath: '/articoli-frontaliere/ambrogio-castiglioni-digital-industries-world',
+    canonicalPath: '/articoli-frontaliere/ambrogio-castiglioni-digital-industries-world/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -545,7 +545,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumento, spese, carburante, france',
     ogTitle: 'Aumento spese carburante Air France: 2,4 miliardi di dollari per 2026',
     ogDescription: 'Air France spenderà 9,3 miliardi di dollari in carburante nel 2026, un aumento di 2,4 miliardi rispetto al 2025.',
-    canonicalPath: '/articoli-frontaliere/aumento-spese-carburante-air-france-2026',
+    canonicalPath: '/articoli-frontaliere/aumento-spese-carburante-air-france-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -573,7 +573,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trenord, linee, insufficienti, febbraio',
     ogTitle: 'Trenord: 17 linee insufficienti a febbraio 2026. Astuti chiede spiegazioni',
     ogDescription: 'A febbraio 2026, 17 linee Trenord su 42 hanno diritto all\'indennizzo per ritardi. Astuti (Pd): \'Assessore Lucente spieghi\'',
-    canonicalPath: '/articoli-frontaliere/trenord-ritardi-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/trenord-ritardi-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -601,7 +601,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, ticinese, progetto, concluso',
     ogTitle: 'Polizia ticinese: progetto concluso, nessun sviluppo',
     ogDescription: 'Il Consiglio di Stato ha deciso di non proseguire con il progetto \'Polizia ticinese\' dopo la fase progettuale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-concluso',
+    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-concluso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -629,7 +629,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, bike, sharing, gratis',
     ogTitle: 'Bike sharing Como gratis 3 ore giugno',
     ogDescription: 'Scopri il nuovo servizio di bike sharing a Como, gratuito per le prime 3 ore fino a giugno. 80 biciclette e 17 stazioni disponibili.',
-    canonicalPath: '/articoli-frontaliere/bike-sharing-como-gratis-giugno',
+    canonicalPath: '/articoli-frontaliere/bike-sharing-como-gratis-giugno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -657,7 +657,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guerra, iran, pressione, sull',
     ogTitle: 'Guerra in Iran: pressione sull\'industria alimentare svizzera',
     ogDescription: 'Dai fertilizzanti al vetro, il conflitto nel Golfo Persico colpisce settori chiave. Ecco gli effetti in Svizzera e le prospettive future.',
-    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-2026',
+    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -685,7 +685,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rientro, incubo, code, rivera',
     ogTitle: 'Rientro A2 da incubo: code da Rivera a Lugano Sud',
     ogDescription: 'Giornata nera per i pendolari: incidenti e traffico intenso sulla A2, code da Rivera a Lugano Sud e valichi di frontiera intasati',
-    canonicalPath: '/articoli-frontaliere/rientro-a2-incubo-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/rientro-a2-incubo-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -713,7 +713,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ultimo, giorno, utile, salire',
     ogTitle: 'Ultimo giorno funivia Säntis 2026',
     ogDescription: 'Scopri quando riapre la funivia del Säntis dopo il rinnovo. Informazioni su date, costi e alternative per i visitatori.',
-    canonicalPath: '/articoli-frontaliere/ultimo-giorno-funivia-santis-2026',
+    canonicalPath: '/articoli-frontaliere/ultimo-giorno-funivia-santis-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -741,7 +741,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, varese, acli',
     ogTitle: 'Primo Maggio a Varese, le ACLI: “Il lavoro dignitoso è l’urgenza del presente”',
     ogDescription: 'Le ACLI provinciali di Varese mettono al centro del dibattito il tema del lavoro dignitoso, indicandolo come urgenza del presente e leva fondamentale per il',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-acli-lavoro-dignitoso',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-acli-lavoro-dignitoso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -769,7 +769,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, consultori, lavoro, dossier',
     ogTitle: 'Crans-Montana: consultori al lavoro su 700 dossier',
     ogDescription: 'Quattro mesi dopo la tragedia, i servizi di aiuto alle vittime gestiscono quasi 700 casi, con 400 solo in Vallese e 20 in Ticino.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-700-dossier-consultori',
+    canonicalPath: '/articoli-frontaliere/crans-montana-700-dossier-consultori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -797,7 +797,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, perequazione, finanziaria, svantaggiato, berna',
     ogTitle: 'Perequazione finanziaria: Ticino svantaggiato per i frontalieri',
     ogDescription: 'Berna considera il Ticino più ricco di quanto sia realmente, influenzando i fondi federali. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/perequazione-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/perequazione-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -825,7 +825,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, viabilità, sperimentale, camion, intorno',
     ogTitle: 'Viabilità sperimentale per camion intorno a Travedona dal 5 maggio',
     ogDescription: 'Dal 5 maggio 2026 nuova viabilità sperimentale per camion in 6 comuni del Varese, con un anello a senso unico per migliorare la sicurezza e la fluidità del',
-    canonicalPath: '/articoli-frontaliere/viabilita-camion-travedona-2026',
+    canonicalPath: '/articoli-frontaliere/viabilita-camion-travedona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -853,7 +853,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, apre, casa, comunità',
     ogTitle: 'Luino: apre la Casa di Comunità con punto unico di accesso',
     ogDescription: 'Da venerdì 1° maggio è operativo il Punto Unico di Accesso nella nuova Casa di Comunità di Luino, finanziata con fondi PNRR.',
-    canonicalPath: '/articoli-frontaliere/casa-comunita-luino-punto-unico-accesso',
+    canonicalPath: '/articoli-frontaliere/casa-comunita-luino-punto-unico-accesso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -881,7 +881,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, disavanzo, 2025, ridotto',
     ogTitle: 'Bellinzona: disavanzo 2025 ridotto a -2,7 milioni',
     ogDescription: 'Il consuntivo 2025 della Città di Bellinzona chiude con un disavanzo ridotto a -2,7 milioni, grazie a un aumento del gettito fiscale e al contenimento delle',
-    canonicalPath: '/articoli-frontaliere/bellinzona-2025-consuntivo-risultati',
+    canonicalPath: '/articoli-frontaliere/bellinzona-2025-consuntivo-risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -909,7 +909,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, democrazia, respinta, consiglio',
     ogTitle: 'Iniziativa per la democrazia respinta dal Consiglio nazionale',
     ogDescription: 'Il Consiglio nazionale ha respinto l\'iniziativa per la democrazia con 130 voti a 62. Scopri le implicazioni per i frontalieri e i requisiti per la n',
-    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-2026',
+    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -937,7 +937,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, storia, infortuni',
     ogTitle: 'Primo Maggio 2026: storia, infortuni e trasformazioni del lavoro',
     ogDescription: 'Stefania Filetti, segretaria generale della CGIL di Varese, ripercorre la storia del Primo Maggio e analizza i dati sugli infortuni sul lavoro in provincia.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-storia-e-trasformazioni',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-storia-e-trasformazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -965,7 +965,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, insubria, uomini, seguiti, centri',
     ogTitle: 'ATS Insubria: 398 uomini seguiti nei centri per autori di violenza',
     ogDescription: 'Scopri il primo bilancio dei Centri per Uomini Autori di Violenza (CUAV) attivi nei territori di ATS Insubria, con 398 uomini seguiti nel primo anno.',
-    canonicalPath: '/articoli-frontaliere/primo-bilancio-centri-violenza-2026',
+    canonicalPath: '/articoli-frontaliere/primo-bilancio-centri-violenza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -993,7 +993,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, salandin, storico, leader',
     ogTitle: 'Addio a Giovanni Salandin, storico leader Cgil',
     ogDescription: 'Il mondo sindacale varesino è in lutto per la scomparsa di Giovanni Salandin, storico dirigente Cgil che ha dedicato la vita alla difesa dei diritti dei',
-    canonicalPath: '/articoli-frontaliere/addio-giovanni-salandin-cgil-frontalieri',
+    canonicalPath: '/articoli-frontaliere/addio-giovanni-salandin-cgil-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1021,7 +1021,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guardia, medica, attiva, ponte',
     ogTitle: 'Guardia medica attiva per il ponte del 1° maggio: ecco cosa sapere',
     ogDescription: 'Continuità Assistenziale attiva fino alle 8 di lunedì 4 maggio. Ambulatorio Pediatrico del sabato attivo il 2 maggio. Numero verde 116 117.',
-    canonicalPath: '/articoli-frontaliere/guardia-medica-como-ponte-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/guardia-medica-como-ponte-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1049,7 +1049,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bilancio, provincia, varese, milioni',
     ogTitle: 'Bilancio Provincia Varese: 1,5 milioni per investimenti',
     ogDescription: 'Il bilancio della Provincia di Varese per il 2025 si chiude con un avanzo di 1,5 milioni, destinati a investimenti in viabilità e patrimonio culturale.',
-    canonicalPath: '/articoli-frontaliere/bilancio-provincia-varese-1-5-milioni',
+    canonicalPath: '/articoli-frontaliere/bilancio-provincia-varese-1-5-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1077,7 +1077,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, città, verdi, europa',
     ogTitle: 'Varese tra le città più verdi d\'Europa',
     ogDescription: 'Varese è tra le sole due città europee dove oltre il 50% della popolazione vive secondo la regola del 3-30-300.',
-    canonicalPath: '/articoli-frontaliere/varese-citta-piu-verde-2026',
+    canonicalPath: '/articoli-frontaliere/varese-citta-piu-verde-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1105,7 +1105,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, denuncia, como, strisce, pedonali',
     ogTitle: 'Denuncia a Como: strisce pedonali pericolose',
     ogDescription: 'Una lettrice segnala lo stato critico delle strisce pedonali in quasi tutta la città di Como, rendendo pericoloso l\'attraversamento delle strade.',
-    canonicalPath: '/articoli-frontaliere/denuncia-strisce-pedonali-como-2026',
+    canonicalPath: '/articoli-frontaliere/denuncia-strisce-pedonali-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1133,7 +1133,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, emergenza, acqua, lombardia, deficit',
     ogTitle: 'Emergenza acqua in Lombardia: deficit del 37%, cosa succede ora',
     ogDescription: 'Situazione critica in Lombardia: deficit idrico del 37%, assenza di neve e misure urgenti per l\'estate',
-    canonicalPath: '/articoli-frontaliere/emergenza-acqua-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/emergenza-acqua-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1161,7 +1161,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bambino, anni, muore, annegato',
     ogTitle: 'Bambino di due anni muore annegato a Morcote',
     ogDescription: 'Tragedia a Vico Morcote: un bambino di due anni è morto annegato in una piscina privata. L\'allarme è scattato nel primo pomeriggio di giovedì 30 aprile.',
-    canonicalPath: '/articoli-frontaliere/bambino-annegato-morcote-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/bambino-annegato-morcote-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1189,7 +1189,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, solaro, chiude, ambulatorio, medico',
     ogTitle: 'Solaro chiude l’ambulatorio medico al Villaggio Brollo',
     ogDescription: 'L’Ambulatorio Medico Temporaneo di Villaggio Brollo a Solaro chiuderà in anticipo il 21 maggio. Scopri i dettagli e i servizi alternativi disponibili.',
-    canonicalPath: '/articoli-frontaliere/solaro-chiude-ambulatorio-medico',
+    canonicalPath: '/articoli-frontaliere/solaro-chiude-ambulatorio-medico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1217,7 +1217,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piano, pandemico, 2025-2029, approvato',
     ogTitle: 'Piano Pandemico 2025-2029 approvato: cosa cambia',
     ogDescription: 'La Conferenza Stato-Regioni ha approvato il nuovo Piano Pandemico 2025-2029 con un investimento di 1,1 miliardi di euro per potenziare il sistema sanitario',
-    canonicalPath: '/articoli-frontaliere/piano-pandemico-2025-2029-approvato',
+    canonicalPath: '/articoli-frontaliere/piano-pandemico-2025-2029-approvato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1245,7 +1245,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, zali, conferma, progetto',
     ogTitle: 'Polizia Ticino: Zali conferma, progetto non accantonato',
     ogDescription: 'Il consigliere di Stato Claudio Zali chiarisce che il progetto Polizia ticinese non è stato scartato, ma resta una delle soluzioni possibili.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-zali-comuni',
+    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-zali-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1273,7 +1273,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siemens, nuovi, treni, miliardi',
     ogTitle: 'FFS e Siemens: 116 nuovi treni per il Ticino',
     ogDescription: 'Due miliardi di franchi per 116 treni a due piani per il traffico suburbano. Entreranno in servizio dal 2031.',
-    canonicalPath: '/articoli-frontaliere/ffs-siemens-116-treni-suburbani-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ffs-siemens-116-treni-suburbani-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1301,7 +1301,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, uscita, melide',
     ogTitle: 'Chiusure notturne uscita Melide autostrada A2',
     ogDescription: 'L\'uscita autostradale di Melide in direzione sud sarà chiusa da domenica 3 maggio a venerdì 8 maggio 2026 dalle 21.30 alle 05.00 per lavori di rinnovo della',
-    canonicalPath: '/articoli-frontaliere/chiusure-melide-autostrada-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-melide-autostrada-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1329,7 +1329,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, webuild, costruzioni, avvia, lavori',
     ogTitle: 'Webuild: CSC Costruzioni avvia lavori per rinnovare la sede ONU a Ginevra',
     ogDescription: 'CSC Costruzioni avvia i lavori per il rinnovamento dell\'Edificio E del Palais des Nations a Ginevra, con un contratto da 215 milioni di euro.',
-    canonicalPath: '/articoli-frontaliere/webuild-csc-rinnovo-sede-onu-ginevra',
+    canonicalPath: '/articoli-frontaliere/webuild-csc-rinnovo-sede-onu-ginevra/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1357,7 +1357,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, migranti, problematici, pasture, progetto',
     ogTitle: 'Migranti problematici a Pasture: progetto congelato',
     ogDescription: 'Il progetto per una sezione di richiedenti asilo problematici a Pasture è stato congelato. La Confederazione punta a creare centri speciali.',
-    canonicalPath: '/articoli-frontaliere/migranti-pasture-progetto-congelato',
+    canonicalPath: '/articoli-frontaliere/migranti-pasture-progetto-congelato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1385,7 +1385,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ricavi, alberghi, 2025, miliardi',
     ogTitle: 'Ricavi alberghi Ticino 2025: +3,9% a 6,2 miliardi',
     ogDescription: 'Il settore alberghiero svizzero ha registrato un aumento del 3,9% nel 2025, con picchi del 6,3% negli hotel a 5 stelle.',
-    canonicalPath: '/articoli-frontaliere/ricavi-alberghi-ticino-2025-crescita',
+    canonicalPath: '/articoli-frontaliere/ricavi-alberghi-ticino-2025-crescita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1413,7 +1413,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cercasi, direttore, controllo, cantonale',
     ogTitle: 'Cercasi direttore per il Controllo cantonale delle finanze',
     ogDescription: 'Il Canton Ticino cerca un nuovo direttore per il Controllo cantonale delle finanze dopo l\'annuncio della pensione di Giovanni cavallero.',
-    canonicalPath: '/articoli-frontaliere/controllo-finanze-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/controllo-finanze-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1441,7 +1441,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, market, index, verde',
     ogTitle: 'Swiss Market Index in verde: spunti utili per i frontalieri',
     ogDescription: 'Il Swiss Market Index chiude in positivo, offrendo spunti interessanti per gli investimenti e le pensioni dei frontalieri',
-    canonicalPath: '/articoli-frontaliere/swiss-market-index-verde-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-market-index-verde-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1469,7 +1469,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crowdfunding, raccolti, quasi, 100mila',
     ogTitle: 'Crowdfunding BCC: raccolti quasi 100mila euro',
     ogDescription: 'La BCC Busto Garolfo e Buguggiate ha raccolto quasi 100mila euro attraverso il crowdfunding, con oltre 1.200 donatori coinvolti e un overfunding del 141%.',
-    canonicalPath: '/articoli-frontaliere/bcc-crowdfunding-100mila-euro',
+    canonicalPath: '/articoli-frontaliere/bcc-crowdfunding-100mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1497,7 +1497,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, truffatrice, seriale, arrestata, como',
     ogTitle: 'Truffatrice seriale arrestata a Como con gioielli e contanti',
     ogDescription: 'Arrestata una 31enne ceca per truffe ai danni di due anziane tra Como e Lecco, con un bottino di 2.400 euro in contanti e gioielli.',
-    canonicalPath: '/articoli-frontaliere/truffatrice-seriale-como-lecco-2026',
+    canonicalPath: '/articoli-frontaliere/truffatrice-seriale-como-lecco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1525,7 +1525,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passaporto, musei, svizzeri, anni',
     ogTitle: 'Passaporto Musei Svizzeri, 30 anni e un record storico',
     ogDescription: 'Il Passaporto Musei Svizzeri celebra 30 anni con un record di 1,5 milioni di ingressi nel 2025. Scopri di più su questo successo culturale.',
-    canonicalPath: '/articoli-frontaliere/passaporto-musei-svizzera-30-anni-record',
+    canonicalPath: '/articoli-frontaliere/passaporto-musei-svizzera-30-anni-record/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1553,7 +1553,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confindustria, como, esplora, legame',
     ogTitle: 'Confindustria Como esplora arte, cultura e salute',
     ogDescription: 'Evento il 13 maggio con esperti per discutere l\'impatto positivo dell\'arte e della cultura sulla salute e il benessere',
-    canonicalPath: '/articoli-frontaliere/confindustria-como-arte-cultura-salute-13-maggio',
+    canonicalPath: '/articoli-frontaliere/confindustria-como-arte-cultura-salute-13-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1581,7 +1581,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tribunale, ferma, pratiche, abusive',
     ogTitle: 'Tribunale ferma pratiche abusive di Sunrise',
     ogDescription: 'Il tribunale distrettuale di Zurigo ha dichiarato illegittime due clausole contrattuali di Sunrise relative agli aumenti di prezzo e alle modalità di disdetta.',
-    canonicalPath: '/articoli-frontaliere/sunrise-pratiche-abusive-fermate-2026',
+    canonicalPath: '/articoli-frontaliere/sunrise-pratiche-abusive-fermate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1609,7 +1609,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, proroga, accise, carburanti, sconto',
     ogTitle: 'Proroga accise carburanti: sconto gasolio a 24,4 centesimi, benzina a 6',
     ogDescription: 'Il governo italiano ha prorogato di tre settimane la riduzione delle accise sui carburanti, con sconto differenziato per benzina e gasolio.',
-    canonicalPath: '/articoli-frontaliere/proroga-accise-carburanti-2026',
+    canonicalPath: '/articoli-frontaliere/proroga-accise-carburanti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1637,7 +1637,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, ticinese, progetto, abbandonato',
     ogTitle: 'Polizia ticinese: progetto abbandonato dal Consiglio di Stato',
     ogDescription: 'Il Consiglio di Stato ha deciso di non proseguire con il progetto Polizia ticinese, avviato nel 2016 per migliorare la collaborazione tra polizia cantonale e',
-    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-abbandonato-2026',
+    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-abbandonato-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1665,7 +1665,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, summer, camp, malnate, natura',
     ogTitle: 'Summer camp a Malnate: natura, fattoria e inglese per bambini',
     ogDescription: 'Alla Tenuta La Novella di Malnate, un\'estate tra animali, attività all\'aperto e inglese per bambini dai 6 ai 10 anni.',
-    canonicalPath: '/articoli-frontaliere/summer-camp-malnate-tenuta-novella',
+    canonicalPath: '/articoli-frontaliere/summer-camp-malnate-tenuta-novella/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1693,7 +1693,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, liuc, federazione, golf, accordo',
     ogTitle: 'Liuc e Federazione Golf: accordo per studenti-atleti',
     ogDescription: 'Protocollo d’intesa triennale tra LIUC e Federazione Italiana Golf per favorire la doppia carriera degli studenti-atleti e promuovere il golf tra la comunità',
-    canonicalPath: '/articoli-frontaliere/liuc-golf-frontalieri-accordo-2026',
+    canonicalPath: '/articoli-frontaliere/liuc-golf-frontalieri-accordo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1721,7 +1721,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pillola, giorno, dopo, senza',
     ogTitle: 'Pillola del giorno dopo senza consulenza: cosa cambia',
     ogDescription: 'Il Consiglio nazionale svizzero approva la vendita della pillola del giorno dopo senza colloquio obbligatorio. Ecco cosa cambia per le donne in Ticino e in',
-    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-vendita-libera-2026',
+    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-vendita-libera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1749,7 +1749,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, isolino, virginia, riapre, viaggio',
     ogTitle: 'L’Isolino Virginia riapre: viaggio nel tempo tra palafitte e natura',
     ogDescription: 'L’Isolino Virginia riapre al pubblico il 2 maggio 2026 con un nuovo allestimento museale e servizi di ristorazione.',
-    canonicalPath: '/articoli-frontaliere/isolino-virginia-riapre-2026',
+    canonicalPath: '/articoli-frontaliere/isolino-virginia-riapre-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1777,7 +1777,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, salone, innovazione, sociale',
     ogTitle: 'Salone CSR Varese 2026: sostenibilità e innovazione',
     ogDescription: 'Il 6 maggio 2026 a Varese si terrà il Salone della CSR, un evento dedicato a sostenibilità e innovazione sociale con imprese, istituzioni e Terzo Settore.',
-    canonicalPath: '/articoli-frontaliere/sostenibilita-salone-csr-varese-2026',
+    canonicalPath: '/articoli-frontaliere/sostenibilita-salone-csr-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1805,7 +1805,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, film, dibattito, collegamento',
     ogTitle: 'Varese: Film \'The Sea\' e dibattito con collegamento live a Gaza',
     ogDescription: 'Il Cineclub Filmstudio 90 di Varese proietta \'The Sea\' con dibattito e collegamento live alla Global Sumud Flotilla verso Gaza il 6 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/film-the-sea-varese-gaza-2026',
+    canonicalPath: '/articoli-frontaliere/film-the-sea-varese-gaza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1833,7 +1833,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, apre, nuovo, solco',
     ogTitle: 'Crans-Montana, nuovo solco Italia-Svizzera',
     ogDescription: 'L\'Italia si costituisce parte civile per l\'incendio di Capodagna a Crans-Montana. Incontro tra Parmelin, Meloni e Mattarella la prossima settimana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-nuovo-solco-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-nuovo-solco-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1861,7 +1861,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, eurodreams, vinta, rendita, mensile',
     ogTitle: 'Eurodreams: vinta una rendita mensile di 22mila franchi per 30 anni',
     ogDescription: 'Una fortunata vincita di Eurodreams: 22.222 franchi al mese per 30 anni, realizzata in Spagna ma gestita da Swisslos e Loterie romande',
-    canonicalPath: '/articoli-frontaliere/eurodreams-vincita-rendita-22mila-franchi',
+    canonicalPath: '/articoli-frontaliere/eurodreams-vincita-rendita-22mila-franchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1889,7 +1889,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piano, casa, meloni, libera',
     ogTitle: 'Piano Casa Meloni: via libera al decreto per l\'emergenza abitativa',
     ogDescription: 'Il Consiglio dei Ministri approva il Piano Casa con 10,5 miliardi per edilizia pubblica e privata. Meloni: priorità per alloggi accessibili',
-    canonicalPath: '/articoli-frontaliere/piano-casa-meloni-emergenza-abitativa',
+    canonicalPath: '/articoli-frontaliere/piano-casa-meloni-emergenza-abitativa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1917,7 +1917,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, targhe, personalizzabili, approvata, mozione',
     ogTitle: 'Targhe personalizzabili in Svizzera: approvata la mozione di Quadri',
     ogDescription: 'Il Consiglio nazionale ha approvato la mozione di Lorenzo Quadri per targhe personalizzabili, aprendo la strada alle \'vanity plates\'',
-    canonicalPath: '/articoli-frontaliere/targhe-personalizzabili-quadri-approvazione',
+    canonicalPath: '/articoli-frontaliere/targhe-personalizzabili-quadri-approvazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1945,7 +1945,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trenord, linee, diritto, indennizzo',
     ogTitle: 'Trenord, 17 linee con diritto all\'indennizzo: peggiore è Como',
     ogDescription: 'Dati allarmanti per i pendolari: 17 linee Trenord su 42 danno diritto all\'indennizzo, con la linea Asso-Seveso-Milano la peggiore in assoluto.',
-    canonicalPath: '/articoli-frontaliere/trenord-indennizzi-pendolari-como-2026',
+    canonicalPath: '/articoli-frontaliere/trenord-indennizzi-pendolari-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -1973,7 +1973,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponte, brivio, milioni, riqualificazione',
     ogTitle: 'Ponte di Brivio, 14 milioni per la riqualificazione: ritardi fino a 40 minuti',
     ogDescription: 'Scopri i dettagli del cantiere da 14 milioni per il Ponte di Brivio e i disagi previsti per chi si sposta.',
-    canonicalPath: '/articoli-frontaliere/ponte-brivio-cantiere-14-milioni',
+    canonicalPath: '/articoli-frontaliere/ponte-brivio-cantiere-14-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2001,7 +2001,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponte, primo, maggio, villa',
     ogTitle: 'Ponte del Primo Maggio a Villa Panza: visite guidate e laboratori per bambini',
     ogDescription: 'Dal 1 al 3 maggio 2026, Villa Panza di Varese ospita visite guidate e laboratori creativi per bambini ispirati all\'artista Josef Albers.',
-    canonicalPath: '/articoli-frontaliere/ponte-maggio-villa-panza-laboratori-bambini',
+    canonicalPath: '/articoli-frontaliere/ponte-maggio-villa-panza-laboratori-bambini/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2029,7 +2029,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, luoghi, culto, arresti',
     ogTitle: 'Furti nei luoghi di culto: due arresti nel Bellinzonese',
     ogDescription: 'Due cittadini rumeni residenti all\'estero sono stati arrestati il 26 aprile nel Bellinzonese, sospettati di aver compiuto ripetuti furti in chiese e un negozio.',
-    canonicalPath: '/articoli-frontaliere/furti-luoghi-culto-bellinzonese',
+    canonicalPath: '/articoli-frontaliere/furti-luoghi-culto-bellinzonese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2057,7 +2057,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hockey, psicodramma, davos, titolo',
     ogTitle: 'Hockey Nl / Psicodramma Davos, il titolo 2025-2026 al FriborgoGottéron',
     ogDescription: 'Il titolo 2025-2026 del Hockey Nl è stato assegnato al FriborgoGottéron, con Stefano Bottini da Lugano che si è preparato per il spareggio.',
-    canonicalPath: '/articoli-frontaliere/hockey-nl-psicodramma-davos-2025-2026-friborgogotteron',
+    canonicalPath: '/articoli-frontaliere/hockey-nl-psicodramma-davos-2025-2026-friborgogotteron/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2085,7 +2085,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, made, switzerland, cosa, cambia',
     ogTitle: 'Made in Switzerland: cosa cambia nel 2026',
     ogDescription: 'Nuove regole per il marchio \'Swiss Made\' dal 2026. Ecco cosa cambia per i prodotti e i consumatori in Ticino',
-    canonicalPath: '/articoli-frontaliere/made-in-switzerland-2026',
+    canonicalPath: '/articoli-frontaliere/made-in-switzerland-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2113,7 +2113,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dialogo, popoli, colori, mondo',
     ogTitle: 'Dialogo dei popoli, colori del mondo a Busto Arsizio',
     ogDescription: 'Una giornata dedicata all\'incontro, all\'integrazione e alla valorizzazione delle diverse culture presenti sul territorio di Busto Arsizio.',
-    canonicalPath: '/articoli-frontaliere/dialogo-popoli-colori-mondo-busto-arsizio',
+    canonicalPath: '/articoli-frontaliere/dialogo-popoli-colori-mondo-busto-arsizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2141,7 +2141,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cavalli, droni, nuova, unità',
     ogTitle: 'Cavalli e droni: la nuova unità speciale dell\'esercito svizzero',
     ogDescription: 'Scopri come l\'esercito svizzero combina cavalli e droni per pattuglie speciali. Implicazioni per la sicurezza e la difesa nazionale.',
-    canonicalPath: '/articoli-frontaliere/cavalli-droni-esercito-svizzero-2026',
+    canonicalPath: '/articoli-frontaliere/cavalli-droni-esercito-svizzero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2169,7 +2169,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, raiffeisen, bioggio, rinnova, inaugurazione',
     ogTitle: 'Raiffeisen Bioggio si rinnova: inaugurazione il 9 maggio',
     ogDescription: 'Scopri il rinnovamento della filiale Raiffeisen di Bioggio e partecipa all\'inaugurazione il 9 maggio 2026. Evento aperto al pubblico con visite guidate.',
-    canonicalPath: '/articoli-frontaliere/raiffeisen-bioggio-rinnovo-2026',
+    canonicalPath: '/articoli-frontaliere/raiffeisen-bioggio-rinnovo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2197,7 +2197,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, percorso, didattico, allora, giubiasco',
     ogTitle: 'Percorso didattico \'Qui...allora\' a Giubiasco: un viaggio nel tempo',
     ogDescription: 'Scopri il nuovo percorso didattico a Giubiasco che confronta il passato e il presente del borgo attraverso fotografie d\'epoca e pannelli espositivi.',
-    canonicalPath: '/articoli-frontaliere/percorso-giubiasco-qui-allora-2026',
+    canonicalPath: '/articoli-frontaliere/percorso-giubiasco-qui-allora-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2225,7 +2225,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nomina, anche, docenti, comunali',
     ogTitle: 'Nomina docenti comunali Ticino 2026',
     ogDescription: 'Modifica legislativa cantonale estende la nomina ai docenti con impiego sotto il 50%, stabilità lavorativa garantita dal 1° agosto 2026',
-    canonicalPath: '/articoli-frontaliere/nomina-docenti-comunali-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/nomina-docenti-comunali-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2253,7 +2253,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cardano, campo, settimana, ecologica',
     ogTitle: 'Cardano al Campo: Settimana Ecologica 2026 sul riciclo Raee',
     ogDescription: 'Dal 5 al 9 maggio 2026, Cardano al Campo promuove il riciclo dei rifiuti elettrici con eventi e raccolte. Focus sui Raee, obiettivo: migliorare la raccolta',
-    canonicalPath: '/articoli-frontaliere/cardano-settimana-ecologica-raee-2026',
+    canonicalPath: '/articoli-frontaliere/cardano-settimana-ecologica-raee-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2281,7 +2281,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grassi, sfide, complesse, liuc',
     ogTitle: 'Grassi: «Sfide complesse, ma la Liuc è pronta»',
     ogDescription: 'Roberto Grassi, nuovo presidente della Liuc-Università Cattaneo di Castellanza, affronta le sfide del mondo manifatturiero e dell\'innovazione.',
-    canonicalPath: '/articoli-frontaliere/grassi-liuc-sfide-complesse',
+    canonicalPath: '/articoli-frontaliere/grassi-liuc-sfide-complesse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2309,7 +2309,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ciclabile, saronno-rovello, porro, quando',
     ogTitle: 'Ciclabile Saronno-Rovello Porro: quando sarà pronta?',
     ogDescription: 'A tre anni dalla posa della ghost bike, Fiab Saronno sollecita i Comuni per la realizzazione della ciclabile protetta tra Saronno e Rovello Porro.',
-    canonicalPath: '/articoli-frontaliere/ciclabile-saronno-rovello-porro-2026',
+    canonicalPath: '/articoli-frontaliere/ciclabile-saronno-rovello-porro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2337,7 +2337,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fiera, dell, asparago, cantello',
     ogTitle: 'Fiera Asparago Cantello 2026: programma e prenotazioni',
     ogDescription: 'Dal 15 al 24 maggio, Cantello celebra l\'asparago bianco De.Co. con cucina, musica e mercatini. Scopri il programma completo e come prenotare.',
-    canonicalPath: '/articoli-frontaliere/fiera-asparago-cantello-2026',
+    canonicalPath: '/articoli-frontaliere/fiera-asparago-cantello-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2365,7 +2365,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asparago, cantello, cose, sapere',
     ogTitle: 'Asparago di Cantello: 5 cose da sapere sul prodotto De.C.O.',
     ogDescription: 'Scopri le caratteristiche uniche dell\'asparago bianco di Cantello, un prodotto protetto dalla Denominazione Comunale di Origine.',
-    canonicalPath: '/articoli-frontaliere/cinque-cose-asparago-cantello-2026',
+    canonicalPath: '/articoli-frontaliere/cinque-cose-asparago-cantello-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2393,7 +2393,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sigarette, elettroniche, vizio, preferito',
     ogTitle: 'Sigarette elettroniche: il vizio preferito dagli adolescenti ticinesi',
     ogDescription: 'Il consumo di sigarette elettroniche tra i 15 e i 17 anni in Ticino è quasi pari a quello delle sigarette tradizionali.',
-    canonicalPath: '/articoli-frontaliere/sigarette-elettroniche-adolescenti-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/sigarette-elettroniche-adolescenti-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2421,7 +2421,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, bellinzona, merci, programma',
     ogTitle: 'Processo Bellinzona merci Russia 2026',
     ogDescription: 'Un 63enne processato a Bellinzona per aver fornito materiali a programma russo di armamenti di distruzione di massa. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/processo-bellinzona-merci-russia-2026',
+    canonicalPath: '/articoli-frontaliere/processo-bellinzona-merci-russia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2449,7 +2449,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, valuta, riduzione, truppe',
     ogTitle: 'Trump valuta riduzione truppe in Italia e Spagna',
     ogDescription: 'Donald Trump considera di ridurre le truppe americane in Italia e Spagna, criticando l\'aiuto ricevuto da questi paesi.',
-    canonicalPath: '/articoli-frontaliere/trump-riduce-truppe-italia-spagna',
+    canonicalPath: '/articoli-frontaliere/trump-riduce-truppe-italia-spagna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2477,7 +2477,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, abolisce, dazi, whisky',
     ogTitle: 'Trump abolisce dazi whisky scozzese per Carlo e Camilla',
     ogDescription: 'Donald Trump annuncia l\'abolizione dei dazi sul whisky scozzese in onore del re e della regina del Regno Unito, Carlo e Camilla.',
-    canonicalPath: '/articoli-frontaliere/whisky-scozzese-dazi-trump-carlo-camilla',
+    canonicalPath: '/articoli-frontaliere/whisky-scozzese-dazi-trump-carlo-camilla/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2505,7 +2505,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, fino, mornasco, albero',
     ogTitle: 'Incidente a Fino Mornasco: albero cade su auto, ferite mamma e bambina',
     ogDescription: 'Un albero marcio è caduto su un\'auto in corsa a Fino Mornasco, ferendo una mamma e sua figlia. Intervento dei vigili del fuoco e del 118.',
-    canonicalPath: '/articoli-frontaliere/incidente-fino-mornasco-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-fino-mornasco-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2533,7 +2533,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gottardo, caduto, primo, diaframma',
     ogTitle: 'Gottardo, caduto il primo diaframma del secondo tubo',
     ogDescription: 'La fresa meccanica \'Alessandra\' ha abbattuto il primo diaframma a nord, a 4 km dall\'imbocco. Una pietra miliare per il progetto.',
-    canonicalPath: '/articoli-frontaliere/galleria-gottardo-secondo-tubo-2026',
+    canonicalPath: '/articoli-frontaliere/galleria-gottardo-secondo-tubo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2561,7 +2561,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, approva, bilancio, avanzo',
     ogTitle: 'Varese approva bilancio 2026 con avanzo record: 17 milioni',
     ogDescription: 'La Provincia di Varese approva un bilancio florido con un avanzo libero di amministrazione di oltre 17 milioni di euro.',
-    canonicalPath: '/articoli-frontaliere/varese-bilancio-2026-avanzo-record',
+    canonicalPath: '/articoli-frontaliere/varese-bilancio-2026-avanzo-record/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2589,7 +2589,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, canton, cerca, nuovo, direttore',
     ogTitle: 'Nuovo direttore Controllo cantonale delle finanze Ticino',
     ogDescription: 'Il Canton Ticino cerca un nuovo direttore per il Controllo cantonale delle finanze. Scopri i dettagli e come candidarti.',
-    canonicalPath: '/articoli-frontaliere/nuovo-direttore-controllo-finanze-ticino',
+    canonicalPath: '/articoli-frontaliere/nuovo-direttore-controllo-finanze-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2617,7 +2617,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riapre, casale, litta, ufficio',
     ogTitle: 'Riapre a Casale Litta l\'ufficio postale con nuovi servizi',
     ogDescription: 'L\'ufficio postale di Casale Litta riapre dopo ristrutturazione con servizi ampliati grazie al progetto Polis. Scopri i nuovi servizi disponibili.',
-    canonicalPath: '/articoli-frontaliere/riapre-ufficio-postale-casale-litta',
+    canonicalPath: '/articoli-frontaliere/riapre-ufficio-postale-casale-litta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2645,7 +2645,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, chiese, negozi, arresti',
     ogTitle: 'Furti in chiese e negozi: arresti e appello a segnalare',
     ogDescription: 'Due rumeni arrestati per furti in chiese e negozi in Ticino e Grigioni. La polizia invita a segnalare eventuali altri episodi.',
-    canonicalPath: '/articoli-frontaliere/furti-chiese-negozi-ticino-arresti',
+    canonicalPath: '/articoli-frontaliere/furti-chiese-negozi-ticino-arresti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2673,7 +2673,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, audit, polizia, governo, chiede',
     ogTitle: 'Audit Polizia Ticino: governo chiede sei mesi in più per il messaggio',
     ogDescription: 'Il Consiglio di Stato del Canton Ticino chiede una proroga per il messaggio sull\'audit della Polizia Cantonale. Dadò e Ferrara insistono sull\'urgenza.',
-    canonicalPath: '/articoli-frontaliere/audit-polizia-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/audit-polizia-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2701,7 +2701,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, lombardia, richiede',
     ogTitle: 'Tassa salute frontalieri: Lombardia richiede allineamento, Piemonte dice no',
     ogDescription: 'La Lombardia insiste sull\'applicazione della tassa salute ai frontalieri, mentre il Piemonte conferma la propria contrarietà. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-piemonte',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-piemonte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2729,7 +2729,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zonaprotetta, festeggia, anni, lotta',
     ogTitle: 'Zonaprotetta festeggia 40 anni: da lotta all\'Aids a sessualità consapevole',
     ogDescription: 'Zonaprotetta celebra 40 anni di attività, passando dalla lotta all\'Aids alla promozione della sessualità consapevole in Ticino.',
-    canonicalPath: '/articoli-frontaliere/zonaprotetta-40-anni-sessualita-consapevole',
+    canonicalPath: '/articoli-frontaliere/zonaprotetta-40-anni-sessualita-consapevole/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2757,7 +2757,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, boom, viaggi, interni',
     ogTitle: 'Cina: boom di viaggi interni e spese per il turismo',
     ogDescription: 'Nel primo trimestre 2026, la Cina registra 1,9 miliardi di viaggi interni e 271 miliardi di dollari di spesa turistica',
-    canonicalPath: '/articoli-frontaliere/cina-turismo-interno-2026',
+    canonicalPath: '/articoli-frontaliere/cina-turismo-interno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2785,7 +2785,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mondiali, iran, giocherà, addio',
     ogTitle: 'Mondiali 2026, l\'Iran giocherà: addio al ripescaggio dell\'Italia',
     ogDescription: 'La FIFA conferma la partecipazione dell\'Iran ai Mondiali 2026, escludendo il ripescaggio dell\'Italia. Ecco le implicazioni per i tifosi e il mondo del calcio.',
-    canonicalPath: '/articoli-frontaliere/mondiali-2026-iran-italia-fifa',
+    canonicalPath: '/articoli-frontaliere/mondiali-2026-iran-italia-fifa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2813,7 +2813,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crystal, palace, passo, dalla',
     ogTitle: 'Crystal Palace a un passo dalla finale di Conference, sogna il Rayo',
     ogDescription: 'Il Crystal Palace vince 3-1 contro lo Shakthar Donetsk e sogna la finale di Conference League. Il Rayo Vallecano batte 1-0 lo Strasburgo.',
-    canonicalPath: '/articoli-frontaliere/crystal-palace-finale-conference-rayo',
+    canonicalPath: '/articoli-frontaliere/crystal-palace-finale-conference-rayo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2841,7 +2841,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, potrebbe, stringere, patto',
     ogTitle: 'Trump potrebbe stringere patto con Cina e Russia',
     ogDescription: 'Massimo Cacciari analizza le mosse di Trump in Iran e le possibili alleanze con Cina e Russia. L\'Europa resta impotente di fronte alla crisi.',
-    canonicalPath: '/articoli-frontaliere/trump-cina-russia-patto-2026',
+    canonicalPath: '/articoli-frontaliere/trump-cina-russia-patto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2869,7 +2869,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, insegna, dell',
     ogTitle: 'Primo Maggio unita sindacale Marghera',
     ogDescription: 'Cgil, Cisl e Uil insieme per celebrare la Festa dei Lavoratori con un focus sul lavoro dignitoso e divergenze sul Dl Lavoro.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-unita-sindacale-marghera',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-unita-sindacale-marghera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2897,7 +2897,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, sindacati, piazza',
     ogTitle: 'Primo maggio, sindacati in piazza per difendere salari e impieghi',
     ogDescription: 'Una cinquantina di località svizzere ospitano manifestazioni per la giornata internazionale dei diritti delle lavoratrici e dei lavoratori.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-sindacati-piazza-2026',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-sindacati-piazza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2925,7 +2925,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, weekend, maggio, varese, eventi',
     ogTitle: 'Weekend del 1° Maggio a Varese: eventi imperdibili',
     ogDescription: 'Scopri gli eventi del weekend del 1° Maggio a Varese, dalla Festa di San Vittore allo spettacolo delle mongolfiere di Angera.',
-    canonicalPath: '/articoli-frontaliere/spasso-weekend-1-maggio-varese-2026',
+    canonicalPath: '/articoli-frontaliere/spasso-weekend-1-maggio-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2953,7 +2953,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, prevenzione, dipendenze, franco, oggi',
     ogTitle: 'Prevenzione dipendenze: un franco oggi per risparmiarne 20 domani',
     ogDescription: 'Tagli ai fondi per la prevenzione delle dipendenze in Ticino, nonostante i costi sanitari in aumento. L\'esperto: si segue una logica di risparmio immediato.',
-    canonicalPath: '/articoli-frontaliere/prevenzione-dipendenze-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/prevenzione-dipendenze-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -2981,7 +2981,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, concertone, primo, maggio, roma',
     ogTitle: 'Concertone Primo Maggio Roma artisti scaletta 2026',
     ogDescription: 'Il Concertone del Primo Maggio a Roma con Arisa, Pierpaolo Spollon e BigMama. Tutti gli artisti in scaletta e informazioni utili per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/concertone-primo-maggio-roma-artisti-2026',
+    canonicalPath: '/articoli-frontaliere/concertone-primo-maggio-roma-artisti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3009,7 +3009,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mondo, radio, piange, alberto',
     ogTitle: 'Il mondo della radio piange Alberto Davoli',
     ogDescription: 'Il pioniere delle emittenti private è mancato a 60 anni dopo una lunga malattia. Funerali domani alla Brunella.',
-    canonicalPath: '/articoli-frontaliere/mondo-radio-piange-alberto-davoli',
+    canonicalPath: '/articoli-frontaliere/mondo-radio-piange-alberto-davoli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3037,7 +3037,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rendiconto, annuale, banca, interpretarlo',
     ogTitle: 'Rendiconto annuale banca: come interpretarlo',
     ogDescription: 'Scopri come leggere il rendiconto annuale su costi e oneri della tua banca e cosa significa per i tuoi investimenti.',
-    canonicalPath: '/articoli-frontaliere/rendiconto-banca-interpretazione-2026',
+    canonicalPath: '/articoli-frontaliere/rendiconto-banca-interpretazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3065,7 +3065,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inchiesta, arbitri, caso, inter-roma',
     ogTitle: 'Inchiesta arbitri, dal caso Inter-Roma alla spiegazione di Rocchi',
     ogDescription: 'Gianluca Rocchi indagato per frode sportiva. Novità sull\'inchiesta arbitri in Italia. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/inchiesta-arbitri-roccchi-inter-roma',
+    canonicalPath: '/articoli-frontaliere/inchiesta-arbitri-roccchi-inter-roma/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3093,7 +3093,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dramma, canton, bimbo, anni',
     ogTitle: 'Dramma in Canton Ticino: bimbo di due anni annega in piscina',
     ogDescription: 'Un tragico incidente in una piscina privata ha sconvolto la comunità del Canton Ticino. Un bimbo di due anni ha perso la vita.',
-    canonicalPath: '/articoli-frontaliere/dramma-canton-ticino-bimbo-annega-piscina',
+    canonicalPath: '/articoli-frontaliere/dramma-canton-ticino-bimbo-annega-piscina/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3121,7 +3121,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giornico, gioco, dell, riflettere',
     ogTitle: 'Gioco dell\'oca su rischi e disastri a Giornico',
     ogDescription: 'Al Museo di Leventina di Giornico, un gioco dell\'oca interattivo racconta i disastri dal Medioevo al Covid. Scopri di più su questa iniziativa.',
-    canonicalPath: '/articoli-frontaliere/gioco-oca-giornico-rischi-disastri',
+    canonicalPath: '/articoli-frontaliere/gioco-oca-giornico-rischi-disastri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3149,7 +3149,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, pace, solidarietà',
     ogTitle: 'Primo Maggio 2026: pace e solidarietà al centro delle riflessioni',
     ogDescription: 'Matteo Muschietti invita a scendere in piazza per la pace e la solidarietà, in un mondo segnato da troppe guerre. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-solidarieta',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-solidarieta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3177,7 +3177,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piano, freddo, como, persone',
     ogTitle: 'Piano Freddo Como: 200 persone accolte per 172 notti',
     ogDescription: 'Il Piano Freddo di Como ha accolto 200 persone senza dimora per 172 notti, grazie alla collaborazione di volontari e donatori.',
-    canonicalPath: '/articoli-frontaliere/piano-freddo-como-200-persone-172-notti',
+    canonicalPath: '/articoli-frontaliere/piano-freddo-como-200-persone-172-notti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3205,7 +3205,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, studenti, diventano, agenti',
     ogTitle: 'Como, 10 studenti diventano agenti di polizia locale con il progetto On the Road',
     ogDescription: 'Un accordo triennale tra il Comune di Como, la Polizia Locale e l\'associazione Ragazzi On the Road per formare giovani agenti',
-    canonicalPath: '/articoli-frontaliere/como-studenti-polizia-on-road-2026',
+    canonicalPath: '/articoli-frontaliere/como-studenti-polizia-on-road-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3233,7 +3233,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinosentieri, nuove, nomine, roland',
     ogTitle: 'TicinoSentieri: nuove nomine per il 2026',
     ogDescription: 'Roland David è il nuovo presidente e Stéphane Grounauer il direttore operativo. Approvate anche due nuove nomine in comitato.',
-    canonicalPath: '/articoli-frontaliere/ticinosentieri-nuove-nomine-2026',
+    canonicalPath: '/articoli-frontaliere/ticinosentieri-nuove-nomine-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3261,7 +3261,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mara, chiusura, ufficio, postale',
     ogTitle: 'Chiusura ufficio postale Val Mara: mazzata ai servizi',
     ogDescription: 'L\'ufficio postale di Val Mara, frazione di Maroggia, chiuderà. Un duro colpo per i residenti e i frontalieri della zona.',
-    canonicalPath: '/articoli-frontaliere/ufficio-postale-val-mara-chiusura',
+    canonicalPath: '/articoli-frontaliere/ufficio-postale-val-mara-chiusura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3289,7 +3289,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controversia, sull, bandiera, sulle',
     ogTitle: 'Controversia bandiera svizzera scarpe On',
     ogDescription: 'L\'Istituto Federale della Proprietà Intellettuale ha concesso a On di usare la bandiera svizzera sulle sue scarpe, nonostante la produzione avvenga all\'estero',
-    canonicalPath: '/articoli-frontaliere/controversia-bandiera-svizzera-scarpe-on',
+    canonicalPath: '/articoli-frontaliere/controversia-bandiera-svizzera-scarpe-on/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3317,7 +3317,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sigarette, elettroniche, giovani, consumano',
     ogTitle: 'Sigarette elettroniche: i giovani le consumano come quelle tradizionali',
     ogDescription: 'Il 25,2% dei giovani consuma sia sigarette tradizionali che elettroniche, con un aumento del 3% rispetto al 2023',
-    canonicalPath: '/articoli-frontaliere/giovani-sigarette-elettroniche-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/giovani-sigarette-elettroniche-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3345,7 +3345,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, riforma, cambia, tutto',
     ogTitle: 'Frontalieri e disoccupazione: la riforma UE che cambia tutto',
     ogDescription: 'Scopri come la nuova riforma UE sull\'indennità di disoccupazione per i frontalieri cambierà le prestazioni per i lavoratori in Ticino',
-    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3373,7 +3373,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sfida, mercato, prezzi, patto',
     ogTitle: 'CBT Italia sfida il mercato: prezzi come patto di fiducia con i ciclisti',
     ogDescription: 'CBT Italia, azienda cuneese con 75 anni di storia, entra nel mercato italiano con prezzi aggressivi e trasparenza, sorprendendo i consumatori',
-    canonicalPath: '/articoli-frontaliere/cbt-italia-ciclisti-mercato',
+    canonicalPath: '/articoli-frontaliere/cbt-italia-ciclisti-mercato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3401,7 +3401,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maserati, celebra, anni, tridente',
     ogTitle: 'Maserati celebra 100 anni del Tridente e la leggenda delle corse',
     ogDescription: 'Maserati festeggia il centenario del Tridente e la prima vittoria sportiva alla Targa Florio nel 1926. Scopri gli eventi e le iniziative in programma.',
-    canonicalPath: '/articoli-frontaliere/maserati-tridente-centenario-2026',
+    canonicalPath: '/articoli-frontaliere/maserati-tridente-centenario-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3429,7 +3429,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, milioni, sostenibile, dibattito',
     ogTitle: 'Iniziativa \'No a una Svizzera da 10 milioni\': sostenibile?',
     ogDescription: 'Il dibattito sull\'iniziativa UDC mette in luce i rischi per economia e servizi legati a un freno dell\'immigrazione',
-    canonicalPath: '/articoli-frontaliere/iniziativa-10-milioni-sostenibile',
+    canonicalPath: '/articoli-frontaliere/iniziativa-10-milioni-sostenibile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3457,7 +3457,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basta, click, arrivano, fatture',
     ogTitle: 'Basta un click e arrivano fatture per servizi hot',
     ogDescription: 'Un adolescente del Ticino ha ricevuto una fattura per un abbonamento a un servizio per adulti sottoscritto per errore. Ecco come reagire e difendersi',
-    canonicalPath: '/articoli-frontaliere/click-fatture-servizio-hot',
+    canonicalPath: '/articoli-frontaliere/click-fatture-servizio-hot/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3485,7 +3485,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, fragole, camorino, anni',
     ogTitle: 'Festa fragole Camorino 70 anni tradizione beneficenza',
     ogDescription: 'La festa delle fragole di Camorino celebra 70 anni con eventi, allegria e donazioni annuali di 17\'000 franchi alle associazioni locali',
-    canonicalPath: '/articoli-frontaliere/festa-fragole-camorino-beneficenza',
+    canonicalPath: '/articoli-frontaliere/festa-fragole-camorino-beneficenza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3513,7 +3513,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, lite, notturna, brogeda',
     ogTitle: 'Lite notturna a Como in via Brogeda',
     ogDescription: 'Una lite notturna in via Brogeda a Como ha coinvolto tre persone, due delle quali sono state ricoverate in ospedale. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/lite-notturna-brogeda-2026',
+    canonicalPath: '/articoli-frontaliere/lite-notturna-brogeda-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3541,7 +3541,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, fatture, ospedaliere, tutti',
     ogTitle: 'Crans-Montana, fatture ospedaliere: non tutti gli ospedali le hanno inviate',
     ogDescription: 'Non tutti gli ospedali svizzeri hanno inviato le fatture ai pazienti italiani feriti nell\'incendio di Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-ospedali-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-ospedali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3569,7 +3569,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, dossier, gestiti, consultori',
     ogTitle: 'Crans-Montana: 700 dossier gestiti dai consultori per le vittime',
     ogDescription: 'Quasi 700 dossier gestiti e 400\'000 franchi versati per le vittime dell\'incendio di Capodanno a Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-aiuto-vittime-700-dossier',
+    canonicalPath: '/articoli-frontaliere/crans-montana-aiuto-vittime-700-dossier/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3597,7 +3597,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, losone, calo, zanzara, tigre',
     ogTitle: 'Losone: calo zanzara tigre nel 2025',
     ogDescription: 'La tecnica del maschio sterile ha ridotto significativamente la presenza della zanzara tigre a Losone. Ecco i dettagli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/zanzara-tigre-losone-2026',
+    canonicalPath: '/articoli-frontaliere/zanzara-tigre-losone-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3625,7 +3625,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rive, libere, rpsi, soddisfatta',
     ogTitle: 'Rive libere: RPSI soddisfatta del gruppo di lavoro',
     ogDescription: 'RPSI entra nel gruppo di lavoro per la valorizzazione delle rive tra Minusio e Tenero-Contra. Petizione per l\'accesso libero tutto l\'anno.',
-    canonicalPath: '/articoli-frontaliere/rive-libere-minusio-tenero-2026',
+    canonicalPath: '/articoli-frontaliere/rive-libere-minusio-tenero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3653,7 +3653,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, senza, pubblicità, iniziativa',
     ogTitle: 'Berna senza pubblicità: l\'iniziativa per vietare gli annunci commerciali',
     ogDescription: 'L\'iniziativa \'Berna senza pubblicità\' mira a vietare gli annunci commerciali senza riferimenti locali nello spazio pubblico. Scopri le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/berna-senza-pubblicita-iniziativa-2026',
+    canonicalPath: '/articoli-frontaliere/berna-senza-pubblicita-iniziativa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3681,7 +3681,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, sale, timori',
     ogTitle: 'Lago Maggiore sale: +15 cm, timori per l\'ambiente',
     ogDescription: 'L\'ADBPO innalza il livello massimo del lago a +1,40 metri. Timori per le località turistiche e gli ecosistemi',
-    canonicalPath: '/articoli-frontaliere/lago-maggiore-sale-ambiente-2026',
+    canonicalPath: '/articoli-frontaliere/lago-maggiore-sale-ambiente-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3709,7 +3709,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, cosa, cambia',
     ogTitle: '25 cm in più per il Lago Maggiore: cosa cambia per i frontalieri',
     ogDescription: 'Dalla prossima estate il livello massimo del Lago Maggiore potrà essere innalzato di 25 centimetri. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/25-centimetri-lago-maggiore-frontalieri',
+    canonicalPath: '/articoli-frontaliere/25-centimetri-lago-maggiore-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3737,7 +3737,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sertori, rapinese, faccio, assessore',
     ogTitle: 'Lungolago Como, Sertori replica a Rapinese',
     ogDescription: 'L\'assessore regionale Massimo Sertori annuncia un incontro con il sindaco di Como Alessandro Rapinese per discutere dei parapetti del lungolago.',
-    canonicalPath: '/articoli-frontaliere/lungolago-como-parapetti-rapinese-sertori',
+    canonicalPath: '/articoli-frontaliere/lungolago-como-parapetti-rapinese-sertori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3765,7 +3765,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como-napoli, sinigaglia, divieti, posteggi',
     ogTitle: 'Como-Napoli al Sinigaglia: divieti e posteggi per la sfida',
     ogDescription: 'Tutto esaurito per la partita di domani alle 18:00. Divieti di sosta e circolazione dalle 6:30. Ordinanza anti-alcol dalle 15:00 alle 21:00',
-    canonicalPath: '/articoli-frontaliere/como-napoli-sinigaglia-divieti-posteggi',
+    canonicalPath: '/articoli-frontaliere/como-napoli-sinigaglia-divieti-posteggi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3793,7 +3793,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, varese, lavoro, diritti',
     ogTitle: 'Primo Maggio Varese: lavoro, diritti e futuro nell\'era dell\'intelligenza artificiale',
     ogDescription: 'CGIL, CISL e UIL in piazza a Varese per il Primo Maggio 2026. Focus su diritti, sicurezza e salari equi nell\'era dell\'intelligenza artificiale.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-diritti',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-diritti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3821,7 +3821,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, algerini, libici, rubano, auto',
     ogTitle: 'Algerini e libici rubano auto: polizia li ferma sul fatto',
     ogDescription: 'Tre individui, due algerini e un libico, sono stati arrestati dalla polizia ticinese mentre rubavano un\'auto a Locarno. Scopri di più su questa operazione.',
-    canonicalPath: '/articoli-frontaliere/algerini-libici-auto-polizia-arresti',
+    canonicalPath: '/articoli-frontaliere/algerini-libici-auto-polizia-arresti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3849,7 +3849,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rete, stradale, mendrisio, sotto',
     ogTitle: 'Rete stradale di Mendrisio sotto pressione: urgenti interventi richiesti',
     ogDescription: 'Quattro consiglieri comunali del PLR chiedono maggiori interventi urgenti per la rete stradale di Mendrisio, criticando la mancanza di fondi cantonali e',
-    canonicalPath: '/articoli-frontaliere/rete-stradale-mendrisio-interventi-urgenti',
+    canonicalPath: '/articoli-frontaliere/rete-stradale-mendrisio-interventi-urgenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3877,7 +3877,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, milano-varese, chiusure, notturne, solbiate',
     ogTitle: 'A8 Milano-Varese, chiusure notturne tra Solbiate e Cavaria per lavori',
     ogDescription: 'Dal 4 all\'8 maggio chiusure notturne tra Solbiate Arno e Cavaria per lavori alle barriere antirumore',
-    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-milano-varese',
+    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-milano-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3905,7 +3905,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, sindacati, piazza',
     ogTitle: 'Primo Maggio 2026: sindacati in piazza contro l\'iniziativa UDC',
     ogDescription: 'Sindacati in piazza per difendere salari e impieghi e contro l\'iniziativa UDC \'No a una Svizzera da 10 milioni di abitanti\'',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3933,7 +3933,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresto, tunisino, como, resistenza',
     ogTitle: 'Arresto di un frontaliere tunisino a Como per resistenza a pubblico ufficiale',
     ogDescription: 'Un 19enne tunisino, regolare in Italia ma senza fissa dimora, è stato arrestato per violenza e resistenza a pubblico ufficiale a Como.',
-    canonicalPath: '/articoli-frontaliere/como-arresto-frontaliere-tunisino',
+    canonicalPath: '/articoli-frontaliere/como-arresto-frontaliere-tunisino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3961,7 +3961,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, indagine, soccorsi, crans-montana, carenze',
     ogTitle: 'Indagine sui soccorsi a Crans-Montana: carenze segnalate',
     ogDescription: 'Due famiglie denunciano gravi carenze nella gestione dei soccorsi durante l\'incendio di Capodanno a Crans-Montana. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/indagine-soccorsi-crans-montana-2026',
+    canonicalPath: '/articoli-frontaliere/indagine-soccorsi-crans-montana-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -3989,7 +3989,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, costituisce, parte, civile',
     ogTitle: 'Crans-Montana: Italia si costituisce parte civile',
     ogDescription: 'L\'Italia si costituisce parte civile nel procedimento per l\'incendio al disco-bar Le Constellation a Crans-Montana, con 41 morti e 115 feriti',
-    canonicalPath: '/articoli-frontaliere/crans-montana-italia-parte-civile-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-italia-parte-civile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4017,7 +4017,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, greta, gysin, candida, capogruppo',
     ogTitle: 'Greta Gysin si candida a capogruppo dei Verdi',
     ogDescription: 'Greta Gysin, consigliera nazionale ticinese, si candida alla presidenza del gruppo parlamentare dei Verdi. Elezione prevista per il 22 maggio.',
-    canonicalPath: '/articoli-frontaliere/gysin-candidata-capogruppo-verdi',
+    canonicalPath: '/articoli-frontaliere/gysin-candidata-capogruppo-verdi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4045,7 +4045,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sesto, calende, controlli, sanzioni',
     ogTitle: 'Sesto Calende: controlli e sanzioni per strade danneggiate dai cantieri',
     ogDescription: 'La polizia locale di Sesto Calende ha avviato controlli e sanzioni per le strade danneggiate dai cantieri della fibra ottica, finanziati dal PNRR.',
-    canonicalPath: '/articoli-frontaliere/sesto-calende-strade-cantieri-2026',
+    canonicalPath: '/articoli-frontaliere/sesto-calende-strade-cantieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4073,7 +4073,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, jans, attacca, iniziativa, rischio',
     ogTitle: 'Jans attacca l\'iniziativa UDC: \'Rischio per la Svizzera\'',
     ogDescription: 'Il consigliere federale Jans critica l\'iniziativa UDC \'No a una Svizzera da 10 milioni\', avvertendo gravi conseguenze per il Paese.',
-    canonicalPath: '/articoli-frontaliere/jans-udc-iniziativa-10-milioni',
+    canonicalPath: '/articoli-frontaliere/jans-udc-iniziativa-10-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4101,7 +4101,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, metri, gobbi',
     ogTitle: 'Lago Maggiore a +1,35 metri: Gobbi, soluzione equilibrata',
     ogDescription: 'Il consigliere di Stato ticinese Norman Gobbi commenta l\'innalzamento del livello massimo del lago Maggiore a +1,35 metri, definendolo una soluzione',
-    canonicalPath: '/articoli-frontaliere/lago-maggiore-135-metri-frontalieri',
+    canonicalPath: '/articoli-frontaliere/lago-maggiore-135-metri-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4129,7 +4129,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, anziani, truffati, arresto, como',
     ogTitle: 'Anziani truffati, arresto a Como. Collegamenti con Ticino',
     ogDescription: 'Arresto di una 31enne ceca a Como per truffe agli anziani. Metodi simili a casi recenti in Ticino. Scoperte prove a Como-San Giovanni.',
-    canonicalPath: '/articoli-frontaliere/anziani-truffati-arresto-como-ticino',
+    canonicalPath: '/articoli-frontaliere/anziani-truffati-arresto-como-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4157,7 +4157,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzonesi, brillano, germania, torneo',
     ogTitle: 'Bellinzonesi brillano in Germania al torneo di karate',
     ogDescription: 'I giovani atleti del club di karate di Bellinzona ottengono ottimi risultati alla Nagai Cup in Germania',
-    canonicalPath: '/articoli-frontaliere/bellinzonesi-germania-karate-2026',
+    canonicalPath: '/articoli-frontaliere/bellinzonesi-germania-karate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4185,7 +4185,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusura, notturna, lomazzo, chiasso',
     ogTitle: 'A9 chiusura notturna Lomazzo Chiasso: cosa cambia per i frontalieri',
     ogDescription: 'Dalle 22:00 del 4 maggio alle 5:00 del 5 maggio, chiusura notturna tra Lomazzo sud e Como Centro verso Chiasso. Deviazioni obbligatorie per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a9-lomazzo-chiasso',
+    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a9-lomazzo-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4213,7 +4213,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, festa, lavoro, diritti',
     ogTitle: 'Como, centinaia in piazza per la Festa del lavoro. \'Più diritti, salari dignitosi, sicurezza, stabilità\'',
     ogDescription: 'Centinaia di persone si sono radunate in piazza Perretta per la Festa del Lavoro, promossa dai sindacati Cgil, Cisl e Uil. Richieste centrali: salari dignitosi',
-    canonicalPath: '/articoli-frontaliere/como-festa-lavoro-diritti-salari',
+    canonicalPath: '/articoli-frontaliere/como-festa-lavoro-diritti-salari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4241,7 +4241,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, denuncia, mancanza, attrezzature, soccorsi',
     ogTitle: 'Denuncia per mancanza di attrezzature ai soccorsi di Crans-Montana',
     ogDescription: 'Avvocati delle vittime denunciano l\'Organizzazione cantonale vallesana per insufficienze nel dispositivo di intervento dopo l\'incendio del bar Le Constellation',
-    canonicalPath: '/articoli-frontaliere/denuncia-soccorsi-crans-montana-2026',
+    canonicalPath: '/articoli-frontaliere/denuncia-soccorsi-crans-montana-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4269,7 +4269,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, cantù, auto, contro',
     ogTitle: 'Incidente a Cantù: auto contro muro, due feriti',
     ogDescription: 'Un incidente stradale a Cantù ha coinvolto due donne, che hanno riportato ferite lievi. L\'incidente è avvenuto in via Como.',
-    canonicalPath: '/articoli-frontaliere/incidente-cantu-due-feriti',
+    canonicalPath: '/articoli-frontaliere/incidente-cantu-due-feriti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4297,7 +4297,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, torino, tensioni',
     ogTitle: 'Primo Maggio a Torino: tensioni tra manifestanti e forze dell\'ordine',
     ogDescription: 'Un gruppo si stacca dal corteo principale verso l\'ex centro sociale Askatasuna, tensioni con la polizia.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-torino-tensioni-askatasuna',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-torino-tensioni-askatasuna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4325,7 +4325,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attivo, telefonata, rompere, silenzio',
     ogTitle: 'Il 142 è attivo: una telefonata per rompere il silenzio sulla violenza',
     ogDescription: 'Da oggi in tutta la Svizzera è attivo il numero 142 per vittime di violenza. Scopri come funziona e chi può aiutarti.',
-    canonicalPath: '/articoli-frontaliere/142-violenza-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/142-violenza-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4353,7 +4353,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, coda, gottardo',
     ogTitle: 'Primo Maggio 2026: 10 km di coda al Gottardo',
     ogDescription: 'Code di 10 km al portale nord del San Gottardo, rallentamenti anche a Chiasso e Brogeda. Ecco cosa sapere per chi viaggia.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-traffico-gottardo',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-traffico-gottardo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4381,7 +4381,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, e-roller, e-bike, lugano',
     ogTitle: 'Incidente con e-roller e e-bike a Lugano: donna gravemente ferita',
     ogDescription: 'Un incidente tra un e-roller e un\'e-bike ha coinvolto una ragazza e una donna, lasciando quest\'ultima gravemente ferita. Scopri di più su questo grave incidente',
-    canonicalPath: '/articoli-frontaliere/incidente-e-roller-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-e-roller-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4409,7 +4409,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, casino, campione, rinviato',
     ogTitle: 'Processo Casino Campione rinviato a dicembre 2026',
     ogDescription: 'La presidente Valeria Costi ha rinviato il processo sul Casinò di Campione a dicembre 2026 per altri processi da celebrare prima.',
-    canonicalPath: '/articoli-frontaliere/processo-campione-dicembre-2026',
+    canonicalPath: '/articoli-frontaliere/processo-campione-dicembre-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4437,7 +4437,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ingresso, gratuito, museo, costume',
     ogTitle: 'Ingresso gratuito al museo in costume da bagno',
     ogDescription: 'La Fondazione Beyeler di Riehen offre ingresso gratuito ai visitatori in costume da bagno, ispirata dalla mostra di Paule Cézanne.',
-    canonicalPath: '/articoli-frontaliere/ingresso-gratuito-museo-costume-bagno',
+    canonicalPath: '/articoli-frontaliere/ingresso-gratuito-museo-costume-bagno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4465,7 +4465,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, busto, gallarate',
     ogTitle: 'A8: chiusure notturne tra Busto e Gallarate e stop all’ingresso di Castellanza',
     ogDescription: 'Nuove modifiche alla viabilità sulla A8 Milano-Varese per lavori alle barriere antirumore. Chiusure notturne tra Busto Arsizio e Gallarate e stop all’ingresso',
-    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-chiusure',
+    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-chiusure/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4493,7 +4493,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, danzante, muove, spettacoli',
     ogTitle: 'Festa Danzante 2026: il Ticino si muove tra spettacoli e partecipazione',
     ogDescription: 'Dal 6 al 10 maggio 2026, oltre 40 città svizzere ospitano la 21ª edizione della Festa Danzante, con Lugano come cuore pulsante degli eventi.',
-    canonicalPath: '/articoli-frontaliere/festa-danzante-ticino-2026-spettacoli',
+    canonicalPath: '/articoli-frontaliere/festa-danzante-ticino-2026-spettacoli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4521,7 +4521,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, pregassona, persone, fonio',
     ogTitle: 'Festa a Pregassona: 400 persone e Fonio contro iniziativa UDC',
     ogDescription: 'Giorgio Fonio critica l\'iniziativa UDC \'No a una Svizzera da 10 milioni\' per i rischi su lavoro e salari. OCST celebra con 400 persone.',
-    canonicalPath: '/articoli-frontaliere/pregassona-festa-400-fonio-iniziativa-udc',
+    canonicalPath: '/articoli-frontaliere/pregassona-festa-400-fonio-iniziativa-udc/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4549,7 +4549,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, numero, combatte, violenza, oggi',
     ogTitle: '142: il numero che combatte la violenza in Ticino',
     ogDescription: 'Da oggi attivo il numero 142 per l\'aiuto alle vittime di violenza in Ticino e in tutta la Svizzera, gratuito e disponibile 24/7.',
-    canonicalPath: '/articoli-frontaliere/142-numero-aiuto-vittime-ticino',
+    canonicalPath: '/articoli-frontaliere/142-numero-aiuto-vittime-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4577,7 +4577,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dopo, ponte, acqua, meteo',
     ogTitle: 'Dopo il ponte, l’acqua: meteo Ticino 2026',
     ogDescription: 'Fine settimana soleggiato, ma da lunedì piogge e temperature più fresche. Ecco cosa aspettarsi in Ticino.',
-    canonicalPath: '/articoli-frontaliere/ponte-l-acqua-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ponte-l-acqua-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4605,7 +4605,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, canile, varese, duni',
     ogTitle: 'Nuovo canile Varese Duni: progetto approvato, realizzazione a tappe',
     ogDescription: 'La Commissione Ambiente ha approvato il progetto per il nuovo canile di Varese ai Duni, ma i costi aumentati impongono una realizzazione in due fasi.',
-    canonicalPath: '/articoli-frontaliere/nuovo-canile-varese-duni-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-canile-varese-duni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4633,7 +4633,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, fritti, glam, varese',
     ogTitle: 'Festa dei fritti al Glam di Varese: gnocco martedì, fritto misto giovedì',
     ogDescription: 'Dal 30 aprile 2026 al Glam Caffè di Varese via Manin ogni martedì e giovedì pranzo con gnocco fritto e fritto misto. Digestivo offerto.',
-    canonicalPath: '/articoli-frontaliere/festa-fritti-glam-varese-2026',
+    canonicalPath: '/articoli-frontaliere/festa-fritti-glam-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4661,7 +4661,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lostallo, soazza, mesocco, titolo',
     ogTitle: 'Lostallo, Soazza e Mesocco per il titolo di "Comune più attivo della Svizzera"',
     ogDescription: 'Lostallo, Soazza e Mesocco partecipano alla "Coop sfida fra comuni" per promuovere l\'attività fisica durante il mese di maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/alta-mesolcina-sfida-movimento-2026',
+    canonicalPath: '/articoli-frontaliere/alta-mesolcina-sfida-movimento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4689,7 +4689,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, flottila, gaza, intercettata, presidio',
     ogTitle: 'Flottila per Gaza intercettata, presidio a Varese',
     ogDescription: 'Presidio di solidarietà a Varese per la Flottila intercettata da Israele. Turchia e Spagna parlano di pirateria.',
-    canonicalPath: '/articoli-frontaliere/flotilla-gaza-varese-presidio-montegrappa',
+    canonicalPath: '/articoli-frontaliere/flotilla-gaza-varese-presidio-montegrappa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4717,7 +4717,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, orso, ripreso, valposchiavo, ritorno',
     ogTitle: 'Orso ripreso in Valposchiavo: ritorno dopo anni',
     ogDescription: 'Una fototrappola ha immortalato un orso il 29 aprile nei boschi tra Le Prese e Miralago, riaprendo il dibattito sulla convivenza con la fauna selvatica',
-    canonicalPath: '/articoli-frontaliere/orso-valposchiavo-2026-ritorno',
+    canonicalPath: '/articoli-frontaliere/orso-valposchiavo-2026-ritorno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4745,7 +4745,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, studenti, premiati, borse, studio',
     ogTitle: '87 studenti premiati con borse di studio a Gallarate',
     ogDescription: 'La cerimonia si è svolta al Maga-Hic di Gallarate, dove 87 studenti sono stati premiati per i loro risultati scolastici ed extrascolastici.',
-    canonicalPath: '/articoli-frontaliere/gallarate-borse-studio-2026',
+    canonicalPath: '/articoli-frontaliere/gallarate-borse-studio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4773,7 +4773,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, sindacati, politica, contro',
     ogTitle: '1° maggio 2026: sindacati e politica contro l\'iniziativa UDC',
     ogDescription: 'Mobilitazione nazionale contro l\'iniziativa UDC \'No a una Svizzera da 10 milioni!\' con manifestazioni in diverse città svizzere.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati-iniziativa-udc',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati-iniziativa-udc/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4801,7 +4801,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, lugano, lavoro, scende',
     ogTitle: '1° Maggio a Lugano: il lavoro scende in piazza',
     ogDescription: 'Centinaia di persone hanno sfilato per le vie di Lugano sotto lo slogan \'Né sfruttati, né divisi\' per rivendicare salari equi e sicurezza sul lavoro',
-    canonicalPath: '/articoli-frontaliere/lavoro-scende-piazza-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/lavoro-scende-piazza-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4829,7 +4829,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, radar, sempre, attivi, ecco',
     ogTitle: 'Radar sempre attivi: ecco dove dal 4 al 10 maggio',
     ogDescription: 'La Polizia cantonale annuncia controlli della velocità in diverse località del Ticino dal 4 al 10 maggio 2026. Ecco dove saranno posizionati i radar.',
-    canonicalPath: '/articoli-frontaliere/radar-ticino-velocita-2026',
+    canonicalPath: '/articoli-frontaliere/radar-ticino-velocita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4857,7 +4857,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, migliaia, piazza',
     ogTitle: 'Primo maggio 2026: migliaia in piazza a Zurigo e Basilea',
     ogDescription: 'Manifestazioni pacifiche a Zurigo e Basilea con 15\'000 e 2\'500 partecipanti, rispettivamente. Isolati atti di vandalismo e critiche alla gestione della sanità.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-zurigo-basilea-2026',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-zurigo-basilea-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4885,7 +4885,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rive, libere, ascona, apre',
     ogTitle: 'Rive libere: Ascona apre al pubblico d\'inverno',
     ogDescription: 'L\'associazione Rive pubbliche della Svizzera italiana celebra due successi: l\'inclusione nel gruppo di lavoro per il Sentiero delle Rive e l\'apertura invernale',
-    canonicalPath: '/articoli-frontaliere/rive-libere-ascona-2026',
+    canonicalPath: '/articoli-frontaliere/rive-libere-ascona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4913,7 +4913,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mezzi, pesanti, biandronno, avvia',
     ogTitle: 'Mezzi pesanti, Biandronno avvia sperimentazione',
     ogDescription: 'Il sindaco Massimo Porotti annuncia l\'inizio della sperimentazione per limitare il traffico dei mezzi pesanti nel Medio Verbano',
-    canonicalPath: '/articoli-frontaliere/mezzi-pesanti-biandronno-2026',
+    canonicalPath: '/articoli-frontaliere/mezzi-pesanti-biandronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4941,7 +4941,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, aumenta, dazi, auto',
     ogTitle: 'Trump aumenta dazi UE del 25% su auto e camion',
     ogDescription: 'Il presidente USA annuncia l\'aumento dei dazi su auto e camion provenienti dall\'UE, accusando l\'Unione Europea di non rispettare l\'accordo commerciale.',
-    canonicalPath: '/articoli-frontaliere/trump-dazi-ue-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/trump-dazi-ue-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4969,7 +4969,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, balerna, celebra, anni, consiglio',
     ogTitle: 'Balerna celebra 100 anni del Consiglio comunale',
     ogDescription: 'Balerna festeggia il centenario del suo Consiglio comunale con una celebrazione dedicata a chi ha lavorato per il paese. Scopri di più sugli eventi e le',
-    canonicalPath: '/articoli-frontaliere/balerna-consiglio-comunale-centenario',
+    canonicalPath: '/articoli-frontaliere/balerna-consiglio-comunale-centenario/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -4997,7 +4997,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confsal, lancia, manifesto, lavoro',
     ogTitle: 'Confsal lancia manifesto del lavoro: dignità, salari e diritti al centro',
     ogDescription: 'Il 1 maggio, la Confsal ha presentato il suo manifesto del lavoro a Napoli, evidenziando la necessità di dignità, salari equi e diritti per i lavoratori.',
-    canonicalPath: '/articoli-frontaliere/confsal-manifesto-lavoro-dignita-salari',
+    canonicalPath: '/articoli-frontaliere/confsal-manifesto-lavoro-dignita-salari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5025,7 +5025,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, usa-iran, tensioni, nucleari, sanzioni',
     ogTitle: 'USA-Iran: tensioni nucleari e sanzioni nel 2026',
     ogDescription: 'Teheran accusa USA di poco impegno nei negoziati e azioni militari parallele. Trump: colloqui in corso telefonicamente.',
-    canonicalPath: '/articoli-frontaliere/usa-iran-nucleare-sanzioni-2026',
+    canonicalPath: '/articoli-frontaliere/usa-iran-nucleare-sanzioni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5053,7 +5053,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, locali, pubblici, convegno',
     ogTitle: 'Convegno sicurezza locali pubblici Ville Ponti 29 giugno',
     ogDescription: 'Convegno sulla sicurezza nei locali pubblici a Ville Ponti il 29 giugno 2026. Focus su prevenzione incendi e normative.',
-    canonicalPath: '/articoli-frontaliere/sicurezza-locali-pubblici-convegno-ville-ponti',
+    canonicalPath: '/articoli-frontaliere/sicurezza-locali-pubblici-convegno-ville-ponti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5081,7 +5081,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sospetta, fuga, stazione, metro',
     ogTitle: 'Sospetta fuga di gas, stazione metro temporaneamente chiusa',
     ogDescription: 'La stazione di Farringdon a Londra evacuata e chiusa al traffico a causa di una sospetta fuga di gas accidentale',
-    canonicalPath: '/articoli-frontaliere/sospetta-fuga-gas-londra-metro-chiusa',
+    canonicalPath: '/articoli-frontaliere/sospetta-fuga-gas-londra-metro-chiusa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5109,7 +5109,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassis, araghchi, discutono, situazione',
     ogTitle: 'Cassis e Araghchi discutono situazione regionale',
     ogDescription: 'Il consigliere federale Ignazio Cassis ha parlato con il ministro degli Esteri iraniano Abbas Araghchi della situazione regionale.',
-    canonicalPath: '/articoli-frontaliere/cassis-aragchi-colloquio-iran',
+    canonicalPath: '/articoli-frontaliere/cassis-aragchi-colloquio-iran/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5137,7 +5137,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colosso, tonnellate, nato, legnano',
     ogTitle: 'Colosso da 35 tonnellate nato a Legnano',
     ogDescription: 'Scopri il T-Mill, la macchina utensile CNC da 35 tonnellate sviluppata dalla Camu Srl di Legnano per lavorazioni ad alta precisione.',
-    canonicalPath: '/articoli-frontaliere/colosso-35-tonnellate-legnano',
+    canonicalPath: '/articoli-frontaliere/colosso-35-tonnellate-legnano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5165,7 +5165,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, villa, visconti, borromeo, litta',
     ogTitle: 'Villa Visconti Borromeo Litta riapre a Lainate: giochi d\'acqua e giardini monumentali',
     ogDescription: 'Scopri la riapertura di Villa Visconti Borromeo Litta a Lainate con i suoi giochi d\'acqua e giardini monumentali. Un\'esperienza unica tra arte e natura.',
-    canonicalPath: '/articoli-frontaliere/riapre-villa-visconti-lainate-2026',
+    canonicalPath: '/articoli-frontaliere/riapre-villa-visconti-lainate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5193,7 +5193,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, teheran, consegna, nuova, proposta',
     ogTitle: 'Teheran consegna nuova proposta negoziale ai mediatori pakistani',
     ogDescription: 'La diplomazia iraniana cerca nuove vie per la fine del conflitto coinvolgendo mediatori pakistani',
-    canonicalPath: '/articoli-frontaliere/teheran-proposta-pakistan-mediatori',
+    canonicalPath: '/articoli-frontaliere/teheran-proposta-pakistan-mediatori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5221,7 +5221,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inflazione, perché, sentono, peso',
     ogTitle: 'Inflazione in Svizzera: perché i frontalieri sentono il peso',
     ogDescription: 'L\'inflazione ufficiale in Svizzera è bassa, ma i frontalieri in Ticino sentono il peso del caro vita. Ecco perché.',
-    canonicalPath: '/articoli-frontaliere/inflazione-svizzera-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/inflazione-svizzera-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5249,7 +5249,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, linea, aiuto, vittime',
     ogTitle: '142: nuova linea d\'aiuto per vittime di violenza in Ticino',
     ogDescription: 'Il numero 142 è ora attivo in Ticino per supportare le vittime di violenza fisica, psichica o sessuale. Gratuito e anonimo, offre consulenza 24 ore su 24.',
-    canonicalPath: '/articoli-frontaliere/142-linea-aiuto-vittime-violenza-ticino',
+    canonicalPath: '/articoli-frontaliere/142-linea-aiuto-vittime-violenza-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5277,7 +5277,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, cadegliano, viconago, ferito',
     ogTitle: 'Incidente a Cadegliano Viconago: ferito un 54enne',
     ogDescription: 'Un incidente tra un\'auto e una moto a Cadegliano Viconago, Varese, ha lasciato un 54enne ferito. Ecco i dettagli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/collisione-cadegliano-varese-ferito-54enne',
+    canonicalPath: '/articoli-frontaliere/collisione-cadegliano-varese-ferito-54enne/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5305,7 +5305,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, congresso, record, lugano, contro',
     ogTitle: 'Congresso record a Lugano contro il cancro alla prostata',
     ogDescription: 'Oltre 1000 medici e ricercatori a Lugano per linee guida internazionali. In Ticino 400 casi l\'anno.',
-    canonicalPath: '/articoli-frontaliere/congresso-lugano-cancro-prostata-2024',
+    canonicalPath: '/articoli-frontaliere/congresso-lugano-cancro-prostata-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5333,7 +5333,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riapre, circolo, albate, piazza',
     ogTitle: 'Riapre il Circolo ad Albate: una piazza al coperto per la comunità',
     ogDescription: 'Il bar Circolo ad Albate riapre i battenti il 1° maggio 2026, diventando un punto di aggregazione sociale e culturale per la comunità.',
-    canonicalPath: '/articoli-frontaliere/circolo-albate-riapertura-2026',
+    canonicalPath: '/articoli-frontaliere/circolo-albate-riapertura-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5361,7 +5361,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aranno, moto, centra, palo',
     ogTitle: 'Incidente motociclistico ad Aranno: un uomo ricoverato',
     ogDescription: 'Un incidente motociclistico ad Aranno: la moto centra un palo e finisce nella scarpata. Un uomo è stato ricoverato in ospedale. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/aranno-incidente-moto-ricoverato-uomo',
+    canonicalPath: '/articoli-frontaliere/aranno-incidente-moto-ricoverato-uomo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5389,7 +5389,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, viaggio, tempo, quinto',
     ogTitle: 'Como, viaggio nel tempo: Quinto, Caffè&Caffè, Ul Pan de Comm',
     ogDescription: 'Scopri come alcune zone di Como mantengono il fascino di un tempo, con locali frequentati da residenti e non da turisti.',
-    canonicalPath: '/articoli-frontaliere/como-viaggio-nel-tempo-2026',
+    canonicalPath: '/articoli-frontaliere/como-viaggio-nel-tempo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5417,7 +5417,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, rapinese, accusa, roma',
     ogTitle: 'Como: Rapinese accusa Roma su fondi per Volta. Replica durissima',
     ogDescription: 'Il sindaco di Como accusa Roma di aver stanziato 6 milioni per una sit-com su Volta, zero per i monumenti. Replica del Comitato Nazionale.',
-    canonicalPath: '/articoli-frontaliere/como-volta-faro-rapinese-6-milioni',
+    canonicalPath: '/articoli-frontaliere/como-volta-faro-rapinese-6-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5445,7 +5445,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, velocità, ecco, dove',
     ogTitle: 'Controlli velocità Ticino: dove saranno i radar dal 4 al 10 maggio',
     ogDescription: 'La Polizia cantonale e le polizie comunali comunicano i luoghi dei controlli della velocità mobili e semi-stazionari nel Canton Ticino dal 4 al 10 maggio 2024.',
-    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-maggio-2024',
+    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-maggio-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5473,7 +5473,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, salari, diritti',
     ogTitle: 'Primo maggio in Ticino: salari e diritti al centro delle proteste',
     ogDescription: 'Circa duemila persone hanno sfilato a Lugano per chiedere salari dignitosi e denunciare il dumping salariale',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-ticino-salari-2024',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-ticino-salari-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5501,7 +5501,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, abusi, viabilistici, moltrasio, lago',
     ogTitle: 'Sosta selvaggia a Moltrasio: il problema degli abusi viabilistici sul Lago di Como',
     ogDescription: 'Il paesino di Moltrasio sul Lago di Como è spesso vittima di sosta selvaggia da parte di auto straniere. Ecco cosa sta succedendo.',
-    canonicalPath: '/articoli-frontaliere/sosta-selvaggia-moltrasio-2026',
+    canonicalPath: '/articoli-frontaliere/sosta-selvaggia-moltrasio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5529,7 +5529,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sconfitta, dalla, svezia, lezione',
     ogTitle: 'Svizzera sconfitta dalla Svezia: una lezione per il futuro',
     ogDescription: 'La nazionale svizzera di hockey subisce una pesante sconfitta contro la Svezia, con un risultato finale di 8-1.',
-    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-svezia',
+    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-svezia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5557,7 +5557,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, lambrugo, 74enne, ospedale',
     ogTitle: 'Incidente Lambrugo: 74enne in ospedale dopo scontro auto-moto',
     ogDescription: 'Un grave incidente stradale a Lambrugo, Como, ha coinvolto un\'auto e una moto, con un 74enne ricoverato in ospedale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lambrugo-incidente-74enne-ospedale',
+    canonicalPath: '/articoli-frontaliere/lambrugo-incidente-74enne-ospedale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5585,7 +5585,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, delia, cambia, testo, bella',
     ogTitle: 'Delia cambia testo Bella Ciao al Concertone: più attuale',
     ogDescription: 'Delia modifica Bella Ciao al Concertone del 1° maggio a Roma, sostituendo \'partigiano\' con \'essere umano\' per rendere il messaggio più attuale.',
-    canonicalPath: '/articoli-frontaliere/delia-bella-ciao-concertone-2026',
+    canonicalPath: '/articoli-frontaliere/delia-bella-ciao-concertone-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5613,7 +5613,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, funivia, säntis, chiusa, mesi',
     ogTitle: 'Funivia del Säntis chiusa per mesi: ammodernamento da 30 milioni',
     ogDescription: 'La funivia del Säntis chiuderà per diversi mesi per un ammodernamento da 30 milioni di franchi. Riapertura prevista in autunno.',
-    canonicalPath: '/articoli-frontaliere/funivia-santis-ammodernamento-2026',
+    canonicalPath: '/articoli-frontaliere/funivia-santis-ammodernamento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5641,7 +5641,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, curiosità, brevetti, svizzeri',
     ogTitle: 'Cinque curiosità sui brevetti svizzeri',
     ogDescription: 'La Svizzera è il paese più innovativo d\'Europa in materia di brevetti. Ecco i dati più interessanti del 2025.',
-    canonicalPath: '/articoli-frontaliere/cinque-curiosita-brevetti-svizzeri-2026',
+    canonicalPath: '/articoli-frontaliere/cinque-curiosita-brevetti-svizzeri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5669,7 +5669,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libertà, stampa, ottava, mondo',
     ogTitle: 'Libertà di stampa in Svizzera: ottava nel mondo',
     ogDescription: 'La Svizzera si posiziona all\'ottavo posto nella classifica mondiale della libertà di stampa, ma presenta criticità giuridiche ed economiche.',
-    canonicalPath: '/articoli-frontaliere/liberta-stampa-minimi-25-anni',
+    canonicalPath: '/articoli-frontaliere/liberta-stampa-minimi-25-anni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5697,7 +5697,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dolore, vicinanza, matteo, famiglia',
     ogTitle: 'Tutto il villaggio dal suo piccolo angelo: il dolore, la vicinanza, l\'affetto per Matteo e la sua famiglia',
     ogDescription: 'Il villaggio di Busto Arsizio si stringe intorno alla famiglia di Matteo, un bambino di 4 anni scomparso, con dolore e affetto.',
-    canonicalPath: '/articoli-frontaliere/villaggio-angelo-busto-arsizio',
+    canonicalPath: '/articoli-frontaliere/villaggio-angelo-busto-arsizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5725,7 +5725,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiese, derubate, graubünden, rumeni',
     ogTitle: 'Chiese derubate in Ticino e Graubünden: due rumeni arrestati',
     ogDescription: 'Due rumeni arrestati per furti in sei chiese tra Ticino e Graubünden. Scopri i dettagli delle indagini e cosa fare se sei stato vittima di un furto.',
-    canonicalPath: '/articoli-frontaliere/chiese-ticino-derubate-2026',
+    canonicalPath: '/articoli-frontaliere/chiese-ticino-derubate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5753,7 +5753,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, sindacati, contro, iniziative',
     ogTitle: '1° maggio: sindacati Ticino contro iniziative UDC e destra',
     ogDescription: '3.000 persone in corteo a Lugano. Critiche a proposte considerate razziste e xenofobe. Fonio: condizioni di lavoro a rischio.',
-    canonicalPath: '/articoli-frontaliere/sindacati-ticino-1-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/sindacati-ticino-1-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5781,7 +5781,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, progetto, abbandonato, dopo',
     ogTitle: 'Polizia Ticino: progetto abbandonato dopo opposizioni',
     ogDescription: 'Il progetto di riforma della polizia ticinese è stato abbandonato dopo 12 mesi di consultazione e forti opposizioni',
-    canonicalPath: '/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026',
+    canonicalPath: '/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5809,7 +5809,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, vico, morcote, bimbo',
     ogTitle: 'Tragedia a Vico Morcote: bimbo di due anni annega in piscina',
     ogDescription: 'Un bambino di due anni ha perso la vita in un incidente in piscina a Vico Morcote. La tragedia si è verificata in una villa privata.',
-    canonicalPath: '/articoli-frontaliere/tragedia-vico-morcote-bimbo-piscina',
+    canonicalPath: '/articoli-frontaliere/tragedia-vico-morcote-bimbo-piscina/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5837,7 +5837,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, denunciata, organizzazione, cantonale',
     ogTitle: 'Crans-Montana, denunciata l\'Organizzazione cantonale di soccorso',
     ogDescription: 'Indagine aperta sul dispositivo di intervento dopo l\'incendio del bar Le Constellation. Avvocati delle vittime denunciano carenze',
-    canonicalPath: '/articoli-frontaliere/crans-montana-soccorso-denunciato',
+    canonicalPath: '/articoli-frontaliere/crans-montana-soccorso-denunciato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5865,7 +5865,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallisce, previsioni, eventi, estremi',
     ogTitle: 'IA fallisce previsioni eventi estremi: studio Università di Ginevra',
     ogDescription: 'Nuovo studio rivela che l\'IA sbaglia sistematicamente previsioni su eventi meteorologici estremi, sottostimando ondate di calore e freddo',
-    canonicalPath: '/articoli-frontaliere/ia-meteo-eventi-estremi',
+    canonicalPath: '/articoli-frontaliere/ia-meteo-eventi-estremi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5893,7 +5893,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, condannato, anni, tentato, assassinio',
     ogTitle: 'Condannato a 11 anni per tentato assassinio a Chiasso',
     ogDescription: 'Un 34enne è stato condannato a 11 anni per tentato assassinio della compagna a Chiasso. La corte ha ordinato anche l\'espulsione.',
-    canonicalPath: '/articoli-frontaliere/tentato-assassinio-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/tentato-assassinio-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5921,7 +5921,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, cortei, pacifici',
     ogTitle: 'Primo Maggio 2026 in Svizzera: cortei pacifici e critiche al capitalismo',
     ogDescription: 'Migliaia di manifestanti hanno partecipato ai cortei del Primo Maggio in Svizzera, con episodi di vandalismo a Zurigo e critiche al G7 e al capitalismo.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-svizzera-cortei',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-svizzera-cortei/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5949,7 +5949,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guardie, svizzere, 2025, anno',
     ogTitle: 'Guardie svizzere: 2025 anno intenso con morte di Papa Francesco e conclave',
     ogDescription: 'Il 2025 è stato un anno eccezionale per la Guardia svizzera pontificia, segnato dalla morte di Papa Francesco, il conclave e il giubileo.',
-    canonicalPath: '/articoli-frontaliere/guardie-svizzere-2025-intenso',
+    canonicalPath: '/articoli-frontaliere/guardie-svizzere-2025-intenso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -5977,7 +5977,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siccità, estate, rischio, aprile',
     ogTitle: 'Siccità in Ticino: estate 2026 a rischio',
     ogDescription: 'Aprile 2026 è stato il più secco degli ultimi anni, con precipitazioni al 10% della media. Rischio incendi e bacini idrici critici.',
-    canonicalPath: '/articoli-frontaliere/siccit-estate-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/siccit-estate-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6005,7 +6005,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, unica, galusero, galli',
     ogTitle: 'Polizia unica in Ticino: Galusero vs Galli, il dibattito si accende',
     ogDescription: 'Il Consiglio di Stato ha deciso di stoppare il progetto \'Polizia ticinese\'. Le reazioni di Galusero e Galli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026',
+    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6033,7 +6033,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nazionale, respinge, iniziativa, democrazia',
     ogTitle: 'Nazionale respinge iniziativa democrazia',
     ogDescription: 'Il Consiglio nazionale ha respinto l\'iniziativa per dimezzare i tempi per la cittadinanza a 5 anni. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-nazionale',
+    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-nazionale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6061,7 +6061,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, uisp, alla, scuola, dante',
     ogTitle: 'UISP alla scuola Dante di Varese per promuovere lo sport inclusivo',
     ogDescription: 'L\'incontro tra UISP e Associazione Genitori alla scuola Dante di Varese ha promosso lo sport per tutti, con progetti inclusivi e attività per disabili.',
-    canonicalPath: '/articoli-frontaliere/uisp-scuola-dante-varese-2026',
+    canonicalPath: '/articoli-frontaliere/uisp-scuola-dante-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6089,7 +6089,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, capanna, soveltra, ricostruzione, avanza',
     ogTitle: 'Capanna Soveltra, ricostruzione avanza più velocemente dell’iter giudiziario',
     ogDescription: 'La ricostruzione della Capanna Soveltra in Val Maggia procede rapidamente, mentre il ricorso al Tribunale federale è ancora in fase di definizione.',
-    canonicalPath: '/articoli-frontaliere/ricostruzione-capanna-soveltra-avanza',
+    canonicalPath: '/articoli-frontaliere/ricostruzione-capanna-soveltra-avanza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6117,7 +6117,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, quadroni, capo, posto',
     ogTitle: 'Processo Quadroni: l\'ex capo posto contesta le accuse',
     ogDescription: 'L\'ex capo del posto di polizia di Scuol contesta le accuse di abuso di autorità, sequestro di persona e violazione di domicilio. La Procura pubblica chiede una',
-    canonicalPath: '/articoli-frontaliere/processo-quadroni-ex-capo-posto-contesta-accuse',
+    canonicalPath: '/articoli-frontaliere/processo-quadroni-ex-capo-posto-contesta-accuse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6145,7 +6145,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, docente, arrestato, giubiasco, richiesta',
     ogTitle: 'Docente arrestato a Giubiasco, richiesta proroga detenzione',
     ogDescription: 'La Procura richiede proroga detenzione per docente arrestato a Giubiasco. Inchiesta su minorenni in corso. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/docente-arrestato-giubiasco-proroga',
+    canonicalPath: '/articoli-frontaliere/docente-arrestato-giubiasco-proroga/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6173,7 +6173,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, angelo, custode, evita, colpi',
     ogTitle: 'L\'angelo custode della IA evita i colpi di sonno al volante?',
     ogDescription: 'Scopri come il sistema Driver-Check, sviluppato in Svizzera, utilizza l\'IA per prevenire i colpi di sonno alla guida e le sue limitazioni.',
-    canonicalPath: '/articoli-frontaliere/angelo-custode-ia-colpo-sonno',
+    canonicalPath: '/articoli-frontaliere/angelo-custode-ia-colpo-sonno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6201,7 +6201,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agenzia, formativa, varese, dimissioni',
     ogTitle: 'Agenzia formativa Varese: dimissioni del CDA',
     ogDescription: 'Ilaria Azzimonti annuncia le dimissioni dal consiglio di amministrazione dell\'Agenzia formativa della Provincia di Varese a causa di tensioni interne.',
-    canonicalPath: '/articoli-frontaliere/agenzia-formativa-varese-dimissioni-2026',
+    canonicalPath: '/articoli-frontaliere/agenzia-formativa-varese-dimissioni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6229,7 +6229,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, presentazione, libro, femminismo',
     ogTitle: 'Varese: presentazione libro sul femminismo pacifista',
     ogDescription: 'Giovedì 7 maggio in Sala Morselli a Varese, presentazione libro \'Al di sopra dell’odio e del massacro\' di Lacaita e Suriano',
-    canonicalPath: '/articoli-frontaliere/presentazione-libro-odio-massacro-varese',
+    canonicalPath: '/articoli-frontaliere/presentazione-libro-odio-massacro-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6257,7 +6257,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, energia, fattura, miliardaria, conflitto',
     ogTitle: 'Energia: la fattura miliardaria del conflitto in Medio Oriente',
     ogDescription: 'Il prezzo del diesel supera i 2 franchi al litro in Svizzera a causa del conflitto in Medio Oriente, con costi aggiuntivi per famiglie e imprese',
-    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-2026',
+    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6285,7 +6285,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arco, frecce, centro, cuore',
     ogTitle: 'Arco e frecce per far centro nel cuore degli appassionati',
     ogDescription: 'Una nuova società di arcieri è stata fondata a Bellinzona. La presidente Rita De Franco: ‘Siamo al Vallone, ma speriamo in un campo fisso’.',
-    canonicalPath: '/articoli-frontaliere/arco-e-frecce-per-far-centro',
+    canonicalPath: '/articoli-frontaliere/arco-e-frecce-per-far-centro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6313,7 +6313,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, museo, paesaggio, verbania, ingresso',
     ogTitle: 'Museo del Paesaggio di Verbania: ingresso gratuito per i residenti',
     ogDescription: 'L\'8 maggio 2026 ingresso gratuito al Museo del Paesaggio di Verbania per i residenti in occasione della festa patronale di San Vittore.',
-    canonicalPath: '/articoli-frontaliere/museo-paesaggio-verbania-gratis-2026',
+    canonicalPath: '/articoli-frontaliere/museo-paesaggio-verbania-gratis-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6341,7 +6341,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, biandronno, incontro, pubblico, astuti',
     ogTitle: 'Biandronno: incontro pubblico con Astuti e Licata su sanità e trasporti',
     ogDescription: 'Biandronno Più organizza un incontro pubblico con i consiglieri regionali Astuti e Licata per discutere di sanità e trasporti nel Varesotto.',
-    canonicalPath: '/articoli-frontaliere/biandronno-incontro-astuti-licata-2026',
+    canonicalPath: '/articoli-frontaliere/biandronno-incontro-astuti-licata-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6369,7 +6369,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gratis, museo, costume, bagno',
     ogTitle: 'Gratis al museo in costume da bagno: l\'iniziativa della Fondazione Beyeler',
     ogDescription: 'La Fondazione Beyeler di Riehen offre ingresso gratuito in costume da bagno per una giornata dedicata a Paul Cézanne e ai suoi dipinti di bagnanti.',
-    canonicalPath: '/articoli-frontaliere/gratis-museo-costume-bagno-2026',
+    canonicalPath: '/articoli-frontaliere/gratis-museo-costume-bagno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6397,7 +6397,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sfratto, agli, allenatori, svicc',
     ogTitle: 'Sfratto agli allenatori: la Svicc chiude le scuderie di Varese',
     ogDescription: 'La Svicc sfratta gli allenatori delle scuderie di Varese entro 60 giorni. Progetto di demolizione e ristrutturazione',
-    canonicalPath: '/articoli-frontaliere/ippodromo-varese-svicc-allenatori',
+    canonicalPath: '/articoli-frontaliere/ippodromo-varese-svicc-allenatori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6425,7 +6425,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luigi, bignami, insubria, arte',
     ogTitle: 'Luigi Bignami all\'Insubria: l\'arte di comunicare la scienza',
     ogDescription: 'Luigi Bignami all\'Università dell\'Insubria per parlare di comunicazione scientifica. Scopri come tradurre la complessità in linguaggio accessibile.',
-    canonicalPath: '/articoli-frontaliere/luigi-bignami-insubria-scienza-2026',
+    canonicalPath: '/articoli-frontaliere/luigi-bignami-insubria-scienza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6453,7 +6453,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carcere, busto, arsizio, denuncia',
     ogTitle: 'Carcere Busto Arsizio: denuncia Strada al Parlamento europeo',
     ogDescription: 'Denuncia di Cecilia Strada al Parlamento europeo sul sovraffollamento del carcere di Busto Arsizio, con tasso oltre il 200% e condizioni disumane.',
-    canonicalPath: '/articoli-frontaliere/busto-arsizio-carcere-denuncia-strada',
+    canonicalPath: '/articoli-frontaliere/busto-arsizio-carcere-denuncia-strada/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6481,7 +6481,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bracconaggio, ittico, lago, maggiore',
     ogTitle: 'Bracconaggio ittico sul Lago Maggiore: denunciato pescatore con fiocina',
     ogDescription: 'Operazione dei Carabinieri Forestali nel Varesotto: sequestri e denuncia penale per pesca illegale di lucioperca in periodo di fermo biologico',
-    canonicalPath: '/articoli-frontaliere/bracconaggio-ittico-lago-maggiore-ispra-2026',
+    canonicalPath: '/articoli-frontaliere/bracconaggio-ittico-lago-maggiore-ispra-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6509,7 +6509,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggiolone, social, park, mese',
     ogTitle: 'Maggiolone Social Park: un mese di feste a Cassano Magnago',
     ogDescription: 'Dal 1° maggio, Cassano Magnago ospita il nuovo Maggiolone Social Park con eventi gratuiti per tutte le età. Scopri il programma e come partecipare.',
-    canonicalPath: '/articoli-frontaliere/maggiolone-social-park-cassano-magnago',
+    canonicalPath: '/articoli-frontaliere/maggiolone-social-park-cassano-magnago/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6537,7 +6537,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grassi, 1925, entra, registro',
     ogTitle: 'Grassi 1925 entra nel Registro Speciale dei Marchi Storici',
     ogDescription: 'Grassi 1925, azienda varesina fondata nel 1925, entra nel Registro Speciale dei Marchi Storici di Interesse Nazionale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/grassi-1925-marchio-storico',
+    canonicalPath: '/articoli-frontaliere/grassi-1925-marchio-storico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6565,7 +6565,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lati, premiata, imprese, vincenti',
     ogTitle: 'LATI premiata tra le Imprese Vincenti di Intesa Sanpaolo',
     ogDescription: 'LATI Industria Termoplastici premiata tra le Imprese Vincenti di Intesa Sanpaolo per solidità, innovazione e visione internazionale',
-    canonicalPath: '/articoli-frontaliere/lati-industria-termoplastici-premiata-intesanpaolo',
+    canonicalPath: '/articoli-frontaliere/lati-industria-termoplastici-premiata-intesanpaolo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6593,7 +6593,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, progettare, sala, riunioni, funzionale',
     ogTitle: 'Come progettare una sala riunioni funzionale',
     ogDescription: 'Scopri come progettare una sala riunioni funzionale e accogliente, con consigli su arredamento, tecnologia e comfort',
-    canonicalPath: '/articoli-frontaliere/progettare-sala-riunioni-ufficio',
+    canonicalPath: '/articoli-frontaliere/progettare-sala-riunioni-ufficio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6621,7 +6621,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giovani, agenti, polizia, locale',
     ogTitle: 'Giovani agenti con la polizia locale a Como',
     ogDescription: 'Dieci studenti diventano agenti per un giorno con la polizia locale di Como, segnalando violazioni e promuovendo la legalità.',
-    canonicalPath: '/articoli-frontaliere/giovani-agenti-como-polizia-locale',
+    canonicalPath: '/articoli-frontaliere/giovani-agenti-como-polizia-locale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6649,7 +6649,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gallarate, fondazione, scuole, materne',
     ogTitle: 'Gallarate: Fondazione Scuole Materne, scontro in consiglio comunale',
     ogDescription: 'Il consiglio comunale di Gallarate si infiamma nuovamente sulla Fondazione Scuole Materne, con dimissioni del presidente e polemiche sui verbali.',
-    canonicalPath: '/articoli-frontaliere/gallarate-fondazione-scuole-materne-2026',
+    canonicalPath: '/articoli-frontaliere/gallarate-fondazione-scuole-materne-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6677,7 +6677,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, formula, riparte, rischi, polemiche',
     ogTitle: 'Formula 1 riparte fra rischi e polemiche',
     ogDescription: 'Il Mondiale di Formula 1 riprende a Miami dopo un mese di stop. Critiche al nuovo regolamento che penalizza piloti e monoposto.',
-    canonicalPath: '/articoli-frontaliere/formula-1-riparte-rischi-polemiche',
+    canonicalPath: '/articoli-frontaliere/formula-1-riparte-rischi-polemiche/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6705,7 +6705,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, unitalsi, busto, varese, sollievo',
     ogTitle: 'Unitalsi Busto e Varese: sollievo spirituale e miracoli per i malati',
     ogDescription: 'Scopri come l\'Unitalsi di Busto Arsizio e Varese offre supporto ai malati attraverso pellegrinaggi e assistenza spirituale.',
-    canonicalPath: '/articoli-frontaliere/unitalsi-busto-varese-malati-spiritualita',
+    canonicalPath: '/articoli-frontaliere/unitalsi-busto-varese-malati-spiritualita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6733,7 +6733,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vita, confini, mondo, sull',
     ogTitle: 'Vita ai confini del mondo sull\'isola artica d\'Islanda',
     ogDescription: 'Scopri la storia di Leonardo Piccione, un pugliese che ha trascorso mesi sull\'isola di Grímsey in Islanda, lavorando e scrivendo un libro sulla sua esperienza.',
-    canonicalPath: '/articoli-frontaliere/isola-artica-islanda-pugliese',
+    canonicalPath: '/articoli-frontaliere/isola-artica-islanda-pugliese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6761,7 +6761,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chocolat, stella, torna, bellinzona',
     ogTitle: 'Chocolat Stella torna a Bellinzona con nuovo negozio',
     ogDescription: 'Chocolat Stella apre nuovo punto vendita in piazza Nosetto, Palazzo civico, Bellinzona. Apertura prevista nei prossimi mesi del 2026.',
-    canonicalPath: '/articoli-frontaliere/cioccolato-illumina-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/cioccolato-illumina-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6789,7 +6789,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luna, park, schiranna, vita',
     ogTitle: 'Luna Park Schiranna: vita tra giostre e carovane',
     ogDescription: 'Scopri la vita dei giostrai e delle giostraie che ogni anno portano musica e luci alla Schiranna di Varese',
-    canonicalPath: '/articoli-frontaliere/varese-luna-park-schiranna-2026',
+    canonicalPath: '/articoli-frontaliere/varese-luna-park-schiranna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6817,7 +6817,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mera, longhi, anni, dolcezza',
     ogTitle: 'Mera & Longhi: 130 anni di dolcezza artigianale premiati a Varese',
     ogDescription: 'La Famiglia Bosina premia l\'azienda storica varesina Mera & Longhi per 130 anni di eccellenza dolciaria. Scopri la storia e i prodotti di questa icona della',
-    canonicalPath: '/articoli-frontaliere/mera-longhi-130-anni-dolcezza-varese',
+    canonicalPath: '/articoli-frontaliere/mera-longhi-130-anni-dolcezza-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6845,7 +6845,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, girometta, andrea, chiodi, varese',
     ogTitle: 'Girometta d\'oro 2026 a Andrea Chiodi: Varese premia il suo regista',
     ogDescription: 'Andrea Chiodi vince la Girometta d\'oro 2026 per aver portato il nome di Varese nel firmamento della cultura e del teatro contemporaneo.',
-    canonicalPath: '/articoli-frontaliere/girometta-doro-andrea-chiodi-varese-2026',
+    canonicalPath: '/articoli-frontaliere/girometta-doro-andrea-chiodi-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6873,7 +6873,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, concerto, luino, vivaldi, bach',
     ogTitle: 'Concerto a Luino: Vivaldi e Bach al Santuario del Carmine',
     ogDescription: 'Sabato 2 maggio 2026 la Milano Festival Chamber Orchestra si esibisce a Luino con un programma di musica classica.',
-    canonicalPath: '/articoli-frontaliere/concerto-luino-vivaldi-bach-2026',
+    canonicalPath: '/articoli-frontaliere/concerto-luino-vivaldi-bach-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6901,7 +6901,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, concerti, cassiano, riscoprire',
     ogTitle: 'Cinque concerti a San Cassiano per riscoprire un gioiello da salvare',
     ogDescription: 'Dal 9 maggio al 6 giugno 2026, cinque concerti di musica antica nella chiesetta di San Cassiano a Varese per sostenere il restauro del luogo',
-    canonicalPath: '/articoli-frontaliere/musica-antica-san-cassiano-2026',
+    canonicalPath: '/articoli-frontaliere/musica-antica-san-cassiano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6929,7 +6929,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, mostre, perdere, maggio',
     ogTitle: 'Cinque mostre da non perdere a maggio in Ticino e dintorni',
     ogDescription: 'Scopri le mostre di maggio 2026 in Ticino e dintorni. Date, luoghi e dettagli delle esposizioni più attese.',
-    canonicalPath: '/articoli-frontaliere/cinque-mostre-maggio-gallarate-verbania-2026',
+    canonicalPath: '/articoli-frontaliere/cinque-mostre-maggio-gallarate-verbania-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6957,7 +6957,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, islanda, materia, storie, circolo',
     ogTitle: 'Mal d’Islanda a Materia: storie dal Circolo Polare Artico',
     ogDescription: 'Incontro sull\'isola di Grímsey a Castronno il 9 maggio con Leonardo Piccione e Francesca Milano. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/mal-dislanda-materia-castronno-2026',
+    canonicalPath: '/articoli-frontaliere/mal-dislanda-materia-castronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -6985,7 +6985,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensione, inps, errori, comuni',
     ogTitle: 'Frontaliere: pensione AVS/INPS 2026, errori comuni e checklist',
     ogDescription: 'Scopri gli errori comuni nel coordinamento AVS/INPS per i frontalieri Ticino e come evitarli con una checklist operativa',
-    canonicalPath: '/articoli-frontaliere/frontaliere-pensione-avs-inps-2026-errori-comuni',
+    canonicalPath: '/articoli-frontaliere/frontaliere-pensione-avs-inps-2026-errori-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7013,7 +7013,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attivisti, flotilla, portati, israele',
     ogTitle: 'Due attivisti Flotilla portati in Israele per interrogatorio',
     ogDescription: 'Saif Abu Keshek e Thiago Ávila, attivisti pro-Palestina, saranno interrogati dalle autorità israeliane dopo l\'intercettazione della Flotilla.',
-    canonicalPath: '/articoli-frontaliere/attivisti-flotilla-israele-interrogati',
+    canonicalPath: '/articoli-frontaliere/attivisti-flotilla-israele-interrogati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7041,7 +7041,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intervento, polizia, pensilina, lugano',
     ogTitle: 'Intervento di polizia a Lugano in Pensilina',
     ogDescription: 'Massiccio intervento della polizia a Lugano con uso di spray lacrimogeno contro un gruppo di persone esagitate',
-    canonicalPath: '/articoli-frontaliere/massiccio-intervento-polizia-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/massiccio-intervento-polizia-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7069,7 +7069,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giovani, rematori, protagonisti, ceresio',
     ogTitle: 'Giovani rematori protagonisti sul Ceresio',
     ogDescription: 'La 22ª Regata giovanile organizzata dalla Canottieri Ceresio Castagnola si è tenuta venerdì 1° maggio 2026 sul Lago Ceresio.',
-    canonicalPath: '/articoli-frontaliere/giovani-rematori-ceresio-2026',
+    canonicalPath: '/articoli-frontaliere/giovani-rematori-ceresio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7097,7 +7097,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, permesso, entro, quando, conviene',
     ogTitle: 'Permesso G vs B frontalieri 2026 entro 20 km: quando conviene cambiare',
     ogDescription: 'Confronto tecnico tra Permesso G e B per frontalieri Ticino nel 2026. Focus su \'entro 20 km\' con checklist operativa e scenari concreti.',
-    canonicalPath: '/articoli-frontaliere/permesso-g-b-2026-20km-frontalieri',
+    canonicalPath: '/articoli-frontaliere/permesso-g-b-2026-20km-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7125,7 +7125,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, lavorato, vita',
     ogTitle: 'Cure a domicilio: chi ha lavorato una vita non può essere penalizzato',
     ogDescription: 'Luca Frasa, Municipale di Quinto, solleva la questione delle cure a domicilio per i pensionati in Ticino, evidenziando il rischio di penalizzazione per chi ha',
-    canonicalPath: '/articoli-frontaliere/cure-domicilio-pensionati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cure-domicilio-pensionati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7153,7 +7153,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, oltre, mille, studenti, gara',
     ogTitle: 'Oltre mille studenti in gara per il concorso Libriamoci a Varese',
     ogDescription: 'La diciottesima edizione del concorso Libriamoci a Varese vede la partecipazione di quasi mille studenti con testi narrativi ed elaborati grafico-pittorici.',
-    canonicalPath: '/articoli-frontaliere/libriamoci-varese-studenti-2026',
+    canonicalPath: '/articoli-frontaliere/libriamoci-varese-studenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7181,7 +7181,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vino, alto, prodotto, scudellate',
     ogTitle: 'Il vino più alto del Ticino prodotto a Scudellate',
     ogDescription: 'Scopri il vino \'909\', prodotto a 909 metri in Valle di Muggio, e le sue caratteristiche uniche. Presentazione ufficiale il 3 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/vino-alto-ticino-scudellate-2026',
+    canonicalPath: '/articoli-frontaliere/vino-alto-ticino-scudellate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7209,7 +7209,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, corteo, palestina, invade, lungolago',
     ogTitle: 'Corteo pro Palestina invade il lungolago di Lugano',
     ogDescription: 'Una cinquantina di manifestanti ha sfilato in via Nassa e poi lungo il lungolago, bloccando il traffico e suscitando reazioni contrastanti.',
-    canonicalPath: '/articoli-frontaliere/corteo-pro-palestina-lungolago-lugano',
+    canonicalPath: '/articoli-frontaliere/corteo-pro-palestina-lungolago-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7237,7 +7237,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, social, media, minori, divieti',
     ogTitle: 'Social media e minori: i divieti non bastano',
     ogDescription: 'Riprogettare le piattaforme per evitare la dipendenza è la soluzione, non limitare l\'accesso',
-    canonicalPath: '/articoli-frontaliere/divieti-social-media-minori',
+    canonicalPath: '/articoli-frontaliere/divieti-social-media-minori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7265,7 +7265,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, baume-schneider, sanità, immigrazione, centro',
     ogTitle: 'Baume-Schneider: sanità, AVS e immigrazione al centro del discorso del 1° maggio',
     ogDescription: 'Elisabeth Baume-Schneider ha parlato di cure, AVS e rapporti con l\'Europa nel suo discorso del 1° maggio a Liestal. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-baume-schneider-sanita-avs',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-baume-schneider-sanita-avs/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7293,7 +7293,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, migros, immigrazione, necessaria, garantire',
     ogTitle: 'Migros: Immigrazione necessaria per garantire l\'offerta',
     ogDescription: 'Il CEO di Migros sottolinea l\'importanza dell\'immigrazione per il settore alimentare e del commercio al dettaglio in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-offerta',
+    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-offerta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7321,7 +7321,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, vico, morcote, bambino',
     ogTitle: 'Tragedia a Vico Morcote: bambino muore in piscina privata',
     ogDescription: 'Un bambino di due anni ha perso la vita in un incidente in piscina a Vico Morcote. La famiglia riceve supporto psicologico.',
-    canonicalPath: '/articoli-frontaliere/vico-morcote-tragedia-bambino-pool',
+    canonicalPath: '/articoli-frontaliere/vico-morcote-tragedia-bambino-pool/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7349,7 +7349,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, limiti, smartphone, social, media',
     ogTitle: 'Limiti età smartphone e social media: Unicef spiega perché non bastano',
     ogDescription: 'Secondo Unicef, i limiti di età per smartphone e social media non sono sufficienti. Ecco perché la regolamentazione deve intervenire sulle piattaforme stesse.',
-    canonicalPath: '/articoli-frontaliere/limiti-eta-smartphone-social-media',
+    canonicalPath: '/articoli-frontaliere/limiti-eta-smartphone-social-media/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7377,7 +7377,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, volandia, battesimo, volo, elicottero',
     ogTitle: 'Volandia: battesimo del volo in elicottero torna nel 2026',
     ogDescription: 'Dal 1 al 3 maggio 2026, Volandia offre voli in elicottero per adulti e bambini, con prezzi fissati a 65 euro per gli adulti e 45 euro per i bambini.',
-    canonicalPath: '/articoli-frontaliere/volandia-battesimo-volo-elicottero-2026',
+    canonicalPath: '/articoli-frontaliere/volandia-battesimo-volo-elicottero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7405,7 +7405,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banche, svizzere, preparano, accoglienza',
     ogTitle: 'Banche svizzere preparano accoglienza clienti Golfo',
     ogDescription: 'Trasferimenti di fondi in corso verso la Svizzera da Paesi del Golfo a causa della guerra in Iran. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/banche-golfo-preparano-frontalieri',
+    canonicalPath: '/articoli-frontaliere/banche-golfo-preparano-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7433,7 +7433,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, storia, paperino, passa, cuasso',
     ogTitle: 'La storia di Paperino passa da Cuasso al Monte',
     ogDescription: 'Scopri il legame tra il padre italiano di Paperino e il Ticino durante la Seconda Guerra Mondiale',
-    canonicalPath: '/articoli-frontaliere/papa-paperino-cuasso-monte',
+    canonicalPath: '/articoli-frontaliere/papa-paperino-cuasso-monte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7461,7 +7461,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, venezia, torna, serie, pareggio',
     ogTitle: 'Venezia torna in Serie A con un pareggio contro lo Spezia',
     ogDescription: 'Il Venezia ottiene la promozione in Serie A con un pareggio 2-2 contro lo Spezia, grazie alla sconfitta del Monza',
-    canonicalPath: '/articoli-frontaliere/venezia-serie-a-promozione-2026',
+    canonicalPath: '/articoli-frontaliere/venezia-serie-a-promozione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7489,7 +7489,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, meloni, governo, secondo, longevo',
     ogTitle: 'Meloni: il mio Governo è il secondo più longevo della Repubblica',
     ogDescription: 'Il Governo Meloni supera i 1.000 giorni di durata, diventando il secondo più longevo della storia repubblicana. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/meloni-governo-longevo-2026',
+    canonicalPath: '/articoli-frontaliere/meloni-governo-longevo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7517,7 +7517,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, newsletter, gratuita, iscriviti, aggiornamenti',
     ogTitle: 'Newsletter gratuita: iscriviti per aggiornamenti su Ticino',
     ogDescription: 'Scopri come ricevere notizie quotidiane, settimanali e mensili sulla Svizzera e il Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/abbonamento-newsletter-ticino',
+    canonicalPath: '/articoli-frontaliere/abbonamento-newsletter-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7545,7 +7545,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, atleti, alla, salewa',
     ogTitle: 'Varese: 100 atleti alla Salewa Cube per la Coppa Italia Lead',
     ogDescription: 'Sabato 2 e domenica 3 maggio, la Salewa Cube di Varese ospita la seconda tappa della Coppa Italia Lead con 109 atleti tra i migliori della nazione.',
-    canonicalPath: '/articoli-frontaliere/varese-arrampicata-salewa-cube-2026',
+    canonicalPath: '/articoli-frontaliere/varese-arrampicata-salewa-cube-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7573,7 +7573,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, migros, immigrazione, necessaria, mario',
     ogTitle: 'Migros: «L\'immigrazione è necessaria per il Ticino»',
     ogDescription: 'Mario Irminger, CEO di Migros, si oppone all\'iniziativa UDC contro l\'immigrazione, sottolineando la sua importanza per il commercio al dettaglio in Ticino.',
-    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-2026',
+    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7601,7 +7601,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, viabilità, mezzi, pesanti',
     ogTitle: 'Nuova viabilità per mezzi pesanti a Travedona Monate',
     ogDescription: 'Dal 7 maggio 2026, i camion non potranno più circolare nel centro di Travedona Monate. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nuova-viabilit-travedona-monate-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-viabilit-travedona-monate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7629,7 +7629,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, graudio, flash, maggio, notizie',
     ogTitle: 'GrAudio Flash del 2 maggio 2026: notizie dal Canton Ticino',
     ogDescription: 'Le ultime notizie dal Canton Ticino e dintorni: eventi sportivi, cronaca locale e molto altro.',
-    canonicalPath: '/articoli-frontaliere/graudio-flash-2-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/graudio-flash-2-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7657,7 +7657,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, investimenti, immobiliari, viene, dall',
     ogTitle: 'Il 60% degli investimenti immobiliari in Italia viene dall’estero',
     ogDescription: 'Secondo Roberto Giovenco, COO di RINA Prime, il 60% degli investimenti immobiliari in Italia proviene dall\'estero, segnale di resilienza del Paese.',
-    canonicalPath: '/articoli-frontaliere/investimenti-immobiliari-italia-estero-2026',
+    canonicalPath: '/articoli-frontaliere/investimenti-immobiliari-italia-estero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7685,7 +7685,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carenza, carburante, rischio, alto',
     ogTitle: 'Carenza carburante Svizzera: rischio alto, ecco perché',
     ogDescription: 'Florence Schurch, Segretaria generale di Suissenégoce, avverte di un rischio elevato di carenza di carburante in Svizzera. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7713,7 +7713,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ermotti, diritto, dibattito, sergio',
     ogTitle: 'Ermotti respinge accuse lobbying UBS: \'Diritto di partecipare al dibattito\'',
     ogDescription: 'Il CEO di UBS Sergio Ermotti respinge le accuse di lobbying aggressivo e difende il diritto della banca a partecipare al dibattito sui fondi propri.',
-    canonicalPath: '/articoli-frontaliere/ermotti-respinge-accuse-lobbying-ubs',
+    canonicalPath: '/articoli-frontaliere/ermotti-respinge-accuse-lobbying-ubs/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7741,7 +7741,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, alex, zanardi, incidente',
     ogTitle: 'Addio ad Alex Zanardi: l\'incidente del 2001 che cambiò la sua vita',
     ogDescription: 'Ripercorriamo la vita straordinaria di Alex Zanardi, dal terribile incidente del 2001 alla sua rinascita sportiva.',
-    canonicalPath: '/articoli-frontaliere/addio-alex-zanardi-2001-incidente-vita',
+    canonicalPath: '/articoli-frontaliere/addio-alex-zanardi-2001-incidente-vita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7769,7 +7769,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caronno, varesino, inaugura, nuovo',
     ogTitle: 'Caronno Varesino inaugura il nuovo campetto in memoria di Dante Mercanti',
     ogDescription: 'Sabato 9 maggio alle 16 l\'inaugurazione del nuovo campo sportivo di via Macchi a Caronno Varesino, intitolato a Dante Mercanti.',
-    canonicalPath: '/articoli-frontaliere/caronno-varesino-campetto-dante-mercanti-2026',
+    canonicalPath: '/articoli-frontaliere/caronno-varesino-campetto-dante-mercanti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7797,7 +7797,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confederazione, valuta, sistemi, difesa',
     ogTitle: 'Confederazione valuta sistemi difesa aerea alternativi',
     ogDescription: 'La Confederazione svizzera valuta sistemi di difesa aerea alternativi a causa dei ritardi nei sistemi Patriot statunitensi.',
-    canonicalPath: '/articoli-frontaliere/confederazione-valuta-sistemi-difesa-aerea',
+    canonicalPath: '/articoli-frontaliere/confederazione-valuta-sistemi-difesa-aerea/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7825,7 +7825,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, penuria, carburante, rischio, molto',
     ogTitle: 'Penuria di carburante in Svizzera: rischio molto elevato',
     ogDescription: 'Florence Schurch di Suissenégoce avverte: le riserve strategiche di carburante potrebbero esaurirsi presto, con conseguenze gravi per la Svizzera.',
-    canonicalPath: '/articoli-frontaliere/penuria-carburante-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/penuria-carburante-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7853,7 +7853,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, christian, bagatin, trionfa, nella',
     ogTitle: 'Christian Bagatin vince la tappa regina del Giro di Turchia',
     ogDescription: 'Christian Bagatin, 23enne di Orino, conquista la prima vittoria da professionista nella sesta tappa del Giro di Turchia, arrivando in solitaria sul traguardo di',
-    canonicalPath: '/articoli-frontaliere/vittoria-bagatin-tappa-turchia',
+    canonicalPath: '/articoli-frontaliere/vittoria-bagatin-tappa-turchia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7881,7 +7881,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, taglio, accise, carburanti, prorogato',
     ogTitle: 'Taglio accise carburanti prorogato al 22 maggio',
     ogDescription: 'Il Consiglio dei ministri ha prorogato il taglio delle accise sui carburanti fino al 22 maggio 2026. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-22-maggio',
+    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-22-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7909,7 +7909,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, generatori, alla, ricostruzione, maxi',
     ogTitle: 'Dai generatori alla ricostruzione: il maxi piano svizzero per Kiev',
     ogDescription: 'Il delegato del Consiglio federale per l\'Ucraina, Jacques Gerber, illustra il programma di aiuti da 1,5 miliardi di franchi.',
-    canonicalPath: '/articoli-frontaliere/aiuti-svizzera-ucraina-2026',
+    canonicalPath: '/articoli-frontaliere/aiuti-svizzera-ucraina-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7937,7 +7937,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elettrici, lugano, problemi, ritardi',
     ogTitle: 'Bus elettrici a Lugano: problemi e ritardi',
     ogDescription: 'Scopri i problemi tecnici dei nuovi bus elettrici di Lugano e le soluzioni per migliorare il servizio di trasporto pubblico.',
-    canonicalPath: '/articoli-frontaliere/bus-elettrici-lugano-problemi-utenti',
+    canonicalPath: '/articoli-frontaliere/bus-elettrici-lugano-problemi-utenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7965,7 +7965,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, galà, sorriso, incanta, magia',
     ogTitle: 'Galà del Sorriso incanta Varese con magia e solidarietà',
     ogDescription: 'Grande successo per il Galà del Sorriso a Varese, con spettacoli di magia e raccolte fondi per le sale parto dell\'Ospedale Del Ponte',
-    canonicalPath: '/articoli-frontaliere/gala-sorriso-solidarieta-ospedale-del-ponte',
+    canonicalPath: '/articoli-frontaliere/gala-sorriso-solidarieta-ospedale-del-ponte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7993,7 +7993,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, rogo, ultimo, piano',
     ogTitle: 'Varese, rogo all\'ultimo piano di un palazzo: fiamme domate, nessun ferito',
     ogDescription: 'Incendio in un appartamento al piano sommitale di un palazzo a Varese, nessun ferito grazie all\'intervento tempestivo dei vigili del fuoco',
-    canonicalPath: '/articoli-frontaliere/varese-incendio-palazzo-frontalieri',
+    canonicalPath: '/articoli-frontaliere/varese-incendio-palazzo-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8021,7 +8021,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carenza, carburante, rischio, concreto',
     ogTitle: 'Carenza carburante Svizzera: rischio concreto per frontalieri',
     ogDescription: 'Florence Schurch di Suissenégoce lancia l\'allarme: prezzo petrolio a 150 dollari al barile e rischi per l\'approvvigionamento energetico',
-    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8049,7 +8049,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scontro, intervento, polizia, spray',
     ogTitle: 'Scontro e intervento di polizia con spray urticante in centro Lugano',
     ogDescription: 'Due gruppi di ragazzi si sono scontrati in centro Lugano, causando l\'intervento della polizia con spray urticante. Due persone ferite e soccorse.',
-    canonicalPath: '/articoli-frontaliere/scontro-polizia-lugano-spray-urticante',
+    canonicalPath: '/articoli-frontaliere/scontro-polizia-lugano-spray-urticante/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8077,7 +8077,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, saronno, licenza, sospesa, dopo',
     ogTitle: 'Saronno: licenza sospesa per bar dopo rissa',
     ogDescription: 'La licenza di un bar a Saronno è stata sospesa dopo una rissa. Ecco cosa è successo e le implicazioni per la zona.',
-    canonicalPath: '/articoli-frontaliere/saronno-bar-licenza-sospesa-rissa',
+    canonicalPath: '/articoli-frontaliere/saronno-bar-licenza-sospesa-rissa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8105,7 +8105,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, movieri, azione, domenica, traffico',
     ogTitle: 'Movieri in azione domenica per il traffico record sul Lago di Como',
     ogDescription: 'Servizio straordinario degli osservatori del traffico domenica 3 maggio lungo la SS 340 Regina per gestire l\'afflusso turistico previsto',
-    canonicalPath: '/articoli-frontaliere/movieri-traffico-ss340-2026',
+    canonicalPath: '/articoli-frontaliere/movieri-traffico-ss340-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8133,7 +8133,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, doppietta, sant, antonino, cosa',
     ogTitle: 'Doppietta frontalieri a Sant\'Antonino: cosa cambia',
     ogDescription: 'A Sant\'Antonino, sempre più frontalieri scelgono la doppietta: lavoro in Svizzera e residenza in Italia. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/doppietta-frontalieri-santonino-2026',
+    canonicalPath: '/articoli-frontaliere/doppietta-frontalieri-santonino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8161,7 +8161,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, taglio, accise, carburanti, diesel',
     ogTitle: 'Taglio accise carburanti: diesel a sconto pieno, benzina ridotto',
     ogDescription: 'Il governo proroga il taglio delle accise sui carburanti, con sconto pieno sul diesel e ridotto sulla benzina. Scopri cosa cambia e come ti riguarda.',
-    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8189,7 +8189,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, yoga, meditazione, passeggiate',
     ogTitle: 'Como: yoga, meditazione e passeggiate nella villa sul lago',
     ogDescription: 'La rassegna \'Coltiviamo l’Energia\' torna a Villa del Grumello con yoga, meditazione e passeggiate nel parco storico affacciato sul lago.',
-    canonicalPath: '/articoli-frontaliere/yoga-meditazione-villa-lago-como',
+    canonicalPath: '/articoli-frontaliere/yoga-meditazione-villa-lago-como/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8217,7 +8217,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, cantù, uniscono, forze',
     ogTitle: 'Como e Cantù uniscono le forze per la Lake Como Creativity Week',
     ogDescription: 'I comuni di Como e Cantù collaborano per la Lake Como Creativity Week, con un accordo triennale firmato il 7 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/como-cantu-creativity-week-2026',
+    canonicalPath: '/articoli-frontaliere/como-cantu-creativity-week-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8245,7 +8245,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, commercio, dettaglio, mini-flessione, ricavi',
     ogTitle: 'Commercio al dettaglio: mini-flessione dei ricavi in marzo',
     ogDescription: 'Marzo 2026: stabilità per i negozi svizzeri, ma calo dello 0,1% del giro d\'affari rispetto al 2025. Dati UST.',
-    canonicalPath: '/articoli-frontaliere/commercio-al-dettaglio-mini-flessione-marzo-2026',
+    canonicalPath: '/articoli-frontaliere/commercio-al-dettaglio-mini-flessione-marzo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8273,7 +8273,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rissa, lugano, feriti, alla',
     ogTitle: 'Rissa a Lugano: due feriti alla Pensilina Botta',
     ogDescription: 'Un tumulto sedato dalla polizia ha coinvolto due persone ferite in un incidente alla Pensilina Botta di Lugano.',
-    canonicalPath: '/articoli-frontaliere/rissa-lugano-pensilina-botta-feriti-2026',
+    canonicalPath: '/articoli-frontaliere/rissa-lugano-pensilina-botta-feriti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8301,7 +8301,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rissa, lugano, durante, primo',
     ogTitle: 'Rissa a Lugano durante il Primo Maggio: spray urticante per calmare i disordini',
     ogDescription: 'Disordini a Lugano durante il Primo Maggio con due feriti lievi e intervento della polizia con spray urticante.',
-    canonicalPath: '/articoli-frontaliere/rissa-lugano-primo-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/rissa-lugano-primo-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8329,7 +8329,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attivo, nuovo, servizio, vittime',
     ogTitle: 'Attivo il 142: nuovo servizio per le vittime di violenza',
     ogDescription: 'Dal 1° maggio 2026 è operativo il numero 142 per le vittime di violenza in Ticino. Scopri come funziona e cosa cambia.',
-    canonicalPath: '/articoli-frontaliere/protezione-vittime-142-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/protezione-vittime-142-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8357,7 +8357,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, golasecca, escursionisti, alla, scoperta',
     ogTitle: 'Golasecca: 140 escursionisti alla scoperta dei luoghi più belli',
     ogDescription: 'Una giornata di cammino di 13 km attraverso i luoghi più suggestivi di Golasecca, con aperitivo, pranzo e merenda. Partecipanti ricevono gadget e defibrillatore',
-    canonicalPath: '/articoli-frontaliere/golasecca-esplorazione-passeggiata-2026',
+    canonicalPath: '/articoli-frontaliere/golasecca-esplorazione-passeggiata-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8385,7 +8385,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, marcia, zurigo, voce, disabilità',
     ogTitle: 'In marcia dal Ticino a Zurigo: la voce della disabilità chiede uguaglianza',
     ogDescription: 'Una ventina di persone dal Ticino partecipano alla manifestazione nazionale per l\'uguaglianza delle persone con disabilità a Zurigo',
-    canonicalPath: '/articoli-frontaliere/marcia-zurigo-disabilita-uguaglianza',
+    canonicalPath: '/articoli-frontaliere/marcia-zurigo-disabilita-uguaglianza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8413,7 +8413,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, posti, moto, como',
     ogTitle: 'Nuovi posti moto a Como: sosta vietata durante le partite del Como',
     ogDescription: 'La polizia locale ha attivato il carro attrezzi per rimuovere le moto parcheggiate illegalmente durante le partite del Como.',
-    canonicalPath: '/articoli-frontaliere/nuovi-posti-moto-lago-como',
+    canonicalPath: '/articoli-frontaliere/nuovi-posti-moto-lago-como/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8441,7 +8441,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guardia, medica, somma, lombardo',
     ogTitle: 'Guardia medica Somma Lombardo si sposta a Lonate Pozzolo',
     ogDescription: 'Il servizio di continuità assistenziale si trasferisce temporaneamente a Lonate Pozzolo fino a luglio per lavori.',
-    canonicalPath: '/articoli-frontaliere/guardia-medica-somma-lombardo-lonate-pozzolo',
+    canonicalPath: '/articoli-frontaliere/guardia-medica-somma-lombardo-lonate-pozzolo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8469,7 +8469,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, prima, panchina, bianca',
     ogTitle: 'Varese, prima panchina bianca contro abusi minori',
     ogDescription: 'Inaugurata a Varese la prima panchina bianca dedicata al numero 114 per la protezione dei minori, in occasione della Giornata nazionale contro la pedofilia e la',
-    canonicalPath: '/articoli-frontaliere/panchina-bianca-varese-2026',
+    canonicalPath: '/articoli-frontaliere/panchina-bianca-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8497,7 +8497,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, chiese, arrestati, rumeni',
     ogTitle: 'Furti in chiese: arrestati due rumeni nel Bellinzonese',
     ogDescription: 'Due cittadini rumeni sono stati arrestati per furti in chiese nel Bellinzonese. Scopri i dettagli dell\'operazione e cosa fare se sei stato vittima di un furto',
-    canonicalPath: '/articoli-frontaliere/furti-chiese-bellinzonese-arresti-2026',
+    canonicalPath: '/articoli-frontaliere/furti-chiese-bellinzonese-arresti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8525,7 +8525,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, milano-brescia, deviazione, obbligatoria, verso',
     ogTitle: 'A4 Milano-Brescia: deviazione obbligatoria verso Varese dal 5 al 6 maggio 2026',
     ogDescription: 'Dalla notte tra il 5 e il 6 maggio 2026, la A4 Milano-Brescia sarà chiusa per lavori. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-diviazione-obbligatoria-2026',
+    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-diviazione-obbligatoria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8553,7 +8553,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, editto, canonizzazione, roberto, malgesini',
     ogTitle: 'Editto canonizzazione Don Roberto Malgesini: cosa succede ora',
     ogDescription: 'Pubblicato l\'editto per la canonizzazione di Don Roberto Malgesini, ucciso nel 2020. Ecco i prossimi passi e cosa chiede la Diocesi di Como',
-    canonicalPath: '/articoli-frontaliere/editto-canonizzazione-don-roberto-malgesini',
+    canonicalPath: '/articoli-frontaliere/editto-canonizzazione-don-roberto-malgesini/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8581,7 +8581,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beat, jans, iniziativa, milioni',
     ogTitle: 'Beat Jans e l’iniziativa 10 milioni: tutto in regola?',
     ogDescription: 'Il consigliere federale Beat Jans è sotto indagine per presunte violazioni delle regole della comunicazione istituzionale nella campagna contro l’iniziativa',
-    canonicalPath: '/articoli-frontaliere/beat-jans-10-milioni-comunicazione',
+    canonicalPath: '/articoli-frontaliere/beat-jans-10-milioni-comunicazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8609,7 +8609,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusa, sesto, monza, notti',
     ogTitle: 'A4 Milano-Brescia chiusa tra Sesto San Giovanni e Monza: tutte le notti interessate',
     ogDescription: 'Chiusura notturna del tratto tra Sesto San Giovanni e Monza per lavori alle barriere di sicurezza. Percorsi alternativi segnalati.',
-    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-chiusura-notturna-2026',
+    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-chiusura-notturna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8637,7 +8637,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giannino, landoni, fagnano, olona',
     ogTitle: 'Via Giannino Landoni a Fagnano Olona: verso l\'inaugurazione',
     ogDescription: 'L\'iter amministrativo per l\'intitolazione della via a Giannino Landoni è concluso. Si attende la data ufficiale della cerimonia.',
-    canonicalPath: '/articoli-frontaliere/via-giannino-landoni-fagnano-olona-inaugurazione',
+    canonicalPath: '/articoli-frontaliere/via-giannino-landoni-fagnano-olona-inaugurazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8665,7 +8665,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scontri, lugano, pensilina, valenzano',
     ogTitle: 'Scontri Lugano Pensilina: Valenzano Rossi, «C\'è molta preoccupazione»',
     ogDescription: 'Due feriti lievi, ma la matrice politica degli scontri preoccupa le autorità luganesi. Karin Valenzano Rossi: «Non c\'entra la movida»',
-    canonicalPath: '/articoli-frontaliere/scontri-lugano-pensilina-2024',
+    canonicalPath: '/articoli-frontaliere/scontri-lugano-pensilina-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8693,7 +8693,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gordola, nuovo, ricorso, blocca',
     ogTitle: 'Gordola, nuovo ricorso blocca Santa Maria',
     ogDescription: 'Il Municipio di Gordola prepara la difesa contro il ricorso che blocca il piano del comparto Santa Maria, approvato dopo 30 anni',
-    canonicalPath: '/articoli-frontaliere/gordola-santa-maria-ricorso-2026',
+    canonicalPath: '/articoli-frontaliere/gordola-santa-maria-ricorso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8721,7 +8721,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vino, amaro, vallese, provins',
     ogTitle: 'Vino amaro in Vallese: Provins SA annuncia perdite e misure drastiche',
     ogDescription: 'Provins SA, azienda chiave della viticoltura vallesana, annuncia una perdita di 6 milioni di franchi per il 2025 e misure drastiche per adattarsi alla crisi del',
-    canonicalPath: '/articoli-frontaliere/vino-amaro-vallese-2026',
+    canonicalPath: '/articoli-frontaliere/vino-amaro-vallese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8749,7 +8749,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beatificazione, roberto, malgesini, avvia',
     ogTitle: 'Beatificazione don Roberto Malgesini: avvia l\'iter la Diocesi di Como',
     ogDescription: 'La Diocesi di Como ha avviato il processo per la beatificazione di don Roberto Malgesini, ucciso nel 2020. Scopri come contribuire.',
-    canonicalPath: '/articoli-frontaliere/beatificazione-don-roberto-malgesini-2026',
+    canonicalPath: '/articoli-frontaliere/beatificazione-don-roberto-malgesini-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8777,7 +8777,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, segrino, alle, piazzole',
     ogTitle: 'Lago Segrino: No alle 105 piazzole per camper, distesa d\'asfalto',
     ogDescription: 'Il Circolo Ambiente \'Ilaria Alpi\' si oppone al progetto di 105 piazzole per camper a Canzo vicino al Lago di Segrino, un sito di importanza comunitaria.',
-    canonicalPath: '/articoli-frontaliere/lago-segrino-camper-2026',
+    canonicalPath: '/articoli-frontaliere/lago-segrino-camper-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8805,7 +8805,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cavalli, esercito, svizzero, costi',
     ogTitle: 'Cavalli esercito svizzero: costi in aumento',
     ogDescription: 'L\'esercito svizzero spenderà 3,8 milioni di franchi per i cavalli dal 2026 al 2028, con critiche alla gestione delle risorse',
-    canonicalPath: '/articoli-frontaliere/cavalli-esercito-svizzero-costi',
+    canonicalPath: '/articoli-frontaliere/cavalli-esercito-svizzero-costi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8832,7 +8832,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sconfitta, dalla, finlandia, nell',
     ogTitle: 'Svizzera sconfitta dalla Finlandia nell\'Euro Hockey Tour',
     ogDescription: 'La nazionale svizzera di hockey su ghiaccio perde 5-3 contro la Finlandia. Prossimo avversario la Repubblica Ceca.',
-    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-finlandia',
+    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-finlandia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8860,7 +8860,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, insiste, sulla, sfiducia',
     ogTitle: 'Pd Como insiste sulla sfiducia a Maccabeo: "Mancanza di responsabilità politica"',
     ogDescription: 'Il Partito Democratico di Como non molla sulla mozione di sfiducia all\'assessore Maccabeo, bocciata in consiglio comunale.',
-    canonicalPath: '/articoli-frontaliere/pd-como-sfiducia-maccabeo-2026',
+    canonicalPath: '/articoli-frontaliere/pd-como-sfiducia-maccabeo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8888,7 +8888,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, patriot, ritardo, berna, valuta',
     ogTitle: 'Patriot in ritardo, Berna valuta altri sistemi',
     ogDescription: 'La Svizzera cerca alternative ai sistemi Patriot in ritardo, interpellando Germania, Francia, Israele e Corea del Sud.',
-    canonicalPath: '/articoli-frontaliere/patriot-ritardo-svizzera-valuta-alternative',
+    canonicalPath: '/articoli-frontaliere/patriot-ritardo-svizzera-valuta-alternative/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8916,7 +8916,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bambini, elementari, visita, carabinieri',
     ogTitle: 'Bambini in visita dai Carabinieri di Como',
     ogDescription: '38 alunni della scuola primaria Nazario Sauro hanno visitato la caserma dei Carabinieri di Como nell\'ambito della campagna \'Cultura della Legalità\'.',
-    canonicalPath: '/articoli-frontaliere/bambini-carabinieri-como-2026',
+    canonicalPath: '/articoli-frontaliere/bambini-carabinieri-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8944,7 +8944,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, malpensa, terminal, intervento',
     ogTitle: 'Incendio Malpensa Terminal 1: intervento Vigili del Fuoco',
     ogDescription: 'Un corto circuito ha causato un principio di incendio al Terminal 1 di Malpensa il 2 maggio 2026. Nessun ferito. Procedure di sicurezza per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incendio-malpensa-terminal-1-2-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/incendio-malpensa-terminal-1-2-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8972,7 +8972,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, parcheggio, abusivo, parco',
     ogTitle: 'Parcheggio abusivo a Como nel parco di Villa Olmo',
     ogDescription: 'Numerose auto, tra cui una ticinese, parcheggiate illegalmente nel parco di Villa Olmo e sui marciapiedi di Como.',
-    canonicalPath: '/articoli-frontaliere/parcheggio-abusivo-como-villa-olmo',
+    canonicalPath: '/articoli-frontaliere/parcheggio-abusivo-como-villa-olmo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9000,7 +9000,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, amplia, caccia, agli, evasori',
     ogTitle: 'Svizzera amplia la caccia agli evasori fiscali: coinvolti 110 Paesi',
     ogDescription: 'Le autorità elvetiche monitorano anche gli svizzeri in Thailandia. Quasi 7mila richieste di assistenza dall\'estero nel 2025.',
-    canonicalPath: '/articoli-frontaliere/svizzera-caccia-evasori-fiscali-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-caccia-evasori-fiscali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9033,7 +9033,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, landsgemeinde, glarona, austerità, ambiente',
     ogTitle: 'Landsgemeinde di Glarona: austerità e ambiente al voto',
     ogDescription: 'Gli elettori di Glarona decidono su tagli alla spesa pubblica, nuove tasse ambientali e alloggi accessibili nella storica assemblea.',
-    canonicalPath: '/articoli-frontaliere/landsgemeinde-glarona-2026',
+    canonicalPath: '/articoli-frontaliere/landsgemeinde-glarona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9066,7 +9066,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, interpellanza, municipio, costi, aeroporto',
     ogTitle: 'Interpellanza al Municipio: costi aeroporto Lugano-Agno',
     ogDescription: 'Le consigliere comunali criticano la gestione finanziaria e i ritardi nei piani di sviluppo dello scalo ticinese di Lugano-Agno',
-    canonicalPath: '/articoli-frontaliere/aeroporto-lugano-costi-interpellanza',
+    canonicalPath: '/articoli-frontaliere/aeroporto-lugano-costi-interpellanza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9099,7 +9099,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agricoltura, crisi, grido, allarme',
     ogTitle: 'Agricoltura in crisi: il grido d\'allarme degli agricoltori ticinesi',
     ogDescription: 'Cambiamenti climatici, lupi e costi crescenti mettono in ginocchio il settore agricolo ticinese. Ecco cosa sta succedendo',
-    canonicalPath: '/articoli-frontaliere/agricoltura-ticino-allarme-2024',
+    canonicalPath: '/articoli-frontaliere/agricoltura-ticino-allarme-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9132,7 +9132,7 @@ const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, seco, blocca, accesso, atti',
     ogTitle: 'SECO blocca accesso atti trattative con Washington',
     ogDescription: 'La SECO mantiene segreti i documenti sulle trattative con gli USA sui dazi, rischiando una causa in tribunale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/seco-dazi-segreti-washington',
+    canonicalPath: '/articoli-frontaliere/seco-dazi-segreti-washington/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",

--- a/services/seo/seo-blog.ts
+++ b/services/seo/seo-blog.ts
@@ -17,7 +17,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto frontaliere 2026, calcolo stipendio svizzera, deduzioni avs lpp, imposta alla fonte ticino, nuovo accordo fiscale frontalieri, stipendio lordo netto svizzera',
  ogTitle: 'Stipendio Netto Frontaliere 2026 | Calcolo Completo',
  ogDescription: 'Guida completa al calcolo dello stipendio netto per frontalieri: deduzioni svizzere, IRPEF, nuovo accordo fiscale corrente.',
- canonicalPath: '/articoli-frontaliere/stipendio-netto-frontaliere-2026',
+ canonicalPath: '/articoli-frontaliere/stipendio-netto-frontaliere-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -41,7 +41,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'lamal frontaliere, cmi frontaliere, assicurazione sanitaria frontaliere, diritto opzione lamal, cassa malati svizzera, ssn frontaliere, confronto lamal cmi',
  ogTitle: 'LAMal vs CMI | Assicurazione Sanitaria Frontaliere',
  ogDescription: 'Confronto completo LAMal vs CMI per frontalieri: costi, copertura, diritto di opzione. Quale conviene?',
- canonicalPath: '/articoli-frontaliere/lamal-vs-cmi-frontaliere',
+ canonicalPath: '/articoli-frontaliere/lamal-vs-cmi-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -66,7 +66,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'primo giorno frontaliere, checklist frontaliere, documenti lavoro svizzera, permesso g primo giorno, dogana primo giorno, consigli frontaliere',
  ogTitle: 'Primo Giorno da Frontaliere | Checklist Completa',
  ogDescription: 'Checklist per il primo giorno di lavoro in Svizzera: documenti, dogana, conto bancario e consigli pratici.',
- canonicalPath: '/articoli-frontaliere/primo-giorno-lavoro-svizzera',
+ canonicalPath: '/articoli-frontaliere/primo-giorno-lavoro-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -91,7 +91,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tredicesima frontaliere, tredicesima netta svizzera, 13esima mensilità frontaliere, deduzioni tredicesima, calcolo tredicesima netta',
  ogTitle: 'Tredicesima Frontaliere Netta | Come Calcolarla',
  ogDescription: 'Come calcolare la tredicesima netta da frontaliere: deduzioni svizzere e impatto fiscale italiano.',
- canonicalPath: '/articoli-frontaliere/tredicesima-netta-frontaliere',
+ canonicalPath: '/articoli-frontaliere/tredicesima-netta-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -116,7 +116,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'terzo pilastro frontaliere, pilastro 3a frontaliere, previdenza privata svizzera, massimale 3a 2026, fondo pensione frontaliere, investimenti frontaliere',
  ogTitle: 'Terzo Pilastro 3a Frontaliere | Conviene?',
  ogDescription: 'Il terzo pilastro 3a conviene al frontaliere? Analisi vantaggi fiscali, massimale 2026 e alternative.',
- canonicalPath: '/articoli-frontaliere/terzo-pilastro-3a-frontaliere',
+ canonicalPath: '/articoli-frontaliere/terzo-pilastro-3a-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -141,7 +141,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'migliori comuni frontalieri, dove vivere frontaliere, comuni frontiera italia svizzera, affitti comuni frontiera, irpef comunale frontaliere, comuni como varese',
  ogTitle: 'Migliori Comuni per Frontalieri 2026 | Classifica',
  ogDescription: 'Top 10 comuni italiani per frontalieri: affitti, tasse comunali, distanza dal confine. Trova il tuo comune ideale.',
- canonicalPath: '/articoli-frontaliere/migliori-comuni-frontalieri',
+ canonicalPath: '/articoli-frontaliere/migliori-comuni-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -166,7 +166,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo vita ticino, costo vita lombardia, confronto svizzera italia costi, affitti lugano como, spesa svizzera italia, trasporti frontaliere costi',
  ogTitle: 'Costo della Vita Ticino vs Lombardia 2026',
  ogDescription: 'Confronto dettagliato dei costi: affitti, spesa, trasporti e sanità tra Ticino e Lombardia per frontalieri.',
- canonicalPath: '/articoli-frontaliere/costo-vita-ticino-vs-lombardia',
+ canonicalPath: '/articoli-frontaliere/costo-vita-ticino-vs-lombardia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -191,7 +191,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tassa salute, ristorni, frontalieri, ticino, italia, accordo fiscale, lavoro transfrontaliero, lega dei ticinesi',
  ogTitle: 'Tassa Salute e Ticino: Tensioni',
  ogDescription: 'La tassa sulla salute tra Italia e Ticino genera tensioni. Scopri le implicazioni per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-aumentano-tensioni-ticino',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-aumentano-tensioni-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -216,7 +216,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'comprare casa italia, frontaliere ticino, immobiliare confine, costo vita ticino, prezzi case lombardia, pendolare svizzera italia, trasferirsi italia',
  ogTitle: 'Comprare Casa in Italia: Quando il Ticino è Troppo Caro',
  ogDescription: 'Sempre più ticinesi si trasferiscono in Italia per comprare casa. Scopri vantaggi, sfide e costi del pendolarismo.',
- canonicalPath: '/articoli-frontaliere/comprare-casa-italia-confine-ticino',
+ canonicalPath: '/articoli-frontaliere/comprare-casa-italia-confine-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -241,7 +241,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'franco forte, cambio CHF EUR, stipendio frontalieri, tasso cambio 2026, franco svizzero euro, frontalieri ticino stipendio, conversione franchi euro',
  ogTitle: 'Franco Forte: Come Cambia lo Stipendio dei Frontalieri',
  ogDescription: 'Il CHF si rafforza: effetti diretti sullo stipendio netto dei frontalieri. Calcola l\'impatto con il simulatore.',
- canonicalPath: '/articoli-frontaliere/franco-forte-effetti-stipendio-frontalieri',
+ canonicalPath: '/articoli-frontaliere/franco-forte-effetti-stipendio-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -266,7 +266,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, CU 2026, certificazione unica, telelavoro, accordo italia svizzera, franchigia fiscale, scadenze fiscali',
  ogTitle: 'CU 2026: Cosa cambia per i Frontalieri?',
  ogDescription: 'Scadenze, telelavoro (25%), 45 giorni senza rientro: tutte le novità per i frontalieri ticinesi!',
- canonicalPath: '/articoli-frontaliere/cu-2026-scadenze-telelavoro-frontalieri',
+ canonicalPath: '/articoli-frontaliere/cu-2026-scadenze-telelavoro-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -296,7 +296,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, telelavoro, italia, svizzera, accordo, fiscale, imposizione',
  ogTitle: 'Telelavoro: Italia-Svizzera, accordo OK!',
  ogDescription: 'Telelavoro fino al 25%? Italia ratifica l\'accordo con la Svizzera. Scopri cosa cambia per il tuo stipendio da frontaliere.',
- canonicalPath: '/articoli-frontaliere/telelavoro-italia-svizzera-ratifica',
+ canonicalPath: '/articoli-frontaliere/telelavoro-italia-svizzera-ratifica/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -326,7 +326,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'telelavoro frontalieri, accordo italia svizzera, ratifica telelavoro, frontalieri ticino, smart working, fiscalità frontalieri, lavoro da casa',
  ogTitle: 'Telelavoro Frontalieri: L\'Italia dice SÌ. Ecco le nuove regole',
  ogDescription: 'È ufficiale: l\'accordo sul telelavoro fino al 40% è legge. Scopri subito cosa significa per il tuo stipendio e le tue tasse come frontaliere in Ticino.',
- canonicalPath: '/articoli-frontaliere/telelavoro-frontalieri-accordo-italia-svizzera-ratifica-definitiva',
+ canonicalPath: '/articoli-frontaliere/telelavoro-frontalieri-accordo-italia-svizzera-ratifica-definitiva/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -356,7 +356,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tassa salute frontalieri, stop ristorni, accordo fiscale italia svizzera, mozione ticino, frontalieri ticino, imposta alla fonte, doppio imposizione',
  ogTitle: 'Tassa Salute: il Ticino pronto a bloccare i soldi per l\'Italia',
  ogDescription: 'Quattro partiti ticinesi uniti: la tassa sulla salute viola gli accordi. Chiesto lo stop immediato al versamento dei ristorni fiscali a Roma.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-ticino-chiede-stop-ristorni-italia',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-ticino-chiede-stop-ristorni-italia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -386,7 +386,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, telelavoro svizzera, accordo fiscale italia svizzera, cu 2026, franchigia 10000 euro, 45 giorni non rientro, tassazione frontalieri',
  ogTitle: 'Telelavoro frontalieri 2026: regole, 25% e 45 giorni',
  ogDescription: 'Il nuovo accordo è legge: scopri come funzionano la soglia del 25% per lo smart working e la flessibilità sui rientri per chi lavora in Ticino. Tutte le novità.',
- canonicalPath: '/articoli-frontaliere/frontalieri-cu-2026-telelavoro-45-giorni-regole-definitive',
+ canonicalPath: '/articoli-frontaliere/frontalieri-cu-2026-telelavoro-45-giorni-regole-definitive/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -416,7 +416,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'smood chiude, lavoro ticino, frontalieri, licenziamento collettivo, syndicom, piano sociale, mercato lavoro ticino, delivery',
  ogTitle: 'Smood chiude in Ticino: cosa succede ora ai lavoratori?',
  ogDescription: 'La piattaforma di delivery cessa le attività dal 30 aprile 2026. Un\'analisi sull\'impatto occupazionale e sulle tutele previste per i dipendenti.',
- canonicalPath: '/articoli-frontaliere/smood-chiude-attivita-ticino-impatto-lavoro-frontalieri',
+ canonicalPath: '/articoli-frontaliere/smood-chiude-attivita-ticino-impatto-lavoro-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -446,7 +446,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'disoccupazione svizzera, lavoro ticino, frontalieri, seco, mercato del lavoro, stipendio ticino, edilizia svizzera, ristorazione ticino',
  ogTitle: 'Mercato del Lavoro Svizzero: Segnali Contrastanti a Gennaio',
  ogDescription: 'La disoccupazione grezza sale al 3.2%, ma i dati depurati migliorano. Focus sul Ticino (3.3%) e sui settori chiave per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/disoccupazione-svizzera-gennaio-2026-dati-ticino-frontalieri',
+ canonicalPath: '/articoli-frontaliere/disoccupazione-svizzera-gennaio-2026-dati-ticino-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -476,7 +476,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'riscaldamento ticino, pompa di calore, norme energetiche RUEn, frontalieri proprietari casa, risparmio energetico, Christian Bernasconi, Calor Tech, bollette ticino',
  ogTitle: 'Bollette del riscaldamento troppo alte? La soluzione in Ticino',
  ogDescription: 'Molti impianti in Ticino hanno più di 15 anni. Con le nuove regole 2026, è ora di agire. Scopri come una consulenza gratuita può farti risparmiare.',
- canonicalPath: '/articoli-frontaliere/riscaldamento-casa-ticino-norme-energetiche-risparmio',
+ canonicalPath: '/articoli-frontaliere/riscaldamento-casa-ticino-norme-energetiche-risparmio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -506,7 +506,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'sostituzione caldaia ticino, pompa di calore ticino, norme energetiche RUEn, incentivi riscaldamento, risparmio energetico, frontalieri ticino, calor tech',
  ogTitle: 'La tua caldaia in Ticino ha più di 15 anni? Attenzione alle nuove norme 2026',
  ogDescription: 'Con le nuove regole energetiche (RUEn) del 2026, molti impianti in Ticino non saranno più efficienti. Scopri come agire e risparmiare migliaia di franchi.',
- canonicalPath: '/articoli-frontaliere/sostituzione-caldaia-ticino-norme-2026-risparmio',
+ canonicalPath: '/articoli-frontaliere/sostituzione-caldaia-ticino-norme-2026-risparmio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -536,7 +536,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, mostra fotografica, confine svizzera, valichi di confine, Gabriele Spalluto, hic sunt leones, lavoro in svizzera',
  ogTitle: 'I 175 volti del confine: una mostra che parla ai frontalieri',
  ogDescription: 'Gabriele Spalluto ha fotografato tutti i valichi svizzeri. Un viaggio visivo che esplora il significato del confine per chi lo attraversa ogni giorno.',
- canonicalPath: '/articoli-frontaliere/mostra-hic-sunt-leones-confini-svizzera-frontalieri',
+ canonicalPath: '/articoli-frontaliere/mostra-hic-sunt-leones-confini-svizzera-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -593,7 +593,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, bambini lugano, vacanze carnevale 2026, museo in erba, laboratori creativi, famiglie frontalieri, attività bambini ticino',
  ogTitle: 'Vacanze di Carnevale 2026: cosa fare con i figli in Ticino?',
  ogDescription: 'Il Museo in erba di Lugano propone una settimana di laboratori creativi per bambini. Scopri date, costi e come prenotare.',
- canonicalPath: '/articoli-frontaliere/carnevale-2026-lugano-laboratori-creativi-figli-frontalieri',
+ canonicalPath: '/articoli-frontaliere/carnevale-2026-lugano-laboratori-creativi-figli-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -650,7 +650,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra arte ticino, frontalieri, lac lugano, masi lugano, sentimento e osservazione, cultura ticino, cosa fare lugano',
  ogTitle: 'Oltre il Lavoro: L\'Arte che Svela la Vera Anima del Ticino',
  ogDescription: 'Una mostra imperdibile al LAC di Lugano per capire a fondo la cultura del cantone dove lavori ogni giorno. Dal 18 aprile 2025.',
- canonicalPath: '/articoli-frontaliere/mostra-arte-ticino-sentimento-osservazione-lac-lugano',
+ canonicalPath: '/articoli-frontaliere/mostra-arte-ticino-sentimento-osservazione-lac-lugano/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -707,7 +707,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'arca russa chiasso, cinema chiasso, eventi culturali ticino, frontalieri como, frontalieri varese, cultura mendrisiotto, sokurov',
  ogTitle: 'Un capolavoro del cinema a due passi dal confine: Arca Russa a Chiasso',
  ogDescription: 'Non solo lavoro: il 18 febbraio 2026 il grande cinema di Sokurov arriva a Chiasso. Un\'occasione unica per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/arca-russa-chiasso-evento-culturale-frontalieri',
+ canonicalPath: '/articoli-frontaliere/arca-russa-chiasso-evento-culturale-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -764,7 +764,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra fotografica ticino, rsi eventi, storia svizzera italiana, frontalieri cultura, caseificio gottardo airolo, eventi gratuiti ticino, leventina, airolo',
  ogTitle: 'Un viaggio nel tempo in Ticino: la mostra gratuita della RSI che ogni frontaliere dovrebbe vedere',
  ogDescription: 'Dal 16 al 22 febbraio ad Airolo, la RSI espone la storia del Ticino in foto. Un\'occasione per capire il presente del Cantone. Ingresso libero.',
- canonicalPath: '/articoli-frontaliere/mostra-rsi-storia-ticino-frontalieri',
+ canonicalPath: '/articoli-frontaliere/mostra-rsi-storia-ticino-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -821,7 +821,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'carnevale bambini ticino, laboratori creativi lugano, vacanze scolastiche, frontalieri figli, museo in erba, attività famiglie ticino, jean tinguely',
  ogTitle: 'Figli a casa per Carnevale? A Lugano laboratori d\'arte a 20 CHF',
  ogDescription: 'Il Museo in erba organizza una settimana di atelier creativi per bambini durante le vacanze di Carnevale 2026. Una soluzione perfetta per i genitori frontalieri.',
- canonicalPath: '/articoli-frontaliere/vacanze-carnevale-bambini-ticino-laboratori-museo-erba-lugano',
+ canonicalPath: '/articoli-frontaliere/vacanze-carnevale-bambini-ticino-laboratori-museo-erba-lugano/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -878,7 +878,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra arte ticino, daniela rebuzzi, caslano eventi, frontalieri tempo libero, cultura ticino, cosa fare lugano, arte contemporanea, malcantone',
  ogTitle: 'Un\'artista ticinese di fama mondiale espone a Caslano: da non perdere',
  ogDescription: 'Dal 16 gennaio 2026, la mostra gratuita di Daniela Rebuzzi, reduce dalla Biennale di Venezia. Un\'occasione culturale unica per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/mostra-daniela-rebuzzi-caslano-arte-ticino',
+ canonicalPath: '/articoli-frontaliere/mostra-daniela-rebuzzi-caslano-arte-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -935,7 +935,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'arte ticino, mostra agno, gloria guidi nobile, corpi in prestito, cultura frontalieri, tempo libero ticino, eventi luganese',
  ogTitle: 'Oltre il lavoro: una mostra a Agno che fa riflettere',
  ogDescription: '"Corpi in prestito": l\'arte di Gloria Guidi Nobile in una sede unica a Serocca d\'Agno. Un\'occasione per vivere il Ticino in modo diverso.',
- canonicalPath: '/articoli-frontaliere/mostra-arte-corpi-in-prestito-agno-ticino',
+ canonicalPath: '/articoli-frontaliere/mostra-arte-corpi-in-prestito-agno-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -992,7 +992,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra RSI Ticino, frontalieri, cultura Ticino, storia Svizzera italiana, evento Airolo, fotografia archivio RSI, Caseificio Gottardo',
  ogTitle: 'RSI in mostra: un viaggio gratuito nella storia del Ticino ad Airolo',
  ogDescription: 'Dal 16 al 22 febbraio 2026, l\'ultima tappa della mostra fotografica RSI ad Airolo per scoprire l\'evoluzione del Cantone. Ingresso libero.',
- canonicalPath: '/articoli-frontaliere/rsi-mostra-storia-svizzera-italiana-foto-archivio-airolo',
+ canonicalPath: '/articoli-frontaliere/rsi-mostra-storia-svizzera-italiana-foto-archivio-airolo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -1049,7 +1049,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra arte ticino, rauschenberg bruzella, fondazione rolla, mendrisiotto eventi, cosa fare ticino frontalieri, arte gratuita svizzera, valle di muggio',
  ogTitle: 'Rauschenberg in Ticino: una mostra gratuita a due passi dall\'Italia',
  ogDescription: 'Un\'occasione unica per ammirare le opere di un maestro dell\'arte moderna. L\'ingresso è libero, a Bruzella, fino a marzo 2026. Perfetto per una gita domenicale.',
- canonicalPath: '/articoli-frontaliere/mostra-rauschenberg-bruzella-mendrisiotto-arte-gratuita-frontalieri',
+ canonicalPath: '/articoli-frontaliere/mostra-rauschenberg-bruzella-mendrisiotto-arte-gratuita-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -1106,7 +1106,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra ticino, eventi culturali giubiasco, galleria job, nakba, frontalieri, arte bellinzona, tempo libero ticino',
  ogTitle: 'A Giubiasco una mostra che scuote le coscienze: \'Nakba\'',
  ogDescription: 'Non solo lavoro: la Galleria Job ospita una potente mostra sulla realtà israelo-palestinese. Un evento da non perdere per chi vive il Ticino.',
- canonicalPath: '/articoli-frontaliere/mostra-nakba-giubiasco-riflessione-culturale-ticino',
+ canonicalPath: '/articoli-frontaliere/mostra-nakba-giubiasco-riflessione-culturale-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -1163,7 +1163,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'fabrizio de andré, anime salve, locarno, frontalieri, ticino, cultura ticino, eventi gratuiti, palazzo congressi muralto',
  ogTitle: 'De André a Locarno: Serata Gratuita sul suo Ultimo Capolavoro',
  ogDescription: 'Scopri i segreti di \'Anime salve\' in una conferenza unica al Palazzo dei Congressi di Muralto. Un evento imperdibile per chi vive e lavora in Ticino.',
- canonicalPath: '/articoli-frontaliere/de-andre-a-locarno-conferenza-anime-salve-per-frontalieri',
+ canonicalPath: '/articoli-frontaliere/de-andre-a-locarno-conferenza-anime-salve-per-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -1220,7 +1220,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra arte lugano, masi lugano, frontalieri ticino, cultura ticino, lac lugano, sentimento e osservazione, lavorare in ticino, arte svizzera italiana',
  ogTitle: 'L\'arte che spiega il Ticino: la nuova mostra al MASI di Lugano',
  ogDescription: 'Fino al 2026, una mostra al LAC esplora l\'anima del Ticino, un mix di Italia e Svizzera che ogni frontaliere vive quotidianamente. Scopri di più.',
- canonicalPath: '/articoli-frontaliere/masi-lugano-mostra-sentimento-osservazione-identita-ticino',
+ canonicalPath: '/articoli-frontaliere/masi-lugano-mostra-sentimento-osservazione-identita-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -1277,7 +1277,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mostra ticino, rsi una storia, eventi airolo, frontalieri cultura, caseificio gottardo, fotografia archivio, svizzera italiana, storia ticino',
  ogTitle: 'Il Ticino si racconta in 60 anni di foto: mostra gratuita RSI ad Airolo',
  ogDescription: 'Dal 16 al 22 febbraio 2026, non perdere l\'ultima tappa della mostra fotografica "Una Storia" con gli scatti d\'archivio della RSI. Ingresso libero.',
- canonicalPath: '/articoli-frontaliere/rsi-mostra-una-storia-ticino-archivio-fotografico-airolo',
+ canonicalPath: '/articoli-frontaliere/rsi-mostra-una-storia-ticino-archivio-fotografico-airolo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -1334,7 +1334,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'carnevale ticino 2026, carnevale chièscia bòsc, ludiano, valle di blenio, eventi frontalieri, tradizioni ticinesi, serravalle, feste ticino',
  ogTitle: 'Carnevale 2026 in Valle di Blenio: 3 giorni di festa a Ludiano',
  ogDescription: 'Non solo lavoro: vivi le tradizioni del Ticino al Carnevale Chièscia Bòsc dal 19 al 21 febbraio. Scopri il programma!',
- canonicalPath: '/articoli-frontaliere/carnevale-chiescia-bosc-2026-ludiano-valle-blenio',
+ canonicalPath: '/articoli-frontaliere/carnevale-chiescia-bosc-2026-ludiano-valle-blenio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Event",
@@ -1391,7 +1391,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso b ticino, integrazione stranieri svizzera, tribunale federale, sezione popolazione ticino, frontalieri, permesso di dimora, ricorso permesso',
  ogTitle: 'Permesso B negato in Ticino? Il Tribunale Federale ribalta tutto',
  ogDescription: 'Una sentenza storica a favore di due stranieri chiarisce i criteri di integrazione. Ecco cosa devono sapere i frontalieri per non sbagliare.',
- canonicalPath: '/articoli-frontaliere/permesso-b-integrazione-tribunale-federale-ticino',
+ canonicalPath: '/articoli-frontaliere/permesso-b-integrazione-tribunale-federale-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1419,7 +1419,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tassazione individuale svizzera, frontalieri ticino, lavoro ticino, imposizione individuale, riforma fiscale 2026, mercato del lavoro svizzero, concorrenza frontalieri',
  ogTitle: 'Riforma Fiscale Svizzera: 16\'000 Nuovi Posti di Lavoro in Arrivo?',
  ogDescription: 'Con la nuova imposizione individuale si stimano fino a 20\'000 posti in più. Ecco l\'impatto diretto per chi lavora come frontaliere in Ticino.',
- canonicalPath: '/articoli-frontaliere/tassazione-individuale-svizzera-impatto-lavoro-ticino-frontalieri',
+ canonicalPath: '/articoli-frontaliere/tassazione-individuale-svizzera-impatto-lavoro-ticino-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1447,7 +1447,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, tassa salute, norman gobbi, accordo fiscale italia svizzera, blocco ristorni, ticino, frontalieri',
  ogTitle: 'Ristorni a Rischio? Il Ticino Minaccia il Blocco, ma Berna Dice No',
  ogDescription: 'Scontro totale tra Ticino e Berna sulla tassa salute italiana: Norman Gobbi valuta lo stop ai ristorni. Ecco cosa rischia di cambiare per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-scontro-ticino-berna-tassa-salute',
+ canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-scontro-ticino-berna-tassa-salute/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1475,7 +1475,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'pendolarismo ticino, affitto frontalieri, costo vita frontaliere, comparis sondaggio, lavoro ticino, stipendio frontaliere, brogeda traffico, tempo vs denaro',
  ogTitle: 'Vale la pena passare ore in coda? Il vero costo del pendolarismo',
  ogDescription: 'Tre svizzeri su quattro non lo farebbero per un affitto più basso. Ecco come il dilemma tempo-denaro impatta i frontalieri del Ticino.',
- canonicalPath: '/articoli-frontaliere/pendolarismo-affitto-tempo-dilemma-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/pendolarismo-affitto-tempo-dilemma-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1503,7 +1503,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, tassa salute, accordo fiscale svizzera italia, frontalieri ticino, plr, lega, centro, udc, tassazione frontalieri',
  ogTitle: 'Scontro Ticino-Italia: Sospesi i Ristorni dei Frontalieri?',
  ogDescription: 'Il centrodestra ticinese unito contro la "tassa sulla salute": chiesta la sospensione immediata dei ristorni fiscali all\'Italia. Ecco cosa sta succedendo.',
- canonicalPath: '/articoli-frontaliere/centrodestra-ticino-stop-ristorni-frontalieri-tassa-salute',
+ canonicalPath: '/articoli-frontaliere/centrodestra-ticino-stop-ristorni-frontalieri-tassa-salute/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1531,7 +1531,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, lavoro svizzera, permesso g, dati statistici, calo frontalieri, economia ticino, accordo fiscale',
  ogTitle: 'Frontalieri in Ticino: Perché il numero sta calando?',
  ogDescription: 'Sorpresa dai dati di fine 2025: i frontalieri in Ticino diminuiscono dell\'1%. Scopri le possibili cause e cosa significa per il tuo lavoro.',
- canonicalPath: '/articoli-frontaliere/frontalieri-ticino-dati-calo-fine-2025',
+ canonicalPath: '/articoli-frontaliere/frontalieri-ticino-dati-calo-fine-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1559,7 +1559,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ingressi irregolari ticino, frontiera chiasso, migranti svizzera, frontalieri, UDSC, sicurezza confine, mendrisiotto, lavoro ticino',
  ogTitle: 'Confine di Chiasso: Crollano gli Ingressi Irregolari. Cosa Cambia?',
  ogDescription: 'I dati ufficiali di gennaio 2026 confermano un netto calo degli ingressi irregolari in Ticino. Meno pressione sui valichi che usi ogni giorno.',
- canonicalPath: '/articoli-frontaliere/calo-entrate-irregolari-migranti-chiasso-ticino',
+ canonicalPath: '/articoli-frontaliere/calo-entrate-irregolari-migranti-chiasso-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1587,7 +1587,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, stipendio, polemica, la regione, lavoro confine, dumping salariale, economia ticino',
  ogTitle: 'Frontalieri nel mirino: è solo una questione di numeri o di stipendi?',
  ogDescription: 'La discussione sui frontalieri si infiamma di nuovo in Ticino. L\'accusa non è al numero, ma all\'effetto sui salari locali. Leggi l\'analisi completa.',
- canonicalPath: '/articoli-frontaliere/frontalieri-stipendi-ticino-polemica-crescente',
+ canonicalPath: '/articoli-frontaliere/frontalieri-stipendi-ticino-polemica-crescente/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1616,7 +1616,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, tassa salute frontalieri, accordo fiscale italia svizzera, ticino, lombardia, frontalieri, tasse svizzera',
  ogTitle: 'Ristorni Bloccati? Il Ticino Minaccia Roma e la Lombardia Reagisce',
  ogDescription: 'Il Canton Ticino propone di sospendere i ristorni fiscali per i frontalieri. Una mossa drastica in risposta alla nuova tassa sulla salute italiana. Ecco cosa succede.',
- canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-scontro-ticino-lombardia-tassa-salute',
+ canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-scontro-ticino-lombardia-tassa-salute/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1645,7 +1645,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tredicesima avs, contributi salariali svizzera, aumento iva svizzera, pensione frontalieri, stipendio netto ticino, finanziamento avs, frontalieri, ticino',
  ogTitle: '13esima AVS: Aumenti su IVA e stipendi. Cosa cambia per te?',
  ogDescription: 'La nuova proposta per finanziare la 13esima AVS prevede un aumento dello 0,3% sui contributi e dello 0,4% sull\'IVA. Ecco le conseguenze.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-aumento-iva-contributi-salariali-frontaliere',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-aumento-iva-contributi-salariali-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1674,7 +1674,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: '13esima avs, finanziamento avs, contributi salariali svizzera, aumento iva svizzera, frontalieri ticino, stipendio netto, pensione svizzera',
  ogTitle: '13esima AVS: prelievi più alti in busta paga. Ecco perché',
  ogDescription: 'Un costo da 4,2 miliardi di franchi: il finanziamento della 13esima AVS si farà con più contributi e IVA. Cosa cambia per il tuo stipendio.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-misto-contributi-iva',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-misto-contributi-iva/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1703,7 +1703,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: '13esima avs, finanziamento avs, contributi salariali svizzera, aumento iva svizzera, frontalieri, ticino, pensione svizzera, stipendio frontaliere',
  ogTitle: '13esima AVS: la tua busta paga e la spesa in Svizzera costeranno di più?',
  ogDescription: 'Il finanziamento della 13esima AVS è in stallo. Si profila un doppio aumento su contributi salariali e IVA. Ecco cosa cambia per te.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-scontro-iva-contributi',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-scontro-iva-contributi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1732,7 +1732,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, tassa salute ticino, calo frontalieri, economia ticino, accordo fiscale svizzera italia, lavoro frontaliere, imprese ticino, aiti',
  ogTitle: 'Ristorni bloccati? Imprese ticinesi lanciano l\'allarme',
  ogDescription: 'Con 2.000 frontalieri in meno e la minaccia di bloccare i ristorni, il padronato teme per il futuro economico del Cantone. Cosa sta succedendo.',
- canonicalPath: '/articoli-frontaliere/blocco-ristorni-imprese-ticino-allarme-calo-frontalieri',
+ canonicalPath: '/articoli-frontaliere/blocco-ristorni-imprese-ticino-allarme-calo-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1761,7 +1761,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'trasporto contanti svizzera italia, dichiarazione valuta dogana, limite contanti confine, frontalieri, ticino, dogana chiasso, sanzioni valuta, 10000 euro',
  ogTitle: 'Nascosti 150mila euro in auto: le regole che ogni frontaliere deve sapere',
  ogDescription: 'Un sequestro record al valico di Brogeda ci ricorda le severe norme sul trasporto di contanti. Sei sicuro di conoscerle? Evita multe salatissime.',
- canonicalPath: '/articoli-frontaliere/denaro-non-dichiarato-dogana-cosa-rischi-frontaliere',
+ canonicalPath: '/articoli-frontaliere/denaro-non-dichiarato-dogana-cosa-rischi-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1790,7 +1790,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, stipendio, salari, dibattito, economia ticinese, dumping salariale, lavoro confine',
  ogTitle: 'Frontalieri nel mirino? La verità sul dibattito salariale in Ticino',
  ogDescription: 'Non è solo una questione di numeri. Ecco perché il tema dei frontalieri e dei salari infiamma il Ticino e cosa significa per il tuo stipendio.',
- canonicalPath: '/articoli-frontaliere/frontalieri-salari-dibattito-ticino-il-cane-che-si-morde-la-coda',
+ canonicalPath: '/articoli-frontaliere/frontalieri-salari-dibattito-ticino-il-cane-che-si-morde-la-coda/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1819,7 +1819,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: '13esima AVS, frontalieri, finanziamento, contributi salariali, IVA, stipendio ticino, pensione svizzera, consiglio degli stati',
  ogTitle: '13esima AVS: Aumento Stipendio o IVA? La Decisione che Tocca il Tuo Portafoglio',
  ogDescription: 'La politica svizzera è divisa su come finanziare i 4,2 miliardi della 13esima AVS. La nuova proposta potrebbe ridurre il tuo stipendio netto. Scopri come.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendio-iva',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendio-iva/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1848,7 +1848,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, tassa salute frontalieri, ticino italia, accordo fiscale svizzera italia, sospensione ristorni, politica ticinese, mozione',
  ogTitle: 'Ristorni all\'Italia a Rischio: la Politica Ticinese Fa Fronte Comune',
  ogDescription: 'Quattro partiti ticinesi chiedono lo stop ai ristorni fiscali a causa della tassa sulla salute. Ecco cosa significa per te e per il tuo stipendio.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-partiti-ticino-chiedono-stop-ristorni',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-partiti-ticino-chiedono-stop-ristorni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1877,7 +1877,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, tassa salute frontalieri, ticino, accordo fiscale svizzera italia, sospensione ristorni, frontalieri vecchi, tassazione frontalieri',
  ogTitle: 'Stop ai Ristorni: il Ticino Alza la Voce Contro la Tassa Salute',
  ogDescription: 'Quattro partiti ticinesi uniti per bloccare i fondi all\'Italia. Scopri perché la tassa sulla salute dei frontalieri viola gli accordi e cosa significa per te.',
- canonicalPath: '/articoli-frontaliere/stop-ristorni-tassa-salute-mozione-politica-ticino',
+ canonicalPath: '/articoli-frontaliere/stop-ristorni-tassa-salute-mozione-politica-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1906,7 +1906,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'conti federali svizzera, aumento IVA svizzera, finanze confederazione, frontalieri ticino, pacchetto sgravio 27, costo vita svizzera, stipendio frontaliere',
  ogTitle: 'Conti Svizzeri in attivo, ma l\'IVA aumenterà: cosa cambia?',
  ogDescription: 'Sorpresa a Berna: avanzo di 259 milioni nel 2025. Ma si prepara un aumento dell\'IVA dello 0,8% che inciderà sui costi per tutti, frontalieri inclusi.',
- canonicalPath: '/articoli-frontaliere/conti-federali-2025-aumento-iva-impatto-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/conti-federali-2025-aumento-iva-impatto-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1935,7 +1935,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tredicesima avs, finanziamento avs, contributi salariali svizzera, aumento iva svizzera, stipendio netto frontaliere, frontalieri ticino, pensione svizzera',
  ogTitle: '13esima AVS: Aumento Contributi e IVA in Vista. Cosa Cambia per il Tuo Stipendio?',
  ogDescription: 'La Commissione degli Stati vuole aumentare contributi e IVA per finanziare la 13esima AVS. Ecco l\'impatto previsto sulla tua busta paga da frontaliere.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-impatto-stipendio-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-impatto-stipendio-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1964,7 +1964,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, tassa salute ticino, accordo fiscale italia svizzera, frontalieri ticino, tasse frontalieri, politica confine, lombardia ticino',
  ogTitle: 'Stop ai Ristorni? La Lombardia frena il Ticino: \'Scelta sbagliata\'',
  ogDescription: 'La politica ticinese vuole bloccare i ristorni come ritorsione alla tassa sulla salute, ma da oltre confine arriva un avvertimento. Ecco cosa sta succedendo.',
- canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-reazione-lombardia-tassa-salute',
+ canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-reazione-lombardia-tassa-salute/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -1993,7 +1993,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'truffa bancaria ticino, spoofing, frontalieri, sicurezza e-banking, polizia cantonale, truffa telefonica, conto svizzero, protezione dati',
  ogTitle: 'Falso bancario al telefono? L\'allarme della Polizia in Ticino',
  ogDescription: 'Malintenzionati si spacciano per la tua banca svizzera. La Polizia Cantonale svela la truffa dello spoofing: non cadere nella trappola.',
- canonicalPath: '/articoli-frontaliere/truffa-falso-bancario-ticino-allarme-polizia',
+ canonicalPath: '/articoli-frontaliere/truffa-falso-bancario-ticino-allarme-polizia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2022,7 +2022,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dazi usa svizzera, economia ticino, frontalieri, lavoro ticino, export svizzero, trump dazi, industria farmaceutica ticino',
  ogTitle: 'Dazi USA al 10%: cosa rischia l\'economia del Ticino e il tuo lavoro?',
  ogDescription: 'Berna è in allerta dopo la proposta di dazi USA al 10%. L\'impatto sull\'export del Ticino potrebbe essere significativo. Scopri le conseguenze.',
- canonicalPath: '/articoli-frontaliere/dazi-usa-10-percento-conseguenze-economia-ticino',
+ canonicalPath: '/articoli-frontaliere/dazi-usa-10-percento-conseguenze-economia-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2051,7 +2051,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, lavoro sanità, clinica varini, clinica hildebrand, licenziamenti ticino, fisioterapia, orselina',
  ogTitle: 'Sanità Ticino: accordo tra cliniche, 8 posti a rischio',
  ogDescription: 'La collaborazione tra la Clinica Varini e la Clinica Hildebrand porterà alla chiusura del team di fisioterapia di Orselina. Otto persone perderanno il lavoro.',
- canonicalPath: '/articoli-frontaliere/sanita-ticino-accordo-varini-hildebrand-8-posti-a-rischio',
+ canonicalPath: '/articoli-frontaliere/sanita-ticino-accordo-varini-hildebrand-8-posti-a-rischio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2080,7 +2080,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dumping salariale, frontalieri, ticino, lavoro part-time, studio architettura, diritti lavoratori, commissione paritetica, mendrisiotto',
  ogTitle: 'Lavoro 100%, Pagato 50%: Scandalo Dumping Salariale in Ticino',
  ogDescription: 'Uno studio di architettura nel mirino per contratti part-time fittizi. Un caso che espone i rischi per i frontalieri e l\'importanza di conoscere i propri diritti.',
- canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-architetti-part-time-fittizi',
+ canonicalPath: '/articoli-frontaliere/dumping-salariale-ticino-architetti-part-time-fittizi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2109,7 +2109,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tredicesima avs, finanziamento avs, contributi sociali svizzera, frontalieri ticino, stipendio netto 2026, pensione svizzera, busta paga frontaliere',
  ogTitle: 'Tredicesima AVS: Aumento contributi in arrivo. Cosa cambia?',
  ogDescription: 'Dal 2026 i contributi AVS aumenteranno dello 0,5%. Ecco la decisione del Consiglio federale e come influenzerà la tua busta paga in Ticino.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-aumento-contributi-2026',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-aumento-contributi-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2138,7 +2138,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: '13esima avs, frontalieri, ticino, contributi salariali, trattenute stipendio, aumento iva, busta paga svizzera, pensione svizzera',
  ogTitle: '13a AVS: la tua busta paga in Ticino potrebbe ridursi',
  ogDescription: 'Berna divisa su come pagare la 13a AVS: più tasse o più trattenute? Ecco cosa rischiano i 90.000 frontalieri che lavorano in Ticino.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-impatto-stipendio-frontalieri',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-impatto-stipendio-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2166,7 +2166,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'polizia cantonale, scambio dati, POLAP, sicurezza ticino, frontalieri, svizzera, protezione dati, criminalità organizzata',
  ogTitle: 'Polizia Ticino: Dati condivisi con l\'Italia prima che con Zurigo?',
  ogDescription: 'Un paradosso svizzero: la polizia ticinese accede più facilmente ai dati UE che a quelli di altri cantoni. Ora Berna vuole cambiare le regole. Ecco cosa succede.',
- canonicalPath: '/articoli-frontaliere/scambio-dati-polizia-svizzera-impatto-ticino',
+ canonicalPath: '/articoli-frontaliere/scambio-dati-polizia-svizzera-impatto-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2194,7 +2194,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: '13esima AVS, finanziamento, contributi salariali, aumento IVA, frontalieri, ticino, stipendio netto, busta paga svizzera',
  ogTitle: '13esima AVS: Più Trattenute in Busta Paga? Il Piano sul Tavolo',
  ogDescription: 'Un nuovo piano per finanziare la 13esima AVS prevede un aumento dei contributi salariali e dell\'IVA. Scopri cosa cambia per il tuo stipendio.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendi-iva',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendi-iva/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2222,7 +2222,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, dati lavoro, permesso g, mercato del lavoro ticino, sostituzione manodopera, statistiche frontalieri, economia ticinese',
  ogTitle: 'Calo dei frontalieri in Ticino? Non è come sembra: i dati settore per settore',
  ogDescription: 'Una flessione dello 0.2% nasconde una crescita boom nei settori IT, ingegneria e finanza. Ecco cosa significano veramente i nuovi dati sul lavoro in Ticino.',
- canonicalPath: '/articoli-frontaliere/frontalieri-ticino-calo-dati-settori-qualificati',
+ canonicalPath: '/articoli-frontaliere/frontalieri-ticino-calo-dati-settori-qualificati/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2251,7 +2251,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tredicesima avs, frontalieri, ticino, stipendio netto, contributi salariali, aumento iva, busta paga svizzera, finanziamento avs',
  ogTitle: '13esima AVS: come cambierà la tua busta paga? Aumento trattenute e IVA',
  ogDescription: 'Si va verso un aumento dei contributi salariali e dell\'IVA per finanziare la 13esima AVS. Ecco l\'impatto concreto sullo stipendio dei frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-aumento-contributi-iva-impatto-stipendio',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-aumento-contributi-iva-impatto-stipendio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2280,7 +2280,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso s, stipendi ticino, frontalieri, lavoro ticino, dumping salariale, mercato del lavoro svizzera, ucraini svizzera, salario minimo ticino',
  ogTitle: 'Stipendi Sotto la Media per i Permessi S: Cosa Cambia in Ticino?',
  ogDescription: 'Con oltre la metà dei lavoratori ucraini con Permesso S che guadagna meno di 3000 CHF, esploriamo le conseguenze per il mercato del lavoro ticinese.',
- canonicalPath: '/articoli-frontaliere/permesso-s-stipendi-bassi-impatto-lavoro-ticino',
+ canonicalPath: '/articoli-frontaliere/permesso-s-stipendi-bassi-impatto-lavoro-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2309,7 +2309,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ristorni, ticino, lombardia, tassa sulla salute, accordo fiscale, tassazione frontalieri, svizzera',
  ogTitle: 'Ristorni Bloccati? La Lombardia Avverte il Ticino: \'Scelta Sbagliata\'',
  ogDescription: 'Una mozione in Ticino propone di sospendere i ristorni fiscali. Ecco la dura reazione dall\'Italia e cosa significa per i comuni di confine.',
- canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-reazione-lombardia-mozione-ticino',
+ canonicalPath: '/articoli-frontaliere/ristorni-frontalieri-reazione-lombardia-mozione-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2338,7 +2338,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: '13esima avs, finanziamento avs, contributi salariali svizzera, aumento iva svizzera, frontalieri ticino, stipendio netto frontaliere, busta paga svizzera',
  ogTitle: '13esima AVS: come verrà pagata? La tua busta paga potrebbe cambiare',
  ogDescription: 'Berna divisa sul finanziamento da 4.2 miliardi. L\'ipotesi di aumentare i contributi salariali tocca direttamente lo stipendio dei frontalieri.',
- canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-contributi-iva-impatto-frontalieri',
+ canonicalPath: '/articoli-frontaliere/tredicesima-avs-finanziamento-contributi-iva-impatto-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2366,7 +2366,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo acqua ticino, tariffe sibm, aumento bollette mendrisiotto, sorvegliante prezzi svizzera, frontalieri, costo vita ticino, bollette svizzera',
  ogTitle: 'Bollette acqua: Rincaro frenato nel Mendrisiotto. Ecco quanto pagherai',
  ogDescription: 'Il costo dell\'acqua potabile sale a 1,55 CHF/m³ nel Basso Mendrisiotto, ma poteva andare peggio. L\'intervento di Berna ha evitato un salasso.',
- canonicalPath: '/articoli-frontaliere/costo-acqua-mendrisiotto-aumento-tariffe-2026',
+ canonicalPath: '/articoli-frontaliere/costo-acqua-mendrisiotto-aumento-tariffe-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2394,7 +2394,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'cooperazione giudiziaria svizzera italia, frontalieri, ticino, assistenza giudiziaria, rogatoria, confine chiasso, sicurezza transfrontaliera, accordi bilaterali',
  ogTitle: 'Svizzera e Italia più unite nelle indagini: cosa cambia al confine ticinese',
  ogDescription: 'Un nuovo patto di collaborazione giudiziaria è stato siglato. Ecco le conseguenze pratiche per i frontalieri che ogni giorno attraversano il confine in Ticino.',
- canonicalPath: '/articoli-frontaliere/cooperazione-giudiziaria-svizzera-italia-impatto-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/cooperazione-giudiziaria-svizzera-italia-impatto-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2422,7 +2422,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'licenziamenti ticino, frontalieri sanità, clinica varini, centro hildebrand, lavoro fisioterapista, crisi lavoro ticino, orselina, brissago',
  ogTitle: 'Doccia fredda nel Locarnese: 8 posti di lavoro persi',
  ogDescription: 'Una nuova alleanza tra due note cliniche ticinesi si traduce in licenziamenti. Ecco cosa sta succedendo nel settore sanitario.',
- canonicalPath: '/articoli-frontaliere/sanita-locarnese-collaborazione-varini-hildebrand-licenziamenti',
+ canonicalPath: '/articoli-frontaliere/sanita-locarnese-collaborazione-varini-hildebrand-licenziamenti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2450,7 +2450,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'legionellosi ticino, legionella svizzera, frontalieri, sanità ticino, ufsp, rischio batteri, acqua contaminata, lavoro ticino',
  ogTitle: 'Legionellosi: il Ticino ha il tasso più alto di tutta la Svizzera',
  ogDescription: 'Con un\'incidenza più che doppia rispetto alla media nazionale, il Ticino è l\'epicentro dell\'aumento dei casi di legionellosi. Ecco cosa devi sapere.',
- canonicalPath: '/articoli-frontaliere/legionellosi-ticino-tasso-piu-alto-svizzera',
+ canonicalPath: '/articoli-frontaliere/legionellosi-ticino-tasso-piu-alto-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2478,7 +2478,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'prezzi dinamici, ticino, frontalieri, costo della vita, spesa svizzera, potere d\'acquisto, stipendio frontaliere, rsi patti chiari',
  ogTitle: 'Il prezzo della tua birra in Ticino potrebbe cambiare ogni minuto',
  ogDescription: 'Gli algoritmi decidono già il costo di pane e concerti in UK. Questa tendenza sta per arrivare in Svizzera? L\'impatto per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/prezzi-dinamici-ticino-rivoluzione-o-trappola-per-frontalieri',
+ canonicalPath: '/articoli-frontaliere/prezzi-dinamici-ticino-rivoluzione-o-trappola-per-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2506,7 +2506,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'manifestazioni lugano, regole ordine pubblico, frontalieri ticino, polemica politica lugano, parità di trattamento, costi polizia, andrea togni plr',
  ogTitle: 'Doppio Standard a Lugano? Manifestazioni Vietate ad Alcuni, Consentite ad Altri',
  ogDescription: 'Un evento autorizzato viene negato, uno abusivo occupa il centro di Lugano. Scoppia la polemica sulla gestione dell\'ordine pubblico e sui costi per i contribuenti.',
- canonicalPath: '/articoli-frontaliere/lugano-manifestazioni-polemica-regole-uguali-per-tutti',
+ canonicalPath: '/articoli-frontaliere/lugano-manifestazioni-polemica-regole-uguali-per-tutti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2534,7 +2534,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere tasse comunali, addizionale irpef, comuni confine, residenza fiscale frontalieri, nuovo accordo fiscale, stipendio netto frontaliere, ticino',
  ogTitle: 'Tasse Comunali: La Scelta della Residenza può Farti Risparmiare 500€',
  ogDescription: 'La tua residenza determina quanto paghi di addizionale IRPEF. Scopri la mappa delle aliquote 2026 nei comuni di frontiera e calcola il tuo netto.',
- canonicalPath: '/articoli-frontaliere/mappa-addizionale-irpef-comuni-confine-frontalieri-tasse',
+ canonicalPath: '/articoli-frontaliere/mappa-addizionale-irpef-comuni-confine-frontalieri-tasse/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2562,7 +2562,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'addizionale comunale irpef, frontalieri ticino, tasse comunali, comuni confine, residenza fiscale, nuovo accordo fiscale, stipendio netto frontaliere, como, varese',
  ogTitle: 'Addizionale IRPEF: Dove ti conviene vivere se lavori in Ticino?',
  ogDescription: 'Trasferirsi può farti risparmiare centinaia di euro all\'anno. Ecco la mappa 2026 delle tasse comunali per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/addizionale-irpef-comuni-confine-mappa-tasse-frontalieri-2026',
+ canonicalPath: '/articoli-frontaliere/addizionale-irpef-comuni-confine-mappa-tasse-frontalieri-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2590,7 +2590,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere maternità, congedo paternità svizzera, indennità maternità ticino, assegni familiari frontalieri, avs maternità, inps frontalieri, congedo parentale italia svizzera',
  ogTitle: 'Genitore e Frontaliere? La Guida 2026 a Maternità e Paternità',
  ogDescription: 'Lavori in Ticino e stai per avere un figlio? Scopri come ottenere fino a CHF 230 al giorno di indennità. La guida completa.',
- canonicalPath: '/articoli-frontaliere/maternita-paternita-frontaliere-svizzera-italia-guida-2026',
+ canonicalPath: '/articoli-frontaliere/maternita-paternita-frontaliere-svizzera-italia-guida-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2618,7 +2618,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere contributi sociali svizzeri, dettaglio busta paga svizzera, trattenute stipendio svizzera, AVS LPP frontalieri, calcolo stipendio netto ticino, lavoro in svizzera',
  ogTitle: 'Busta Paga Svizzera 2026: AVS, LPP e LAINF',
  ogDescription: 'Aliquote sociali, esempio su 5.500 CHF lordi e calcolatore netto per frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/guida-contributi-sociali-svizzeri-busta-paga-frontaliere',
+ canonicalPath: '/articoli-frontaliere/guida-contributi-sociali-svizzeri-busta-paga-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2646,7 +2646,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo vita lugano, vivere a lugano, frontaliere trasferimento ticino, affitti lugano, lamal costo, tasse residenti ticino, budget mensile svizzera',
  ogTitle: 'Quanto Costa Vivere a Lugano nel 2026',
  ogDescription: 'Affitto, LAMal, tasse, trasporti e spesa: il budget mensile per chi valuta il trasferimento in Ticino.',
- canonicalPath: '/articoli-frontaliere/quanto-costa-vivere-a-lugano-da-frontaliere-analisi-costi-2026',
+ canonicalPath: '/articoli-frontaliere/quanto-costa-vivere-a-lugano-da-frontaliere-analisi-costi-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2674,7 +2674,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso g vantaggi, permesso g svantaggi, frontaliere ticino 2026, nuovo accordo fiscale, lavorare in svizzera, permesso frontaliere, fiscalità frontalieri, pensione lpp',
  ogTitle: 'Permesso G: Conviene Ancora Lavorare in Ticino nel 2026?',
  ogDescription: 'Fisco, pensione, sanità: scopri tutti i pro e i contro del permesso G per frontalieri dopo il nuovo accordo fiscale Italia-Svizzera.',
- canonicalPath: '/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontalieri-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontalieri-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2702,7 +2702,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'calcolo pensione frontalieri svizzera, calcolo pensione frontaliere, pensione avs italiana, totalizzazione contributi svizzera italia, pensione frontalieri ticino, rendita avs, inps frontalieri, accordo pensioni',
  ogTitle: 'Calcolo Pensione Frontalieri Svizzera: AVS + INPS',
  ogDescription: 'Hai versato contributi in Svizzera e in Italia? Ecco la guida pratica per calcolare la tua pensione da frontaliere nel 2026.',
- canonicalPath: '/articoli-frontaliere/calcolo-pensione-frontaliere-avs-inps-guida-completa',
+ canonicalPath: '/articoli-frontaliere/calcolo-pensione-frontaliere-avs-inps-guida-completa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2730,7 +2730,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere nuovo accordo fiscale 2026, simulazione tasse frontalieri, tassazione frontalieri ticino, calcolo stipendio netto frontaliere, irpef frontalieri, imposta alla fonte',
  ogTitle: 'Accordo Fiscale 2026: Quanto ti costerà? La simulazione',
  ogDescription: 'Un salario di 65\'000 CHF in Ticino: ecco la differenza netta in busta paga tra vecchio e nuovo accordo fiscale per frontalieri. Calcola il tuo.',
- canonicalPath: '/articoli-frontaliere/frontaliere-nuovo-accordo-fiscale-2026-simulazione',
+ canonicalPath: '/articoli-frontaliere/frontaliere-nuovo-accordo-fiscale-2026-simulazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2758,7 +2758,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'LAMal frontaliere 2026, CMI frontaliere, assicurazione malattia svizzera italia, diritto opzione frontaliere, costo LAMal ticino, sanità frontalieri ticino, quale assicurazione scegliere',
  ogTitle: 'LAMal vs CMI 2026: la scelta che può farti risparmiare 2000€ l\'anno',
  ogDescription: 'Frontaliere in Ticino? Con premi LAMal a 350 CHF e CMI a 180€, la scelta dell\'assicurazione malattia è cruciale. Analisi e casi pratici per decidere.',
- canonicalPath: '/articoli-frontaliere/lamal-o-cmi-frontaliere-quale-conviene-2026',
+ canonicalPath: '/articoli-frontaliere/lamal-o-cmi-frontaliere-quale-conviene-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2786,7 +2786,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere doppia imposizione, credito imposta, come funziona, tasse frontalieri ticino, quadro ce 730, nuovo accordo fiscale, dichiarazione redditi frontalieri',
  ogTitle: 'Frontalieri, stop alla doppia tassa: la guida al credito d\'imposta',
  ogDescription: 'Lavori in Ticino e temi la doppia imposizione? Ecco come funziona il credito d\'imposta e come risparmiare migliaia di euro con il Modello 730.',
- canonicalPath: '/articoli-frontaliere/frontaliere-doppia-imposizione-credito-imposta-come-funziona',
+ canonicalPath: '/articoli-frontaliere/frontaliere-doppia-imposizione-credito-imposta-come-funziona/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2814,7 +2814,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo auto frontaliere, pendolare ticino, spesa auto svizzera, benzina ticino, parcheggio lugano, vignetta autostradale, frontalieri, ticino',
  ogTitle: 'L\'auto ti costa 8\'500 CHF l\'anno? La verità sul pendolarismo in Ticino',
  ogDescription: 'Scopri il costo reale di usare l\'auto come frontaliere nel 2026: dalla benzina ai parcheggi, l\'analisi che ogni pendolare dovrebbe leggere.',
- canonicalPath: '/articoli-frontaliere/costo-auto-pendolare-frontaliere-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/costo-auto-pendolare-frontaliere-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2842,7 +2842,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'congedo parentale frontaliere, maternità svizzera, paternità svizzera, indennità maternità ticino, frontalieri genitori, assegni familiari svizzera, cassa compensazione ticino',
  ogTitle: 'Maternità e Paternità da Frontaliere: La Guida Completa 2026',
  ogDescription: 'Lavori in Ticino e stai per diventare genitore? Ecco tutto quello che devi sapere su congedi e indennità svizzere. Cifre e procedure aggiornate.',
- canonicalPath: '/articoli-frontaliere/congedo-parentale-frontaliere-svizzera-italia-guida-2026',
+ canonicalPath: '/articoli-frontaliere/congedo-parentale-frontaliere-svizzera-italia-guida-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2870,7 +2870,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo auto frontaliere, pendolare ticino, spese auto svizzera, vignetta autostradale 2026, parcheggio lugano, conviene treno o auto',
  ogTitle: 'L\'auto ti costa fino a 8.500 CHF l\'anno? La verità sui costi da frontaliere',
  ogDescription: 'Abbiamo calcolato tutte le spese nascoste dell\'auto per chi lavora in Ticino. La cifra finale potrebbe sorprenderti. Leggi l\'analisi 2026.',
- canonicalPath: '/articoli-frontaliere/costo-auto-frontaliere-ticino-guida-completa-2026',
+ canonicalPath: '/articoli-frontaliere/costo-auto-frontaliere-ticino-guida-completa-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2898,7 +2898,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dichiarazione redditi frontaliere, modello 730 frontalieri, quadro ce, credito imposta svizzera, tasse frontalieri ticino, fiscalità frontalieri, guida fiscale',
  ogTitle: 'Frontaliere e 730: La Guida Definitiva per non Sbagliare',
  ogDescription: 'Evita errori e sanzioni. Ecco come compilare la dichiarazione dei redditi 2026 se lavori in Ticino e vivi in Italia. La guida passo passo.',
- canonicalPath: '/articoli-frontaliere/guida-dichiarazione-redditi-730-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/guida-dichiarazione-redditi-730-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2926,7 +2926,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere documenti, lavoro svizzera, permesso g, contratto lavoro svizzero, conto svizzero, avs frontaliere, ticino, iniziare lavoro svizzera',
  ogTitle: 'Lavoro in Svizzera? La lista dei 6 documenti che devi avere PRONTI',
  ogDescription: 'Inizi un nuovo lavoro in Ticino? Evita ritardi e problemi. Ecco la checklist definitiva dal Permesso G al conto bancario per partire col piede giusto.',
- canonicalPath: '/articoli-frontaliere/documenti-necessari-lavoro-svizzera-frontaliere-ticino',
+ canonicalPath: '/articoli-frontaliere/documenti-necessari-lavoro-svizzera-frontaliere-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2954,7 +2954,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'asilo nido svizzera, costo asilo nido ticino, frontaliere con figli, sussidi asilo nido svizzera, asili nido lugano, lavoro svizzera famiglia, rette asilo ticino',
  ogTitle: 'Asilo Nido in Ticino per Frontalieri: una spesa fino a 2.800 CHF/mese',
  ogDescription: 'Quanto costa davvero un asilo nido in Ticino per un frontaliere? La nostra guida 2026 analizza costi, sussidi e l\'alternativa italiana. Leggi ora.',
- canonicalPath: '/articoli-frontaliere/asilo-nido-svizzera-frontaliere-ticino-costi-guida',
+ canonicalPath: '/articoli-frontaliere/asilo-nido-svizzera-frontaliere-ticino-costi-guida/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -2982,7 +2982,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'residenze secondarie, locarno, lex weber, mercato immobiliare ticino, frontalieri, edilizia ticino, comune di locarno',
  ogTitle: 'Locarno, scatta lo stop: niente più nuove case di vacanza',
  ogDescription: 'La città sul Verbano ha superato la quota federale del 20% di residenze secondarie. Ecco cosa cambia per il mercato immobiliare.',
- canonicalPath: '/articoli-frontaliere/locarno-stop-nuove-residenze-secondarie-quota-20',
+ canonicalPath: '/articoli-frontaliere/locarno-stop-nuove-residenze-secondarie-quota-20/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3010,7 +3010,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo della vita svizzera, vivere in svizzera, classifica comuni svizzeri, affitti ticino, cassa malati ticino, imposte svizzera, frontalieri, permesso b',
  ogTitle: 'Vivere in Svizzera: Classifica Costi per Comune 2026',
  ogDescription: 'Da 3.000 a 7.000 CHF/mese. Classifica comuni svizzeri per costo della vita: affitti, imposte e cassa malati.',
- canonicalPath: '/articoli-frontaliere/costo-vita-svizzera-classifica-comuni-ticino',
+ canonicalPath: '/articoli-frontaliere/costo-vita-svizzera-classifica-comuni-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3038,7 +3038,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'sicurezza sul lavoro, frontalieri, ticino, SUVA, infortuni professionali, controlli aziende, audit federale, CFST',
  ogTitle: 'Sicurezza sul lavoro in Ticino a rischio? Un audit federale accusa la SUVA',
  ogDescription: 'Controlli inefficaci e conflitti d\'interesse: un report ufficiale svela le debolezze del sistema di protezione dei lavoratori in Svizzera. Le conseguenze per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-svizzera-audit-federale-falle-conflitti-suva',
+ canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-svizzera-audit-federale-falle-conflitti-suva/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3066,7 +3066,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo vita svizzera, vivere in ticino, classifica comuni svizzeri, affitti svizzera, tasse svizzera, cassa malati ticino, frontalieri, permesso b',
  ogTitle: 'Vivere in Svizzera: ecco dove costa 4\'000 CHF in meno al mese',
  ogDescription: 'Uno studio svela i comuni più economici e quelli più cari. Sorpresa: non è sempre dove pensi. Scopri la classifica e i dati sul Ticino.',
- canonicalPath: '/articoli-frontaliere/costo-vita-svizzera-classifica-comuni-cari-economici',
+ canonicalPath: '/articoli-frontaliere/costo-vita-svizzera-classifica-comuni-cari-economici/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3094,7 +3094,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'architetti ticino, dumping salariale, mendrisio, lavoro frontalieri, sfruttamento lavoro svizzera, stipendio architetti, commissione paritetica',
  ogTitle: 'Ore gratis fino a tardi: lo sfogo di un architetto a Mendrisio',
  ogDescription: 'Multa da 160\'000 CHF a due studi di Mendrisio. Un giovane racconta la sua esperienza di stage sottopagato e promesse non mantenute.',
- canonicalPath: '/articoli-frontaliere/architetti-sottopagati-ticino-mendrisio-testimonianza',
+ canonicalPath: '/articoli-frontaliere/architetti-sottopagati-ticino-mendrisio-testimonianza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3122,7 +3122,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, calo frontalieri, economia ticino, tassa salute frontalieri, lavoro svizzera, cgil, permesso g',
  ogTitle: 'Frontalieri in calo in Ticino? La vera causa non è quella che pensi',
  ogDescription: 'I numeri dei frontalieri scendono, ma la tassa sulla salute c\'entra poco. Un\'analisi sindacale rivela il vero motivo: la difficile congiuntura economica ticinese.',
- canonicalPath: '/articoli-frontaliere/calo-frontalieri-ticino-economia-non-tassa-salute',
+ canonicalPath: '/articoli-frontaliere/calo-frontalieri-ticino-economia-non-tassa-salute/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3150,7 +3150,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'indennità maternità, frontalieri, ticino, cassazione, diritti lavoratrici, INPS, naspi, totalizzazione contributi',
  ogTitle: 'Svolta per le mamme frontaliere: la Cassazione riconosce l\'indennità INPS',
  ogDescription: 'Una storica sentenza tutela le lavoratrici in Ticino: i contributi svizzeri ora contano per la maternità in Italia. Scopri cosa cambia.',
- canonicalPath: '/articoli-frontaliere/maternita-frontaliere-cassazione-riconosce-indennita-inps',
+ canonicalPath: '/articoli-frontaliere/maternita-frontaliere-cassazione-riconosce-indennita-inps/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3178,7 +3178,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'Galenica, lavoro Svizzera, posti di lavoro, frontalieri, Ticino, farmacie, Amavita, ristrutturazione',
  ogTitle: 'Terremoto in Galenica: 170 posti a rischio. Cosa significa per il Ticino?',
  ogDescription: 'Il colosso delle farmacie svizzere ristruttura e chiude la filiale Bichsel. Un segnale per tutto il settore sanitario, frontalieri inclusi.',
- canonicalPath: '/articoli-frontaliere/galenica-chiude-bichsel-170-posti-a-rischio-impatto-ticino',
+ canonicalPath: '/articoli-frontaliere/galenica-chiude-bichsel-170-posti-a-rischio-impatto-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3206,7 +3206,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dazi usa svizzera, tariffe trump ticino, export farmaceutico ticino, lavoro frontalieri, economia mendrisiotto, aiti, protezionismo usa, commercio internazionale',
  ogTitle: 'Dazi USA al 15%: l\'industria del Ticino trema? Ecco cosa rischi',
  ogDescription: 'Le nuove tariffe di Trump colpiscono l\'export. Analisi delle possibili conseguenze per chi lavora nel farmaceutico e nella meccanica di precisione in Ticino.',
- canonicalPath: '/articoli-frontaliere/dazi-trump-usa-impatto-export-ticino-lavoro',
+ canonicalPath: '/articoli-frontaliere/dazi-trump-usa-impatto-export-ticino-lavoro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3234,7 +3234,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'campione d\'italia, dissesto finanziario, frontalieri, lavoro ticino, comune campione, assunzioni, economia luganese',
  ogTitle: 'Svolta a Campione d\'Italia: via libera a nuove assunzioni',
  ogDescription: 'Dopo anni di crisi, il Ministero dell\'Interno conferma la fine del dissesto. Si aprono nuove prospettive di lavoro nell\'exclave italiana.',
- canonicalPath: '/articoli-frontaliere/campione-italia-fuori-dissesto-finanziario-nuove-assunzioni',
+ canonicalPath: '/articoli-frontaliere/campione-italia-fuori-dissesto-finanziario-nuove-assunzioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3262,7 +3262,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'architetti sottopagati, dumping salariale ticino, lavoro mendrisio, frontalieri, contratto di lavoro svizzera, stipendio ticino, commissione paritetica, sfruttamento lavoro',
  ogTitle: '"Ore gratis la sera": lo sfogo di un architetto sfruttato in Ticino',
  ogDescription: 'Assunto come stagista a Mendrisio, lavorava a tempo pieno per pochi spiccioli. Un caso che scuote il mercato del lavoro ticinese.',
- canonicalPath: '/articoli-frontaliere/gavetta-tossica-architetti-ticino-denuncia',
+ canonicalPath: '/articoli-frontaliere/gavetta-tossica-architetti-ticino-denuncia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3290,7 +3290,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'eurocity bloccato, ffs, treni svizzera, pendolari ticino, disagio treni, ritardo treno milano, frontaliere',
  ogTitle: 'Odissea in galleria: 2 ore di ritardo sul treno per Milano',
  ogDescription: '500 passeggeri bloccati sull\'Eurocity Basilea-Milano. Ecco cosa è successo e le conseguenze per chi viaggia tra Svizzera e Italia.',
- canonicalPath: '/articoli-frontaliere/odissea-eurocity-milano-treno-bloccato-galleria-pendolari',
+ canonicalPath: '/articoli-frontaliere/odissea-eurocity-milano-treno-bloccato-galleria-pendolari/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3318,7 +3318,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'sicurezza lavoro svizzera, suva, controlli lavoro ticino, frontalieri, infortuni professionali, cfst, audit cdf, ispettorato lavoro',
  ogTitle: 'Lavoro Sicuro in Svizzera? Un Audit Ufficiale Svela Controlli "Troppo Larghi"',
  ogDescription: 'Falle sistemiche e conflitti d\'interesse: la sicurezza dei lavoratori, inclusi i frontalieri in Ticino, è a rischio secondo un nuovo report federale.',
- canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-svizzera-controlli-insufficienti-suva',
+ canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-svizzera-controlli-insufficienti-suva/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3346,7 +3346,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'startup svizzera, investimenti ticino, intelligenza artificiale, lavoro frontalieri, economia ticino, medtech, fintech, opportunità lavoro',
  ogTitle: 'Boom Startup in Svizzera (+44%): 53 Milioni per il Ticino, nuove opportunità',
  ogDescription: 'Gli investimenti in startup svizzere esplodono a 3,3 mld, con l\'IA protagonista. Il Ticino attrae 53 milioni: ecco cosa cambia per il lavoro frontaliero.',
- canonicalPath: '/articoli-frontaliere/startup-svizzera-boom-investimenti-ia-opportunita-ticino',
+ canonicalPath: '/articoli-frontaliere/startup-svizzera-boom-investimenti-ia-opportunita-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3374,7 +3374,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'long covid, malattia professionale, tribunale federale, frontalieri, ticino, assicurazione infortuni, la bâloise, sanità',
  ogTitle: 'Long Covid: Sentenza storica del Tribunale Federale Svizzero',
  ogDescription: 'Una vittoria per un infermiere apre la strada a tutele importanti per chi lavora in sanità. La Bâloise deve pagare. Scopri le implicazioni.',
- canonicalPath: '/articoli-frontaliere/long-covid-malattia-professionale-sentenza-tribunale-federale',
+ canonicalPath: '/articoli-frontaliere/long-covid-malattia-professionale-sentenza-tribunale-federale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3402,7 +3402,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'accordi bilaterali svizzera ue, frontalieri ticino, mercato interno europeo, permesso g, libera circolazione persone, salari ticino, politica europea svizzera',
  ogTitle: 'Bruxelles dà il via libera: cosa cambia per chi lavora in Ticino?',
  ogDescription: 'L\'UE approva i nuovi accordi con la Svizzera. Ecco le possibili ripercussioni sul tuo lavoro da frontaliere e sul mercato ticinese.',
- canonicalPath: '/articoli-frontaliere/accordo-ue-svizzera-mercato-interno-impatto-frontalieri',
+ canonicalPath: '/articoli-frontaliere/accordo-ue-svizzera-mercato-interno-impatto-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3430,7 +3430,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'fonderie svizzere, crisi industria, lavoro ticino, frontalieri, settore metalmeccanico, economia ticino, dazi trump, franco forte',
  ogTitle: 'Fonderie Svizzere: Produzione in calo del 7.6%. Cosa significa per il tuo lavoro in Ticino?',
  ogDescription: 'Il settore metalmeccanico svizzero soffre: la produzione è scesa del 7.6% nel 2025. Scopri le cause e l\'impatto sui posti di lavoro per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/fonderie-svizzere-crisi-produzione-2025-impatto-ticino',
+ canonicalPath: '/articoli-frontaliere/fonderie-svizzere-crisi-produzione-2025-impatto-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3458,7 +3458,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'salario minimo ticino, stipendio frontalieri, aumento salario svizzera, lavoro ticino, 22 franchi ora, contratti collettivi, busta paga svizzera',
  ogTitle: 'Salario minimo in Ticino verso i 22 CHF orari: cosa significa per la tua busta paga',
  ogDescription: 'Un accordo politico potrebbe portare il salario minimo ticinese a 4\'000 CHF mensili. Ecco il piano di aumento e le novità per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-accordo-aumento-22-franchi',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-accordo-aumento-22-franchi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3486,7 +3486,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'trasporti pubblici svizzera, frontalieri ticino, abbonamento arcobaleno, pendolarismo svizzera, costo treno frontaliere, TILO, Alliance SwissPass',
  ogTitle: 'Trasporti pubblici da record: treni più cari o più affollati per i frontalieri?',
  ogDescription: 'Con un fatturato di oltre 7 miliardi, i trasporti svizzeri sono in piena salute. Analizziamo l\'impatto sui pendolari del Ticino.',
- canonicalPath: '/articoli-frontaliere/trasporti-pubblici-svizzera-crescita-fatturato-impatto-frontalieri',
+ canonicalPath: '/articoli-frontaliere/trasporti-pubblici-svizzera-crescita-fatturato-impatto-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3514,7 +3514,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'lavori stradali lugano, cantieri notturni ticino, strade chiuse lugano, traffico frontalieri, viabilità viganello, polizia lugano, pendolari ticino',
  ogTitle: 'Attenzione Frontalieri: Cantieri Notturni a Lugano per Tutto Marzo',
  ogDescription: 'Da Viganello a Pregassona, ecco la mappa completa delle strade chiuse di notte a Lugano. Controlla qui per evitare sorprese.',
- canonicalPath: '/articoli-frontaliere/lavori-notturni-lugano-marzo-2026-strade-chiuse',
+ canonicalPath: '/articoli-frontaliere/lavori-notturni-lugano-marzo-2026-strade-chiuse/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3542,7 +3542,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'SUPSI, Daniela Willi-Piezzi, formazione docenti, Ticino, università, scuola ticinese, frontalieri, lavoro Ticino',
  ogTitle: 'Nuova guida per la formazione docenti in Ticino: chi è Daniela Willi-Piezzi',
  ogDescription: 'SUPSI ha scelto la sua nuova direttrice per il Dipartimento formazione e apprendimento. Una nomina strategica per il futuro della scuola in Ticino.',
- canonicalPath: '/articoli-frontaliere/supsi-daniela-willi-piezzi-direttrice-dipartimento-formazione',
+ canonicalPath: '/articoli-frontaliere/supsi-daniela-willi-piezzi-direttrice-dipartimento-formazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3570,7 +3570,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'bps suisse, frontalieri, ticino, bper banca, risultati finanziari, banca popolare sondrio, conti correnti svizzera',
  ogTitle: 'BPS Suisse: utile quasi record. Ecco cosa cambia con l\'arrivo di BPER.',
  ogDescription: 'Con 27,6 milioni di utile e una raccolta record, BPS Suisse si rafforza. L\'acquisizione da parte di BPER apre nuovi scenari per i clienti transfrontalieri.',
- canonicalPath: '/articoli-frontaliere/bps-suisse-risultati-solidi-2025-impatto-bper-frontalieri',
+ canonicalPath: '/articoli-frontaliere/bps-suisse-risultati-solidi-2025-impatto-bper-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3598,7 +3598,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'aiuti energia svizzera, CAPTE-N, imprese energetiche, costi elettricità ticino, paracadute finanziario, frontalieri, economia ticino',
  ogTitle: 'Energia: Berna taglia i fondi di salvataggio. Meno rischi per le bollette?',
  ogDescription: 'La commissione parlamentare dimezza a 5 miliardi gli aiuti per le aziende energetiche. Una mossa che influenzerà i costi per famiglie e imprese in Ticino.',
- canonicalPath: '/articoli-frontaliere/aiuti-imprese-energetiche-proroga-taglio-fondi',
+ canonicalPath: '/articoli-frontaliere/aiuti-imprese-energetiche-proroga-taglio-fondi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3626,7 +3626,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'salario minimo ticino, frontalieri, stipendio svizzera, lavoro ticino, controprogetto PS, dumping salariale, CCL, retribuzione ticino',
  ogTitle: 'Salario Minimo in Ticino: la Politica Cerca un Accordo. E il Tuo Stipendio?',
  ogDescription: 'Un controprogetto al vaglio del Gran Consiglio potrebbe fissare una nuova soglia salariale minima in Ticino. Ecco cosa significa per i lavoratori frontalieri.',
- canonicalPath: '/articoli-frontaliere/salario-minimo-sociale-ticino-dibattito-frontalieri',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-sociale-ticino-dibattito-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3654,7 +3654,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'banca popolare sondrio suisse, bps suisse, utili 2025, consigli finanziari, mutui ticino, risparmio frontalieri, investimenti svizzera, mauro de stefani',
  ogTitle: 'BPS Suisse: Utili Record e Consigli Anti-Crisi per i Frontalieri',
  ogDescription: 'Con un utile di quasi 28 milioni, BPS (Suisse) naviga l\'incertezza. Ecco i consigli pratici del CEO per chi lavora in Ticino e gestisce risparmi o un mutuo.',
- canonicalPath: '/articoli-frontaliere/bps-suisse-utili-record-consigli-frontalieri',
+ canonicalPath: '/articoli-frontaliere/bps-suisse-utili-record-consigli-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3682,7 +3682,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'accordo quadro 2.0, referendum obbligatorio, UDC ticino, frontalieri, svizzera ue, sovranità, doppia maggioranza, canton ticino',
  ogTitle: 'Accordo UE: da Bellinzona un muro contro la \'sottomissione\'',
  ogDescription: 'Il Ticino alza la voce: il nuovo accordo con l\'UE dovrà essere approvato da Popolo e Cantoni. Cosa significa per il tuo lavoro da frontaliere?',
- canonicalPath: '/articoli-frontaliere/accordo-ue-svizzera-ticino-chiede-referendum-obbligatorio',
+ canonicalPath: '/articoli-frontaliere/accordo-ue-svizzera-ticino-chiede-referendum-obbligatorio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3710,7 +3710,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'accordo svizzera ue, frontalieri ticino, libera circolazione persone, protezione salari, bilaterali III, referendum svizzera, lavoro in svizzera, permesso g',
  ogTitle: 'Accordo Svizzera-UE: Cosa Significa per il Tuo Lavoro in Ticino?',
  ogDescription: 'Bruxelles dice sì al nuovo accordo. Scopri l\'impatto su libera circolazione, stipendi e perché il Ticino è preoccupato. La guida completa per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/accordo-svizzera-ue-cosa-cambia-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/accordo-svizzera-ue-cosa-cambia-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3738,7 +3738,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, locarno, case secondarie, lex weber, mercato immobiliare, affitti, costo vita, alloggi',
  ogTitle: 'Locarno: Blocco licenze case vacanza, cosa cambia per i frontalieri?',
  ogDescription: 'La città di Locarno ferma le licenze per le case secondarie. Analisi dell\'impatto sul mercato immobiliare e sui frontalieri che cercano casa in Ticino.',
- canonicalPath: '/articoli-frontaliere/locarno-stop-licenze-case-secondarie',
+ canonicalPath: '/articoli-frontaliere/locarno-stop-licenze-case-secondarie/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3766,7 +3766,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'accordi bilaterali svizzera ue, frontalieri ticino, libera circolazione persone, protezione salari, accordo quadro, voto svizzera ue, Guy Parmelin',
  ogTitle: 'Accordi UE-Svizzera: Firma a un passo. Cosa cambia per te?',
  ogDescription: 'Bruxelles dà il via libera. Dalla libera circolazione alla protezione dei salari, ecco i punti chiave del nuovo accordo che decideranno il futuro dei frontalieri.',
- canonicalPath: '/articoli-frontaliere/accordi-ue-svizzera-firma-vicina-cosa-cambia-frontalieri',
+ canonicalPath: '/articoli-frontaliere/accordi-ue-svizzera-firma-vicina-cosa-cambia-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3794,7 +3794,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'aumento IVA svizzera, finanziamento esercito, costo vita ticino, stipendio frontaliere, imposta valore aggiunto, spesa frontalieri, sicurezza svizzera',
  ogTitle: 'Aumento IVA in arrivo? Come cambierà la tua spesa in Ticino',
  ogDescription: 'Un rincaro di 80 centesimi ogni 100 franchi per finanziare l\'esercito: ecco l\'impatto concreto per i frontalieri e come prepararsi.',
- canonicalPath: '/articoli-frontaliere/aumento-iva-svizzera-esercito-impatto-stipendio-frontalieri',
+ canonicalPath: '/articoli-frontaliere/aumento-iva-svizzera-esercito-impatto-stipendio-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3822,7 +3822,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, maternità, paternità, Ticino, congedo parentale, Svizzera, Italia, indennità',
  ogTitle: 'Scopri i tuoi diritti di maternità e paternità in Ticino',
  ogDescription: 'Tutto sul congedo parentale per frontalieri: differenze tra Svizzera e Italia, indennità, e come fare domanda.',
- canonicalPath: '/articoli-frontaliere/maternita-paternita-ticino',
+ canonicalPath: '/articoli-frontaliere/maternita-paternita-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3849,7 +3849,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, valposchiavo, turismo 2025, premio wakker, musei valposchiavo, pernottamenti, lavoro turismo',
  ogTitle: 'Valposchiavo: Turismo 2025 in crescita',
  ogDescription: '81.000 pernottamenti e record culturale a Poschiavo nel 2025. Novità per frontalieri e turismo.',
- canonicalPath: '/articoli-frontaliere/turismo-valposchiavo-2025',
+ canonicalPath: '/articoli-frontaliere/turismo-valposchiavo-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3877,7 +3877,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, economia, permesso G, tassa salute, ristorni, costo della vita, lavoro Svizzera',
  ogTitle: 'Frontalieri in calo: cosa sta succedendo in Ticino?',
  ogDescription: 'Scopri perché i frontalieri in Ticino stanno diminuendo e quali sono le implicazioni economiche e fiscali.',
- canonicalPath: '/articoli-frontaliere/frontalieri-economia-ticino',
+ canonicalPath: '/articoli-frontaliere/frontalieri-economia-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3905,7 +3905,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, inflazione svizzera, cambio franco euro, IPC 2026, economia transfrontaliera, potere d\'acquisto',
  ogTitle: 'Inflazione stabile in Svizzera: cosa cambia per i frontalieri',
  ogDescription: 'Inflazione minima in Svizzera: scopri gli effetti sul reddito dei frontalieri e sul cambio CHF-EUR.',
- canonicalPath: '/articoli-frontaliere/inflazione-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/inflazione-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3933,7 +3933,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'conto bancario frontalieri svizzera, aprire conto bancario svizzero, compte bancaire frontaliers suisse, banche ticino, costi conto svizzero, carte debito credito svizzera',
  ogTitle: 'Conto bancario svizzero per frontalieri: guida completa',
  ogDescription: 'Quale banca scegliere in Ticino? Costi, carte, online banking e requisiti per frontalieri. Guida aggiornata 2026.',
- canonicalPath: '/articoli-frontaliere/aprire-conto-bancario-frontalieri',
+ canonicalPath: '/articoli-frontaliere/aprire-conto-bancario-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3961,7 +3961,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni fiscali, frontalieri, ticino, accordo fiscale, imposte, lavoro, comuni di frontiera',
  ogTitle: 'Guida ai ristorni fiscali frontalieri 2026',
  ogDescription: 'Scopri come funzionano i ristorni fiscali per i frontalieri in Ticino e il loro impatto sui comuni italiani.',
- canonicalPath: '/articoli-frontaliere/ristorni-fiscali-frontaliere',
+ canonicalPath: '/articoli-frontaliere/ristorni-fiscali-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -3989,7 +3989,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, contributi sociali, busta paga, AVS, AI, LPP, trattenute, stipendio netto',
  ogTitle: 'Contributi sociali svizzeri: tutto sulla busta paga',
  ogDescription: 'Scopri come funzionano le trattenute in Svizzera per i frontalieri: AVS, AI, LPP, AD e altro. Calcola il tuo netto con il nostro simulatore.',
- canonicalPath: '/articoli-frontaliere/contributi-sociali-busta-paga',
+ canonicalPath: '/articoli-frontaliere/contributi-sociali-busta-paga/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4017,7 +4017,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, Ticino, sicurezza stradale, Vezia, Cureglia, incidenti, strada cantonale, traffico',
  ogTitle: 'Vezia-Cureglia: troppi incidenti sul tratto',
  ogDescription: 'La strada tra Vezia e Cureglia è teatro di frequenti incidenti. Il Municipio chiede interventi urgenti al Cantone.',
- canonicalPath: '/articoli-frontaliere/strada-incidenti-vezia-cureglia',
+ canonicalPath: '/articoli-frontaliere/strada-incidenti-vezia-cureglia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4045,7 +4045,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'assicurazione malattia, frontalieri, ticino, LAMal, EHIC, polizze integrative, sanitario, famiglia',
  ogTitle: 'Assicurazione malattia per tutta la famiglia',
  ogDescription: 'Proteggi la tua famiglia con le migliori opzioni di assicurazione malattia per frontalieri in Ticino: LAMal, EHIC e integrative.',
- canonicalPath: '/articoli-frontaliere/assicurazione-malattia-famiglia',
+ canonicalPath: '/articoli-frontaliere/assicurazione-malattia-famiglia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4072,7 +4072,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, economia ticino, tassa salute, lavoro frontalieri, crisi economica, frontalieri 2026',
  ogTitle: 'Frontalieri in calo: ecco le vere ragioni',
  ogDescription: 'Non è la tassa sulla salute il problema, ma le difficoltà economiche del Ticino. Approfondisci e scopri come tutelarti.',
- canonicalPath: '/articoli-frontaliere/frontalieri-calo-economia-ticinese',
+ canonicalPath: '/articoli-frontaliere/frontalieri-calo-economia-ticinese/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4100,7 +4100,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, innovation hub, startup, USI, Lugano, incubatori, imprenditorialità',
  ogTitle: 'USI Startup Centre: un\'eccellenza europea',
  ogDescription: 'Il centro dell\'USI è tra i migliori incubatori europei. Posizione strategica per frontalieri e startup. Leggi i dettagli!',
- canonicalPath: '/articoli-frontaliere/usi-centro-startup-classifica',
+ canonicalPath: '/articoli-frontaliere/usi-centro-startup-classifica/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4128,7 +4128,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, pratico, svizzera, italia',
  ogTitle: 'Sciopero in Italia: Impatti sui Treni Tilo',
  ogDescription: 'Dal 27 al 28 febbraio, i treni Tilo subiscono interruzioni per sciopero in Italia. Ecco cosa sapere.',
- canonicalPath: '/articoli-frontaliere/sciopero-treni-tilo-febbraio-2026',
+ canonicalPath: '/articoli-frontaliere/sciopero-treni-tilo-febbraio-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4156,7 +4156,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, chiasso, piscina comunale, copertura pressostatica, sicurezza, costi, infrastruttura',
  ogTitle: 'Piscina di Chiasso: 850\'000 CHF per la sicurezza',
  ogDescription: 'Nuova copertura per la piscina di Chiasso: costi, sicurezza e innovazioni. Scopri tutti i dettagli del progetto.',
- canonicalPath: '/articoli-frontaliere/piscina-chiasso-copertura',
+ canonicalPath: '/articoli-frontaliere/piscina-chiasso-copertura/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4184,7 +4184,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'centrale elettrica, Grono, frontalieri, Ticino, Axpo, energia idroelettrica, alluvione 2024, riparazioni',
  ogTitle: 'Centrale di Grono torna attiva: impatto per il Ticino',
  ogDescription: 'Dopo 18 mesi di lavori e 8 milioni spesi, la centrale di Grono riparte. Ecco cosa cambia per il Ticino e i frontalieri.',
- canonicalPath: '/articoli-frontaliere/centrale-elettrica-grono-attiva',
+ canonicalPath: '/articoli-frontaliere/centrale-elettrica-grono-attiva/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4212,7 +4212,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'NASpI frontalieri, indennità disoccupazione Italia, requisiti NASpI, calcolo NASpI, frontalieri Ticino, disoccupazione svizzera, frontalieri 2026',
  ogTitle: 'NASpI frontalieri: calcolo e requisiti 2026',
  ogDescription: 'Guida pratica per frontalieri: scopri come ottenere la NASpI, i requisiti e gli importi aggiornati al 2026!',
- canonicalPath: '/articoli-frontaliere/naspi-frontaliere-italia-requisiti',
+ canonicalPath: '/articoli-frontaliere/naspi-frontaliere-italia-requisiti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4240,7 +4240,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, pensione, svizzera, italia',
  ogTitle: 'Prelievo del secondo pilastro LPP per frontalieri',
  ogDescription: 'Guida pratica sul prelievo del secondo pilastro LPP per frontalieri: quando, tassazione e strategie ottimali.',
- canonicalPath: '/articoli-frontaliere/prelievo-secondo-pilastro-frontaliere',
+ canonicalPath: '/articoli-frontaliere/prelievo-secondo-pilastro-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4268,7 +4268,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, novita, svizzera, italia',
  ogTitle: 'Accordo Svizzera-UE, firma in arrivo per i frontalieri',
  ogDescription: 'Il pacchetto di accordi con l\'UE sarà firmato il 2 marzo, un passo cruciale per i frontalieri del Ticino.',
- canonicalPath: '/articoli-frontaliere/accordo-ue-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/accordo-ue-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4296,7 +4296,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, Ticino, ristorni fiscali, tassa salute, Berna Italia, Norman Gobbi, relazioni transfrontaliere',
  ogTitle: 'Ticino: possibile blocco dei ristorni fiscali',
  ogDescription: 'Norman Gobbi annuncia il possibile congelamento dei ristorni fiscali verso l\'Italia. Leggi le conseguenze per frontalieri e comuni di confine.',
- canonicalPath: '/articoli-frontaliere/ristorni-congelati-ticino-italia',
+ canonicalPath: '/articoli-frontaliere/ristorni-congelati-ticino-italia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4324,7 +4324,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'naspi ex frontalieri 2026, naspi frontalieri svizzera italia, domanda naspi ex frontalieri, documenti naspi frontalieri, requisiti naspi ex frontalieri, tempi inps naspi frontalieri',
  ogTitle: 'NASpI Ex Frontalieri 2026: Requisiti, Importi e Domanda',
  ogDescription: 'Licenziato dalla Svizzera? Ecco come richiedere la NASpI: requisiti, documenti e importi calcolati per ex frontalieri.',
- canonicalPath: '/articoli-frontaliere/naspi-ex-frontalieri-2026',
+ canonicalPath: '/articoli-frontaliere/naspi-ex-frontalieri-2026/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -4384,7 +4384,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mutuo frontaliere, mutuo casa stipendio svizzero, comprare casa frontaliere, banche frontalieri italia, mutuo italia stipendio svizzera, acquisto casa frontaliere, mutuo svizzera per casa italia',
  ogTitle: 'Mutuo Casa con Stipendio Svizzero: Guida Frontalieri',
  ogDescription: 'Quali banche accettano frontalieri? Requisiti, documenti e tassi mutuo per comprare casa in Italia con stipendio svizzero.',
- canonicalPath: '/articoli-frontaliere/mutuo-casa-frontalieri-italia',
+ canonicalPath: '/articoli-frontaliere/mutuo-casa-frontalieri-italia/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -4435,7 +4435,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, piscina Chiasso, copertura piscina, investimenti Chiasso, piscina comunale, frontalieri Chiasso, valichi di confine',
  ogTitle: 'Piscina di Chiasso: nuovo investimento da 850mila CHF',
  ogDescription: 'Chiasso rinnova la copertura della piscina comunale con un investimento di 850mila CHF. Una struttura più moderna per la comunità e i frontalieri.',
- canonicalPath: '/articoli-frontaliere/piscina-chiasso-investimento',
+ canonicalPath: '/articoli-frontaliere/piscina-chiasso-investimento/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4463,7 +4463,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, Ticino, ristorni fiscali, tassa salute, comuni di frontiera, Norman Gobbi, Svizzera, Italia',
  ogTitle: 'Ristorni congelati: ecco cosa cambia per i frontalieri',
  ogDescription: 'Tensioni tra Ticino e Berna: Gobbi minaccia di bloccare i ristorni verso l\'Italia. Conseguenze per i frontalieri e i comuni di confine.',
- canonicalPath: '/articoli-frontaliere/ristorni-congelati-gobbi-2026',
+ canonicalPath: '/articoli-frontaliere/ristorni-congelati-gobbi-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4491,7 +4491,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'asilo nido Ticino, frontaliere con figli, costi asilo nido, sussidi asilo Ticino, liste attesa nidi, alternative nidi Italia',
  ogTitle: 'Frontaliere con figli: guida agli asili nido in Ticino',
  ogDescription: 'Costi, sussidi e liste d\'attesa per gli asili nido in Ticino. Scopri le opzioni per i frontalieri e le alternative italiane.',
- canonicalPath: '/articoli-frontaliere/asilo-nido-ticino-guida-2026',
+ canonicalPath: '/articoli-frontaliere/asilo-nido-ticino-guida-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4519,7 +4519,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, ristorni salute, tasse, sanità, lavoro',
  ogTitle: 'Congelamento ristorni salute: cosa significa?',
  ogDescription: 'Informati sul congelamento dei ristorni per frontalieri e le sue conseguenze fiscali.',
- canonicalPath: '/articoli-frontaliere/ristorni-salute-2026-ticino',
+ canonicalPath: '/articoli-frontaliere/ristorni-salute-2026-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4547,7 +4547,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni fiscali, tassa salute, frontalieri, Ticino, Berna, Italia, Norman Gobbi, accordi bilaterali, laRegione',
  ogTitle: 'Crisi Ristorni: Ticino contro Berna per la Tassa Salute Frontalieri',
  ogDescription: 'Il Canton Ticino minaccia di bloccare i ristorni fiscali all\'Italia a causa dei costi per la tassa salute dei frontalieri. Una mossa senza precedenti che scuote i rapporti con Berna.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-scontro-ticino-berna',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-scontro-ticino-berna/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4575,7 +4575,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'chiasso, piscina, copertura pressostatica, sicurezza, investimento, ticino, frontalieri, mendrisiotto',
  ogTitle: 'Piscina di Chiasso: un investimento da 850\'000 CHF per la sicurezza',
  ogDescription: 'Chiasso rinnova la copertura della piscina comunale con un investimento da 850\'000 franchi, garantendo maggiore sicurezza e durabilità. Scopri i dettagli.',
- canonicalPath: '/articoli-frontaliere/piscina-chiasso-rinnovo-copertura-sicurezza',
+ canonicalPath: '/articoli-frontaliere/piscina-chiasso-rinnovo-copertura-sicurezza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4603,7 +4603,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'sciopero treni, tilo, frontalieri, ticino, italia, trasporti, pendolari, disagi, febbraio 2026',
  ogTitle: 'Allerta Sciopero Tilo: Cosa cambia per il tuo viaggio in Ticino?',
  ogDescription: 'Non farti trovare impreparato: scopri le linee Tilo interrotte il 27-28 febbraio e le alternative per i frontalieri!',
- canonicalPath: '/articoli-frontaliere/sciopero-tilo-italia-disagi-frontalieri',
+ canonicalPath: '/articoli-frontaliere/sciopero-tilo-italia-disagi-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4631,7 +4631,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, trasporto pubblico, sconti, abbonamenti, TILO, Arcobaleno, Lombardia',
  ogTitle: 'Scopri gli sconti sui trasporti Ticino-Lombardia',
  ogDescription: 'Guida completa agli abbonamenti e agevolazioni per i frontalieri sui mezzi pubblici tra Ticino e Lombardia. Risparmia nel 2026!',
- canonicalPath: '/articoli-frontaliere/abbonamenti-sconti-treni-ticino',
+ canonicalPath: '/articoli-frontaliere/abbonamenti-sconti-treni-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4659,7 +4659,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, bonus famiglia, assegni familiari, detrazioni fiscali, permesso G, bonus nido, economia svizzera',
  ogTitle: 'Bonus famiglia frontalieri 2026: tutte le novità',
  ogDescription: 'Assegni familiari fino a 4.200 CHF, bonus nido e detrazioni fiscali: scopri i vantaggi per frontalieri nel 2026.',
- canonicalPath: '/articoli-frontaliere/bonus-famiglia-frontalieri-2026',
+ canonicalPath: '/articoli-frontaliere/bonus-famiglia-frontalieri-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4687,7 +4687,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, smart working, Ticino, regole 2026, fiscalità frontalieri, permesso G, lavoro da remoto',
  ogTitle: 'Smart Working Frontalieri: Nuove Regole 2026',
  ogDescription: 'Scopri le regole aggiornate sullo smart working per i frontalieri in Ticino: limiti, fiscalità e procedure pratiche per il 2026.',
- canonicalPath: '/articoli-frontaliere/smart-working-frontalieri-regole',
+ canonicalPath: '/articoli-frontaliere/smart-working-frontalieri-regole/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4715,7 +4715,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'assicurazione auto, frontalieri, Ticino, Svizzera, Italia, costi RC auto, polizze auto frontalieri, sinistri transfrontalieri',
  ogTitle: 'Assicurazioni auto frontalieri: Italia vs Svizzera',
  ogDescription: 'Confronto assicurazioni auto per frontalieri: costi, coperture e consigli pratici. Scopri quale polizza conviene nel 2026.',
- canonicalPath: '/articoli-frontaliere/confronto-assicurazioni-auto',
+ canonicalPath: '/articoli-frontaliere/confronto-assicurazioni-auto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4743,7 +4743,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso b vs g, differenze permesso b g, permesso g frontaliere, permesso b svizzera, lavorare in svizzera permesso, frontaliere residenza',
  ogTitle: 'Permesso B vs G: Quale Conviene nel 2026?',
  ogDescription: 'Permesso B o G? Confronto completo per frontalieri: tasse, residenza, diritti e costi. Scopri quale conviene nel 2026.',
- canonicalPath: '/articoli-frontaliere/permesso-b-vs-g-differenze',
+ canonicalPath: '/articoli-frontaliere/permesso-b-vs-g-differenze/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4772,7 +4772,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, spese sanitarie, rimborso, LAMal, SSN, ASL, Italia-Svizzera',
  ogTitle: 'Spese sanitarie rimborsabili per frontalieri',
  ogDescription: 'Guida pratica per frontalieri: scopri quali spese sanitarie in Svizzera puoi farti rimborsare in Italia.',
- canonicalPath: '/articoli-frontaliere/spese-sanitarie-frontalieri',
+ canonicalPath: '/articoli-frontaliere/spese-sanitarie-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4804,7 +4804,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dichiarazione dei redditi, ticino, frontalieri, tasse, eTax 2025, proroga scadenza, imposte svizzera',
  ogTitle: 'Dichiarazione dei redditi Ticino 2026: tutto quello che devi sapere',
  ogDescription: 'Moduli dichiarazione d\'imposta 2025 in Ticino: scadenze, istruzioni e vantaggi di eTax. Guida pratica per frontalieri.',
- canonicalPath: '/articoli-frontaliere/dichiarazione-redditi-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/dichiarazione-redditi-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4833,7 +4833,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, traffico, A9, Chiasso, code, pedaggio, trasporto pendolari, lavori stradali',
  ogTitle: 'Cantieri sull\'A9: disagi per i frontalieri',
  ogDescription: 'Scopri come i lavori sulla A9 stanno influenzando traffico e costi per i frontalieri. Consigli pratici e strumenti utili.',
- canonicalPath: '/articoli-frontaliere/cantieri-traffico-a9-ticino',
+ canonicalPath: '/articoli-frontaliere/cantieri-traffico-a9-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4862,7 +4862,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'migranti, ticino, frontalieri, giubiasco, seghezzone, risparmi, canton ticino, bellinzona',
  ogTitle: 'Migranti al Seghezzone: risparmi fino a 2 milioni',
  ogDescription: 'Nuova struttura prefabbricata per richiedenti asilo a Giubiasco: 88 posti letto e risparmi significativi per il Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/migranti-seghezzone-risparmi',
+ canonicalPath: '/articoli-frontaliere/migranti-seghezzone-risparmi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4891,7 +4891,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cantieri, sull, disagi, torna',
  ogTitle: 'Traffico frontalieri: cantieri sull\'A9',
  ogDescription: 'Lavori sull\'A9: code e disagi fino all\'Ascensione per chi attraversa il confine. Scopri strumenti utili per calcolare l\'impatto.',
- canonicalPath: '/articoli-frontaliere/cantieri-traffico-frontiera',
+ canonicalPath: '/articoli-frontaliere/cantieri-traffico-frontiera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4920,7 +4920,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, approva, compromesso',
  ogTitle: 'Salario minimo: compromesso PS approvato',
  ogDescription: 'Il Partito Socialista ticinese approva il compromesso sul salario minimo: benefici e deroghe per i frontalieri. Scopri di più.',
- canonicalPath: '/articoli-frontaliere/salario-minimo-ps-compromesso',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-ps-compromesso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4949,7 +4949,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, traffico, cocaina, perquisizioni, operazione',
  ogTitle: 'Traffico di Cocaina: Perquisizioni in Ticino',
  ogDescription: 'Operazione internazionale contro il traffico di cocaina: perquisizioni in Ticino e arresti in Italia e Francia. Scopri i dettagli.',
- canonicalPath: '/articoli-frontaliere/traffico-cocaina-ticino-lusso',
+ canonicalPath: '/articoli-frontaliere/traffico-cocaina-ticino-lusso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -4978,7 +4978,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, calcolo, tasse, entro, confine',
  ogTitle: 'Calcolo tasse frontalieri entro 20 km',
  ogDescription: 'Guida pratica per calcolare le tasse dei frontalieri entro 20 km: franchigia a 10.000€, credito d\'imposta e novità fiscali 2026.',
- canonicalPath: '/articoli-frontaliere/calcolo-tasse-frontalieri-entro-20-km',
+ canonicalPath: '/articoli-frontaliere/calcolo-tasse-frontalieri-entro-20-km/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5007,7 +5007,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, riforma, giustizia, pace, approvata',
  ogTitle: 'Riforma Giustizia di Pace Ticino',
  ogDescription: 'La nuova Riforma della Giustizia di pace in Ticino punta a maggiore efficienza e professionalizzazione. Scopri i dettagli.',
- canonicalPath: '/articoli-frontaliere/riforma-giustizia-pace-ticino',
+ canonicalPath: '/articoli-frontaliere/riforma-giustizia-pace-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5036,7 +5036,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cantieri, sulla, disagi, valichi',
  ogTitle: 'Cantieri sulla A9: disagi ai valichi di frontiera',
  ogDescription: 'Lavori sulla A9 al viadotto Fati: scopri come ridurre i disagi e pianificare i tuoi spostamenti tra Italia e Svizzera.',
- canonicalPath: '/articoli-frontaliere/cantieri-a9-disagi-frontiera',
+ canonicalPath: '/articoli-frontaliere/cantieri-a9-disagi-frontiera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5065,7 +5065,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, magliaso, revoca, avviso, parsimonioso',
  ogTitle: 'Magliaso, revocato l\'uso parsimonioso dell\'acqua',
  ogDescription: 'Conclusa l\'emergenza idrica a Magliaso: riparata la condotta, l\'acqua potabile torna regolare.',
- canonicalPath: '/articoli-frontaliere/revoca-uso-acqua-magliaso',
+ canonicalPath: '/articoli-frontaliere/revoca-uso-acqua-magliaso/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5094,7 +5094,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, 25mila, casi, malattie, rare',
  ogTitle: 'Malattie rare in Ticino: 25mila casi da supportare',
  ogDescription: 'Scopri come i frontalieri in Ticino possono affrontare le sfide legate alle malattie rare e alla copertura sanitaria.',
- canonicalPath: '/articoli-frontaliere/malattie-rare-ticino',
+ canonicalPath: '/articoli-frontaliere/malattie-rare-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5123,7 +5123,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, frontaliers, sabotage, arriva, varese',
  ogTitle: 'Frontaliers Sabotage arriva a Varese',
  ogDescription: 'Il celebre film sui frontalieri debutta in Italia con due eventi speciali a Varese. Scopri i dettagli!',
- canonicalPath: '/articoli-frontaliere/frontaliers-sabotage-varese',
+ canonicalPath: '/articoli-frontaliere/frontaliers-sabotage-varese/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5152,7 +5152,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ristorni, congelati, scontro, berna',
  ogTitle: 'Ristorni congelati: tensioni tra Ticino e Berna',
  ogDescription: 'Ticino minaccia di congelare i ristorni fiscali verso l\'Italia: ecco cosa significa per frontalieri e comuni di confine.',
- canonicalPath: '/articoli-frontaliere/ristorni-congelati-scontro-ticino',
+ canonicalPath: '/articoli-frontaliere/ristorni-congelati-scontro-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5181,7 +5181,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassazione, individuale, lavoro, donne',
  ogTitle: 'Tassazione individuale: impatto sui frontalieri',
  ogDescription: 'Scopri come la riforma sulla tassazione individuale in Svizzera potrebbe creare migliaia di posti di lavoro e aiutare le famiglie.',
- canonicalPath: '/articoli-frontaliere/tassazione-individuale-donne-lavoro',
+ canonicalPath: '/articoli-frontaliere/tassazione-individuale-donne-lavoro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5210,7 +5210,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, comunità, religiose, record, svizzero',
  ogTitle: 'Ticino: oltre 500 comunità religiose',
  ogDescription: 'Il Ticino è una terra di pluralismo religioso con oltre 500 comunità. Scopri come questa diversità tocca anche i frontalieri.',
- canonicalPath: '/articoli-frontaliere/diversita-religiosa-ticino',
+ canonicalPath: '/articoli-frontaliere/diversita-religiosa-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5239,7 +5239,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, voto, corrispondenza, scelta, futuro',
  ogTitle: 'Voto per corrispondenza: la scelta del futuro',
  ogDescription: 'Il voto per corrispondenza in Ticino è ormai preferito dal 90-95% degli elettori. Scopri i vantaggi e le novità per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/voto-corrispondenza-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/voto-corrispondenza-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5268,7 +5268,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, viale, geno, como, lavori',
  ogTitle: 'Lavori a Viale Geno: cosa cambia per i frontalieri',
  ogDescription: 'Disagi per frontalieri e commercianti: il cantiere di Viale Geno a Como divide. Scopri impatti e consigli.',
- canonicalPath: '/articoli-frontaliere/cantiere-viale-geno-rischi',
+ canonicalPath: '/articoli-frontaliere/cantiere-viale-geno-rischi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5297,7 +5297,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, controlli, mobili, velocità, marzo',
  ogTitle: 'Controlli di velocità in Ticino: date e località',
  ogDescription: 'La Polizia ticinese attiverà controlli mobili della velocità per tutta la settimana dal 2 all\'8 marzo 2026. Leggi i dettagli.',
- canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5326,7 +5326,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sanremo, aiello, gassmann, incantano',
  ogTitle: 'Sanremo 2026: Aiello e Leo Gassmann incantano',
  ogDescription: 'Sanremo 2026: scopri l\'esibizione di Aiello e Leo Gassmann e il legame culturale con il Canton Ticino.',
- canonicalPath: '/articoli-frontaliere/sanremo-2026-aiello-gassmann',
+ canonicalPath: '/articoli-frontaliere/sanremo-2026-aiello-gassmann/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5355,7 +5355,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, violenza, giovanile, allarme, crescente',
  ogTitle: 'Violenza giovanile in Ticino: dati e sicurezza',
  ogDescription: 'Un uomo aggredito da adolescenti in Svizzera. Impatti sulla sicurezza dei frontalieri e misure nei valichi di confine.',
- canonicalPath: '/articoli-frontaliere/violenza-adolescenti-ticino',
+ canonicalPath: '/articoli-frontaliere/violenza-adolescenti-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5384,7 +5384,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, comuni, distanza, conta, nuovi',
  ogTitle: 'Comuni frontalieri: la distanza che conta',
  ogDescription: 'Scopri come una manciata di metri può fare la differenza per i frontalieri e il loro status fiscale.',
- canonicalPath: '/articoli-frontaliere/comuni-frontalieri-distanza',
+ canonicalPath: '/articoli-frontaliere/comuni-frontalieri-distanza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5413,7 +5413,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, elezioni, comunali, cosa, cambia',
  ogTitle: 'Elezioni Comunali in Ticino: Impatti per i Frontalieri',
  ogDescription: 'Analisi post-elettorale: come le nuove politiche comunali in Ticino influenzeranno frontalieri e residenti.',
- canonicalPath: '/articoli-frontaliere/elezioni-comunali-ticino',
+ canonicalPath: '/articoli-frontaliere/elezioni-comunali-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5442,7 +5442,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, chiasso-brogeda, sequestrati, eroina, auto',
  ogTitle: 'Eroina a Brogeda: scoperti 5 kg in auto',
  ogDescription: 'Coppia fermata per traffico di stupefacenti al confine di Chiasso-Brogeda. Scopri le implicazioni per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/eroina-auto-chiasso-brogeda',
+ canonicalPath: '/articoli-frontaliere/eroina-auto-chiasso-brogeda/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5471,7 +5471,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cassis, prodotto, buono, accordo',
  ogTitle: 'Bilaterali III, Cassis: "Il prodotto è buono". L\'accordo per',
  ogDescription: 'L\'accordo Bilaterali III prevede la creazione di una zona di libero scambio tra la Svizzera e l\'Unione Europea. L\'accordo permetterebbe di mantenere relazioni',
- canonicalPath: '/articoli-frontaliere/bilaterali-iii-cassis-ticino',
+ canonicalPath: '/articoli-frontaliere/bilaterali-iii-cassis-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5499,7 +5499,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fermato, brogeda, oltre, chili',
  ogTitle: 'Fermato a Brogeda con oltre 15 chili di cocaina nell\'auto',
  ogDescription: 'Un cittadino dominicano residente in Spagna è stato arrestato con l\'accusa di traffico internazionale di stupefacenti.',
- canonicalPath: '/articoli-frontaliere/fermato-brogeda-cocaina',
+ canonicalPath: '/articoli-frontaliere/fermato-brogeda-cocaina/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5528,7 +5528,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dominicano, auto, trafficante, arresto',
  ogTitle: 'Dominicano con auto svizzera e trafficante: arresto in',
  ogDescription: 'Un cittadino dominicano con un veicolo con targhe svizzere è stato arrestato al valico di Chiasso con oltre 15 chilogrammi di cocaina',
- canonicalPath: '/articoli-frontaliere/dominicano-auto-svizzera-arresto',
+ canonicalPath: '/articoli-frontaliere/dominicano-auto-svizzera-arresto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5557,7 +5557,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salari, bassi, rischio, povertà',
  ogTitle: 'Salari bassi e rischio povertà in Ticino',
  ogDescription: 'Il PLR presenta un\'interrogazione al Consiglio di Stato sul tema dei salari bassi e del rischio povertà in Ticino.',
- canonicalPath: '/articoli-frontaliere/salari-bassi-rischio-povert',
+ canonicalPath: '/articoli-frontaliere/salari-bassi-rischio-povert/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5586,7 +5586,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, svolta, storica, apprendisti, consiglio',
  ogTitle: 'Ticino, svolta storica per gli apprendisti frontalieri',
  ogDescription: 'Il Consiglio nazionale approva la riforma che estende la validità del permesso di lavoro G per gli apprendisti frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/ticino-svolta-per-apprendisti',
+ canonicalPath: '/articoli-frontaliere/ticino-svolta-per-apprendisti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5615,7 +5615,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, alta, qualità, vita',
  ogTitle: 'Bellinzona: alta qualità di vita e impieghi di qualità',
  ogDescription: 'Il Municipio di Bellinzona punta su alta qualità di vita e posti di lavoro specialistici per attrarre profili qualificati.',
- canonicalPath: '/articoli-frontaliere/bellinzona-crescita-qualita-vita',
+ canonicalPath: '/articoli-frontaliere/bellinzona-crescita-qualita-vita/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5644,7 +5644,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crisi, spermatozoi, problema, anche',
  ogTitle: 'La crisi degli spermatozoi in Svizzera',
  ogDescription: 'Un problema che può avere gravi conseguenze per le coppie che cercano di avere figli',
- canonicalPath: '/articoli-frontaliere/crisi-spermatozoi-svizzera-ticino',
+ canonicalPath: '/articoli-frontaliere/crisi-spermatozoi-svizzera-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5672,7 +5672,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, brogeda, chili, cocaina, sequestrati',
  ogTitle: 'Sequestrati 15 kg di cocaina a Brogeda: operazione al',
  ogDescription: 'Operazione antidroga al valico di Brogeda: sequestrati 15 kg di cocaina in un\'auto. Le Fiamme Gialle hanno intercettato il carico destinato al mercato svizzero',
- canonicalPath: '/articoli-frontaliere/droga-brogeda-sequestro-cocaina',
+ canonicalPath: '/articoli-frontaliere/droga-brogeda-sequestro-cocaina/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5701,7 +5701,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, mancano, posti, auto',
  ogTitle: 'A Bellinzona mancano 75 posti auto pubblici e la soluzione è',
  ogDescription: 'Il comune di Bellinzona ha annunciato la costruzione di un nuovo autosilo interrato con parco pubblico e nuovo edificio amministrativo.',
- canonicalPath: '/articoli-frontaliere/bellinzona-auscultazione-2026',
+ canonicalPath: '/articoli-frontaliere/bellinzona-auscultazione-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5730,7 +5730,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dalla, lombardia, affitto, famiglie',
  ogTitle: '228.463€ dalla Lombardia per l\'affitto: 218 famiglie salvate',
  ogDescription: 'Guida completa al bando regionale per contrastare la morosità incolpevole: requisiti, importi e scadenze per i frontalieri che vivono a Varese.',
- canonicalPath: '/articoli-frontaliere/lombardia-affitto-famiglie-varesine',
+ canonicalPath: '/articoli-frontaliere/lombardia-affitto-famiglie-varesine/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5759,7 +5759,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, trovare, malcantone, giornate, primavera',
  ogTitle: 'Malcantone Fai di Primavera 2026 | Frontaliere Ticino',
  ogDescription: 'Le Giornate Fai di Primavera tornano in Ticino con un focus sul Malcantone. Scopri i borghi, i monumenti, le chiese e le dimore storiche della regione.',
- canonicalPath: '/articoli-frontaliere/malcantone-fai-di-primavera-2026',
+ canonicalPath: '/articoli-frontaliere/malcantone-fai-di-primavera-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5788,7 +5788,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, privata, sotto, accusa',
  ogTitle: 'Sicurezza privata sotto accusa dopo Nebiopoli',
  ogDescription: 'Deputato UDC Tuto Rossi chiede chiarimenti al governo su selezione e formazione agenti dopo episodi di violenza a Chiasso',
- canonicalPath: '/articoli-frontaliere/sicurezza-privata-chiasso-nebiopoli',
+ canonicalPath: '/articoli-frontaliere/sicurezza-privata-chiasso-nebiopoli/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5817,7 +5817,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sfruttamento, corrieri, verità, nascosta',
  ogTitle: 'Sfruttamento corrieri: la verità nascosta dietro le consegne',
  ogDescription: 'Paghe da fame, turni massacranti e controlli digitali: l\'inchiesta di Milano svela il lato oscuro del lavoro dei fattorini in Ticino e Lombardia',
- canonicalPath: '/articoli-frontaliere/sfruttamento-corsieri-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/sfruttamento-corsieri-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5846,7 +5846,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fuga, talenti, zurigo, anche',
  ogTitle: 'La fuga di talenti a Zurigo: anche le aziende si lamentano',
  ogDescription: 'La carenza di alloggi a Zurigo è un problema serio che sta scoraggiando i candidati dalle aziende zurighesi',
- canonicalPath: '/articoli-frontaliere/lavoro-economia-2026',
+ canonicalPath: '/articoli-frontaliere/lavoro-economia-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5875,7 +5875,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cocaina, sequestrati, brogeda, cosa',
  ogTitle: 'Cocaina a Brogeda: guida sopravvivenza frontaliere',
  ogDescription: 'Maxi-sequestro al valico: 15 kg di cocaina nascosti sotto il sedile. Cosa cambia per chi attraversa il confine ogni giorno per lavorare.',
- canonicalPath: '/articoli-frontaliere/sequestro-cocaina-brogeda-2026',
+ canonicalPath: '/articoli-frontaliere/sequestro-cocaina-brogeda-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5904,7 +5904,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cultura, soldi, infiltrazioni, criminali',
  ogTitle: 'Cultura, soldi, infiltrazioni criminali: Ticino e Grigion',
  ogDescription: 'Il confronto tra il Ticino e il Grigioni in materia di infiltrazioni criminali e cultura economica.',
- canonicalPath: '/articoli-frontaliere/infiltrazioni-criminali-ticino-grigioni',
+ canonicalPath: '/articoli-frontaliere/infiltrazioni-criminali-ticino-grigioni/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5933,7 +5933,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, luganese, punta, sulla, formazione',
  ogTitle: 'Il Luganese punta sulla formazione per migliorare',
  ogDescription: 'L\'Ente Turistico del Luganese (ETL) ha lanciato il progetto \'Lugano Region Ti Conosco\', che ha coinvolto 68 operatori di 24 strutture ricettive dei comprensori',
- canonicalPath: '/articoli-frontaliere/turismo-luganese-formazione',
+ canonicalPath: '/articoli-frontaliere/turismo-luganese-formazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5961,7 +5961,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, incidente, sulla, rampa, chiasso',
  ogTitle: 'Incidente sulla rampa A9 per Chiasso: code e feriti lievi',
  ogDescription: 'Tre auto coinvolte in un incidente sulla rampa dell\'A9 verso Chiasso. Strada chiusa per due ore. Ferite lievi per tre persone.',
- canonicalPath: '/articoli-frontaliere/incidente-rampa-a9-chiasso-2026',
+ canonicalPath: '/articoli-frontaliere/incidente-rampa-a9-chiasso-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -5989,7 +5989,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tilo, fermate, varese, malpensa',
  ogTitle: 'TILO S50: fermate tra Varese e Malpensa cambiano il 11-12',
  ogDescription: 'Sabato 11 e domenica 12 aprile 2026 fermate TILO S50 tra Varese, Gallarate e Malpensa Aeroporto sostituite da bus. Tempi di viaggio allungati, soppressioni e bu',
- canonicalPath: '/articoli-frontaliere/tilo-s50-lavori-mal-pensa-varese-2026',
+ canonicalPath: '/articoli-frontaliere/tilo-s50-lavori-mal-pensa-varese-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6017,7 +6017,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, modifiche, collegamenti, tilo, varese',
  ogTitle: 'Modifiche TILO S50: Cosa cambia per i frontalieri?',
  ogDescription: 'L\'11 e 12 aprile i treni TILO S50 subiscono variazioni. Scopri gli orari dei bus sostitutivi e i consigli per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/tilo-s50-modifiche-aprile',
+ canonicalPath: '/articoli-frontaliere/tilo-s50-modifiche-aprile/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6045,7 +6045,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, perequazione, deluso, berna, blocca',
  ogTitle: 'Perequazione, Ticino deluso: Berna blocca fino al 2030',
  ogDescription: 'Il Consiglio federale non modifica l’ordinanza sulla perequazione finanziaria intercantonale fino al 2030. Il Ticino chiedeva una ponderazione diversa per i fro',
- canonicalPath: '/articoli-frontaliere/consiglio-federale-ferma-perequazione-2030',
+ canonicalPath: '/articoli-frontaliere/consiglio-federale-ferma-perequazione-2030/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6073,7 +6073,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, caso, camionisti, furbetti, decisione',
  ogTitle: 'Caso camionisti furbetti, decisione su Governo Ticino',
  ogDescription: 'Il governo ticinese si confronta con il problema dei camionisti che aggirano i controlli a Giornico.',
- canonicalPath: '/articoli-frontaliere/camionisti-furbetti-governo-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/camionisti-furbetti-governo-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6101,7 +6101,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, multe, mancata, vignetta, autostradale',
  ogTitle: 'Multe per Vignetta Autostradale a Chiasso: 190 Sanzioni',
  ogDescription: 'Controlli a tappeto al valico di Chiasso: 190 multe per mancata vignetta autostradale. Cosa devono sapere i frontalieri.',
- canonicalPath: '/articoli-frontaliere/multe-vignetta-chiasso-2024',
+ canonicalPath: '/articoli-frontaliere/multe-vignetta-chiasso-2024/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6129,7 +6129,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, petizione, mantenere, produzione, aromat',
  ogTitle: 'Petizione per mantenere la produzione di Aromat in Svizzera',
  ogDescription: 'Una petizione online raccoglie firme per preservare la produzione svizzera dell\'Aromat, minacciata dalla fusione tra Unilever e McCormick.',
- canonicalPath: '/articoli-frontaliere/petizione-aromat-svizzera',
+ canonicalPath: '/articoli-frontaliere/petizione-aromat-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6157,7 +6157,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, sulla, salute, scontro',
  ogTitle: 'Frontalieri e tassa sulla salute: scontro in consiglio regionale',
  ogDescription: 'Il Pd presenta una mozione per bloccare l\'imposta e tutelare i ristorni dei Comuni di frontiera.',
- canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-scontro',
+ canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-scontro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6185,7 +6185,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, pasqua, multati, chiasso, vignetta',
  ogTitle: 'Pasqua 2026: 190 frontalieri multati a Chiasso per la vig',
  ogDescription: 'Durante il lungo weekend pasquale 2026, la dogana di Chiasso ha inflitto 190 multe a conducenti senza vignetta. Il 45% dei frontalieri ha optato per l’e-vignett',
- canonicalPath: '/articoli-frontaliere/multe-vignetta-chiasso-pasqua-2026',
+ canonicalPath: '/articoli-frontaliere/multe-vignetta-chiasso-pasqua-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6213,7 +6213,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, penalizzato, gonfiano, ricchezza, fittizia',
  ogTitle: 'Ticino penalizzato: frontalieri gonfiano la ricchezza fit',
  ogDescription: 'Berna considera il Ticino più ricco di quanto sia realmente a causa dei salari dei frontalieri. Risultato: 9 milioni di franchi in meno all’anno per le casse ca',
- canonicalPath: '/articoli-frontaliere/tasse-ticino-frontalieri-perequazione-2026',
+ canonicalPath: '/articoli-frontaliere/tasse-ticino-frontalieri-perequazione-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6241,7 +6241,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, asili, bellinzona, progetto, pilota',
  ogTitle: 'Asili a Bellinzona: progetto pilota per orario prolungato',
  ogDescription: 'Mozione interpartitica chiede a Bellinzona di avviare entro il 2027/2028 sezioni a orario prolungato in 1-2 asili. Soluzione già attiva a Lugano, Locarno e Mend',
- canonicalPath: '/articoli-frontaliere/asili-bellinzona-progetto-pilota-orario-prolungato-2027',
+ canonicalPath: '/articoli-frontaliere/asili-bellinzona-progetto-pilota-orario-prolungato-2027/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6269,7 +6269,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, multe, vignetta, mancante, chiasso',
  ogTitle: 'Multe per vignetta a Chiasso: 190 sanzioni in 4 giorni',
  ogDescription: 'Controlli intensificati al valico di Chiasso-Brogeda: 190 multe da 200 CHF per mancanza della vignetta autostradale svizzera.',
- canonicalPath: '/articoli-frontaliere/multe-vignetta-chiasso-2026',
+ canonicalPath: '/articoli-frontaliere/multe-vignetta-chiasso-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6297,7 +6297,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, servizio, trasfusionale, locarno, chiude',
  ogTitle: 'Servizio Trasfusionale di Locarno chiude il 24 giugno: do',
  ogDescription: 'Dal 24 giugno 2026 il Servizio Trasfusionale di Locarno cesserà l’attività. La scelta, maturata in 4 anni di riflessioni, è dovuta al calo delle entrate dalla v',
- canonicalPath: '/articoli-frontaliere/servizio-trasfusionale-locarno-chiusura-24-giugno',
+ canonicalPath: '/articoli-frontaliere/servizio-trasfusionale-locarno-chiusura-24-giugno/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6325,7 +6325,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, ancora, ritardi, versamenti, disoccupazione',
  ogTitle: 'Ritardi pagamenti disoccupazione Ticino | Frontaliere Ticino',
  ogDescription: 'Disoccupati in Ticino affrontano ancora ritardi nei versamenti a causa di problemi tecnici. Scopri come procedere e cosa fare.',
- canonicalPath: '/articoli-frontaliere/ritardi-disoccupazione-ticino',
+ canonicalPath: '/articoli-frontaliere/ritardi-disoccupazione-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6353,7 +6353,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, presi, assalto, benzinai, lombardi',
  ogTitle: 'Frontalieri presi d’assalto: benzinai lombardi esauriti,',
  ogDescription: 'Da Como a Varese distributori a secco per i frontalieri ticinesi. I prezzi in Svizzera caleranno lentamente, mentre in Lombardia lo sciopero delle scorte costri',
- canonicalPath: '/articoli-frontaliere/benzina-lombardia-frontalieri-ticinesi-2026',
+ canonicalPath: '/articoli-frontaliere/benzina-lombardia-frontalieri-ticinesi-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6381,7 +6381,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, diploma, statunitense, bloccato, odissea',
  ogTitle: 'Diploma statunitense bloccato in Ticino: un’odissea buroc',
  ogDescription: 'Lugano, 10 aprile 2026. Riconoscimento del titolo statunitense rifiutato: un esame attitudinale ad hoc e attese di oltre un anno. La storia di Anna, ticinese co',
- canonicalPath: '/articoli-frontaliere/diploma-usa-non-riconosciuto-ticino',
+ canonicalPath: '/articoli-frontaliere/diploma-usa-non-riconosciuto-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6409,7 +6409,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, discovereu, 40mila, pass, gratuiti',
  ogTitle: 'DiscoverEU 2026: 40mila pass gratuiti in treno per 18enni',
  ogDescription: 'Scadenza candidature 22 aprile 2026 per viaggiare gratis in treno fino al 30 settembre 2027. Aperto anche a frontalieri ticinesi se residenti in Paesi UE o asso',
- canonicalPath: '/articoli-frontaliere/discover-eu-2026-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/discover-eu-2026-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6437,7 +6437,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, banche, svizzere, allerta, clienti',
  ogTitle: 'Banche svizzere in allerta per i clienti del Golfo: cosa',
  ogDescription: 'Trasferimenti di fondi verso la Svizzera già in atto. I patrimoni del Golfo rivalutano la Confederazione per sicurezza e neutralità. Apprezzamento del franco co',
- canonicalPath: '/articoli-frontaliere/banche-svizzere-pronti-clienti-golfo-2026',
+ canonicalPath: '/articoli-frontaliere/banche-svizzere-pronti-clienti-golfo-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6465,7 +6465,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fertilizzanti, crisi, hormuz, colpisce',
  ogTitle: 'Fertilizzanti +40% in Ticino: la crisi di Hormuz colpisce',
  ogDescription: 'Blocco dello Stretto di Hormuz fa lievitare azoto, potassio e fosforo. Agricoltori ticinesi rischiano perdite fino al 10% sui margini.',
- canonicalPath: '/articoli-frontaliere/fertilizzanti-crisi-hormuz-rincari-ticino-40',
+ canonicalPath: '/articoli-frontaliere/fertilizzanti-crisi-hormuz-rincari-ticino-40/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6493,7 +6493,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, lombardia, sola',
  ogTitle: 'Tassa salute frontalieri: Lombardia sola a insistere, Tic',
  ogDescription: 'La Lombardia è l\'unica regione italiana a voler applicare la "tassa salute" per i frontalieri, entrata in vigore 27 mesi fa ma mai applicata. Minacce di decurta',
- canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-isola-2026',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-isola-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6521,7 +6521,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, reclutatori, ticinesi, caccia, futuri',
  ogTitle: 'Reclutamento Infermieri Lombardia Ticino',
  ogDescription: 'Reclutatori ticinesi offrono preassunzioni a studenti di infermieristica in Lombardia. Dettagli su opportunità e requisiti.',
- canonicalPath: '/articoli-frontaliere/reclutamento-infermieri-lombardia',
+ canonicalPath: '/articoli-frontaliere/reclutamento-infermieri-lombardia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6549,7 +6549,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, autostrada, verso, chiasso, chiusa',
  ogTitle: 'Autostrada A9 verso Chiasso chiusa di notte: ecco quando',
  ogDescription: 'Tratto Como Centro-Chiasso dell\'A9 bloccato dalle 22 alle 5 per pavimentazione, sostituzione cavo alta tensione e transito mezzi speciali dal 13 al 15 aprile 20',
- canonicalPath: '/articoli-frontaliere/autostrada-a9-chiude-de-notti-2026',
+ canonicalPath: '/articoli-frontaliere/autostrada-a9-chiude-de-notti-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6577,7 +6577,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, multati, notte, chiasso, ecco',
  ogTitle: '190 multe a Chiasso per mancanza vignetta: la guida per',
  ogDescription: 'Scopri perché 190 automobilisti sono stati multati alla dogana di Chiasso durante Pasqua 2024 e come evitare la multa da 200 CHF con semplici passaggi.',
- canonicalPath: '/articoli-frontaliere/multa-vignetta-pasqua-chiasso-2024',
+ canonicalPath: '/articoli-frontaliere/multa-vignetta-pasqua-chiasso-2024/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6605,7 +6605,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salva, compie, anni, meno',
  ogTitle: 'SALVA compie 20 anni: meno della metà chiama l’ambulanza',
  ogDescription: 'Il Servizio Ambulanza Locarnese e Valli (SALVA) celebra 20 anni con un monito: solo il 40% degli infartuati chiama il 144. Punti salienti della giornata porte a',
- canonicalPath: '/articoli-frontaliere/salva-venti-anni-monito-infarti',
+ canonicalPath: '/articoli-frontaliere/salva-venti-anni-monito-infarti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6633,7 +6633,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, migros, meno, marchi, 2025',
  ogTitle: 'Migros Ticino: meno marchi, più ‘Migros’ dal 2025',
  ogDescription: 'Migros riduce i marchi propri da 250 a 80 entro il 2030. La linea ‘American Favorites’ cambia nome e aspetto senza riferimenti agli USA. Scopri come cambia la',
- canonicalPath: '/articoli-frontaliere/marchi-migros-riduzione-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/marchi-migros-riduzione-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6661,7 +6661,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, disagi, alla, linea, tilo',
  ogTitle: 'Disagi Tilo Mendrisio-Malpensa: Cosa Cambia ad Aprile 2026',
  ogDescription: 'Tutto quello che devi sapere sui disagi alla linea Tilo S50 tra Mendrisio e Malpensa l\'11 e 12 aprile 2026. Orari, bus sostitutivi e consigli pratici.',
- canonicalPath: '/articoli-frontaliere/disagi-tilo-mendrisio-malpensa-2026',
+ canonicalPath: '/articoli-frontaliere/disagi-tilo-mendrisio-malpensa-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6689,7 +6689,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, soglia, 150mila, euro, vale',
  ogTitle: 'CPB: la soglia dei 150mila euro vale anche se si passa da',
  ogDescription: 'L’Agenzia delle Entrate conferma: chi ha aderito al Concordato Preventivo Biennale come forfettario deve rispettare la soglia di 150mila euro di ricavi, anche d',
- canonicalPath: '/articoli-frontaliere/cpb-forfettario-semplificato-soglia-150mila',
+ canonicalPath: '/articoli-frontaliere/cpb-forfettario-semplificato-soglia-150mila/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6717,7 +6717,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, verbano, accordo, livello, massimo',
  ogTitle: 'Verbano: accordo su livello massimo d’acqua, +20 milioni',
  ogDescription: 'Da metà aprile a fine luglio il Verbano sarà innalzato di 135 cm per garantire 20 milioni di metri cubi d’acqua ai campi lombardi. Sperimento fino al 2027 con d',
- canonicalPath: '/articoli-frontaliere/verbano-livello-max-accordo-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/verbano-livello-max-accordo-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6745,7 +6745,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, lombardia, sotto',
  ogTitle: 'Tassa salute frontalieri: Lombardia e Ticino allo scontro',
  ogDescription: 'La Lombardia insiste sulla tassa salute per i frontalieri. Ticino minaccia ritorsioni sui ristorni. Analisi, scenari e procedure per i lavoratori tr',
- canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-minacce-ticino',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-minacce-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6773,7 +6773,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, manca, lavoro, quello, serve',
  ogTitle: 'Frontalieri Ticino: manca il lavoro, ma non quello che se',
  ogDescription: 'Mancano infermieri in Lombardia, ma i corsi dell’Insubria restano semivuoti. E tra robot che imparano e dottorandi respinti all’estero, il mercato del lavoro fa',
- canonicalPath: '/articoli-frontaliere/lavoro-frontalieri-ticino-scarse-incastri',
+ canonicalPath: '/articoli-frontaliere/lavoro-frontalieri-ticino-scarse-incastri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6801,7 +6801,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fuga, giovani, claudio, isabella',
  ogTitle: 'Fuga dei giovani dal Ticino: Claudio Isabella chiede una',
  ogDescription: 'Il deputato del Centro Claudio Isabella chiede al Consiglio di Stato ticinese di abbandonare la posizione attendista sul fenomeno della fuga dei giovani dal Can',
- canonicalPath: '/articoli-frontaliere/visione-politica-fuga-giovani-ticino',
+ canonicalPath: '/articoli-frontaliere/visione-politica-fuga-giovani-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6829,7 +6829,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, atlas, scende',
  ogTitle: 'Cure a domicilio: ATLaS protesta Bellinzona 18 aprile',
  ogDescription: 'Il Cantone Ticino vuole aumentare i costi delle cure a domicilio di 450 franchi l’anno. ATLaS organizza una protesta a Bellinzona per il 18 aprile. Scopri come',
- canonicalPath: '/articoli-frontaliere/cure-a-domicilio-atlas-protesta-18-aprile',
+ canonicalPath: '/articoli-frontaliere/cure-a-domicilio-atlas-protesta-18-aprile/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6857,7 +6857,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salari, perequazione, fiscale, conti',
  ogTitle: 'Frontalieri in Ticino: salari e perequazione fiscale, i c',
  ogDescription: 'Il Ticino è il sesto cantone più ricco della Svizzera, ma la distribuzione della ricchezza e i meccanismi di perequazione federale non convincono gli analisti.',
- canonicalPath: '/articoli-frontaliere/frontalieri-salari-perequazione-ricchezza-2026',
+ canonicalPath: '/articoli-frontaliere/frontalieri-salari-perequazione-ricchezza-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6885,7 +6885,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, acqua, nuovo, potabile, lavizzara',
  ogTitle: 'Acqua di nuovo potabile a Lavizzara: Piano di Peccia e Mo',
  ogDescription: 'Dal 1° aprile 2024 l’acqua è di nuovo sicura in tutte le zone di Lavizzara. Revocate le restrizioni dopo interventi su Piano di Peccia e Monti di Rima.',
- canonicalPath: '/articoli-frontaliere/acqua-potabile-lavizzara-piano-peccia-monti-rima',
+ canonicalPath: '/articoli-frontaliere/acqua-potabile-lavizzara-piano-peccia-monti-rima/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6913,7 +6913,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, giovani, fuga, mancato, rientro',
  ogTitle: 'Ticino: giovani e politica del rientro',
  ogDescription: 'Esplora la posizione politica sul fenomeno della fuga dei giovani dal Ticino.',
- canonicalPath: '/articoli-frontaliere/giovani-fuga-ticino',
+ canonicalPath: '/articoli-frontaliere/giovani-fuga-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6941,7 +6941,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, nell, alleanza, porti, europei',
  ogTitle: 'Svizzera nell’Alleanza dei porti europei contro il traffi',
  ogDescription: 'Il Consiglio federale valuta la partecipazione per potenziare la condivisione dati e norme comuni contro i cartelli. Porti del Ticino coinvolti tramite i Canton',
- canonicalPath: '/articoli-frontaliere/svizzera-alleanza-porti-europei-anti-droga',
+ canonicalPath: '/articoli-frontaliere/svizzera-alleanza-porti-europei-anti-droga/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6969,7 +6969,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, glarona, vieta, auto, domenica',
  ogTitle: 'Domeniche senza auto in Ticino: Glarona fa da apripista',
  ogDescription: 'Il Canton Glarona vieta le auto per tre domeniche all’anno al lago di Klöntal. In Ticino si discute se adottare misure simili: Val Verzasca, Bellinzona e Lugano',
- canonicalPath: '/articoli-frontaliere/glarona-domeniche-senzauto-ticino-frontalieri',
+ canonicalPath: '/articoli-frontaliere/glarona-domeniche-senzauto-ticino-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -6997,7 +6997,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, polizia, confine, 2mila, controlli',
  ogTitle: 'Controlli al confine Ticino: cosa cambia per i frontalieri',
  ogDescription: 'La polizia di frontiera di Ponte Chiasso ha controllato 6\'212 veicoli nel 2025 (+47% vs 2023). Ecco cosa devono sapere i frontalieri ticinesi sui documenti, i',
- canonicalPath: '/articoli-frontaliere/controlli-frontalieri-ponte-chiasso-2025',
+ canonicalPath: '/articoli-frontaliere/controlli-frontalieri-ponte-chiasso-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7025,7 +7025,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, como, varese, dominano, 2025',
  ogTitle: 'Frontalieri Ticino 2025: Como e Varese dominano, Brianza',
  ogDescription: 'Dati UST 2025: 64.700 frontalieri lombardi in Ticino. Como con 32.200, Varese con 31.400. Monza e Brianza cresce del 77,7%. Scopri procedure, costi e novità.',
- canonicalPath: '/articoli-frontaliere/frontalieri-ticino-dati-ust-2025',
+ canonicalPath: '/articoli-frontaliere/frontalieri-ticino-dati-ust-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7053,7 +7053,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bibo, calcola, tariffe, mezzi',
  ogTitle: 'Bibo: l’app che calcola le tariffe dei mezzi pubblici in',
  ogDescription: 'Dal 2026 debutta Bibo: rileva automaticamente i viaggi in bus, treno o tram e addebita solo il percorso effettivo. Test con 3.000 frontalieri dal 30 aprile.',
- canonicalPath: '/articoli-frontaliere/bibo-app-mezzi-pubblici-2026',
+ canonicalPath: '/articoli-frontaliere/bibo-app-mezzi-pubblici-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7081,7 +7081,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, varese, 7mila, posti, vacanti',
  ogTitle: 'Varese: 7mila posti vacanti nel 2026. Ecco cosa cambia pe',
  ogDescription: 'Nel primo trimestre 2026 il Varesotto registra 7.772 assunzioni impossibili. Settori critici: metalmeccanica, costruzioni e ICT. Costo del mismatch tra 42 e 105',
- canonicalPath: '/articoli-frontaliere/varese-frontalieri-7000-postivacanti-2026',
+ canonicalPath: '/articoli-frontaliere/varese-frontalieri-7000-postivacanti-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7109,7 +7109,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iniziative, cassa, malati, lega',
  ogTitle: 'Iniziative cassa malati: Lega e PS insoddisfatti dopo l’i',
  ogDescription: 'Le due iniziative popolari approvate il 28 settembre 2025 incontrano l’opposizione del Consiglio di Stato. Aspettativa delusa per i promotori: nessuna implement',
- canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-governo-ticinese-insoddisfazione-lega-ps',
+ canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-governo-ticinese-insoddisfazione-lega-ps/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7137,7 +7137,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, fermo, treni, gallarate-sesto, cosa',
  ogTitle: 'Fermo treni Gallarate-Sesto: cosa cambia per i frontalier',
  ogDescription: 'Sabato 19 e domenica 20 aprile 2026 stop totale tra Gallarate e Sesto Calende. Bus sostitutivi con prenotazione obbligatoria e without bici/animali. Eurocity ca',
- canonicalPath: '/articoli-frontaliere/fermo-treni-gallarate-sesto-aprile-2026',
+ canonicalPath: '/articoli-frontaliere/fermo-treni-gallarate-sesto-aprile-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7165,7 +7165,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, bibo, biglietto, digitale, attiva',
  ogTitle: 'Bibo: il biglietto digitale che si attiva da solo sui mez',
  ogDescription: 'Dal 30 aprile 2026 in Svizzera parte il test di Bibo, che fattura i viaggi in automatico senza bisogno di check-in. Ecco come funziona per i pendolari ticinesi',
- canonicalPath: '/articoli-frontaliere/bibo-sistema-biglietti-digitali-mezzi-2026',
+ canonicalPath: '/articoli-frontaliere/bibo-sistema-biglietti-digitali-mezzi-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7193,7 +7193,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, infermieri, ticinesi, fuga, verso',
  ogTitle: 'Infermieri ticinesi: la fuga verso Milano per trovare lav',
  ogDescription: 'Una neolaureata SUPSI denuncia la mancanza di opportunità in Ticino. Il 94,9% dei laureati SUPSI trova impiego, ma il caso di Martina mostra una realtà diversa.',
- canonicalPath: '/articoli-frontaliere/infermieri-ticinesi-ricerca-lavoro-milano',
+ canonicalPath: '/articoli-frontaliere/infermieri-ticinesi-ricerca-lavoro-milano/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7221,7 +7221,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, campione, commissione, paritetica, punto',
  ogTitle: 'Ticino e Campione d’Italia: la Commissione paritetica fa',
  ogDescription: 'Norman Gobbi presiede l’incontro annuale con Campione d’Italia. Servizi ticinesi, rifiuti e sanità al centro del confronto. Elezioni comunali in vista.',
- canonicalPath: '/articoli-frontaliere/tappa-campione-ditalia-2025-commissione',
+ canonicalPath: '/articoli-frontaliere/tappa-campione-ditalia-2025-commissione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7249,7 +7249,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, affida, privati, lotta',
     ogTitle: 'Chiasso affida ai privati la lotta alla zanzara tigre: co',
     ogDescription: 'Da maggio a ottobre cambia la gestione dei focolai di zanzara tigre a Chiasso. I privati dovranno occuparsi dei tombini sui loro terreni, mentre il Comune inter',
-    canonicalPath: '/articoli-frontaliere/nuova-strategia-zanzara-tigre-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-strategia-zanzara-tigre-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7277,7 +7277,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, stanzia, milioni, dottori',
     ogTitle: 'Lombardia stanzia 7 milioni per dottori di ricerca nelle',
     ogDescription: 'La Regione Lombardia investe 7 milioni nel bando \'Talenti – Trasferimento delle conoscenze\' per assumere dottori di ricerca nelle PMI. Contributi fino a 56mila',
-    canonicalPath: '/articoli-frontaliere/lombardia-7mln-talenti-pmi-frontalieri',
+    canonicalPath: '/articoli-frontaliere/lombardia-7mln-talenti-pmi-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7305,7 +7305,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, slowup, aprile, giornata, senza',
     ogTitle: 'slowUp Ticino 2026: 19 aprile per una giornata senza auto',
     ogDescription: 'Domenica 19 aprile 2026, 50 km di strade tra Locarno e Bellinzona chiuse al traffico. 18 eventi in Svizzera, primo in Ticino con animazioni, soste agricole e in',
-    canonicalPath: '/articoli-frontaliere/slowup-ticino-2026-giornata-senz-auto',
+    canonicalPath: '/articoli-frontaliere/slowup-ticino-2026-giornata-senz-auto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7333,7 +7333,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bike, sharing, como, bici',
     ogTitle: 'Bike sharing a Como: 80 bici dal 30 aprile. Dove trovarle',
     ogDescription: 'Il servizio di bike sharing a Como torna operativo il 30 aprile 2026 con 80 bici customizzate e 17 punti di prelievo. Tariffe agevolate in arrivo per la stagion',
-    canonicalPath: '/articoli-frontaliere/bike-sharing-como-riapre-30-aprile',
+    canonicalPath: '/articoli-frontaliere/bike-sharing-como-riapre-30-aprile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7361,7 +7361,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticosa, 1000, parcheggi, acinque',
     ogTitle: 'Ticosa: 1000 parcheggi per frontalieri, Acinque accelera il',
     ogDescription: 'Acinque conferma la volontà di realizzare 1000 parcheggi a Ticosa con copertura fotovoltaica. Scopri tempistiche, impatto per i frontalieri e strumenti per',
-    canonicalPath: '/articoli-frontaliere/progetto-ticosa-parcheggi-acinque-frontalieri',
+    canonicalPath: '/articoli-frontaliere/progetto-ticosa-parcheggi-acinque-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7389,7 +7389,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, alla, raccolta, firme',
     ogTitle: 'Bellinzona: raccolta firme per asili nido pubblici fino a',
     ogDescription: 'Il Comune di Bellinzona respinge la richiesta di un asilo nido pubblico. Partito Socialista e Verdi lanciano l’iniziativa ‘Più nidi d’infanzia pubblici’ con',
-    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-iniziativa-firme-2026',
+    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-iniziativa-firme-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7417,7 +7417,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cannabis, medica, casse, malati',
     ogTitle: 'Cannabis medica: casse malati bloccano i rimborsi in Ticino',
     ogDescription: 'Pazienti ticinesi perdono la copertura delle cure con cannabis terapeutica. Solo l’11% dei trattamenti segnalati è rimborsato.',
-    canonicalPath: '/articoli-frontaliere/cannabis-medica-rimborsi-casse-malati-ticino',
+    canonicalPath: '/articoli-frontaliere/cannabis-medica-rimborsi-casse-malati-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7445,7 +7445,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asili, nido, pubblici, parte',
     ogTitle: 'Asili nido pubblici in Ticino: come firmare l’iniziativa',
     ogDescription: 'Guida pratica per sostenere l’iniziativa popolare che chiede asili nido pubblici in Ticino. Raccolta firme fino al 15 ottobre 2026.',
-    canonicalPath: '/articoli-frontaliere/asili-nido-pubblici-ticino-iniziativa-popolare-2026',
+    canonicalPath: '/articoli-frontaliere/asili-nido-pubblici-ticino-iniziativa-popolare-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7473,7 +7473,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, limita, acquisto, immobili',
     ogTitle: 'Limite acquisto immobili stranieri 2026: le nuove regole per',
     ogDescription: 'Il Consiglio federale limita l’acquisto di immobili da parte di stranieri. Obbligo di autorizzazione, stop agli investimenti e nuove restrizioni per frontalieri',
-    canonicalPath: '/articoli-frontaliere/berna-limita-acquisto-immobili-stranieri-2026',
+    canonicalPath: '/articoli-frontaliere/berna-limita-acquisto-immobili-stranieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7501,7 +7501,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premi, cassa, malati, riforma',
     ogTitle: 'Premi cassa malati: riforma completa dal 2029, prima tapp',
     ogDescription: 'Il Consiglio di Stato ticinese presenta il programma per l’attuazione delle due iniziative popolari sui premi di cassa malati. Costo annuo di 61.4 milioni dal 2',
-    canonicalPath: '/articoli-frontaliere/riforma-cassa-malati-ticino-2029',
+    canonicalPath: '/articoli-frontaliere/riforma-cassa-malati-ticino-2029/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7529,7 +7529,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, slowup, strade, chiuse, trasporti',
     ogTitle: 'SlowUp 2026: strade chiuse e trasporti limitati a Bellinzona',
     ogDescription: 'Domenica 19 aprile 2026 strade e trasporti pubblici limitati per SlowUp. Scopri le restrizioni e le alternative per frontalieri e pendolari tra Bellinzona e',
-    canonicalPath: '/articoli-frontaliere/slowup-strade-trasporti-limiti-2026',
+    canonicalPath: '/articoli-frontaliere/slowup-strade-trasporti-limiti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7557,7 +7557,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petrolio, approvvigionamento, sicuro, nonostante',
     ogTitle: 'Petrolio e gas in Svizzera: forniture stabili nel 2026',
     ogDescription: 'Analisi degli aumenti di marzo 2026 e impatto per frontalieri e ticinesi. Scopri da dove arriva il petrolio e come contenere i costi.',
-    canonicalPath: '/articoli-frontaliere/petrolio-e-gas-svizzera-approvvigionamento-2026',
+    canonicalPath: '/articoli-frontaliere/petrolio-e-gas-svizzera-approvvigionamento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7585,7 +7585,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuochi, aperto, divieto, revocato',
     ogTitle: 'Divieto fuochi all\'aperto revocato in Ticino: norme e rischi',
     ogDescription: 'Dal 1° maggio 2024 i fuochi all’aperto tornano legali in Ticino, ma non nel Grigioni italiano. Scopri tutte le regole, le sanzioni e i rischi per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/fuochi-allaperto-ticino-grazie-normativa-2024',
+    canonicalPath: '/articoli-frontaliere/fuochi-allaperto-ticino-grazie-normativa-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7613,7 +7613,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, acquisti, immobiliari, dall, estero',
     ogTitle: 'Acquisti immobiliari dall’estero: il Governo svizzero ina',
     ogDescription: 'Dal 15 aprile al 15 luglio 2026 consultazione pubblica su nuove restrizioni per stranieri non UE/AELS. Cosa cambia per case, chalet e investimenti.',
-    canonicalPath: '/articoli-frontaliere/governo-limita-acquisti-immobiliari-estero-2026',
+    canonicalPath: '/articoli-frontaliere/governo-limita-acquisti-immobiliari-estero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7641,7 +7641,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, cassano, magnago, ticinesi',
     ogTitle: 'Incidente a Cassano Magnago: due frontalieri ticinesi fer',
     ogDescription: 'Due lavoratori frontalieri ticinesi ricoverati dopo violenta collisione tra auto a Cassano Magnago (Varese). Niente traffico deviante su A26 o A8.',
-    canonicalPath: '/articoli-frontaliere/incidente-cassano-magnago-frontalieri-ticinesi',
+    canonicalPath: '/articoli-frontaliere/incidente-cassano-magnago-frontalieri-ticinesi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7669,7 +7669,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ristoratore, ticinese, sorprende, ladro',
     ogTitle: 'Ristoratore ticinese sorprende ladro: arrestato un uomo d',
     ogDescription: 'Un ristoratore di Mendrisio ha sorpreso un uomo di 35 anni intento a rubare in cucina. L\'intruso, di nazionalità marocchina, è stato bloccato e consegnato alla',
-    canonicalPath: '/articoli-frontaliere/wirt-sorpreso-einbrecher-marokkaner-ticino',
+    canonicalPath: '/articoli-frontaliere/wirt-sorpreso-einbrecher-marokkaner-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7697,7 +7697,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iran, taglia, speranze, ripescaggio',
     ogTitle: 'Italia fuori dai Mondiali 2026? L\'Iran spegne le speranze',
     ogDescription: 'Il ct iraniano esclude il forfait della sua Nazionale. Cosa cambia per frontalieri e tifosi ticinesi?',
-    canonicalPath: '/articoli-frontaliere/irania-nazionale-italia-riqualifica-2026',
+    canonicalPath: '/articoli-frontaliere/irania-nazionale-italia-riqualifica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7725,7 +7725,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, webuild, salini, serve, collaborazione',
     ogTitle: 'Webuild e Salini: serve collaborazione per un Ticino comp',
     ogDescription: 'Amministratore delegato di Webuild chiede alleanza tra istituzioni e imprese per progetti infrastrutturali in Ticino e Italia. Mercato globale delle costruzioni',
-    canonicalPath: '/articoli-frontaliere/collaborazione-imprese-istituzioni-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/collaborazione-imprese-istituzioni-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7753,7 +7753,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, monte, paschi, siena, lovaglio',
     ogTitle: 'Monte dei Paschi di Siena: Lovaglio vince l’assemblea, Ti',
     ogDescription: 'Luigi Lovaglio torna nel Cda di Mps con il 49,95% dei voti grazie al sostegno di Delfin (17,5%) e Banco Bpm (3,7%). Affluenza al 64,1% del capitale. Cosa cambia',
-    canonicalPath: '/articoli-frontaliere/ribaltone-mps-lovaglio-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/ribaltone-mps-lovaglio-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7781,7 +7781,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giro, bellinzona-carì, maggio, tappa',
     ogTitle: 'Giro d’Italia 2026: Bellinzona-Carì in 113 km per il Tici',
     ogDescription: 'Il 26 maggio 2026 la 16ª tappa del Giro d’Italia si correrà interamente in Ticino: 113 km da Bellinzona a Carì con 3.000 metri di dislivello e 5 GPM. Rischio tr',
-    canonicalPath: '/articoli-frontaliere/giro-italia-2026-bellinzona-cari-tappa',
+    canonicalPath: '/articoli-frontaliere/giro-italia-2026-bellinzona-cari-tappa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7809,7 +7809,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, operaio, frontaliero, bulgaro, muore',
     ogTitle: 'Operaio frontaliero bulgaro muore in incidente sul lavoro',
     ogDescription: 'Un 50enne bulgaro residente nel Locarnese perde la vita travolto da alberi durante lavori forestali. Polizia e soccorritori hanno attivato il Care Team per supp',
-    canonicalPath: '/articoli-frontaliere/infortunio-locarnese-operaio-frontaliero-decede',
+    canonicalPath: '/articoli-frontaliere/infortunio-locarnese-operaio-frontaliero-decede/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7837,7 +7837,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, film, swiss, sabotage, frontaliers',
     ogTitle: 'Film Swiss Sabotage: i Frontaliers ticinesi sbarcano in t',
     ogDescription: 'Dopo 15mila spettatori in Ticino, il film \'Frontaliers Sabotage\' approda in 16 sale svizzere tedesche e romande con il nuovo titolo \'Swiss Sabotage\'. Proiezioni',
-    canonicalPath: '/articoli-frontaliere/film-swiss-sabotage-frontalieri-ticinesi',
+    canonicalPath: '/articoli-frontaliere/film-swiss-sabotage-frontalieri-ticinesi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7865,7 +7865,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pendolare, inverso, altdorf, lugano',
     ogTitle: 'Pendolare inverso: da Altdorf a Lugano ogni giorno. Ma i',
     ogDescription: 'Carla Scheidegger viaggia ogni giorno da Kriens ad Altdorf per lavorare al MASI a Lugano. Criticità: treni ogni due ore e vagoni affollati. La sua battaglia per',
-    canonicalPath: '/articoli-frontaliere/pendolare-inverso-altdorf-lugano-problemi',
+    canonicalPath: '/articoli-frontaliere/pendolare-inverso-altdorf-lugano-problemi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7893,7 +7893,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, risparmio, casa, arriva, centro',
     ogTitle: 'Risparmio Casa arriva al Centro Breggia di Balerna: cosa',
     ogDescription: 'Il Centro Breggia di Balerna si rinnova con l\'arrivo di Risparmio Casa nel reparto ex Manor. Convenienza e quotidianità per i frontalieri del Mendrisiotto.',
-    canonicalPath: '/articoli-frontaliere/centro-breggia-risparmio-casa-arriva-balerna',
+    canonicalPath: '/articoli-frontaliere/centro-breggia-risparmio-casa-arriva-balerna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7921,7 +7921,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trafico, droga, bloccato, brogeda',
     ogTitle: 'Trafico di droga bloccato a Brogeda: due arresti e due ch',
     ogDescription: 'Carabinieri sequestrano 1,1 kg di eroina e 800 g di cocaina in auto a noleggio al valico di Como Brogeda. Arrestati due uomini nigeriani di 30 e 33 anni.',
-    canonicalPath: '/articoli-frontaliere/blocco-droga-confine-brogeda-2026',
+    canonicalPath: '/articoli-frontaliere/blocco-droga-confine-brogeda-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7949,7 +7949,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, treni, diretti, rimini, francia',
     ogTitle: 'Nuovi collegamenti FFS 2026: treni diretti a Rimini e',
     ogDescription: 'Scopri i nuovi collegamenti estivi delle FFS dal 30 maggio 2026: treni diretti Zurigo-Rimini e TGV verso la Francia. Attenzione ai cantieri sul Sempione che',
-    canonicalPath: '/articoli-frontaliere/ffs-collegamenti-estivi-rimini-francia-2026',
+    canonicalPath: '/articoli-frontaliere/ffs-collegamenti-estivi-rimini-francia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -7977,7 +7977,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, cerca, soluzioni, assumere',
     ogTitle: 'Chiasso cerca soluzioni per assumere più residenti: cosa',
     ogDescription: 'Il consigliere comunale Francesco Romano chiede al Municipio di Chiasso quali strumenti concreti possono incentivare le aziende a preferire residenti ticinesi r',
-    canonicalPath: '/articoli-frontaliere/strumenti-comune-chiasso-assunzione-residenti',
+    canonicalPath: '/articoli-frontaliere/strumenti-comune-chiasso-assunzione-residenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8005,7 +8005,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, statua, ritorno, alla, natura',
     ogTitle: 'Statua ‘Ritorno alla natura’ a Chiasso: petizione ferma d',
     ogDescription: 'La petizione per la rimozione della statua ‘Ritorno alla natura’ a Chiasso, sottoscritta da 433 persone a maggio 2025, attende ancora una risposta ufficiale dal',
-    canonicalPath: '/articoli-frontaliere/petizione-chiasso-ritorno-alla-natura-2025',
+    canonicalPath: '/articoli-frontaliere/petizione-chiasso-ritorno-alla-natura-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8033,7 +8033,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, congresso, fisco, lavoro',
     ogTitle: 'Varese 2026: Congresso Svizzera Italia su fisco e lavoro',
     ogDescription: 'Fisco, criptovalute e immobili: il Congresso Svizzera Italia a Varese analizza le novità per frontalieri e imprese con 1,7 milioni di arrivi turistici nel 2025.',
-    canonicalPath: '/articoli-frontaliere/congresso-varese-2026-fisco-lavoro-ticino',
+    canonicalPath: '/articoli-frontaliere/congresso-varese-2026-fisco-lavoro-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8061,7 +8061,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, deprexis, rimborsata, cassa, malati',
     ogTitle: 'Deprexis rimborsata da cassa malati: cosa cambia per fron',
     ogDescription: 'Dal 1° luglio 2026 l’app Deprexis sarà prescrivibile dai medici e rimborsata dalle casse malati. Strumento digitale per depressione lieve/moderata, ma con limit',
-    canonicalPath: '/articoli-frontaliere/psicoterapia-digitale-deprexis-rimborsata-2026',
+    canonicalPath: '/articoli-frontaliere/psicoterapia-digitale-deprexis-rimborsata-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8089,7 +8089,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, deputato, varesino, forno, massa',
     ogTitle: 'Deputato varesino a Forno di Massa: «La vergogna nazifasc',
     ogDescription: 'Antonio Ferrara (M5S) sanzionato per aver bloccato convegno sulla remigrazione con estrema destra. Il 10 aprile ha commemorato la strage del 1944 a Forno con 60',
-    canonicalPath: '/articoli-frontaliere/deputato-varesino-ferrara-forno-massacro-2026',
+    canonicalPath: '/articoli-frontaliere/deputato-varesino-ferrara-forno-massacro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8117,7 +8117,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, servono, riforme, sanitarie, aumenti',
     ogTitle: 'Ticino: servono riforme sanitarie, non aumenti fiscali',
     ogDescription: 'Due iniziative popolari sulle casse malati costano 25,8 milioni all’anno. Economia ticinese boccia i nuovi prelievi: aliquota sostanza transitoria, tasse fondia',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-ticino-riforme-invece-aggravi',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-ticino-riforme-invece-aggravi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8145,7 +8145,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiassoletteraria, festeggia, anni, maggio',
     ogTitle: 'ChiassoLetteraria festeggia 20 anni dal 6 al 10 maggio 20',
     ogDescription: 'Dal 6 al 10 maggio 2026 il festival letterario di Chiasso torna dopo 20 anni con oltre 50 eventi tra incontri, reading e dibattiti. Tra gli ospiti confermati Ma',
-    canonicalPath: '/articoli-frontaliere/chiassolitteratura-venti-anniversario-2026',
+    canonicalPath: '/articoli-frontaliere/chiassolitteratura-venti-anniversario-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8173,7 +8173,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, finanze, 2025, migliori, previsto',
     ogTitle: 'Ticino: finanze 2025 migliorate ma fragile',
     ogDescription: 'Consuntivo 2025 del Cantone Ticino con disavanzo di 32,5 milioni, miglioramento rispetto alle previsioni. Analisi, implicazioni e procedure per frontalieri.',
-    canonicalPath: '/articoli-frontaliere/finanze-2025-fragile-ticino',
+    canonicalPath: '/articoli-frontaliere/finanze-2025-fragile-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8201,7 +8201,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, lombardia, rinvia',
     ogTitle: 'Tassa salute frontalieri Lombardia: rinvio mozione fino al',
     ogDescription: 'La Regione Lombardia rimanda la discussione sulla tassa sanitaria per i frontalieri storici al 23 aprile 2026. Scopri quali sono i rischi per i 80.000 ticinesi',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-rinvio-2026',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-rinvio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8229,7 +8229,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arrestati, brogeda, quasi, chili',
     ogTitle: 'Droga al confine Brogeda: arresti e rischi per i frontalieri',
     ogDescription: 'Due corrieri fermati con 1.96 kg di droga a Brogeda. Scopri le implicazioni per i frontalieri, le procedure in caso di controllo e gli strumenti per tutelarsi.',
-    canonicalPath: '/articoli-frontaliere/arresto-droga-confine-brogeda-2026',
+    canonicalPath: '/articoli-frontaliere/arresto-droga-confine-brogeda-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8257,7 +8257,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, manutenzione, ustat, chiusure, natalizie',
     ogTitle: 'Manutenzione USTAT e chiusure natalizie 2025: cosa cambia',
     ogDescription: 'Scopri le date delle chiusure USTAT a fine 2025 e come evitare ritardi nelle tue pratiche da frontaliero in Ticino.',
-    canonicalPath: '/articoli-frontaliere/manutenzione-ustat-servizi-chiusure-31-12-2025',
+    canonicalPath: '/articoli-frontaliere/manutenzione-ustat-servizi-chiusure-31-12-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8285,7 +8285,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confine, italia-svizzera, regole, doganali',
     ogTitle: 'Confine Italia-Svizzera: 6 regole doganali per frontalier',
     ogDescription: 'Dal limite di 10.000 euro per il contante alle franchigie su alcol e sigarette: cosa cambia per chi viaggia tra Ticino e Lombardia.',
-    canonicalPath: '/articoli-frontaliere/confine-italia-svizzera-6-regole-doganali',
+    canonicalPath: '/articoli-frontaliere/confine-italia-svizzera-6-regole-doganali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8313,7 +8313,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nigeriani, arrestati, chiasso-brogeda, eroina',
     ogTitle: 'Arresti al confine Ticino: 2 nigeriani fermati con 5 kg di',
     ogDescription: 'Due cittadini nigeriani fermati a Chiasso-Brogeda con 5 kg di droga. Blocco traffico per 3 ore, indagini in corso. Impatto sui frontalieri e procedure di',
-    canonicalPath: '/articoli-frontaliere/due-arresti-brogeda-smuggling-droga-2024',
+    canonicalPath: '/articoli-frontaliere/due-arresti-brogeda-smuggling-droga-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8341,7 +8341,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, regole, contro, specie',
     ogTitle: 'Ticino: nuove regole contro specie invasive per frontalie',
     ogDescription: 'Dal 2026 aiuti cantonali per combattere formiche Tapinoma, cozze quagga e gamberi della Louisiana. Obbligo di pulizia imbarcazioni per evitare contaminazioni.',
-    canonicalPath: '/articoli-frontaliere/tutela-frontalieri-specie-invasive-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/tutela-frontalieri-specie-invasive-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8369,7 +8369,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, taglio, milioni, supsi, cosa',
     ogTitle: 'Taglio da 25 milioni per USI e SUPSI: cosa cambia per i f',
     ogDescription: 'Il Consiglio di Stato riduce i contributi a USI e SUPSI di 6,8 milioni. Aumento tasse per studenti stranieri e attingimento dalle riserve. Priorità alla competi',
-    canonicalPath: '/articoli-frontaliere/usi-supsi-25-milioni-casse-malati',
+    canonicalPath: '/articoli-frontaliere/usi-supsi-25-milioni-casse-malati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8397,7 +8397,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lega, prima, solidarietà, inizia',
     ogTitle: 'Lega Ticino: «Prima il Ticino, solidarietà inizia a casa',
     ogDescription: 'La Lega dei Ticinesi chiede a Berna di priorizzare i finanziamenti al Cantone prima di quelli all’estero, denunciando una «perequazione penalizzante» e l’abband',
-    canonicalPath: '/articoli-frontaliere/lega-ticino-solidarieta-casa-propria-2026',
+    canonicalPath: '/articoli-frontaliere/lega-ticino-solidarieta-casa-propria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8425,7 +8425,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moon, stars, sconti, residenti',
     ogTitle: 'Moon&Stars: sconti per residenti con Locarno Card 2026',
     ogDescription: 'Locarno Card offre biglietti a 75 CHF per 11 concerti serali e 45 CHF per l\'Opening Night del 9 luglio 2026. Vendita online dal 22 aprile al 29 maggio con codic',
-    canonicalPath: '/articoli-frontaliere/moon-stars-resident-discount-locarno-card',
+    canonicalPath: '/articoli-frontaliere/moon-stars-resident-discount-locarno-card/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8453,7 +8453,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scoperta, record, colverde, sequestrato',
     ogTitle: 'Scoperta record a Colverde: sequestrato oltre un quintale',
     ogDescription: 'La polizia provinciale di Como ha sequestrato 105 kg di marijuana in sacchi abbandonati vicino al confine ticinese. Operazione nata da un controllo ambientale.',
-    canonicalPath: '/articoli-frontaliere/scoperta-quantita-marijuana-colverde-confine-ticino',
+    canonicalPath: '/articoli-frontaliere/scoperta-quantita-marijuana-colverde-confine-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8481,7 +8481,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, straordinari, lavena, ponte',
     ogTitle: 'Controlli straordinari a Lavena Ponte Tresa: droga e arma',
     ogDescription: 'Nella notte tra il 14 e 15 aprile 2026, quattro pattuglie della polizia locale di Lavena Ponte Tresa, congiunte alla Questura e ad altri comandi, hanno identifi',
-    canonicalPath: '/articoli-frontaliere/controlli-serali-lavena-ponte-tresa-15-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/controlli-serali-lavena-ponte-tresa-15-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8509,7 +8509,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzera-canada, verso, aggiornamento, dell',
     ogTitle: 'Svizzera-Canada: accordo commerciale in modernizzazione nel',
     ogDescription: 'Modernizzazione dell’accordo di libero scambio tra Svizzera e Canada nel 2026. Doppia imposizione e agricoltura al centro delle trattative. Impatto per',
-    canonicalPath: '/articoli-frontaliere/svizzera-canada-mercati-alternativi-trump',
+    canonicalPath: '/articoli-frontaliere/svizzera-canada-mercati-alternativi-trump/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8537,7 +8537,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, milioni, meno',
     ogTitle: 'Casse malati Ticino: 61 milioni in meno per Lugano e Bell',
     ogDescription: 'Le due iniziative cantonali costano 61,4 milioni ai comuni ticinesi. Lugano rischia 11-12 milioni in meno con l’abolizione del valore locativo.',
-    canonicalPath: '/articoli-frontaliere/iniziative-casse-malati-61-milioni-ticino',
+    canonicalPath: '/articoli-frontaliere/iniziative-casse-malati-61-milioni-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8565,7 +8565,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, allentamenti, affitti, brevi, cosa',
     ogTitle: 'Allentamenti affitti brevi in Ticino: cosa cambia per fro',
     ogDescription: 'HotellerieSuisse Ticino valuta positivo il 2025 ma lancia l\'allarme su regole più flessibili per affitti brevi tramite piattaforme online. Analisi dei rischi pe',
-    canonicalPath: '/articoli-frontaliere/allentamenti-affitti-brevi-ticino-2025',
+    canonicalPath: '/articoli-frontaliere/allentamenti-affitti-brevi-ticino-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8593,7 +8593,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuoriuscita, ammoniaca, alla, rapelli',
     ogTitle: 'Fuoriuscita di ammoniaca alla Rapelli di Stabio',
     ogDescription: 'L\'azienda conferma la sicurezza dei prodotti dopo l\'incidente tecnico di giovedì sera. Evacuate 100 persone, situazione ora sotto controllo.',
-    canonicalPath: '/articoli-frontaliere/fuoriuscita-ammoniaca-rapelli-stabio',
+    canonicalPath: '/articoli-frontaliere/fuoriuscita-ammoniaca-rapelli-stabio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8621,7 +8621,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nella, selezione, personale, rischi',
     ogTitle: 'IA nella selezione del personale: rischi e opportunità',
     ogDescription: 'L\'IA nel recruiting in Ticino: rischi di discriminazione e opportunità per i candidati nel 2026.',
-    canonicalPath: '/articoli-frontaliere/ia-selezione-personale-ticino',
+    canonicalPath: '/articoli-frontaliere/ia-selezione-personale-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8649,7 +8649,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, market, index, territorio',
     ogTitle: 'Swiss Market Index in territorio positivo: cosa significa',
     ogDescription: 'Il Swiss Market Index (SMI) chiude in territorio positivo con piccoli guadagni a New York e resistenza endemica a Zurigo. Analisi per frontalieri e residenti de',
-    canonicalPath: '/articoli-frontaliere/swiss-market-index-vedi-breve-rimbalzo',
+    canonicalPath: '/articoli-frontaliere/swiss-market-index-vedi-breve-rimbalzo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8677,7 +8677,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sussidi, cassa, malati, mendrisio',
     ogTitle: 'Sussidi cassa malati a Mendrisio: ritardi inaccettabili p',
     ogDescription: 'A Mendrisio il Municipio sotto tiro: ritardi fino a maggio per i sussidi cassa malati. Il consigliere Robbiani chiede spiegazioni e interventi straordinari per',
-    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-rallentamenti',
+    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-rallentamenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8705,7 +8705,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, sussidi, cassa, malati',
     ogTitle: 'Mendrisio: sussidi cassa malati in ritardo, cittadini in',
     ogDescription: 'Mendrisio: ritardi inaccettabili nell\'erogazione dei sussidi per i premi cassa malati, secondo l\'interrogazione del consigliere Robbiani. Cittadini senza rispos',
-    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi',
+    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8733,7 +8733,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, economia, crescita, cosa',
     ogTitle: 'Varese economia in crescita: cosa cambia per i frontalier',
     ogDescription: 'La provincia di Varese registra +3,2% di export nel 2024, ma giovani e transizione verde restano gli ostacoli principali. Analisi per i 68mila frontalieri ticin',
-    canonicalPath: '/articoli-frontaliere/varese-economia-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/varese-economia-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8761,7 +8761,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, investe, milioni, moda',
     ogTitle: 'Lombardia investe 12,3 milioni in moda: opportunità per f',
     ogDescription: 'Regione Lombardia stanzia oltre 12 milioni per il bando Next Fashion, con 73 imprese coinvolte e focus su PMI e sostenibilità. Come coinvolgere anche le aziende',
-    canonicalPath: '/articoli-frontaliere/lombardia-investimento-moda-ticinesi-next-fashion',
+    canonicalPath: '/articoli-frontaliere/lombardia-investimento-moda-ticinesi-next-fashion/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8789,7 +8789,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzera-usa, parmelin, avvia, nuova',
     ogTitle: 'Svizzera-USA: Parmelin avvia nuova fase negoziale commerc',
     ogDescription: 'Il presidente della Confederazione Guy Parmelin incontra a Washington il rappresentante USA per il commercio Jamieson Greer. Obiettivo: definire un quadro chiar',
-    canonicalPath: '/articoli-frontaliere/svizzera-usa-nuovi-negoziati-commerciali-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-usa-nuovi-negoziati-commerciali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8817,7 +8817,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, voli, cancellati, causa, kerosene',
     ogTitle: 'Tagli voli aerei: cosa cambia per i frontalieri Ticino',
     ogDescription: 'Scopri quali compagnie tagliano rotte e come affrontare i cambiamenti per i viaggi in Europa e Usa. Consigli pratici per i frontalieri ticinesi.',
-    canonicalPath: '/articoli-frontaliere/aumento-kerosene-voli-cancellati-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/aumento-kerosene-voli-cancellati-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8845,7 +8845,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, radar, mobili, dove, quando',
     ogTitle: 'Radar mobili in Ticino: dove e quando faranno più rumore',
     ogDescription: 'Controlli sulla velocità con radar mobili in 40 comuni del Cantone Ticino dal 16 aprile 2026. Elenco completo delle aree interessate e corpi di polizia coinvolt',
-    canonicalPath: '/articoli-frontaliere/radar-controlli-velocita-ticino-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/radar-controlli-velocita-ticino-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8873,7 +8873,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, tratte, estive, verso',
     ogTitle: 'FFS: nuove tratte estive per frontalieri verso Italia e',
     ogDescription: 'Scopri le nuove tratte ferroviarie FFS 2026 per raggiungere Italia, Francia, Austria e Germania. Date, costi e consigli per i frontalieri ticinesi.',
-    canonicalPath: '/articoli-frontaliere/nuove-tratte-estive-ffs-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-tratte-estive-ffs-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8901,7 +8901,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malpensa, senza, carburante, cosa',
     ogTitle: 'Malpensa senza carburante: cosa rischiano i frontalieri t',
     ogDescription: 'Malpensa dipende da due oleodotti per il Jet A-1. Una crisi energetica potrebbe cancellare voli e colpire 40mila lavoratori transfrontalieri.',
-    canonicalPath: '/articoli-frontaliere/malpensa-carburante-rischio-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/malpensa-carburante-rischio-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8929,7 +8929,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, potabilizzatore, mobile, rivera',
     ogTitle: 'Nuovo potabilizzatore mobile in Ticino: emergenza idrica',
     ogDescription: 'Il Cantone Ticino presenta un potabilizzatore mobile da 24 m³/ora per affrontare emergenze idriche. Scopri come funziona e cosa cambia per frontalieri e',
-    canonicalPath: '/articoli-frontaliere/nuovo-potabilizzatore-mobile-emergenza-ticino',
+    canonicalPath: '/articoli-frontaliere/nuovo-potabilizzatore-mobile-emergenza-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8957,7 +8957,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, acqua, potabile, emergenza, presenta',
     ogTitle: 'Acqua potabile in emergenza: Ticino presenta il nuovo pot',
     ogDescription: 'Il Cantone investe 260mila franchi in un impianto mobile per garantire acqua potabile in caso di contaminazioni o guasti. Fino a 24 m³/ora di acqua sicura per 2',
-    canonicalPath: '/articoli-frontaliere/nuovo-potabilizzatore-mobile-ticino-emergenza',
+    canonicalPath: '/articoli-frontaliere/nuovo-potabilizzatore-mobile-ticino-emergenza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -8985,7 +8985,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, palaraiffeisen, lugano, porte, aperte',
     ogTitle: 'PalaRaiffeisen a Lugano: porte aperte per la maxi-opera del',
     ogDescription: 'Visita il cantiere del futuro PalaRaiffeisen a Lugano durante la giornata di porte aperte del 18 aprile 2026. Scopri programma, accesso e opportunità per',
-    canonicalPath: '/articoli-frontaliere/palaraiffeisen-porta-aperte-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/palaraiffeisen-porta-aperte-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9013,7 +9013,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fashion, outlet, landquart, nuovi',
     ogTitle: 'Fashion Outlet Landquart: 15 nuovi negozi e +1\'000 posti',
     ogDescription: 'Il centro commerciale Foxtown Landquart raggiunge quota 100 spazi commerciali con 15 nuovi negozi. Investimento multi milioni e benefici fiscali per il Comune d',
-    canonicalPath: '/articoli-frontaliere/fashion-outlet-landquart-15-nuovi-negozi-expansion',
+    canonicalPath: '/articoli-frontaliere/fashion-outlet-landquart-15-nuovi-negozi-expansion/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9041,7 +9041,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, movimento, socialismo',
     ogTitle: 'Salario minimo a 25 CHF in Ticino: Proposta MPS e Impatto',
     ogDescription: 'Il MPS propone un salario minimo di 25 CHF l’ora in Ticino. Analisi delle implicazioni per i lavoratori ticinesi e frontalieri.',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-25-chf-ticino',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-25-chf-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9069,7 +9069,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confindustria, varese, paciaroni, riconfermato',
     ogTitle: 'Confindustria Varese: Paciaroni riconfermato alla guida d',
     ogDescription: 'Roberto Paciaroni (Hupac) guidò 78 imprese e 9.532 addetti nel Gruppo strategico. Focus su logistica, automazione e AI nel 2026.',
-    canonicalPath: '/articoli-frontaliere/confindustria-varese-paciaroni-2026',
+    canonicalPath: '/articoli-frontaliere/confindustria-varese-paciaroni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9097,7 +9097,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, finanza, ticinese, reinventa, economia',
     ogTitle: 'Finanza ticinese si reinventa: l’economia va in digitale',
     ogDescription: 'Gli asset immateriali superano quelli fisici. Il credito bancario perde terreno a favore del capitale proprio e di nuovi strumenti finanziari. Le implicazioni p',
-    canonicalPath: '/articoli-frontaliere/finanza-ticino-si-reinventa-economia-dati',
+    canonicalPath: '/articoli-frontaliere/finanza-ticino-si-reinventa-economia-dati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9125,7 +9125,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, coppa, mondo, corsa, orientamento',
     ogTitle: 'Coppa del Mondo orientamento 2026: Locarno e Ascona in prima',
     ogDescription: 'Dal 24 al 26 aprile 2026 Locarno e Ascona ospiteranno la prima tappa della Coppa del Mondo di corsa d’orientamento 2026 con 250 atleti da 30 Paesi e oltre 1’800',
-    canonicalPath: '/articoli-frontaliere/coppa-del-mondo-orientamento-locarnese-2026',
+    canonicalPath: '/articoli-frontaliere/coppa-del-mondo-orientamento-locarnese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9153,7 +9153,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, nove, candidati, cinque',
     ogTitle: 'Grigioni: nove candidati per cinque seggi al Governo',
     ogDescription: 'Il 14 giugno 2026 si voterà per il Governo grigionese. Nove i nomi in lizza, tra cui quattro uscenti. Scopri chi sono e cosa cambia per i frontalieri ticinesi.',
-    canonicalPath: '/articoli-frontaliere/grigioni-governo-2026-nove-candidati',
+    canonicalPath: '/articoli-frontaliere/grigioni-governo-2026-nove-candidati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9181,7 +9181,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzera-usa, accordo, commerciale, bilico',
     ogTitle: 'Svizzera-USA: accordo commerciale in bilico, Parmelin chi',
     ogDescription: 'Guy Parmelin incontra a Washington il rappresentante commerciale USA per definire un quadro negoziale stabile. Le accuse di pratiche sleali e l’indagine USA com',
-    canonicalPath: '/articoli-frontaliere/svizzera-usa-accordo-commerciale-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-usa-accordo-commerciale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9208,7 +9208,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, federviti, lancia, risoluzione, vino',
     ogTitle: 'Federviti lancia risoluzione: vino ticinese prima scelta,',
     ogDescription: 'L’Assemblea annuale di Federviti a Biasca, il 2025 con le rese più basse degli ultimi 25 anni e consumi in calo. Il presidente Cadenazzi chiede priorità al vino',
-    canonicalPath: '/articoli-frontaliere/risoluzione-federviti-vino-ticinese-2025',
+    canonicalPath: '/articoli-frontaliere/risoluzione-federviti-vino-ticinese-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9236,7 +9236,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziative, cassa, malati, piano',
     ogTitle: 'Iniziative cassa malati: il piano da 51 milioni bocciato',
     ogDescription: 'Il Consiglio di Stato ticinese propone un piano da 51 milioni l’anno per le iniziative sulla cassa malati. La Lega bolla la proposta come inaccettabile e chiede',
-    canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-piano-lega-ticino',
+    canonicalPath: '/articoli-frontaliere/iniziative-cassa-malati-piano-lega-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9264,7 +9264,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, a8-a9, verso, chiasso, chiusa',
     ogTitle: 'A8-A9 verso Chiasso chiusa di notte: percorsi alternativi',
     ogDescription: 'Da mercoledì 22 a giovedì 23 aprile 2026 stop al ramo A8-A9 verso Chiasso per manutenzione. Percorsi alternativi via Lainate Arese, Origgio e Saronno per chi vi',
-    canonicalPath: '/articoli-frontaliere/chiusura-ramo-a8-a9-notte-lavori-2026',
+    canonicalPath: '/articoli-frontaliere/chiusura-ramo-a8-a9-notte-lavori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9292,7 +9292,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riduce, tempi, determinazione, prezzi',
     ogTitle: 'L’IA riduce i tempi di determinazione dei prezzi del 75%',
     ogDescription: 'L’intelligenza artificiale di Swiss Re accelera i processi assicurativi fino all’80% e libera tempo per i collaboratori. Il CEO Andreas Berger illustra l’impatt',
-    canonicalPath: '/articoli-frontaliere/ia-swiss-re-produttivita-ceo-berger',
+    canonicalPath: '/articoli-frontaliere/ia-swiss-re-produttivita-ceo-berger/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9320,7 +9320,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, progetto, echo, praterie, sommerse',
     ogTitle: 'Progetto Echo: praterie sommerse per salvare i laghi di L',
     ogDescription: 'Il progetto Interreg Echo (2025-2027) sperimenta il restauro delle praterie sommerse con biochar per combattere il cambiamento climatico nei laghi di Lugano e C',
-    canonicalPath: '/articoli-frontaliere/rinascita-praterie-sommerse-laghi-ticino',
+    canonicalPath: '/articoli-frontaliere/rinascita-praterie-sommerse-laghi-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9348,7 +9348,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, stabio, cosa',
     ogTitle: 'Fuga di ammoniaca a Stabio: cosa sapere e come reagire',
     ogDescription: 'Giovedì 16 aprile 2026, fuga di ammoniaca nella fabbrica alimentare Rapelli a Stabio. Autorità chiedono di chiudere porte e finestre in un raggio di 1 km. Nessu',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-stabio-rapelli-allerta-ticino',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-stabio-rapelli-allerta-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9376,7 +9376,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arena, lugano, porte, aperte',
     ogTitle: 'AIL Arena a Lugano: porte aperte il 30 e 31 maggio per sc',
     ogDescription: 'Il 30 e 31 maggio 2025 il FC Lugano apre la nuova AIL Arena con due giornate di eventi gratuiti: tour guidati, Fan Village e concorso con una Renault Clio in pa',
-    canonicalPath: '/articoli-frontaliere/inaugurazione-ail-arena-lugano-30-31-maggio',
+    canonicalPath: '/articoli-frontaliere/inaugurazione-ail-arena-lugano-30-31-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9404,7 +9404,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ritardi, negli, assegni, cassa',
     ogTitle: 'Ritardi negli assegni cassa malati a Mendrisio: cosa risc',
     ogDescription: 'Mendrisio chiede al Canton Ticino di sbloccare i pagamenti dei sussidi cassa malati ritardati da mesi. Frontalieri e residenti rischiano di non pagare i premi a',
-    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi-2026',
+    canonicalPath: '/articoli-frontaliere/sussidi-cassa-malati-mendrisio-ritardi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9432,7 +9432,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mercato, immobiliare, alloggi, anni',
     ogTitle: 'Mercato immobiliare Ticino 2025: la crisi degli alloggi in',
     ogDescription: 'Calo del 33% degli alloggi in affitto in Ticino. Analisi dei dati federali e consigli pratici per i frontalieri che cercano casa in Ticino.',
-    canonicalPath: '/articoli-frontaliere/alloggi-frontalieri-ticino-crisi-2025',
+    canonicalPath: '/articoli-frontaliere/alloggi-frontalieri-ticino-crisi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9460,7 +9460,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grandine, bellinzona, allerta, meteo',
     ogTitle: 'Grandine Ticino: allerta Lugano e Chiasso 19 aprile 2026',
     ogDescription: 'Allerta meteo grado 3 per grandine a Lugano e Chiasso. Procedure per frontalieri, danni ai veicoli e consigli per spostamenti. Aggiornamenti in tempo reale.',
-    canonicalPath: '/articoli-frontaliere/grandine-bellinzonese-allerta-lugano-chiasso-19-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/grandine-bellinzonese-allerta-lugano-chiasso-19-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9488,7 +9488,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, apertura, sportello, didi, dipendenze',
     ogTitle: 'Ticino: apertura sportello DIDI per dipendenze digitali',
     ogDescription: 'OSC lancia sportello dedicato alle dipendenze digitali. 6,8% ticinesi a rischio, 22% under 15. Servizio operativo a Lugano e Bellinzona',
-    canonicalPath: '/articoli-frontaliere/sportello-dipendenze-digitali-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/sportello-dipendenze-digitali-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9516,7 +9516,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, paradiso, fiscale, milionari, fuga',
     ogTitle: 'Ticino, paradiso fiscale per milionari in fuga dal Golfo',
     ogDescription: 'Dallo scoppio della guerra in Iran, le richieste di immobili nel Ticino sono aumentate del 15%. Agevolazioni fiscali forfettarie e case vacanza senza permesso d',
-    canonicalPath: '/articoli-frontaliere/tasse-agevolate-milionari-ticino-golfo',
+    canonicalPath: '/articoli-frontaliere/tasse-agevolate-milionari-ticino-golfo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9544,7 +9544,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermiere, pratiche, avanzate, nuovo',
     ogTitle: 'APN Ticino: formazione, ruoli e vantaggi per frontalieri',
     ogDescription: 'Scopri come la figura dell\'Infermiere di Pratiche Avanzate (APN) sta rivoluzionando il sistema sanitario ticinese e quali vantaggi offre ai frontalieri.',
-    canonicalPath: '/articoli-frontaliere/infermiere-pratiche-avanzate-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/infermiere-pratiche-avanzate-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9572,7 +9572,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, medio, oriente, fiamme, costi',
     ogTitle: 'Medio Oriente in fiamme: costi e rischi per imprese ticin',
     ogDescription: 'Materie prime in aumento del 30-50% a causa del conflitto. Direttore SSIC Bagnovini chiede interventi urgenti per salvare cantieri edili.',
-    canonicalPath: '/articoli-frontaliere/caos-medioriente-e-impatti-costruzione-ticino',
+    canonicalPath: '/articoli-frontaliere/caos-medioriente-e-impatti-costruzione-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9600,7 +9600,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dazi, parmelin, washington, rilanciare',
     ogTitle: 'Dazi USA: Parmelin a Washington per rilanciare accordo co',
     ogDescription: 'Il presidente della Confederazione Guy Parmelin incontra il rappresentante USA per i dazi Jamieson Greer. Volontà di accordo, ma senza certezze su tempistiche e',
-    canonicalPath: '/articoli-frontaliere/parmelin-washington-dazi-usa-2026',
+    canonicalPath: '/articoli-frontaliere/parmelin-washington-dazi-usa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9628,7 +9628,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colombiani, arrestati, furto, verbano',
     ogTitle: 'Tre colombiani arrestati per furto sul Verbano: uno in Ti',
     ogDescription: 'Tre membri di una banda colombiana hanno rubato gioielli per 50mila franchi a un orafo sul Lago Maggiore. Uno dei ladri è stato arrestato in Ticino dopo 10 mesi',
-    canonicalPath: '/articoli-frontaliere/gang-colombiani-verbano-arresti-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/gang-colombiani-verbano-arresti-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9656,7 +9656,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parmelin, firma, accordo, bahrein',
     ogTitle: 'Parmelin firma accordo con Bahrein per proteggere gli inv',
     ogDescription: 'Guy Parmelin ha firmato a Washington un accordo bilaterale per proteggere gli investimenti tra Svizzera e Bahrein. L’intesa entra in vigore dopo le approvazioni',
-    canonicalPath: '/articoli-frontaliere/parmelin-accordo-investimenti-bahrein-2026',
+    canonicalPath: '/articoli-frontaliere/parmelin-accordo-investimenti-bahrein-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9684,7 +9684,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, palazzo, civico, collegiata, bellinzona',
     ogTitle: 'Palazzo civico e Collegiata di Bellinzona più accessibili',
     ogDescription: 'Il Municipio di Bellinzona stanzia 1,385 milioni per eliminare barriere architettoniche a Palazzo Civico e Collegiata. Ascensori rifatti, piattaforme elevatrici',
-    canonicalPath: '/articoli-frontaliere/palazzo-civico-collegiata-accessibilita-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/palazzo-civico-collegiata-accessibilita-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9712,7 +9712,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roche, investe, miliardi, farmaci',
     ogTitle: 'Roche investe su farmaci anti-obesità: cosa cambia per i',
     ogDescription: 'Petrelintide di Roche promette perdita di peso del 10,7% in 42 settimane. Analisi su costi, copertura e opportunità per frontalieri Ticino-Lombardia.',
-    canonicalPath: '/articoli-frontaliere/roche-farmaci-obesita-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/roche-farmaci-obesita-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9740,7 +9740,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, chiusure, sull, autostrada',
     ogTitle: 'Chiusure autostrada A9: cosa cambia per i frontalieri |',
     ogDescription: 'Autostrade per l\'Italia annuncia chiusure notturne sull\'A9 tra Como e Chiasso per lavori di manutenzione. Ecco gli itinerari alternativi e le implicazioni per',
-    canonicalPath: '/articoli-frontaliere/chiusure-autostrada-a9-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-autostrada-a9-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9768,7 +9768,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, capre, alla, dogana, gandria',
     ogTitle: 'Capre alla dogana di Gandria: rischio incidente |',
     ogDescription: 'Quattro capre hanno attirato l\'attenzione delle autorità doganali, rischiando di causare due incidenti. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-incidenti-2026',
+    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-incidenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9796,7 +9796,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavori, autostrade, chiusure, notturne',
     ogTitle: 'Lavori autostrade Ticino: chiusure notturne | Frontaliere',
     ogDescription: 'Autostrade per l\'Italia programma interventi notturni dal 20 al 24 aprile 2026. Chiusure a Besnate, Turate e sulla A9 Lainate-Como-Chiasso',
-    canonicalPath: '/articoli-frontaliere/lavori-autostrade-ticino-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/lavori-autostrade-ticino-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9824,7 +9824,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, militari, treni, trenord, euro',
     ogTitle: 'Militari sui treni Trenord: 20 euro all\'anno per maggiore',
     ogDescription: 'Dal 1° maggio 2026, i militari potranno viaggiare su Trenord in Lombardia con un abbonamento agevolato di 20 euro annui per incrementare la sicurezza sui',
-    canonicalPath: '/articoli-frontaliere/militari-treni-ticino-20-euro',
+    canonicalPath: '/articoli-frontaliere/militari-treni-ticino-20-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9852,7 +9852,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, just, consegna, prodotti, migros',
     ogTitle: 'Just Eat consegna Migros in Ticino | Frontaliere Ticino',
     ogDescription: 'Dal 4 maggio 2026, Just Eat consegna prodotti Migros in Ticino, Vallese e Ginevra con consegna in meno di un\'ora. Prezzi identici a quelli dei negozi.',
-    canonicalPath: '/articoli-frontaliere/just-eat-migros-ticino-consegna-2026',
+    canonicalPath: '/articoli-frontaliere/just-eat-migros-ticino-consegna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9880,7 +9880,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intervento, alla, dogana, gandria',
     ogTitle: 'Intervento alla dogana di Gandria: salvate quattro capre |',
     ogDescription: 'L\'Ufficio federale della dogana e della sicurezza dei confini ha salvato quattro capre che mettevano a rischio la circolazione.',
-    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-intervento-30-marzo',
+    canonicalPath: '/articoli-frontaliere/capre-dogana-gandria-intervento-30-marzo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9908,7 +9908,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, fatture, continuano',
     ogTitle: 'Cure a domicilio: costi in Ticino | Frontaliere Ticino',
     ogDescription: 'Il Parlamento ticinese ha bocciato la richiesta di urgenza per abolire la partecipazione ai costi delle cure a domicilio. Scopri cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/costi-cure-domocilio-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/costi-cure-domocilio-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9936,7 +9936,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, ecco, cambia',
     ogTitle: 'Salario minimo Ticino 2027-2029 | Frontaliere Ticino',
     ogDescription: 'Il Gran Consiglio ha approvato il compromesso sul salario minimo in Ticino: da 20,50 a 21,75-22,25 franchi l\'ora entro il 2029',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9964,7 +9964,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, palla, tribuna',
     ogTitle: 'Cure a domicilio, palla in tribuna | Frontaliere Ticino',
     ogDescription: 'Il Gran Consiglio del Ticino ha respinto la richiesta d\'urgenza sull\'iniziativa che chiedeva di stralciare la partecipazione ai costi per le cure a domicilio.',
-    canonicalPath: '/articoli-frontaliere/cure-domocilio-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cure-domocilio-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -9992,7 +9992,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asili, nido, bellinzona, polemiche',
     ogTitle: 'Asili nido Bellinzona: polemiche sussidi | Frontaliere',
     ogDescription: 'Scopri le ultime novità sul sistema di sussidi per gli asili nido a Bellinzona e come questo potrebbe influenzare i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-sussidi-2026',
+    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-sussidi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10020,7 +10020,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sette, cantoni, stanno, scomparendo',
     ogTitle: 'Giovani in calo in 7 cantoni svizzeri: il caso Ticino',
     ogDescription: 'Nel 2024, i dati ufficiali mostrano una diminuzione della popolazione under 65 in sette cantoni, con gravi conseguenze per l\'economia e la previdenza nel',
-    canonicalPath: '/articoli-frontaliere/giovani-scomparsi-7-cantoni',
+    canonicalPath: '/articoli-frontaliere/giovani-scomparsi-7-cantoni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10048,7 +10048,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svizzeri, italiani, cucina, italiana',
     ogTitle: 'Cucina italiana preferita dagli svizzeri | Frontaliere',
     ogDescription: 'Un sondaggio rivela che il 79% degli svizzeri preferisce la cucina italiana quando mangia fuori, seguita dalla cucina elvetica al 71%.',
-    canonicalPath: '/articoli-frontaliere/svizzeri-italiani-cucina-preferita',
+    canonicalPath: '/articoli-frontaliere/svizzeri-italiani-cucina-preferita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10076,7 +10076,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, restrizioni, investitori, immobiliari',
     ogTitle: 'Nuove restrizioni per investitori immobiliari stranieri in',
     ogDescription: 'Il Consiglio federale svizzero propone modifiche alla Lex Koller per limitare gli acquisti di immobili da parte di stranieri non residenti.',
-    canonicalPath: '/articoli-frontaliere/svizzera-chiude-investitori-immobiliari-stranieri',
+    canonicalPath: '/articoli-frontaliere/svizzera-chiude-investitori-immobiliari-stranieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10104,7 +10104,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, nuove, regole',
     ogTitle: 'Nuovo salario minimo in Ticino dal 2027',
     ogDescription: 'Dal 2027 il salario minimo in Ticino sarà tra i 20,50 e i 21 franchi all\'ora. Scopri le nuove regole e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029-nuove-regole',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2027-2029-nuove-regole/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10132,7 +10132,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cybercrimepolice, disponibile, italiano, maggiore',
     ogTitle: 'Cybercrimepolice.ch ora in italiano | Frontaliere Ticino',
     ogDescription: 'La piattaforma nazionale di prevenzione Cybercrimepolice.ch è ora disponibile anche in italiano, grazie al contributo della Polizia cantonale ticinese.',
-    canonicalPath: '/articoli-frontaliere/cybercrimepolice-ticino-italiano-2026',
+    canonicalPath: '/articoli-frontaliere/cybercrimepolice-ticino-italiano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10160,7 +10160,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, azienda, assume, autisti, lombardia',
     ogTitle: 'Azienda assume autisti in Lombardia | Frontaliere Ticino',
     ogDescription: 'FNM Autoservizi cerca nuovi autisti con un percorso formativo retribuito e un premio di ingresso di 3000 euro',
-    canonicalPath: '/articoli-frontaliere/azienda-assume-autisti-lombardia-800-euro',
+    canonicalPath: '/articoli-frontaliere/azienda-assume-autisti-lombardia-800-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10188,7 +10188,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bancastato, walking, mendrisio, percorsi',
     ogTitle: 'BancaStato Walking Mendrisio 2026 | Frontaliere Ticino',
     ogDescription: 'Domenica 26 aprile 2026 a Mendrisio tre percorsi di diversa difficoltà, pranzo offerto e animazioni per la nuova edizione di BancaStato Walking Mendrisio.',
-    canonicalPath: '/articoli-frontaliere/bancastato-walking-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/bancastato-walking-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10216,7 +10216,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premia, aziende, salute, lavoro',
     ogTitle: 'WHP premia 90 aziende del Ticino | Frontaliere Ticino',
     ogDescription: 'ATS Insubria e Confindustria Varese premiano quasi 90 aziende del territorio per la loro adesione al programma WHP, promuovendo la salute nei luoghi di lavoro.',
-    canonicalPath: '/articoli-frontaliere/whp-premia-aziende-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/whp-premia-aziende-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10244,7 +10244,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rapina, milano, frontaliero, ticinese',
     ogTitle: 'Rapina a Milano: frontaliero ticinese derubato | Frontaliere',
     ogDescription: 'Tre arresti per la rapina ai danni di un cittadino svizzero domiciliato in Canton Lucerna, pedinato e derubato a Milano dopo un viaggio in treno da Lugano.',
-    canonicalPath: '/articoli-frontaliere/rapina-milano-frontaliere-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/rapina-milano-frontaliere-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10272,7 +10272,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, approvata, mozione, contributo, sanitario',
     ogTitle: 'Frontalieri: mozione per contributo sanitario equo',
     ogDescription: 'Scopri come la mozione approvata da Zocchi (FdI) mira a rendere il contributo sanitario meno gravoso per i frontalieri e a distribuire le risorse nei territori',
-    canonicalPath: '/articoli-frontaliere/frontalieri-contributo-sanitario-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-contributo-sanitario-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10300,7 +10300,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcio, licenza, negata, bellinzona',
     ogTitle: 'Bellinzona: licenza negata, dubbi sulle finanze |',
     ogDescription: 'Il Bellinzona non ottiene la licenza Dnb a causa di dubbi sulle finanze, sollevando nuove preoccupazioni sul futuro del club.',
-    canonicalPath: '/articoli-frontaliere/bellinzona-calcio-licenza-negata-finanze',
+    canonicalPath: '/articoli-frontaliere/bellinzona-calcio-licenza-negata-finanze/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10328,7 +10328,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, approvata, unanimità, mozione, salute',
     ogTitle: 'Mozione salute vigili fuoco | Frontaliere Ticino',
     ogDescription: 'Regione Lombardia approva mozione per screening e studi epidemiologici sui vigili del fuoco, classificati a rischio cancerogeno.',
-    canonicalPath: '/articoli-frontaliere/mozione-salute-vigili-fuoco-lombardia',
+    canonicalPath: '/articoli-frontaliere/mozione-salute-vigili-fuoco-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10356,7 +10356,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cuasso, monte, chiusura, definitiva',
     ogTitle: 'Cuasso al Monte: chiusura ospedale frontalieri | Frontaliere',
     ogDescription: 'Dopo vent\'anni di dibattiti, l\'ospedale dei frontalieri di Cuasso al Monte chiude definitivamente. Servizi trasferiti nel palazzo comunale.',
-    canonicalPath: '/articoli-frontaliere/cuasso-monte-ospedale-frontalieri-chiusura',
+    canonicalPath: '/articoli-frontaliere/cuasso-monte-ospedale-frontalieri-chiusura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10384,7 +10384,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, bocciata, abrogazione',
     ogTitle: 'Tassa salute frontalieri: cosa cambia nel 2026',
     ogDescription: 'La Regione Lombardia ha bocciato la mozione del Pd per abolire la tassa salute per i frontalieri, ma punta a detrazioni e aliquote minime.',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10412,7 +10412,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dalla, vita, alla, tela',
     ogTitle: 'Donna in arte a Chiasso | Frontaliere Ticino',
     ogDescription: 'Una mostra a Chiasso celebra l\'arte di sette donne, portando cultura e inclusione nel Centro diurno OSC',
-    canonicalPath: '/articoli-frontaliere/donne-arte-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/donne-arte-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10440,7 +10440,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, nuovi, bandi, camera',
     ogTitle: 'Varese: Nuovi bandi 2026 della Camera di Commercio per l’',
     ogDescription: 'La Camera di Commercio di Varese investe 150mila euro in due bandi per il 2026, focalizzati su formazione e mobilità, per favorire l’integrazione professionale',
-    canonicalPath: '/articoli-frontaliere/cameradi-commercio-2026-integrazione',
+    canonicalPath: '/articoli-frontaliere/cameradi-commercio-2026-integrazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10468,7 +10468,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basiletti, accede, main, draw',
     ogTitle: 'Basiletti accede al main draw: vittoria a Chiasso',
     ogDescription: 'La giovane tennista italiana Noemi Basiletti supera l\'ex numero 60 del mondo Cagla Buyukakcay all\'Axion Open di Chiasso, conquistando l\'accesso al main draw.',
-    canonicalPath: '/articoli-frontaliere/basiletti-main-draw-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/basiletti-main-draw-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10496,7 +10496,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trasporto, pubblico, sfida, nils',
     ogTitle: 'Trasporto pubblico: la sfida per il Ticino',
     ogDescription: 'Nils Planzer, CEO di un\'azienda di trasporti, sottolinea l\'importanza di investire nel trasporto pubblico per affrontare le sfide del traffico in Ticino.',
-    canonicalPath: '/articoli-frontaliere/ticino-trasporto-pubblico-priorita',
+    canonicalPath: '/articoli-frontaliere/ticino-trasporto-pubblico-priorita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10524,7 +10524,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, omaggio, agli, angeli',
     ogTitle: 'Omaggio agli Angeli di Ponte Chiasso | Frontaliere Ticino',
     ogDescription: 'Finalmente a Ponte Chiasso viene posata la targa in onore degli Angeli che salvarono vite durante la Seconda Guerra Mondiale. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso',
+    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10552,7 +10552,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dogana, chiasso, limitazioni, traffico',
     ogTitle: 'Dogana Chiasso: limitazioni traffico 2026 | Frontaliere',
     ogDescription: 'Venerdì 24 aprile 2026, dalle 9:20 alle 10:00, traffico deviato verso Maslianico/Pizzamiglio per cerimonia in onore degli Angeli di Ponte Chiasso',
-    canonicalPath: '/articoli-frontaliere/dogana-chiasso-traffico-2026',
+    canonicalPath: '/articoli-frontaliere/dogana-chiasso-traffico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10580,7 +10580,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, spinge, integrazione, lavorativa',
     ogTitle: 'Integrazione lavorativa stranieri Ticino 2026',
     ogDescription: 'Scopri le nuove misure per l\'integrazione lavorativa degli stranieri in Ticino. Supporto nella formazione e nella ricerca di un impiego.',
-    canonicalPath: '/articoli-frontaliere/integrazione-lavoro-stranieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/integrazione-lavoro-stranieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10608,7 +10608,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, franchi, lordi',
     ogTitle: 'Salario minimo Ticino 2029: 4.000 franchi | Frontaliere',
     ogDescription: 'Il Parlamento cantonale ticinese ha approvato l\'aumento del salario minimo a 4.000 franchi lordi al mese dal 2029, beneficiando 23.000 lavoratori, di cui 15.000',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2029-4000-franchi',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-ticino-2029-4000-franchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10636,7 +10636,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guasti, trenord, ritardi, cancellazioni',
     ogTitle: 'Guasti Trenord: ritardi e cancellazioni in Lombardia il 21',
     ogDescription: 'Doppio guasto tecnico ad Albizzate e Milano Certosa causa disagi diffusi sulla rete ferroviaria lombarda nella giornata di martedì 21 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/guasti-trenord-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/guasti-trenord-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10664,7 +10664,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponte, chiasso, prelievi, parrocchia',
     ogTitle: 'Ponte Chiasso: prelievi in parrocchia | Frontaliere Ticino',
     ogDescription: 'A Ponte Chiasso, un infermiere volontario offre servizi di prelievo nella parrocchia locale, mentre il Comitato Obiettivo Salute chiede un presidio sanitario',
-    canonicalPath: '/articoli-frontaliere/ponte-chiasso-sanita-2026',
+    canonicalPath: '/articoli-frontaliere/ponte-chiasso-sanita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10692,7 +10692,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, soloaffitti, como, partner, ideale',
     ogTitle: 'SoloAffitti Como: il partner ideale per affitti senza',
     ogDescription: 'Scopri come SoloAffitti Como offre un servizio completo per affitti di abitazioni e locali commerciali, garantendo sicurezza e professionalità.',
-    canonicalPath: '/articoli-frontaliere/soloaffitti-como-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/soloaffitti-como-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10720,7 +10720,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumenti, medici, infermieri, confine',
     ogTitle: 'Aumenti del 20% per medici e infermieri al confine',
     ogDescription: 'Lombardia stanzia 10.000 euro per medici e 5.400 euro per infermieri che operano nelle zone di confine con la Svizzera',
-    canonicalPath: '/articoli-frontaliere/aumenti-stipendi-medici-infermieri-lombardia',
+    canonicalPath: '/articoli-frontaliere/aumenti-stipendi-medici-infermieri-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10748,7 +10748,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, svincolo, sigirino, ritardo, possibile',
     ogTitle: 'Svincolo A2 Sigirino: ritardo possibile',
     ogDescription: 'Lo svincolo A2 di Sigirino potrebbe slittare a dopo il 2030. Scopri le implicazioni per i frontalieri e come seguire l\'evoluzione del progetto',
-    canonicalPath: '/articoli-frontaliere/svincolo-a2-sigirino-ritardo',
+    canonicalPath: '/articoli-frontaliere/svincolo-a2-sigirino-ritardo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10776,7 +10776,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salari, aumentati, 2025, media',
     ogTitle: 'Salari in Svizzera aumentati nel 2025: +1,8% in media',
     ogDescription: 'Scopri come i salari in Svizzera sono aumentati del 1,8% nel 2025 e quali sono le implicazioni per i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/salari-svizzera-aumentati-2025',
+    canonicalPath: '/articoli-frontaliere/salari-svizzera-aumentati-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10804,7 +10804,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, diventare, autista, costo, zero',
     ogTitle: 'Academy FNMA: autisti bus a costo zero | Frontaliere Ticino',
     ogDescription: 'Scopri come diventare autista di bus con l’Academy di FNM Autoservizi. Formazione gratuita, assunzione a tempo indeterminato e bonus di 3.000 euro.',
-    canonicalPath: '/articoli-frontaliere/academy-fnma-autisti-bus-2026',
+    canonicalPath: '/articoli-frontaliere/academy-fnma-autisti-bus-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10832,7 +10832,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, patentino, digitale, libera, lombardia',
     ogTitle: 'Patentino Digitale: via libera in Lombardia',
     ogDescription: 'Approvato il primo progetto di legge regionale per l\'istituzione del Patentino Digitale per contrastare bullismo e dipendenza tecnologica tra i giovani',
-    canonicalPath: '/articoli-frontaliere/patentino-digitale-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/patentino-digitale-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10860,7 +10860,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, truffe, agli, anziani, arresti',
     ogTitle: 'Truffe agli anziani: due arresti nel Locarnese | Frontaliere',
     ogDescription: 'Due cittadini cechi arrestati per truffe telefoniche ai danni di anziani a Gordola. Recuperata la refurtiva. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/chiamate-shock-arresti-locarnese-2024',
+    canonicalPath: '/articoli-frontaliere/chiamate-shock-arresti-locarnese-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10888,7 +10888,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, valbianca, forti, difficoltà, airolo',
     ogTitle: 'Valbianca in forti difficoltà: Airolo mette 1,5 milioni e',
     ogDescription: 'Il comune di Airolo investe 1,5 milioni di franchi per salvare Valbianca, un\'azienda in difficoltà. Scopri le implicazioni per i frontalieri e come monitorare',
-    canonicalPath: '/articoli-frontaliere/valbianca-in-forti-difficolta-airolo-mette-1-5-milioni-e-aumenta-il-moltiplicatore',
+    canonicalPath: '/articoli-frontaliere/valbianca-in-forti-difficolta-airolo-mette-1-5-milioni-e-aumenta-il-moltiplicatore/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10916,7 +10916,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumento, medici, infermieri, frontiera',
     ogTitle: 'Aumento stipendi medici e infermieri | Frontaliere Ticino',
     ogDescription: 'La Lombardia introduce un aumento del 20% per medici e infermieri di frontiera per contrastare la fuga verso la Svizzera.',
-    canonicalPath: '/articoli-frontaliere/aumento-stipendi-frontalieri-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/aumento-stipendi-frontalieri-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10944,7 +10944,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantieri, situazione, sottoceneri, estate',
     ogTitle: 'Cantieri Sottoceneri | Frontaliere Ticino',
     ogDescription: '11 cantieri attivi nel Sottoceneri, tra cui il Tunnel di Genzana a Lugano. Lavori notturni e viabilità modificata fino al 2027',
-    canonicalPath: '/articoli-frontaliere/cantieri-sottoceneri-estate-2024',
+    canonicalPath: '/articoli-frontaliere/cantieri-sottoceneri-estate-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -10972,7 +10972,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, stazioni, ricarica, ultraveloci',
     ogTitle: 'Nuove stazioni di ricarica a Campione d\'Italia',
     ogDescription: 'Ewiva attiva colonnine ultraveloci a Campione d\'Italia per frontalieri e turisti. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/ricarica-auto-elettriche-campione-2026',
+    canonicalPath: '/articoli-frontaliere/ricarica-auto-elettriche-campione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11000,7 +11000,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cena, primavera, libano, avsi',
     ogTitle: 'Cena di primavera per il Libano | Frontaliere Ticino',
     ogDescription: 'Sabato 9 maggio 2026 a Castiglione Olona, la Fondazione AVSI organizza una cena benefica per le comunità libanesi colpite dalla guerra.',
-    canonicalPath: '/articoli-frontaliere/cena-spring-avsi-libano-castiglione',
+    canonicalPath: '/articoli-frontaliere/cena-spring-avsi-libano-castiglione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11028,7 +11028,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, cambia, prassi, permessi',
     ogTitle: 'Grigioni cambia prassi per i permessi di dimora |',
     ogDescription: 'Nuove regole per i permessi di dimora nel Canton Grigioni: dichiarazione obbligatoria di precedenti penali e procedimenti in corso.',
-    canonicalPath: '/articoli-frontaliere/permessi-dimora-grigioni-cambia-prassi',
+    canonicalPath: '/articoli-frontaliere/permessi-dimora-grigioni-cambia-prassi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11056,7 +11056,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, divario, salariale, residenti, studio',
     ogTitle: 'Divario salariale frontalieri Ticino 2026',
     ogDescription: 'Scopri il divario salariale tra frontalieri e residenti in Ticino nel 2026, con dati e analisi dell\'Ufficio di statistica del Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/divario-salariale-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/divario-salariale-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11084,7 +11084,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bandecchi, quarti, chiasso, sento',
     ogTitle: 'Bandecchi ai quarti a Chiasso | Frontaliere Ticino',
     ogDescription: 'Susan Bandecchi raggiunge i quarti di finale dell\'Axion Open di Chiasso, sconfiggendo la croata Lucija Ciric Bagaric in due set.',
-    canonicalPath: '/articoli-frontaliere/bandecchi-quarti-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/bandecchi-quarti-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11112,7 +11112,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantello, amministrazione, legambiente, unite',
     ogTitle: 'Cantello: Amministrazione e Legambiente contro il \'peduncolo',
     ogDescription: 'Amministrazione comunale e Legambiente Cantello chiedono lo stralcio del progetto della superstrada a quattro corsie tra Italia e Svizzera.',
-    canonicalPath: '/articoli-frontaliere/cantello-peduncolo-gaggiolo-2026',
+    canonicalPath: '/articoli-frontaliere/cantello-peduncolo-gaggiolo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11140,7 +11140,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assegno, educativo, mendrisio, scadenza',
     ogTitle: 'Assegno educativo Mendrisio 2026: scadenza 30 giugno',
     ogDescription: 'Scadenza 30 giugno 2026 per richiedere l\'Assegno educativo, Contributo per colonie e Sussidio all\'alloggio a Mendrisio. Requisiti e procedure.',
-    canonicalPath: '/articoli-frontaliere/assegno-educativo-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/assegno-educativo-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11168,7 +11168,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, autocertificazione, penali, permessi',
     ogTitle: 'Grigioni: autocertificazione penali per permessi di dimora',
     ogDescription: 'Da maggio 2026, chi richiede un permesso di dimora nei Grigioni dovrà dichiarare eventuali precedenti penali o procedimenti in corso.',
-    canonicalPath: '/articoli-frontaliere/grigioni-permessi-dimora-2026',
+    canonicalPath: '/articoli-frontaliere/grigioni-permessi-dimora-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11196,7 +11196,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, aumenta, stipendi, medici',
     ogTitle: 'Aumento stipendi medici e infermieri Lombardia 2026',
     ogDescription: 'Dal settembre 2026, medici e infermieri delle zone di confine con la Svizzera vedranno aumenti fino a 10.000 euro lordi annui. La Lombardia investe 45 milioni',
-    canonicalPath: '/articoli-frontaliere/aumento-stipendi-medici-infermieri-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/aumento-stipendi-medici-infermieri-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11224,7 +11224,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dividere, lavoratori, significa, abbassare',
     ogTitle: 'Dividere i lavoratori significa abbassare i salari |',
     ogDescription: 'Il Primo Maggio torna a Lugano con un focus sui diritti dei lavoratori, indipendentemente dall\'origine, dal contratto o dal settore economico.',
-    canonicalPath: '/articoli-frontaliere/dividere-lavoratori-salari-2026',
+    canonicalPath: '/articoli-frontaliere/dividere-lavoratori-salari-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11252,7 +11252,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lufthansa, elimina, bagaglio, mano',
     ogTitle: 'Lufthansa elimina il bagaglio a mano gratuito | Frontaliere',
     ogDescription: 'Dal 19 maggio 2026, solo un oggetto personale incluso nella tariffa base. Ecco cosa cambia per i passeggeri e i frontalieri',
-    canonicalPath: '/articoli-frontaliere/lufthansa-bagaglio-gratuito-eliminato',
+    canonicalPath: '/articoli-frontaliere/lufthansa-bagaglio-gratuito-eliminato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11280,7 +11280,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banditi, assaltano, gioielleria, tavernola',
     ogTitle: 'Banditi assaltano gioielleria a Tavernola: l\'assalto e le',
     ogDescription: 'Rapina a mano armata a Tavernola: tre banditi hanno seminato il panico e hanno prelevato gioielli dal centro commerciale Lario.',
-    canonicalPath: '/articoli-frontaliere/como-frazione-tavernola-banditi-assaltano-gioielleria-e-si-dileguano',
+    canonicalPath: '/articoli-frontaliere/como-frazione-tavernola-banditi-assaltano-gioielleria-e-si-dileguano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11308,7 +11308,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, regione, lombardia, aumento, stipendi',
     ogTitle: 'Regione Lombardia: aumento stipendi medici e infermieri',
     ogDescription: 'La Regione Lombardia introduce una norma per aumentare lo stipendio dei medici e infermieri nelle zone al confine con la Svizzera. La misura mira a trattenere',
-    canonicalPath: '/articoli-frontaliere/regione-lombardia-aumento-stipendi-medici-infermieri',
+    canonicalPath: '/articoli-frontaliere/regione-lombardia-aumento-stipendi-medici-infermieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11336,7 +11336,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, divario, salariale, residenti, guadagnano',
     ogTitle: 'Divario salariale in Ticino: residenti guadagnano 1.157',
     ogDescription: 'L\'Ufficio cantonale di statistica rivela che i residenti in Ticino guadagnano mediamente 5.957 franchi, mentre i frontalieri 4.800 franchi. Il divario è del',
-    canonicalPath: '/articoli-frontaliere/divario-salari-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/divario-salari-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11364,7 +11364,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'permesso g, frontalieri, ticino, 2026, rientro settimanale, 25 telelavoro, 45 giorni, imposta alla fonte, guida permesso g, permesso g vs permesso b',
     ogTitle: 'Permesso G 2026: la guida definitiva per frontalieri',
     ogDescription: 'Tutto quello che serve al frontaliere sul Permesso G: procedura, costi, rinnovo, rientro settimanale, telelavoro e fiscalità nel 2026.',
-    canonicalPath: '/articoli-frontaliere/permesso-g-guida-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/permesso-g-guida-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -11394,7 +11394,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'imposta alla fonte svizzera, quellensteuer 2026, confronto cantoni, nov 120000, pilastro 3a frontalieri, imposta fonte ticino grigioni vallese berna zurigo',
     ogTitle: 'Imposta alla fonte Svizzera 2026: dove pagare meno',
     ogDescription: 'Confronto completo dell\'imposta alla fonte 2026 nei principali cantoni frontalieri: aliquote, NOV, deduzioni e pilastro 3a.',
-    canonicalPath: '/articoli-frontaliere/imposta-fonte-svizzera-2026-confronto-cantoni',
+    canonicalPath: '/articoli-frontaliere/imposta-fonte-svizzera-2026-confronto-cantoni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -11424,7 +11424,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'permesso b, imposta alla fonte 2026, ticino, tassazione ordinaria ulteriore, tou, nov, frontalieri, svizzera, tasse, pilastro 3a, deduzioni',
     ogTitle: 'Permesso B e imposta alla fonte 2026: guida fiscale',
     ogDescription: 'Guida fiscale completa ai titolari di permesso B in Ticino: aliquote imposta alla fonte 2026, deduzioni, soglia TOU e confronto con il permesso G.',
-    canonicalPath: '/articoli-frontaliere/permesso-b-imposta-fonte-2026',
+    canonicalPath: '/articoli-frontaliere/permesso-b-imposta-fonte-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -11454,7 +11454,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'ai frontalieri, assistente ai frontalieri, chatbot frontaliere, intelligenza artificiale frontalieri, gemini frontaliere, chatbot gratis frontalieri, ai ticino',
     ogTitle: 'Assistente AI per frontalieri: la guida completa 2026',
     ogDescription: 'Chatbot gratuito per frontalieri: permesso G, imposta alla fonte, job search, privacy e 15 FAQ reali.',
-    canonicalPath: '/articoli-frontaliere/assistente-ai-frontalieri',
+    canonicalPath: '/articoli-frontaliere/assistente-ai-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -11484,7 +11484,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, economia, rischio, burocrazia, divisioni',
     ogTitle: 'Economia svizzera a rischio: burocrazia e divisioni interne',
     ogDescription: 'L\'economista Rudolf Walser lancia l\'allarme: la Svizzera rischia di perdere competitività a causa della burocrazia federale e delle divisioni interne.',
-    canonicalPath: '/articoli-frontaliere/economia-svizzera-rischio-burocrazia',
+    canonicalPath: '/articoli-frontaliere/economia-svizzera-rischio-burocrazia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11512,7 +11512,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, samira, stefano, semifinale, chiasso',
     ogTitle: 'Samira De Stefano in semifinale a Chiasso | Frontaliere',
     ogDescription: 'La tennista varesina Samira De Stefano raggiunge la semifinale a Chiasso e migliora il suo best ranking. Scopri di più su questa promessa del tennis italiano.',
-    canonicalPath: '/articoli-frontaliere/samira-de-stefano-semifinale-chiasso',
+    canonicalPath: '/articoli-frontaliere/samira-de-stefano-semifinale-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11540,7 +11540,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, omaggio, agli, angeli, ponte',
     ogTitle: 'Omaggio agli Angeli di Ponte Chiasso | Frontaliere Ticino',
     ogDescription: 'Scoperta targa commemorativa per Giuseppina Panzìca, Giovanni Gavino Tolis e Paolo Boetti, eroi che salvarono ebrei dai nazifascisti al confine italo-svizzero',
-    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/omaggio-angeli-ponte-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11568,7 +11568,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, comunale, stabio, futuro',
     ogTitle: 'Polizia Stabio: futuro incerto, presenza costante |',
     ogDescription: 'Il futuro della polizia comunale di Stabio è incerto, ma la sua presenza rimane costante. Scopri di più sulle attività 2025 e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-stabio-futuro-incerto',
+    canonicalPath: '/articoli-frontaliere/polizia-stabio-futuro-incerto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11596,7 +11596,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, settimana, giorni, esperimento, rivoluziona',
     ogTitle: 'Settimana di 4 giorni in Ticino | Frontaliere Ticino',
     ogDescription: 'Scopri come la settimana di 4 giorni sta rivoluzionando il lavoro in Ticino e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/settimana-corta-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/settimana-corta-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11624,7 +11624,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, mancano, criteri, chiari',
     ogTitle: 'COMCO usa l’IA: ma mancano criteri chiari',
     ogDescription: 'La Commissione della concorrenza svizzera utilizza l’intelligenza artificiale per combattere i cartelli, ma il CdF critica la mancanza di una strategia chiara',
-    canonicalPath: '/articoli-frontaliere/comco-ia-criteri-2026',
+    canonicalPath: '/articoli-frontaliere/comco-ia-criteri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11652,7 +11652,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, autista, belga, fila, polizia',
     ogTitle: 'Autista belga guida 20 ore: polizia Thurgau interviene',
     ogDescription: 'Un autista belga è stato fermato dopo aver guidato quasi 20 ore consecutive. La polizia del Canton Thurgau ha preso provvedimenti.',
-    canonicalPath: '/articoli-frontaliere/autista-belga-20-ore-thurgau-intervento',
+    canonicalPath: '/articoli-frontaliere/autista-belga-20-ore-thurgau-intervento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11680,7 +11680,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, neuch, dipendenti, telelavoro, guasto',
     ogTitle: 'UST Neuchâtel: 300 dipendenti in telelavoro | Frontaliere',
     ogDescription: 'Circa 300 dipendenti dell’Ufficio federale di statistica di Neuchâtel sono in telelavoro a causa di un malfunzionamento del sistema antincendio.',
-    canonicalPath: '/articoli-frontaliere/ust-neuchatel-telelavoro-300-dipendenti',
+    canonicalPath: '/articoli-frontaliere/ust-neuchatel-telelavoro-300-dipendenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11708,7 +11708,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, alla, carta, identità',
     ogTitle: 'Addio alla carta d\'identità cartacea | Frontaliere Ticino',
     ogDescription: 'Dal 3 agosto 2026, la carta d\'identità cartacea non sarà più valida. Ecco cosa cambia e come richiedere la CIE',
-    canonicalPath: '/articoli-frontaliere/cartaelettronica-varese-2026',
+    canonicalPath: '/articoli-frontaliere/cartaelettronica-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11736,7 +11736,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, frode, crediti, covid, 3334',
     ogTitle: 'Frode crediti Covid: 3334 casi aperti in Ticino',
     ogDescription: 'Le autorità svizzere affrontano 3334 procedimenti per frodi sui crediti Covid, per un valore di oltre 406 milioni di franchi.',
-    canonicalPath: '/articoli-frontaliere/frode-crediti-covid-ticino-3334-casi',
+    canonicalPath: '/articoli-frontaliere/frode-crediti-covid-ticino-3334-casi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11764,7 +11764,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, sulla, salute, entro',
     ogTitle: 'Frontalieri, “tassa sulla salute” al via entro settembre',
     ogDescription: 'Regione Lombardia conferma il cronoprogramma per il contributo economico che servirà a sostenere gli stipendi del personale sanitario nelle zone al confine con',
-    canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-lombardia',
+    canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11792,7 +11792,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trovare, casa, mercato, immobiliare',
     ogTitle: 'Trovare casa in Ticino: il mercato immobiliare nel 2026',
     ogDescription: 'Scopri come trovare casa in Ticino nel 2026: analisi del mercato immobiliare, implicazioni per i frontalieri e azioni concrete per trovare un alloggio.',
-    canonicalPath: '/articoli-frontaliere/casa-ticino-2026-piu-difficile',
+    canonicalPath: '/articoli-frontaliere/casa-ticino-2026-piu-difficile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11820,7 +11820,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, quadranti, chiede, controlli',
     ogTitle: 'Sicurezza frontalieri Ticino: Quadranti chiede più controlli',
     ogDescription: 'Il capogruppo PLR Matteo Quadranti chiede al Consiglio di Stato misure per aumentare la sicurezza, soprattutto nel sottoceneri e nelle aree frontaliere',
-    canonicalPath: '/articoli-frontaliere/sicurezza-frontalieri-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/sicurezza-frontalieri-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11848,7 +11848,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vacanze, estive, costi, aumento',
     ogTitle: 'Vacanze estive 2026: costi in aumento per la guerra |',
     ogDescription: 'Un\'analisi di HolidayCheck rivela che i prezzi delle vacanze estive 2026 sono superiori del 10-20% rispetto all\'anno scorso, ma alcune destinazioni registrano',
-    canonicalPath: '/articoli-frontaliere/vacanze-estive-2026-costi-guerra',
+    canonicalPath: '/articoli-frontaliere/vacanze-estive-2026-costi-guerra/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11876,7 +11876,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, anni, ricerca, biomedica',
     ogTitle: 'IRB Bellinzona: 25 anni di ricerca biomedica | Frontaliere',
     ogDescription: 'L\'Istituto di Ricerca in Biomedicina di Bellinzona festeggia 25 anni di attività con 160 collaboratori e quasi 1000 pubblicazioni scientifiche.',
-    canonicalPath: '/articoli-frontaliere/irb-bellinzona-valore-aggiunto-ticino',
+    canonicalPath: '/articoli-frontaliere/irb-bellinzona-valore-aggiunto-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11904,7 +11904,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incentivo, alla, remigrazione, cosa',
     ogTitle: 'Incentivo alla remigrazione: cosa cambia per i frontalieri',
     ogDescription: 'Il governo italiano introduce un bonus di 615 euro per avvocati che convincono richiedenti asilo a tornare in patria. La misura solleva critiche in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/incentivo-remigrazione-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/incentivo-remigrazione-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11932,7 +11932,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confederazione, cantoni, ridiscutono, compiti',
     ogTitle: 'Confederazione e Cantoni ridiscutono i compiti | Frontaliere',
     ogDescription: 'Il progetto Dissociazione 27 propone modifiche in 14 settori, tra cui trasporti e formazione. Ecco le implicazioni per chi lavora in Ticino.',
-    canonicalPath: '/articoli-frontaliere/confederazione-cantoni-ridiscutono-compiti-2026',
+    canonicalPath: '/articoli-frontaliere/confederazione-cantoni-ridiscutono-compiti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11960,7 +11960,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asili, nido, pubblici, bellinzona',
     ogTitle: 'Asili nido pubblici Bellinzona: l\'Asp sostiene l\'iniziativa',
     ogDescription: 'L\'Associazione per la difesa del servizio pubblico sostiene l\'iniziativa per più asili nido pubblici a Bellinzona, evidenziando l\'importanza dell\'equità sociale',
-    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-asp-2026',
+    canonicalPath: '/articoli-frontaliere/asili-nido-bellinzona-asp-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -11988,7 +11988,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavena, ponte, tresa, celebra',
     ogTitle: 'Lavena Ponte Tresa celebra la Libertà: successo del',
     ogDescription: 'La comunità di Lavena Ponte Tresa ha festeggiato l\'81° anniversario della Liberazione con una partecipata cerimonia che ha visto protagonisti i giovani del',
-    canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-battesimo-civico-2026',
+    canonicalPath: '/articoli-frontaliere/lavena-ponte-tresa-battesimo-civico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12016,7 +12016,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tilo, fermo, fino, alle',
     ogTitle: 'Tilo S40 fermo fino alle 21: manca personale in Italia',
     ogDescription: 'La linea S40 tra Mendrisio e Como San Giovanni e Varese è limitata fino alle 21 per mancanza di personale in Italia. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ferrovia-tilo-s40-fermi-italia-personale',
+    canonicalPath: '/articoli-frontaliere/ferrovia-tilo-s40-fermi-italia-personale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12044,7 +12044,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, stretta, permessi, dimora',
     ogTitle: 'Grigioni: stretta sui permessi di dimora | Frontaliere',
     ogDescription: 'Nuove regole per i permessi di dimora nei Grigioni: dichiarazione obbligatoria di precedenti penali e procedimenti in corso. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-dimora-2026',
+    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-dimora-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12072,7 +12072,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spese, cura, ufas, chiarisce',
     ogTitle: 'Spese di cura frontalieri: UFAS chiarisce la procedura',
     ogDescription: 'L\'Ufficio federale delle assicurazioni sociali spiega come vengono gestite le spese mediche per i frontalieri italiani infortunati in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/spese-cura-frontalieri-ufas-2026',
+    canonicalPath: '/articoli-frontaliere/spese-cura-frontalieri-ufas-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12100,7 +12100,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, miliardari, dubai, alla, lugano',
     ogTitle: 'Miliardari da Dubai alla Svizzera: Lugano nel mirino',
     ogDescription: 'L\'incertezza geopolitica spinge i miliardari di Dubai a trasferirsi in Svizzera, con Lugano come meta preferita. Decine di miliardi in arrivo.',
-    canonicalPath: '/articoli-frontaliere/miliardari-dubai-svizzera-lugano',
+    canonicalPath: '/articoli-frontaliere/miliardari-dubai-svizzera-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12128,7 +12128,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, ufas, chiarisce, spese',
     ogTitle: 'Crans-Montana: UFAS chiarisce le spese di cura per i',
     ogDescription: 'L\'Ufficio federale delle assicurazioni sociali spiega la procedura per il rimborso delle spese mediche per i pazienti italiani infortunati in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-ufas-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-ufas-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12156,7 +12156,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cantone, comuni, uniti, contro',
     ogTitle: 'Alleanza clima Ticino Comuni | Frontaliere Ticino',
     ogDescription: 'Cantone e Comuni uniti contro i cambiamenti climatici. Scopri le implicazioni per i frontalieri e come contribuire alla sostenibilità.',
-    canonicalPath: '/articoli-frontaliere/alleanza-clima-ticino-comuni',
+    canonicalPath: '/articoli-frontaliere/alleanza-clima-ticino-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12184,7 +12184,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, riceve, euro, valorizzare',
     ogTitle: 'Varese riceve 35.000 euro per valorizzare le sue bellezze |',
     ogDescription: 'Regione Lombardia finanzia il marketing territoriale: Varese ottiene 35.000 euro per promuovere le sue eccellenze culturali e turistiche.',
-    canonicalPath: '/articoli-frontaliere/marketing-territoriale-varese-35000-euro',
+    canonicalPath: '/articoli-frontaliere/marketing-territoriale-varese-35000-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12212,7 +12212,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, tassa, finanziare, stipendi',
     ogTitle: 'Nuova tassa sui frontalieri: 3% in più per finanziare gli',
     ogDescription: 'Dal settembre 2026, i frontalieri in Lombardia pagheranno una tassa del 3% per finanziare aumenti salariali per medici e infermieri',
-    canonicalPath: '/articoli-frontaliere/nuova-tassa-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-tassa-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12240,7 +12240,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, fatture, cure, pazienti',
     ogTitle: 'Crans-Montana: fatture cure italiani | Frontaliere Ticino',
     ogDescription: 'L\'Italia ribadisce che non pagherà le fatture delle cure per i pazienti italiani ricoverati in Svizzera dopo il rogo di Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-cure-italiani-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-cure-italiani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12268,7 +12268,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, shopping, milioni, svizzeri, preferiscono',
     ogTitle: 'Shopping in Italia per 700 milioni: svizzeri preferiscono',
     ogDescription: 'Scopri come gli svizzeri spendono 700 milioni all\'anno in Italia, con il 67% degli acquisti nei supermercati comaschi. Implicazioni per i frontalieri e',
-    canonicalPath: '/articoli-frontaliere/svizzeri-shopping-como-700-milioni',
+    canonicalPath: '/articoli-frontaliere/svizzeri-shopping-como-700-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12296,7 +12296,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, apprendisti, cifre, allarmanti, sugli',
     ogTitle: 'Apprendisti in Ticino: cifre allarmanti sugli incidenti',
     ogDescription: 'Quasi 23.000 apprendisti svizzeri sono vittime di incidenti ogni anno, con tre casi mortali in media. Unia chiede misure urgenti.',
-    canonicalPath: '/articoli-frontaliere/apprendisti-ticino-incidenti-2026',
+    canonicalPath: '/articoli-frontaliere/apprendisti-ticino-incidenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12324,7 +12324,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fiorenzo, dadò, statali, nella',
     ogTitle: 'Fiorenzo Dadò, le sue tre «P» e gli statali nella morsa p',
     ogDescription: 'Fiorenzo Dadò, presidente dell\'OCST, discute con Alain Buehler, capogruppo UDC, sulle iniziative statali.',
-    canonicalPath: '/articoli-frontaliere/fiorenzo-dado-le-sue-tre-p-e-gli-statali-nella-morsa-politica',
+    canonicalPath: '/articoli-frontaliere/fiorenzo-dado-le-sue-tre-p-e-gli-statali-nella-morsa-politica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12352,7 +12352,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, medici, senza, permesso, fenomeno',
     ogTitle: 'Medici senza permesso in Svizzera | Frontaliere Ticino',
     ogDescription: 'Scopri il fenomeno preoccupante dei medici che esercitano senza permesso in Svizzera e le implicazioni per i frontalieri del Ticino.',
-    canonicalPath: '/articoli-frontaliere/medici-senza-permesso-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/medici-senza-permesso-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12380,7 +12380,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, spese, mediche, respinge',
     ogTitle: 'Crans-Montana, spese mediche: Italia respinge richiesta',
     ogDescription: 'La premier Meloni annuncia che l\'Italia non pagherà le spese mediche per i feriti di Crans-Montana, nonostante la Svizzera intenda chiedere il rimborso',
-    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-spese-cura-italiani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12408,7 +12408,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, aumenta, stipendi, sanitari',
     ogTitle: 'Lombardia aumenta stipendi sanitari al confine | Frontaliere',
     ogDescription: 'La Lombardia introduce un aumento del 20% per medici e infermieri al confine con la Svizzera, finanziato da un contributo sui salari dei frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lombardia-aumenta-stipendi-sanitari-2026',
+    canonicalPath: '/articoli-frontaliere/lombardia-aumenta-stipendi-sanitari-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12436,7 +12436,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petizione, contro, tassa, esenzione',
     ogTitle: 'Petizione contro tassa esenzione militare | Frontaliere',
     ogDescription: 'La Gioventù comunista lancia una petizione per abolire la tassa d\'esenzione dall\'obbligo militare in Ticino, accusando il governo di privilegiare l\'esercito.',
-    canonicalPath: '/articoli-frontaliere/petizione-gioventu-comunista-tassa-esenzione-militare',
+    canonicalPath: '/articoli-frontaliere/petizione-gioventu-comunista-tassa-esenzione-militare/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12464,7 +12464,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, petizione, abolire, tassa, esenzione',
     ogTitle: 'Petizione per abolire la tassa di esenzione dal servizio',
     ogDescription: 'La Gioventù Comunista lancia una petizione per abolire la tassa di esenzione dal servizio militare, definita ingiusta e discriminatoria.',
-    canonicalPath: '/articoli-frontaliere/petizione-tassa-esenzione-militare-ticino',
+    canonicalPath: '/articoli-frontaliere/petizione-tassa-esenzione-militare-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12492,7 +12492,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, immigrazione, anni, dibattito, iniziative',
     ogTitle: 'Immigrazione in Svizzera: 60 anni di dibattito',
     ogDescription: 'Scopri come l\'immigrazione ha plasmato la Svizzera in 60 anni e le implicazioni per i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/immigrazione-svizzera-60-anni-2026',
+    canonicalPath: '/articoli-frontaliere/immigrazione-svizzera-60-anni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12520,7 +12520,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, supermercati, migros, coop, aldi',
     ogTitle: 'Supermercati Ticino: Nessun rincaro immediato | Frontaliere',
     ogDescription: 'Migros, Coop e Aldi rassicurano: con la crisi in Medio Oriente nessun rincaro immediato per i prodotti di largo consumo in Ticino',
-    canonicalPath: '/articoli-frontaliere/supermercati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/supermercati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12548,7 +12548,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, latte, ticinese, situazione, urgente',
     ogTitle: 'Latte ticinese, la situazione è urgente e la politica è già',
     ogDescription: 'Il Partito comunista interpella il governo sul prezzo del latte in Ticino, ai minimi storici. Urge una risposta politica alla crisi della filiera la',
-    canonicalPath: '/articoli-frontaliere/latte-ticino-crisi-politica-ritardo',
+    canonicalPath: '/articoli-frontaliere/latte-ticino-crisi-politica-ritardo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12576,7 +12576,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maria, timofeeva, trionfa, torneo',
     ogTitle: 'Maria Timofeeva trionfa al torneo di Chiasso | Frontaliere',
     ogDescription: 'La ventiduenne uzbeka Maria Timofeeva ha vinto l\'Axion Open di Chiasso sconfiggendo Lisa Pigato in finale. Scopri di più su questa vittoria storica.',
-    canonicalPath: '/articoli-frontaliere/maria-timofeeva-trionfa-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/maria-timofeeva-trionfa-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12604,7 +12604,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, paga, cure, italiani',
     ogTitle: 'Crans-Montana: chi paga le cure per gli italiani? |',
     ogDescription: 'Le fatture delle cure per i tre italiani feriti a Crans-Montana hanno scatenato polemiche. Ecco chi deve pagare e come funziona il sistema.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-cure-italiani-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-cure-italiani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12632,7 +12632,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costi, salute, esperto, avverte',
     ogTitle: 'Costi salute Svizzera: esperto avverte, «Sistema al',
     ogDescription: 'Nel 2025 i costi sanitari svizzeri toccheranno i 100 miliardi, con una spesa pro capite di 900 CHF al mese. L\'esperto Igor Francetic della SUPSI avverte: il',
-    canonicalPath: '/articoli-frontaliere/costi-salute-svizzera-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/costi-salute-svizzera-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12660,7 +12660,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, imposta, ocse, sulle, multinazionali',
     ogTitle: 'Imposta OCSE Multinazionali: Obiettivi Lontani | Frontaliere',
     ogDescription: 'L\'imposta minima del 15% per le multinazionali in Svizzera ha incassato 564 milioni nel 2025, ben al di sotto degli obiettivi miliardari del Consiglio federale.',
-    canonicalPath: '/articoli-frontaliere/imposta-ocse-multinazionali-obiettivi-lontani',
+    canonicalPath: '/articoli-frontaliere/imposta-ocse-multinazionali-obiettivi-lontani/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12688,7 +12688,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, settimana, corta, meno, produttività',
     ogTitle: 'Settimana corta in Svizzera: meno ore, più produttività',
     ogDescription: 'Un esperimento svizzero mostra che lavorare meno ore a parità di salario riduce assenze e aumenta la motivazione dei dipendenti',
-    canonicalPath: '/articoli-frontaliere/settimana-corta-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/settimana-corta-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12716,7 +12716,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, adulti, ricevono, soldi, genitori',
     ogTitle: 'Adulti che ricevono soldi dai genitori | Frontaliere Ticino',
     ogDescription: 'Scopri come il sostegno finanziario all’interno delle famiglie sta aumentando in Ticino e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/adulti-genitori-sostegno-finanziario-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/adulti-genitori-sostegno-finanziario-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12744,7 +12744,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, lufthansa, lanciano, economy',
     ogTitle: 'Swiss e Lufthansa Economy Basic | Frontaliere Ticino',
     ogDescription: 'Scopri la nuova tariffa Economy Basic di Swiss e Lufthansa per voli europei con bagaglio a mano piccolo. Disponibile dal 28 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/swiss-lufthansa-economy-basic-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-lufthansa-economy-basic-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12772,7 +12772,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, frode, twint, proteggere, account',
     ogTitle: 'Frode TWINT: come proteggere il tuo account',
     ogDescription: 'Scopri come i criminali rubano gli account TWINT e come proteggere il tuo. Consigli pratici e cosa fare se sei vittima di frode.',
-    canonicalPath: '/articoli-frontaliere/twint-account-frode-frontalieri',
+    canonicalPath: '/articoli-frontaliere/twint-account-frode-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12800,7 +12800,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, costi, sanitari, 2024, famiglie',
     ogTitle: 'Costi sanitari Ticino 2024: +4% | Frontaliere Ticino',
     ogDescription: 'Scopri l\'aumento dei costi sanitari in Ticino nel 2024 e le implicazioni per i frontalieri. Confronta i premi delle assicurazioni malattie e pianifica le tue',
-    canonicalPath: '/articoli-frontaliere/costi-sanitari-ticino-2024-4-percento',
+    canonicalPath: '/articoli-frontaliere/costi-sanitari-ticino-2024-4-percento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12828,7 +12828,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cybersicurezza, industriale, proteggere, produzione',
     ogTitle: 'Cybersicurezza industriale: proteggere produzione e',
     ogDescription: 'Le imprese del Canton Ticino devono adottare un approccio integrato per la sicurezza informatica industriale, secondo un webinar promosso da ANIMA C',
-    canonicalPath: '/articoli-frontaliere/cybersicurezza-industriale-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cybersicurezza-industriale-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12856,7 +12856,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, redditi, 2024, luvinate, comune',
     ogTitle: 'Redditi 2024: Luvinate è il comune più ricco della provincia',
     ogDescription: 'Luvinate supera Galliate Lombardo con un reddito medio di 37.654 euro. I dati dei frontalieri non sono inclusi.',
-    canonicalPath: '/articoli-frontaliere/redditi-varesotti-2024-luvinate',
+    canonicalPath: '/articoli-frontaliere/redditi-varesotti-2024-luvinate/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12884,7 +12884,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, autostrade, cosa',
     ogTitle: 'Chiusure notturne autostrade: cosa cambia per i frontalieri',
     ogDescription: 'Dalla notte tra il 28 e il 29 aprile, chiusure notturne tra A8, Raccordo Fiera e Diramazione Gallarate-Gattico. Ecco le alternative',
-    canonicalPath: '/articoli-frontaliere/chiusure-autostrade-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-autostrade-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12912,7 +12912,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accordo, storico, navigazione, tedesca',
     ogTitle: 'Accordo navigazione Lago di Costanza | Frontaliere Ticino',
     ogDescription: 'Biglietti validi reciprocamente dal 2026 e ripresa degli scali a Costanza. Cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/accordo-navigazione-costanza-2026',
+    canonicalPath: '/articoli-frontaliere/accordo-navigazione-costanza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12940,7 +12940,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, germignaga, comunità, energetica, rinnovabile',
     ogTitle: 'Germignaga: Comunità Energetica Rinnovabile del Luinese',
     ogDescription: 'La Comunità Energetica Rinnovabile del Luinese raggiunge 400 kW di potenza e punta a 1000 kW entro fine 2026. 17 Comuni e 287 soci coinvolti.',
-    canonicalPath: '/articoli-frontaliere/comunita-energetica-rinnovabile-luinese-400-kw',
+    canonicalPath: '/articoli-frontaliere/comunita-energetica-rinnovabile-luinese-400-kw/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12968,7 +12968,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusura, notturna, uscita, gallarate',
     ogTitle: 'Chiusura notturna uscita A8 Gallarate: cosa cambia per i',
     ogDescription: 'L\'uscita di Gallarate sulla A8 Milano-Varese sarà chiusa nella notte tra mercoledì 29 e giovedì 30 aprile per lavori di manutenzione. Ecco le alternative',
-    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a8-gallarate-29-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a8-gallarate-29-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -12996,7 +12996,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sovranità, alimentare, latte, ticinese',
     ogTitle: 'Sovranità alimentare e latte in Ticino: crisi e soluzioni',
     ogDescription: 'Il Partito Comunista segnala il rischio di smantellamento della filiera del latte in Ticino. Analisi, scenari e azioni concrete.',
-    canonicalPath: '/articoli-frontaliere/sovranita-latte-ticino',
+    canonicalPath: '/articoli-frontaliere/sovranita-latte-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13024,7 +13024,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, giornata, alla, scoperta',
     ogTitle: 'Chiasso: Una giornata alla scoperta degli enti di primo',
     ogDescription: 'Scopri chi sono gli enti di primo intervento a Chiasso e partecipa alla Missione Emergenza.',
-    canonicalPath: '/articoli-frontaliere/chiasso-scoperta-enti-primo-intervento',
+    canonicalPath: '/articoli-frontaliere/chiasso-scoperta-enti-primo-intervento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13052,7 +13052,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tennis, donne, open, chiasso',
     ogTitle: 'Tennis donne / “Open” di Chiasso, a Marija Glebovna',
     ogDescription: 'La russa Marija Glebovna Timofeeva ha vinto il titolo dell\'“Open” di Chiasso, una delle competizioni più prestigiose in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/tennis-donne-open-di-chiasso-a-marija-glebovna-timofeeva-il-titolo',
+    canonicalPath: '/articoli-frontaliere/tennis-donne-open-di-chiasso-a-marija-glebovna-timofeeva-il-titolo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13080,7 +13080,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, foreste, sommerse, salvare, laghi',
     ogTitle: 'Foreste sommerse per salvare i laghi di Como e Lugano',
     ogDescription: 'Scopri come il progetto Echo utilizza piante acquatiche per ripristinare gli ecosistemi lacustri e combattere il cambiamento climatico nei laghi di Como e',
-    canonicalPath: '/articoli-frontaliere/foreste-sommerse-lago-como-lugano',
+    canonicalPath: '/articoli-frontaliere/foreste-sommerse-lago-como-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13108,7 +13108,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, viabilità, olimpica, grigioni, risparmiano',
     ogTitle: 'Viabilità olimpica: Grigioni risparmiano, Lombardia tace',
     ogDescription: 'I costi per la gestione del traffico olimpico sono inferiori alle previsioni, ma la Lombardia non ha ancora confermato il suo contributo.',
-    canonicalPath: '/articoli-frontaliere/grigioni-viabilita-olimpica-2026',
+    canonicalPath: '/articoli-frontaliere/grigioni-viabilita-olimpica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13136,7 +13136,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mobilità, sostenibile, città, vivibili',
     ogTitle: 'Mobilità sostenibile e città vivibili | Frontaliere Ticino',
     ogDescription: 'Scopri come Barcellona, Parigi e Singapore stanno ridisegnando lo spazio urbano per ridurre inquinamento e migliorare la qualità della vita per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/mobilita-sostenibile-citta-vivibili-2026',
+    canonicalPath: '/articoli-frontaliere/mobilita-sostenibile-citta-vivibili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13164,7 +13164,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, relazioni, italo-svizzere, novità, sviluppi',
     ogTitle: 'Relazioni italo-svizzere: novità e sviluppi',
     ogDescription: 'Scoperte geologiche, controversie su cure mediche e design svizzero al Fuorisalone milanese. Ecco gli ultimi aggiornamenti.',
-    canonicalPath: '/articoli-frontaliere/relazioni-italo-svizzere-2026',
+    canonicalPath: '/articoli-frontaliere/relazioni-italo-svizzere-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13192,7 +13192,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, integrazione, inclusione, dibattito, futuro',
     ogTitle: 'Integrazione o inclusione? Il dibattito sul futuro in Ticino',
     ogDescription: 'Esperti si riuniscono a Bellinzona per discutere il futuro dell\'integrazione e dell\'inclusione in Ticino, con progetti partecipativi e culturali in corso.',
-    canonicalPath: '/articoli-frontaliere/integrazione-inclusione-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/integrazione-inclusione-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13220,7 +13220,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, provincia, como, ricca, cresce',
     ogTitle: 'Provincia di Como più ricca: cresce il reddito | Frontaliere',
     ogDescription: 'Scopri come il reddito pro capite della provincia di Como è aumentato e le implicazioni per i frontalieri che lavorano in questa zona.',
-    canonicalPath: '/articoli-frontaliere/reddito-como-2024-frontalieri',
+    canonicalPath: '/articoli-frontaliere/reddito-como-2024-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13248,7 +13248,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moritz, costruisce, case, prezzi',
     ogTitle: 'St. Moritz costruisce case con prezzi basati sul reddito |',
     ogDescription: 'Il Comune di St. Moritz avvia la costruzione di 19 appartamenti a prezzi accessibili basati sul reddito, con altri progetti per 150-200 unità abitative in fase',
-    canonicalPath: '/articoli-frontaliere/st-moritz-case-accessibili-2026',
+    canonicalPath: '/articoli-frontaliere/st-moritz-case-accessibili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13276,7 +13276,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, macello, residenze, secondarie, quota',
     ogTitle: 'Ex Gas ex Macello: residenze secondarie, quota inefficace |',
     ogDescription: 'Locarno non aggiorna il piano per il comparto dopo la decisione dell\'Are. La quota di residenze secondarie risulta inefficace.',
-    canonicalPath: '/articoli-frontaliere/ex-gas-macello-residenze-secondarie',
+    canonicalPath: '/articoli-frontaliere/ex-gas-macello-residenze-secondarie/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13304,7 +13304,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, contratto, lago, lands, lake',
     ogTitle: 'Contratto di Lago: Lands Lake chiama a confronto i candidati',
     ogDescription: 'L\'associazione Lands Lake organizza incontri pubblici con i candidati sindaco di Baveno, Stresa, Luino e Laveno Mombello per discutere il futuro del Lago',
-    canonicalPath: '/articoli-frontaliere/contratto-lago-lands-lake-2026',
+    canonicalPath: '/articoli-frontaliere/contratto-lago-lands-lake-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13332,7 +13332,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, radar, controlli, aprile, maggio',
     ogTitle: 'Radar in Ticino: controlli dal 27 aprile al 3 maggio |',
     ogDescription: 'La Polizia cantonale e le polizie comunali annunciano i controlli della velocità in Ticino per la settimana dal 27 aprile al 3 maggio.',
-    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-aprile-maggio',
+    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-aprile-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13360,7 +13360,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, finanze, pubbliche, allarme, commercialisti',
     ogTitle: 'Finanze pubbliche Ticino: allarme commercialisti',
     ogDescription: 'L\'Ordine dei commercialisti del Canton Ticino esprime preoccupazione per le finanze pubbliche e il rischio di delocalizzazioni.',
-    canonicalPath: '/articoli-frontaliere/finanze-pubbliche-ticino-2026-preoccupazioni',
+    canonicalPath: '/articoli-frontaliere/finanze-pubbliche-ticino-2026-preoccupazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13388,7 +13388,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, premi, oltre, dato, dimezza',
     ogTitle: 'Premi non oltre il 10%, il dato che dimezza i costi',
     ogDescription: 'Il governo ticinese riduce i costi dell\'iniziativa a 130 milioni. De Pietro (SUPSI): \'Più impegno nel socio-sanitario\'',
-    canonicalPath: '/articoli-frontaliere/premi-non-oltre-10-percento',
+    canonicalPath: '/articoli-frontaliere/premi-non-oltre-10-percento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13416,7 +13416,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guerra, iran, pressione, sull',
     ogTitle: 'Guerra in Iran: pressione sull\'industria alimentare svizzera',
     ogDescription: 'La guerra in Iran sta mettendo sotto pressione l\'industria alimentare svizzera, con possibili ripercussioni sui consumatori e sui lavoratori del settore.',
-    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-svizzera',
+    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13444,7 +13444,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bollini, rossi, gottardo, caos',
     ogTitle: 'Bollini rossi al San Gottardo: caos traffico in maggio |',
     ogDescription: 'Maggio 2026: previsti giorni neri per il traffico al tunnel del San Gottardo, con code fino a 20 km e ritardi fino a 2 ore. Scopri le previsioni del TCS e cosa',
-    canonicalPath: '/articoli-frontaliere/bollini-rossi-traffico-san-gottardo-2026',
+    canonicalPath: '/articoli-frontaliere/bollini-rossi-traffico-san-gottardo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13472,7 +13472,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, treno, lugano-zurigo, panne, passeggeri',
     ogTitle: 'Treno Lugano-Zurigo in panne: passeggeri a piedi da',
     ogDescription: 'Guasto tecnico sopprime il treno delle 19:00, nessun sostitutivo. Passeggeri in attesa alla stazione di Bellinzona',
-    canonicalPath: '/articoli-frontaliere/treno-guasto-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/treno-guasto-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13500,7 +13500,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elezioni, comuni, provincia, como',
     ogTitle: 'Elezioni Como 2026: 10 comuni al voto | Frontaliere Ticino',
     ogDescription: 'Si vota il 24 e 25 maggio 2026 in 10 comuni della Provincia di Como. Ecco i candidati e le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/elezioni-como-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/elezioni-como-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13528,7 +13528,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, teatro, dell, architettura, stagione',
     ogTitle: 'Teatro dell\'Architettura: stagione espositiva 2026',
     ogDescription: 'Scopri la stagione espositiva 2026 del Teatro dell\'Architettura di Mendrisio con tre mostre distinte su architettura e design.',
-    canonicalPath: '/articoli-frontaliere/teatro-architettura-mendrisio-stagione-2026',
+    canonicalPath: '/articoli-frontaliere/teatro-architettura-mendrisio-stagione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13556,7 +13556,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arrestato, truffatore, maggia, frode',
     ogTitle: 'Arrestato truffatore a Maggia: frode con schockanruf',
     ogDescription: 'Un truffatore è stato arrestato a Maggia dopo essere stato colto in flagrante durante una frode telefonica. Scopri i dettagli dell\'operazione e come',
-    canonicalPath: '/articoli-frontaliere/frontalieri-arresto-maggia-truffa',
+    canonicalPath: '/articoli-frontaliere/frontalieri-arresto-maggia-truffa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13584,7 +13584,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, study, china, opportunità, oltre',
     ogTitle: 'Study in China: opportunità per frontalieri Ticino',
     ogDescription: 'Scopri le opportunità di studio in Cina per i frontalieri del Ticino. Oltre 380.000 studenti internazionali nel 2024-2025, con un aumento del 15%.',
-    canonicalPath: '/articoli-frontaliere/study-china-ticino-frontalieri',
+    canonicalPath: '/articoli-frontaliere/study-china-ticino-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13612,7 +13612,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, treno, senza, biglietto, sperimenta',
     ogTitle: 'Treno senza biglietto: la Svizzera sperimenta il futuro',
     ogDescription: 'La Svizzera introduce il sistema Bibo per viaggiare senza biglietti. Test nazionale dal 27 aprile con 3000 utenti, tra cui frontalieri ticinesi.',
-    canonicalPath: '/articoli-frontaliere/treno-senza-biglietto-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/treno-senza-biglietto-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13640,7 +13640,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, stradale, oltre, patenti',
     ogTitle: 'Polizia Stradale: 1.600 patenti ritirate | Frontaliere',
     ogDescription: 'Nel 2025, la Polizia Stradale di Varese ha ritirato oltre 1.600 patenti, con un calo del 42% per eccesso di velocità e del 25% per guida in stato di ebbrezza.',
-    canonicalPath: '/articoli-frontaliere/polizia-stradale-varese-1600-patenti',
+    canonicalPath: '/articoli-frontaliere/polizia-stradale-varese-1600-patenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13668,7 +13668,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lupo, cinghiali, burocrazia, sfide',
     ogTitle: 'Lupo, cinghiali e burocrazia: le sfide degli agricoltori',
     ogDescription: 'La 79ª assemblea di Confagricoltura Varese evidenzia le criticità del settore agricolo, tra fauna selvatica, costi elevati e Green Deal.',
-    canonicalPath: '/articoli-frontaliere/agricoltori-varesini-sfide-burocrazia',
+    canonicalPath: '/articoli-frontaliere/agricoltori-varesini-sfide-burocrazia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13696,7 +13696,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, banconote, euro, temi',
     ogTitle: 'Nuove banconote in euro: restyling e temi in gara',
     ogDescription: 'Scopri i due temi proposti per le nuove banconote in euro: cultura europea e natura. Decisione finale entro fine 2026.',
-    canonicalPath: '/articoli-frontaliere/nuove-banconote-euro-restyling-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-banconote-euro-restyling-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13724,7 +13724,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, amazon, made, italy, days',
     ogTitle: 'Amazon Made in Italy Days 2026: 5.500 eccellenze italiane in',
     ogDescription: 'Dal 13 al 19 maggio 2026, Amazon ospita 5.500 prodotti Made in Italy su 11 mercati internazionali. Collaborazione con Agenzia Ice.',
-    canonicalPath: '/articoli-frontaliere/amazon-made-in-italy-days-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/amazon-made-in-italy-days-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13752,7 +13752,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro-carburanti, dove, fare, pieno',
     ogTitle: 'Caro-carburanti: dove fare il pieno in Ticino | Frontaliere',
     ogDescription: 'Confronta i prezzi della benzina e del diesel in Ticino e risparmia con i nostri consigli pratici',
-    canonicalPath: '/articoli-frontaliere/carburanti-ticino-confronto-2024',
+    canonicalPath: '/articoli-frontaliere/carburanti-ticino-confronto-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13780,7 +13780,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, contratto, collettivo, edilizia',
     ogTitle: 'Nuovo CCL-Ti 2026-2031: cosa cambia per i lavoratori',
     ogDescription: 'Scopri le novità del nuovo Contratto Collettivo di Lavoro per l’edilizia e il genio civile in Ticino, valido dal 1° maggio 2026 al 31 dicembre 2031.',
-    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026-2031',
+    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026-2031/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13808,7 +13808,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, varese, sindacati',
     ogTitle: 'Primo Maggio Varese 2026: sindacati in corteo per un lavoro',
     ogDescription: 'Scopri di più sulla manifestazione del Primo Maggio 2026 a Varese, organizzata dai sindacati CGIL, CISL e UIL per un lavoro dignitoso.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-dignitoso',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-dignitoso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13836,7 +13836,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallimenti, fotovoltaico, clienti, rischio',
     ogTitle: 'Fallimenti fotovoltaico: clienti a rischio | Frontaliere',
     ogDescription: 'Diverse aziende fotovoltaiche fallite in Ticino, clienti con impianti incompleti e acconti a rischio. Swissolar consiglia verifiche e garanzie.',
-    canonicalPath: '/articoli-frontaliere/fallimenti-fotovoltaico-clienti-ticino',
+    canonicalPath: '/articoli-frontaliere/fallimenti-fotovoltaico-clienti-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13864,7 +13864,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, coop, ritira, insetti, commestibili',
     ogTitle: 'Coop Svizzera ritira insetti commestibili | Frontaliere',
     ogDescription: 'Coop Svizzera ritira insetti commestibili dagli scaffali. Scopri le implicazioni per i frontalieri e le alternative disponibili.',
-    canonicalPath: '/articoli-frontaliere/coop-svizzera-insetti-commestibili-2026',
+    canonicalPath: '/articoli-frontaliere/coop-svizzera-insetti-commestibili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13892,7 +13892,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, rafforzati, airolo, doppia',
     ogTitle: 'Controlli rafforzati a Airolo: doppia verifica per i',
     ogDescription: 'Nuovi controlli radar in arrivo per chi entra in Svizzera da Airolo. Doppia verifica per i frontalieri, tempi di attesa più lunghi. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/controlli-frontalieri-airolo-2026',
+    canonicalPath: '/articoli-frontaliere/controlli-frontalieri-airolo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13920,7 +13920,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallimenti, startup, boom, insolito',
     ogTitle: 'Fallimenti e startup in Svizzera 2026 | Frontaliere Ticino',
     ogDescription: 'Analisi del boom di fallimenti e startup in Svizzera nel 2026 e le implicazioni per i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/fallimenti-startup-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/fallimenti-startup-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13948,7 +13948,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, limite, dimezzare, inquinamento, acustico',
     ogTitle: 'Limite a 30 km/h per dimezzare l\'inquinamento acustico in',
     ogDescription: 'L\'ATA chiede maggiore autonomia per introdurre zone a 30 km/h nelle aree più esposte al rumore, migliorando la qualità della vita e la sicurezza stradale in',
-    canonicalPath: '/articoli-frontaliere/limite-velocita-30-ticino-inquinamento-acustico',
+    canonicalPath: '/articoli-frontaliere/limite-velocita-30-ticino-inquinamento-acustico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -13976,7 +13976,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, tavolo, tecnico, risolvere',
     ogTitle: 'Varese: tavolo tecnico per parcheggi ospedale Sette Laghi |',
     ogDescription: 'Comune di Varese e ASST Sette Laghi si incontrano per risolvere problemi parcheggi lavoratori sanitari. Incontro fissato per il 28 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/varese-parcheggi-ospedale-sette-laghi-2026',
+    canonicalPath: '/articoli-frontaliere/varese-parcheggi-ospedale-sette-laghi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14004,7 +14004,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zecche, punture, 2025, ecco',
     ogTitle: 'Zecche in Ticino: 18.000 punture nel 2025 | Frontaliere',
     ogDescription: 'Nel 2025 in Svizzera sono state registrate 18.000 punture di zecche. La dottoressa Luisa Carnino dell\'EOC spiega sintomi e prevenzione',
-    canonicalPath: '/articoli-frontaliere/zecche-ticino-2026-18000-punture',
+    canonicalPath: '/articoli-frontaliere/zecche-ticino-2026-18000-punture/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14032,7 +14032,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, over, raddoppiati, anni',
     ogTitle: 'Lavoratori over 65: raddoppiati in 20 anni | Frontaliere',
     ogDescription: 'Nel 2025, 220\'000 persone continuano a lavorare dopo i 65 anni, più del doppio rispetto al 2005. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14060,7 +14060,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcio, bellinzona, batte, stade',
     ogTitle: 'Calcio Dnb: Bellinzona batte Stade Nyonnais | Frontaliere',
     ogDescription: 'Il Bellinzona ha sconfitto lo Stade Nyonnais negli anticipi del campionato di calcio Dnb, approfittando della vittoria ottenuta grazie agli errori degli',
-    canonicalPath: '/articoli-frontaliere/calcio-dnb-bellinzona-vittoria-stade-nyonnais',
+    canonicalPath: '/articoli-frontaliere/calcio-dnb-bellinzona-vittoria-stade-nyonnais/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14088,7 +14088,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, senza, indipendenza, energetica, oggi',
     ogTitle: 'Svizzera senza indipendenza energetica | Frontaliere Ticino',
     ogDescription: 'Dal 27 aprile 2026 la Svizzera non è più autosufficiente energeticamente. Ecco cosa cambia per i frontalieri e il Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/svizzera-indipendenza-energetica-importazioni-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-indipendenza-energetica-importazioni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14116,7 +14116,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, misure, contro, violenza',
     ogTitle: 'Nuove misure contro violenza domestica in Svizzera |',
     ogDescription: 'Scopri le nuove misure introdotte dal Dipartimento federale di giustizia e polizia per contrastare la violenza domestica in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/nuove-misure-violenza-domestica-svizzera',
+    canonicalPath: '/articoli-frontaliere/nuove-misure-violenza-domestica-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14144,7 +14144,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ruag, giotto, creano, dati',
     ogTitle: 'RUAG e Giotto.AI creano IA svizzera per dati militari',
     ogDescription: 'La RUAG collabora con Giotto.AI per sviluppare un\'IA nazionale per dati sensibili, presentando LLARA a Thun.',
-    canonicalPath: '/articoli-frontaliere/ruag-ia-svizzera-difesa-2026',
+    canonicalPath: '/articoli-frontaliere/ruag-ia-svizzera-difesa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14172,7 +14172,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, leggi, strategia, nazionale',
     ogTitle: 'Nuove leggi e strategia nazionale contro la violenza',
     ogDescription: 'Confederazione e Cantoni annunciano progressi ma servono strumenti più efficaci. Nuove leggi in arrivo per il 2027.',
-    canonicalPath: '/articoli-frontaliere/nuove-leggi-violenza-domestica-2027',
+    canonicalPath: '/articoli-frontaliere/nuove-leggi-violenza-domestica-2027/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14200,7 +14200,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, regione, lombardia, stanzia, milioni',
     ogTitle: 'Regione Lombardia stanzia 6,4 milioni per case popolari |',
     ogDescription: 'Regione Lombardia ha stanziato oltre 6,4 milioni di euro per il recupero di alloggi sfitti e l\'accessibilità in Lombardia. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/regione-lombardia-casa-popolari-6-4-milioni',
+    canonicalPath: '/articoli-frontaliere/regione-lombardia-casa-popolari-6-4-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14228,7 +14228,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, domestica, gallo, prevenzione',
     ogTitle: 'Violenza domestica: prevenzione a San Gallo | Frontaliere',
     ogDescription: 'Scopri come la polizia di San Gallo previene la violenza domestica attraverso colloqui preventivi con un tasso di successo del 90%.',
-    canonicalPath: '/articoli-frontaliere/prevenzione-violenza-domestica-san-gallo-2026',
+    canonicalPath: '/articoli-frontaliere/prevenzione-violenza-domestica-san-gallo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14256,7 +14256,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zurigo, economia, cresce, meno',
     ogTitle: 'Zurigo guida l\'economia svizzera, ma cresce meno della media',
     ogDescription: 'Zurigo contribuisce al 21% del PIL svizzero, ma cresce solo dell\'1,3% contro il 1,7% nazionale. Scopri perché e cosa significa per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita-media-2026',
+    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita-media-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14284,7 +14284,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swisscom, avverte, minacce, informatiche',
     ogTitle: 'Swisscom avverte: minacce informatiche in aumento nel 2026 |',
     ogDescription: 'Swisscom segnala un forte aumento delle minacce informatiche, con rischi legati all\'IA e alle tensioni geopolitiche. Scopri come proteggere la tua azienda.',
-    canonicalPath: '/articoli-frontaliere/swisscom-minacce-cyber-2026',
+    canonicalPath: '/articoli-frontaliere/swisscom-minacce-cyber-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14312,7 +14312,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, istruzioni, sfide, dall, immigrazione',
     ogTitle: 'Svizzera, istruzioni per l\'uso: le sfide del 2026',
     ogDescription: 'Dall\'immigrazione alla casa, ecco i temi caldi che stanno cambiando il Paese e le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/svizzera-istruzioni-uso-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-istruzioni-uso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14340,7 +14340,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, reparto, securizzato, pasture, solo',
     ogTitle: 'Reparto securizzato a Pasture: consenso Cantone e Comuni |',
     ogDescription: 'La Commissione delle Istituzioni politiche della Camera bassa ha trovato una via mediana per il progetto pilota a Pasture, coinvolgendo gli enti locali.',
-    canonicalPath: '/articoli-frontaliere/reparto-securizzato-pasture-consenso-cantone-comuni',
+    canonicalPath: '/articoli-frontaliere/reparto-securizzato-pasture-consenso-cantone-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14368,7 +14368,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, edilizia, firmato, nuovo, ticinese',
     ogTitle: 'Nuovo CCL edilizia Ticino 2026-2031 | Frontaliere Ticino',
     ogDescription: 'Il nuovo contratto collettivo di lavoro per l\'edilizia e il genio civile in Ticino è stato firmato, valido dal 1° maggio 2026 al 2031. Scopri le novità e le',
-    canonicalPath: '/articoli-frontaliere/nuovo-ccnl-edilizia-ticino-2026-2031',
+    canonicalPath: '/articoli-frontaliere/nuovo-ccnl-edilizia-ticino-2026-2031/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14396,7 +14396,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morcote, apre, stagione, eventi',
     ogTitle: 'Morcote 2026: Scalinata di Corsa e Caccia al Tesoro |',
     ogDescription: 'Scopri gli eventi di Morcote 2026: la Morcote Scal il 2 maggio e la Caccia al Tesoro il 9 maggio. Iscrizioni aperte fino al 30 aprile.',
-    canonicalPath: '/articoli-frontaliere/morcote-eventi-2026-scalinata-caccia-tesoro',
+    canonicalPath: '/articoli-frontaliere/morcote-eventi-2026-scalinata-caccia-tesoro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14424,7 +14424,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, credito, energetico, cosa, cambia',
     ogTitle: 'Svizzera a credito energetico: cosa cambia per i frontalieri',
     ogDescription: 'Dal 27 aprile 2026 la Svizzera dipende dalle importazioni per il 68% del suo fabbisogno energetico. Ecco le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/svizzera-credito-energetico-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-credito-energetico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14452,7 +14452,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, oftalmologi, ticinesi, messico, operazioni',
     ogTitle: 'Oftalmologi ticinesi in Messico: operazioni gratuite',
     ogDescription: 'Un\'équipe di medici svizzeri, in gran parte ticinesi, opera gratuitamente pazienti nel Quintana Roo, Messico, per curare la cataratta.',
-    canonicalPath: '/articoli-frontaliere/oftalmologi-svizzeri-messico-vista',
+    canonicalPath: '/articoli-frontaliere/oftalmologi-svizzeri-messico-vista/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14480,7 +14480,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rumore, traffico, morti, anno',
     ogTitle: 'Rumore traffico Svizzera: 2.000 morti l\'anno | Frontaliere',
     ogDescription: 'Il rumore del traffico stradale causa fino a 2.000 decessi prematuri l\'anno in Svizzera, con 850.000 persone esposte a rumori nocivi',
-    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14508,7 +14508,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controversia, sull, bandiera, sulle',
     ogTitle: 'Controversia bandiera svizzera su scarpe On | Frontaliere',
     ogDescription: 'Scopri le polemiche sull\'uso della bandiera svizzera sulle scarpe On prodotte all\'estero e le implicazioni per il mercato elvetico.',
-    canonicalPath: '/articoli-frontaliere/bandiera-svizzera-scarpe-on-controversia',
+    canonicalPath: '/articoli-frontaliere/bandiera-svizzera-scarpe-on-controversia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14536,7 +14536,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incontro, solidarietà, sicurezza, bioggio',
     ogTitle: 'Incontro tra solidarietà e sicurezza a Bioggio',
     ogDescription: 'Volontari di City Angels Svizzera condividono esperienze dirette il 16 maggio al Centro Faressere di Bioggio',
-    canonicalPath: '/articoli-frontaliere/incontro-solidarieta-sicurezza-bioggio',
+    canonicalPath: '/articoli-frontaliere/incontro-solidarieta-sicurezza-bioggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14564,7 +14564,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, introvabili, boom, arrivi',
     ogTitle: 'Infermieri introvabili: boom di arrivi da Tunisia, India e',
     ogDescription: 'Scopri come la carenza di infermieri in Italia spinge le aziende a reclutare all\'estero, con oltre 1.000 professionisti selezionati negli ultimi tre anni.',
-    canonicalPath: '/articoli-frontaliere/infermieri-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14592,7 +14592,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, deepfake, pornografici, cosa, dice',
     ogTitle: 'Deepfake pornografici: cosa dice la legge svizzera |',
     ogDescription: 'Scopri cosa dice la legge svizzera sui deepfake pornografici e cosa fare se sei vittima di questi contenuti illegali.',
-    canonicalPath: '/articoli-frontaliere/deepfake-legge-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/deepfake-legge-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14620,7 +14620,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinesi, missione, umanitaria, ucraina',
     ogTitle: 'Ticinesi in missione umanitaria in Ucraina | Frontaliere',
     ogDescription: 'Volontari ticinesi si preparano per portare assistenza medica e conforto alla popolazione ucraina colpita dalla guerra. Scopri di più su questa missione',
-    canonicalPath: '/articoli-frontaliere/ticinesi-missione-ucraina-2026',
+    canonicalPath: '/articoli-frontaliere/ticinesi-missione-ucraina-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14648,7 +14648,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, posto, lavoro, solo, basta',
     ogTitle: 'Frontalieri e lavoro in Ticino: annuncio scandaloso |',
     ogDescription: 'Fabrizio Sirica denuncia un annuncio di lavoro a Massagno riservato esclusivamente ai frontalieri con uno stipendio di 2.900 franchi lordi al mese.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-massagno-salario-scandaloso',
+    canonicalPath: '/articoli-frontaliere/frontalieri-massagno-salario-scandaloso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14676,7 +14676,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, infermieristiche, 190mila, firme',
     ogTitle: 'Cure infermieristiche: 190mila firme per l\'applicazione',
     ogDescription: '190mila firme consegnate a Berna per l\'applicazione immediata dell\'iniziativa sulle cure infermieristiche. Il Consiglio nazionale discute la nuova legge.',
-    canonicalPath: '/articoli-frontaliere/cure-infermieristiche-190mila-firme-2026',
+    canonicalPath: '/articoli-frontaliere/cure-infermieristiche-190mila-firme-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14704,7 +14704,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maxi, spiegamento, fiamme, gialle',
     ogTitle: 'Maxi spiegamento Fiamme Gialle Comasco | Frontaliere Ticino',
     ogDescription: 'Controlli intensi nel Comasco: scoperti lavoratori in nero e sequestrati stupefacenti. Ecco i dettagli dell\'operazione.',
-    canonicalPath: '/articoli-frontaliere/maxi-spiegamento-fiamme-gialle-comasco-2026',
+    canonicalPath: '/articoli-frontaliere/maxi-spiegamento-fiamme-gialle-comasco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14732,7 +14732,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, medici, famiglia, sumai',
     ogTitle: 'Riforma medici famiglia: Sumai, il nodo è organizzazione |',
     ogDescription: 'Antonio Magi, segretario generale del Sumai-Assoprof, contesta l\'idea di dipendenza dei medici di base, evidenziando problemi organizzativi e carenza di',
-    canonicalPath: '/articoli-frontaliere/riforma-medici-famiglia-sumai-organizzazione',
+    canonicalPath: '/articoli-frontaliere/riforma-medici-famiglia-sumai-organizzazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14760,7 +14760,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, pensionabile, anni, 2025',
     ogTitle: 'Lavoratori in età pensionabile in Ticino: +220% in 20 anni',
     ogDescription: 'Nel 2025, 220.000 persone in Svizzera lavoravano oltre l\'età pensionabile. Ecco cosa cambia per i frontalieri del Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026-2046',
+    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-ticino-2026-2046/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14788,7 +14788,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intelligenza, artificiale, università, varese',
     ogTitle: 'Intelligenza artificiale all\'Università di Varese |',
     ogDescription: 'L\'Università dell\'Insubria organizza un evento sull\'intelligenza artificiale il 6 maggio 2026 a Varese, con interventi di esperti e nuove linee guida per',
-    canonicalPath: '/articoli-frontaliere/universita-varese-intelligenza-artificiale-2026',
+    canonicalPath: '/articoli-frontaliere/universita-varese-intelligenza-artificiale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14816,7 +14816,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, visite, gratuite, prevenzione, tumore',
     ogTitle: 'Visite Gratuite Prevenzione Tumore Seno Gallarate |',
     ogDescription: 'Due giornate di visite senologiche gratuite con ecografia a Gallarate in piazza Libertà nel mese di maggio. Prenotazione obbligatoria al numero 380 8644677.',
-    canonicalPath: '/articoli-frontaliere/visite-gratuite-prevenzione-tumore-seno-gallarate-lilt',
+    canonicalPath: '/articoli-frontaliere/visite-gratuite-prevenzione-tumore-seno-gallarate-lilt/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14844,7 +14844,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mozione, contro, discriminazione, lavorativa',
     ogTitle: 'Frontalieri: mozione contro discriminazione lavorativa in',
     ogDescription: 'Fabrizio Sirica presenta mozione per contrastare il dumping salariale e favorire l\'occupazione dei residenti nel Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-mozione-sirica-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/frontalieri-mozione-sirica-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14872,7 +14872,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aiutare, altri, corsi, gratuiti',
     ogTitle: 'Corsi gratuiti Varese sociale | Frontaliere Ticino',
     ogDescription: 'Your Self Company offre corsi gratuiti per ASA, OSS e ASACOM a Varese. Finanziati da Regione Lombardia, posti limitati. Iscrizioni aperte.',
-    canonicalPath: '/articoli-frontaliere/corsi-gratuiti-varese-sociale-2026',
+    canonicalPath: '/articoli-frontaliere/corsi-gratuiti-varese-sociale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14900,7 +14900,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, solaro, incontri, pubblici, rifiuti',
     ogTitle: 'Solaro: incontri su rifiuti e tariffazione puntuale |',
     ogDescription: 'Il Comune di Solaro organizza due serate informative su raccolta differenziata e tariffazione puntuale per chiarire dubbi ai cittadini.',
-    canonicalPath: '/articoli-frontaliere/solaro-rifiuti-differenziata-tariffazione-puntuale',
+    canonicalPath: '/articoli-frontaliere/solaro-rifiuti-differenziata-tariffazione-puntuale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14928,7 +14928,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, quadri, deve, pagare',
     ogTitle: 'Disoccupazione frontalieri: Quadri, «La Svizzera non deve',
     ogDescription: 'Il consigliere nazionale ticinese Lorenzo Quadri (Lega) presenta una mozione per evitare che la Svizzera versi le indennità di disoccupazione ai frontalieri.',
-    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri',
+    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14956,7 +14956,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, lugano, strade, chiuse',
     ogTitle: '1° maggio a Lugano: strade chiuse per corteo sindacale',
     ogDescription: 'Dalle 16:00 alle 17:00 saranno chiuse le vie centrali di Lugano per il corteo sindacale. Mercatini sul lungolago dalle 09:00 alle 20:00.',
-    canonicalPath: '/articoli-frontaliere/corteo-maggio-lugano-traffico-2024',
+    canonicalPath: '/articoli-frontaliere/corteo-maggio-lugano-traffico-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -14984,7 +14984,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, suva, incidenti, mortali, lavoro',
     ogTitle: 'SUVA: incidenti mortali sul lavoro -80% | Frontaliere Ticino',
     ogDescription: 'Dati SUVA: infortuni mortali sul lavoro ridotti dell\'80% dal 1986-1990 al 2020-2024, nonostante aumento occupati. Innovazione e formazione chiave.',
-    canonicalPath: '/articoli-frontaliere/incidenti-mortali-lavoro-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/incidenti-mortali-lavoro-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15012,7 +15012,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, coldiretti, brennero, stop, falso',
     ogTitle: 'Coldiretti al Brennero: Stop al falso Made in Italy |',
     ogDescription: 'Agricoltori varesini si uniscono alla protesta per modificare il codice doganale e contrastare il falso Made in Italy. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/coldiretti-brennero-made-italy-2026',
+    canonicalPath: '/articoli-frontaliere/coldiretti-brennero-made-italy-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15040,7 +15040,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sempre, amato, tedeschi, record',
     ogTitle: 'Ticino sempre più amato dai tedeschi | Frontaliere Ticino',
     ogDescription: 'Scopri come il Ticino attira i turisti tedeschi con oltre 450.000 pernottamenti nel 2025 e una crescita dell\'8,2% rispetto al 2024.',
-    canonicalPath: '/articoli-frontaliere/ticino-tedeschi-turismo-2026',
+    canonicalPath: '/articoli-frontaliere/ticino-tedeschi-turismo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15068,7 +15068,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tagli, contributi, numero, chiuso',
     ogTitle: 'Tagli USI 2026: rette raddoppiate e numero chiuso |',
     ogDescription: 'L\'USI taglia i posti per studenti esteri e raddoppia le rette. Dal 2027 tagli federali alle università. Cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/universita-ticino-tagli-contributi-2026',
+    canonicalPath: '/articoli-frontaliere/universita-ticino-tagli-contributi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15096,7 +15096,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, arrestati, uomini, furto',
     ogTitle: 'Chiasso: arrestati per furto di biciclette',
     ogDescription: 'Due cittadini rumeni arrestati a Chiasso per furto di biciclette. Scoperti attrezzi da scasso e biciclette rubate. Consigli per la sicurezza delle biciclette.',
-    canonicalPath: '/articoli-frontaliere/chiasso-arresti-furto-biciclette-2026',
+    canonicalPath: '/articoli-frontaliere/chiasso-arresti-furto-biciclette-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15124,7 +15124,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, lavoro, impegno, insubria',
     ogTitle: 'Sicurezza sul lavoro: l’impegno di ATS Insubria |',
     ogDescription: 'ATS Insubria presenta i dati del Servizio di Prevenzione e Sicurezza negli Ambienti di Lavoro (PSAL) per il 2025. Scopri di più su vigilanza e prevenzione.',
-    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-2026',
+    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15152,7 +15152,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furto, biciclette, giubiasco, arrestati',
     ogTitle: 'Furto biciclette Giubiasco: arrestati per mancato pagamento',
     ogDescription: 'Tre biciclette elettriche rubate a Giubiasco, due arrestati per mancato pagamento del carburante. Scopri i dettagli dell\'operazione e le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/furto-biciclette-giubiasco-2026',
+    canonicalPath: '/articoli-frontaliere/furto-biciclette-giubiasco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15180,7 +15180,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, osservatori, traffico, attivi, anche',
     ogTitle: 'Osservatori traffico Lago di Como | Frontaliere Ticino',
     ogDescription: 'Dal 2 maggio 2026, gli osservatori del traffico saranno attivi anche il sabato sulla Statale Regina tra Colonno e Ossuccio.',
-    canonicalPath: '/articoli-frontaliere/osservatori-traffico-lago-como-2026',
+    canonicalPath: '/articoli-frontaliere/osservatori-traffico-lago-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15208,7 +15208,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, prevenzione, varese, como',
     ogTitle: 'Sicurezza sul lavoro: ATS Insubria aumenta controlli |',
     ogDescription: 'ATS Insubria presenta i dati delle attività ispettive e dei progetti di prevenzione tra Varese e Como, con oltre 8.125 interventi nel 2025.',
-    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-varese-como-2026',
+    canonicalPath: '/articoli-frontaliere/sicurezza-lavoro-ats-insubria-varese-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15236,7 +15236,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, biciclette, benzina, chiasso',
     ogTitle: 'Furti di biciclette e benzina a Chiasso | Frontaliere Ticino',
     ogDescription: 'Due individui sono stati arrestati a Chiasso per furti di biciclette e benzina. Scopri di più su questo episodio e le misure preventive da adottare.',
-    canonicalPath: '/articoli-frontaliere/furto-biciclette-benzina-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/furto-biciclette-benzina-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15264,7 +15264,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bando, direzione, formazione, professionale',
     ogTitle: 'Bando Formazione Professionale | Critiche PLR | Frontaliere',
     ogDescription: 'Il PLR critica i requisiti del bando per la direzione della Formazione professionale in Ticino, sollevando perplessità sulla gestione procedurale.',
-    canonicalPath: '/articoli-frontaliere/bando-formazione-professionale-plr-2026',
+    canonicalPath: '/articoli-frontaliere/bando-formazione-professionale-plr-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15292,7 +15292,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavoratori, pensionati, 220mila, 2025',
     ogTitle: 'Lavoratori pensionati in Svizzera: +220mila nel 2025',
     ogDescription: 'Nel 2025, 220mila persone continuano a lavorare dopo i 65 anni in Svizzera. Scopri le implicazioni per i frontalieri e come pianificare il futuro.',
-    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/lavoratori-pensionati-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15320,7 +15320,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, metà, percepisce, sistema, ingiusto',
     ogTitle: 'Metà della Svizzera percepisce il sistema come ingiusto',
     ogDescription: 'Un sondaggio rivela che oltre la metà della popolazione svizzera considera il sistema sociale ingiusto, con un aumento dell\'insoddisfazione rispetto al 2024.',
-    canonicalPath: '/articoli-frontaliere/met-svizzera-insoddisfatta-sistema-2026',
+    canonicalPath: '/articoli-frontaliere/met-svizzera-insoddisfatta-sistema-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15348,7 +15348,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, esperti, gestione, dell',
     ogTitle: 'Nuovi EGE a Varese | Frontaliere Ticino',
     ogDescription: 'Scopri i nuovi Esperti in Gestione dell’Energia certificati a Varese e le opportunità per i frontalieri nel settore energetico.',
-    canonicalPath: '/articoli-frontaliere/nuovi-esperti-gestione-energia-varese',
+    canonicalPath: '/articoli-frontaliere/nuovi-esperti-gestione-energia-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15376,7 +15376,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, negoziati, falliti, sullo, stretto',
     ogTitle: 'Negoziati falliti sullo Stretto di Hormuz | Frontaliere',
     ogDescription: 'Il ministro degli Esteri iraniano Abbas Araghchi ha dichiarato che le richieste eccessive degli USA hanno fatto fallire i negoziati sullo Stretto di Hormuz.',
-    canonicalPath: '/articoli-frontaliere/negoziati-falliti-stretto-hormuz-2026',
+    canonicalPath: '/articoli-frontaliere/negoziati-falliti-stretto-hormuz-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15404,7 +15404,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roadmap, violenza, domestica, jans',
     ogTitle: 'Roadmap violenza domestica: Jans traccia un bilancio',
     ogDescription: 'La roadmap contro la violenza domestica e sessuale ha dimostrato efficacia, ma servono ulteriori misure per contrastare i femminicidi. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/roadmap-violenza-domestica-bilancio-positivo',
+    canonicalPath: '/articoli-frontaliere/roadmap-violenza-domestica-bilancio-positivo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15432,7 +15432,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beneessere, integrità, allievi, nuovi',
     ogTitle: 'Nuovi programmi educativi a Bellinzona | Frontaliere Ticino',
     ogDescription: 'Scopri i nuovi programmi educativi per il benessere e l’integrità degli allievi a Bellinzona, in collaborazione con la Fondazione ASPI.',
-    canonicalPath: '/articoli-frontaliere/benessere-integrita-allievi-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/benessere-integrita-allievi-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15460,7 +15460,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, made, switzerland, cosa, cambia',
     ogTitle: 'Made in Switzerland: cosa cambia | Frontaliere Ticino',
     ogDescription: 'Scopri le nuove regole per l\'uso del marchio Swiss Made e il suo impatto economico. L\'Istituto federale della proprietà intellettuale ha modificato le norme.',
-    canonicalPath: '/articoli-frontaliere/cosa-significa-made-switzerland',
+    canonicalPath: '/articoli-frontaliere/cosa-significa-made-switzerland/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15488,7 +15488,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, equans, licenzia, dipendenti, monteceneri',
     ogTitle: 'Equans licenzia 19 dipendenti a Monteceneri | Frontaliere',
     ogDescription: 'Equans ha annunciato 19 licenziamenti nella sua sede di Monteceneri, colpendo i settori delle fibre ottiche e della gestione impianti. Scopri le implicazioni',
-    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-19-dipendenti',
+    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-19-dipendenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15516,7 +15516,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, verdi, strategia, cantonali, esplorano',
     ogTitle: 'Verdi Ticino: strategia per le cantonali 2026 | Frontaliere',
     ogDescription: 'I Verdi del Ticino esplorano alleanze per le elezioni cantonali del 2026, puntando a un fronte progressista più ampio con MPS e PS.',
-    canonicalPath: '/articoli-frontaliere/verdi-ticino-cantonali-2026',
+    canonicalPath: '/articoli-frontaliere/verdi-ticino-cantonali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15544,7 +15544,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borse, studio, bracco, opportunità',
     ogTitle: 'Borse di studio Bracco: 11 opportunità per studenti di sei',
     ogDescription: 'La Fondazione Bracco ha aperto il bando per 11 borse di studio, con contributi fino a 4mila euro, per studenti meritevoli di Bovisio Masciago, Ceriano Laghetto',
-    canonicalPath: '/articoli-frontaliere/borse-studio-bracco-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/borse-studio-bracco-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15572,7 +15572,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sportello, incontri, gratuiti, cunardo',
     ogTitle: 'Sportello ME-TE a Cunardo e Marchirolo | Frontaliere Ticino',
     ogDescription: 'Incontri gratuiti per genitori a Cunardo e Marchirolo con il progetto ME-TE. Scopri come partecipare e le date degli eventi.',
-    canonicalPath: '/articoli-frontaliere/sportello-me-te-cunardo-marchirolo-2026',
+    canonicalPath: '/articoli-frontaliere/sportello-me-te-cunardo-marchirolo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15600,7 +15600,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, accordo, record, edilizia, ticinese',
     ogTitle: 'Accordo record edilizia Ticino 2026-2031',
     ogDescription: 'Firmato il nuovo contratto collettivo cantonale per l\'edilizia ticinese, valido fino al 2031. Stabilità e opportunità di formazione per lavoratori e imprese.',
-    canonicalPath: '/articoli-frontaliere/accordo-edilizia-ticino-2026-2031',
+    canonicalPath: '/articoli-frontaliere/accordo-edilizia-ticino-2026-2031/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15628,7 +15628,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, equans, rivera, taglia, posti',
     ogTitle: 'Equans Rivera taglia 19 posti di lavoro, rifiuta piano',
     ogDescription: 'La multinazionale Equans di Rivera licenzia 19 dipendenti senza accordo sociale. Jelmini: \'Dispiace per la mancanza di riguardo\'',
-    canonicalPath: '/articoli-frontaliere/equans-rivera-19-licenziamenti',
+    canonicalPath: '/articoli-frontaliere/equans-rivera-19-licenziamenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15656,7 +15656,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, finanza, persone, identificate',
     ogTitle: 'Controlli Finanza Comasco: 226 persone identificate',
     ogDescription: 'La Guardia di Finanza ha condotto controlli in provincia di Como, identificando 226 persone e scoprendo 3 lavoratori in nero e sostanze stupefacenti.',
-    canonicalPath: '/articoli-frontaliere/controlli-finanza-comasco-226-persone',
+    canonicalPath: '/articoli-frontaliere/controlli-finanza-comasco-226-persone/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15684,7 +15684,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, auto, cinesi, quota, mercato',
     ogTitle: 'Auto cinesi in Svizzera: quota di mercato al 3,7% nel 2026',
     ogDescription: 'BYD, MG e Leapmotor dominano le vendite di auto cinesi in Svizzera, con una quota di mercato del 3,7% nel primo trimestre 2026. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/auto-cinesi-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/auto-cinesi-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15712,7 +15712,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dengue, verso, sistema, rapido',
     ogTitle: 'Dengue: sistema rapido per individuarla in Ticino |',
     ogDescription: 'Nuove misure per la diagnosi precoce della dengue in Canton Ticino. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/dengue-sistema-rapido-individuazione',
+    canonicalPath: '/articoli-frontaliere/dengue-sistema-rapido-individuazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15740,7 +15740,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aprile, secco, allarme, siccità',
     ogTitle: 'Aprile secco: allarme siccità in Ticino',
     ogDescription: 'MeteoSvizzera lancia l\'allarme: aprile 2026 è il più secco dalla rilevazione, con gravi carenze di pioggia in Ticino e altre regioni.',
-    canonicalPath: '/articoli-frontaliere/aprile-secco-siccita-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/aprile-secco-siccita-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15768,7 +15768,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, multa, fino, franchi, svapa',
     ogTitle: 'Multa fino a 500 franchi per chi svapa in stazione |',
     ogDescription: 'L\'Associazione svizzera per la prevenzione del tabagismo propone multe fino a 500 franchi per chi viola il divieto di fumo e svapo nei binari delle stazioni',
-    canonicalPath: '/articoli-frontaliere/multa-svapo-stazioni-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/multa-svapo-stazioni-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15796,7 +15796,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, pagherà, spesa, fino',
     ogTitle: 'Disoccupazione frontalieri: la Svizzera non pagherà |',
     ogDescription: 'La Svizzera respinge la proposta UE di pagare le indennità di disoccupazione ai frontalieri, con costi fino a un miliardo di franchi all\'anno.',
-    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-disoccupazione-frontalieri-quadri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15824,7 +15824,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, allerta, gialla, temporali, tutta',
     ogTitle: 'Allerta gialla per temporali su Varese | Frontaliere Ticino',
     ogDescription: 'La Protezione Civile della Regione Lombardia ha emesso un\'allerta meteo gialla per temporali su tutta la provincia di Varese. Scopri cosa fare e come',
-    canonicalPath: '/articoli-frontaliere/allerta-gialla-temporali-varese-2026',
+    canonicalPath: '/articoli-frontaliere/allerta-gialla-temporali-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15852,7 +15852,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ostetriche, conferenza, parto, fisiologico',
     ogTitle: 'Conferenza ostetriche EOC Mendrisio 2026 | Frontaliere',
     ogDescription: 'Scopri la conferenza sull\'assistenza ostetrica organizzata dall\'EOC a Mendrisio il 6 maggio 2026. Focus su parto fisiologico e continuità assistenziale.',
-    canonicalPath: '/articoli-frontaliere/ostetriche-eoc-mendrisio-2026',
+    canonicalPath: '/articoli-frontaliere/ostetriche-eoc-mendrisio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15880,7 +15880,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, domestica, convince, modello',
     ogTitle: 'Violenza domestica: convince il modello Zurigo',
     ogDescription: 'Il progetto pilota di sorveglianza elettronica in tempo reale per contrastare la violenza domestica ha dato risultati positivi. L\'obiettivo è estenderlo a',
-    canonicalPath: '/articoli-frontaliere/modello-zurigo-violenza-domestica',
+    canonicalPath: '/articoli-frontaliere/modello-zurigo-violenza-domestica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15908,7 +15908,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, approva, sepoltura, animali',
     ogTitle: 'Berna approva sepoltura con animali domestici | Frontaliere',
     ogDescription: 'Dal 2026 a Berna sarà possibile essere sepolti con il proprio animale domestico in aree dedicate. Ecco cosa cambia e come funziona',
-    canonicalPath: '/articoli-frontaliere/sepolti-con-animali-domestici-berna-2026',
+    canonicalPath: '/articoli-frontaliere/sepolti-con-animali-domestici-berna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15936,7 +15936,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guasti, swiss, cosa, cambia',
     ogTitle: 'Due guasti in 48 ore per Swiss: implicazioni per i',
     ogDescription: 'Due incidenti tecnici in meno di 48 ore per la compagnia aerea Swiss. Ecco cosa cambia per i frontalieri che viaggiano tra Ticino e Svizzera.',
-    canonicalPath: '/articoli-frontaliere/swiss-guasti-voli-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-guasti-voli-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15964,7 +15964,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banca, varese, anni, dopo',
     ogTitle: 'Banca d\'Italia Varese: 10 anni dopo | Frontaliere Ticino',
     ogDescription: 'L\'ex sede della Banca d\'Italia a Varese è in vendita dal 2018 ma non trova acquirenti. Scopri perché e cosa fare per acquistarla.',
-    canonicalPath: '/articoli-frontaliere/banca-ditalia-varese-10-anni-dopo',
+    canonicalPath: '/articoli-frontaliere/banca-ditalia-varese-10-anni-dopo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -15992,7 +15992,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sempre, meno, svizzeri, pagano',
     ogTitle: 'Contributo clima online | Frontaliere Ticino',
     ogDescription: 'Dati Galaxus: nel 2026 solo il 9% degli ordini online in Svizzera include il contributo volontario per il clima, contro l\'11% del 2024 e il 12% del 2022.',
-    canonicalPath: '/articoli-frontaliere/svizzeri-contributo-clima-acquisti-online-2026',
+    canonicalPath: '/articoli-frontaliere/svizzeri-contributo-clima-acquisti-online-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16020,7 +16020,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passeggiata, lago, inverno, lido',
     ogTitle: 'Passeggiata a lago in inverno al lido di Ascona, test',
     ogDescription: 'La stagione di prova della passeggiata invernale al lido di Ascona ha avuto successo. La presidente del Patriziato annuncia che l\'iniziativa sarà riproposta.',
-    canonicalPath: '/articoli-frontaliere/passeggiata-lago-inverno-ascona-2026',
+    canonicalPath: '/articoli-frontaliere/passeggiata-lago-inverno-ascona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16048,7 +16048,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, notifiche, 2025, controlli, diminuiscono',
     ogTitle: 'Notifiche frontalieri Ticino: -16% nel 2025',
     ogDescription: 'Diminuiscono le notifiche irregolari per i frontalieri in Ticino, ma le autorità avvertono: non si può abbassare la guardia. Ecco i dati 2025.',
-    canonicalPath: '/articoli-frontaliere/notifiche-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/notifiche-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16076,7 +16076,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, minacce, informatiche, swisscom, lancia',
     ogTitle: 'Minacce informatiche in Svizzera: Swisscom lancia l\'allarme',
     ogDescription: 'Swisscom rileva un aumento significativo delle minacce informatiche in Svizzera, con rischi crescenti per le imprese a causa dell\'IA e delle tensioni',
-    canonicalPath: '/articoli-frontaliere/minacce-informatiche-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/minacce-informatiche-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16104,7 +16104,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gamberetti, avariati, torneo, madrid',
     ogTitle: 'Gamberetti avariati al torneo di Madrid: intossicazioni e',
     ogDescription: 'Intossicazioni alimentari colpiscono i giocatori al Masters 1000 di Madrid, con Jim Courier che accusa i gamberetti serviti alla mensa',
-    canonicalPath: '/articoli-frontaliere/gamberetti-torneo-madrid-2026',
+    canonicalPath: '/articoli-frontaliere/gamberetti-torneo-madrid-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16132,7 +16132,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro, carburanti, rischio, stop',
     ogTitle: 'Caro carburanti, rischio stop trasporto pubblico in Ticino',
     ogDescription: 'Il caro carburanti minaccia il trasporto pubblico locale, con costi aggiuntivi stimati in 0,54 milioni di euro al giorno per il diesel. Scopri l\'impatto sui',
-    canonicalPath: '/articoli-frontaliere/carburanti-tpl-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/carburanti-tpl-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16160,7 +16160,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alla, scoperta, dell, africa',
     ogTitle: 'Alla scoperta dell’Africa a Materia: dialogo su opportunità',
     ogDescription: 'Martedì 28 aprile 2026 a Castronno, un incontro con Martino Ghielmi e Alfie Nze per esplorare un nuovo rapporto culturale con l\'Africa.',
-    canonicalPath: '/articoli-frontaliere/scoperta-africa-materia-castronno-2026',
+    canonicalPath: '/articoli-frontaliere/scoperta-africa-materia-castronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16188,7 +16188,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, università, numero, chiuso, rette',
     ogTitle: 'Università Ticino: numero chiuso e rette in aumento',
     ogDescription: 'Dal 2026 l\'Università della Svizzera italiana introduce il numero chiuso e le rette aumentano, soprattutto per gli studenti stranieri',
-    canonicalPath: '/articoli-frontaliere/universita-ticino-numero-chiuso-2026',
+    canonicalPath: '/articoli-frontaliere/universita-ticino-numero-chiuso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16216,7 +16216,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pedaggi, autostrada, lombardia, addio',
     ogTitle: 'Pedaggi autostrada Lombardia: addio viaggi gratis per frontalieri',
     ogDescription: 'Dal 1° maggio 2026 pedaggio obbligatorio sulla Corda Molle con sconti del 50% per residenti di 22 comuni. Agevolazioni in arrivo per pendolari',
-    canonicalPath: '/articoli-frontaliere/pedaggi-autostrada-lombardia-frontalieri',
+    canonicalPath: '/articoli-frontaliere/pedaggi-autostrada-lombardia-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16244,7 +16244,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, semaforo, melide, venti, paradiso-melide',
     ogTitle: 'Semaforo Melide: un\'ora e venti per Paradiso-Melide',
     ogDescription: 'Un automobilista racconta di un\'odissea di un\'ora e venti per andare da Paradiso a Melide a causa di un semaforo malfunzionante.',
-    canonicalPath: '/articoli-frontaliere/semaforo-paradiso-melide-2026',
+    canonicalPath: '/articoli-frontaliere/semaforo-paradiso-melide-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16272,7 +16272,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zurigo, economia, cresce, meno',
     ogTitle: 'Zurigo guida l\'economia svizzera ma cresce meno della media',
     ogDescription: 'Zurigo genera il 21% del PIL svizzero ma cresce solo dell\'1,3% annuo, meno della media nazionale dell\'1,7%. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita',
+    canonicalPath: '/articoli-frontaliere/zurigo-economia-svizzera-crescita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16300,7 +16300,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 58enne, fugge, trottinetti, viene',
     ogTitle: '58enne fugge in trottinetti a 127 km/h e viene fermato dalla polizia',
     ogDescription: 'Un 58enne è stato fermato dalla polizia dopo aver raggiunto i 127 km/h su un trottinetti elettrico a Lugano. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-trottinetti-velocita-polizia',
+    canonicalPath: '/articoli-frontaliere/frontalieri-trottinetti-velocita-polizia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16328,7 +16328,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, insubria, sperimenta, diffusa, blocker',
     ogTitle: 'ATS Insubria sperimenta RSA diffusa e bed blocker per liberare gli ospedali',
     ogDescription: 'Due progetti pilota per ridurre i tempi di degenza e liberare letti ospedalieri in Lombardia, con finanziamenti regionali',
-    canonicalPath: '/articoli-frontaliere/ats-insubria-soluzioni-ospedali-2026',
+    canonicalPath: '/articoli-frontaliere/ats-insubria-soluzioni-ospedali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16356,7 +16356,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, avis, lombardia, lancia, allarme',
     ogTitle: 'Avis Lombardia lancia l\'allarme: il dono del sangue sotto attacco dei privati',
     ogDescription: 'I dati del 2025 mostrano un aumento dell\'8,24% nella raccolta di plasma, ma l\'Avis Lombardia avverte del rischio di speculazioni commerciali',
-    canonicalPath: '/articoli-frontaliere/avis-lombardia-dono-sangue-privati-2026',
+    canonicalPath: '/articoli-frontaliere/avis-lombardia-dono-sangue-privati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16384,7 +16384,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, raduno, moto, storiche, varese',
     ogTitle: 'Raduno moto storiche Varese 2026',
     ogDescription: 'Domenica 26 aprile 2026, raduno di moto storiche tra Varese e il Lago Maggiore. Circa 100 motociclette iconiche in mostra.',
-    canonicalPath: '/articoli-frontaliere/varese-moto-storiche-2026',
+    canonicalPath: '/articoli-frontaliere/varese-moto-storiche-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16412,7 +16412,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, contratto, edilizia, giornate',
     ogTitle: 'Nuovo contratto edilizia Ticino: giornate più corte e tutela dalle intemperie',
     ogDescription: 'Accordo fino al 2031 con nuove regole su orari e condizioni di lavoro. Focus su sicurezza e ricambio generazionale nel settore edile ticinese',
-    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-contratto-edilizia-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16440,7 +16440,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusura, parziale, raccordo, varese-a8',
     ogTitle: 'Chiusura parziale raccordo Varese-A8 lunedì sera',
     ogDescription: 'Dalle 22:00 alle 24:00 di lunedì 27 aprile 2026 chiuso il ramo di immissione sulla A8 Milano-Varese, verso Varese.',
-    canonicalPath: '/articoli-frontaliere/viabilita-varese-racordo-chiuso-2026',
+    canonicalPath: '/articoli-frontaliere/viabilita-varese-racordo-chiuso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16468,7 +16468,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresti, furti, biciclette, mendrisiotto',
     ogTitle: 'Due arresti per furti di biciclette nel Mendrisiotto',
     ogDescription: 'Due cittadini rumeni arrestati con tre biciclette smontate e attrezzi da scasso. Polizia ricorda consigli per prevenire furti.',
-    canonicalPath: '/articoli-frontaliere/furti-biciclette-mendrisiotto-2026',
+    canonicalPath: '/articoli-frontaliere/furti-biciclette-mendrisiotto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16496,7 +16496,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giümai, acquista, ultimi, edifici',
     ogTitle: 'Per Giümai acquista gli ultimi tre edifici del Monte Piaroi',
     ogDescription: 'L\'associazione Per Giümai ha completato l\'acquisto degli ultimi tre edifici sul Monte Piaroi, grazie al contributo di privati e alla collaborazione con la',
-    canonicalPath: '/articoli-frontaliere/per-giumai-acquisti-monte-piaroi-2026',
+    canonicalPath: '/articoli-frontaliere/per-giumai-acquisti-monte-piaroi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16524,7 +16524,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scoperte, rovine, romane, magliaso',
     ogTitle: 'Rovine romane Magliaso: nuove scuole e patrimonio storico',
     ogDescription: 'Scoperte rovine dell\'epoca tardo romana durante la costruzione delle nuove scuole elementari a Magliaso. Archeologi al lavoro per documentazione.',
-    canonicalPath: '/articoli-frontaliere/rovine-magliaso-scuole-nuove-2026',
+    canonicalPath: '/articoli-frontaliere/rovine-magliaso-scuole-nuove-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16552,7 +16552,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, misure, sono, estreme, presidente',
     ogTitle: 'BNS: Le misure per UBS non sono estreme',
     ogDescription: 'Il presidente della BNS, Martin Schlegel, difende le nuove regole per UBS, minimizzando il rischio di una partenza dell\'istituto.',
-    canonicalPath: '/articoli-frontaliere/bns-ubs-misure-non-estreme-2026',
+    canonicalPath: '/articoli-frontaliere/bns-ubs-misure-non-estreme-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16580,7 +16580,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, maestri, lavoro, leonardo',
     ogTitle: 'Nuovi Maestri del Lavoro 2026: Leonardo primeggia in provincia di Varese',
     ogDescription: 'Celebrati a Milano i nuovi Maestri del Lavoro 2026. Leonardo S.p.A. è l\'azienda con il maggior numero di premiati nella provincia di Varese.',
-    canonicalPath: '/articoli-frontaliere/nuovi-maestri-lavoro-varese-leonardo-2026',
+    canonicalPath: '/articoli-frontaliere/nuovi-maestri-lavoro-varese-leonardo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16608,7 +16608,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cambio, guardia, velo, sabbadini',
     ogTitle: 'Cambio di guardia a Pro Velo Ticino: Sabbadini succede a Vitali',
     ogDescription: 'Claudio Sabbadini è il nuovo presidente di Pro Velo Ticino, sostituendo Marco Vitali. Discussione su progetti per migliorare la mobilità ciclistica nelle valli',
-    canonicalPath: '/articoli-frontaliere/cambio-guardia-pro-velo-ticino-sabbadini-vitali',
+    canonicalPath: '/articoli-frontaliere/cambio-guardia-pro-velo-ticino-sabbadini-vitali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16636,7 +16636,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, ambulatorio, ecocardiografia, busto',
     ogTitle: 'Nuovo ambulatorio di ecocardiografia a Busto Arsizio: apertura il 7 maggio',
     ogDescription: 'Dal 7 maggio 2026, un nuovo servizio di ecocardiografia sarà disponibile presso la Casa di Comunità di Busto Arsizio, su prenotazione con impegnativa medica.',
-    canonicalPath: '/articoli-frontaliere/nuovo-ambulatorio-ecocardiografia-busto-arsizio',
+    canonicalPath: '/articoli-frontaliere/nuovo-ambulatorio-ecocardiografia-busto-arsizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16664,7 +16664,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, velafrica, torna, luganese, seconda',
     ogTitle: 'Velafrica torna nel Luganese: seconda vita per le bici usate',
     ogDescription: 'Il progetto Velafrica ritorna nel Luganese per dare una seconda vita alle biciclette usate. Un\'iniziativa che coinvolge la comunità e promuove la sostenibilità',
-    canonicalPath: '/articoli-frontaliere/velafrica-bici-usate-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/velafrica-bici-usate-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16692,7 +16692,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedale, varese, senza, acqua',
     ogTitle: 'Ospedale Varese senza acqua calda in oncologia',
     ogDescription: 'Disservizi segnalati nel reparto di oncologia e pneumologia. La Sette Laghi: soluzione in tempi brevi.',
-    canonicalPath: '/articoli-frontaliere/ospedale-varese-acqua-calda-oncologia',
+    canonicalPath: '/articoli-frontaliere/ospedale-varese-acqua-calda-oncologia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16720,7 +16720,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, nordafricani, arrestati, furti',
     ogTitle: 'Cinque nordafricani arrestati per furti d\'auto',
     ogDescription: 'Notte di arresti ad Aarau: cinque uomini nordafricani fermati per sospetti furti d\'auto. Scopri cosa è successo e come proteggere i tuoi veicoli.',
-    canonicalPath: '/articoli-frontaliere/cinque-nordafricani-festnati-auto-aarau',
+    canonicalPath: '/articoli-frontaliere/cinque-nordafricani-festnati-auto-aarau/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16748,7 +16748,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, discariche, abusive, doppio, sequestro',
     ogTitle: 'Discariche abusive: doppio sequestro tra Varese e cintura',
     ogDescription: 'Tre indagati e due siti sequestrati per smaltimento illecito di rifiuti speciali in provincia di Varese',
-    canonicalPath: '/articoli-frontaliere/doppio-sequestro-discariche-abusive-varese',
+    canonicalPath: '/articoli-frontaliere/doppio-sequestro-discariche-abusive-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16776,7 +16776,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sfida, comuni, coop, sarà',
     ogTitle: 'Sfida tra comuni Coop 2026: chi sarà il più attivo?',
     ogDescription: 'Dal 1° al 31 maggio 2026, oltre 200 comuni svizzeri, tra cui diversi in Ticino, si sfidano per promuovere l\'attività fisica. Scopri come partecipare e',
-    canonicalPath: '/articoli-frontaliere/sfida-comuni-coop-2026-attivita-fisica',
+    canonicalPath: '/articoli-frontaliere/sfida-comuni-coop-2026-attivita-fisica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16804,7 +16804,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, rafforza, tutela, lavoratori',
     ogTitle: 'La Cina rafforza la tutela dei lavoratori nelle nuove occupazioni',
     ogDescription: 'Nuove linee guida per proteggere i lavoratori delle piattaforme digitali, con focus su compensi e algoritmi.',
-    canonicalPath: '/articoli-frontaliere/cina-tutela-lavoratori-nuove-occupazioni',
+    canonicalPath: '/articoli-frontaliere/cina-tutela-lavoratori-nuove-occupazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16832,7 +16832,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dovremo, tagliare, vivo, misure',
     ogTitle: 'USI: tagli strutturali e revisione piano strategico',
     ogDescription: 'Monica Duca Widmer annuncia tagli strutturali per l’USI a causa dei ridotti finanziamenti. Scopri le implicazioni per studenti e personale.',
-    canonicalPath: '/articoli-frontaliere/usi-ticino-tagli-bilancio-2026',
+    canonicalPath: '/articoli-frontaliere/usi-ticino-tagli-bilancio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16860,7 +16860,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, campione, sfida, poltrona, sindaco',
     ogTitle: 'Campione d’Italia, sfida a tre per la poltrona di sindaco',
     ogDescription: 'Tre candidati in lizza per la carica di sindaco a Campione d’Italia. Scopri chi sono e cosa propongono.',
-    canonicalPath: '/articoli-frontaliere/campione-ditalia-elezioni-sindaco-2026',
+    canonicalPath: '/articoli-frontaliere/campione-ditalia-elezioni-sindaco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16888,7 +16888,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gioventù, dibatte, studenti, gara',
     ogTitle: 'La gioventù dibatte: 500 studenti in gara a Bellinzona',
     ogDescription: '500 studenti si sfidano nella finale de \'La gioventù dibatte\' a Bellinzona, difendendo tesi su temi di attualità davanti a una giuria.',
-    canonicalPath: '/articoli-frontaliere/gioventu-dibatte-500-studenti-gara',
+    canonicalPath: '/articoli-frontaliere/gioventu-dibatte-500-studenti-gara/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16916,7 +16916,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tallero, anni, nuovo, design',
     ogTitle: 'Tallero d\'oro: 80 anni e nuovo design',
     ogDescription: 'Il Tallero d\'oro compie 80 anni e si rinnova nel design. Il prezzo aumenta a 8 franchi per la prima volta dal 1998.',
-    canonicalPath: '/articoli-frontaliere/tallero-doro-80-anni-nuovo-design',
+    canonicalPath: '/articoli-frontaliere/tallero-doro-80-anni-nuovo-design/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16944,7 +16944,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inaugurata, nuova, sede, conservatorio',
     ogTitle: 'Inaugurata nuova sede Conservatorio Svizzera italiana Bellinzona',
     ogDescription: 'Il direttore Luca Medici sottolinea l\'importanza della formazione musicale per trasmettere valori fondamentali nella nuova sede del Conservatorio a Bellinzona.',
-    canonicalPath: '/articoli-frontaliere/conservatorio-bellinzona-valori-musicali',
+    canonicalPath: '/articoli-frontaliere/conservatorio-bellinzona-valori-musicali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -16972,7 +16972,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, national, geographic, scuola, sergio',
     ogTitle: 'National Geographic a scuola: Sergio Pitamitz incontra gli studenti dell\'Einaudi',
     ogDescription: 'Il celebre fotografo ha parlato di conservazione ambientale e fotografia naturalistica con gli studenti di Varese.',
-    canonicalPath: '/articoli-frontaliere/national-geographic-scuola-einaudi-varese',
+    canonicalPath: '/articoli-frontaliere/national-geographic-scuola-einaudi-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17000,7 +17000,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, nuovi, programmi, benessere',
     ogTitle: 'Nuovi programmi educativi a Bellinzona per il benessere scolastico',
     ogDescription: 'Scopri i nuovi programmi educativi introdotti a Bellinzona per il benessere degli studenti dal 2026',
-    canonicalPath: '/articoli-frontaliere/benessere-scolastico-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/benessere-scolastico-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17028,7 +17028,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, capitale, culturale, opportunità',
     ogTitle: 'Mendrisio Capitale Culturale: Opportunità da Cogliere',
     ogDescription: 'La maggioranza della Gestione di Mendrisio rassicura sui costi e allontana il rischio di sudditanza verso Lugano',
-    canonicalPath: '/articoli-frontaliere/mendrisio-capitale-culturale-opportunita',
+    canonicalPath: '/articoli-frontaliere/mendrisio-capitale-culturale-opportunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17056,7 +17056,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, velo, marco, vitali, lascia',
     ogTitle: 'Pro Velo Ticino: Marco Vitali lascia la presidenza',
     ogDescription: 'Marco Vitali lascia la presidenza di Pro Velo Ticino dopo aver trasferito il domicilio in Alsazia. Claudio Sabbadini è il nuovo presidente.',
-    canonicalPath: '/articoli-frontaliere/pro-velo-ticino-cambiamento-presidenza-2026',
+    canonicalPath: '/articoli-frontaliere/pro-velo-ticino-cambiamento-presidenza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17084,7 +17084,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallimento, nomine, sims, posizione',
     ogTitle: 'Fallimento nomine SIMS in Ticino',
     ogDescription: 'La vicenda delle nomine SIMS mette in discussione la gestione dei concorsi pubblici nel Canton Ticino, con ripercussioni sulla credibilità istituzionale.',
-    canonicalPath: '/articoli-frontaliere/nomine-sims-fallimento',
+    canonicalPath: '/articoli-frontaliere/nomine-sims-fallimento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17112,7 +17112,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, fatture, riaprono, scontro',
     ogTitle: 'Crans-Montana, le fatture riaprono lo scontro con Roma',
     ogDescription: 'Le fatture per le cure prestate in Svizzera alle vittime italiane della tragedia di Crans-Montana hanno riacceso le tensioni tra Roma e Berna.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-scontro-roma-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-scontro-roma-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17140,7 +17140,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basta, lamentele, addio, alla',
     ogTitle: 'Ticino, basta lamentele: addio alla sindrome di Calimero',
     ogDescription: 'Nicoletta Casanova, presidente Aiti, critica il dibattito economico ticinese e invita a cambiare atteggiamento per migliorare le opportunità per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ticino-calimero-sindrome-2026',
+    canonicalPath: '/articoli-frontaliere/ticino-calimero-sindrome-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17168,7 +17168,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, mediano, mette',
     ogTitle: 'Salario minimo e mediano: il mix che mette a rischio il Ticino',
     ogDescription: 'Analisi delle tensioni salariali tra frontalieri e residenti, con impatti sul mercato del lavoro ticinese.',
-    canonicalPath: '/articoli-frontaliere/salario-minimo-mediano-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/salario-minimo-mediano-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17196,7 +17196,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, padroncini, lavoratori, distaccati, stabili',
     ogTitle: 'Padroncini e lavoratori distaccati stabili su livelli bassi',
     ogDescription: 'Il numero di ditte notificate in Ticino rimane stabile su livelli bassi, ma l\'AIC avverte: non abbassare la guardia',
-    canonicalPath: '/articoli-frontaliere/padroncini-lavoratori-stabili-bassi-2025',
+    canonicalPath: '/articoli-frontaliere/padroncini-lavoratori-stabili-bassi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17224,7 +17224,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, busto, garolfo, milioni, utile',
     ogTitle: 'Bcc Busto Garolfo: 14,4 milioni di utile e 2 milioni per il territorio',
     ogDescription: 'L\'assemblea dei soci approva il bilancio 2025 con un utile netto di 14,4 milioni e 2 milioni destinati al territorio',
-    canonicalPath: '/articoli-frontaliere/bcc-busto-garolfo-2-milioni-territorio',
+    canonicalPath: '/articoli-frontaliere/bcc-busto-garolfo-2-milioni-territorio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17252,7 +17252,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, legge, polizia, controllo',
     ogTitle: 'Nuova legge polizia Ticino: controllo periodico obbligatorio',
     ogDescription: 'Padlina e Rigamonti propongono rapporto annuale per la polizia cantonale. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nuova-legge-polizia-ticino-controllo-periodico',
+    canonicalPath: '/articoli-frontaliere/nuova-legge-polizia-ticino-controllo-periodico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17280,7 +17280,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malpensa, parigi, galline, complessità',
     ogTitle: 'Malpensa, Parigi e due galline: la complessità del vivere semplice',
     ogDescription: 'Un viaggio tra lavoro transfrontaliero e regolamentazioni svizzere sugli animali domestici',
-    canonicalPath: '/articoli-frontaliere/malpensa-parigi-galline-frontalieri',
+    canonicalPath: '/articoli-frontaliere/malpensa-parigi-galline-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17308,7 +17308,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borsa, zurigo, giornata, altalenante',
     ogTitle: 'Borsa di Zurigo: giornata altalenante per i frontalieri',
     ogDescription: 'Lo Swiss market index chiude a 13\'165.23 punti, con Lonza Group e UBS Group in positivo',
-    canonicalPath: '/articoli-frontaliere/borsa-zurigo-frontalieri-27-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/borsa-zurigo-frontalieri-27-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17336,7 +17336,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colpi, arma, fuoco, como',
     ogTitle: 'Colpi d\'arma da fuoco a Como: ferito giovane straniero',
     ogDescription: 'Un giovane straniero è stato ferito da colpi d\'arma da fuoco sparati da un\'auto a San Fermo della Battaglia, vicino a Como. Scopri di più sull\'incidente e le',
-    canonicalPath: '/articoli-frontaliere/colpi-arma-da-fuoco-como-ferito-frontaliere',
+    canonicalPath: '/articoli-frontaliere/colpi-arma-da-fuoco-como-ferito-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17364,7 +17364,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disagi, linea, tilo, errore',
     ogTitle: 'Disagi linea TiLo S40: errore nella programmazione del personale',
     ogDescription: 'Trenord spiega i disagi del 25 aprile: problema nella programmazione dei turni del personale. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/disagi-trenord-tilo-s40-25-aprile-2024',
+    canonicalPath: '/articoli-frontaliere/disagi-trenord-tilo-s40-25-aprile-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17392,7 +17392,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scommesse, guerra, trump, boom',
     ogTitle: 'Scommesse su guerra e Trump: il boom dei prediction market',
     ogDescription: 'Scopri come le piattaforme di prediction market stanno diventando popolari, permettendo scommesse su eventi globali con rischi etici e finanziari.',
-    canonicalPath: '/articoli-frontaliere/scommesse-guerra-trump-prediction-market',
+    canonicalPath: '/articoli-frontaliere/scommesse-guerra-trump-prediction-market/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17420,7 +17420,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, lusso, auto, rubate',
     ogTitle: 'Furti di lusso in Ticino: 5 auto rubate in un weekend',
     ogDescription: 'Due furti in una sola garage a Murten: 5 auto di lusso rubate in un weekend. Scopri le implicazioni per i frontalieri e le misure di sicurezza.',
-    canonicalPath: '/articoli-frontaliere/furti-lusso-murten-2026',
+    canonicalPath: '/articoli-frontaliere/furti-lusso-murten-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17448,7 +17448,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gestione, illecita, rifiuti, varese',
     ogTitle: 'Gestione illecita rifiuti Varese Arcisate',
     ogDescription: 'Operazione Carabinieri Forestali per smaltimento illegale rifiuti tra Varese e Arcisate. Tre denunciati e sequestri di capannone e mezzi.',
-    canonicalPath: '/articoli-frontaliere/gestione-illecita-rifiuti-varese-arcisate-2026',
+    canonicalPath: '/articoli-frontaliere/gestione-illecita-rifiuti-varese-arcisate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17476,7 +17476,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, anni, superati, dall, ufficio',
     ogTitle: 'Frontalieri Ticino: +30% in 10 anni, superati i 91.000',
     ogDescription: 'Dall\'Ufficio federale di statistica: frontalieri italiani in Svizzera cresciuti del 30% in 10 anni, con il Ticino che resta il polo principale',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-crescita-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-crescita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17504,7 +17504,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trasparenza, nelle, iniziative, popolari',
     ogTitle: 'Trasparenza iniziative popolari Ticino 2026',
     ogDescription: 'Una nuova iniziativa parlamentare mira a rafforzare la trasparenza finanziaria nelle iniziative popolari in Ticino, con soglie ben definite per la s',
-    canonicalPath: '/articoli-frontaliere/trasparenza-iniziative-popolari-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/trasparenza-iniziative-popolari-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17532,7 +17532,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tristan, brenn, difende, decisione',
     ogTitle: 'Tristan Brenn difende la decisione sul caso Fischer',
     ogDescription: 'Tristan Brenn, direttore del DFE, spiega le ragioni della decisione sul caso Fischer e le implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/tristan-brenn-fischer-decisione',
+    canonicalPath: '/articoli-frontaliere/tristan-brenn-fischer-decisione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17560,7 +17560,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, leader, brevetti, curiosità, roche',
     ogTitle: 'Svizzera leader in brevetti: 5 curiosità 2026',
     ogDescription: 'Roche supera Novartis, sigarette elettroniche e seggiolini per bambini: ecco i dati EPO su brevetti svizzeri',
-    canonicalPath: '/articoli-frontaliere/svizzera-brevetti-innovazione-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-brevetti-innovazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17588,7 +17588,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intervento, rega, boglia, soccorso',
     ogTitle: 'Intervento Rega sul Boglia: soccorso in montagna',
     ogDescription: 'Un elicottero della Rega è intervenuto sul Monte Boglia per soccorrere un escursionista in difficoltà. Ecco cosa è successo.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-rega-boglia-intervento',
+    canonicalPath: '/articoli-frontaliere/frontalieri-rega-boglia-intervento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17616,7 +17616,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, equans, licenziamenti, confermati, posti',
     ogTitle: 'Equans licenzia 19 dipendenti a Monteceneri',
     ogDescription: 'Equans procederà con 19 licenziamenti presso la sua sede di Monteceneri. I lavoratori interessati sono liberi da subito. Scopri le implicazioni e le',
-    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-2026',
+    canonicalPath: '/articoli-frontaliere/equans-licenziamenti-monteceneri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17644,7 +17644,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momenti, paura, velivolo, swiss',
     ogTitle: 'Momenti di paura su un velivolo Swiss',
     ogDescription: 'Un incidente tecnico su un velivolo Swiss ha causato momenti di tensione. Ecco cosa è successo e le implicazioni per i passeggeri.',
-    canonicalPath: '/articoli-frontaliere/momenti-paura-velivolo-swiss-2026',
+    canonicalPath: '/articoli-frontaliere/momenti-paura-velivolo-swiss-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17672,7 +17672,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, allerta, meteo, lombardia, piogge',
     ogTitle: 'Allerta meteo in Ticino e Lombardia: piogge e temporali',
     ogDescription: 'La Protezione civile lombarda ha emesso un\'allerta per piogge e temporali in Ticino e nord Lombardia, con rischio di vento forte in Valtellina.',
-    canonicalPath: '/articoli-frontaliere/allerta-meteo-ticino-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/allerta-meteo-ticino-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17700,7 +17700,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rottamazione-quinquies, domande, entro, aprile',
     ogTitle: 'Rottamazione-quinquies: domande entro il 30 aprile',
     ogDescription: 'Scade il 30 aprile il termine per aderire alla rottamazione-quinquies. Ecco cosa sapere e come fare la domanda per regolarizzare i debiti senza sanzioni e',
-    canonicalPath: '/articoli-frontaliere/rottamazione-quinquies-scadenza-30-aprile',
+    canonicalPath: '/articoli-frontaliere/rottamazione-quinquies-scadenza-30-aprile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17728,7 +17728,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, architettura, sostenibile, nuovo, iast',
     ogTitle: 'Architettura sostenibile in Ticino: il nuovo IAST dell\'USI',
     ogDescription: 'Scopri come il nuovo Istituto per l\'architettura sostenibile e la tecnologia dell\'USI promuove il riuso e la conservazione degli edifici esistenti.',
-    canonicalPath: '/articoli-frontaliere/architettura-sostenibile-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/architettura-sostenibile-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17756,7 +17756,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sisa, attacca, piano, governo',
     ogTitle: 'SISA attacca il piano del Governo sulle casse malati',
     ogDescription: 'Il sindacato studentesco critica i tagli ai servizi essenziali e l’aumento delle tasse universitarie in Ticino',
-    canonicalPath: '/articoli-frontaliere/sisa-contro-tagli-governo-2024',
+    canonicalPath: '/articoli-frontaliere/sisa-contro-tagli-governo-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17784,7 +17784,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pista, ciclopedonale, bodio-giornico, mobilità',
     ogTitle: 'Pista ciclopedonale Bodio-Giornico: mobilità lenta e sostenibile',
     ogDescription: 'Scopri la nuova pista ciclopedonale tra Bodio e Giornico, un progetto per la mobilità sostenibile nella regione del Canton Ticino.',
-    canonicalPath: '/articoli-frontaliere/pista-ciclopedonale-bodio-giornico-2026',
+    canonicalPath: '/articoli-frontaliere/pista-ciclopedonale-bodio-giornico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17812,7 +17812,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, sfida, carpooling, benefica',
     ogTitle: 'MomòRide: carpooling benefico Chiasso Balerna Novazzano',
     ogDescription: 'Dal 1° maggio parte MomòRide, iniziativa biennale di carpooling per aziende e pendolari di Chiasso, Balerna e Novazzano. Obiettivo: 40.000 punti in un mese per',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17840,7 +17840,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, escursionisti, lasciare, traccia, montagna',
     ogTitle: 'Kit per escursionisti: come non lasciare traccia in montagna',
     ogDescription: 'Scopri il kit \'Non lascio traccia\' per escursionisti e impara a rispettare l\'ambiente montano con pratiche sostenibili.',
-    canonicalPath: '/articoli-frontaliere/kit-escursionisti-montagna-pulita',
+    canonicalPath: '/articoli-frontaliere/kit-escursionisti-montagna-pulita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17868,7 +17868,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moda, sostenibile, bellinzona, giornata',
     ogTitle: 'Moda sostenibile a Bellinzona: giornata dedicata al riuso e alla riparazione',
     ogDescription: 'Sabato 9 maggio a Bellinzona laboratori, upcycling e tosatura delle pecore per sensibilizzare contro la fast fashion',
-    canonicalPath: '/articoli-frontaliere/moda-sostenibile-bellinzona-9-maggio',
+    canonicalPath: '/articoli-frontaliere/moda-sostenibile-bellinzona-9-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17896,7 +17896,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, chiasso, situazione',
     ogTitle: 'Fuga di ammoniaca a Chiasso, situazione sotto controllo',
     ogDescription: 'Incidente alla pista di ghiaccio di Chiasso, tre persone intossicate ma nessuna grave. La popolazione non è in pericolo.',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-controllo',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-controllo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17924,7 +17924,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, perdita, ammoniaca, allo, stadio',
     ogTitle: 'Perdita di ammoniaca a Chiasso: tre intossicati',
     ogDescription: 'Tre persone intossicate a causa di una perdita di ammoniaca allo stadio del ghiaccio di Chiasso. Intervento dei pompieri e dei sanitari.',
-    canonicalPath: '/articoli-frontaliere/chiasso-ammoniaca-stadio-ghiaccio',
+    canonicalPath: '/articoli-frontaliere/chiasso-ammoniaca-stadio-ghiaccio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17952,7 +17952,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, alla, pista',
     ogTitle: 'Fuga di ammoniaca alla pista di ghiaccio di Chiasso',
     ogDescription: 'Tre addetti alla manutenzione visitati dai soccorritori, ma nessuno ha bisogno di ricovero ospedaliero',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-pista-ghiaccio',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-pista-ghiaccio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -17980,7 +17980,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, biglietti, trenord, whatsapp, funziona',
     ogTitle: 'Biglietti Trenord su WhatsApp: come funziona',
     ogDescription: 'Scopri come acquistare biglietti Trenord su WhatsApp, disponibili alle self-service e ai Digital Gate di Milano e Malpensa T1',
-    canonicalPath: '/articoli-frontaliere/biglietto-trenord-whatsapp-ticino',
+    canonicalPath: '/articoli-frontaliere/biglietto-trenord-whatsapp-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18008,7 +18008,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, aerei, finanziare, treni',
     ogTitle: 'Tassa su aerei per finanziare i treni in Ticino',
     ogDescription: 'Un comitato propone di tassare i biglietti aerei per sostenere i trasporti pubblici in Svizzera, con un contributo minimo di 30 franchi.',
-    canonicalPath: '/articoli-frontaliere/tassa-aerei-sostegno-treni',
+    canonicalPath: '/articoli-frontaliere/tassa-aerei-sostegno-treni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18036,7 +18036,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comune, como, maggio, solo',
     ogTitle: 'Comune di Como: appuntamenti obbligatori per 12 servizi dal 4 maggio 2026',
     ogDescription: 'Dal 4 maggio 2026, 12 servizi del Comune di Como saranno disponibili solo su appuntamento, tra cui il rilascio della Carta d\'Identità Elettronica (CIE).',
-    canonicalPath: '/articoli-frontaliere/comune-como-appuntamenti-cie-2026',
+    canonicalPath: '/articoli-frontaliere/comune-como-appuntamenti-cie-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18064,7 +18064,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, auto, elettriche, momento, ricarica',
     ogTitle: 'Auto elettriche: il momento della ricarica è il più delicato',
     ogDescription: 'Un incendio in un\'autorimessa di Breganzona ha riacceso i riflettori sui rischi legati alla ricarica delle auto elettriche. Scopri cosa fare per garantire la',
-    canonicalPath: '/articoli-frontaliere/auto-elettriche-ricarica-breganzona',
+    canonicalPath: '/articoli-frontaliere/auto-elettriche-ricarica-breganzona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18092,7 +18092,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, università, insubria, milioni, ricerca',
     ogTitle: 'Università Insubria: 4,4 milioni per ricerca a Como e Varese',
     ogDescription: 'Regione Lombardia finanzia progetti IMPACTT e SustAA per potenziare infrastrutture di ricerca e innovazione sostenibile.',
-    canonicalPath: '/articoli-frontaliere/universita-insubria-4-4-milioni-ricerca',
+    canonicalPath: '/articoli-frontaliere/universita-insubria-4-4-milioni-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18120,7 +18120,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, airpack, lombardia, lavoratori, rischio',
     ogTitle: 'Airpack Lombardia: 41 lavoratori a rischio licenziamento',
     ogDescription: 'La proprietà belga Abriso insiste sulla chiusura dello stabilimento di Ossago Lodigiano, nonostante le offerte di acquisto.',
-    canonicalPath: '/articoli-frontaliere/airpack-lombardia-41-lavoratori',
+    canonicalPath: '/articoli-frontaliere/airpack-lombardia-41-lavoratori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18148,7 +18148,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, tassa, aerei, miliardi',
     ogTitle: 'Iniziativa tassa aerei: 1,5 miliardi per treni e buoni mobilità',
     ogDescription: 'Un\'iniziativa popolare svizzera vuole tassare i biglietti aerei per finanziare trasporti pubblici e buoni mobilità. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/tassa-aerei-trasporto-pubblico',
+    canonicalPath: '/articoli-frontaliere/tassa-aerei-trasporto-pubblico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18176,7 +18176,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, settimana, formazione, professionale, eventi',
     ogTitle: 'Settimana formazione professionale Ticino 2024',
     ogDescription: 'Dal 4 all’8 maggio, oltre 30 eventi tra radio, TV e sul territorio per scoprire le professioni in Ticino. Scopri come partecipare.',
-    canonicalPath: '/articoli-frontaliere/settimanaprofessionale-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/settimanaprofessionale-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18204,7 +18204,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colazione, equa, eventi, giornata',
     ogTitle: 'Colazione equa in Ticino: eventi per la Giornata mondiale del commercio equo',
     ogDescription: 'Il 9 maggio 2026 il Ticino celebra la Giornata mondiale del commercio equo con colazioni, degustazioni e promozioni in varie Botteghe del Mondo.',
-    canonicalPath: '/articoli-frontaliere/colazione-equo-ticino-9-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/colazione-equo-ticino-9-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18232,7 +18232,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caro, energia, provincia, varese',
     ogTitle: 'Caro energia in provincia di Varese: impatti su imprese e frontalieri',
     ogDescription: 'Analisi dell\'impatto del caro energia in provincia di Varese, con focus su imprese metalmeccaniche e lavoratori frontalieri.',
-    canonicalPath: '/articoli-frontaliere/costo-energia-varese-impatti-frontalieri',
+    canonicalPath: '/articoli-frontaliere/costo-energia-varese-impatti-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18260,7 +18260,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedali, varesini, meno, letti',
     ogTitle: 'Ospedali varesini: meno letti, più specializzazione in 20 anni',
     ogDescription: 'Negli ultimi vent\'anni i posti letto negli ospedali del Varesotto si sono ridotti del 30-40%, con un modello di cura più efficiente ma anche più fragile.',
-    canonicalPath: '/articoli-frontaliere/ospedali-varesini-cambiamenti-20-anni',
+    canonicalPath: '/articoli-frontaliere/ospedali-varesini-cambiamenti-20-anni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18288,7 +18288,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sunrise, dovrà, integrare, offerta',
     ogTitle: 'Sunrise dovrà integrare l’offerta HBB della SSR',
     ogDescription: 'Il Tribunale amministrativo federale ha sancito che Sunrise deve includere l’offerta HBB della SSR, con funzionalità per disabili sensoriali.',
-    canonicalPath: '/articoli-frontaliere/sunrise-integra-hbb-ssr-2026',
+    canonicalPath: '/articoli-frontaliere/sunrise-integra-hbb-ssr-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18316,7 +18316,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, alla, riduzione, settimanali',
     ogTitle: 'Infermieri: no alla riduzione delle ore settimanali',
     ogDescription: 'Il Consiglio nazionale ha deciso di mantenere a 50 ore la durata massima settimanale del lavoro per gli infermieri, nonostante l\'iniziativa popolare approvata',
-    canonicalPath: '/articoli-frontaliere/infermieri-lavoro-ore-settimanali',
+    canonicalPath: '/articoli-frontaliere/infermieri-lavoro-ore-settimanali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18344,7 +18344,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sorveglianza, telecomunicazioni, rallenta, tempo',
     ogTitle: 'Sorveglianza telecomunicazioni: +40% in Svizzera, ma rallenta in tempo reale',
     ogDescription: 'Nel 2025, le ricerche tramite antenna sono aumentate del 69%, mentre la sorveglianza in tempo reale è cresciuta solo del 3%.',
-    canonicalPath: '/articoli-frontaliere/sorveglianza-telecomunicazioni-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/sorveglianza-telecomunicazioni-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18372,7 +18372,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spese, bancarie, titoli, meierhans',
     ogTitle: 'Spese bancarie per titoli: Meierhans critica i costi',
     ogDescription: 'Le spese per il trasferimento di titoli in Svizzera sono tra i 60 e i 120 franchi, secondo la Sorveglianza dei prezzi.',
-    canonicalPath: '/articoli-frontaliere/spese-bancarie-titoli-frontalieri',
+    canonicalPath: '/articoli-frontaliere/spese-bancarie-titoli-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18400,7 +18400,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pendolarismo, sostenibile, bici, insubria',
     ogTitle: 'In bicicletta all\'università dell\'Insubria: la sfida del pendolarismo sostenibile',
     ogDescription: 'Un docente racconta la sua esperienza di pendolarismo in bicicletta tra Milano e Varese, evidenziando le difficoltà e le potenzialità di un sistema più',
-    canonicalPath: '/articoli-frontaliere/bicicletta-insubria-varese-2026',
+    canonicalPath: '/articoli-frontaliere/bicicletta-insubria-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18428,7 +18428,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, montessori, castellanza, menù, basso',
     ogTitle: 'Montessori Castellanza: menù a basso impatto e lotta agli sprechi',
     ogDescription: 'La scuola Montessori di Castellanza partecipa alla Green Food Week 2026 con menù vegetali e attività educative per ridurre gli sprechi alimentari.',
-    canonicalPath: '/articoli-frontaliere/montessori-green-food-week-2026',
+    canonicalPath: '/articoli-frontaliere/montessori-green-food-week-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18456,7 +18456,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passi, solidarietà, camminata, porto',
     ogTitle: 'Passi di solidarietà: camminata a Porto Ceresio per la donazione di sangue',
     ogDescription: 'Domenica 3 maggio, Avis Valceresio organizza una camminata lungo il lago per sensibilizzare sulla donazione di sangue. Ritrovo alle 9 in piazza Bossi.',
-    canonicalPath: '/articoli-frontaliere/passi-solidarieta-porto-ceresio-2026',
+    canonicalPath: '/articoli-frontaliere/passi-solidarieta-porto-ceresio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18484,7 +18484,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, karimova, archiviazione, parziale',
     ogTitle: 'Processo Karimova: archiviazione parziale per Gulnara',
     ogDescription: 'Il Tribunale penale federale archivia il caso contro Gulnara Karimova, figlia dell’ex presidente uzbeko, ma prosegue per la banca e il gestore patrimoniale',
-    canonicalPath: '/articoli-frontaliere/processo-karimova-archiviazione-parziale',
+    canonicalPath: '/articoli-frontaliere/processo-karimova-archiviazione-parziale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18512,7 +18512,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cardiocentro, lugano, piani, panoramico',
     ogTitle: 'Cardiocentro Lugano: tre piani in più e un bar panoramico',
     ogDescription: 'Il Cardiocentro di Lugano si presenta con tre piani in più e un bar panoramico dopo tre anni di lavori. Comfort e panorami mozzafiato per pazienti e personale.',
-    canonicalPath: '/articoli-frontaliere/cardiocentro-lugano-ristrutturazione-2026',
+    canonicalPath: '/articoli-frontaliere/cardiocentro-lugano-ristrutturazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18540,7 +18540,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, capo, dell, esercito, kaiser',
     ogTitle: 'Ex capo dell\'esercito nel Cda di Kaiser Partner Privatbank',
     ogDescription: 'Thomas Süssli, ex capo dell\'esercito svizzero, entra nel consiglio d\'amministrazione della banca di Vaduz. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ex-capo-esercito-kaiser-partner-privatbank',
+    canonicalPath: '/articoli-frontaliere/ex-capo-esercito-kaiser-partner-privatbank/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18568,7 +18568,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, saronno, nuove, regole, centri',
     ogTitle: 'Nuove regole centri estivi Saronno 2026',
     ogDescription: 'Scopri le nuove regole per i centri estivi comunali di Saronno: regia unica, sconti per fratelli e contributi fino a 400 euro.',
-    canonicalPath: '/articoli-frontaliere/nuove-regole-centri-estivi-saronno-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-regole-centri-estivi-saronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18596,7 +18596,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sede, banca, vendita, varese',
     ogTitle: 'Ex sede Banca d\'Italia in vendita a Varese: quanto costa e perché non si vende',
     ogDescription: 'L\'ex sede della Banca d\'Italia a Varese è in vendita da anni. Scopriamo il prezzo e i motivi per cui non trova acquirenti.',
-    canonicalPath: '/articoli-frontaliere/ex-sede-banca-ditalia-vendita-varese',
+    canonicalPath: '/articoli-frontaliere/ex-sede-banca-ditalia-vendita-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18624,7 +18624,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, national, summer, games, special',
     ogTitle: '139 frontalieri del Ticino ai National Summer Games di Special Olympics',
     ogDescription: '139 atleti con disabilità intellettiva dal Ticino partecipano ai National Summer Games di Special Olympics a Zugo dal 28 al 31 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/139-frontalieri-ticino-special-olympics',
+    canonicalPath: '/articoli-frontaliere/139-frontalieri-ticino-special-olympics/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18652,7 +18652,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andrea, giuliani, gastrobellinzona, alto',
     ogTitle: 'Andrea Giuliani guida GastroBellinzona Alto Ticino',
     ogDescription: 'Andrea Giuliani è il nuovo presidente di GastroBellinzona Alto Ticino. L\'associazione affronta sfide economiche e speranze per la ristorazione.',
-    canonicalPath: '/articoli-frontaliere/gastrobellinzona-andrea-giuliani',
+    canonicalPath: '/articoli-frontaliere/gastrobellinzona-andrea-giuliani/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18680,7 +18680,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, settimana, lavorativa, accorciata',
     ogTitle: 'Infermieri Ticino: settimana lavorativa non accorciata',
     ogDescription: 'Il Consiglio nazionale svizzero ha deciso di mantenere la durata massima della settimana lavorativa degli infermieri a 50 ore, rifiutando la proposta di ridurla',
-    canonicalPath: '/articoli-frontaliere/infermieri-ticino-ore-lavorative-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-ticino-ore-lavorative-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18708,7 +18708,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dezonare, terreni, edificabili, emergenza',
     ogTitle: 'Dezonare terreni edificabili: emergenza per la Val di Blenio',
     ogDescription: 'I sindaci di Blenio preoccupati per esuberi del 600-900% e silenzio istituzionale. Quali sono le implicazioni per i frontalieri?',
-    canonicalPath: '/articoli-frontaliere/dezonare-terreni-blenio-2026',
+    canonicalPath: '/articoli-frontaliere/dezonare-terreni-blenio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18736,7 +18736,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bankitalia, margini, limitati, debito',
     ogTitle: 'Dfp, Bankitalia: Margini limitati più per debito che per regole Ue',
     ogDescription: 'I margini limitati derivano dall\'esigenza di ridurre il debito, non solo dalle regole Ue. Dal 2027 sentiero discendente.',
-    canonicalPath: '/articoli-frontaliere/dfp-bankitalia-margini-debito-ue-2026',
+    canonicalPath: '/articoli-frontaliere/dfp-bankitalia-margini-debito-ue-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18764,7 +18764,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, sfida, carpooling, benefico',
     ogTitle: 'MomòRide: carpooling benefico in Ticino',
     ogDescription: 'La prima sfida collettiva di carpooling a scopo benefico inizia il 1° maggio in Ticino, con l\'obiettivo di raccogliere punti per donare mille franchi.',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2024',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-benefico-ticino-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18792,7 +18792,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borse, europee, flessione, zurigo',
     ogTitle: 'Borse europee in flessione, Zurigo non decolla',
     ogDescription: 'Le borse europee mostrano una linea comune incerta, mentre Zurigo registra un listino primario in flessione.',
-    canonicalPath: '/articoli-frontaliere/borse-zurigo-flessione-2026',
+    canonicalPath: '/articoli-frontaliere/borse-zurigo-flessione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18820,7 +18820,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, droga, arresti, estero',
     ogTitle: 'Traffico di droga: sei arresti tra Svizzera ed estero',
     ogDescription: 'Operazione congiunta del Ministero pubblico della Confederazione e della Polizia giudiziaria federale contro un\'organizzazione criminale.',
-    canonicalPath: '/articoli-frontaliere/traffico-droga-arresti-svizzera-estero-2026',
+    canonicalPath: '/articoli-frontaliere/traffico-droga-arresti-svizzera-estero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18848,7 +18848,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caslano, ribalta, previsioni, chiude',
     ogTitle: 'Caslano chiude 2025 con 311mila franchi di avanzo',
     ogDescription: 'Il Comune di Caslano ha chiuso il 2025 con un avanzo di 311mila franchi, superando le previsioni di disavanzo di 79mila franchi.',
-    canonicalPath: '/articoli-frontaliere/caslano-2025-bilancio-avanzamento',
+    canonicalPath: '/articoli-frontaliere/caslano-2025-bilancio-avanzamento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18876,7 +18876,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, milioni, piano, ciclabile',
     ogTitle: 'Lombardia: 115 milioni per il piano ciclabile',
     ogDescription: 'La Regione Lombardia investe 115 milioni di euro nel piano ciclabile con 25 grandi percorsi',
-    canonicalPath: '/articoli-frontaliere/lombardia-piano-ciclabile-115-milioni',
+    canonicalPath: '/articoli-frontaliere/lombardia-piano-ciclabile-115-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18904,7 +18904,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, anni, emergenze, sanitarie, mendrisiotto',
     ogTitle: '25 anni di emergenze sanitarie: il S.A.M. di Mendrisiotto',
     ogDescription: 'Dal 1999 il Servizio Autoambulanze Mendrisiotto risponde alle emergenze. Oggi il direttore Carlo Realini racconta le sfide attuali',
-    canonicalPath: '/articoli-frontaliere/sam-mendrisiotto-25-anni-emergenze',
+    canonicalPath: '/articoli-frontaliere/sam-mendrisiotto-25-anni-emergenze/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18932,7 +18932,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nidi, extrascolastico, verso, unico',
     ogTitle: 'Ticino: Nidi ed Extrascolastico verso un Unico Servizio',
     ogDescription: 'Bellinzona affronta la carenza di posti nei nidi con una lista d\'attesa unica e una visione integrata dei servizi (Fonte: laRegione.ch)',
-    canonicalPath: '/articoli-frontaliere/nidi-extrascolastico-ticino-un-servizio',
+    canonicalPath: '/articoli-frontaliere/nidi-extrascolastico-ticino-un-servizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18960,7 +18960,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinesi, parigi, roland, garros',
     ogTitle: 'Due ticinesi a Parigi per il Roland Garros',
     ogDescription: 'Rémy Bertola e Susan Bandecchi saranno impegnati nel tabellone delle qualificazioni del Roland Garros. Scopri chi altri svizzeri partecipano.',
-    canonicalPath: '/articoli-frontaliere/ticinesi-parigi-roland-garros',
+    canonicalPath: '/articoli-frontaliere/ticinesi-parigi-roland-garros/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -18988,7 +18988,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, locarno, smaltisce, rifiuti, landquart',
     ogTitle: 'Locarno smaltisce rifiuti a Landquart: 1000 tonnellate su 156 km',
     ogDescription: 'Locarno smaltisce rifiuti vegetali a Landquart, generando 6,5 tonnellate di CO2 annuali. Interrogazione al Municipio per la mancanza di coerenza ambientale.',
-    canonicalPath: '/articoli-frontaliere/locarno-landquart-rifiuti-1000-tonnellate',
+    canonicalPath: '/articoli-frontaliere/locarno-landquart-rifiuti-1000-tonnellate/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19016,7 +19016,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stipendi, svizzeri, crescita, 2025',
     ogTitle: 'Stipendi svizzeri in crescita: +1,6% nel 2025',
     ogDescription: 'I salari reali in Svizzera sono aumentati dell\'1,6% nel 2025, il guadagno più consistente dal 2009. Scopri di più sugli aumenti e le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/stipendi-svizzeri-crescono-2025',
+    canonicalPath: '/articoli-frontaliere/stipendi-svizzeri-crescono-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19044,7 +19044,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, traffico, pesante, entrate',
     ogTitle: 'Tassa traffico pesante: entrate mancate e lacune nei controlli',
     ogDescription: 'Lorenzo Quadri denuncia problemi nel nuovo sistema di riscossione della tassa sul traffico pesante, con rischi di frodi e mancati introiti.',
-    canonicalPath: '/articoli-frontaliere/tassa-traffico-pesante-lacune-controlli',
+    canonicalPath: '/articoli-frontaliere/tassa-traffico-pesante-lacune-controlli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19072,7 +19072,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, quadri, incalza, consiglio, federale',
     ogTitle: 'Quadri incalza il Consiglio federale su frontiere e tasse sui camion',
     ogDescription: 'Lorenzo Quadri (Lega dei Ticinesi) presenta un\'interpellanza sul nuovo sistema NMTS per la tassa sul traffico pesante.',
-    canonicalPath: '/articoli-frontaliere/quadri-interpella-consiglio-frontiere-tasse',
+    canonicalPath: '/articoli-frontaliere/quadri-interpella-consiglio-frontiere-tasse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19100,7 +19100,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, decreto, lavoro, fenealuil, moderatamente',
     ogTitle: 'Decreto Lavoro 2026: FenealUil moderatamente soddisfatta',
     ogDescription: 'Mauro Franzolini, segretario generale FenealUil, commenta la bozza del decreto lavoro in esame al Consiglio dei ministri.',
-    canonicalPath: '/articoli-frontaliere/fenealuil-decreto-lavoro-2026',
+    canonicalPath: '/articoli-frontaliere/fenealuil-decreto-lavoro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19128,7 +19128,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mara, bilancio, 2025, avanzo',
     ogTitle: 'Val Mara: bilancio 2025 in avanzo di 616mila franchi',
     ogDescription: 'Il Comune di Val Mara chiude il 2025 con un avanzo di 616mila franchi, superando le previsioni negative. Investimenti mirati e pressione fiscale stabile',
-    canonicalPath: '/articoli-frontaliere/bilancio-val-mara-2025-avanzamento-616mila',
+    canonicalPath: '/articoli-frontaliere/bilancio-val-mara-2025-avanzamento-616mila/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19156,7 +19156,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, villa, giuseppe, nuovo, ambulatorio',
     ogTitle: 'Villa San Giuseppe KOS: nuovo ambulatorio cardio-metabolico',
     ogDescription: 'Scopri il nuovo ambulatorio cardio-metabolico presso la Clinica Villa San Giuseppe KOS ad Anzano del Parco. Servizio multidisciplinare per la salute',
-    canonicalPath: '/articoli-frontaliere/ambulatorio-cardio-metabolico-villa-san-giuseppe',
+    canonicalPath: '/articoli-frontaliere/ambulatorio-cardio-metabolico-villa-san-giuseppe/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19184,7 +19184,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, disoccupazione, costerà, caro',
     ogTitle: 'Riforma UE: disoccupazione frontalieri costerà caro alla Svizzera',
     ogDescription: 'La revisione europea cambierebbe le regole: oggi paga il Paese di residenza, in futuro quello di lavoro. Un caso che mette alla prova i nuovi accordi tra',
-    canonicalPath: '/articoli-frontaliere/riforma-ue-disoccupazione-frontalieri',
+    canonicalPath: '/articoli-frontaliere/riforma-ue-disoccupazione-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19212,7 +19212,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, dadò, propone',
     ogTitle: 'Casse malati, Dadò propone la scissione del dossier',
     ogDescription: 'Fiorenzo Dadò suggerisce di suddividere il dossier sulle casse malati in due rapporti distinti. Possibile votazione popolare.',
-    canonicalPath: '/articoli-frontaliere/casse-malati-dado-scissione-dossier',
+    canonicalPath: '/articoli-frontaliere/casse-malati-dado-scissione-dossier/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19240,7 +19240,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iliad, presenta, veloci, piano',
     ogTitle: 'Iliad presenta \'Più veloci\', piano per reti mobili di nuova generazione',
     ogDescription: 'Iliad presenta \'Più Veloci\', un piano per accelerare lo sviluppo delle reti mobili in Italia, con impatto su cittadini, imprese e operatori.',
-    canonicalPath: '/articoli-frontaliere/iliad-piu-veloci-rete-mobili',
+    canonicalPath: '/articoli-frontaliere/iliad-piu-veloci-rete-mobili/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19268,7 +19268,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ferrero, ministero, sport, nelle',
     ogTitle: 'Formazione, intesa tra Ministero e Ferrero per promuovere attività sportive nelle scuole',
     ogDescription: 'Ministero dell’Istruzione e del Merito e Ferrero spa firmano protocollo d’intesa per attività educative e formative nelle scuole primarie e secondarie di I',
-    canonicalPath: '/articoli-frontaliere/formazione-ferrero-ministero-2026',
+    canonicalPath: '/articoli-frontaliere/formazione-ferrero-ministero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19296,7 +19296,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, condannato, mesi, truffe, online',
     ogTitle: 'Frontaliere condannato a 16 mesi per truffe online',
     ogDescription: 'Un 33enne del Bellinzonese, affetto da ludopatia, è stato condannato a 16 mesi per 82 raggiri online e 65 tentati',
-    canonicalPath: '/articoli-frontaliere/frontalieri-bellinzonese-truffe-16-mesi',
+    canonicalPath: '/articoli-frontaliere/frontalieri-bellinzonese-truffe-16-mesi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19324,7 +19324,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, decreto, lavoro, meloni, incentivi',
     ogTitle: 'Decreto Lavoro Meloni: incentivi e salario giusto per i frontalieri',
     ogDescription: 'Via libera del Consiglio dei Ministri al decreto lavoro con incentivi per assunzioni e salario giusto per i lavoratori',
-    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-2026-frontalieri',
+    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-2026-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19352,7 +19352,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, calcio, belli, passo, baratro',
     ogTitle: 'Calcio Dnb: Belli a un passo dal baratro dopo la sconfitta',
     ogDescription: 'La squadra di calcio Dnb Belli ha segnato un solo goal in due tiri, ma non è bastato per evitare una situazione critica. Analisi e soluzioni.',
-    canonicalPath: '/articoli-frontaliere/calcio-dnb-belli-crisi',
+    canonicalPath: '/articoli-frontaliere/calcio-dnb-belli-crisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19380,7 +19380,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alain, berset, sostiene, mathias',
     ogTitle: 'Alain Berset sostiene Mathias Reynard dopo la tragedia di Crans-Montana',
     ogDescription: 'L\'ex consigliere federale Alain Berset ha offerto sostegno psicologico e professionale a Mathias Reynard dopo l\'incendio di Capodanno a Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/berset-sostegno-reynard-crans-montana',
+    canonicalPath: '/articoli-frontaliere/berset-sostegno-reynard-crans-montana/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19408,7 +19408,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, biasca, rimanda, finale, uttigen',
     ogTitle: 'Biasca rimanda la finale: Uttigen vince ai supplementari',
     ogDescription: 'Il Biasca dovrà attendere ancora per la finale dopo la sconfitta ai supplementari contro l\'Uttigen. La serie va a gara 4.',
-    canonicalPath: '/articoli-frontaliere/biasca-roller-hockey-uttigen-2026',
+    canonicalPath: '/articoli-frontaliere/biasca-roller-hockey-uttigen-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19436,7 +19436,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basket, divario, ginevra, olympic',
     ogTitle: 'Basket: il divario tra Ginevra e Olympic',
     ogDescription: 'Analisi del campionato svizzero di basket con un divario evidente tra le prime e le altre squadre',
-    canonicalPath: '/articoli-frontaliere/vuoto-ginevra-olympic-basket',
+    canonicalPath: '/articoli-frontaliere/vuoto-ginevra-olympic-basket/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19464,7 +19464,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, pista, ciclopedonale, bodio-giornico',
     ogTitle: 'Nuova pista ciclopedonale Bodio-Giornico: 2,1 km di sicurezza e connessione',
     ogDescription: 'Scopri la nuova pista ciclopedonale che collega Bodio e Giornico lungo il fiume Ticino, con un investimento di 3,7 milioni di franchi.',
-    canonicalPath: '/articoli-frontaliere/nuova-pista-ciclopedonale-bodio-giornico-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-pista-ciclopedonale-bodio-giornico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19492,7 +19492,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, hotel, lusso, lago',
     ogTitle: 'Nuovo hotel di lusso sul Lago di Como: The Lake Como EDITION',
     ogDescription: 'Scopri il nuovo hotel di lusso sul Lago di Como, The Lake Como EDITION, con eventi esclusivi e cucina stellata.',
-    canonicalPath: '/articoli-frontaliere/lago-como-edition-hotel-lusso',
+    canonicalPath: '/articoli-frontaliere/lago-como-edition-hotel-lusso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19520,7 +19520,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, lancia, sfida, carpooling',
     ogTitle: 'MomòRide lancia sfida di carpooling per pendolari del Mendrisiotto',
     ogDescription: 'MomòRide lancia una sfida collettiva di carpooling per pendolari del Mendrisiotto. Obiettivo: raccogliere 40.000 punti in un mese per donare 1.000 CHF alla',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-sfida-collettiva',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-sfida-collettiva/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19548,7 +19548,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, scuole, vernate, neggio',
     ogTitle: 'Nuove scuole Vernate Neggio 2026',
     ogDescription: 'Le comunità di Vernate e Neggio hanno inaugurato le nuove scuole intercomunali, un progetto strategico per l\'educazione e l\'aggregazione',
-    canonicalPath: '/articoli-frontaliere/nuove-scuole-vernate-neggio-2026',
+    canonicalPath: '/articoli-frontaliere/nuove-scuole-vernate-neggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19576,7 +19576,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, iniziative, potrebbero',
     ogTitle: 'Casse malati Ticino: le due iniziative potrebbero dividersi',
     ogDescription: 'Il Consiglio di Stato ticinese presenta un piano parziale per le iniziative casse malati, ma i partiti propongono di separarle',
-    canonicalPath: '/articoli-frontaliere/casse-malati-ticino-divise-2026',
+    canonicalPath: '/articoli-frontaliere/casse-malati-ticino-divise-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19604,7 +19604,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, picco, spostamenti, transfrontalieri',
     ogTitle: 'Cina, picco di spostamenti transfrontalieri per il Primo Maggio',
     ogDescription: 'La Cina si prepara a un aumento record di viaggi transfrontalieri durante le vacanze del Primo Maggio, con picchi di oltre 2,4 milioni di passeggeri al giorno.',
-    canonicalPath: '/articoli-frontaliere/cina-spostamenti-frontalieri-primo-maggio',
+    canonicalPath: '/articoli-frontaliere/cina-spostamenti-frontalieri-primo-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19632,7 +19632,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, cultura, rinnova, arriva',
     ogTitle: 'Lugano Cultura digitale: nuovo spazio culturale unico',
     ogDescription: 'Scopri la nuova piattaforma digitale di Lugano Cultura con eventi, operatori e progetti interdisciplinari. Partecipa alla vita culturale di Lugano.',
-    canonicalPath: '/articoli-frontaliere/lugano-cultura-digitale-2024',
+    canonicalPath: '/articoli-frontaliere/lugano-cultura-digitale-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19660,7 +19660,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fondazione, xenia, patto, generazionale',
     ogTitle: 'Fondazione Xenia: il Patto Generazionale per l\'assistenza ai figli disabili',
     ogDescription: 'Scopri il progetto innovativo della Fondazione Xenia per garantire un futuro sereno ai figli disabili, ispirato alla tradizione della casa di corte.',
-    canonicalPath: '/articoli-frontaliere/fondazione-xenia-patto-generazionale',
+    canonicalPath: '/articoli-frontaliere/fondazione-xenia-patto-generazionale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19688,7 +19688,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, podcast, europa, basso, ruolo',
     ogTitle: 'Podcast su \'Un’Europa dal basso\': il ruolo delle regioni con Matteo Bianchi',
     ogDescription: 'Scopri il ruolo delle regioni nelle politiche di coesione dell\'UE nel podcast con Matteo Bianchi, vicepresidente del Comitato delle Regioni.',
-    canonicalPath: '/articoli-frontaliere/europa-dal-basso-regioni-podcast-bianchi',
+    canonicalPath: '/articoli-frontaliere/europa-dal-basso-regioni-podcast-bianchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19716,7 +19716,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, viggiù, bando, giovani, mille',
     ogTitle: 'Bando giovani Viggiù 2026: 1000 euro per progetti comunitari',
     ogDescription: 'Scopri il bando per i giovani di Viggiù: 1000 euro per realizzare progetti per la comunità. Scadenza 10 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/viggi-bando-giovani-comunit-2026',
+    canonicalPath: '/articoli-frontaliere/viggi-bando-giovani-comunit-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19744,7 +19744,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, centro, pacchi, cadenazzo',
     ogTitle: 'Furti al Centro pacchi di Cadenazzo: licenziati due dipendenti',
     ogDescription: 'Due dipendenti della Posta svizzera sono stati licenziati per furti al Centro pacchi di Cadenazzo. Parte della refurtiva è stata recuperata.',
-    canonicalPath: '/articoli-frontaliere/furti-centro-pacchi-cadenazzo',
+    canonicalPath: '/articoli-frontaliere/furti-centro-pacchi-cadenazzo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19772,7 +19772,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, conflitto, medio, oriente, fattura',
     ogTitle: 'Conflitto in Medio Oriente: la fattura energetica per Svizzera e Italia',
     ogDescription: 'Il conflitto in Medio Oriente fa lievitare i prezzi dei carburanti, con costi aggiuntivi di quasi 5 miliardi per la Svizzera e 15 per l\'Italia.',
-    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-medio-oriente',
+    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-medio-oriente/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19800,7 +19800,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, infermieristica, orario, lavoro',
     ogTitle: 'Riforma infermieristica in Ticino: orario di lavoro e reazioni contrastanti',
     ogDescription: 'Il Consiglio nazionale ha deciso di non accorciare l’orario massimo settimanale degli infermieri, che resta fissato a 50 ore. Reazioni contrastanti tra',
-    canonicalPath: '/articoli-frontaliere/riforma-infermieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/riforma-infermieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19828,7 +19828,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, emergenza, casa, como, analisi',
     ogTitle: 'Emergenza casa a Como: analisi e visioni del PD',
     ogDescription: 'Il Partito Democratico di Como organizza un incontro per discutere l\'emergenza abitativa in città, con esperti e relatori.',
-    canonicalPath: '/articoli-frontaliere/emergenza-casa-como-analisi',
+    canonicalPath: '/articoli-frontaliere/emergenza-casa-como-analisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19856,7 +19856,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, annullare, acquisto, f-35',
     ogTitle: 'Iniziativa per annullare l\'acquisto degli F-35',
     ogDescription: 'Un\'associazione civica lancia un\'iniziativa per far annullare il contratto degli F-35, considerati troppo costosi e inadatti. Scopri le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/iniziativa-f-35-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/iniziativa-f-35-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19884,7 +19884,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giro-e, tappa, angera, verbania',
     ogTitle: 'Giro-E 2026: tappa Angera-Verbania sul Lago Maggiore',
     ogDescription: 'Una tappa del Giro-E unisce sport, sostenibilità e promozione turistica lungo il Lago Maggiore, con partenza da Angera il 22 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/giro-e-angera-verbania-2026',
+    canonicalPath: '/articoli-frontaliere/giro-e-angera-verbania-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19912,7 +19912,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziative, casse, malati, spunta',
     ogTitle: 'Iniziative casse malati: spunta il piano Dadò',
     ogDescription: 'Ogni iniziativa sulle casse malati prosegue per la propria strada con misure di finanziamento separate. La proposta di Fiorenzo Dadò.',
-    canonicalPath: '/articoli-frontaliere/iniziative-casse-malati-dado-scissione-dossier',
+    canonicalPath: '/articoli-frontaliere/iniziative-casse-malati-dado-scissione-dossier/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19940,7 +19940,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moschea, pregassona, interroga, municipio',
     ogTitle: 'Moschea Pregassona: UDC interroga Municipio',
     ogDescription: 'L\'UDC chiede garanzie e trasparenza per il progetto di un centro culturale islamico con moschea e appartamenti a Pregassona.',
-    canonicalPath: '/articoli-frontaliere/moschea-pregassona-udc-interroga-municipio',
+    canonicalPath: '/articoli-frontaliere/moschea-pregassona-udc-interroga-municipio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19968,7 +19968,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, lavori, area, camper',
     ogTitle: 'Como, al via i lavori per l\'area camper da 26 posti',
     ogDescription: 'Il cantiere per l\'ampliamento dell\'area camper di Tavernola è iniziato. Ecco quando finiranno i lavori e i dettagli del progetto.',
-    canonicalPath: '/articoli-frontaliere/como-area-camper-26-posti-lavori',
+    canonicalPath: '/articoli-frontaliere/como-area-camper-26-posti-lavori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -19996,7 +19996,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caricabatteria, unico, portatili, cosa',
     ogTitle: 'Caricabatteria unico per portatili: cosa cambia dal 28 aprile',
     ogDescription: 'Dal 28 aprile 2024, i computer portatili nell\'UE devono supportare la ricarica via USB-C e i produttori devono offrire versioni senza alimentatore',
-    canonicalPath: '/articoli-frontaliere/caricabatteria-unico-portatili-2024',
+    canonicalPath: '/articoli-frontaliere/caricabatteria-unico-portatili-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20024,7 +20024,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ufficio, open, space, genera',
     ogTitle: 'Ufficio open space genera stress, non comunicazione',
     ogDescription: 'Secondo lo psicoanalista Peter Schneider, gli open space sacrificano il benessere dei dipendenti per ottimizzare gli spazi, causando stress e micro-conflitti',
-    canonicalPath: '/articoli-frontaliere/ufficio-open-space-stress-frontalieri',
+    canonicalPath: '/articoli-frontaliere/ufficio-open-space-stress-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20052,7 +20052,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estival, jazz, pagamento, polemica',
     ogTitle: 'Estival Jazz a pagamento: la polemica a Lugano',
     ogDescription: 'Il consigliere comunale Omar Wicht critica le serate a pagamento dell\'evento musicale Estival Jazz a Lugano, chiedendo chiarimenti all\'Esecutivo',
-    canonicalPath: '/articoli-frontaliere/estival-pagamento-caduta-stile-lugano',
+    canonicalPath: '/articoli-frontaliere/estival-pagamento-caduta-stile-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20080,7 +20080,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giornata, contro, rumore, controlli',
     ogTitle: 'Giornata contro il rumore: controlli a Lugano dal 28 al 30 aprile',
     ogDescription: 'La Polizia comunale di Lugano estende i controlli sul rumore dal 28 al 30 aprile. Focus su veicoli rumorosi e cantieri',
-    canonicalPath: '/articoli-frontaliere/giornata-contro-rumore-lugano-2024',
+    canonicalPath: '/articoli-frontaliere/giornata-contro-rumore-lugano-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20108,7 +20108,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estival, jazz, lugano, introduce',
     ogTitle: 'Estival Jazz Lugano introduce biglietti a pagamento',
     ogDescription: 'Dal 2024 due serate su tre del festival saranno a pagamento per garantire la sostenibilità dell\'evento. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-pagamento-2024',
+    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-pagamento-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20136,7 +20136,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, capitale, sostenibilità, salone',
     ogTitle: 'Varese sostenibilità CSR Camera Commercio',
     ogDescription: 'Il Salone della CSR e dell\'Innovazione Sociale approda a Varese con focus su ecosistema circolare e vantaggi competitivi per le imprese.',
-    canonicalPath: '/articoli-frontaliere/varese-sostenibilita-csr-camera-commercio',
+    canonicalPath: '/articoli-frontaliere/varese-sostenibilita-csr-camera-commercio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20164,7 +20164,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, milioni, quartiere, rivoluziona',
     ogTitle: 'Lombardia: 30 milioni per il quartiere che rivoluziona le bollette',
     ogDescription: 'Scopri come il progetto Livorno Parco a Brescia sta rivoluzionando le bollette energetiche con un investimento di 30 milioni di euro.',
-    canonicalPath: '/articoli-frontaliere/lombardia-30-milioni-quartiere-efficientamento',
+    canonicalPath: '/articoli-frontaliere/lombardia-30-milioni-quartiere-efficientamento/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20192,7 +20192,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, moschea, lugano, interrogazioni',
     ogTitle: 'Nuova moschea a Lugano: interrogazioni e dubbi',
     ogDescription: 'Sette consiglieri comunali UDC presentano interrogazione al Municipio di Lugano su progetto moschea a Pregassona',
-    canonicalPath: '/articoli-frontaliere/moschea-lugano-pregassona-2026',
+    canonicalPath: '/articoli-frontaliere/moschea-lugano-pregassona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20220,7 +20220,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fuga, ammoniaca, chiasso, causa',
     ogTitle: 'Fuga di ammoniaca a Chiasso: causa individuata',
     ogDescription: 'La fuga di ammoniaca alla pista di ghiaccio di Chiasso è stata causata da una guarnizione difettosa. Tre dipendenti leggermente intossicati.',
-    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-causa-trovata',
+    canonicalPath: '/articoli-frontaliere/fuga-ammoniaca-chiasso-causa-trovata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20248,7 +20248,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, unitas, festeggia, anni, rivista',
     ogTitle: 'Unitas festeggia 80 anni con una rivista audio',
     ogDescription: 'L\'associazione per non vedenti celebra il traguardo con una rivista audio e progetti per il futuro',
-    canonicalPath: '/articoli-frontaliere/unitas-80-anni-innovazione-inclusione',
+    canonicalPath: '/articoli-frontaliere/unitas-80-anni-innovazione-inclusione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20276,7 +20276,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giorgetti, deficit, ridotto, senza',
     ogTitle: 'Dfp, Giorgetti: deficit ridotto senza manovre restrittive',
     ogDescription: 'Il ministro dell\'Economia annuncia una riduzione del deficit senza manovre restrittive grazie a una gestione prudente della finanza pubblica.',
-    canonicalPath: '/articoli-frontaliere/dfp-giorgetti-deficit-ridotto',
+    canonicalPath: '/articoli-frontaliere/dfp-giorgetti-deficit-ridotto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20304,7 +20304,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, castiglione, olona, riaperto, ufficio',
     ogTitle: 'Castiglione Olona: riaperto l\'ufficio postale con nuovi servizi',
     ogDescription: 'L\'ufficio postale di Castiglione Olona è stato riaperto dopo una completa ristrutturazione, offrendo nuovi servizi e migliorando l\'accessibilità.',
-    canonicalPath: '/articoli-frontaliere/castiglione-olona-ufficio-postale-riaperto',
+    canonicalPath: '/articoli-frontaliere/castiglione-olona-ufficio-postale-riaperto/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20332,7 +20332,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, programmi, educativi, bellinzona',
     ogTitle: 'Nuovi programmi educativi a Bellinzona: prevenzione e rispetto',
     ogDescription: 'Da settembre 2026, l\'Istituto scolastico comunale di Bellinzona avvia tre programmi educativi per il secondo ciclo della scuola elementare.',
-    canonicalPath: '/articoli-frontaliere/programmi-educativi-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/programmi-educativi-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20360,7 +20360,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aeroporti, milano, boom, fatturato',
     ogTitle: 'Aeroporti Milano: boom fatturato e dividendi 197 milioni',
     ogDescription: 'Malpensa e Linate chiudono il 2025 con ricavi a 876,8 milioni e traffico passeggeri in aumento dell\'8%. Dividendi record per gli azionisti.',
-    canonicalPath: '/articoli-frontaliere/aeroporti-milano-boom-fatturato-197-milioni',
+    canonicalPath: '/articoli-frontaliere/aeroporti-milano-boom-fatturato-197-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20388,7 +20388,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, servizio, clienti, bancario, digitali',
     ogTitle: 'Servizio clienti bancario: UBS al top, le digitali bocciate',
     ogDescription: 'UBS e Banca cantonale di Basilea Campagna garantiscono servizio 24/7, mentre le banche online come Revolut e Neon sono ultime in classifica.',
-    canonicalPath: '/articoli-frontaliere/servizio-clienti-bancario-promossi-bocciati',
+    canonicalPath: '/articoli-frontaliere/servizio-clienti-bancario-promossi-bocciati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20416,7 +20416,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agricoltura, spaziale, primo, centro',
     ogTitle: 'Agricoltura spaziale: primo centro europeo in Svizzera',
     ogDescription: 'Inaugurato il primo centro europeo di ricerca sull\'agricoltura spaziale in Svizzera. Innovazione per il futuro dell\'alimentazione.',
-    canonicalPath: '/articoli-frontaliere/agricoltura-spaziale-svizzera-ricerca',
+    canonicalPath: '/articoli-frontaliere/agricoltura-spaziale-svizzera-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20444,7 +20444,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sotto, accusa, lobbying, aggressivo',
     ogTitle: 'UBS sotto accusa: lobbying aggressivo sul Parlamento svizzero',
     ogDescription: 'La banca UBS esercita pressioni senza precedenti sui parlamentari per ostacolare una legge che la obbligherebbe a rafforzare i capitali.',
-    canonicalPath: '/articoli-frontaliere/ubs-lobbying-parlamento-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-lobbying-parlamento-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20472,7 +20472,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andrea, giuliani, nuovo, presidente',
     ogTitle: 'Andrea Giuliani nuovo presidente di Gastro Bellinzona e Alto Ticino',
     ogDescription: 'Andrea Giuliani è il nuovo presidente di Gastro Bellinzona e Alto Ticino. Scopri le implicazioni per i frontalieri e le strategie per affrontare le sfide',
-    canonicalPath: '/articoli-frontaliere/nuovo-presidente-gastro-bellinzona',
+    canonicalPath: '/articoli-frontaliere/nuovo-presidente-gastro-bellinzona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20500,7 +20500,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, presidio, varese, parcheggi, carenza',
     ogTitle: 'Presidio UIL FP a Varese: parcheggi e carenza di personale all\'ospedale',
     ogDescription: 'La UIL FP protesta davanti all\'ospedale di Varese per parcheggi insufficienti e carenza di personale, con turni massacranti per i lavoratori',
-    canonicalPath: '/articoli-frontaliere/varese-ospedale-parcheggi-personale-2026',
+    canonicalPath: '/articoli-frontaliere/varese-ospedale-parcheggi-personale-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20528,7 +20528,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, coalizione, sanitaria, calpestata, volontà',
     ogTitle: 'Coalizione sanitaria: «Calpestata la volontà popolare»',
     ogDescription: 'La Coalizione del personale sanitario critica la decisione del Consiglio nazionale di non ridurre il tempo di lavoro degli infermieri.',
-    canonicalPath: '/articoli-frontaliere/coalizione-sanitario-volonta-calpestata',
+    canonicalPath: '/articoli-frontaliere/coalizione-sanitario-volonta-calpestata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20556,7 +20556,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, volo, swiss, evacuato, passeggeri',
     ogTitle: 'Volo Swiss evacuato: passeggeri non mollano il bagaglio a mano',
     ogDescription: 'Un Airbus A330 della Swiss è stato evacuato a New Delhi dopo un\'interruzione del decollo. Molti passeggeri non hanno seguito le istruzioni di sicurezza.',
-    canonicalPath: '/articoli-frontaliere/volo-swiss-evacuato-passeggeri-bagaglio',
+    canonicalPath: '/articoli-frontaliere/volo-swiss-evacuato-passeggeri-bagaglio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20584,7 +20584,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banche, svizzere, pronte, clienti',
     ogTitle: 'Banche svizzere pronte per i clienti del Golfo',
     ogDescription: 'Trasferimenti di capitali e potenziali trasferimenti di residenza verso la Svizzera a causa del conflitto in Iran',
-    canonicalPath: '/articoli-frontaliere/banche-golfo-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/banche-golfo-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20612,7 +20612,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, saronno, rilanciare, commercio, interventi',
     ogTitle: 'Saronno: rilanciare il commercio con interventi strutturali',
     ogDescription: 'Il Consiglio comunale di Saronno esamina una mozione per rilanciare il commercio cittadino con interventi strutturali e permanenti',
-    canonicalPath: '/articoli-frontaliere/rilanciare-commercio-saronno-2026',
+    canonicalPath: '/articoli-frontaliere/rilanciare-commercio-saronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20640,7 +20640,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, aggressione, donne, casa',
     ogTitle: 'Lugano: aggressione a due donne in casa, arrestato l\'aggressore',
     ogDescription: 'Un uomo ha aggredito due donne nella loro abitazione a Lugano. L\'aggressore è stato preso e interrogato dalle autorità.',
-    canonicalPath: '/articoli-frontaliere/lugano-aggressione-abitazione-2024',
+    canonicalPath: '/articoli-frontaliere/lugano-aggressione-abitazione-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20668,7 +20668,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, chiese, fermati, rumeni',
     ogTitle: 'Furti in chiese: fermati due rumeni in Ticino',
     ogDescription: 'Due cittadini rumeni sono stati fermati per furti in chiese ticinesi. Scopri i dettagli dell\'operazione e le misure di sicurezza.',
-    canonicalPath: '/articoli-frontaliere/furti-chiese-ticino-rumeni-fermati',
+    canonicalPath: '/articoli-frontaliere/furti-chiese-ticino-rumeni-fermati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20696,7 +20696,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attentato, washington, illeso, donald',
     ogTitle: 'Attentato a Washington, illeso Donald Trump',
     ogDescription: 'Donald Trump scampato a un attentato durante una cena di gala a Washington. L\'attentatore arrestato. Implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026',
+    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20724,7 +20724,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, montana, nante, governo',
     ogTitle: 'Casa montana di Nante: il Governo conferma tutto regolare',
     ogDescription: 'Il Consiglio di Stato ticinese ha respinto il ricorso contro il progetto di ristrutturazione della casa montana Madonna delle Nevi a Nante, confermando un',
-    canonicalPath: '/articoli-frontaliere/casa-montana-nante-governo-regolare',
+    canonicalPath: '/articoli-frontaliere/casa-montana-nante-governo-regolare/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20752,7 +20752,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, neuch, vieta, palloncini, lanterne',
     ogTitle: 'Neuchâtel vieta palloncini e lanterne: prima svizzera',
     ogDescription: 'Il Gran Consiglio del Canton Neuchâtel ha approvato il divieto di lancio di palloncini e lanterne volanti, con 55 voti a favore.',
-    canonicalPath: '/articoli-frontaliere/neuchatel-palloncini-lanterne-vietati',
+    canonicalPath: '/articoli-frontaliere/neuchatel-palloncini-lanterne-vietati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20780,7 +20780,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vaud, parlamento, chiede, dimissioni',
     ogTitle: 'Vaud, il Parlamento chiede le dimissioni di Valérie Dittli',
     ogDescription: 'Il Gran Consiglio vodese ha approvato una risoluzione simbolica per chiedere le dimissioni della consigliera di Stato Valérie Dittli.',
-    canonicalPath: '/articoli-frontaliere/vaud-parlamento-dimissioni-dittli',
+    canonicalPath: '/articoli-frontaliere/vaud-parlamento-dimissioni-dittli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20808,7 +20808,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rogo, fermo, battaglia, nessuno',
     ogTitle: 'Rogo a San Fermo della Battaglia, nessuno ferito',
     ogDescription: 'Un incendio è divampato sul Pin Umbrèla a San Fermo della Battaglia, in provincia di Como, senza causare vittime.',
-    canonicalPath: '/articoli-frontaliere/rogo-san-fermo-battaglia-2024',
+    canonicalPath: '/articoli-frontaliere/rogo-san-fermo-battaglia-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20836,7 +20836,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, terremoto, canton, gallo, magnitudo',
     ogTitle: 'Terremoto in Canton San Gallo: magnitudo 3.8, scosse avvertite in tutta la Svizzera',
     ogDescription: 'Un terremoto di magnitudo 3.8 ha colpito il Canton San Gallo il 26 aprile 2026, con epicentro vicino a Walenstadt. Scosse avvertite in tutta la Svizzera.',
-    canonicalPath: '/articoli-frontaliere/terremoto-san-gallo-2026',
+    canonicalPath: '/articoli-frontaliere/terremoto-san-gallo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20864,7 +20864,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, indipendenti, riconoscimento, critiche',
     ogTitle: 'Infermieri indipendenti in Ticino: tra riconoscimento e critiche',
     ogDescription: 'Andrè Brusasco, infermiere indipendente, racconta la realtà del lavoro a domicilio in Ticino e le sfide attuali',
-    canonicalPath: '/articoli-frontaliere/infermieri-indipendenti-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-indipendenti-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20892,7 +20892,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, deposito, sequestrato, como, indagini',
     ogTitle: 'Deposito carrozzeria sequestrato a Como: indagini partite da pezzi d\'auto abbandonati',
     ogDescription: 'La Polizia locale di Como ha sequestrato un deposito di una carrozzeria per violazioni ambientali, scoprendo rifiuti abbandonati e irregolarità nel deposito',
-    canonicalPath: '/articoli-frontaliere/deposito-carrozzeria-sequestrato-como-2026',
+    canonicalPath: '/articoli-frontaliere/deposito-carrozzeria-sequestrato-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20920,7 +20920,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agesp, orari, raccolta, rifiuti',
     ogTitle: 'Agesp: orari raccolta rifiuti primo maggio 2026',
     ogDescription: 'Variazioni nei servizi Agesp il 1° maggio a Busto Arsizio, Fagnano Olona e Venegono Superiore. Info su raccolta rifiuti e chiusure uffici.',
-    canonicalPath: '/articoli-frontaliere/agesp-rifiuti-primo-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/agesp-rifiuti-primo-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20948,7 +20948,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, blocca, acquisizione, manus',
     ogTitle: 'Cina blocca acquisizione Manus: ecco perché',
     ogDescription: 'Pechino ferma l\'acquisto da Meta per 2 miliardi di dollari, temendo perdita di tecnologia strategica',
-    canonicalPath: '/articoli-frontaliere/stop-cinese-acquisizione-manus-implicazioni',
+    canonicalPath: '/articoli-frontaliere/stop-cinese-acquisizione-manus-implicazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -20976,7 +20976,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gita, cuore, soncino, sostenere',
     ogTitle: 'Gita del cuore a Soncino per sostenere Saronno Point',
     ogDescription: 'Una giornata tra storia, arte e solidarietà per finanziare le attività di Saronno Point dedicate ai malati oncologici.',
-    canonicalPath: '/articoli-frontaliere/gita-cuore-soncino-saronno-point',
+    canonicalPath: '/articoli-frontaliere/gita-cuore-soncino-saronno-point/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21004,7 +21004,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, decreto, lavoro, meloni, salario',
     ogTitle: 'Decreto lavoro Meloni: salario giusto e stop ai contratti pirata',
     ogDescription: 'Via libera al decreto lavoro con salario giusto e incentivi per le assunzioni. Meloni: patto con imprese e sindacati.',
-    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/decreto-lavoro-meloni-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21032,7 +21032,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, othermovie, lugano, trionfa, witness',
     ogTitle: 'OtherMovie Lugano 2026: trionfa \'God as my Witness\'',
     ogDescription: 'Scopri il vincitore di OtherMovie Lugano 2026 e le implicazioni per i frontalieri che lavorano in Ticino. Partecipa al festival e approfitta delle opportunità',
-    canonicalPath: '/articoli-frontaliere/othermovie-lugano-2026-god-witness',
+    canonicalPath: '/articoli-frontaliere/othermovie-lugano-2026-god-witness/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21060,7 +21060,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nasce, emporio, solidarietà, olgiate',
     ogTitle: 'Nasce l’Emporio della Solidarietà di Olgiate Olona',
     ogDescription: 'Inaugurazione sabato 9 maggio con stand informativi e aperitivo comunitario. Partecipano realtà locali come Mensa del Padre Nostro e CAV di Castellanza.',
-    canonicalPath: '/articoli-frontaliere/emporio-solidarieta-olgiate-olona',
+    canonicalPath: '/articoli-frontaliere/emporio-solidarieta-olgiate-olona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21088,7 +21088,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estival, jazz, lugano, cambia',
     ogTitle: 'Estival Jazz Lugano cambia formula: due serate a pagamento',
     ogDescription: 'Dal 2026 Estival Jazz propone due serate a pagamento con Ernia e Antonello Venditti. Fine dell\'era dei concerti gratuiti.',
-    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-cambia-formula-2026',
+    canonicalPath: '/articoli-frontaliere/estival-jazz-lugano-cambia-formula-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21116,7 +21116,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, eurovision, ballad, emozionano, scopri',
     ogTitle: 'Eurovision 2026: le ballad che emozionano',
     ogDescription: 'Scopri le canzoni che emozionano all\'Eurovision 2026, tra ballad e scelte artistiche d\'impatto.',
-    canonicalPath: '/articoli-frontaliere/eurovision-ballad-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/eurovision-ballad-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21144,7 +21144,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, unitas, compie, anni, bilancio',
     ogTitle: 'Unitas compie 80 anni: bilancio e futuro dell\'associazione',
     ogDescription: 'L\'associazione ciechi e ipovedenti della Svizzera italiana festeggia 80 anni. Scopri le sfide e i progetti futuri presentati a Lugano.',
-    canonicalPath: '/articoli-frontaliere/unitas-ottantesimo-futuro-ticino',
+    canonicalPath: '/articoli-frontaliere/unitas-ottantesimo-futuro-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21172,7 +21172,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scaletta, indecente, comune, vuole',
     ogTitle: 'Como, io ho segnalato ma il Comune non ne vuole sapere. Indecente la scaletta che usiamo tutti i giorni',
     ogDescription: 'Segnalazione di una cittadina sul Comune di Como: la scaletta da via Spartaco Cappelletti a via Bellinzona è in una situazione indecente.',
-    canonicalPath: '/articoli-frontaliere/como-io-ho-segnalato-ma-il-comune-non-ne-vuole-sapere',
+    canonicalPath: '/articoli-frontaliere/como-io-ho-segnalato-ma-il-comune-non-ne-vuole-sapere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21200,7 +21200,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ucraina, supera, russia, negli',
     ogTitle: 'Ucraina supera Russia negli attacchi con droni',
     ogDescription: 'Per la prima volta dall\'inizio del conflitto, l\'Ucraina ha lanciato più droni della Russia a marzo 2026, secondo i dati militari analizzati da ABC News.',
-    canonicalPath: '/articoli-frontaliere/ucraina-russia-droni-2026',
+    canonicalPath: '/articoli-frontaliere/ucraina-russia-droni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21228,7 +21228,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, serie, documentari, play',
     ogTitle: 'Nuove serie e documentari su Play Suisse',
     ogDescription: 'Scopri le nuove serie e documentari disponibili su Play Suisse, la piattaforma streaming della SSR. Registrati gratuitamente e inizia a guardare.',
-    canonicalPath: '/articoli-frontaliere/play-suisse-novita-streaming-2026',
+    canonicalPath: '/articoli-frontaliere/play-suisse-novita-streaming-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21256,7 +21256,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dehors, como, ricorso, decisione',
     ogTitle: 'Dehors a Como: ricorso del bar e decisione del Tar',
     ogDescription: 'La rimozione del dehors del bar La Quinta a Como è sospesa. Udienza di merito il 20 maggio 2026. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/dehors-como-ricorso-tar-20-maggio',
+    canonicalPath: '/articoli-frontaliere/dehors-como-ricorso-tar-20-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21284,7 +21284,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bruno, breguet, scomparso, pretore',
     ogTitle: 'Bruno Breguet scomparso: il pretore di Locarno chiude il caso',
     ogDescription: 'La giustizia civile ticinese ha ufficializzato la scomparsa di Bruno Breguet, ex terrorista legato a Carlos e forse agente CIA',
-    canonicalPath: '/articoli-frontaliere/bruno-breguet-scomparsa-ufficializzata',
+    canonicalPath: '/articoli-frontaliere/bruno-breguet-scomparsa-ufficializzata/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21312,7 +21312,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, profumo, prato, tagliato, grido',
     ogTitle: 'Il profumo di prato tagliato è un grido d’aiuto delle piante',
     ogDescription: 'Scopri come il profumo dell\'erba tagliata è un segnale di allarme per le piante e attira insetti predatori utili.',
-    canonicalPath: '/articoli-frontaliere/profumo-prato-tagliato-grido-aiuto-piante',
+    canonicalPath: '/articoli-frontaliere/profumo-prato-tagliato-grido-aiuto-piante/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21340,7 +21340,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, novartis, calo, nell, utile',
     ogTitle: 'Novartis: calo del 13% nell\'utile netto nel primo trimestre 2026',
     ogDescription: 'Novartis registra un calo del 13% nell\'utile netto nel primo trimestre 2026, con vendite di Entresto in forte diminuzione.',
-    canonicalPath: '/articoli-frontaliere/novartis-calo-utile-2026',
+    canonicalPath: '/articoli-frontaliere/novartis-calo-utile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21368,7 +21368,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, taglio, accise, energia, proroga',
     ogTitle: 'Taglio accise energia: proroga in arrivo, Meloni chiede coraggio all\'UE',
     ogDescription: 'Il governo italiano lavora a una proroga più breve per il taglio delle accise sull\'energia. Meloni invoca coraggio dall\'Europa per affrontare la crisi',
-    canonicalPath: '/articoli-frontaliere/taglio-accise-proroga-meloni-2026',
+    canonicalPath: '/articoli-frontaliere/taglio-accise-proroga-meloni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21396,7 +21396,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agente, fedpol, arrestato, corruzione',
     ogTitle: 'Agente Fedpol arrestato per corruzione e violazione del segreto d\'ufficio',
     ogDescription: 'Sei persone, tra cui un dipendente di Fedpol, arrestate in un\'operazione contro la criminalità organizzata in Svizzera, Francia e Germania.',
-    canonicalPath: '/articoli-frontaliere/fedpol-arresto-corruzione-2026',
+    canonicalPath: '/articoli-frontaliere/fedpol-arresto-corruzione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21424,7 +21424,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, momòride, prima, sfida, benefica',
     ogTitle: 'MomòRide: prima sfida benefica per pendolari ticinesi',
     ogDescription: 'A maggio parte la prima sfida collettiva di MomòRide per promuovere il carpooling e raccogliere fondi per enti benefici del Mendrisiotto.',
-    canonicalPath: '/articoli-frontaliere/momoride-benefico-mendrisiotto-2024',
+    canonicalPath: '/articoli-frontaliere/momoride-benefico-mendrisiotto-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21452,7 +21452,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, uzbekistan, centro, mondo, implicazioni',
     ogTitle: 'Uzbekistan, oro e gas al centro del mondo: implicazioni per il Ticino',
     ogDescription: 'Scopri come l\'apertura economica dell\'Uzbekistan influisce sul Ticino e i frontalieri, con focus su oro, gas e processi finanziari.',
-    canonicalPath: '/articoli-frontaliere/uzbekistan-oro-gas-ticino-implicazioni',
+    canonicalPath: '/articoli-frontaliere/uzbekistan-oro-gas-ticino-implicazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21480,7 +21480,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attentato, trump, aggressore, davanti',
     ogTitle: 'Attentato a Trump: l\'aggressore davanti al giudice',
     ogDescription: 'Cole Allen, 31enne californiano, accusato di aggressione a un agente federale e uso di arma da fuoco, comparirà davanti a un giudice lunedì',
-    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026-analisi',
+    canonicalPath: '/articoli-frontaliere/attentato-washington-trump-2026-analisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21508,7 +21508,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, spese, militari, 2025, miliardi',
     ogTitle: 'Spese militari 2025: +2.9% a 2.900 miliardi',
     ogDescription: 'Il mondo ha destinato quasi 2.900 miliardi di dollari alle spese militari nel 2025, un dato in crescita per l\'undicesimo anno consecutivo',
-    canonicalPath: '/articoli-frontaliere/spese-militari-2025-aumento-2900-miliardi',
+    canonicalPath: '/articoli-frontaliere/spese-militari-2025-aumento-2900-miliardi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21536,7 +21536,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, karimova, bellinzona, accuse',
     ogTitle: 'Processo a Karimova a Bellinzona: accuse di riciclaggio e corruzione',
     ogDescription: 'Gulnara Karimova, figlia dell\'ex presidente uzbeko, è accusata di reati finanziari. Il processo si tiene a Bellinzona.',
-    canonicalPath: '/articoli-frontaliere/karimova-processo-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/karimova-processo-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21564,7 +21564,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, truffe, sentimentali, arresti, milioni',
     ogTitle: 'Truffe sentimentali in Svizzera: 10 arresti per milioni di franchi',
     ogDescription: 'Operazione su larga scala in 6 cantoni svizzeri smantella rete di truffe sentimentali legate al gruppo criminale nigeriano Black Axe.',
-    canonicalPath: '/articoli-frontaliere/truffe-sentimentali-zurigo-2026',
+    canonicalPath: '/articoli-frontaliere/truffe-sentimentali-zurigo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21592,7 +21592,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, esposizione, nazionale, segugi, svizzeri',
     ogTitle: 'Esposizione Nazionale Segugi Svizzeri Malvaglia 2026',
     ogDescription: 'Domenica 3 maggio 2026 a Malvaglia si terrà l\'Esposizione Nazionale dei Segugi Svizzeri, con competizioni e celebrazione delle razze autoctone.',
-    canonicalPath: '/articoli-frontaliere/esposizione-segughi-malvaglia-2026',
+    canonicalPath: '/articoli-frontaliere/esposizione-segughi-malvaglia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21620,7 +21620,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ragazza, 22enne, trovata, morta',
     ogTitle: 'Ragazza 22enne trovata morta in un campo: perquisita la casa di un amico',
     ogDescription: 'Il cadavere di una giovane di 22 anni è stato ritrovato in un campo a Cecima, in Oltrepò Pavese. Le indagini sono in corso.',
-    canonicalPath: '/articoli-frontaliere/ragazza-morta-campo-perquisita-casa-amico',
+    canonicalPath: '/articoli-frontaliere/ragazza-morta-campo-perquisita-casa-amico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21648,7 +21648,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, domestica, nuove, misure',
     ogTitle: 'Violenza domestica: nuove misure urgenti per contrastare il fenomeno',
     ogDescription: 'Il consigliere federale Beat Jans annuncia il numero nazionale 142 e altre iniziative per combattere la violenza domestica in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/violenza-domestica-misure-urgenti',
+    canonicalPath: '/articoli-frontaliere/violenza-domestica-misure-urgenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21676,7 +21676,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, robot, umanoidi, vincono, mezza',
     ogTitle: 'Robot umanoidi vincono maratona: progresso o fascinazione?',
     ogDescription: 'Un robot umanoide ha battuto il record mondiale di mezza maratona a Pechino, suscitando dibattiti sull\'utilità e l\'etica di queste tecnologie',
-    canonicalPath: '/articoli-frontaliere/robot-umanoidi-maratona-fascinazione',
+    canonicalPath: '/articoli-frontaliere/robot-umanoidi-maratona-fascinazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21704,7 +21704,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alla, tutto, quello, devi',
     ogTitle: 'Guida alla Svizzera per frontalieri del Ticino',
     ogDescription: 'Tutto quello che devi sapere per vivere e lavorare in Svizzera, con focus su Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/guida-svizzera-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/guida-svizzera-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21732,7 +21732,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, commesse, pubbliche, servizi, essenziali',
     ogTitle: 'Commesse pubbliche e servizi essenziali: procedure da snellire',
     ogDescription: 'Il Cantone Ticino punta a semplificare le procedure per le commesse pubbliche e i servizi essenziali, con l\'obiettivo di ridurre i ritardi e migliorare',
-    canonicalPath: '/articoli-frontaliere/commesse-pubbliche-servizi-essenziali-2026',
+    canonicalPath: '/articoli-frontaliere/commesse-pubbliche-servizi-essenziali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21760,7 +21760,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sente, criminali, denuncia, dell',
     ogTitle: 'Frontalieri in Ticino: \'Ci si sente come criminali\'',
     ogDescription: 'Denuncia dell\'antropologa Lederrey sui Centri federali d\'asilo in Ticino. La replica della SEM.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-sentono-criminali',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-sentono-criminali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21788,7 +21788,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, esubero, zone, edificabili, leventina',
     ogTitle: 'Esubero zone edificabili in Leventina: il Cantone risponda',
     ogDescription: 'Corrado Nastasi, presidente Acl, chiede chiarimenti sul sovradimensionamento delle zone edificabili in Leventina. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/esubero-leventina-zone-edificabili-2026',
+    canonicalPath: '/articoli-frontaliere/esubero-leventina-zone-edificabili-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21816,7 +21816,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, corsi, occasione, fare',
     ogTitle: 'Varese Corsi Net: opportunità per fare rete e sviluppare sinergie',
     ogDescription: 'Un incontro conviviale a Castronno per creare connessioni e sviluppare sinergie con la rete Varese Corsi. Conferma presenza entro il 29 aprile 2026.',
-    canonicalPath: '/articoli-frontaliere/varese-corsi-net-opportunita-rete-sinergie-2026',
+    canonicalPath: '/articoli-frontaliere/varese-corsi-net-opportunita-rete-sinergie-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21844,7 +21844,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, centri, responsabilità, sofferenza, richiedenti',
     ogTitle: 'Centri di responsabilità: la sofferenza dei richiedenti asilo',
     ogDescription: 'Analisi delle condizioni nei centri federali d\'asilo in Ticino e le scelte politiche dietro la gestione delle politiche migratorie.',
-    canonicalPath: '/articoli-frontaliere/centri-responsabilita-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/centri-responsabilita-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21872,7 +21872,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incontro, sem-cantone-comuni, annullato, cosa',
     ogTitle: 'Incontro SEM-Cantone-Comuni annullato: cosa cambia per i frontalieri',
     ogDescription: 'L\'incontro tra la SEM e i rappresentanti del Cantone Ticino e dei Comuni di Mendrisiotto è stato annullato. Berna attende i risultati di una sperimentazione.',
-    canonicalPath: '/articoli-frontaliere/incontro-sem-cantone-comuni-annullato',
+    canonicalPath: '/articoli-frontaliere/incontro-sem-cantone-comuni-annullato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21900,7 +21900,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, centrosinistra, varese, patto, città',
     ogTitle: 'Centrosinistra Varese: Patto per la città 2027-2032',
     ogDescription: 'Il centrosinistra di Varese lancia il \'Patto per Varese\', una coalizione aperta con candidato sindaco entro fine anno per le elezioni amministrative del 2027.',
-    canonicalPath: '/articoli-frontaliere/centrosinistra-varese-patto-2027',
+    canonicalPath: '/articoli-frontaliere/centrosinistra-varese-patto-2027/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21928,7 +21928,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, magadino, nuovo, parco, giochi',
     ogTitle: 'Magadino: nuovo parco giochi in riva al lago',
     ogDescription: 'Il Comune di Magadino sostituisce il parco giochi alle Bolle con una nuova area attrezzata in riva al lago, con un investimento di 70mila franchi.',
-    canonicalPath: '/articoli-frontaliere/magadino-parco-giochi-nuova-area-ludica',
+    canonicalPath: '/articoli-frontaliere/magadino-parco-giochi-nuova-area-ludica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21956,7 +21956,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, valle, verzasca, motociclista',
     ogTitle: 'Incidente in Valle Verzasca: motociclista grave',
     ogDescription: 'Un 23enne svizzero ha riportato serie ferite in un incidente in Valle Verzasca. La strada è stata temporaneamente chiusa.',
-    canonicalPath: '/articoli-frontaliere/incidente-valle-verzasca-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-valle-verzasca-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -21984,7 +21984,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, affettuosa, separazioni, tutelare, figli',
     ogTitle: 'Guida affettuosa per separazioni in Ticino: supporto giuridico ed economico',
     ogDescription: 'FaMo+ presenta una guida completa per affrontare la separazione con supporto multidisciplinare. Focus su bisogni giuridici, economici e psicologici.',
-    canonicalPath: '/articoli-frontaliere/guida-affettuosa-separazione-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/guida-affettuosa-separazione-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22012,7 +22012,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, tentato, omicidio, chiasso',
     ogTitle: 'Processo tentato omicidio Chiasso: aggressione con manubrio',
     ogDescription: 'Si apre il processo a carico di un cittadino eritreo accusato di aver aggredito la compagna con un manubrio da palestra a Chiasso.',
-    canonicalPath: '/articoli-frontaliere/processo-tentato-omicidio-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/processo-tentato-omicidio-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22040,7 +22040,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, cultura, 2030, costruire',
     ogTitle: 'Varese Cultura 2030: costruire un ecosistema culturale',
     ogDescription: 'Varese Cultura 2030 è un progetto per ridisegnare il futuro culturale della provincia di Varese, con un piano strategico condiviso e una piattaforma digitale di',
-    canonicalPath: '/articoli-frontaliere/varese-cultura-2030-ecosistema-culturale',
+    canonicalPath: '/articoli-frontaliere/varese-cultura-2030-ecosistema-culturale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22068,7 +22068,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, montana, nante, ricorso',
     ogTitle: 'Casa montana Nante, ricorso al Tram | Frontaliere Ticino',
     ogDescription: 'Il comitato referendario evidenzia le discrepanze del Municipio sui costi di ristrutturazione della casa montana Nante-Airolo',
-    canonicalPath: '/articoli-frontaliere/casa-montana-nante-ricorso-tram',
+    canonicalPath: '/articoli-frontaliere/casa-montana-nante-ricorso-tram/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22096,7 +22096,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, atleti, ticinesi, trionfano, arcegno',
     ogTitle: 'Atleti ticinesi trionfano ad Arcegno e Ascona',
     ogDescription: 'Mattia e Tobia Pezzati conquistano le prove di corsa d\'orientamento nel Ticino. Scopri di più sulle loro vittorie e le implicazioni per lo sport regionale.',
-    canonicalPath: '/articoli-frontaliere/atleti-ticinesi-vittoria-arcegno-ascona',
+    canonicalPath: '/articoli-frontaliere/atleti-ticinesi-vittoria-arcegno-ascona/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22124,7 +22124,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malnate, parte, lavoro, comitati',
     ogTitle: 'Malnate: parte il lavoro dei Comitati di Quartiere',
     ogDescription: 'I nuovi Comitati di Quartiere di Malnate iniziano il loro mandato con un bilancio partecipativo e progetti mirati per il miglioramento delle aree locali.',
-    canonicalPath: '/articoli-frontaliere/malnate-comitati-quartiere-bilancio-partecipativo',
+    canonicalPath: '/articoli-frontaliere/malnate-comitati-quartiere-bilancio-partecipativo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22152,7 +22152,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, montana, nante, valido',
     ogTitle: 'Casa montana di Nante, valido il voto del Cc di Monteceneri',
     ogDescription: 'Il Consiglio di Stato respinge il ricorso contro la risoluzione adottata dal Legislativo lo scorso giugno',
-    canonicalPath: '/articoli-frontaliere/casa-montana-nante-voto-validato',
+    canonicalPath: '/articoli-frontaliere/casa-montana-nante-voto-validato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22180,7 +22180,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, nelle, cantine, luganese',
     ogTitle: 'Furti nelle cantine del Luganese: condannato 44enne ticinese',
     ogDescription: 'Un 44enne ticinese è stato condannato per furti nelle cantine del Luganese per finanziare la dipendenza da cocaina. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/furti-cantine-luganese-condannato',
+    canonicalPath: '/articoli-frontaliere/furti-cantine-luganese-condannato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22208,7 +22208,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, corsi, corso, intermedio',
     ogTitle: 'Corso intermedio di public speaking a Varese',
     ogDescription: 'Varese Corsi propone un corso intermedio di public speaking per migliorare le tecniche di comunicazione e coinvolgimento del pubblico',
-    canonicalPath: '/articoli-frontaliere/varese-corsi-parlare-pubblico-2026',
+    canonicalPath: '/articoli-frontaliere/varese-corsi-parlare-pubblico-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22236,7 +22236,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, sondaggio, tamedia, futuro',
     ogTitle: 'Iniziativa UDC: sondaggio Tamedia sul futuro demografico della Svizzera',
     ogDescription: 'Il 52% degli intervistati sostiene l\'iniziativa UDC \'No a una Svizzera da 10 milioni\' secondo il sondaggio Tamedia del 22-23 aprile 2026',
-    canonicalPath: '/articoli-frontaliere/svizzera-10-milioni-votazione-ticino',
+    canonicalPath: '/articoli-frontaliere/svizzera-10-milioni-votazione-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22264,7 +22264,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, conferma, tassa, sanitaria',
     ogTitle: 'Lombardia conferma tassa sanitaria per frontalieri',
     ogDescription: 'La Lombardia ha respinto la mozione per abolire la tassa sanitaria per i frontalieri, ma promette sconti. Ecco le implicazioni per chi lavora in Svizzera',
-    canonicalPath: '/articoli-frontaliere/lombardia-tassa-sanitaria-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/lombardia-tassa-sanitaria-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22292,7 +22292,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, precompilato, online, aprile, cosa',
     ogTitle: '730 precompilato online dal 30 aprile: cosa cambia per i frontalieri',
     ogDescription: 'Dal 30 aprile 2026 il 730 precompilato è online. Ecco cosa sapere per non sbagliare, con dati e scadenze aggiornati.',
-    canonicalPath: '/articoli-frontaliere/730-precompilato-frontalieri-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/730-precompilato-frontalieri-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22320,7 +22320,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tosatura, pecore, riparazione, vestiti',
     ogTitle: 'Tosatura pecore e riparazione vestiti a Bellinzona',
     ogDescription: 'Evento di sostenibilità a Bellinzona il 9 maggio 2026 con laboratori di upcycling e tosatura pecore. Partecipa e scopri come ridurre l\'impatto ambientale.',
-    canonicalPath: '/articoli-frontaliere/tosatura-pecore-riparazione-vestiti-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/tosatura-pecore-riparazione-vestiti-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22348,7 +22348,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, geopolitica, sindacati, nuovi, equilibri',
     ogTitle: 'Geopolitica e vita quotidiana: il sindacato alla prova dei nuovi equilibri globali',
     ogDescription: 'Il consiglio generale della Fnp Cisl dei Laghi a Varese analizza l\'impatto delle tensioni internazionali su lavoro, pensioni e welfare.',
-    canonicalPath: '/articoli-frontaliere/geopolitica-sindacato-nuovi-equilibri-varese',
+    canonicalPath: '/articoli-frontaliere/geopolitica-sindacato-nuovi-equilibri-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22376,7 +22376,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ferrara, beko, cassinetta, servono',
     ogTitle: 'Ferrara (M5S): Beko a Cassinetta, servono risultati concreti',
     ogDescription: 'Dopo un anno, il Movimento 5 Stelle chiede una verifica sull\'impianto Beko a Cassinetta di Biandronno per valutare l\'impatto sull\'occupazione e lo sviluppo',
-    canonicalPath: '/articoli-frontaliere/ferrara-m5s-beko-cassinetta-verifica',
+    canonicalPath: '/articoli-frontaliere/ferrara-m5s-beko-cassinetta-verifica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22404,7 +22404,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, azienda, comasca, riduce, impianto',
     ogTitle: 'Azienda comasca riduce CO2 con impianto fotovoltaico: 25 tonnellate in meno',
     ogDescription: 'Un impianto fotovoltaico su un tetto industriale a Cucciago riduce le emissioni di 25,71 tonnellate di CO2 all\'anno, con benefici per la comunità locale.',
-    canonicalPath: '/articoli-frontaliere/azienda-comasca-fotovoltaico-25-tonnellate-co2',
+    canonicalPath: '/articoli-frontaliere/azienda-comasca-fotovoltaico-25-tonnellate-co2/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22432,7 +22432,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, città, fiore, balconi, como',
     ogTitle: 'Città in fiore: balconi a Como e Cernobbio omaggiano il Tricolore',
     ogDescription: 'Orticolario lancia l\'iniziativa \'Città in fiore\' per celebrare gli 80 anni della Repubblica Italiana, trasformando balconi e vetrine in opere d\'arte a tema',
-    canonicalPath: '/articoli-frontaliere/citta-fiore-orticolario-tricolore-2026',
+    canonicalPath: '/articoli-frontaliere/citta-fiore-orticolario-tricolore-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22460,7 +22460,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, friborg-gottéron, allo, spareggio, titolo',
     ogTitle: 'Friborg-Gottéron allo spareggio per il titolo di hockey',
     ogDescription: 'La squadra di hockey Friborg-Gottéron si gioca il titolo in uno spareggio cruciale. Tutti i dettagli sulla partita decisiva.',
-    canonicalPath: '/articoli-frontaliere/friborgogotteron-spareggio-titolo-hockey',
+    canonicalPath: '/articoli-frontaliere/friborgogotteron-spareggio-titolo-hockey/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22488,7 +22488,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elogio, verdi, rapinese, così',
     ogTitle: 'Elogio dei Verdi a Rapinese: così si curano gli alberi',
     ogDescription: 'Elisabetta Patelli elogia l\'amministrazione Rapinese per la cura degli alberi a Como, prima del voto di sfiducia all\'assessore al Verde.',
-    canonicalPath: '/articoli-frontaliere/como-verdi-elogio-rapinese-alberi',
+    canonicalPath: '/articoli-frontaliere/como-verdi-elogio-rapinese-alberi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22516,7 +22516,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, approvvigionamento, energetico, sicuro, attacco',
     ogTitle: 'Petrolio e gas in Svizzera, approvvigionamento sicuro nonostante il conflitto in Medio Oriente',
     ogDescription: 'L\'attacco all\'Iran e le rappresaglie hanno aumentato i prezzi di benzina e diesel anche in Svizzera, ma l\'approvvigionamento è sicuro.',
-    canonicalPath: '/articoli-frontaliere/petrolio-gas-svizzera-approvvigionamento-sicuro',
+    canonicalPath: '/articoli-frontaliere/petrolio-gas-svizzera-approvvigionamento-sicuro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22544,7 +22544,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, leyen, guerra, iran, costa',
     ogTitle: 'Von der Leyen: "Guerra in Iran costa all\'Ue 500 milioni al giorno per l\'energia"',
     ogDescription: 'La presidente della Commissione europea avverte che il conflitto in Medio Oriente sta causando gravi ripercussioni economiche, con un costo di 500 milioni al',
-    canonicalPath: '/articoli-frontaliere/von-der-leyen-ue-energia-500-milioni-giorno',
+    canonicalPath: '/articoli-frontaliere/von-der-leyen-ue-energia-500-milioni-giorno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22572,7 +22572,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sempre, cashless, vuole, sistema',
     ogTitle: 'Svizzera sempre più cashless, BNS vuole sistema più equo',
     ogDescription: 'Il contante scende al 30% delle transazioni, le app di pagamento raggiungono il 20%. La BNS avverte sui rischi di concentrazione.',
-    canonicalPath: '/articoli-frontaliere/svizzera-cashless-bns-sistema-equo',
+    canonicalPath: '/articoli-frontaliere/svizzera-cashless-bns-sistema-equo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22600,7 +22600,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dati, consultabili, digitale, 2028',
     ogTitle: 'AVS/AI: dati consultabili in digitale dal 2028',
     ogDescription: 'Via libera del Consiglio nazionale alla nuova legge sui sistemi d\'informazione delle assicurazioni sociali. Risparmi di 35 milioni di franchi',
-    canonicalPath: '/articoli-frontaliere/avs-dati-digitale-frontalieri',
+    canonicalPath: '/articoli-frontaliere/avs-dati-digitale-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22628,7 +22628,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scorte, carburante, approvvigionamento, garantito',
     ogTitle: 'Scorte carburante Svizzera: approvvigionamento garantito fino a maggio 2026',
     ogDescription: 'Le scorte svizzere di carburante sono destinate esclusivamente al fabbisogno nazionale. Approfondiamo la situazione attuale e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/scorte-carburante-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/scorte-carburante-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22656,7 +22656,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, elimina, duty, free',
     ogTitle: 'Swiss elimina il duty free dal 30 settembre 2026',
     ogDescription: 'Swiss International Air Lines ha annunciato l\'eliminazione del servizio duty free a bordo a partire dal 30 settembre 2026.',
-    canonicalPath: '/articoli-frontaliere/swiss-duty-free-addio-30-settembre',
+    canonicalPath: '/articoli-frontaliere/swiss-duty-free-addio-30-settembre/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22684,7 +22684,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carpooling, aziendale, guadagnano, fino',
     ogTitle: 'Carpooling aziendale: frontalieri guadagnano fino a 500 franchi',
     ogDescription: 'Scopri come il progetto MomòRide offre incentivi economici e opportunità di beneficenza per i frontalieri di Balerna, Chiasso e Novazzano',
-    canonicalPath: '/articoli-frontaliere/momoride-carpooling-frontalieri-benefici',
+    canonicalPath: '/articoli-frontaliere/momoride-carpooling-frontalieri-benefici/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22712,7 +22712,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, interrompe, vendite, duty-free',
     ogTitle: 'Swiss interrompe vendite duty-free a bordo',
     ogDescription: 'Dal 30 settembre 2026, i prodotti duty-free saranno disponibili solo online. Sconti fino al 50% da giugno.',
-    canonicalPath: '/articoli-frontaliere/swiss-duty-free-fine-vendite-bordo',
+    canonicalPath: '/articoli-frontaliere/swiss-duty-free-fine-vendite-bordo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22740,7 +22740,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, aarau, 18enne, frontaliero',
     ogTitle: 'Incidente ad Aarau: 18enne frontaliero ubriaco causa danni totali',
     ogDescription: 'Un giovane apprendista di 18 anni, residente in Ticino, ha causato un incidente stradale ad Aarau, provocando danni totali all\'auto.',
-    canonicalPath: '/articoli-frontaliere/incidente-aarau-18enne-frontaliere',
+    canonicalPath: '/articoli-frontaliere/incidente-aarau-18enne-frontaliere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22768,7 +22768,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gallo, vince, ultimo, minuto',
     ogTitle: 'San Gallo vince all\'ultimo minuto, festa rinviata per il Thun',
     ogDescription: 'Il San Gallo segna al 92° minuto e vince contro il Thun, mentre la festa del Thun viene rinviata per la seconda volta',
-    canonicalPath: '/articoli-frontaliere/san-gallo-vince-thun-ritardo-festa',
+    canonicalPath: '/articoli-frontaliere/san-gallo-vince-thun-ritardo-festa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22796,7 +22796,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hupac, cresce, rafforza, busto',
     ogTitle: 'Hupac cresce e rafforza Busto: utile positivo e nuovi collegamenti',
     ogDescription: 'Hupac chiude il 2025 con un utile di 3,5 milioni di franchi e volumi in aumento, nonostante le criticità della rete ferroviaria.',
-    canonicalPath: '/articoli-frontaliere/hupac-busto-utile-positivo-collegamenti',
+    canonicalPath: '/articoli-frontaliere/hupac-busto-utile-positivo-collegamenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22824,7 +22824,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hupac, chiude, 2025, utile',
     ogTitle: 'Hupac chiude 2025 con utile in calo ma bilancio positivo',
     ogDescription: 'Hupac chiude il 2025 con un utile netto di 3,5 milioni di franchi svizzeri, in calo rispetto ai 9,4 milioni del 2024, ma con volumi in crescita del 4,3%.',
-    canonicalPath: '/articoli-frontaliere/hupac-bilancio-positivo-2025',
+    canonicalPath: '/articoli-frontaliere/hupac-bilancio-positivo-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22852,7 +22852,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, infermieri, riduzione, orario, massimo',
     ogTitle: 'Infermieri, no a riduzione orario massimo settimanale',
     ogDescription: 'Il Consiglio nazionale ha bocciato la proposta di ridurre l\'orario massimo settimanale per infermieri e infermiere, mantenendolo a 50 ore.',
-    canonicalPath: '/articoli-frontaliere/infermieri-orario-lavoro-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/infermieri-orario-lavoro-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22880,7 +22880,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rumore, traffico, morti, anno',
     ogTitle: 'Rumore traffico Svizzera: 500 morti l\'anno',
     ogDescription: 'In Svizzera 500 morti l\'anno per il rumore del traffico. Le strategie del Canton Ticino per ridurlo: asfalto fonoassorbente e rumorometro.',
-    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-500-morti-anno',
+    canonicalPath: '/articoli-frontaliere/rumore-traffico-svizzera-500-morti-anno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22908,7 +22908,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parchi, vandalizzati, rompe, paga',
     ogTitle: 'Parchi vandalizzati in Ticino: chi rompe non paga',
     ogDescription: 'Bottiglie rotte nei parchi giochi di Azzate, Buguggiate e Daverio. I sindaci denunciano l\'inciviltà e chiedono il rispetto degli spazi pubblici.',
-    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-parchi-vandalismo-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-ticino-parchi-vandalismo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22936,7 +22936,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casse, malati, proposto, spacchettamento',
     ogTitle: 'Casse malati, proposto lo spacchettamento delle due iniziative',
     ogDescription: 'Fiorenzo Dadò propone di trattare separatamente le due iniziative sulle casse malati approvate in Ticino per evitare blocchi e offrire risposte rapide ai',
-    canonicalPath: '/articoli-frontaliere/spacchettamento-casse-malati-2026',
+    canonicalPath: '/articoli-frontaliere/spacchettamento-casse-malati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22964,7 +22964,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, athora, over, rimpiange, adesione',
     ogTitle: 'Athora Italia: 30% over 55 rimpiange adesione tardiva',
     ogDescription: 'Studio Athora Italia rivela che il 30% degli over 55 rimpiange di non aver aderito prima alla previdenza complementare. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/athora-italia-previdenza-complementare-2026',
+    canonicalPath: '/articoli-frontaliere/athora-italia-previdenza-complementare-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -22992,7 +22992,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, annuario, impresari, ticinesi, sicurezza',
     ogTitle: 'Annuario 2026 impresari ticinesi: sicurezza e trasparenza',
     ogDescription: 'Pubblicato l\'Annuario 2026 degli impresari ticinesi, strumento essenziale per committenti e progettisti. Scopri come orientarti tra le imprese edili',
-    canonicalPath: '/articoli-frontaliere/annuario-impresari-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/annuario-impresari-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23020,7 +23020,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, francisca, lucomagno, anni, turismo',
     ogTitle: 'Via Francisca del Lucomagno: 10 anni di turismo e connessioni',
     ogDescription: 'La Via Francisca del Lucomagno compie dieci anni, unendo Castiglione a Roma e celebrando il turismo e le relazioni tra territori',
-    canonicalPath: '/articoli-frontaliere/via-francisca-10-anni-turismo-ticino',
+    canonicalPath: '/articoli-frontaliere/via-francisca-10-anni-turismo-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23048,7 +23048,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scuola, viganello, gaza, gemellano',
     ogTitle: 'Scuola di Viganello e Gaza si gemellano: scambi culturali e mostre',
     ogDescription: 'Dal 27 aprile al 7 maggio, la scuola media di Viganello ospita una mostra dedicata al gemellaggio con la scuola Al-Salam di Gaza, con scambi di lettere e',
-    canonicalPath: '/articoli-frontaliere/scuola-viganello-gaza-gemellaggio-2026',
+    canonicalPath: '/articoli-frontaliere/scuola-viganello-gaza-gemellaggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23076,7 +23076,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libera, fascicolo, digitale, cosa',
     ogTitle: 'Via libera al fascicolo AVS/AI digitale: cosa cambia per i frontalieri',
     ogDescription: 'Il Consiglio nazionale approva la digitalizzazione dei fascicoli AVS/AI. Dal 2028 accesso online ai dati previdenziali per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/digitalizzazione-avs-ai-frontalieri',
+    canonicalPath: '/articoli-frontaliere/digitalizzazione-avs-ai-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23104,7 +23104,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, domenica, segreti, celti, parco',
     ogTitle: 'Celti a Tradate: evento gratuito al Parco Pineta',
     ogDescription: 'Scopri i segreti dei Celti al Parco Pineta di Tradate con l\'associazione Kaitorikes. Un evento gratuito per immergersi nella storia e nelle usanze del V secolo.',
-    canonicalPath: '/articoli-frontaliere/celti-tradate-parco-pineta-2026',
+    canonicalPath: '/articoli-frontaliere/celti-tradate-parco-pineta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23132,7 +23132,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, canapa, controllata, losanna, bilancio',
     ogTitle: 'Canapa controllata a Losanna: bilancio positivo',
     ogDescription: 'Il progetto pilota per la vendita controllata di cannabis a Losanna ha sottratto 2 milioni di franchi al mercato nero e creato nuovi posti di lavoro',
-    canonicalPath: '/articoli-frontaliere/canapa-losanna-bilancio-positivo-2026',
+    canonicalPath: '/articoli-frontaliere/canapa-losanna-bilancio-positivo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23160,7 +23160,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, jacky, marti, lascia, estival',
     ogTitle: 'Jacky Marti lascia Estival Jazz dopo 47 anni',
     ogDescription: 'Jacky Marti, fondatore e direttore artistico di Estival Jazz, si ritira dopo 47 anni. Presentato il programma della 46esima edizione con due serate a pagamento.',
-    canonicalPath: '/articoli-frontaliere/estival-jazz-marti-ritiro-2026',
+    canonicalPath: '/articoli-frontaliere/estival-jazz-marti-ritiro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23188,7 +23188,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, licata, schengen, euro, aprono',
     ogTitle: 'Licata: Schengen ed euro aprono nuove opportunità per Lombardia e Bulgaria',
     ogDescription: 'Giuseppe Licata, consigliere regionale di Forza Italia, sottolinea l\'importanza di rafforzare l\'asse Lombardia-Bulgaria dopo l\'ingresso del Paese in Schengen ed',
-    canonicalPath: '/articoli-frontaliere/licata-lombardia-bulgaria-opportunita',
+    canonicalPath: '/articoli-frontaliere/licata-lombardia-bulgaria-opportunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23216,7 +23216,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maroggia, posta, riorganizza, servizi',
     ogTitle: 'Maroggia, la Posta riorganizza i servizi dal 2026',
     ogDescription: 'Dal settembre 2026, Maroggia avrà un nuovo servizio postale a domicilio in attesa di una collaborazione con un commercio locale.',
-    canonicalPath: '/articoli-frontaliere/maroggia-servizi-postali-2026',
+    canonicalPath: '/articoli-frontaliere/maroggia-servizi-postali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23244,7 +23244,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gemellaggio, scuole, viganello, gaza',
     ogTitle: 'Gemellaggio scuole Viganello Gaza 2026',
     ogDescription: 'Scopri il gemellaggio tra la scuola di Viganello e la scuola Al-Salam di Gaza, sostenuta da Future in Peace. Mostra dal 27 aprile al 7 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/gemellaggio-scuole-viganello-gaza-2026',
+    canonicalPath: '/articoli-frontaliere/gemellaggio-scuole-viganello-gaza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23272,7 +23272,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, laurent, morel, nuovo, direttore',
     ogTitle: 'Laurent Morel nuovo Direttore Generale di EF Svizzera',
     ogDescription: 'EF Education First nomina Laurent Morel come nuovo Direttore Generale per rafforzare la presenza sul mercato svizzero.',
-    canonicalPath: '/articoli-frontaliere/laurent-morel-nominato-direttore-ef-svizzera',
+    canonicalPath: '/articoli-frontaliere/laurent-morel-nominato-direttore-ef-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23300,7 +23300,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gottardo, caduto, primo, diaframma',
     ogTitle: 'San Gottardo: caduto il primo diaframma a nord',
     ogDescription: 'Importante traguardo nel cantiere del secondo tubo della galleria stradale del San Gottardo. Caduto il primo diaframma sul lato nord.',
-    canonicalPath: '/articoli-frontaliere/san-gottardo-secondo-tubo-caduto-diaframma',
+    canonicalPath: '/articoli-frontaliere/san-gottardo-secondo-tubo-caduto-diaframma/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23328,7 +23328,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, antonello, venditti, lugano, prevendita',
     ogTitle: 'Antonello Venditti a Lugano: concerto del 10 luglio 2026',
     ogDescription: 'Antonello Venditti in concerto a Lugano il 10 luglio 2026 con i brani di \'Cuore\' e \'Notte prima degli esami\'. Posti solo a sedere, prevendita già attiva.',
-    canonicalPath: '/articoli-frontaliere/venditti-estival-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/venditti-estival-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23356,7 +23356,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, syndicom, approva, accordo, editori',
     ogTitle: 'Syndicom approva accordo con editori VSM per Ticino e Svizzera tedesca',
     ogDescription: 'Dopo 20 anni senza intesa, operatori media Ticino e Svizzera tedesca verso regolamentazione condizioni minime lavoro stampa',
-    canonicalPath: '/articoli-frontaliere/accordo-syndicom-vsm-2026',
+    canonicalPath: '/articoli-frontaliere/accordo-syndicom-vsm-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23384,7 +23384,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, philipp, plein, mendrisio, interrogazione',
     ogTitle: 'Philipp Plein a Mendrisio: interrogazione sullo stile controverso',
     ogDescription: 'Il marchio Philipp Plein trasferisce la sede legale a Mendrisio. Interrogazione sul suo stile controverso e impatto sulla città.',
-    canonicalPath: '/articoli-frontaliere/philipp-plein-mendrisio-interrogazione',
+    canonicalPath: '/articoli-frontaliere/philipp-plein-mendrisio-interrogazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23412,7 +23412,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mercatino, primavera, lugano, traffico',
     ogTitle: 'Mercatino di Primavera a Lugano: traffico chiuso sul lungolago',
     ogDescription: 'Venerdì 1 maggio il lungolago di Lugano si trasforma in un\'isola pedonale con bancarelle di artigianato e prodotti locali.',
-    canonicalPath: '/articoli-frontaliere/mercatino-primavera-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/mercatino-primavera-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23440,7 +23440,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, uniscono, forze, nella, ricerca',
     ogTitle: 'Italia e Svizzera uniscono le forze nella ricerca',
     ogDescription: 'La nona Giornata della ricerca italiana nel mondo celebrata a Plan-les-Ouates con focus su scienze della salute e innovazione',
-    canonicalPath: '/articoli-frontaliere/italia-svizzera-ricerca-2026',
+    canonicalPath: '/articoli-frontaliere/italia-svizzera-ricerca-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23468,7 +23468,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ricerca, italiana, focus, scienze',
     ogTitle: 'Ricerca italiana in Svizzera: focus su scienze della vita',
     ogDescription: 'Ginevra ospita la Giornata della ricerca italiana nel mondo, con focus su cooperazione scientifica italo-svizzera e opportunità per frontalieri',
-    canonicalPath: '/articoli-frontaliere/ricerca-italiana-ginevra-2026',
+    canonicalPath: '/articoli-frontaliere/ricerca-italiana-ginevra-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23496,7 +23496,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, programma, cooperazione, svizzera-serbia',
     ogTitle: 'Nuovo programma di cooperazione Svizzera-Serbia 2026-29',
     ogDescription: 'Il presidente Guy Parmelin presenta un nuovo programma di cooperazione con la Serbia, con focus su economia e innovazione.',
-    canonicalPath: '/articoli-frontaliere/svizzera-serbia-cooperazione-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-serbia-cooperazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23524,7 +23524,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, finanzia, politica, oltre, milioni',
     ogTitle: 'Chi finanzia la politica svizzera? Oltre 130 milioni in campagne',
     ogDescription: 'Dall’entrata in vigore delle regole sulla trasparenza, oltre 130 milioni di franchi sono stati investiti nelle campagne politiche svizzere.',
-    canonicalPath: '/articoli-frontaliere/chi-finanzia-politica-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/chi-finanzia-politica-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23552,7 +23552,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, accordo, italia-svizzera',
     ogTitle: 'Lago Maggiore: accordo Italia-Svizzera per più acqua in primavera',
     ogDescription: 'Il livello massimo del Lago Maggiore può ora raggiungere 1,40 metri per contrastare la crisi idrica. Scopri di più sull\'accordo Italia-Svizzera.',
-    canonicalPath: '/articoli-frontaliere/accordo-lago-maggiore-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/accordo-lago-maggiore-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23580,7 +23580,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, webinar, sull, azienda, strategia',
     ogTitle: 'Webinar sull\'AI in azienda: strategia e casi concreti',
     ogDescription: 'Il Gruppo Acinque organizza un webinar sull\'uso strategico dell\'AI in azienda, con un focus sui costi di integrazione e sulle opportunità di innovazione.',
-    canonicalPath: '/articoli-frontaliere/webinar-ai-azienda-strategia-casi-concreti',
+    canonicalPath: '/articoli-frontaliere/webinar-ai-azienda-strategia-casi-concreti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23608,7 +23608,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incontri, cambiamenti, climatici, rancio',
     ogTitle: 'Incontri su cambiamenti climatici a Rancio Valcuvia',
     ogDescription: 'La Comunità Montana Valli del Verbano organizza un ciclo di incontri su biodiversità e cambiamenti climatici da aprile a novembre 2026.',
-    canonicalPath: '/articoli-frontaliere/comunita-montana-valli-verbano-incontri-natura-cambia',
+    canonicalPath: '/articoli-frontaliere/comunita-montana-valli-verbano-incontri-natura-cambia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23636,7 +23636,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libera, innalzamento, lago, maggiore',
     ogTitle: 'Via libera all\'innalzamento del Lago Maggiore fino a 1,40 metri',
     ogDescription: 'Decisivo accordo per aumentare la capacità idrica del lago di 20-30 milioni di metri cubi',
-    canonicalPath: '/articoli-frontaliere/innalzamento-lago-maggiore-140-metri',
+    canonicalPath: '/articoli-frontaliere/innalzamento-lago-maggiore-140-metri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23664,7 +23664,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuove, guardie, svizzere, giureranno',
     ogTitle: '28 nuove guardie svizzere giureranno al Vaticano',
     ogDescription: 'La cerimonia si terrà il 6 maggio nel Cortile di S. Damaso del Palazzo Apostolico alla presenza del Papa e del presidente della Confederazione Guy Parmelin.',
-    canonicalPath: '/articoli-frontaliere/guardie-svizzere-giuramento-vaticano-2026',
+    canonicalPath: '/articoli-frontaliere/guardie-svizzere-giuramento-vaticano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23692,7 +23692,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, apprendistato, inespresso, varese, solo',
     ogTitle: 'Apprendistato inespresso a Varese: solo il 2,7% degli ingressi al lavoro',
     ogDescription: 'Il progetto Tutor Sapiens punta a rafforzare l\'apprendistato di terzo livello in provincia di Varese, con solo il 2,7% degli ingressi al lavoro nel 2025.',
-    canonicalPath: '/articoli-frontaliere/apprendistato-varese-2-7-ingressi-lavoro',
+    canonicalPath: '/articoli-frontaliere/apprendistato-varese-2-7-ingressi-lavoro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23720,7 +23720,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, casa, dell, hockey, aggiornamenti',
     ogTitle: 'Casa dell\'Hockey: novità e aggiornamenti dal Ticino',
     ogDescription: 'Scopri le ultime novità e aggiornamenti dal mondo dell\'hockey ticinese, con un focus sulle squadre di Lugano e Ambrì Piotta.',
-    canonicalPath: '/articoli-frontaliere/casa-hockey-lugano-ambri-2026',
+    canonicalPath: '/articoli-frontaliere/casa-hockey-lugano-ambri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23748,7 +23748,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, stop, vendita, duty-free',
     ogTitle: 'Swiss: stop vendita duty-free a bordo aerei',
     ogDescription: 'Swiss interrompe la vendita di prodotti duty-free a bordo degli aerei da fine settembre 2026. L\'offerta sarà disponibile solo online sul negozio Worldshop di',
-    canonicalPath: '/articoli-frontaliere/swiss-duty-free-cambia-vendite-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-duty-free-cambia-vendite-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23776,7 +23776,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tutor, sapiens, strumenti, apprendistato',
     ogTitle: 'Tutor Sapiens: strumenti per l’apprendistato di terzo livello',
     ogDescription: 'Camera di Commercio e Provincia di Varese presentano i risultati del percorso formativo Tutor Sapiens per favorire l’inserimento dei giovani talenti.',
-    canonicalPath: '/articoli-frontaliere/tutor-sapiens-apprendistato-terzo-livello',
+    canonicalPath: '/articoli-frontaliere/tutor-sapiens-apprendistato-terzo-livello/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23804,7 +23804,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tunnel, milioni, viabilità, lombardia',
     ogTitle: 'Tunnel Tonale: 16,5 milioni per la viabilità in Lombardia',
     ogDescription: 'Scopri il nuovo tunnel da 16,5 milioni al Passo del Tonale: dettagli, tempi e impatto sulla viabilità in Lombardia.',
-    canonicalPath: '/articoli-frontaliere/tunnel-tonale-viabilita-lombardia',
+    canonicalPath: '/articoli-frontaliere/tunnel-tonale-viabilita-lombardia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23832,7 +23832,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, torna, spring, giubiasco, sport',
     ogTitle: 'Spring Giubiasco 2026: sport e convivialità dal 13 al 17 maggio',
     ogDescription: 'Dal 13 al 17 maggio 2026, Giubiasco ospita la Spring Giubiasco con gare di corsa, ciclismo, musica e gastronomia per tutte le età.',
-    canonicalPath: '/articoli-frontaliere/spring-giubiasco-sport-convivialita-2026',
+    canonicalPath: '/articoli-frontaliere/spring-giubiasco-sport-convivialita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23860,7 +23860,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carnago, fratelli, attacca, pendolarismo',
     ogTitle: 'Carnago: Fratelli d\'Italia attacca il pendolarismo di Forza Italia',
     ogDescription: 'Analisi dei costi del consigliere di minoranza Fausto Benzi: oltre 2.400 euro di previsione di spesa fino a fine mandato',
-    canonicalPath: '/articoli-frontaliere/carnago-forza-italia-pendolarismo',
+    canonicalPath: '/articoli-frontaliere/carnago-forza-italia-pendolarismo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23888,7 +23888,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, usa-svizzera, nuove, tensioni, prodotti',
     ogTitle: 'USA-Svizzera: nuove tensioni su prodotti biologici e dazi',
     ogDescription: 'Washington critica Berna per le norme agricole e il predominio di Coop e Migros. Nuovi dazi al 10% fino al 2027',
-    canonicalPath: '/articoli-frontaliere/usa-svizzera-frizioni-commerciali-2026',
+    canonicalPath: '/articoli-frontaliere/usa-svizzera-frizioni-commerciali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23916,7 +23916,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, terremoto, controllato, gottardo, cosa',
     ogTitle: 'Terremoto controllato nel Gottardo: implicazioni per i frontalieri',
     ogDescription: 'Ricercatori provocano terremoto controllato nel massiccio del Gottardo. Cosa sappiamo e quali sono le implicazioni per i frontalieri in Ticino.',
-    canonicalPath: '/articoli-frontaliere/terremoto-gottardo-frontalieri',
+    canonicalPath: '/articoli-frontaliere/terremoto-gottardo-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23944,7 +23944,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, benzina, record, annuale, mesi',
     ogTitle: 'Benzina in Svizzera a record annuale: +13% in 3 mesi',
     ogDescription: 'Il prezzo della benzina in Svizzera ha raggiunto il record annuale a 1,90 CHF/litro. Il diesel è a 2,17 CHF/litro.',
-    canonicalPath: '/articoli-frontaliere/benzina-record-annuale-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/benzina-record-annuale-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -23972,7 +23972,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giovane, gambizzato, colpi, arma',
     ogTitle: 'Giovane gambizzato con tre colpi d\'arma da fuoco a Como',
     ogDescription: 'Un 20enne è stato ferito alla gamba con tre colpi d\'arma da fuoco alla periferia di Como. Gli inquirenti indagano sui motivi del gesto.',
-    canonicalPath: '/articoli-frontaliere/giovane-gambizzato-como-2026',
+    canonicalPath: '/articoli-frontaliere/giovane-gambizzato-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24000,7 +24000,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, andré, wyss, nuovo, presidente',
     ogTitle: 'André Wyss nuovo presidente FFS: innovazione e stabilità',
     ogDescription: 'André Wyss è il nuovo presidente delle FFS. Scopri le implicazioni per i frontalieri e le nuove opportunità offerte dalle Ferrovie federali svizzere.',
-    canonicalPath: '/articoli-frontaliere/andre-wyss-nuovo-presidente-ffs',
+    canonicalPath: '/articoli-frontaliere/andre-wyss-nuovo-presidente-ffs/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24028,7 +24028,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moncucco, risultati, positivi, 2025',
     ogTitle: 'Moncucco: risultati positivi nel 2025',
     ogDescription: 'Aumento pazienti, fatturato e utile per il gruppo ospedaliero Moncucco. Preoccupazioni per l\'invecchiamento demografico.',
-    canonicalPath: '/articoli-frontaliere/moncucco-risultati-positivi-2025',
+    canonicalPath: '/articoli-frontaliere/moncucco-risultati-positivi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24056,7 +24056,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, verso, conciliabilità, vita-lavoro',
     ogTitle: 'Bellinzona verso conciliabilità vita-lavoro per dipendenti',
     ogDescription: 'Modifica al regolamento per promuovere equilibrio tra vita privata e professionale. Priorità per benessere e attrattività come datore di lavoro.',
-    canonicalPath: '/articoli-frontaliere/bellinzona-datore-lavoro-conciliabilita',
+    canonicalPath: '/articoli-frontaliere/bellinzona-datore-lavoro-conciliabilita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24084,7 +24084,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, anni, conti, positivo',
     ogTitle: 'Mendrisio: 4 anni di conti in positivo',
     ogDescription: 'Mendrisio chiude il 2025 con un avanzo di 0,8 milioni di franchi, segnando il quarto anno consecutivo di risultati positivi',
-    canonicalPath: '/articoli-frontaliere/mendrisio-conti-positivi-2025',
+    canonicalPath: '/articoli-frontaliere/mendrisio-conti-positivi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24112,7 +24112,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, criminalità, organizzata, arresto, funzionario',
     ogTitle: 'Criminalità organizzata in Svizzera: arresto funzionario fedpol',
     ogDescription: 'Un duro colpo per fedpol: arrestato un funzionario per sospetta corruzione. La criminalità organizzata è ben radicata in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/criminalita-organizzata-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/criminalita-organizzata-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24140,7 +24140,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stazioni, sciistiche, ticinesi, criticità',
     ogTitle: 'Stazioni sciistiche ticinesi: criticità e riforma contributi',
     ogDescription: 'Interrogazione parlamentare per rivedere i finanziamenti alle stazioni sciistiche ticinesi, con 5,6 milioni per la manutenzione fino al 2028.',
-    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-contributi-2026',
+    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-contributi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24168,7 +24168,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, karin, keller-sutter, scontro, lobbismo',
     ogTitle: 'UBS e Karin Keller-Sutter: scontro sul lobbismo',
     ogDescription: 'UBS e Karin Keller-Sutter si scontrano sul lobbismo. Ermotti nega pressioni, Matter lo definisce ridicolo. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/ubs-keller-sutter-lobbismo-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-keller-sutter-lobbismo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24196,7 +24196,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, daverio, pazienti, spostano, gazzada',
     ogTitle: 'Daverio: i pazienti si spostano a Gazzada, cambia l\'assistenza sanitaria',
     ogDescription: 'I circa 400 cittadini di Daverio senza medico di base verranno trasferiti alla Casa di Comunità di Gazzada per un\'assistenza più integrata.',
-    canonicalPath: '/articoli-frontaliere/daverio-gazzada-assistenza-medica-2026',
+    canonicalPath: '/articoli-frontaliere/daverio-gazzada-assistenza-medica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24224,7 +24224,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trivella, raggiunge, zona, faglia',
     ogTitle: 'Trivella raggiunge zona di faglia al San Gottardo',
     ogDescription: 'La fresa meccanica \'Alessandra\' ha completato un traguardo cruciale nella costruzione della seconda galleria del tunnel stradale del San Gottardo.',
-    canonicalPath: '/articoli-frontaliere/trivella-san-gottardo-zona-faglia',
+    canonicalPath: '/articoli-frontaliere/trivella-san-gottardo-zona-faglia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24252,7 +24252,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, ambulatori, medici, temporanei',
     ogTitle: 'Varese: ambulatori medici temporanei per oltre 5000 cittadini',
     ogDescription: 'Dal 1° maggio 2026, quattro ambulatori medici temporanei in Varese servono oltre 5000 cittadini senza medico curante.',
-    canonicalPath: '/articoli-frontaliere/ambulatori-medici-temporanei-varese-2026',
+    canonicalPath: '/articoli-frontaliere/ambulatori-medici-temporanei-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24280,7 +24280,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, copernicus, europa, temperature, sopra',
     ogTitle: 'Copernicus: 95% Europa con temperature sopra media nel 2025',
     ogDescription: 'Ondate di calore record in Scandinavia, ghiacciai in calo e incendi boschivi estesi. Ecco i dati chiave del rapporto Copernicus 2025.',
-    canonicalPath: '/articoli-frontaliere/copernicus-clima-2025-europa',
+    canonicalPath: '/articoli-frontaliere/copernicus-clima-2025-europa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24308,7 +24308,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, credinvest, bank, cresce, utili',
     ogTitle: 'Credinvest Bank cresce: utili in aumento e spinta su innovazione',
     ogDescription: 'Credinvest Bank chiude il 2025 con ricavi a 22,80 milioni e utile lordo a 4,93 milioni, investendo in tecnologia e talenti.',
-    canonicalPath: '/articoli-frontaliere/credinvest-bank-crescita-2026',
+    canonicalPath: '/articoli-frontaliere/credinvest-bank-crescita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24336,7 +24336,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, costi, aggiuntivi, approvata',
     ogTitle: 'Riforma frontalieri: costi aggiuntivi per la Svizzera?',
     ogDescription: 'Approvata la riforma UE sull\'assicurazione disoccupazione per i frontalieri. Cosa cambia per la Svizzera?',
-    canonicalPath: '/articoli-frontaliere/riforma-frontalieri-costi-svizzera',
+    canonicalPath: '/articoli-frontaliere/riforma-frontalieri-costi-svizzera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24364,7 +24364,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, conciliabilità, vita-lavoro, mozione',
     ogTitle: 'Conciliabilità vita-lavoro Bellinzona 2026',
     ogDescription: 'La mozione per inserire il principio di conciliabilità vita-lavoro nel Rod di Bellinzona e le implicazioni per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/conciliabilita-vita-lavoro-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/conciliabilita-vita-lavoro-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24392,7 +24392,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiasso, anni, carcere, richiesti',
     ogTitle: 'Chiasso: 15 anni di carcere richiesti per tentativo di omicidio',
     ogDescription: 'Il processo a un 34enne per aver aggredito la compagna con attrezzi ginnici il 20 gennaio 2024',
-    canonicalPath: '/articoli-frontaliere/chiasso-assassinio-mancato-15-anni-carcere',
+    canonicalPath: '/articoli-frontaliere/chiasso-assassinio-mancato-15-anni-carcere/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24420,7 +24420,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lite, alla, dogana, ponte',
     ogTitle: 'Lite alla dogana di Ponte Chiasso: un ferito, un contuso',
     ogDescription: 'Un incidente alla dogana di Ponte Chiasso ha coinvolto due persone, lasciando un ferito e un contuso. Ecco cosa è successo e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lite-dogana-ponte-chiasso-ferito-contuso',
+    canonicalPath: '/articoli-frontaliere/lite-dogana-ponte-chiasso-ferito-contuso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24448,7 +24448,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intesa, sanpaolo, premia, imprese',
     ogTitle: 'Intesa Sanpaolo premia 10 imprese vincenti: tra queste Lati di Vedano e Pizval di Somma',
     ogDescription: 'Varese prima in Lombardia nel 2025 per crescita di esportazioni. Le due aziende premiate per eccellenza in plastica e moda.',
-    canonicalPath: '/articoli-frontaliere/intesa-sanpaolo-premia-10-imprese-vincenti',
+    canonicalPath: '/articoli-frontaliere/intesa-sanpaolo-premia-10-imprese-vincenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24476,7 +24476,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pillola, giorno, dopo, senza',
     ogTitle: 'Pillola giorno dopo senza consulenza, il Nazionale dice sì',
     ogDescription: 'Il Consiglio nazionale approva mozione per declassare contraccettivi d\'emergenza, rendendoli accessibili senza colloquio obbligatorio.',
-    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-consulenza-nazionale',
+    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-consulenza-nazionale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24504,7 +24504,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sindaci, italiani, contro, innalzamento',
     ogTitle: 'Sindaci italiani contro l\'innalzamento del lago Maggiore',
     ogDescription: 'I sindaci di Verbania, Baveno e Cannobio criticano la decisione di aumentare il livello massimo del lago Maggiore a 1,40 metri.',
-    canonicalPath: '/articoli-frontaliere/sindaci-verbania-baveno-cannobio-opposizione',
+    canonicalPath: '/articoli-frontaliere/sindaci-verbania-baveno-cannobio-opposizione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24532,7 +24532,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, chiude, 2025, quarto',
     ogTitle: 'Mendrisio chiude il 2025 con il quarto bilancio positivo',
     ogDescription: 'Mendrisio annuncia un quarto risultato finanziario positivo consecutivo nel 2025, nonostante le incertezze geopolitiche.',
-    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025',
+    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24560,7 +24560,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tenero, inaugurato, terzo, frigo',
     ogTitle: 'Tenero, terzo frigo anti-spreco inaugurato',
     ogDescription: 'Il 28 aprile 2026 è stato inaugurato a Tenero, in Ticino, il terzo frigo pubblico anti-spreco alimentare promosso dall\'associazione Madame Frigo.',
-    canonicalPath: '/articoli-frontaliere/terzo-frigo-tenero-anti-spreco',
+    canonicalPath: '/articoli-frontaliere/terzo-frigo-tenero-anti-spreco/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24588,7 +24588,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, pagherà, stato, dove',
     ogTitle: 'Frontalieri, la disoccupazione la pagherà lo Stato dove lavoravano',
     ogDescription: 'Riforma UE approvata: cambiamenti significativi per i frontalieri in Svizzera. Ecco cosa cambia e cosa fare',
-    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-stato-lavoro',
+    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-stato-lavoro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24616,7 +24616,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, estate, openjobmetis, offre, oltre',
     ogTitle: 'Estate 2026: Openjobmetis offre oltre 2000 opportunità lavorative in Italia',
     ogDescription: 'Openjobmetis registra oltre 2000 posizioni aperte in Italia per l\'estate 2026, con forte domanda nel turismo e nella produzione',
-    canonicalPath: '/articoli-frontaliere/lavoro-openjobmetis-2026-opportunita',
+    canonicalPath: '/articoli-frontaliere/lavoro-openjobmetis-2026-opportunita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24644,7 +24644,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, openjobmetis, materia, sportello, ascolto',
     ogTitle: 'Openjobmetis a Materia: sportello di ascolto e orientamento ogni giovedì',
     ogDescription: 'Ogni giovedì pomeriggio, lo sportello Openjobmetis a Materia offre supporto e orientamento per chi cerca lavoro nella provincia di Varese.',
-    canonicalPath: '/articoli-frontaliere/openjobmetis-materia-castronno-2026',
+    canonicalPath: '/articoli-frontaliere/openjobmetis-materia-castronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24672,7 +24672,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, variante, vaiolo, scimmie',
     ogTitle: 'Nuova variante vaiolo scimmie predominante in Svizzera',
     ogDescription: 'La nuova variante di vaiolo delle scimmie è diventata predominante in Svizzera con 32 casi segnalati dall\'inizio dell\'anno, di cui 19 di clade Ib.',
-    canonicalPath: '/articoli-frontaliere/vaiolo-delle-scimmie-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/vaiolo-delle-scimmie-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24700,7 +24700,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maroggia, posta, domicilio, 2024',
     ogTitle: 'Maroggia, la Posta a domicilio dal 2024',
     ogDescription: 'Dal settembre 2024, i residenti di Maroggia potranno usufruire del servizio postale a domicilio in attesa della nuova filiale prevista per il 2027.',
-    canonicalPath: '/articoli-frontaliere/maroggia-postale-domestico-2024',
+    canonicalPath: '/articoli-frontaliere/maroggia-postale-domestico-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24728,7 +24728,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, convegno, milano, sulla, cooperazione',
     ogTitle: 'Convegno Milano mafia Italia Svizzera 2026',
     ogDescription: 'Convegno a Milano sulla cooperazione Italia-Svizzera contro la mafia con Fiorenza Bergomi, giudice del Tribunale penale federale',
-    canonicalPath: '/articoli-frontaliere/convegno-milano-mafia-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/convegno-milano-mafia-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24756,7 +24756,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gruppo, moncucco, 2025, 120mila',
     ogTitle: 'Gruppo Moncucco: 2025 con 120mila ospedalizzazioni e 187 milioni di fatturato',
     ogDescription: 'Il Gruppo Moncucco chiude il 2025 con 120mila ospedalizzazioni e un fatturato di 187 milioni, puntando sulla formazione del personale.',
-    canonicalPath: '/articoli-frontaliere/gruppo-moncucco-2025-risultati',
+    canonicalPath: '/articoli-frontaliere/gruppo-moncucco-2025-risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24784,7 +24784,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, distretto, benessere, ombra, campo',
     ogTitle: 'Distretto del benessere: 2% dei contribuenti ha il 15% del reddito',
     ogDescription: 'Scopri come il 2% dei contribuenti detiene il 15% del reddito nei comuni della collina varesina. Analisi e implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/distretto-benessere-campo-fiori-2026',
+    canonicalPath: '/articoli-frontaliere/distretto-benessere-campo-fiori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24812,7 +24812,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ospedale, circolo, varese, chiusure',
     ogTitle: 'Chiusure Ospedale Circolo Varese 1° maggio e San Vittore 2026',
     ogDescription: 'Modifiche agli orari dei servizi sanitari per il ponte del 1° maggio e la festività di San Vittore a Varese. Scopri cosa cambia e come organizzarti.',
-    canonicalPath: '/articoli-frontaliere/chiusure-ospedale-circolo-varese-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-ospedale-circolo-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24840,7 +24840,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, overtourism, lucerna, grindelwald, collasso',
     ogTitle: 'Overtourism in Svizzera: Lucerna e Grindelwald al collasso',
     ogDescription: 'Lucerna supera Venezia in pernottamenti turistici. Iniziativa per bloccare nuovi hotel e restrizioni su Airbnb in Ticino, Zurigo, Lucerna e Ginevra.',
-    canonicalPath: '/articoli-frontaliere/svizzera-overtourism-lucerna-grindelwald',
+    canonicalPath: '/articoli-frontaliere/svizzera-overtourism-lucerna-grindelwald/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24868,7 +24868,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, alluvione, lavizzara, approvato, piano',
     ogTitle: 'Alluvione Lavizzara: piano zone pericolo approvato',
     ogDescription: 'Il Consiglio di Stato ticinese ha approvato il piano delle zone di pericolo per Lavizzara dopo l\'alluvione del 29-30 giugno 2024',
-    canonicalPath: '/articoli-frontaliere/alluvione-lavizzara-piano-pericoli-approvato',
+    canonicalPath: '/articoli-frontaliere/alluvione-lavizzara-piano-pericoli-approvato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24896,7 +24896,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bedretto, microterremoti, indotti, studiare',
     ogTitle: 'Bedretto Lab: microterremoti indotti per studiare le faglie',
     ogDescription: 'Ricercatori del Politecnico di Zurigo indotti microterremoti in Val Bedretto per studiare il comportamento delle faglie',
-    canonicalPath: '/articoli-frontaliere/bedretto-lab-microterremoti-ricerca',
+    canonicalPath: '/articoli-frontaliere/bedretto-lab-microterremoti-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24924,7 +24924,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, micro, terremoto, controllato, successo',
     ogTitle: 'Micro terremoto controllato in Ticino: un successo per il test',
     ogDescription: 'Ricercatori provocano un sisma nel massiccio del Gottardo. Scosse registrate ma non percepibili in superficie.',
-    canonicalPath: '/articoli-frontaliere/microterremoto-ticino-successo-test',
+    canonicalPath: '/articoli-frontaliere/microterremoto-ticino-successo-test/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24952,7 +24952,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, famiglie, lugano, condivisione',
     ogTitle: 'Festa delle famiglie a Lugano: condivisione e inclusione',
     ogDescription: 'Domenica 26 aprile 2026, il Rotary Club Lugano-Lago e l\'Associazione Amélie hanno organizzato una giornata di condivisione e inclusione per famiglie.',
-    canonicalPath: '/articoli-frontaliere/festa-famiglie-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/festa-famiglie-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -24980,7 +24980,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stop, milioni, alle, casse',
     ogTitle: 'Stop ai milioni delle casse malati ai club sportivi: Il Nazionale approva la mozione di Quadri',
     ogDescription: 'Il Consiglio nazionale approva la mozione di Lorenzo Quadri per limitare le sponsorizzazioni delle casse malati ai grandi club sportivi.',
-    canonicalPath: '/articoli-frontaliere/stop-milioni-casse-malati-club-sportivi',
+    canonicalPath: '/articoli-frontaliere/stop-milioni-casse-malati-club-sportivi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25008,7 +25008,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, delusi, dalla, guadagna, poco',
     ogTitle: 'Delusi dalla Svizzera: chi guadagna poco si sente abbandonato',
     ogDescription: 'Un sondaggio rivela che oltre la metà della popolazione svizzera considera il sistema ingiusto, con chi guadagna meno che si sente trattato peggio',
-    canonicalPath: '/articoli-frontaliere/delusi-svizzera-frontalieri-abbandonati',
+    canonicalPath: '/articoli-frontaliere/delusi-svizzera-frontalieri-abbandonati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25036,7 +25036,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, separazioni, rete, supporto, genitori',
     ogTitle: 'Separazioni in Ticino: rete di supporto e guida per genitori',
     ogDescription: 'FaMo+ celebra 40 anni con una nuova guida per famiglie in fase di separazione. Approccio di rete e tavola rotonda a Bellinzona.',
-    canonicalPath: '/articoli-frontaliere/separazioni-ticino-famiglie-monoparentali',
+    canonicalPath: '/articoli-frontaliere/separazioni-ticino-famiglie-monoparentali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25064,7 +25064,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dichiarazione, precompilata, disponibile, oggi',
     ogTitle: 'Dichiarazione precompilata 2026: disponibile da oggi',
     ogDescription: 'Dal 30 aprile 2026 è disponibile la dichiarazione precompilata 2026 per tutti i contribuenti italiani. Ecco cosa cambia.',
-    canonicalPath: '/articoli-frontaliere/dichiarazione-precompilata-2026-disponibile',
+    canonicalPath: '/articoli-frontaliere/dichiarazione-precompilata-2026-disponibile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25092,7 +25092,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gruppo, moncucco, utile, raddoppiato',
     ogTitle: 'Gruppo Moncucco: utile raddoppiato e stipendi aumentati',
     ogDescription: 'Il Gruppo ospedaliero Moncucco chiude il 2025 con un utile di 5,3 milioni di franchi e adeguamenti salariali per i dipendenti',
-    canonicalPath: '/articoli-frontaliere/moncucco-utile-raddoppiato-2026',
+    canonicalPath: '/articoli-frontaliere/moncucco-utile-raddoppiato-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25120,7 +25120,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, domenica, natura, spazio, centro',
     ogTitle: 'Una domenica tra natura e spazio al Centro Didattico Scientifico di Tradate',
     ogDescription: 'Domenica 31 maggio 2026, dalle 14.30 alle 18.00, il Centro Didattico Scientifico di Tradate offre attività tra natura e spazio.',
-    canonicalPath: '/articoli-frontaliere/domenica-natura-spazio-tradate-2026',
+    canonicalPath: '/articoli-frontaliere/domenica-natura-spazio-tradate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25148,7 +25148,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, libera, innalzamento',
     ogTitle: 'Lago Maggiore, via libera all’innalzamento: 20-30 milioni di metri cubi in più',
     ogDescription: 'La decisione aumenterà la disponibilità di acqua di 20-30 milioni di metri cubi. Accordo Italia-Svizzera per l’innalzamento di 15 cm.',
-    canonicalPath: '/articoli-frontaliere/lago-maggiore-innalzamento-2026',
+    canonicalPath: '/articoli-frontaliere/lago-maggiore-innalzamento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25176,7 +25176,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, criticano, regole, duopolio, migros-coop',
     ogTitle: 'USA criticano Svizzera per regole bio e duopolio Migros-Coop',
     ogDescription: 'Norme agricole e predominio di Coop e Migros al centro delle critiche statunitensi. Deficit commerciale in calo, ma tensioni persistono.',
-    canonicalPath: '/articoli-frontaliere/usa-critica-svizzera-bio-duopolio',
+    canonicalPath: '/articoli-frontaliere/usa-critica-svizzera-bio-duopolio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25204,7 +25204,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bollette, novità, consumatori, giugno',
     ogTitle: 'Dl Bollette: novità per i consumatori dal 19 giugno 2026',
     ogDescription: 'Novità per i consumatori: dal 19 giugno 2026 nuove regole su telemarketing e contratti luce-gas. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/dl-bollette-novita-consumatori-2026',
+    canonicalPath: '/articoli-frontaliere/dl-bollette-novita-consumatori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25232,7 +25232,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bonus, sicurezza, ottenere, scopri',
     ogTitle: 'Bonus sicurezza 2026: spese detraibili e come ottenere fino al 50%',
     ogDescription: 'Scopri quali spese per la sicurezza domestica sono detraibili nel 2026 e come evitare errori comuni per ottenere fino al 50% di detrazione.',
-    canonicalPath: '/articoli-frontaliere/bonus-sicurezza-2026-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/bonus-sicurezza-2026-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25260,7 +25260,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, palma, muralto, rinnova, punta',
     ogTitle: 'La Palma di Muralto rinnovata e aperta tutto l\'anno',
     ogDescription: 'L\'hotel La Palma di Muralto ha completato un rinnovamento da 12,7 milioni di franchi e cambia strategia, restando aperto tutto l\'anno.',
-    canonicalPath: '/articoli-frontaliere/palma-muralto-ristrutturazione-strategia-2024',
+    canonicalPath: '/articoli-frontaliere/palma-muralto-ristrutturazione-strategia-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25288,7 +25288,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, insubria, olona, proteggere, ambiente',
     ogTitle: 'GEV Insubria Olona: protezione ambientale in Ticino',
     ogDescription: 'Scopri come le Guardie Ecologiche Volontarie Insubria Olona proteggono l’ambiente in Ticino e offrono opportunità di volontariato',
-    canonicalPath: '/articoli-frontaliere/gev-ticino-ambiente-2026',
+    canonicalPath: '/articoli-frontaliere/gev-ticino-ambiente-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25316,7 +25316,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siccità, lombardia, mancano, riserve',
     ogTitle: 'Siccità in Lombardia: mancano il 37% delle riserve idriche',
     ogDescription: 'Regione Lombardia chiede un uso contenuto dell\'acqua. Accordo tra Piemonte, Lombardia e Canton Ticino per aumentare la disponibilità del Lago Maggiore.',
-    canonicalPath: '/articoli-frontaliere/siccita-lombardia-riserve-idriche-2026',
+    canonicalPath: '/articoli-frontaliere/siccita-lombardia-riserve-idriche-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25344,7 +25344,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, powell, tassi, invariati',
     ogTitle: 'Fed: l\'addio di Powell a tassi invariati',
     ogDescription: 'Jerome Powell lascia la Federal Reserve rivendicando l\'indipendenza dell\'istituzione, mentre i tassi restano tra il 3,50% e il 3,75%.',
-    canonicalPath: '/articoli-frontaliere/fed-powell-addio-tassi-invariati',
+    canonicalPath: '/articoli-frontaliere/fed-powell-addio-tassi-invariati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25372,7 +25372,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, utile, oltre, miliardi, istituto',
     ogTitle: 'UBS, utile oltre i 3 miliardi nel 2026',
     ogDescription: 'UBS registra un utile netto di 3,04 miliardi di dollari nel primo trimestre 2026, superando le aspettative e confermando la propria leadership nel settore',
-    canonicalPath: '/articoli-frontaliere/ubs-utile-3-miliardi-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-utile-3-miliardi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25400,7 +25400,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, borse, europee, calo, timori',
     ogTitle: 'Borse europee in calo, timori dalle trimestrali',
     ogDescription: 'Analisi delle flessioni delle Borse europee e impatti per i frontalieri. Zurigo ansima ma poi fa quasi pari.',
-    canonicalPath: '/articoli-frontaliere/borse-europee-zurigo-trimestrali',
+    canonicalPath: '/articoli-frontaliere/borse-europee-zurigo-trimestrali/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25428,7 +25428,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, supsi, nomina, nuovi, professori',
     ogTitle: 'SUPSI nomina 20 nuovi professori e professoresse',
     ogDescription: 'La cerimonia di conferimento si è tenuta a Mendrisio il 28 aprile 2026. Assegnate anche 12 nomine a senior.',
-    canonicalPath: '/articoli-frontaliere/supsi-20-nuovi-professori-2026',
+    canonicalPath: '/articoli-frontaliere/supsi-20-nuovi-professori-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25456,7 +25456,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, morto, italiano, incidente, e-bike',
     ogTitle: 'Incidente e-bike nel Canton Bern: morto italiano',
     ogDescription: 'Tragico incidente a Bätterkinden, nel Canton Bern, il 28 aprile 2026: un uomo di 60 anni ha perso la vita in seguito a una caduta dalla bici elettrica.',
-    canonicalPath: '/articoli-frontaliere/italian-e-bike-tragedy-bern',
+    canonicalPath: '/articoli-frontaliere/italian-e-bike-tragedy-bern/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25484,7 +25484,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violenza, sessuale, conseguenze, sono',
     ogTitle: 'Violenza sessuale, le conseguenze sono tante e durature',
     ogDescription: 'Un nuovo studio romando ha dimostrato che le conseguenze di un\'aggressione sessuale sono indelebili e persistono per mesi con alti tassi di depressione, ansia e',
-    canonicalPath: '/articoli-frontaliere/violenza-sessuale-conseguenze-ticino',
+    canonicalPath: '/articoli-frontaliere/violenza-sessuale-conseguenze-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25512,7 +25512,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mendrisio, chiude, 2025, avanzo',
     ogTitle: 'Mendrisio chiude 2025 con avanzo di 800mila franchi',
     ogDescription: 'Per il quarto anno consecutivo, Mendrisio presenta un bilancio positivo con un avanzo di 800mila franchi, nonostante un preventivo in rosso.',
-    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025-analisi',
+    canonicalPath: '/articoli-frontaliere/mendrisio-bilancio-positivo-2025-analisi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25540,7 +25540,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, utile, record, grazie, integrazione',
     ogTitle: 'UBS: utile record grazie all\'integrazione di Credit Suisse',
     ogDescription: 'UBS chiude il primo trimestre 2026 con un utile netto di 3,04 miliardi di dollari, grazie all\'integrazione di Credit Suisse',
-    canonicalPath: '/articoli-frontaliere/ubs-credit-suisse-integrazione-risultati-2026',
+    canonicalPath: '/articoli-frontaliere/ubs-credit-suisse-integrazione-risultati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25568,7 +25568,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, diventa, digitale, visita',
     ogTitle: 'Varese diventa digitale: visita la città in 3D con un click',
     ogDescription: 'Scopri come esplorare Varese in 3D grazie al nuovo portale Varesedigitale.it. Visita la città virtualmente e scopri i suoi luoghi simbolo.',
-    canonicalPath: '/articoli-frontaliere/varese-digitale-3d-visita',
+    canonicalPath: '/articoli-frontaliere/varese-digitale-3d-visita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25596,7 +25596,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, detiene, ricchezza, scoperte',
     ogTitle: 'Varese: il 2% detiene il 15% della ricchezza',
     ogDescription: 'Scoperte sulla concentrazione di ricchezza nel Varesotto e decisioni su Lago Maggiore per l\'estate 2026',
-    canonicalPath: '/articoli-frontaliere/varesotto-paperoni-lago-maggiore-2026',
+    canonicalPath: '/articoli-frontaliere/varesotto-paperoni-lago-maggiore-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25624,7 +25624,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lombardia, finanzia, ricerca, insubria',
     ogTitle: 'Regione Lombardia finanzia l\'Università dell\'Insubria con 4,4 milioni per la ricerca',
     ogDescription: 'Regione Lombardia ha assegnato 4,4 milioni di euro all\'Università dell\'Insubria per nuove infrastrutture di ricerca a Varese, Como e Busto Arsizio.',
-    canonicalPath: '/articoli-frontaliere/regione-lombardia-4-4-milioni-insubria',
+    canonicalPath: '/articoli-frontaliere/regione-lombardia-4-4-milioni-insubria/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25652,7 +25652,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luve, sigla, accordo, milioni',
     ogTitle: 'LUVE sigla accordo da 100 milioni con hyperscaler globale',
     ogDescription: 'LUVE, azienda varesina specializzata in sistemi di raffreddamento industriale, firma accordo da oltre 100 milioni con hyperscaler globale per data center ad',
-    canonicalPath: '/articoli-frontaliere/luve-hyperscaler-ai-accordo-100-milioni',
+    canonicalPath: '/articoli-frontaliere/luve-hyperscaler-ai-accordo-100-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25680,7 +25680,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, social, media, lavoro, cosa',
     ogTitle: 'Social media e lavoro: cosa evitare e cosa postare',
     ogDescription: 'Un esperto spiega quali contenuti sui social possono compromettere la carriera dei frontalieri in Ticino',
-    canonicalPath: '/articoli-frontaliere/social-media-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/social-media-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25708,7 +25708,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, stazioni, sciistiche, prossimo, credito',
     ogTitle: 'Stazioni sciistiche Ticino: più dati per il prossimo credito',
     ogDescription: 'Interrogazione parlamentare chiede bilancio stagionale e nuovi criteri per valutare le stazioni sciistiche ticinesi',
-    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-credito-dati-2026',
+    canonicalPath: '/articoli-frontaliere/stazioni-sciistiche-ticino-credito-dati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25736,7 +25736,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lavori, notturni, clemente, maraini',
     ogTitle: 'Lavori notturni su via Clemente Maraini a Lugano',
     ogDescription: 'Da domenica 3 maggio a venerdì 22 maggio, lavori notturni su via Clemente Maraini a Lugano per estensione e potenziamento delle sottostrutture AIL.',
-    canonicalPath: '/articoli-frontaliere/lavori-notturni-via-clemente-maraini',
+    canonicalPath: '/articoli-frontaliere/lavori-notturni-via-clemente-maraini/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25764,7 +25764,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parcheggi, viabilità, ospedale, circolo',
     ogTitle: 'Parcheggi e viabilità all’Ospedale di Circolo: confronto costruttivo',
     ogDescription: 'Incontro tra Asst Sette Laghi, Comune di Varese e sindacati per migliorare parcheggi e viabilità all’Ospedale di Circolo.',
-    canonicalPath: '/articoli-frontaliere/parcheggi-ospedale-circolo-varese-2026',
+    canonicalPath: '/articoli-frontaliere/parcheggi-ospedale-circolo-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25792,7 +25792,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mani, pulite, vite, salvate',
     ogTitle: 'Mani pulite, vite salvate: l\'iniziativa di ASST Sette Laghi',
     ogDescription: 'Test pratici per l\'igiene delle mani negli ospedali e case di comunità del Canton Ticino il 5 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/mani-pulite-vite-salvate-asst-iniziativa',
+    canonicalPath: '/articoli-frontaliere/mani-pulite-vite-salvate-asst-iniziativa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25820,7 +25820,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, manager, insubria, rasizza, battioni',
     ogTitle: 'Manager all’Insubria: Rasizza e Battioni in cattedra il 4 maggio',
     ogDescription: 'Rosario Rasizza e Stefano Battioni incontrano gli studenti dell’Università dell’Insubria per discutere di gestione d’impresa e cambiamenti tecnologici.',
-    canonicalPath: '/articoli-frontaliere/manager-insubria-rasizza-battioni-4-maggio',
+    canonicalPath: '/articoli-frontaliere/manager-insubria-rasizza-battioni-4-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25848,7 +25848,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, convegno, liuc, etica, responsabilità',
     ogTitle: 'Convegno LIUC: etica e responsabilità nel lavoro',
     ogDescription: 'Venerdì 8 maggio convegno alla LIUC su etica e responsabilità nel lavoro con UCID. Intervengono il card. Angelo Bagnasco e il vescovo di Lodi.',
-    canonicalPath: '/articoli-frontaliere/lavoro-etico-convegno-liuc-ucid',
+    canonicalPath: '/articoli-frontaliere/lavoro-etico-convegno-liuc-ucid/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25876,7 +25876,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, eremo, monastero, lago',
     ogTitle: '1° maggio tra Eremo e Monastero sul Lago Maggiore e in Valle Olona',
     ogDescription: 'Visite guidate e picnic per la Festa dei Lavoratori all\'Eremo di Santa Caterina del Sasso e al Monastero di Torba il 1° maggio 2026',
-    canonicalPath: '/articoli-frontaliere/1maggio-eremo-monastero-legge-varese',
+    canonicalPath: '/articoli-frontaliere/1maggio-eremo-monastero-legge-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25904,7 +25904,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vergiate, colora, torna, color',
     ogTitle: 'Color Run Vergiate 2026: corsa non competitiva per tutte le età',
     ogDescription: 'Scopri la Color Run di Vergiate 2026, una corsa non competitiva di 4 km aperta a tutte le età. Iscrizioni aperte fino al 10 maggio.',
-    canonicalPath: '/articoli-frontaliere/vergiate-color-run-2026-non-competitiva',
+    canonicalPath: '/articoli-frontaliere/vergiate-color-run-2026-non-competitiva/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25932,7 +25932,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gemellaggio, ticino-gaza, mostra, viganello',
     ogTitle: 'Mostra gemellaggio studenti Ticino Gaza | Frontaliere Ticino',
     ogDescription: 'Scopri la mostra sul gemellaggio tra studenti ticinesi e di Gaza a Viganello. Un progetto di Future in Peace per l\'educazione ai diritti umani.',
-    canonicalPath: '/articoli-frontaliere/due-scuole-due-mondi-un-solo-legame',
+    canonicalPath: '/articoli-frontaliere/due-scuole-due-mondi-un-solo-legame/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25960,7 +25960,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, camion, incastrato, grantola, strada',
     ogTitle: 'Camion incastrato a Grantola: strada bloccata in attesa dell\'autogru',
     ogDescription: 'I vigili del fuoco intervengono per liberare un camion bloccato su un tornante a Grantola, causando interruzioni al traffico.',
-    canonicalPath: '/articoli-frontaliere/camion-incastrato-grantola-2026',
+    canonicalPath: '/articoli-frontaliere/camion-incastrato-grantola-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -25988,7 +25988,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vedano, olona, sindaco, denuncia',
     ogTitle: 'Vedano Olona, sindaco scrive ad ASST: «Servizio medici instabile, servono garanzie»',
     ogDescription: 'Il sindaco di Vedano Olona, Sergio Mina, denuncia l\'instabilità del servizio di medicina generale e chiede interventi urgenti per garantire assistenza ai',
-    canonicalPath: '/articoli-frontaliere/vedano-olona-medici-servizio-instabile',
+    canonicalPath: '/articoli-frontaliere/vedano-olona-medici-servizio-instabile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26016,7 +26016,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elmec, innovation, summit, cybersecurity',
     ogTitle: 'Elmec Innovation Summit 2026: AI, Cybersecurity e Infrastrutture IT a Brunello',
     ogDescription: 'Il 14 maggio 2026 torna a Brunello l\'Elmec Innovation Summit, un evento dedicato all\'innovazione IT con workshop, esperienze tecnologiche e confronto su AI',
-    canonicalPath: '/articoli-frontaliere/elmec-innovation-summit-brunello-2026',
+    canonicalPath: '/articoli-frontaliere/elmec-innovation-summit-brunello-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26044,7 +26044,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scuola, austriaca, protagonista, plan',
     ogTitle: 'Scuola austriaca protagonista al Plan ₿ Forum di Lugano',
     ogDescription: 'Saifedean Ammous, Rahim Taghizadegan e Knut Svanholm hanno discusso le radici intellettuali di Bitcoin al Plan ₿ Forum di Lugano.',
-    canonicalPath: '/articoli-frontaliere/scuola-austriaca-bitcoin-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/scuola-austriaca-bitcoin-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26072,7 +26072,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, domus, donato, autonomia, sicura',
     ogTitle: 'Domus San Donato: autonomia sicura per la terza età',
     ogDescription: 'Nuovi appartamenti protetti per anziani a Domus San Donato, realizzati nell\'ex stabile delle Suore. Libertà e servizi assistiti',
-    canonicalPath: '/articoli-frontaliere/domus-san-donato-autonomia-terza-eta',
+    canonicalPath: '/articoli-frontaliere/domus-san-donato-autonomia-terza-eta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26100,7 +26100,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, moda, sostenibile, storie, rinascita',
     ogTitle: 'Moda sostenibile e storie di rinascita a Varese',
     ogDescription: 'Scopri come studenti e donne oncologiche hanno unito le forze per una sfilata di moda sostenibile a Varese, con abiti riciclati e messaggi di resilienza.',
-    canonicalPath: '/articoli-frontaliere/moda-sostenibile-varese-2026',
+    canonicalPath: '/articoli-frontaliere/moda-sostenibile-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26128,7 +26128,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sciopero, fame, varese, battaglia',
     ogTitle: 'Sciopero della fame a Varese: la battaglia di Timoc per un terreno conteso',
     ogDescription: 'Timoc, 70 anni, protesta davanti alla caserma dei Carabinieri per accedere a documenti bloccati nella sua abitazione.',
-    canonicalPath: '/articoli-frontaliere/sciopero-fame-timoc-terreno-conteso',
+    canonicalPath: '/articoli-frontaliere/sciopero-fame-timoc-terreno-conteso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26156,7 +26156,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ispra, successo, secondo, pranzo',
     ogTitle: 'Ispra: successo al secondo pranzo solidale in oratorio',
     ogDescription: 'Grande partecipazione a Ispra per il pranzo solidale organizzato dalla Comunità pastorale e dall\'Associazione Volontari ispresi.',
-    canonicalPath: '/articoli-frontaliere/ispra-pranzo-solidale-oratorio-2026',
+    canonicalPath: '/articoli-frontaliere/ispra-pranzo-solidale-oratorio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26184,7 +26184,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, malpensa, milioni, contanti, sequestrati',
     ogTitle: 'Malpensa: 6 milioni in contanti sequestrati in 3 mesi',
     ogDescription: 'Controlli della Guardia di Finanza e Dogane rivelano violazioni per oltre 6 milioni di euro in contanti non dichiarati.',
-    canonicalPath: '/articoli-frontaliere/malpensa-contanti-sequestri-370mila-euro',
+    canonicalPath: '/articoli-frontaliere/malpensa-contanti-sequestri-370mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26212,7 +26212,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grigioni, stretta, permessi, dopo',
     ogTitle: 'Grigioni, stretta sui permessi dopo infiltrazione mafiosa',
     ogDescription: 'Nuove regole per i permessi di dimora in Grigioni dopo arresti legati alla camorra e \'ndrangheta a Roveredo',
-    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-mafia-roveredo',
+    canonicalPath: '/articoli-frontaliere/grigioni-stretta-permessi-mafia-roveredo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26240,7 +26240,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, intenso, ritardi, oltre',
     ogTitle: 'A2: traffico intenso e ritardi oltre l\'ora',
     ogDescription: 'Restringimento a una corsia sulla A2 causa ritardi fino a 100 minuti tra Chiasso e Grancia. Polizia presente per controlli.',
-    canonicalPath: '/articoli-frontaliere/restringimento-a2-ritardi-2026',
+    canonicalPath: '/articoli-frontaliere/restringimento-a2-ritardi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26268,7 +26268,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, repressione, cinese, criticano, berna',
     ogTitle: 'Repressione cinese in Svizzera: ONG criticano Berna',
     ogDescription: 'ONG denunciano la mancanza di misure concrete per proteggere tibetani e uiguri in Svizzera nonostante il riconoscimento della repressione transnazionale',
-    canonicalPath: '/articoli-frontaliere/repressione-cinese-svizzera-ong-critiche',
+    canonicalPath: '/articoli-frontaliere/repressione-cinese-svizzera-ong-critiche/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26296,7 +26296,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, verso, lugano, traffico, intenso',
     ogTitle: 'Traffico intenso A2 Lugano: ritardi fino a 1h30',
     ogDescription: 'Traffico intenso sull’A2 verso Lugano, con ritardi fino a un’ora e trenta. Scopri le cause e le alternative per evitare i disagi.',
-    canonicalPath: '/articoli-frontaliere/traffico-intenso-a2-lugano-ritardi',
+    canonicalPath: '/articoli-frontaliere/traffico-intenso-a2-lugano-ritardi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26324,7 +26324,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, traffico, congestionato, sull, fino',
     ogTitle: 'Traffico congestionato sull\'A2: fino a un\'ora e quaranta di ritardi',
     ogDescription: 'Mattinata da bollino rosso sull\'autostrada A2 tra Chiasso e Lugano, con ritardi fino a 104 minuti a causa di un veicolo in avaria.',
-    canonicalPath: '/articoli-frontaliere/ritardi-a2-tra-chiasso-lugano',
+    canonicalPath: '/articoli-frontaliere/ritardi-a2-tra-chiasso-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26352,7 +26352,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tilt, sola, corsia, ritardi',
     ogTitle: 'A2 in tilt: una sola corsia, ritardi oltre l\'ora',
     ogDescription: 'Traffico intenso tra Chiasso e Grancia, coda da Chiasso/Balerna, ritardi fino a 1h40. Polizia controlla la carreggiata. Cosa fare per evitare ritardi.',
-    canonicalPath: '/articoli-frontaliere/a2-corsia-ritardi-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/a2-corsia-ritardi-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26380,7 +26380,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aquanexa, visita, acquedotto, alfa',
     ogTitle: 'Aquanexa visita acquedotto Alfa a Laveno Mombello',
     ogDescription: 'Una delegazione di Aquanexa ha visitato l\'acquedotto IX Fontane di Laveno Mombello per il progetto Aquamind, esplorando tecnologie avanzate per la gestione del',
-    canonicalPath: '/articoli-frontaliere/aquanexa-visita-acquedotto-alfa-laveno',
+    canonicalPath: '/articoli-frontaliere/aquanexa-visita-acquedotto-alfa-laveno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26408,7 +26408,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bollino, rosso, sull, chiasso',
     ogTitle: 'Bollino rosso sull\'A2 tra Chiasso e Lugano',
     ogDescription: 'Ritardi fino a un\'ora e quaranta minuti sull\'A2 in direzione nord tra Chiasso e Lugano nord a causa di un veicolo in avaria.',
-    canonicalPath: '/articoli-frontaliere/bollino-rosso-a2-chiasso-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/bollino-rosso-a2-chiasso-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26436,7 +26436,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 715mila, euro, pnrr, autonomia',
     ogTitle: '715mila euro PNRR per autonomia disabili Medio Olona',
     ogDescription: 'Scopri come il progetto finanziato dal PNRR sta promuovendo l\'autonomia delle persone con disabilità nel Medio Olona con appartamenti attrezzati e tirocini',
-    canonicalPath: '/articoli-frontaliere/pnrr-disabilita-medio-olona-715mila-euro',
+    canonicalPath: '/articoli-frontaliere/pnrr-disabilita-medio-olona-715mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26464,7 +26464,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, problemi, informatici, casellario, giudiziale',
     ogTitle: 'Problemi informatici al casellario giudiziale di Varese, richieste solo cartacee',
     ogDescription: 'Il sito per prenotare il ritiro del casellario giudiziale di Varese è in tilt. Si accettano solo richieste cartacee con documento d\'identità.',
-    canonicalPath: '/articoli-frontaliere/problemi-casellario-giudiziale-varese-2026',
+    canonicalPath: '/articoli-frontaliere/problemi-casellario-giudiziale-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26492,7 +26492,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, indaga, accordi, illeciti',
     ogTitle: 'COMCO indaga su accordi illeciti nella pubblicità online',
     ogDescription: 'La Commissione della concorrenza svizzera apre due inchieste sui motori di ricerca per presunti accordi illeciti tra aziende di viaggi e casinò online.',
-    canonicalPath: '/articoli-frontaliere/comco-inchieste-pubblicita-online-2026',
+    canonicalPath: '/articoli-frontaliere/comco-inchieste-pubblicita-online-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26520,7 +26520,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, glaciazione, demografica, allarme, futuro',
     ogTitle: 'Glaciazione demografica in Ticino: allarme per il futuro',
     ogDescription: 'Basso tasso di natalità e invecchiamento della popolazione preoccupano il Canton Ticino. Interrogazione parlamentare per una strategia cantonale.',
-    canonicalPath: '/articoli-frontaliere/glaciazione-demografica-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/glaciazione-demografica-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26548,7 +26548,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tilt, ritardi, oltre, chiasso',
     ogTitle: 'A2 in tilt: ritardi oltre l\'ora tra Chiasso e Lugano',
     ogDescription: 'Mattinata da incubo sulla A2 in direzione nord con ritardi fino a un\'ora e quaranta minuti. Incidenti e controlli della polizia complicano il traffico',
-    canonicalPath: '/articoli-frontaliere/a2-traffico-ritardi-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/a2-traffico-ritardi-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26576,7 +26576,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, roberto, grassi, nuovo, presidente',
     ogTitle: 'Roberto Grassi nuovo presidente LIUC Castellanza',
     ogDescription: 'Roberto Grassi è il nuovo presidente della LIUC di Castellanza. Scopri le implicazioni per i frontalieri e le nuove opportunità formative.',
-    canonicalPath: '/articoli-frontaliere/roberto-grassi-nuovo-presidente-liuc-castellanza',
+    canonicalPath: '/articoli-frontaliere/roberto-grassi-nuovo-presidente-liuc-castellanza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26604,7 +26604,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, assunzioni, nuove, sfide, mercato',
     ogTitle: 'IA e assunzioni: le nuove sfide per il mercato ticinese',
     ogDescription: 'L\'uso dell\'IA nella selezione del personale solleva dubbi su discriminazioni e bias. Analisi dei rischi per i candidati e le aziende in Ticino.',
-    canonicalPath: '/articoli-frontaliere/ia-selezione-personale-rischi-ticino',
+    canonicalPath: '/articoli-frontaliere/ia-selezione-personale-rischi-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26632,7 +26632,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, denatalità, deputato, isabella, chiede',
     ogTitle: 'Denatalità in Ticino: il deputato Isabella chiede azioni concrete',
     ogDescription: 'Claudio Isabella del Centro critica la mancanza di misure efficaci contro il calo delle nascite nel Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/denatalita-ticino-azione-urgente-2026',
+    canonicalPath: '/articoli-frontaliere/denatalita-ticino-azione-urgente-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26660,7 +26660,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beko, cassinetta, superata, crisi',
     ogTitle: 'Beko Cassinetta: superata la crisi, ora contano i risultati',
     ogDescription: 'A un anno dall\'accordo che ha salvato lo stabilimento Beko di Cassinetta, emergono i primi risultati e le sfide future',
-    canonicalPath: '/articoli-frontaliere/beko-cassinetta-risultati-2026',
+    canonicalPath: '/articoli-frontaliere/beko-cassinetta-risultati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26688,7 +26688,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, samantha, bourgoin, nuova, presidente',
     ogTitle: 'Samantha Bourgoin è la nuova presidente di Apisuisse',
     ogDescription: 'La deputata dei Verdi è stata eletta il 18 aprile. Apisuisse rappresenta circa 18\'000 apicoltori in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/samantha-bourgoin-apisuisse-2026',
+    canonicalPath: '/articoli-frontaliere/samantha-bourgoin-apisuisse-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26716,7 +26716,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, birdwatching, monteviasco, escursione, riscoprire',
     ogTitle: 'Birdwatching a Monteviasco: escursione per riscoprire la natura',
     ogDescription: 'Domenica escursione tra sentieri e boschi alla scoperta dell’avifauna locale. Colombo (LIPU): “Un’esperienza per osservare, ascoltare e imparare a proteggere',
-    canonicalPath: '/articoli-frontaliere/birdwatching-monteviasco-2026',
+    canonicalPath: '/articoli-frontaliere/birdwatching-monteviasco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26744,7 +26744,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gallarate, bilancio, cassani, opere',
     ogTitle: 'Gallarate: Bilancio Cassani 2026, opere ma scontro sul debito',
     ogDescription: 'Approvato il decimo bilancio dell\'era Cassani a Gallarate con 92 milioni di entrate e 16 milioni di saldo di cassa. Scopri i dettagli.',
-    canonicalPath: '/articoli-frontaliere/gallarate-bilancio-cassani-2026',
+    canonicalPath: '/articoli-frontaliere/gallarate-bilancio-cassani-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26772,7 +26772,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, greco, antico, certificato, lombardia',
     ogTitle: 'Greco antico certificato in Lombardia: prima volta in Italia',
     ogDescription: 'Dal 6 al 7 maggio 2026, studenti dei licei classici lombardi potranno ottenere una certificazione ufficiale in greco antico.',
-    canonicalPath: '/articoli-frontaliere/certificazione-greco-antico-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/certificazione-greco-antico-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26800,7 +26800,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rokj, serata, solidale, maggio',
     ogTitle: 'ROKJ Ticino: serata solidale il 6 maggio a Lugano',
     ogDescription: 'Partecipa alla serata solidale di ROKJ Ticino il 6 maggio a Lugano con Sebalter per sostenere bambini e giovani in difficoltà.',
-    canonicalPath: '/articoli-frontaliere/rokj-lugano-serata-solidale',
+    canonicalPath: '/articoli-frontaliere/rokj-lugano-serata-solidale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26828,7 +26828,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fogliaro, festeggia, giuseppe, lavoratore',
     ogTitle: 'Fogliaro festeggia San Giuseppe lavoratore con messa, gastronomia e mercatino',
     ogDescription: 'Il rione di Fogliaro a Varese celebra San Giuseppe lavoratore con una giornata di eventi tra messa solenne, bancarelle e gastronomia locale',
-    canonicalPath: '/articoli-frontaliere/varese-fogliaro-san-giuseppe-2026',
+    canonicalPath: '/articoli-frontaliere/varese-fogliaro-san-giuseppe-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26856,7 +26856,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, ticinese, conclusa, fase',
     ogTitle: 'Polizia ticinese: conclusa la fase progettuale',
     ogDescription: 'Il Consiglio di Stato ha deciso di non proseguire con il progetto «Polizia ticinese» dopo la consultazione. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticinese-fase-progettuale-conclusa',
+    canonicalPath: '/articoli-frontaliere/polizia-ticinese-fase-progettuale-conclusa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26884,7 +26884,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, melide, chiusure, notturne, lavori',
     ogTitle: 'A2 Melide: chiusure notturne per lavori alla pavimentazione',
     ogDescription: 'Da domenica 3 maggio a venerdì 8 maggio 2026, l\'uscita di Melide sarà chiusa ogni notte dalle 21.30 alle 5.00 per lavori di manutenzione.',
-    canonicalPath: '/articoli-frontaliere/a2-melide-chiusure-notturne-lavori',
+    canonicalPath: '/articoli-frontaliere/a2-melide-chiusure-notturne-lavori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26912,7 +26912,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, violare, sanzioni, reato, imprese',
     ogTitle: 'Violare le sanzioni UE è reato: le imprese italiane corrono ai ripari',
     ogDescription: 'Dal 24 gennaio 2026, violare le sanzioni UE può comportare pene fino a 6 anni di reclusione per le persone fisiche e sanzioni fino al 5% del fatturato per le',
-    canonicalPath: '/articoli-frontaliere/sanzioni-ue-imprese-italiane-2026',
+    canonicalPath: '/articoli-frontaliere/sanzioni-ue-imprese-italiane-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26940,7 +26940,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, lavoro, disponibile, mancano',
     ogTitle: 'Varese: lavoro disponibile ma mancano i lavoratori specializzati',
     ogDescription: 'Occupazione in crescita ma difficoltà a trovare profili tecnici e scientifici. Ecco i dati del 2025',
-    canonicalPath: '/articoli-frontaliere/varese-lavoro-specializzato-paradosso-2026',
+    canonicalPath: '/articoli-frontaliere/varese-lavoro-specializzato-paradosso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26968,7 +26968,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, domanda, lavoro, alta',
     ogTitle: 'Varese: domanda di lavoro alta ma competenze sempre più difficili da trovare',
     ogDescription: 'Il mercato del lavoro di Varese mostra un paradosso: alta domanda ma crescente difficoltà nel reperire competenze specializzate, con tassi di occupazione al 70%',
-    canonicalPath: '/articoli-frontaliere/varese-competenze-lavoro-2026',
+    canonicalPath: '/articoli-frontaliere/varese-competenze-lavoro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -26996,7 +26996,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, economia, ripresa, prospettive, modeste',
     ogTitle: 'Economia svizzera in ripresa, ma prospettive modeste',
     ogDescription: 'Il barometro del KOF segna 97,9 punti in aprile, con segnali misti dai vari settori economici.',
-    canonicalPath: '/articoli-frontaliere/kof-barometro-ripresa-economica-2026',
+    canonicalPath: '/articoli-frontaliere/kof-barometro-ripresa-economica-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27024,7 +27024,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, parità, paura, solo, paesi',
     ogTitle: 'La parità che fa paura ai frontalieri del Ticino',
     ogDescription: 'Solo 28 Paesi al mondo sono guidati da una donna. In Ticino, la parità di genere è ancora un obiettivo lontano. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/parita-paura-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/parita-paura-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27052,7 +27052,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, presunti, maltrattamenti, asilo, nido',
     ogTitle: 'Presunti maltrattamenti in asilo nido a Chiasso',
     ogDescription: 'Tre denunce per presunti maltrattamenti in un asilo nido privato di Chiasso. Accertamenti in corso da parte di polizia e Ministero pubblico.',
-    canonicalPath: '/articoli-frontaliere/presunti-maltrattamenti-asilo-chiasso',
+    canonicalPath: '/articoli-frontaliere/presunti-maltrattamenti-asilo-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27080,7 +27080,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, commercio, dettaglio, primo, trimestre',
     ogTitle: 'Commercio al dettaglio in Ticino: +2,7% nel primo trimestre 2026',
     ogDescription: 'Il commercio al dettaglio in Ticino registra un aumento dei ricavi del 2,7% nel primo trimestre 2026, con il segmento alimentare in crescita del 3,2%.',
-    canonicalPath: '/articoli-frontaliere/commercio-dettaglio-ricavi-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/commercio-dettaglio-ricavi-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27108,7 +27108,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, chiude, 2025, rosso',
     ogTitle: 'Bellinzona chiude 2025 con un rosso più contenuto',
     ogDescription: 'Il consuntivo 2025 della Città di Bellinzona mostra un disavanzo di 2,7 milioni, molto inferiore ai 13,4 milioni previsti.',
-    canonicalPath: '/articoli-frontaliere/contibellinzona-2025-risultati',
+    canonicalPath: '/articoli-frontaliere/contibellinzona-2025-risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27136,7 +27136,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inadempiente, crediti, sanitari, quadri',
     ogTitle: 'Italia inadempiente sui crediti sanitari: Quadri chiede chiarezza',
     ogDescription: 'Il consigliere nazionale Lorenzo Quadri interroga il Consiglio federale sui ritardi italiani nei rimborsi sanitari alla Svizzera',
-    canonicalPath: '/articoli-frontaliere/italia-inadempiente-crediti-sanitari',
+    canonicalPath: '/articoli-frontaliere/italia-inadempiente-crediti-sanitari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27164,7 +27164,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ricavi, alberghieri, crescita, 2025',
     ogTitle: 'Ricavi alberghieri in crescita: +3,9% nel 2025',
     ogDescription: 'Il settore alberghiero svizzero registra un aumento del 3,9% nel fatturato 2025, con picchi estivi e differenze tra categorie e zone turistiche.',
-    canonicalPath: '/articoli-frontaliere/settore-alberghiero-ricavi-2025',
+    canonicalPath: '/articoli-frontaliere/settore-alberghiero-ricavi-2025/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27192,7 +27192,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, skopje, rafforzano, scambi',
     ogTitle: 'Berna e Skopje rafforzano scambi economici e cooperazione',
     ogDescription: 'Il presidente della Confederazione Guy Parmelin visita la Macedonia del Nord per rafforzare le relazioni economiche e la cooperazione internazionale.',
-    canonicalPath: '/articoli-frontaliere/berna-skopje-scambi-economici-2026',
+    canonicalPath: '/articoli-frontaliere/berna-skopje-scambi-economici-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27220,7 +27220,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, conti, bellinzona, 2025, balzo',
     ogTitle: 'Conti Bellinzona 2025: balzo in avanti di 11 milioni',
     ogDescription: 'I conti 2025 di Bellinzona chiudono con un rosso di 2,7 milioni, migliorando di 10,7 milioni rispetto al preventivo. Analisi e implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/conti-bellinzona-2025-balzo-11-milioni',
+    canonicalPath: '/articoli-frontaliere/conti-bellinzona-2025-balzo-11-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27248,7 +27248,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, 2025, conti, migliori',
     ogTitle: 'Bellinzona 2025: conti migliori del previsto, disavanzo ridotto',
     ogDescription: 'Il consuntivo 2025 di Bellinzona chiude con un disavanzo di 2,7 milioni, migliorando di 10,7 milioni rispetto al preventivo. Investimenti per 25 milioni.',
-    canonicalPath: '/articoli-frontaliere/contibellinzona2025risultati',
+    canonicalPath: '/articoli-frontaliere/contibellinzona2025risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27276,7 +27276,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, calo, previsioni, dell',
     ogTitle: 'Disoccupazione in calo in Ticino: le previsioni dell\'USI',
     ogDescription: 'L\'Istituto di ricerche economiche dell\'USI prevede un ribasso del tasso di disoccupazione in Ticino nei prossimi trimestri.',
-    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-usi-2026',
+    canonicalPath: '/articoli-frontaliere/disoccupazione-ticino-usi-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27304,7 +27304,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cessione, bper-bcc, filiali, interessate',
     ogTitle: 'Cessione Bper-BCC: le sei filiali interessate in provincia di Varese',
     ogDescription: 'BPER Banca cede sei filiali al Gruppo BCC Iccrea nelle province di Varese e Como. Ecco cosa cambia per i clienti e i dipendenti.',
-    canonicalPath: '/articoli-frontaliere/cessione-bper-bcc-varese-2026',
+    canonicalPath: '/articoli-frontaliere/cessione-bper-bcc-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27332,7 +27332,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, innalzamento, lago, maggiore, impatti',
     ogTitle: 'Innalzamento Lago Maggiore: impatti economici e ambientali',
     ogDescription: 'L\'Autorità di Bacino del Po fissa il livello massimo a 140 cm, ma il territorio teme danni irreversibili all\'economia e alla biodiversità.',
-    canonicalPath: '/articoli-frontaliere/innalzamento-livello-verbano-impatti-economici',
+    canonicalPath: '/articoli-frontaliere/innalzamento-livello-verbano-impatti-economici/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27360,7 +27360,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, barometro, ripresa, modesta, economia',
     ogTitle: 'Barometro KOF: ripresa modesta per l\'economia svizzera',
     ogDescription: 'Il barometro del KOF segnala un leggero miglioramento in aprile, ma le prospettive economiche restano modeste sotto la media pluriennale.',
-    canonicalPath: '/articoli-frontaliere/barometro-kof-ripresa-modesta-2026',
+    canonicalPath: '/articoli-frontaliere/barometro-kof-ripresa-modesta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27388,7 +27388,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inflazione, aprile, carrello, spesa',
     ogTitle: 'Inflazione Italia aprile 2026: +2,8% e carrello della spesa in aumento',
     ogDescription: 'Ad aprile 2026 l\'inflazione in Italia sale al +2,8%, con un aumento del carrello della spesa al +2,5%. Scopri l\'impatto per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/inflazione-aprile-2026-italia',
+    canonicalPath: '/articoli-frontaliere/inflazione-aprile-2026-italia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27416,7 +27416,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, azienda, bardello, cerca, operatore',
     ogTitle: 'Azienda Bardello cerca operatore CNC: esperienza richiesta',
     ogDescription: 'Onostampi Srl, azienda certificata ISO 9001:2015, cerca operatore CNC con almeno 5 anni di esperienza per lavorazioni su 3, 4 e 5 assi.',
-    canonicalPath: '/articoli-frontaliere/azienda-bardello-cerca-operatore-cnc',
+    canonicalPath: '/articoli-frontaliere/azienda-bardello-cerca-operatore-cnc/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27444,7 +27444,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensionati, penalizzati, fino, euro',
     ogTitle: 'Pensionati penalizzati: fino a 2.400 euro in più di Irpef',
     ogDescription: 'Una simulazione del Caf Cgil evidenzia un divario fiscale tra lavoratori dipendenti e pensionati sotto i 50mila euro annui',
-    canonicalPath: '/articoli-frontaliere/divario-irpef-pensionati-2026',
+    canonicalPath: '/articoli-frontaliere/divario-irpef-pensionati-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27472,7 +27472,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, indaga, accordi, illeciti',
     ogTitle: 'COMCO indaga su accordi illeciti nel keyword bidding',
     ogDescription: 'Due inchieste aperte dalla COMCO nel settore dei viaggi e dei casinò online per presunti accordi illeciti nel keyword bidding.',
-    canonicalPath: '/articoli-frontaliere/comco-inchieste-keyword-bidding-2026',
+    canonicalPath: '/articoli-frontaliere/comco-inchieste-keyword-bidding-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27500,7 +27500,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dezonamenti, serve, dialogo, diretto',
     ogTitle: 'Dezonamenti in Ticino: serve dialogo diretto con il Dipartimento',
     ogDescription: 'L\'Associazione dei Comuni Ticino chiede confronto diretto con il Dipartimento del Territorio per risolvere problemi di dezonamento',
-    canonicalPath: '/articoli-frontaliere/dezonamenti-ticino-2026-confronti',
+    canonicalPath: '/articoli-frontaliere/dezonamenti-ticino-2026-confronti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27528,7 +27528,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pizza, bibita, sempre, care',
     ogTitle: 'Pizza e bibita sempre più care: la classifica delle 30 città più costose',
     ogDescription: 'Scopri la classifica delle 30 città italiane più costose per pizza e bibita. Bolzano in testa con 15 euro di media. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/pizza-bibita-costi-citta',
+    canonicalPath: '/articoli-frontaliere/pizza-bibita-costi-citta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27556,7 +27556,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, education, scuole, imprese, confronto',
     ogTitle: 'Education Day 2026: scuole e imprese a confronto',
     ogDescription: 'La terza edizione dell\'Education Day di Confindustria Varese si terrà il 5 maggio 2026 alle Ville Ponti con centinaia di studenti.',
-    canonicalPath: '/articoli-frontaliere/education-day-confindustria-varese-2026',
+    canonicalPath: '/articoli-frontaliere/education-day-confindustria-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27584,7 +27584,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, polizia, progetto, fermo',
     ogTitle: 'Riforma polizia Ticino: progetto fermo',
     ogDescription: 'Il Consiglio di Stato non attua la riorganizzazione tra polizia cantonale e comunale. Zali: \'Decisione politica non ancora presa\'',
-    canonicalPath: '/articoli-frontaliere/riforma-polizia-ticino-progetto-fermo',
+    canonicalPath: '/articoli-frontaliere/riforma-polizia-ticino-progetto-fermo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27612,7 +27612,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siemens, firmano, contratto, nuovi',
     ogTitle: 'FFS e Siemens firmano contratto per 116 nuovi treni',
     ogDescription: 'Le FFS e Siemens Mobility Svizzera hanno firmato il contratto per 116 nuovi treni a due piani per la S-Bahn, con un investimento di fino a 2 miliardi di',
-    canonicalPath: '/articoli-frontaliere/ffs-siemens-nuovi-treni-ticino',
+    canonicalPath: '/articoli-frontaliere/ffs-siemens-nuovi-treni-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27640,7 +27640,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passaporto, uffici, postali, italiani',
     ogTitle: 'Passaporto in 7.500 uffici postali italiani',
     ogDescription: 'Scopri come richiedere il passaporto in 7.500 uffici postali italiani, inclusi quelli del progetto Polis. Vantaggi e procedure per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/passaporto-poste-italiane-uffici',
+    canonicalPath: '/articoli-frontaliere/passaporto-poste-italiane-uffici/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27668,7 +27668,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, comco, indaga, pubblicità, motori',
     ogTitle: 'COMCO indaga su pubblicità via motori di ricerca: viaggi e casinò online',
     ogDescription: 'La Commissione della Concorrenza svizzera apre due indagini su accordi illeciti tra aziende del settore viaggi e casinò online',
-    canonicalPath: '/articoli-frontaliere/comco-indaga-pubblicita-motori-ricerca',
+    canonicalPath: '/articoli-frontaliere/comco-indaga-pubblicita-motori-ricerca/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27696,7 +27696,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, record, passeggeri, treni, svizzeri',
     ogTitle: 'Record di passeggeri sui treni svizzeri nel 2026',
     ogDescription: 'Le principali compagnie ferroviarie svizzere registrano un aumento del 5% nel primo trimestre 2026, mentre il trasporto merci cala del 4%.',
-    canonicalPath: '/articoli-frontaliere/record-passeggeri-treni-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/record-passeggeri-treni-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27724,7 +27724,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ferrovia, passi, avanti, nell',
     ogTitle: 'Ferrovia: passi avanti nell\'estensione dell\'infrastruttura',
     ogDescription: '300 progetti in corso per l\'ampliamento della rete ferroviaria svizzera entro il 2035, con lavori in corso a Losanna e Friburgo.',
-    canonicalPath: '/articoli-frontaliere/ferrovia-svizzera-300-progetti-2026',
+    canonicalPath: '/articoli-frontaliere/ferrovia-svizzera-300-progetti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27752,7 +27752,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassi, invariati, impatto, canton',
     ogTitle: 'Bce: tassi invariati, impatto sul Canton Ticino',
     ogDescription: 'La Bce mantiene i tassi di interesse invariati, con implicazioni per i frontalieri e l\'economia ticinese.',
-    canonicalPath: '/articoli-frontaliere/bce-tassi-invariati-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/bce-tassi-invariati-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27780,7 +27780,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, telefonare, navigare, costerà, sunrise',
     ogTitle: 'Aumenti tariffe Sunrise 2026: cosa cambia per i frontalieri',
     ogDescription: 'Scopri gli aumenti delle tariffe di Sunrise, Yallo e Lebara dal 2026 e come influenzano i frontalieri in Ticino. Confronta le offerte e pianifica il tuo budget.',
-    canonicalPath: '/articoli-frontaliere/aumenti-tariffe-sunrise-2026',
+    canonicalPath: '/articoli-frontaliere/aumenti-tariffe-sunrise-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27808,7 +27808,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, 18mila, lavoratori, cercano, riconoscimento',
     ogTitle: 'ICT Ticino: 18mila lavoratori cercano riconoscimento',
     ogDescription: 'Il settore ICT in Ticino, con 18mila addetti, chiede di essere rappresentato nella Commissione Tripartita. Il Consiglio di Stato riconosce l\'importanza',
-    canonicalPath: '/articoli-frontaliere/settore-ict-ticino-riconoscimento-istituzioni',
+    canonicalPath: '/articoli-frontaliere/settore-ict-ticino-riconoscimento-istituzioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27836,7 +27836,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassi, fermi, rischi, inflazione',
     ogTitle: 'Bce tassi fermi ma rischi inflazione aumentati',
     ogDescription: 'La Bce mantiene i tassi invariati ma avverte su rischi inflazione per conflitto Medio Oriente. Impatti per frontalieri Ticino.',
-    canonicalPath: '/articoli-frontaliere/bce-tassi-inflazione-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/bce-tassi-inflazione-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27864,7 +27864,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, microterremoto, artificiale, esperimento, storico',
     ogTitle: 'Microterremoto artificiale in Ticino: esperimento storico nel San Gottardo',
     ogDescription: 'Ricercatori svizzeri, italiani e tedeschi innescano un terremoto controllato nel massiccio del San Gottardo per studiare la prevedibilità dei sismi',
-    canonicalPath: '/articoli-frontaliere/microterremoto-artificiale-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/microterremoto-artificiale-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27892,7 +27892,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, flottila, gaza, otto, svizzeri',
     ogTitle: 'Flottila Svizzera a Gaza: Otto Svizzeri Sani e Salvi',
     ogDescription: 'Gli otto svizzeri partiti con la Global Sumud Flotilla sono sani e salvi dopo l\'intervento della marina israeliana. Greenpeace chiede protezione.',
-    canonicalPath: '/articoli-frontaliere/flotilla-svizzera-gaza-2026',
+    canonicalPath: '/articoli-frontaliere/flotilla-svizzera-gaza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27920,7 +27920,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vittoria, consumatori, illegittime, clausole',
     ogTitle: 'Vittoria consumatori: illegittime le clausole Sunrise',
     ogDescription: 'Il tribunale di Zurigo accoglie la causa contro Sunrise, giudicando illegittime le clausole su disdette e aumenti tariffari',
-    canonicalPath: '/articoli-frontaliere/clausole-sunrise-illegittime-2026',
+    canonicalPath: '/articoli-frontaliere/clausole-sunrise-illegittime-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27948,7 +27948,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lidl, introduce, formazione, duale',
     ogTitle: 'Lidl introduce formazione duale in Ticino',
     ogDescription: 'Lidl Italia porta il modello di formazione duale nella grande distribuzione organizzata, con oltre 23.000 candidature in quattro anni.',
-    canonicalPath: '/articoli-frontaliere/lidl-formazione-duale-gdo-ticino',
+    canonicalPath: '/articoli-frontaliere/lidl-formazione-duale-gdo-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -27976,7 +27976,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lugano, rafforza, attrattiva, grandi',
     ogTitle: 'Lugano rafforza l\'attrattiva per grandi contribuenti',
     ogDescription: 'Il Municipio di Lugano conferma un piano d\'azione per attrarre contribuenti facoltosi e investitori internazionali. Scopri le implicazioni pratiche.',
-    canonicalPath: '/articoli-frontaliere/lugano-red-carpet-contribuenti-2026',
+    canonicalPath: '/articoli-frontaliere/lugano-red-carpet-contribuenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28004,7 +28004,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trenord, linee, indennizzo, inizio',
     ogTitle: 'Trenord: 25 linee con indennizzo, inizio 2026 disastroso',
     ogDescription: 'Dati allarmanti per Trenord: 25 linee con indennizzo a gennaio 2026, 17 a febbraio. Il Pd chiede chiarezza su disservizi e indennizzi.',
-    canonicalPath: '/articoli-frontaliere/trenord-disservizi-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/trenord-disservizi-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28032,7 +28032,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pulmino, elettrico, granello, cislago',
     ogTitle: 'Pulmino elettrico per Il Granello di Cislago: viaggi più sostenibili',
     ogDescription: 'Un pulmino elettrico messo a disposizione gratuitamente per alcuni mesi da un concessionario di Gallarate supporta le attività quotidiane e gli spostamenti dei',
-    canonicalPath: '/articoli-frontaliere/pulmino-elettrico-granello-cislago-2026',
+    canonicalPath: '/articoli-frontaliere/pulmino-elettrico-granello-cislago-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28060,7 +28060,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ambrogio, castiglioni, nuovo, presidente',
     ogTitle: 'Ambrogio Castiglioni nuovo presidente di Digital Industries World',
     ogDescription: 'Ambrogio Castiglioni, originario di Carnago, è stato nominato nuovo presidente di Digital Industries World. Scopri le implicazioni per i frontalieri e le',
-    canonicalPath: '/articoli-frontaliere/ambrogio-castiglioni-digital-industries-world',
+    canonicalPath: '/articoli-frontaliere/ambrogio-castiglioni-digital-industries-world/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28088,7 +28088,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aumento, spese, carburante, france',
     ogTitle: 'Aumento spese carburante Air France: 2,4 miliardi di dollari per 2026',
     ogDescription: 'Air France spenderà 9,3 miliardi di dollari in carburante nel 2026, un aumento di 2,4 miliardi rispetto al 2025.',
-    canonicalPath: '/articoli-frontaliere/aumento-spese-carburante-air-france-2026',
+    canonicalPath: '/articoli-frontaliere/aumento-spese-carburante-air-france-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28116,7 +28116,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trenord, linee, insufficienti, febbraio',
     ogTitle: 'Trenord: 17 linee insufficienti a febbraio 2026. Astuti chiede spiegazioni',
     ogDescription: 'A febbraio 2026, 17 linee Trenord su 42 hanno diritto all\'indennizzo per ritardi. Astuti (Pd): \'Assessore Lucente spieghi\'',
-    canonicalPath: '/articoli-frontaliere/trenord-ritardi-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/trenord-ritardi-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28144,7 +28144,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, ticinese, progetto, concluso',
     ogTitle: 'Polizia ticinese: progetto concluso, nessun sviluppo',
     ogDescription: 'Il Consiglio di Stato ha deciso di non proseguire con il progetto \'Polizia ticinese\' dopo la fase progettuale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-concluso',
+    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-concluso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28172,7 +28172,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, bike, sharing, gratis',
     ogTitle: 'Bike sharing Como gratis 3 ore giugno',
     ogDescription: 'Scopri il nuovo servizio di bike sharing a Como, gratuito per le prime 3 ore fino a giugno. 80 biciclette e 17 stazioni disponibili.',
-    canonicalPath: '/articoli-frontaliere/bike-sharing-como-gratis-giugno',
+    canonicalPath: '/articoli-frontaliere/bike-sharing-como-gratis-giugno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28200,7 +28200,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guerra, iran, pressione, sull',
     ogTitle: 'Guerra in Iran: pressione sull\'industria alimentare svizzera',
     ogDescription: 'Dai fertilizzanti al vetro, il conflitto nel Golfo Persico colpisce settori chiave. Ecco gli effetti in Svizzera e le prospettive future.',
-    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-2026',
+    canonicalPath: '/articoli-frontaliere/guerra-iran-industria-alimentare-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28228,7 +28228,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rientro, incubo, code, rivera',
     ogTitle: 'Rientro A2 da incubo: code da Rivera a Lugano Sud',
     ogDescription: 'Giornata nera per i pendolari: incidenti e traffico intenso sulla A2, code da Rivera a Lugano Sud e valichi di frontiera intasati',
-    canonicalPath: '/articoli-frontaliere/rientro-a2-incubo-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/rientro-a2-incubo-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28256,7 +28256,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ultimo, giorno, utile, salire',
     ogTitle: 'Ultimo giorno funivia Säntis 2026',
     ogDescription: 'Scopri quando riapre la funivia del Säntis dopo il rinnovo. Informazioni su date, costi e alternative per i visitatori.',
-    canonicalPath: '/articoli-frontaliere/ultimo-giorno-funivia-santis-2026',
+    canonicalPath: '/articoli-frontaliere/ultimo-giorno-funivia-santis-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28284,7 +28284,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, varese, acli',
     ogTitle: 'Primo Maggio a Varese, le ACLI: “Il lavoro dignitoso è l’urgenza del presente”',
     ogDescription: 'Le ACLI provinciali di Varese mettono al centro del dibattito il tema del lavoro dignitoso, indicandolo come urgenza del presente e leva fondamentale per il',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-acli-lavoro-dignitoso',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-acli-lavoro-dignitoso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28312,7 +28312,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, consultori, lavoro, dossier',
     ogTitle: 'Crans-Montana: consultori al lavoro su 700 dossier',
     ogDescription: 'Quattro mesi dopo la tragedia, i servizi di aiuto alle vittime gestiscono quasi 700 casi, con 400 solo in Vallese e 20 in Ticino.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-700-dossier-consultori',
+    canonicalPath: '/articoli-frontaliere/crans-montana-700-dossier-consultori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28340,7 +28340,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, perequazione, finanziaria, svantaggiato, berna',
     ogTitle: 'Perequazione finanziaria: Ticino svantaggiato per i frontalieri',
     ogDescription: 'Berna considera il Ticino più ricco di quanto sia realmente, influenzando i fondi federali. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/perequazione-ticino-frontalieri-2026',
+    canonicalPath: '/articoli-frontaliere/perequazione-ticino-frontalieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28368,7 +28368,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, viabilità, sperimentale, camion, intorno',
     ogTitle: 'Viabilità sperimentale per camion intorno a Travedona dal 5 maggio',
     ogDescription: 'Dal 5 maggio 2026 nuova viabilità sperimentale per camion in 6 comuni del Varese, con un anello a senso unico per migliorare la sicurezza e la fluidità del',
-    canonicalPath: '/articoli-frontaliere/viabilita-camion-travedona-2026',
+    canonicalPath: '/articoli-frontaliere/viabilita-camion-travedona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28396,7 +28396,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luino, apre, casa, comunità',
     ogTitle: 'Luino: apre la Casa di Comunità con punto unico di accesso',
     ogDescription: 'Da venerdì 1° maggio è operativo il Punto Unico di Accesso nella nuova Casa di Comunità di Luino, finanziata con fondi PNRR.',
-    canonicalPath: '/articoli-frontaliere/casa-comunita-luino-punto-unico-accesso',
+    canonicalPath: '/articoli-frontaliere/casa-comunita-luino-punto-unico-accesso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28424,7 +28424,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzona, disavanzo, 2025, ridotto',
     ogTitle: 'Bellinzona: disavanzo 2025 ridotto a -2,7 milioni',
     ogDescription: 'Il consuntivo 2025 della Città di Bellinzona chiude con un disavanzo ridotto a -2,7 milioni, grazie a un aumento del gettito fiscale e al contenimento delle',
-    canonicalPath: '/articoli-frontaliere/bellinzona-2025-consuntivo-risultati',
+    canonicalPath: '/articoli-frontaliere/bellinzona-2025-consuntivo-risultati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28452,7 +28452,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, democrazia, respinta, consiglio',
     ogTitle: 'Iniziativa per la democrazia respinta dal Consiglio nazionale',
     ogDescription: 'Il Consiglio nazionale ha respinto l\'iniziativa per la democrazia con 130 voti a 62. Scopri le implicazioni per i frontalieri e i requisiti per la n',
-    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-2026',
+    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28480,7 +28480,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, storia, infortuni',
     ogTitle: 'Primo Maggio 2026: storia, infortuni e trasformazioni del lavoro',
     ogDescription: 'Stefania Filetti, segretaria generale della CGIL di Varese, ripercorre la storia del Primo Maggio e analizza i dati sugli infortuni sul lavoro in provincia.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-storia-e-trasformazioni',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-storia-e-trasformazioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28508,7 +28508,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, insubria, uomini, seguiti, centri',
     ogTitle: 'ATS Insubria: 398 uomini seguiti nei centri per autori di violenza',
     ogDescription: 'Scopri il primo bilancio dei Centri per Uomini Autori di Violenza (CUAV) attivi nei territori di ATS Insubria, con 398 uomini seguiti nel primo anno.',
-    canonicalPath: '/articoli-frontaliere/primo-bilancio-centri-violenza-2026',
+    canonicalPath: '/articoli-frontaliere/primo-bilancio-centri-violenza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28536,7 +28536,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, salandin, storico, leader',
     ogTitle: 'Addio a Giovanni Salandin, storico leader Cgil',
     ogDescription: 'Il mondo sindacale varesino è in lutto per la scomparsa di Giovanni Salandin, storico dirigente Cgil che ha dedicato la vita alla difesa dei diritti dei',
-    canonicalPath: '/articoli-frontaliere/addio-giovanni-salandin-cgil-frontalieri',
+    canonicalPath: '/articoli-frontaliere/addio-giovanni-salandin-cgil-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28564,7 +28564,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guardia, medica, attiva, ponte',
     ogTitle: 'Guardia medica attiva per il ponte del 1° maggio: ecco cosa sapere',
     ogDescription: 'Continuità Assistenziale attiva fino alle 8 di lunedì 4 maggio. Ambulatorio Pediatrico del sabato attivo il 2 maggio. Numero verde 116 117.',
-    canonicalPath: '/articoli-frontaliere/guardia-medica-como-ponte-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/guardia-medica-como-ponte-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28592,7 +28592,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bilancio, provincia, varese, milioni',
     ogTitle: 'Bilancio Provincia Varese: 1,5 milioni per investimenti',
     ogDescription: 'Il bilancio della Provincia di Varese per il 2025 si chiude con un avanzo di 1,5 milioni, destinati a investimenti in viabilità e patrimonio culturale.',
-    canonicalPath: '/articoli-frontaliere/bilancio-provincia-varese-1-5-milioni',
+    canonicalPath: '/articoli-frontaliere/bilancio-provincia-varese-1-5-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28620,7 +28620,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, città, verdi, europa',
     ogTitle: 'Varese tra le città più verdi d\'Europa',
     ogDescription: 'Varese è tra le sole due città europee dove oltre il 50% della popolazione vive secondo la regola del 3-30-300.',
-    canonicalPath: '/articoli-frontaliere/varese-citta-piu-verde-2026',
+    canonicalPath: '/articoli-frontaliere/varese-citta-piu-verde-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28648,7 +28648,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, denuncia, como, strisce, pedonali',
     ogTitle: 'Denuncia a Como: strisce pedonali pericolose',
     ogDescription: 'Una lettrice segnala lo stato critico delle strisce pedonali in quasi tutta la città di Como, rendendo pericoloso l\'attraversamento delle strade.',
-    canonicalPath: '/articoli-frontaliere/denuncia-strisce-pedonali-como-2026',
+    canonicalPath: '/articoli-frontaliere/denuncia-strisce-pedonali-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28676,7 +28676,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, emergenza, acqua, lombardia, deficit',
     ogTitle: 'Emergenza acqua in Lombardia: deficit del 37%, cosa succede ora',
     ogDescription: 'Situazione critica in Lombardia: deficit idrico del 37%, assenza di neve e misure urgenti per l\'estate',
-    canonicalPath: '/articoli-frontaliere/emergenza-acqua-lombardia-2026',
+    canonicalPath: '/articoli-frontaliere/emergenza-acqua-lombardia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28704,7 +28704,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bambino, anni, muore, annegato',
     ogTitle: 'Bambino di due anni muore annegato a Morcote',
     ogDescription: 'Tragedia a Vico Morcote: un bambino di due anni è morto annegato in una piscina privata. L\'allarme è scattato nel primo pomeriggio di giovedì 30 aprile.',
-    canonicalPath: '/articoli-frontaliere/bambino-annegato-morcote-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/bambino-annegato-morcote-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28732,7 +28732,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, solaro, chiude, ambulatorio, medico',
     ogTitle: 'Solaro chiude l’ambulatorio medico al Villaggio Brollo',
     ogDescription: 'L’Ambulatorio Medico Temporaneo di Villaggio Brollo a Solaro chiuderà in anticipo il 21 maggio. Scopri i dettagli e i servizi alternativi disponibili.',
-    canonicalPath: '/articoli-frontaliere/solaro-chiude-ambulatorio-medico',
+    canonicalPath: '/articoli-frontaliere/solaro-chiude-ambulatorio-medico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28760,7 +28760,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piano, pandemico, 2025-2029, approvato',
     ogTitle: 'Piano Pandemico 2025-2029 approvato: cosa cambia',
     ogDescription: 'La Conferenza Stato-Regioni ha approvato il nuovo Piano Pandemico 2025-2029 con un investimento di 1,1 miliardi di euro per potenziare il sistema sanitario',
-    canonicalPath: '/articoli-frontaliere/piano-pandemico-2025-2029-approvato',
+    canonicalPath: '/articoli-frontaliere/piano-pandemico-2025-2029-approvato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28788,7 +28788,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, zali, conferma, progetto',
     ogTitle: 'Polizia Ticino: Zali conferma, progetto non accantonato',
     ogDescription: 'Il consigliere di Stato Claudio Zali chiarisce che il progetto Polizia ticinese non è stato scartato, ma resta una delle soluzioni possibili.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-zali-comuni',
+    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-zali-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28816,7 +28816,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siemens, nuovi, treni, miliardi',
     ogTitle: 'FFS e Siemens: 116 nuovi treni per il Ticino',
     ogDescription: 'Due miliardi di franchi per 116 treni a due piani per il traffico suburbano. Entreranno in servizio dal 2031.',
-    canonicalPath: '/articoli-frontaliere/ffs-siemens-116-treni-suburbani-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ffs-siemens-116-treni-suburbani-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28844,7 +28844,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, uscita, melide',
     ogTitle: 'Chiusure notturne uscita Melide autostrada A2',
     ogDescription: 'L\'uscita autostradale di Melide in direzione sud sarà chiusa da domenica 3 maggio a venerdì 8 maggio 2026 dalle 21.30 alle 05.00 per lavori di rinnovo della',
-    canonicalPath: '/articoli-frontaliere/chiusure-melide-autostrada-2026',
+    canonicalPath: '/articoli-frontaliere/chiusure-melide-autostrada-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28872,7 +28872,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, webuild, costruzioni, avvia, lavori',
     ogTitle: 'Webuild: CSC Costruzioni avvia lavori per rinnovare la sede ONU a Ginevra',
     ogDescription: 'CSC Costruzioni avvia i lavori per il rinnovamento dell\'Edificio E del Palais des Nations a Ginevra, con un contratto da 215 milioni di euro.',
-    canonicalPath: '/articoli-frontaliere/webuild-csc-rinnovo-sede-onu-ginevra',
+    canonicalPath: '/articoli-frontaliere/webuild-csc-rinnovo-sede-onu-ginevra/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28900,7 +28900,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, migranti, problematici, pasture, progetto',
     ogTitle: 'Migranti problematici a Pasture: progetto congelato',
     ogDescription: 'Il progetto per una sezione di richiedenti asilo problematici a Pasture è stato congelato. La Confederazione punta a creare centri speciali.',
-    canonicalPath: '/articoli-frontaliere/migranti-pasture-progetto-congelato',
+    canonicalPath: '/articoli-frontaliere/migranti-pasture-progetto-congelato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28928,7 +28928,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ricavi, alberghi, 2025, miliardi',
     ogTitle: 'Ricavi alberghi Ticino 2025: +3,9% a 6,2 miliardi',
     ogDescription: 'Il settore alberghiero svizzero ha registrato un aumento del 3,9% nel 2025, con picchi del 6,3% negli hotel a 5 stelle.',
-    canonicalPath: '/articoli-frontaliere/ricavi-alberghi-ticino-2025-crescita',
+    canonicalPath: '/articoli-frontaliere/ricavi-alberghi-ticino-2025-crescita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28956,7 +28956,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cercasi, direttore, controllo, cantonale',
     ogTitle: 'Cercasi direttore per il Controllo cantonale delle finanze',
     ogDescription: 'Il Canton Ticino cerca un nuovo direttore per il Controllo cantonale delle finanze dopo l\'annuncio della pensione di Giovanni cavallero.',
-    canonicalPath: '/articoli-frontaliere/controllo-finanze-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/controllo-finanze-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -28984,7 +28984,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, swiss, market, index, verde',
     ogTitle: 'Swiss Market Index in verde: spunti utili per i frontalieri',
     ogDescription: 'Il Swiss Market Index chiude in positivo, offrendo spunti interessanti per gli investimenti e le pensioni dei frontalieri',
-    canonicalPath: '/articoli-frontaliere/swiss-market-index-verde-2026',
+    canonicalPath: '/articoli-frontaliere/swiss-market-index-verde-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29012,7 +29012,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crowdfunding, raccolti, quasi, 100mila',
     ogTitle: 'Crowdfunding BCC: raccolti quasi 100mila euro',
     ogDescription: 'La BCC Busto Garolfo e Buguggiate ha raccolto quasi 100mila euro attraverso il crowdfunding, con oltre 1.200 donatori coinvolti e un overfunding del 141%.',
-    canonicalPath: '/articoli-frontaliere/bcc-crowdfunding-100mila-euro',
+    canonicalPath: '/articoli-frontaliere/bcc-crowdfunding-100mila-euro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29040,7 +29040,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, truffatrice, seriale, arrestata, como',
     ogTitle: 'Truffatrice seriale arrestata a Como con gioielli e contanti',
     ogDescription: 'Arrestata una 31enne ceca per truffe ai danni di due anziane tra Como e Lecco, con un bottino di 2.400 euro in contanti e gioielli.',
-    canonicalPath: '/articoli-frontaliere/truffatrice-seriale-como-lecco-2026',
+    canonicalPath: '/articoli-frontaliere/truffatrice-seriale-como-lecco-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29068,7 +29068,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, passaporto, musei, svizzeri, anni',
     ogTitle: 'Passaporto Musei Svizzeri, 30 anni e un record storico',
     ogDescription: 'Il Passaporto Musei Svizzeri celebra 30 anni con un record di 1,5 milioni di ingressi nel 2025. Scopri di più su questo successo culturale.',
-    canonicalPath: '/articoli-frontaliere/passaporto-musei-svizzera-30-anni-record',
+    canonicalPath: '/articoli-frontaliere/passaporto-musei-svizzera-30-anni-record/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29096,7 +29096,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confindustria, como, esplora, legame',
     ogTitle: 'Confindustria Como esplora arte, cultura e salute',
     ogDescription: 'Evento il 13 maggio con esperti per discutere l\'impatto positivo dell\'arte e della cultura sulla salute e il benessere',
-    canonicalPath: '/articoli-frontaliere/confindustria-como-arte-cultura-salute-13-maggio',
+    canonicalPath: '/articoli-frontaliere/confindustria-como-arte-cultura-salute-13-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29124,7 +29124,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tribunale, ferma, pratiche, abusive',
     ogTitle: 'Tribunale ferma pratiche abusive di Sunrise',
     ogDescription: 'Il tribunale distrettuale di Zurigo ha dichiarato illegittime due clausole contrattuali di Sunrise relative agli aumenti di prezzo e alle modalità di disdetta.',
-    canonicalPath: '/articoli-frontaliere/sunrise-pratiche-abusive-fermate-2026',
+    canonicalPath: '/articoli-frontaliere/sunrise-pratiche-abusive-fermate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29152,7 +29152,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, proroga, accise, carburanti, sconto',
     ogTitle: 'Proroga accise carburanti: sconto gasolio a 24,4 centesimi, benzina a 6',
     ogDescription: 'Il governo italiano ha prorogato di tre settimane la riduzione delle accise sui carburanti, con sconto differenziato per benzina e gasolio.',
-    canonicalPath: '/articoli-frontaliere/proroga-accise-carburanti-2026',
+    canonicalPath: '/articoli-frontaliere/proroga-accise-carburanti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29180,7 +29180,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, ticinese, progetto, abbandonato',
     ogTitle: 'Polizia ticinese: progetto abbandonato dal Consiglio di Stato',
     ogDescription: 'Il Consiglio di Stato ha deciso di non proseguire con il progetto Polizia ticinese, avviato nel 2016 per migliorare la collaborazione tra polizia cantonale e',
-    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-abbandonato-2026',
+    canonicalPath: '/articoli-frontaliere/polizia-ticinese-progetto-abbandonato-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29208,7 +29208,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, summer, camp, malnate, natura',
     ogTitle: 'Summer camp a Malnate: natura, fattoria e inglese per bambini',
     ogDescription: 'Alla Tenuta La Novella di Malnate, un\'estate tra animali, attività all\'aperto e inglese per bambini dai 6 ai 10 anni.',
-    canonicalPath: '/articoli-frontaliere/summer-camp-malnate-tenuta-novella',
+    canonicalPath: '/articoli-frontaliere/summer-camp-malnate-tenuta-novella/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29236,7 +29236,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, liuc, federazione, golf, accordo',
     ogTitle: 'Liuc e Federazione Golf: accordo per studenti-atleti',
     ogDescription: 'Protocollo d’intesa triennale tra LIUC e Federazione Italiana Golf per favorire la doppia carriera degli studenti-atleti e promuovere il golf tra la comunità',
-    canonicalPath: '/articoli-frontaliere/liuc-golf-frontalieri-accordo-2026',
+    canonicalPath: '/articoli-frontaliere/liuc-golf-frontalieri-accordo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29264,7 +29264,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pillola, giorno, dopo, senza',
     ogTitle: 'Pillola del giorno dopo senza consulenza: cosa cambia',
     ogDescription: 'Il Consiglio nazionale svizzero approva la vendita della pillola del giorno dopo senza colloquio obbligatorio. Ecco cosa cambia per le donne in Ticino e in',
-    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-vendita-libera-2026',
+    canonicalPath: '/articoli-frontaliere/pillola-giorno-dopo-vendita-libera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29292,7 +29292,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, isolino, virginia, riapre, viaggio',
     ogTitle: 'L’Isolino Virginia riapre: viaggio nel tempo tra palafitte e natura',
     ogDescription: 'L’Isolino Virginia riapre al pubblico il 2 maggio 2026 con un nuovo allestimento museale e servizi di ristorazione.',
-    canonicalPath: '/articoli-frontaliere/isolino-virginia-riapre-2026',
+    canonicalPath: '/articoli-frontaliere/isolino-virginia-riapre-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29320,7 +29320,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, salone, innovazione, sociale',
     ogTitle: 'Salone CSR Varese 2026: sostenibilità e innovazione',
     ogDescription: 'Il 6 maggio 2026 a Varese si terrà il Salone della CSR, un evento dedicato a sostenibilità e innovazione sociale con imprese, istituzioni e Terzo Settore.',
-    canonicalPath: '/articoli-frontaliere/sostenibilita-salone-csr-varese-2026',
+    canonicalPath: '/articoli-frontaliere/sostenibilita-salone-csr-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29348,7 +29348,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, film, dibattito, collegamento',
     ogTitle: 'Varese: Film \'The Sea\' e dibattito con collegamento live a Gaza',
     ogDescription: 'Il Cineclub Filmstudio 90 di Varese proietta \'The Sea\' con dibattito e collegamento live alla Global Sumud Flotilla verso Gaza il 6 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/film-the-sea-varese-gaza-2026',
+    canonicalPath: '/articoli-frontaliere/film-the-sea-varese-gaza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29376,7 +29376,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, apre, nuovo, solco',
     ogTitle: 'Crans-Montana, nuovo solco Italia-Svizzera',
     ogDescription: 'L\'Italia si costituisce parte civile per l\'incendio di Capodagna a Crans-Montana. Incontro tra Parmelin, Meloni e Mattarella la prossima settimana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-nuovo-solco-italia-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-nuovo-solco-italia-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29404,7 +29404,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, eurodreams, vinta, rendita, mensile',
     ogTitle: 'Eurodreams: vinta una rendita mensile di 22mila franchi per 30 anni',
     ogDescription: 'Una fortunata vincita di Eurodreams: 22.222 franchi al mese per 30 anni, realizzata in Spagna ma gestita da Swisslos e Loterie romande',
-    canonicalPath: '/articoli-frontaliere/eurodreams-vincita-rendita-22mila-franchi',
+    canonicalPath: '/articoli-frontaliere/eurodreams-vincita-rendita-22mila-franchi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29432,7 +29432,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piano, casa, meloni, libera',
     ogTitle: 'Piano Casa Meloni: via libera al decreto per l\'emergenza abitativa',
     ogDescription: 'Il Consiglio dei Ministri approva il Piano Casa con 10,5 miliardi per edilizia pubblica e privata. Meloni: priorità per alloggi accessibili',
-    canonicalPath: '/articoli-frontaliere/piano-casa-meloni-emergenza-abitativa',
+    canonicalPath: '/articoli-frontaliere/piano-casa-meloni-emergenza-abitativa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29460,7 +29460,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, targhe, personalizzabili, approvata, mozione',
     ogTitle: 'Targhe personalizzabili in Svizzera: approvata la mozione di Quadri',
     ogDescription: 'Il Consiglio nazionale ha approvato la mozione di Lorenzo Quadri per targhe personalizzabili, aprendo la strada alle \'vanity plates\'',
-    canonicalPath: '/articoli-frontaliere/targhe-personalizzabili-quadri-approvazione',
+    canonicalPath: '/articoli-frontaliere/targhe-personalizzabili-quadri-approvazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29488,7 +29488,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trenord, linee, diritto, indennizzo',
     ogTitle: 'Trenord, 17 linee con diritto all\'indennizzo: peggiore è Como',
     ogDescription: 'Dati allarmanti per i pendolari: 17 linee Trenord su 42 danno diritto all\'indennizzo, con la linea Asso-Seveso-Milano la peggiore in assoluto.',
-    canonicalPath: '/articoli-frontaliere/trenord-indennizzi-pendolari-como-2026',
+    canonicalPath: '/articoli-frontaliere/trenord-indennizzi-pendolari-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29516,7 +29516,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponte, brivio, milioni, riqualificazione',
     ogTitle: 'Ponte di Brivio, 14 milioni per la riqualificazione: ritardi fino a 40 minuti',
     ogDescription: 'Scopri i dettagli del cantiere da 14 milioni per il Ponte di Brivio e i disagi previsti per chi si sposta.',
-    canonicalPath: '/articoli-frontaliere/ponte-brivio-cantiere-14-milioni',
+    canonicalPath: '/articoli-frontaliere/ponte-brivio-cantiere-14-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29544,7 +29544,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ponte, primo, maggio, villa',
     ogTitle: 'Ponte del Primo Maggio a Villa Panza: visite guidate e laboratori per bambini',
     ogDescription: 'Dal 1 al 3 maggio 2026, Villa Panza di Varese ospita visite guidate e laboratori creativi per bambini ispirati all\'artista Josef Albers.',
-    canonicalPath: '/articoli-frontaliere/ponte-maggio-villa-panza-laboratori-bambini',
+    canonicalPath: '/articoli-frontaliere/ponte-maggio-villa-panza-laboratori-bambini/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29572,7 +29572,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, luoghi, culto, arresti',
     ogTitle: 'Furti nei luoghi di culto: due arresti nel Bellinzonese',
     ogDescription: 'Due cittadini rumeni residenti all\'estero sono stati arrestati il 26 aprile nel Bellinzonese, sospettati di aver compiuto ripetuti furti in chiese e un negozio.',
-    canonicalPath: '/articoli-frontaliere/furti-luoghi-culto-bellinzonese',
+    canonicalPath: '/articoli-frontaliere/furti-luoghi-culto-bellinzonese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29600,7 +29600,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, hockey, psicodramma, davos, titolo',
     ogTitle: 'Hockey Nl / Psicodramma Davos, il titolo 2025-2026 al FriborgoGottéron',
     ogDescription: 'Il titolo 2025-2026 del Hockey Nl è stato assegnato al FriborgoGottéron, con Stefano Bottini da Lugano che si è preparato per il spareggio.',
-    canonicalPath: '/articoli-frontaliere/hockey-nl-psicodramma-davos-2025-2026-friborgogotteron',
+    canonicalPath: '/articoli-frontaliere/hockey-nl-psicodramma-davos-2025-2026-friborgogotteron/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29628,7 +29628,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, made, switzerland, cosa, cambia',
     ogTitle: 'Made in Switzerland: cosa cambia nel 2026',
     ogDescription: 'Nuove regole per il marchio \'Swiss Made\' dal 2026. Ecco cosa cambia per i prodotti e i consumatori in Ticino',
-    canonicalPath: '/articoli-frontaliere/made-in-switzerland-2026',
+    canonicalPath: '/articoli-frontaliere/made-in-switzerland-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29656,7 +29656,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dialogo, popoli, colori, mondo',
     ogTitle: 'Dialogo dei popoli, colori del mondo a Busto Arsizio',
     ogDescription: 'Una giornata dedicata all\'incontro, all\'integrazione e alla valorizzazione delle diverse culture presenti sul territorio di Busto Arsizio.',
-    canonicalPath: '/articoli-frontaliere/dialogo-popoli-colori-mondo-busto-arsizio',
+    canonicalPath: '/articoli-frontaliere/dialogo-popoli-colori-mondo-busto-arsizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29684,7 +29684,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cavalli, droni, nuova, unità',
     ogTitle: 'Cavalli e droni: la nuova unità speciale dell\'esercito svizzero',
     ogDescription: 'Scopri come l\'esercito svizzero combina cavalli e droni per pattuglie speciali. Implicazioni per la sicurezza e la difesa nazionale.',
-    canonicalPath: '/articoli-frontaliere/cavalli-droni-esercito-svizzero-2026',
+    canonicalPath: '/articoli-frontaliere/cavalli-droni-esercito-svizzero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29712,7 +29712,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, raiffeisen, bioggio, rinnova, inaugurazione',
     ogTitle: 'Raiffeisen Bioggio si rinnova: inaugurazione il 9 maggio',
     ogDescription: 'Scopri il rinnovamento della filiale Raiffeisen di Bioggio e partecipa all\'inaugurazione il 9 maggio 2026. Evento aperto al pubblico con visite guidate.',
-    canonicalPath: '/articoli-frontaliere/raiffeisen-bioggio-rinnovo-2026',
+    canonicalPath: '/articoli-frontaliere/raiffeisen-bioggio-rinnovo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29740,7 +29740,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, percorso, didattico, allora, giubiasco',
     ogTitle: 'Percorso didattico \'Qui...allora\' a Giubiasco: un viaggio nel tempo',
     ogDescription: 'Scopri il nuovo percorso didattico a Giubiasco che confronta il passato e il presente del borgo attraverso fotografie d\'epoca e pannelli espositivi.',
-    canonicalPath: '/articoli-frontaliere/percorso-giubiasco-qui-allora-2026',
+    canonicalPath: '/articoli-frontaliere/percorso-giubiasco-qui-allora-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29768,7 +29768,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nomina, anche, docenti, comunali',
     ogTitle: 'Nomina docenti comunali Ticino 2026',
     ogDescription: 'Modifica legislativa cantonale estende la nomina ai docenti con impiego sotto il 50%, stabilità lavorativa garantita dal 1° agosto 2026',
-    canonicalPath: '/articoli-frontaliere/nomina-docenti-comunali-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/nomina-docenti-comunali-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29796,7 +29796,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cardano, campo, settimana, ecologica',
     ogTitle: 'Cardano al Campo: Settimana Ecologica 2026 sul riciclo Raee',
     ogDescription: 'Dal 5 al 9 maggio 2026, Cardano al Campo promuove il riciclo dei rifiuti elettrici con eventi e raccolte. Focus sui Raee, obiettivo: migliorare la raccolta',
-    canonicalPath: '/articoli-frontaliere/cardano-settimana-ecologica-raee-2026',
+    canonicalPath: '/articoli-frontaliere/cardano-settimana-ecologica-raee-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29824,7 +29824,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grassi, sfide, complesse, liuc',
     ogTitle: 'Grassi: «Sfide complesse, ma la Liuc è pronta»',
     ogDescription: 'Roberto Grassi, nuovo presidente della Liuc-Università Cattaneo di Castellanza, affronta le sfide del mondo manifatturiero e dell\'innovazione.',
-    canonicalPath: '/articoli-frontaliere/grassi-liuc-sfide-complesse',
+    canonicalPath: '/articoli-frontaliere/grassi-liuc-sfide-complesse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29852,7 +29852,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ciclabile, saronno-rovello, porro, quando',
     ogTitle: 'Ciclabile Saronno-Rovello Porro: quando sarà pronta?',
     ogDescription: 'A tre anni dalla posa della ghost bike, Fiab Saronno sollecita i Comuni per la realizzazione della ciclabile protetta tra Saronno e Rovello Porro.',
-    canonicalPath: '/articoli-frontaliere/ciclabile-saronno-rovello-porro-2026',
+    canonicalPath: '/articoli-frontaliere/ciclabile-saronno-rovello-porro-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29880,7 +29880,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fiera, dell, asparago, cantello',
     ogTitle: 'Fiera Asparago Cantello 2026: programma e prenotazioni',
     ogDescription: 'Dal 15 al 24 maggio, Cantello celebra l\'asparago bianco De.Co. con cucina, musica e mercatini. Scopri il programma completo e come prenotare.',
-    canonicalPath: '/articoli-frontaliere/fiera-asparago-cantello-2026',
+    canonicalPath: '/articoli-frontaliere/fiera-asparago-cantello-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29908,7 +29908,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, asparago, cantello, cose, sapere',
     ogTitle: 'Asparago di Cantello: 5 cose da sapere sul prodotto De.C.O.',
     ogDescription: 'Scopri le caratteristiche uniche dell\'asparago bianco di Cantello, un prodotto protetto dalla Denominazione Comunale di Origine.',
-    canonicalPath: '/articoli-frontaliere/cinque-cose-asparago-cantello-2026',
+    canonicalPath: '/articoli-frontaliere/cinque-cose-asparago-cantello-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29936,7 +29936,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sigarette, elettroniche, vizio, preferito',
     ogTitle: 'Sigarette elettroniche: il vizio preferito dagli adolescenti ticinesi',
     ogDescription: 'Il consumo di sigarette elettroniche tra i 15 e i 17 anni in Ticino è quasi pari a quello delle sigarette tradizionali.',
-    canonicalPath: '/articoli-frontaliere/sigarette-elettroniche-adolescenti-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/sigarette-elettroniche-adolescenti-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29964,7 +29964,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, bellinzona, merci, programma',
     ogTitle: 'Processo Bellinzona merci Russia 2026',
     ogDescription: 'Un 63enne processato a Bellinzona per aver fornito materiali a programma russo di armamenti di distruzione di massa. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/processo-bellinzona-merci-russia-2026',
+    canonicalPath: '/articoli-frontaliere/processo-bellinzona-merci-russia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -29992,7 +29992,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, valuta, riduzione, truppe',
     ogTitle: 'Trump valuta riduzione truppe in Italia e Spagna',
     ogDescription: 'Donald Trump considera di ridurre le truppe americane in Italia e Spagna, criticando l\'aiuto ricevuto da questi paesi.',
-    canonicalPath: '/articoli-frontaliere/trump-riduce-truppe-italia-spagna',
+    canonicalPath: '/articoli-frontaliere/trump-riduce-truppe-italia-spagna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30020,7 +30020,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, abolisce, dazi, whisky',
     ogTitle: 'Trump abolisce dazi whisky scozzese per Carlo e Camilla',
     ogDescription: 'Donald Trump annuncia l\'abolizione dei dazi sul whisky scozzese in onore del re e della regina del Regno Unito, Carlo e Camilla.',
-    canonicalPath: '/articoli-frontaliere/whisky-scozzese-dazi-trump-carlo-camilla',
+    canonicalPath: '/articoli-frontaliere/whisky-scozzese-dazi-trump-carlo-camilla/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30048,7 +30048,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, fino, mornasco, albero',
     ogTitle: 'Incidente a Fino Mornasco: albero cade su auto, ferite mamma e bambina',
     ogDescription: 'Un albero marcio è caduto su un\'auto in corsa a Fino Mornasco, ferendo una mamma e sua figlia. Intervento dei vigili del fuoco e del 118.',
-    canonicalPath: '/articoli-frontaliere/incidente-fino-mornasco-30-aprile-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-fino-mornasco-30-aprile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30076,7 +30076,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gottardo, caduto, primo, diaframma',
     ogTitle: 'Gottardo, caduto il primo diaframma del secondo tubo',
     ogDescription: 'La fresa meccanica \'Alessandra\' ha abbattuto il primo diaframma a nord, a 4 km dall\'imbocco. Una pietra miliare per il progetto.',
-    canonicalPath: '/articoli-frontaliere/galleria-gottardo-secondo-tubo-2026',
+    canonicalPath: '/articoli-frontaliere/galleria-gottardo-secondo-tubo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30104,7 +30104,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, approva, bilancio, avanzo',
     ogTitle: 'Varese approva bilancio 2026 con avanzo record: 17 milioni',
     ogDescription: 'La Provincia di Varese approva un bilancio florido con un avanzo libero di amministrazione di oltre 17 milioni di euro.',
-    canonicalPath: '/articoli-frontaliere/varese-bilancio-2026-avanzo-record',
+    canonicalPath: '/articoli-frontaliere/varese-bilancio-2026-avanzo-record/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30132,7 +30132,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, canton, cerca, nuovo, direttore',
     ogTitle: 'Nuovo direttore Controllo cantonale delle finanze Ticino',
     ogDescription: 'Il Canton Ticino cerca un nuovo direttore per il Controllo cantonale delle finanze. Scopri i dettagli e come candidarti.',
-    canonicalPath: '/articoli-frontaliere/nuovo-direttore-controllo-finanze-ticino',
+    canonicalPath: '/articoli-frontaliere/nuovo-direttore-controllo-finanze-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30160,7 +30160,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riapre, casale, litta, ufficio',
     ogTitle: 'Riapre a Casale Litta l\'ufficio postale con nuovi servizi',
     ogDescription: 'L\'ufficio postale di Casale Litta riapre dopo ristrutturazione con servizi ampliati grazie al progetto Polis. Scopri i nuovi servizi disponibili.',
-    canonicalPath: '/articoli-frontaliere/riapre-ufficio-postale-casale-litta',
+    canonicalPath: '/articoli-frontaliere/riapre-ufficio-postale-casale-litta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30188,7 +30188,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, chiese, negozi, arresti',
     ogTitle: 'Furti in chiese e negozi: arresti e appello a segnalare',
     ogDescription: 'Due rumeni arrestati per furti in chiese e negozi in Ticino e Grigioni. La polizia invita a segnalare eventuali altri episodi.',
-    canonicalPath: '/articoli-frontaliere/furti-chiese-negozi-ticino-arresti',
+    canonicalPath: '/articoli-frontaliere/furti-chiese-negozi-ticino-arresti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30216,7 +30216,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, audit, polizia, governo, chiede',
     ogTitle: 'Audit Polizia Ticino: governo chiede sei mesi in più per il messaggio',
     ogDescription: 'Il Consiglio di Stato del Canton Ticino chiede una proroga per il messaggio sull\'audit della Polizia Cantonale. Dadò e Ferrara insistono sull\'urgenza.',
-    canonicalPath: '/articoli-frontaliere/audit-polizia-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/audit-polizia-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30244,7 +30244,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, lombardia, richiede',
     ogTitle: 'Tassa salute frontalieri: Lombardia richiede allineamento, Piemonte dice no',
     ogDescription: 'La Lombardia insiste sull\'applicazione della tassa salute ai frontalieri, mentre il Piemonte conferma la propria contrarietà. Ecco cosa cambia',
-    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-piemonte',
+    canonicalPath: '/articoli-frontaliere/tassa-salute-frontalieri-lombardia-piemonte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30272,7 +30272,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, zonaprotetta, festeggia, anni, lotta',
     ogTitle: 'Zonaprotetta festeggia 40 anni: da lotta all\'Aids a sessualità consapevole',
     ogDescription: 'Zonaprotetta celebra 40 anni di attività, passando dalla lotta all\'Aids alla promozione della sessualità consapevole in Ticino.',
-    canonicalPath: '/articoli-frontaliere/zonaprotetta-40-anni-sessualita-consapevole',
+    canonicalPath: '/articoli-frontaliere/zonaprotetta-40-anni-sessualita-consapevole/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30300,7 +30300,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cina, boom, viaggi, interni',
     ogTitle: 'Cina: boom di viaggi interni e spese per il turismo',
     ogDescription: 'Nel primo trimestre 2026, la Cina registra 1,9 miliardi di viaggi interni e 271 miliardi di dollari di spesa turistica',
-    canonicalPath: '/articoli-frontaliere/cina-turismo-interno-2026',
+    canonicalPath: '/articoli-frontaliere/cina-turismo-interno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30328,7 +30328,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mondiali, iran, giocherà, addio',
     ogTitle: 'Mondiali 2026, l\'Iran giocherà: addio al ripescaggio dell\'Italia',
     ogDescription: 'La FIFA conferma la partecipazione dell\'Iran ai Mondiali 2026, escludendo il ripescaggio dell\'Italia. Ecco le implicazioni per i tifosi e il mondo del calcio.',
-    canonicalPath: '/articoli-frontaliere/mondiali-2026-iran-italia-fifa',
+    canonicalPath: '/articoli-frontaliere/mondiali-2026-iran-italia-fifa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30356,7 +30356,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crystal, palace, passo, dalla',
     ogTitle: 'Crystal Palace a un passo dalla finale di Conference, sogna il Rayo',
     ogDescription: 'Il Crystal Palace vince 3-1 contro lo Shakthar Donetsk e sogna la finale di Conference League. Il Rayo Vallecano batte 1-0 lo Strasburgo.',
-    canonicalPath: '/articoli-frontaliere/crystal-palace-finale-conference-rayo',
+    canonicalPath: '/articoli-frontaliere/crystal-palace-finale-conference-rayo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30384,7 +30384,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, potrebbe, stringere, patto',
     ogTitle: 'Trump potrebbe stringere patto con Cina e Russia',
     ogDescription: 'Massimo Cacciari analizza le mosse di Trump in Iran e le possibili alleanze con Cina e Russia. L\'Europa resta impotente di fronte alla crisi.',
-    canonicalPath: '/articoli-frontaliere/trump-cina-russia-patto-2026',
+    canonicalPath: '/articoli-frontaliere/trump-cina-russia-patto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30412,7 +30412,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, insegna, dell',
     ogTitle: 'Primo Maggio unita sindacale Marghera',
     ogDescription: 'Cgil, Cisl e Uil insieme per celebrare la Festa dei Lavoratori con un focus sul lavoro dignitoso e divergenze sul Dl Lavoro.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-unita-sindacale-marghera',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-unita-sindacale-marghera/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30440,7 +30440,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, sindacati, piazza',
     ogTitle: 'Primo maggio, sindacati in piazza per difendere salari e impieghi',
     ogDescription: 'Una cinquantina di località svizzere ospitano manifestazioni per la giornata internazionale dei diritti delle lavoratrici e dei lavoratori.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-sindacati-piazza-2026',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-sindacati-piazza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30468,7 +30468,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, weekend, maggio, varese, eventi',
     ogTitle: 'Weekend del 1° Maggio a Varese: eventi imperdibili',
     ogDescription: 'Scopri gli eventi del weekend del 1° Maggio a Varese, dalla Festa di San Vittore allo spettacolo delle mongolfiere di Angera.',
-    canonicalPath: '/articoli-frontaliere/spasso-weekend-1-maggio-varese-2026',
+    canonicalPath: '/articoli-frontaliere/spasso-weekend-1-maggio-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30496,7 +30496,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, prevenzione, dipendenze, franco, oggi',
     ogTitle: 'Prevenzione dipendenze: un franco oggi per risparmiarne 20 domani',
     ogDescription: 'Tagli ai fondi per la prevenzione delle dipendenze in Ticino, nonostante i costi sanitari in aumento. L\'esperto: si segue una logica di risparmio immediato.',
-    canonicalPath: '/articoli-frontaliere/prevenzione-dipendenze-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/prevenzione-dipendenze-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30524,7 +30524,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, concertone, primo, maggio, roma',
     ogTitle: 'Concertone Primo Maggio Roma artisti scaletta 2026',
     ogDescription: 'Il Concertone del Primo Maggio a Roma con Arisa, Pierpaolo Spollon e BigMama. Tutti gli artisti in scaletta e informazioni utili per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/concertone-primo-maggio-roma-artisti-2026',
+    canonicalPath: '/articoli-frontaliere/concertone-primo-maggio-roma-artisti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30552,7 +30552,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mondo, radio, piange, alberto',
     ogTitle: 'Il mondo della radio piange Alberto Davoli',
     ogDescription: 'Il pioniere delle emittenti private è mancato a 60 anni dopo una lunga malattia. Funerali domani alla Brunella.',
-    canonicalPath: '/articoli-frontaliere/mondo-radio-piange-alberto-davoli',
+    canonicalPath: '/articoli-frontaliere/mondo-radio-piange-alberto-davoli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30580,7 +30580,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rendiconto, annuale, banca, interpretarlo',
     ogTitle: 'Rendiconto annuale banca: come interpretarlo',
     ogDescription: 'Scopri come leggere il rendiconto annuale su costi e oneri della tua banca e cosa significa per i tuoi investimenti.',
-    canonicalPath: '/articoli-frontaliere/rendiconto-banca-interpretazione-2026',
+    canonicalPath: '/articoli-frontaliere/rendiconto-banca-interpretazione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30608,7 +30608,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inchiesta, arbitri, caso, inter-roma',
     ogTitle: 'Inchiesta arbitri, dal caso Inter-Roma alla spiegazione di Rocchi',
     ogDescription: 'Gianluca Rocchi indagato per frode sportiva. Novità sull\'inchiesta arbitri in Italia. Scopri di più su Frontaliere Ticino.',
-    canonicalPath: '/articoli-frontaliere/inchiesta-arbitri-roccchi-inter-roma',
+    canonicalPath: '/articoli-frontaliere/inchiesta-arbitri-roccchi-inter-roma/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30636,7 +30636,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dramma, canton, bimbo, anni',
     ogTitle: 'Dramma in Canton Ticino: bimbo di due anni annega in piscina',
     ogDescription: 'Un tragico incidente in una piscina privata ha sconvolto la comunità del Canton Ticino. Un bimbo di due anni ha perso la vita.',
-    canonicalPath: '/articoli-frontaliere/dramma-canton-ticino-bimbo-annega-piscina',
+    canonicalPath: '/articoli-frontaliere/dramma-canton-ticino-bimbo-annega-piscina/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30664,7 +30664,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giornico, gioco, dell, riflettere',
     ogTitle: 'Gioco dell\'oca su rischi e disastri a Giornico',
     ogDescription: 'Al Museo di Leventina di Giornico, un gioco dell\'oca interattivo racconta i disastri dal Medioevo al Covid. Scopri di più su questa iniziativa.',
-    canonicalPath: '/articoli-frontaliere/gioco-oca-giornico-rischi-disastri',
+    canonicalPath: '/articoli-frontaliere/gioco-oca-giornico-rischi-disastri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30692,7 +30692,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, pace, solidarietà',
     ogTitle: 'Primo Maggio 2026: pace e solidarietà al centro delle riflessioni',
     ogDescription: 'Matteo Muschietti invita a scendere in piazza per la pace e la solidarietà, in un mondo segnato da troppe guerre. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-solidarieta',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-solidarieta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30720,7 +30720,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, piano, freddo, como, persone',
     ogTitle: 'Piano Freddo Como: 200 persone accolte per 172 notti',
     ogDescription: 'Il Piano Freddo di Como ha accolto 200 persone senza dimora per 172 notti, grazie alla collaborazione di volontari e donatori.',
-    canonicalPath: '/articoli-frontaliere/piano-freddo-como-200-persone-172-notti',
+    canonicalPath: '/articoli-frontaliere/piano-freddo-como-200-persone-172-notti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30748,7 +30748,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, studenti, diventano, agenti',
     ogTitle: 'Como, 10 studenti diventano agenti di polizia locale con il progetto On the Road',
     ogDescription: 'Un accordo triennale tra il Comune di Como, la Polizia Locale e l\'associazione Ragazzi On the Road per formare giovani agenti',
-    canonicalPath: '/articoli-frontaliere/como-studenti-polizia-on-road-2026',
+    canonicalPath: '/articoli-frontaliere/como-studenti-polizia-on-road-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30776,7 +30776,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ticinosentieri, nuove, nomine, roland',
     ogTitle: 'TicinoSentieri: nuove nomine per il 2026',
     ogDescription: 'Roland David è il nuovo presidente e Stéphane Grounauer il direttore operativo. Approvate anche due nuove nomine in comitato.',
-    canonicalPath: '/articoli-frontaliere/ticinosentieri-nuove-nomine-2026',
+    canonicalPath: '/articoli-frontaliere/ticinosentieri-nuove-nomine-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30804,7 +30804,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mara, chiusura, ufficio, postale',
     ogTitle: 'Chiusura ufficio postale Val Mara: mazzata ai servizi',
     ogDescription: 'L\'ufficio postale di Val Mara, frazione di Maroggia, chiuderà. Un duro colpo per i residenti e i frontalieri della zona.',
-    canonicalPath: '/articoli-frontaliere/ufficio-postale-val-mara-chiusura',
+    canonicalPath: '/articoli-frontaliere/ufficio-postale-val-mara-chiusura/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30832,7 +30832,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controversia, sull, bandiera, sulle',
     ogTitle: 'Controversia bandiera svizzera scarpe On',
     ogDescription: 'L\'Istituto Federale della Proprietà Intellettuale ha concesso a On di usare la bandiera svizzera sulle sue scarpe, nonostante la produzione avvenga all\'estero',
-    canonicalPath: '/articoli-frontaliere/controversia-bandiera-svizzera-scarpe-on',
+    canonicalPath: '/articoli-frontaliere/controversia-bandiera-svizzera-scarpe-on/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30860,7 +30860,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sigarette, elettroniche, giovani, consumano',
     ogTitle: 'Sigarette elettroniche: i giovani le consumano come quelle tradizionali',
     ogDescription: 'Il 25,2% dei giovani consuma sia sigarette tradizionali che elettroniche, con un aumento del 3% rispetto al 2023',
-    canonicalPath: '/articoli-frontaliere/giovani-sigarette-elettroniche-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/giovani-sigarette-elettroniche-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30888,7 +30888,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, riforma, cambia, tutto',
     ogTitle: 'Frontalieri e disoccupazione: la riforma UE che cambia tutto',
     ogDescription: 'Scopri come la nuova riforma UE sull\'indennità di disoccupazione per i frontalieri cambierà le prestazioni per i lavoratori in Ticino',
-    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/frontalieri-disoccupazione-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30916,7 +30916,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sfida, mercato, prezzi, patto',
     ogTitle: 'CBT Italia sfida il mercato: prezzi come patto di fiducia con i ciclisti',
     ogDescription: 'CBT Italia, azienda cuneese con 75 anni di storia, entra nel mercato italiano con prezzi aggressivi e trasparenza, sorprendendo i consumatori',
-    canonicalPath: '/articoli-frontaliere/cbt-italia-ciclisti-mercato',
+    canonicalPath: '/articoli-frontaliere/cbt-italia-ciclisti-mercato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30944,7 +30944,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maserati, celebra, anni, tridente',
     ogTitle: 'Maserati celebra 100 anni del Tridente e la leggenda delle corse',
     ogDescription: 'Maserati festeggia il centenario del Tridente e la prima vittoria sportiva alla Targa Florio nel 1926. Scopri gli eventi e le iniziative in programma.',
-    canonicalPath: '/articoli-frontaliere/maserati-tridente-centenario-2026',
+    canonicalPath: '/articoli-frontaliere/maserati-tridente-centenario-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -30972,7 +30972,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, milioni, sostenibile, dibattito',
     ogTitle: 'Iniziativa \'No a una Svizzera da 10 milioni\': sostenibile?',
     ogDescription: 'Il dibattito sull\'iniziativa UDC mette in luce i rischi per economia e servizi legati a un freno dell\'immigrazione',
-    canonicalPath: '/articoli-frontaliere/iniziativa-10-milioni-sostenibile',
+    canonicalPath: '/articoli-frontaliere/iniziativa-10-milioni-sostenibile/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31000,7 +31000,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, basta, click, arrivano, fatture',
     ogTitle: 'Basta un click e arrivano fatture per servizi hot',
     ogDescription: 'Un adolescente del Ticino ha ricevuto una fattura per un abbonamento a un servizio per adulti sottoscritto per errore. Ecco come reagire e difendersi',
-    canonicalPath: '/articoli-frontaliere/click-fatture-servizio-hot',
+    canonicalPath: '/articoli-frontaliere/click-fatture-servizio-hot/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31028,7 +31028,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, fragole, camorino, anni',
     ogTitle: 'Festa fragole Camorino 70 anni tradizione beneficenza',
     ogDescription: 'La festa delle fragole di Camorino celebra 70 anni con eventi, allegria e donazioni annuali di 17\'000 franchi alle associazioni locali',
-    canonicalPath: '/articoli-frontaliere/festa-fragole-camorino-beneficenza',
+    canonicalPath: '/articoli-frontaliere/festa-fragole-camorino-beneficenza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31056,7 +31056,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, lite, notturna, brogeda',
     ogTitle: 'Lite notturna a Como in via Brogeda',
     ogDescription: 'Una lite notturna in via Brogeda a Como ha coinvolto tre persone, due delle quali sono state ricoverate in ospedale. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/lite-notturna-brogeda-2026',
+    canonicalPath: '/articoli-frontaliere/lite-notturna-brogeda-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31084,7 +31084,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, fatture, ospedaliere, tutti',
     ogTitle: 'Crans-Montana, fatture ospedaliere: non tutti gli ospedali le hanno inviate',
     ogDescription: 'Non tutti gli ospedali svizzeri hanno inviato le fatture ai pazienti italiani feriti nell\'incendio di Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-ospedali-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-fatture-ospedali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31112,7 +31112,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, dossier, gestiti, consultori',
     ogTitle: 'Crans-Montana: 700 dossier gestiti dai consultori per le vittime',
     ogDescription: 'Quasi 700 dossier gestiti e 400\'000 franchi versati per le vittime dell\'incendio di Capodanno a Crans-Montana.',
-    canonicalPath: '/articoli-frontaliere/crans-montana-aiuto-vittime-700-dossier',
+    canonicalPath: '/articoli-frontaliere/crans-montana-aiuto-vittime-700-dossier/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31140,7 +31140,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, losone, calo, zanzara, tigre',
     ogTitle: 'Losone: calo zanzara tigre nel 2025',
     ogDescription: 'La tecnica del maschio sterile ha ridotto significativamente la presenza della zanzara tigre a Losone. Ecco i dettagli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/zanzara-tigre-losone-2026',
+    canonicalPath: '/articoli-frontaliere/zanzara-tigre-losone-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31168,7 +31168,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rive, libere, rpsi, soddisfatta',
     ogTitle: 'Rive libere: RPSI soddisfatta del gruppo di lavoro',
     ogDescription: 'RPSI entra nel gruppo di lavoro per la valorizzazione delle rive tra Minusio e Tenero-Contra. Petizione per l\'accesso libero tutto l\'anno.',
-    canonicalPath: '/articoli-frontaliere/rive-libere-minusio-tenero-2026',
+    canonicalPath: '/articoli-frontaliere/rive-libere-minusio-tenero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31196,7 +31196,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, berna, senza, pubblicità, iniziativa',
     ogTitle: 'Berna senza pubblicità: l\'iniziativa per vietare gli annunci commerciali',
     ogDescription: 'L\'iniziativa \'Berna senza pubblicità\' mira a vietare gli annunci commerciali senza riferimenti locali nello spazio pubblico. Scopri le implicazioni per i',
-    canonicalPath: '/articoli-frontaliere/berna-senza-pubblicita-iniziativa-2026',
+    canonicalPath: '/articoli-frontaliere/berna-senza-pubblicita-iniziativa-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31224,7 +31224,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, sale, timori',
     ogTitle: 'Lago Maggiore sale: +15 cm, timori per l\'ambiente',
     ogDescription: 'L\'ADBPO innalza il livello massimo del lago a +1,40 metri. Timori per le località turistiche e gli ecosistemi',
-    canonicalPath: '/articoli-frontaliere/lago-maggiore-sale-ambiente-2026',
+    canonicalPath: '/articoli-frontaliere/lago-maggiore-sale-ambiente-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31252,7 +31252,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, cosa, cambia',
     ogTitle: '25 cm in più per il Lago Maggiore: cosa cambia per i frontalieri',
     ogDescription: 'Dalla prossima estate il livello massimo del Lago Maggiore potrà essere innalzato di 25 centimetri. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/25-centimetri-lago-maggiore-frontalieri',
+    canonicalPath: '/articoli-frontaliere/25-centimetri-lago-maggiore-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31280,7 +31280,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sertori, rapinese, faccio, assessore',
     ogTitle: 'Lungolago Como, Sertori replica a Rapinese',
     ogDescription: 'L\'assessore regionale Massimo Sertori annuncia un incontro con il sindaco di Como Alessandro Rapinese per discutere dei parapetti del lungolago.',
-    canonicalPath: '/articoli-frontaliere/lungolago-como-parapetti-rapinese-sertori',
+    canonicalPath: '/articoli-frontaliere/lungolago-como-parapetti-rapinese-sertori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31308,7 +31308,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como-napoli, sinigaglia, divieti, posteggi',
     ogTitle: 'Como-Napoli al Sinigaglia: divieti e posteggi per la sfida',
     ogDescription: 'Tutto esaurito per la partita di domani alle 18:00. Divieti di sosta e circolazione dalle 6:30. Ordinanza anti-alcol dalle 15:00 alle 21:00',
-    canonicalPath: '/articoli-frontaliere/como-napoli-sinigaglia-divieti-posteggi',
+    canonicalPath: '/articoli-frontaliere/como-napoli-sinigaglia-divieti-posteggi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31336,7 +31336,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, varese, lavoro, diritti',
     ogTitle: 'Primo Maggio Varese: lavoro, diritti e futuro nell\'era dell\'intelligenza artificiale',
     ogDescription: 'CGIL, CISL e UIL in piazza a Varese per il Primo Maggio 2026. Focus su diritti, sicurezza e salari equi nell\'era dell\'intelligenza artificiale.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-diritti',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-varese-2026-lavoro-diritti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31364,7 +31364,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, algerini, libici, rubano, auto',
     ogTitle: 'Algerini e libici rubano auto: polizia li ferma sul fatto',
     ogDescription: 'Tre individui, due algerini e un libico, sono stati arrestati dalla polizia ticinese mentre rubavano un\'auto a Locarno. Scopri di più su questa operazione.',
-    canonicalPath: '/articoli-frontaliere/algerini-libici-auto-polizia-arresti',
+    canonicalPath: '/articoli-frontaliere/algerini-libici-auto-polizia-arresti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31392,7 +31392,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rete, stradale, mendrisio, sotto',
     ogTitle: 'Rete stradale di Mendrisio sotto pressione: urgenti interventi richiesti',
     ogDescription: 'Quattro consiglieri comunali del PLR chiedono maggiori interventi urgenti per la rete stradale di Mendrisio, criticando la mancanza di fondi cantonali e',
-    canonicalPath: '/articoli-frontaliere/rete-stradale-mendrisio-interventi-urgenti',
+    canonicalPath: '/articoli-frontaliere/rete-stradale-mendrisio-interventi-urgenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31420,7 +31420,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, milano-varese, chiusure, notturne, solbiate',
     ogTitle: 'A8 Milano-Varese, chiusure notturne tra Solbiate e Cavaria per lavori',
     ogDescription: 'Dal 4 all\'8 maggio chiusure notturne tra Solbiate Arno e Cavaria per lavori alle barriere antirumore',
-    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-milano-varese',
+    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-milano-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31448,7 +31448,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, sindacati, piazza',
     ogTitle: 'Primo Maggio 2026: sindacati in piazza contro l\'iniziativa UDC',
     ogDescription: 'Sindacati in piazza per difendere salari e impieghi e contro l\'iniziativa UDC \'No a una Svizzera da 10 milioni di abitanti\'',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31476,7 +31476,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arresto, tunisino, como, resistenza',
     ogTitle: 'Arresto di un frontaliere tunisino a Como per resistenza a pubblico ufficiale',
     ogDescription: 'Un 19enne tunisino, regolare in Italia ma senza fissa dimora, è stato arrestato per violenza e resistenza a pubblico ufficiale a Como.',
-    canonicalPath: '/articoli-frontaliere/como-arresto-frontaliere-tunisino',
+    canonicalPath: '/articoli-frontaliere/como-arresto-frontaliere-tunisino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31504,7 +31504,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, indagine, soccorsi, crans-montana, carenze',
     ogTitle: 'Indagine sui soccorsi a Crans-Montana: carenze segnalate',
     ogDescription: 'Due famiglie denunciano gravi carenze nella gestione dei soccorsi durante l\'incendio di Capodanno a Crans-Montana. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/indagine-soccorsi-crans-montana-2026',
+    canonicalPath: '/articoli-frontaliere/indagine-soccorsi-crans-montana-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31532,7 +31532,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, costituisce, parte, civile',
     ogTitle: 'Crans-Montana: Italia si costituisce parte civile',
     ogDescription: 'L\'Italia si costituisce parte civile nel procedimento per l\'incendio al disco-bar Le Constellation a Crans-Montana, con 41 morti e 115 feriti',
-    canonicalPath: '/articoli-frontaliere/crans-montana-italia-parte-civile-2026',
+    canonicalPath: '/articoli-frontaliere/crans-montana-italia-parte-civile-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31560,7 +31560,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, greta, gysin, candida, capogruppo',
     ogTitle: 'Greta Gysin si candida a capogruppo dei Verdi',
     ogDescription: 'Greta Gysin, consigliera nazionale ticinese, si candida alla presidenza del gruppo parlamentare dei Verdi. Elezione prevista per il 22 maggio.',
-    canonicalPath: '/articoli-frontaliere/gysin-candidata-capogruppo-verdi',
+    canonicalPath: '/articoli-frontaliere/gysin-candidata-capogruppo-verdi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31588,7 +31588,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sesto, calende, controlli, sanzioni',
     ogTitle: 'Sesto Calende: controlli e sanzioni per strade danneggiate dai cantieri',
     ogDescription: 'La polizia locale di Sesto Calende ha avviato controlli e sanzioni per le strade danneggiate dai cantieri della fibra ottica, finanziati dal PNRR.',
-    canonicalPath: '/articoli-frontaliere/sesto-calende-strade-cantieri-2026',
+    canonicalPath: '/articoli-frontaliere/sesto-calende-strade-cantieri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31616,7 +31616,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, jans, attacca, iniziativa, rischio',
     ogTitle: 'Jans attacca l\'iniziativa UDC: \'Rischio per la Svizzera\'',
     ogDescription: 'Il consigliere federale Jans critica l\'iniziativa UDC \'No a una Svizzera da 10 milioni\', avvertendo gravi conseguenze per il Paese.',
-    canonicalPath: '/articoli-frontaliere/jans-udc-iniziativa-10-milioni',
+    canonicalPath: '/articoli-frontaliere/jans-udc-iniziativa-10-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31644,7 +31644,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, maggiore, metri, gobbi',
     ogTitle: 'Lago Maggiore a +1,35 metri: Gobbi, soluzione equilibrata',
     ogDescription: 'Il consigliere di Stato ticinese Norman Gobbi commenta l\'innalzamento del livello massimo del lago Maggiore a +1,35 metri, definendolo una soluzione',
-    canonicalPath: '/articoli-frontaliere/lago-maggiore-135-metri-frontalieri',
+    canonicalPath: '/articoli-frontaliere/lago-maggiore-135-metri-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31672,7 +31672,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, anziani, truffati, arresto, como',
     ogTitle: 'Anziani truffati, arresto a Como. Collegamenti con Ticino',
     ogDescription: 'Arresto di una 31enne ceca a Como per truffe agli anziani. Metodi simili a casi recenti in Ticino. Scoperte prove a Como-San Giovanni.',
-    canonicalPath: '/articoli-frontaliere/anziani-truffati-arresto-como-ticino',
+    canonicalPath: '/articoli-frontaliere/anziani-truffati-arresto-como-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31700,7 +31700,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bellinzonesi, brillano, germania, torneo',
     ogTitle: 'Bellinzonesi brillano in Germania al torneo di karate',
     ogDescription: 'I giovani atleti del club di karate di Bellinzona ottengono ottimi risultati alla Nagai Cup in Germania',
-    canonicalPath: '/articoli-frontaliere/bellinzonesi-germania-karate-2026',
+    canonicalPath: '/articoli-frontaliere/bellinzonesi-germania-karate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31728,7 +31728,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusura, notturna, lomazzo, chiasso',
     ogTitle: 'A9 chiusura notturna Lomazzo Chiasso: cosa cambia per i frontalieri',
     ogDescription: 'Dalle 22:00 del 4 maggio alle 5:00 del 5 maggio, chiusura notturna tra Lomazzo sud e Como Centro verso Chiasso. Deviazioni obbligatorie per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a9-lomazzo-chiasso',
+    canonicalPath: '/articoli-frontaliere/chiusura-notturna-a9-lomazzo-chiasso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31756,7 +31756,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, festa, lavoro, diritti',
     ogTitle: 'Como, centinaia in piazza per la Festa del lavoro. \'Più diritti, salari dignitosi, sicurezza, stabilità\'',
     ogDescription: 'Centinaia di persone si sono radunate in piazza Perretta per la Festa del Lavoro, promossa dai sindacati Cgil, Cisl e Uil. Richieste centrali: salari dignitosi',
-    canonicalPath: '/articoli-frontaliere/como-festa-lavoro-diritti-salari',
+    canonicalPath: '/articoli-frontaliere/como-festa-lavoro-diritti-salari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31784,7 +31784,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, denuncia, mancanza, attrezzature, soccorsi',
     ogTitle: 'Denuncia per mancanza di attrezzature ai soccorsi di Crans-Montana',
     ogDescription: 'Avvocati delle vittime denunciano l\'Organizzazione cantonale vallesana per insufficienze nel dispositivo di intervento dopo l\'incendio del bar Le Constellation',
-    canonicalPath: '/articoli-frontaliere/denuncia-soccorsi-crans-montana-2026',
+    canonicalPath: '/articoli-frontaliere/denuncia-soccorsi-crans-montana-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31812,7 +31812,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, cantù, auto, contro',
     ogTitle: 'Incidente a Cantù: auto contro muro, due feriti',
     ogDescription: 'Un incidente stradale a Cantù ha coinvolto due donne, che hanno riportato ferite lievi. L\'incidente è avvenuto in via Como.',
-    canonicalPath: '/articoli-frontaliere/incidente-cantu-due-feriti',
+    canonicalPath: '/articoli-frontaliere/incidente-cantu-due-feriti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31840,7 +31840,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, torino, tensioni',
     ogTitle: 'Primo Maggio a Torino: tensioni tra manifestanti e forze dell\'ordine',
     ogDescription: 'Un gruppo si stacca dal corteo principale verso l\'ex centro sociale Askatasuna, tensioni con la polizia.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-torino-tensioni-askatasuna',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-torino-tensioni-askatasuna/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31868,7 +31868,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attivo, telefonata, rompere, silenzio',
     ogTitle: 'Il 142 è attivo: una telefonata per rompere il silenzio sulla violenza',
     ogDescription: 'Da oggi in tutta la Svizzera è attivo il numero 142 per vittime di violenza. Scopri come funziona e chi può aiutarti.',
-    canonicalPath: '/articoli-frontaliere/142-violenza-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/142-violenza-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31896,7 +31896,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, coda, gottardo',
     ogTitle: 'Primo Maggio 2026: 10 km di coda al Gottardo',
     ogDescription: 'Code di 10 km al portale nord del San Gottardo, rallentamenti anche a Chiasso e Brogeda. Ecco cosa sapere per chi viaggia.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-traffico-gottardo',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-traffico-gottardo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31924,7 +31924,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, e-roller, e-bike, lugano',
     ogTitle: 'Incidente con e-roller e e-bike a Lugano: donna gravemente ferita',
     ogDescription: 'Un incidente tra un e-roller e un\'e-bike ha coinvolto una ragazza e una donna, lasciando quest\'ultima gravemente ferita. Scopri di più su questo grave incidente',
-    canonicalPath: '/articoli-frontaliere/incidente-e-roller-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/incidente-e-roller-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31952,7 +31952,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, casino, campione, rinviato',
     ogTitle: 'Processo Casino Campione rinviato a dicembre 2026',
     ogDescription: 'La presidente Valeria Costi ha rinviato il processo sul Casinò di Campione a dicembre 2026 per altri processi da celebrare prima.',
-    canonicalPath: '/articoli-frontaliere/processo-campione-dicembre-2026',
+    canonicalPath: '/articoli-frontaliere/processo-campione-dicembre-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -31980,7 +31980,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ingresso, gratuito, museo, costume',
     ogTitle: 'Ingresso gratuito al museo in costume da bagno',
     ogDescription: 'La Fondazione Beyeler di Riehen offre ingresso gratuito ai visitatori in costume da bagno, ispirata dalla mostra di Paule Cézanne.',
-    canonicalPath: '/articoli-frontaliere/ingresso-gratuito-museo-costume-bagno',
+    canonicalPath: '/articoli-frontaliere/ingresso-gratuito-museo-costume-bagno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32008,7 +32008,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusure, notturne, busto, gallarate',
     ogTitle: 'A8: chiusure notturne tra Busto e Gallarate e stop all’ingresso di Castellanza',
     ogDescription: 'Nuove modifiche alla viabilità sulla A8 Milano-Varese per lavori alle barriere antirumore. Chiusure notturne tra Busto Arsizio e Gallarate e stop all’ingresso',
-    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-chiusure',
+    canonicalPath: '/articoli-frontaliere/lavori-autostradali-a8-chiusure/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32036,7 +32036,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, danzante, muove, spettacoli',
     ogTitle: 'Festa Danzante 2026: il Ticino si muove tra spettacoli e partecipazione',
     ogDescription: 'Dal 6 al 10 maggio 2026, oltre 40 città svizzere ospitano la 21ª edizione della Festa Danzante, con Lugano come cuore pulsante degli eventi.',
-    canonicalPath: '/articoli-frontaliere/festa-danzante-ticino-2026-spettacoli',
+    canonicalPath: '/articoli-frontaliere/festa-danzante-ticino-2026-spettacoli/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32064,7 +32064,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, pregassona, persone, fonio',
     ogTitle: 'Festa a Pregassona: 400 persone e Fonio contro iniziativa UDC',
     ogDescription: 'Giorgio Fonio critica l\'iniziativa UDC \'No a una Svizzera da 10 milioni\' per i rischi su lavoro e salari. OCST celebra con 400 persone.',
-    canonicalPath: '/articoli-frontaliere/pregassona-festa-400-fonio-iniziativa-udc',
+    canonicalPath: '/articoli-frontaliere/pregassona-festa-400-fonio-iniziativa-udc/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32092,7 +32092,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, numero, combatte, violenza, oggi',
     ogTitle: '142: il numero che combatte la violenza in Ticino',
     ogDescription: 'Da oggi attivo il numero 142 per l\'aiuto alle vittime di violenza in Ticino e in tutta la Svizzera, gratuito e disponibile 24/7.',
-    canonicalPath: '/articoli-frontaliere/142-numero-aiuto-vittime-ticino',
+    canonicalPath: '/articoli-frontaliere/142-numero-aiuto-vittime-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32120,7 +32120,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dopo, ponte, acqua, meteo',
     ogTitle: 'Dopo il ponte, l’acqua: meteo Ticino 2026',
     ogDescription: 'Fine settimana soleggiato, ma da lunedì piogge e temperature più fresche. Ecco cosa aspettarsi in Ticino.',
-    canonicalPath: '/articoli-frontaliere/ponte-l-acqua-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/ponte-l-acqua-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32148,7 +32148,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovo, canile, varese, duni',
     ogTitle: 'Nuovo canile Varese Duni: progetto approvato, realizzazione a tappe',
     ogDescription: 'La Commissione Ambiente ha approvato il progetto per il nuovo canile di Varese ai Duni, ma i costi aumentati impongono una realizzazione in due fasi.',
-    canonicalPath: '/articoli-frontaliere/nuovo-canile-varese-duni-2026',
+    canonicalPath: '/articoli-frontaliere/nuovo-canile-varese-duni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32176,7 +32176,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, festa, fritti, glam, varese',
     ogTitle: 'Festa dei fritti al Glam di Varese: gnocco martedì, fritto misto giovedì',
     ogDescription: 'Dal 30 aprile 2026 al Glam Caffè di Varese via Manin ogni martedì e giovedì pranzo con gnocco fritto e fritto misto. Digestivo offerto.',
-    canonicalPath: '/articoli-frontaliere/festa-fritti-glam-varese-2026',
+    canonicalPath: '/articoli-frontaliere/festa-fritti-glam-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32204,7 +32204,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lostallo, soazza, mesocco, titolo',
     ogTitle: 'Lostallo, Soazza e Mesocco per il titolo di "Comune più attivo della Svizzera"',
     ogDescription: 'Lostallo, Soazza e Mesocco partecipano alla "Coop sfida fra comuni" per promuovere l\'attività fisica durante il mese di maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/alta-mesolcina-sfida-movimento-2026',
+    canonicalPath: '/articoli-frontaliere/alta-mesolcina-sfida-movimento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32232,7 +32232,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, flottila, gaza, intercettata, presidio',
     ogTitle: 'Flottila per Gaza intercettata, presidio a Varese',
     ogDescription: 'Presidio di solidarietà a Varese per la Flottila intercettata da Israele. Turchia e Spagna parlano di pirateria.',
-    canonicalPath: '/articoli-frontaliere/flotilla-gaza-varese-presidio-montegrappa',
+    canonicalPath: '/articoli-frontaliere/flotilla-gaza-varese-presidio-montegrappa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32260,7 +32260,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, orso, ripreso, valposchiavo, ritorno',
     ogTitle: 'Orso ripreso in Valposchiavo: ritorno dopo anni',
     ogDescription: 'Una fototrappola ha immortalato un orso il 29 aprile nei boschi tra Le Prese e Miralago, riaprendo il dibattito sulla convivenza con la fauna selvatica',
-    canonicalPath: '/articoli-frontaliere/orso-valposchiavo-2026-ritorno',
+    canonicalPath: '/articoli-frontaliere/orso-valposchiavo-2026-ritorno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32288,7 +32288,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, studenti, premiati, borse, studio',
     ogTitle: '87 studenti premiati con borse di studio a Gallarate',
     ogDescription: 'La cerimonia si è svolta al Maga-Hic di Gallarate, dove 87 studenti sono stati premiati per i loro risultati scolastici ed extrascolastici.',
-    canonicalPath: '/articoli-frontaliere/gallarate-borse-studio-2026',
+    canonicalPath: '/articoli-frontaliere/gallarate-borse-studio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32316,7 +32316,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, sindacati, politica, contro',
     ogTitle: '1° maggio 2026: sindacati e politica contro l\'iniziativa UDC',
     ogDescription: 'Mobilitazione nazionale contro l\'iniziativa UDC \'No a una Svizzera da 10 milioni!\' con manifestazioni in diverse città svizzere.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati-iniziativa-udc',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-ticino-sindacati-iniziativa-udc/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32344,7 +32344,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, lugano, lavoro, scende',
     ogTitle: '1° Maggio a Lugano: il lavoro scende in piazza',
     ogDescription: 'Centinaia di persone hanno sfilato per le vie di Lugano sotto lo slogan \'Né sfruttati, né divisi\' per rivendicare salari equi e sicurezza sul lavoro',
-    canonicalPath: '/articoli-frontaliere/lavoro-scende-piazza-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/lavoro-scende-piazza-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32372,7 +32372,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, radar, sempre, attivi, ecco',
     ogTitle: 'Radar sempre attivi: ecco dove dal 4 al 10 maggio',
     ogDescription: 'La Polizia cantonale annuncia controlli della velocità in diverse località del Ticino dal 4 al 10 maggio 2026. Ecco dove saranno posizionati i radar.',
-    canonicalPath: '/articoli-frontaliere/radar-ticino-velocita-2026',
+    canonicalPath: '/articoli-frontaliere/radar-ticino-velocita-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32400,7 +32400,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, migliaia, piazza',
     ogTitle: 'Primo maggio 2026: migliaia in piazza a Zurigo e Basilea',
     ogDescription: 'Manifestazioni pacifiche a Zurigo e Basilea con 15\'000 e 2\'500 partecipanti, rispettivamente. Isolati atti di vandalismo e critiche alla gestione della sanità.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-zurigo-basilea-2026',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-zurigo-basilea-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32428,7 +32428,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rive, libere, ascona, apre',
     ogTitle: 'Rive libere: Ascona apre al pubblico d\'inverno',
     ogDescription: 'L\'associazione Rive pubbliche della Svizzera italiana celebra due successi: l\'inclusione nel gruppo di lavoro per il Sentiero delle Rive e l\'apertura invernale',
-    canonicalPath: '/articoli-frontaliere/rive-libere-ascona-2026',
+    canonicalPath: '/articoli-frontaliere/rive-libere-ascona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32456,7 +32456,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mezzi, pesanti, biandronno, avvia',
     ogTitle: 'Mezzi pesanti, Biandronno avvia sperimentazione',
     ogDescription: 'Il sindaco Massimo Porotti annuncia l\'inizio della sperimentazione per limitare il traffico dei mezzi pesanti nel Medio Verbano',
-    canonicalPath: '/articoli-frontaliere/mezzi-pesanti-biandronno-2026',
+    canonicalPath: '/articoli-frontaliere/mezzi-pesanti-biandronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32484,7 +32484,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, trump, aumenta, dazi, auto',
     ogTitle: 'Trump aumenta dazi UE del 25% su auto e camion',
     ogDescription: 'Il presidente USA annuncia l\'aumento dei dazi su auto e camion provenienti dall\'UE, accusando l\'Unione Europea di non rispettare l\'accordo commerciale.',
-    canonicalPath: '/articoli-frontaliere/trump-dazi-ue-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/trump-dazi-ue-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32512,7 +32512,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, balerna, celebra, anni, consiglio',
     ogTitle: 'Balerna celebra 100 anni del Consiglio comunale',
     ogDescription: 'Balerna festeggia il centenario del suo Consiglio comunale con una celebrazione dedicata a chi ha lavorato per il paese. Scopri di più sugli eventi e le',
-    canonicalPath: '/articoli-frontaliere/balerna-consiglio-comunale-centenario',
+    canonicalPath: '/articoli-frontaliere/balerna-consiglio-comunale-centenario/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32540,7 +32540,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confsal, lancia, manifesto, lavoro',
     ogTitle: 'Confsal lancia manifesto del lavoro: dignità, salari e diritti al centro',
     ogDescription: 'Il 1 maggio, la Confsal ha presentato il suo manifesto del lavoro a Napoli, evidenziando la necessità di dignità, salari equi e diritti per i lavoratori.',
-    canonicalPath: '/articoli-frontaliere/confsal-manifesto-lavoro-dignita-salari',
+    canonicalPath: '/articoli-frontaliere/confsal-manifesto-lavoro-dignita-salari/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32568,7 +32568,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, usa-iran, tensioni, nucleari, sanzioni',
     ogTitle: 'USA-Iran: tensioni nucleari e sanzioni nel 2026',
     ogDescription: 'Teheran accusa USA di poco impegno nei negoziati e azioni militari parallele. Trump: colloqui in corso telefonicamente.',
-    canonicalPath: '/articoli-frontaliere/usa-iran-nucleare-sanzioni-2026',
+    canonicalPath: '/articoli-frontaliere/usa-iran-nucleare-sanzioni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32596,7 +32596,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sicurezza, locali, pubblici, convegno',
     ogTitle: 'Convegno sicurezza locali pubblici Ville Ponti 29 giugno',
     ogDescription: 'Convegno sulla sicurezza nei locali pubblici a Ville Ponti il 29 giugno 2026. Focus su prevenzione incendi e normative.',
-    canonicalPath: '/articoli-frontaliere/sicurezza-locali-pubblici-convegno-ville-ponti',
+    canonicalPath: '/articoli-frontaliere/sicurezza-locali-pubblici-convegno-ville-ponti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32624,7 +32624,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sospetta, fuga, stazione, metro',
     ogTitle: 'Sospetta fuga di gas, stazione metro temporaneamente chiusa',
     ogDescription: 'La stazione di Farringdon a Londra evacuata e chiusa al traffico a causa di una sospetta fuga di gas accidentale',
-    canonicalPath: '/articoli-frontaliere/sospetta-fuga-gas-londra-metro-chiusa',
+    canonicalPath: '/articoli-frontaliere/sospetta-fuga-gas-londra-metro-chiusa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32652,7 +32652,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cassis, araghchi, discutono, situazione',
     ogTitle: 'Cassis e Araghchi discutono situazione regionale',
     ogDescription: 'Il consigliere federale Ignazio Cassis ha parlato con il ministro degli Esteri iraniano Abbas Araghchi della situazione regionale.',
-    canonicalPath: '/articoli-frontaliere/cassis-aragchi-colloquio-iran',
+    canonicalPath: '/articoli-frontaliere/cassis-aragchi-colloquio-iran/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32680,7 +32680,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, colosso, tonnellate, nato, legnano',
     ogTitle: 'Colosso da 35 tonnellate nato a Legnano',
     ogDescription: 'Scopri il T-Mill, la macchina utensile CNC da 35 tonnellate sviluppata dalla Camu Srl di Legnano per lavorazioni ad alta precisione.',
-    canonicalPath: '/articoli-frontaliere/colosso-35-tonnellate-legnano',
+    canonicalPath: '/articoli-frontaliere/colosso-35-tonnellate-legnano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32708,7 +32708,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, villa, visconti, borromeo, litta',
     ogTitle: 'Villa Visconti Borromeo Litta riapre a Lainate: giochi d\'acqua e giardini monumentali',
     ogDescription: 'Scopri la riapertura di Villa Visconti Borromeo Litta a Lainate con i suoi giochi d\'acqua e giardini monumentali. Un\'esperienza unica tra arte e natura.',
-    canonicalPath: '/articoli-frontaliere/riapre-villa-visconti-lainate-2026',
+    canonicalPath: '/articoli-frontaliere/riapre-villa-visconti-lainate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32736,7 +32736,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, teheran, consegna, nuova, proposta',
     ogTitle: 'Teheran consegna nuova proposta negoziale ai mediatori pakistani',
     ogDescription: 'La diplomazia iraniana cerca nuove vie per la fine del conflitto coinvolgendo mediatori pakistani',
-    canonicalPath: '/articoli-frontaliere/teheran-proposta-pakistan-mediatori',
+    canonicalPath: '/articoli-frontaliere/teheran-proposta-pakistan-mediatori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32764,7 +32764,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, inflazione, perché, sentono, peso',
     ogTitle: 'Inflazione in Svizzera: perché i frontalieri sentono il peso',
     ogDescription: 'L\'inflazione ufficiale in Svizzera è bassa, ma i frontalieri in Ticino sentono il peso del caro vita. Ecco perché.',
-    canonicalPath: '/articoli-frontaliere/inflazione-svizzera-frontalieri-ticino',
+    canonicalPath: '/articoli-frontaliere/inflazione-svizzera-frontalieri-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32792,7 +32792,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, linea, aiuto, vittime',
     ogTitle: '142: nuova linea d\'aiuto per vittime di violenza in Ticino',
     ogDescription: 'Il numero 142 è ora attivo in Ticino per supportare le vittime di violenza fisica, psichica o sessuale. Gratuito e anonimo, offre consulenza 24 ore su 24.',
-    canonicalPath: '/articoli-frontaliere/142-linea-aiuto-vittime-violenza-ticino',
+    canonicalPath: '/articoli-frontaliere/142-linea-aiuto-vittime-violenza-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32820,7 +32820,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, cadegliano, viconago, ferito',
     ogTitle: 'Incidente a Cadegliano Viconago: ferito un 54enne',
     ogDescription: 'Un incidente tra un\'auto e una moto a Cadegliano Viconago, Varese, ha lasciato un 54enne ferito. Ecco i dettagli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/collisione-cadegliano-varese-ferito-54enne',
+    canonicalPath: '/articoli-frontaliere/collisione-cadegliano-varese-ferito-54enne/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32848,7 +32848,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, congresso, record, lugano, contro',
     ogTitle: 'Congresso record a Lugano contro il cancro alla prostata',
     ogDescription: 'Oltre 1000 medici e ricercatori a Lugano per linee guida internazionali. In Ticino 400 casi l\'anno.',
-    canonicalPath: '/articoli-frontaliere/congresso-lugano-cancro-prostata-2024',
+    canonicalPath: '/articoli-frontaliere/congresso-lugano-cancro-prostata-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32876,7 +32876,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riapre, circolo, albate, piazza',
     ogTitle: 'Riapre il Circolo ad Albate: una piazza al coperto per la comunità',
     ogDescription: 'Il bar Circolo ad Albate riapre i battenti il 1° maggio 2026, diventando un punto di aggregazione sociale e culturale per la comunità.',
-    canonicalPath: '/articoli-frontaliere/circolo-albate-riapertura-2026',
+    canonicalPath: '/articoli-frontaliere/circolo-albate-riapertura-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32904,7 +32904,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, aranno, moto, centra, palo',
     ogTitle: 'Incidente motociclistico ad Aranno: un uomo ricoverato',
     ogDescription: 'Un incidente motociclistico ad Aranno: la moto centra un palo e finisce nella scarpata. Un uomo è stato ricoverato in ospedale. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/aranno-incidente-moto-ricoverato-uomo',
+    canonicalPath: '/articoli-frontaliere/aranno-incidente-moto-ricoverato-uomo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32932,7 +32932,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, viaggio, tempo, quinto',
     ogTitle: 'Como, viaggio nel tempo: Quinto, Caffè&Caffè, Ul Pan de Comm',
     ogDescription: 'Scopri come alcune zone di Como mantengono il fascino di un tempo, con locali frequentati da residenti e non da turisti.',
-    canonicalPath: '/articoli-frontaliere/como-viaggio-nel-tempo-2026',
+    canonicalPath: '/articoli-frontaliere/como-viaggio-nel-tempo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32960,7 +32960,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, rapinese, accusa, roma',
     ogTitle: 'Como: Rapinese accusa Roma su fondi per Volta. Replica durissima',
     ogDescription: 'Il sindaco di Como accusa Roma di aver stanziato 6 milioni per una sit-com su Volta, zero per i monumenti. Replica del Comitato Nazionale.',
-    canonicalPath: '/articoli-frontaliere/como-volta-faro-rapinese-6-milioni',
+    canonicalPath: '/articoli-frontaliere/como-volta-faro-rapinese-6-milioni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -32988,7 +32988,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, controlli, velocità, ecco, dove',
     ogTitle: 'Controlli velocità Ticino: dove saranno i radar dal 4 al 10 maggio',
     ogDescription: 'La Polizia cantonale e le polizie comunali comunicano i luoghi dei controlli della velocità mobili e semi-stazionari nel Canton Ticino dal 4 al 10 maggio 2024.',
-    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-maggio-2024',
+    canonicalPath: '/articoli-frontaliere/controlli-velocita-ticino-maggio-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33016,7 +33016,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, salari, diritti',
     ogTitle: 'Primo maggio in Ticino: salari e diritti al centro delle proteste',
     ogDescription: 'Circa duemila persone hanno sfilato a Lugano per chiedere salari dignitosi e denunciare il dumping salariale',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-ticino-salari-2024',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-ticino-salari-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33044,7 +33044,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, abusi, viabilistici, moltrasio, lago',
     ogTitle: 'Sosta selvaggia a Moltrasio: il problema degli abusi viabilistici sul Lago di Como',
     ogDescription: 'Il paesino di Moltrasio sul Lago di Como è spesso vittima di sosta selvaggia da parte di auto straniere. Ecco cosa sta succedendo.',
-    canonicalPath: '/articoli-frontaliere/sosta-selvaggia-moltrasio-2026',
+    canonicalPath: '/articoli-frontaliere/sosta-selvaggia-moltrasio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33072,7 +33072,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sconfitta, dalla, svezia, lezione',
     ogTitle: 'Svizzera sconfitta dalla Svezia: una lezione per il futuro',
     ogDescription: 'La nazionale svizzera di hockey subisce una pesante sconfitta contro la Svezia, con un risultato finale di 8-1.',
-    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-svezia',
+    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-svezia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33100,7 +33100,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incidente, lambrugo, 74enne, ospedale',
     ogTitle: 'Incidente Lambrugo: 74enne in ospedale dopo scontro auto-moto',
     ogDescription: 'Un grave incidente stradale a Lambrugo, Como, ha coinvolto un\'auto e una moto, con un 74enne ricoverato in ospedale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/lambrugo-incidente-74enne-ospedale',
+    canonicalPath: '/articoli-frontaliere/lambrugo-incidente-74enne-ospedale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33128,7 +33128,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, delia, cambia, testo, bella',
     ogTitle: 'Delia cambia testo Bella Ciao al Concertone: più attuale',
     ogDescription: 'Delia modifica Bella Ciao al Concertone del 1° maggio a Roma, sostituendo \'partigiano\' con \'essere umano\' per rendere il messaggio più attuale.',
-    canonicalPath: '/articoli-frontaliere/delia-bella-ciao-concertone-2026',
+    canonicalPath: '/articoli-frontaliere/delia-bella-ciao-concertone-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33156,7 +33156,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, funivia, säntis, chiusa, mesi',
     ogTitle: 'Funivia del Säntis chiusa per mesi: ammodernamento da 30 milioni',
     ogDescription: 'La funivia del Säntis chiuderà per diversi mesi per un ammodernamento da 30 milioni di franchi. Riapertura prevista in autunno.',
-    canonicalPath: '/articoli-frontaliere/funivia-santis-ammodernamento-2026',
+    canonicalPath: '/articoli-frontaliere/funivia-santis-ammodernamento-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33184,7 +33184,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, curiosità, brevetti, svizzeri',
     ogTitle: 'Cinque curiosità sui brevetti svizzeri',
     ogDescription: 'La Svizzera è il paese più innovativo d\'Europa in materia di brevetti. Ecco i dati più interessanti del 2025.',
-    canonicalPath: '/articoli-frontaliere/cinque-curiosita-brevetti-svizzeri-2026',
+    canonicalPath: '/articoli-frontaliere/cinque-curiosita-brevetti-svizzeri-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33212,7 +33212,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, libertà, stampa, ottava, mondo',
     ogTitle: 'Libertà di stampa in Svizzera: ottava nel mondo',
     ogDescription: 'La Svizzera si posiziona all\'ottavo posto nella classifica mondiale della libertà di stampa, ma presenta criticità giuridiche ed economiche.',
-    canonicalPath: '/articoli-frontaliere/liberta-stampa-minimi-25-anni',
+    canonicalPath: '/articoli-frontaliere/liberta-stampa-minimi-25-anni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33240,7 +33240,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, dolore, vicinanza, matteo, famiglia',
     ogTitle: 'Tutto il villaggio dal suo piccolo angelo: il dolore, la vicinanza, l\'affetto per Matteo e la sua famiglia',
     ogDescription: 'Il villaggio di Busto Arsizio si stringe intorno alla famiglia di Matteo, un bambino di 4 anni scomparso, con dolore e affetto.',
-    canonicalPath: '/articoli-frontaliere/villaggio-angelo-busto-arsizio',
+    canonicalPath: '/articoli-frontaliere/villaggio-angelo-busto-arsizio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33268,7 +33268,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiese, derubate, graubünden, rumeni',
     ogTitle: 'Chiese derubate in Ticino e Graubünden: due rumeni arrestati',
     ogDescription: 'Due rumeni arrestati per furti in sei chiese tra Ticino e Graubünden. Scopri i dettagli delle indagini e cosa fare se sei stato vittima di un furto.',
-    canonicalPath: '/articoli-frontaliere/chiese-ticino-derubate-2026',
+    canonicalPath: '/articoli-frontaliere/chiese-ticino-derubate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33296,7 +33296,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggio, sindacati, contro, iniziative',
     ogTitle: '1° maggio: sindacati Ticino contro iniziative UDC e destra',
     ogDescription: '3.000 persone in corteo a Lugano. Critiche a proposte considerate razziste e xenofobe. Fonio: condizioni di lavoro a rischio.',
-    canonicalPath: '/articoli-frontaliere/sindacati-ticino-1-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/sindacati-ticino-1-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33324,7 +33324,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, progetto, abbandonato, dopo',
     ogTitle: 'Polizia Ticino: progetto abbandonato dopo opposizioni',
     ogDescription: 'Il progetto di riforma della polizia ticinese è stato abbandonato dopo 12 mesi di consultazione e forti opposizioni',
-    canonicalPath: '/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026',
+    canonicalPath: '/articoli-frontaliere/polizia-ticino-abbandono-progetto-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33352,7 +33352,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, vico, morcote, bimbo',
     ogTitle: 'Tragedia a Vico Morcote: bimbo di due anni annega in piscina',
     ogDescription: 'Un bambino di due anni ha perso la vita in un incidente in piscina a Vico Morcote. La tragedia si è verificata in una villa privata.',
-    canonicalPath: '/articoli-frontaliere/tragedia-vico-morcote-bimbo-piscina',
+    canonicalPath: '/articoli-frontaliere/tragedia-vico-morcote-bimbo-piscina/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33380,7 +33380,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, crans-montana, denunciata, organizzazione, cantonale',
     ogTitle: 'Crans-Montana, denunciata l\'Organizzazione cantonale di soccorso',
     ogDescription: 'Indagine aperta sul dispositivo di intervento dopo l\'incendio del bar Le Constellation. Avvocati delle vittime denunciano carenze',
-    canonicalPath: '/articoli-frontaliere/crans-montana-soccorso-denunciato',
+    canonicalPath: '/articoli-frontaliere/crans-montana-soccorso-denunciato/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33408,7 +33408,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, fallisce, previsioni, eventi, estremi',
     ogTitle: 'IA fallisce previsioni eventi estremi: studio Università di Ginevra',
     ogDescription: 'Nuovo studio rivela che l\'IA sbaglia sistematicamente previsioni su eventi meteorologici estremi, sottostimando ondate di calore e freddo',
-    canonicalPath: '/articoli-frontaliere/ia-meteo-eventi-estremi',
+    canonicalPath: '/articoli-frontaliere/ia-meteo-eventi-estremi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33436,7 +33436,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, condannato, anni, tentato, assassinio',
     ogTitle: 'Condannato a 11 anni per tentato assassinio a Chiasso',
     ogDescription: 'Un 34enne è stato condannato a 11 anni per tentato assassinio della compagna a Chiasso. La corte ha ordinato anche l\'espulsione.',
-    canonicalPath: '/articoli-frontaliere/tentato-assassinio-chiasso-2026',
+    canonicalPath: '/articoli-frontaliere/tentato-assassinio-chiasso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33464,7 +33464,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, primo, maggio, cortei, pacifici',
     ogTitle: 'Primo Maggio 2026 in Svizzera: cortei pacifici e critiche al capitalismo',
     ogDescription: 'Migliaia di manifestanti hanno partecipato ai cortei del Primo Maggio in Svizzera, con episodi di vandalismo a Zurigo e critiche al G7 e al capitalismo.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-svizzera-cortei',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-2026-svizzera-cortei/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33492,7 +33492,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guardie, svizzere, 2025, anno',
     ogTitle: 'Guardie svizzere: 2025 anno intenso con morte di Papa Francesco e conclave',
     ogDescription: 'Il 2025 è stato un anno eccezionale per la Guardia svizzera pontificia, segnato dalla morte di Papa Francesco, il conclave e il giubileo.',
-    canonicalPath: '/articoli-frontaliere/guardie-svizzere-2025-intenso',
+    canonicalPath: '/articoli-frontaliere/guardie-svizzere-2025-intenso/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33520,7 +33520,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, siccità, estate, rischio, aprile',
     ogTitle: 'Siccità in Ticino: estate 2026 a rischio',
     ogDescription: 'Aprile 2026 è stato il più secco degli ultimi anni, con precipitazioni al 10% della media. Rischio incendi e bacini idrici critici.',
-    canonicalPath: '/articoli-frontaliere/siccit-estate-2026-ticino',
+    canonicalPath: '/articoli-frontaliere/siccit-estate-2026-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33548,7 +33548,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, polizia, unica, galusero, galli',
     ogTitle: 'Polizia unica in Ticino: Galusero vs Galli, il dibattito si accende',
     ogDescription: 'Il Consiglio di Stato ha deciso di stoppare il progetto \'Polizia ticinese\'. Le reazioni di Galusero e Galli e le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026',
+    canonicalPath: '/articoli-frontaliere/polizia-ticino-progetto-abbandono-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33576,7 +33576,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nazionale, respinge, iniziativa, democrazia',
     ogTitle: 'Nazionale respinge iniziativa democrazia',
     ogDescription: 'Il Consiglio nazionale ha respinto l\'iniziativa per dimezzare i tempi per la cittadinanza a 5 anni. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-nazionale',
+    canonicalPath: '/articoli-frontaliere/iniziativa-democrazia-respinta-nazionale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33604,7 +33604,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, uisp, alla, scuola, dante',
     ogTitle: 'UISP alla scuola Dante di Varese per promuovere lo sport inclusivo',
     ogDescription: 'L\'incontro tra UISP e Associazione Genitori alla scuola Dante di Varese ha promosso lo sport per tutti, con progetti inclusivi e attività per disabili.',
-    canonicalPath: '/articoli-frontaliere/uisp-scuola-dante-varese-2026',
+    canonicalPath: '/articoli-frontaliere/uisp-scuola-dante-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33632,7 +33632,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, capanna, soveltra, ricostruzione, avanza',
     ogTitle: 'Capanna Soveltra, ricostruzione avanza più velocemente dell’iter giudiziario',
     ogDescription: 'La ricostruzione della Capanna Soveltra in Val Maggia procede rapidamente, mentre il ricorso al Tribunale federale è ancora in fase di definizione.',
-    canonicalPath: '/articoli-frontaliere/ricostruzione-capanna-soveltra-avanza',
+    canonicalPath: '/articoli-frontaliere/ricostruzione-capanna-soveltra-avanza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33660,7 +33660,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, processo, quadroni, capo, posto',
     ogTitle: 'Processo Quadroni: l\'ex capo posto contesta le accuse',
     ogDescription: 'L\'ex capo del posto di polizia di Scuol contesta le accuse di abuso di autorità, sequestro di persona e violazione di domicilio. La Procura pubblica chiede una',
-    canonicalPath: '/articoli-frontaliere/processo-quadroni-ex-capo-posto-contesta-accuse',
+    canonicalPath: '/articoli-frontaliere/processo-quadroni-ex-capo-posto-contesta-accuse/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33688,7 +33688,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, docente, arrestato, giubiasco, richiesta',
     ogTitle: 'Docente arrestato a Giubiasco, richiesta proroga detenzione',
     ogDescription: 'La Procura richiede proroga detenzione per docente arrestato a Giubiasco. Inchiesta su minorenni in corso. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/docente-arrestato-giubiasco-proroga',
+    canonicalPath: '/articoli-frontaliere/docente-arrestato-giubiasco-proroga/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33716,7 +33716,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, angelo, custode, evita, colpi',
     ogTitle: 'L\'angelo custode della IA evita i colpi di sonno al volante?',
     ogDescription: 'Scopri come il sistema Driver-Check, sviluppato in Svizzera, utilizza l\'IA per prevenire i colpi di sonno alla guida e le sue limitazioni.',
-    canonicalPath: '/articoli-frontaliere/angelo-custode-ia-colpo-sonno',
+    canonicalPath: '/articoli-frontaliere/angelo-custode-ia-colpo-sonno/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33744,7 +33744,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agenzia, formativa, varese, dimissioni',
     ogTitle: 'Agenzia formativa Varese: dimissioni del CDA',
     ogDescription: 'Ilaria Azzimonti annuncia le dimissioni dal consiglio di amministrazione dell\'Agenzia formativa della Provincia di Varese a causa di tensioni interne.',
-    canonicalPath: '/articoli-frontaliere/agenzia-formativa-varese-dimissioni-2026',
+    canonicalPath: '/articoli-frontaliere/agenzia-formativa-varese-dimissioni-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33772,7 +33772,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, presentazione, libro, femminismo',
     ogTitle: 'Varese: presentazione libro sul femminismo pacifista',
     ogDescription: 'Giovedì 7 maggio in Sala Morselli a Varese, presentazione libro \'Al di sopra dell’odio e del massacro\' di Lacaita e Suriano',
-    canonicalPath: '/articoli-frontaliere/presentazione-libro-odio-massacro-varese',
+    canonicalPath: '/articoli-frontaliere/presentazione-libro-odio-massacro-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33800,7 +33800,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, energia, fattura, miliardaria, conflitto',
     ogTitle: 'Energia: la fattura miliardaria del conflitto in Medio Oriente',
     ogDescription: 'Il prezzo del diesel supera i 2 franchi al litro in Svizzera a causa del conflitto in Medio Oriente, con costi aggiuntivi per famiglie e imprese',
-    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-2026',
+    canonicalPath: '/articoli-frontaliere/fattura-miliardaria-energia-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33828,7 +33828,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, arco, frecce, centro, cuore',
     ogTitle: 'Arco e frecce per far centro nel cuore degli appassionati',
     ogDescription: 'Una nuova società di arcieri è stata fondata a Bellinzona. La presidente Rita De Franco: ‘Siamo al Vallone, ma speriamo in un campo fisso’.',
-    canonicalPath: '/articoli-frontaliere/arco-e-frecce-per-far-centro',
+    canonicalPath: '/articoli-frontaliere/arco-e-frecce-per-far-centro/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33856,7 +33856,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, museo, paesaggio, verbania, ingresso',
     ogTitle: 'Museo del Paesaggio di Verbania: ingresso gratuito per i residenti',
     ogDescription: 'L\'8 maggio 2026 ingresso gratuito al Museo del Paesaggio di Verbania per i residenti in occasione della festa patronale di San Vittore.',
-    canonicalPath: '/articoli-frontaliere/museo-paesaggio-verbania-gratis-2026',
+    canonicalPath: '/articoli-frontaliere/museo-paesaggio-verbania-gratis-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33884,7 +33884,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, biandronno, incontro, pubblico, astuti',
     ogTitle: 'Biandronno: incontro pubblico con Astuti e Licata su sanità e trasporti',
     ogDescription: 'Biandronno Più organizza un incontro pubblico con i consiglieri regionali Astuti e Licata per discutere di sanità e trasporti nel Varesotto.',
-    canonicalPath: '/articoli-frontaliere/biandronno-incontro-astuti-licata-2026',
+    canonicalPath: '/articoli-frontaliere/biandronno-incontro-astuti-licata-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33912,7 +33912,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gratis, museo, costume, bagno',
     ogTitle: 'Gratis al museo in costume da bagno: l\'iniziativa della Fondazione Beyeler',
     ogDescription: 'La Fondazione Beyeler di Riehen offre ingresso gratuito in costume da bagno per una giornata dedicata a Paul Cézanne e ai suoi dipinti di bagnanti.',
-    canonicalPath: '/articoli-frontaliere/gratis-museo-costume-bagno-2026',
+    canonicalPath: '/articoli-frontaliere/gratis-museo-costume-bagno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33940,7 +33940,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sfratto, agli, allenatori, svicc',
     ogTitle: 'Sfratto agli allenatori: la Svicc chiude le scuderie di Varese',
     ogDescription: 'La Svicc sfratta gli allenatori delle scuderie di Varese entro 60 giorni. Progetto di demolizione e ristrutturazione',
-    canonicalPath: '/articoli-frontaliere/ippodromo-varese-svicc-allenatori',
+    canonicalPath: '/articoli-frontaliere/ippodromo-varese-svicc-allenatori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33968,7 +33968,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luigi, bignami, insubria, arte',
     ogTitle: 'Luigi Bignami all\'Insubria: l\'arte di comunicare la scienza',
     ogDescription: 'Luigi Bignami all\'Università dell\'Insubria per parlare di comunicazione scientifica. Scopri come tradurre la complessità in linguaggio accessibile.',
-    canonicalPath: '/articoli-frontaliere/luigi-bignami-insubria-scienza-2026',
+    canonicalPath: '/articoli-frontaliere/luigi-bignami-insubria-scienza-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -33996,7 +33996,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carcere, busto, arsizio, denuncia',
     ogTitle: 'Carcere Busto Arsizio: denuncia Strada al Parlamento europeo',
     ogDescription: 'Denuncia di Cecilia Strada al Parlamento europeo sul sovraffollamento del carcere di Busto Arsizio, con tasso oltre il 200% e condizioni disumane.',
-    canonicalPath: '/articoli-frontaliere/busto-arsizio-carcere-denuncia-strada',
+    canonicalPath: '/articoli-frontaliere/busto-arsizio-carcere-denuncia-strada/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34024,7 +34024,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bracconaggio, ittico, lago, maggiore',
     ogTitle: 'Bracconaggio ittico sul Lago Maggiore: denunciato pescatore con fiocina',
     ogDescription: 'Operazione dei Carabinieri Forestali nel Varesotto: sequestri e denuncia penale per pesca illegale di lucioperca in periodo di fermo biologico',
-    canonicalPath: '/articoli-frontaliere/bracconaggio-ittico-lago-maggiore-ispra-2026',
+    canonicalPath: '/articoli-frontaliere/bracconaggio-ittico-lago-maggiore-ispra-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34052,7 +34052,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, maggiolone, social, park, mese',
     ogTitle: 'Maggiolone Social Park: un mese di feste a Cassano Magnago',
     ogDescription: 'Dal 1° maggio, Cassano Magnago ospita il nuovo Maggiolone Social Park con eventi gratuiti per tutte le età. Scopri il programma e come partecipare.',
-    canonicalPath: '/articoli-frontaliere/maggiolone-social-park-cassano-magnago',
+    canonicalPath: '/articoli-frontaliere/maggiolone-social-park-cassano-magnago/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34080,7 +34080,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, grassi, 1925, entra, registro',
     ogTitle: 'Grassi 1925 entra nel Registro Speciale dei Marchi Storici',
     ogDescription: 'Grassi 1925, azienda varesina fondata nel 1925, entra nel Registro Speciale dei Marchi Storici di Interesse Nazionale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/grassi-1925-marchio-storico',
+    canonicalPath: '/articoli-frontaliere/grassi-1925-marchio-storico/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34108,7 +34108,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lati, premiata, imprese, vincenti',
     ogTitle: 'LATI premiata tra le Imprese Vincenti di Intesa Sanpaolo',
     ogDescription: 'LATI Industria Termoplastici premiata tra le Imprese Vincenti di Intesa Sanpaolo per solidità, innovazione e visione internazionale',
-    canonicalPath: '/articoli-frontaliere/lati-industria-termoplastici-premiata-intesanpaolo',
+    canonicalPath: '/articoli-frontaliere/lati-industria-termoplastici-premiata-intesanpaolo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34136,7 +34136,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, progettare, sala, riunioni, funzionale',
     ogTitle: 'Come progettare una sala riunioni funzionale',
     ogDescription: 'Scopri come progettare una sala riunioni funzionale e accogliente, con consigli su arredamento, tecnologia e comfort',
-    canonicalPath: '/articoli-frontaliere/progettare-sala-riunioni-ufficio',
+    canonicalPath: '/articoli-frontaliere/progettare-sala-riunioni-ufficio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34164,7 +34164,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giovani, agenti, polizia, locale',
     ogTitle: 'Giovani agenti con la polizia locale a Como',
     ogDescription: 'Dieci studenti diventano agenti per un giorno con la polizia locale di Como, segnalando violazioni e promuovendo la legalità.',
-    canonicalPath: '/articoli-frontaliere/giovani-agenti-como-polizia-locale',
+    canonicalPath: '/articoli-frontaliere/giovani-agenti-como-polizia-locale/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34192,7 +34192,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gallarate, fondazione, scuole, materne',
     ogTitle: 'Gallarate: Fondazione Scuole Materne, scontro in consiglio comunale',
     ogDescription: 'Il consiglio comunale di Gallarate si infiamma nuovamente sulla Fondazione Scuole Materne, con dimissioni del presidente e polemiche sui verbali.',
-    canonicalPath: '/articoli-frontaliere/gallarate-fondazione-scuole-materne-2026',
+    canonicalPath: '/articoli-frontaliere/gallarate-fondazione-scuole-materne-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34220,7 +34220,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, formula, riparte, rischi, polemiche',
     ogTitle: 'Formula 1 riparte fra rischi e polemiche',
     ogDescription: 'Il Mondiale di Formula 1 riprende a Miami dopo un mese di stop. Critiche al nuovo regolamento che penalizza piloti e monoposto.',
-    canonicalPath: '/articoli-frontaliere/formula-1-riparte-rischi-polemiche',
+    canonicalPath: '/articoli-frontaliere/formula-1-riparte-rischi-polemiche/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34248,7 +34248,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, unitalsi, busto, varese, sollievo',
     ogTitle: 'Unitalsi Busto e Varese: sollievo spirituale e miracoli per i malati',
     ogDescription: 'Scopri come l\'Unitalsi di Busto Arsizio e Varese offre supporto ai malati attraverso pellegrinaggi e assistenza spirituale.',
-    canonicalPath: '/articoli-frontaliere/unitalsi-busto-varese-malati-spiritualita',
+    canonicalPath: '/articoli-frontaliere/unitalsi-busto-varese-malati-spiritualita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34276,7 +34276,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vita, confini, mondo, sull',
     ogTitle: 'Vita ai confini del mondo sull\'isola artica d\'Islanda',
     ogDescription: 'Scopri la storia di Leonardo Piccione, un pugliese che ha trascorso mesi sull\'isola di Grímsey in Islanda, lavorando e scrivendo un libro sulla sua esperienza.',
-    canonicalPath: '/articoli-frontaliere/isola-artica-islanda-pugliese',
+    canonicalPath: '/articoli-frontaliere/isola-artica-islanda-pugliese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34304,7 +34304,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chocolat, stella, torna, bellinzona',
     ogTitle: 'Chocolat Stella torna a Bellinzona con nuovo negozio',
     ogDescription: 'Chocolat Stella apre nuovo punto vendita in piazza Nosetto, Palazzo civico, Bellinzona. Apertura prevista nei prossimi mesi del 2026.',
-    canonicalPath: '/articoli-frontaliere/cioccolato-illumina-bellinzona-2026',
+    canonicalPath: '/articoli-frontaliere/cioccolato-illumina-bellinzona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34332,7 +34332,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, luna, park, schiranna, vita',
     ogTitle: 'Luna Park Schiranna: vita tra giostre e carovane',
     ogDescription: 'Scopri la vita dei giostrai e delle giostraie che ogni anno portano musica e luci alla Schiranna di Varese',
-    canonicalPath: '/articoli-frontaliere/varese-luna-park-schiranna-2026',
+    canonicalPath: '/articoli-frontaliere/varese-luna-park-schiranna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34360,7 +34360,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, mera, longhi, anni, dolcezza',
     ogTitle: 'Mera & Longhi: 130 anni di dolcezza artigianale premiati a Varese',
     ogDescription: 'La Famiglia Bosina premia l\'azienda storica varesina Mera & Longhi per 130 anni di eccellenza dolciaria. Scopri la storia e i prodotti di questa icona della',
-    canonicalPath: '/articoli-frontaliere/mera-longhi-130-anni-dolcezza-varese',
+    canonicalPath: '/articoli-frontaliere/mera-longhi-130-anni-dolcezza-varese/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34388,7 +34388,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, girometta, andrea, chiodi, varese',
     ogTitle: 'Girometta d\'oro 2026 a Andrea Chiodi: Varese premia il suo regista',
     ogDescription: 'Andrea Chiodi vince la Girometta d\'oro 2026 per aver portato il nome di Varese nel firmamento della cultura e del teatro contemporaneo.',
-    canonicalPath: '/articoli-frontaliere/girometta-doro-andrea-chiodi-varese-2026',
+    canonicalPath: '/articoli-frontaliere/girometta-doro-andrea-chiodi-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34416,7 +34416,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, concerto, luino, vivaldi, bach',
     ogTitle: 'Concerto a Luino: Vivaldi e Bach al Santuario del Carmine',
     ogDescription: 'Sabato 2 maggio 2026 la Milano Festival Chamber Orchestra si esibisce a Luino con un programma di musica classica.',
-    canonicalPath: '/articoli-frontaliere/concerto-luino-vivaldi-bach-2026',
+    canonicalPath: '/articoli-frontaliere/concerto-luino-vivaldi-bach-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34444,7 +34444,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, concerti, cassiano, riscoprire',
     ogTitle: 'Cinque concerti a San Cassiano per riscoprire un gioiello da salvare',
     ogDescription: 'Dal 9 maggio al 6 giugno 2026, cinque concerti di musica antica nella chiesetta di San Cassiano a Varese per sostenere il restauro del luogo',
-    canonicalPath: '/articoli-frontaliere/musica-antica-san-cassiano-2026',
+    canonicalPath: '/articoli-frontaliere/musica-antica-san-cassiano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34472,7 +34472,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cinque, mostre, perdere, maggio',
     ogTitle: 'Cinque mostre da non perdere a maggio in Ticino e dintorni',
     ogDescription: 'Scopri le mostre di maggio 2026 in Ticino e dintorni. Date, luoghi e dettagli delle esposizioni più attese.',
-    canonicalPath: '/articoli-frontaliere/cinque-mostre-maggio-gallarate-verbania-2026',
+    canonicalPath: '/articoli-frontaliere/cinque-mostre-maggio-gallarate-verbania-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34500,7 +34500,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, islanda, materia, storie, circolo',
     ogTitle: 'Mal d’Islanda a Materia: storie dal Circolo Polare Artico',
     ogDescription: 'Incontro sull\'isola di Grímsey a Castronno il 9 maggio con Leonardo Piccione e Francesca Milano. Scopri di più.',
-    canonicalPath: '/articoli-frontaliere/mal-dislanda-materia-castronno-2026',
+    canonicalPath: '/articoli-frontaliere/mal-dislanda-materia-castronno-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34528,7 +34528,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, pensione, inps, errori, comuni',
     ogTitle: 'Frontaliere: pensione AVS/INPS 2026, errori comuni e checklist',
     ogDescription: 'Scopri gli errori comuni nel coordinamento AVS/INPS per i frontalieri Ticino e come evitarli con una checklist operativa',
-    canonicalPath: '/articoli-frontaliere/frontaliere-pensione-avs-inps-2026-errori-comuni',
+    canonicalPath: '/articoli-frontaliere/frontaliere-pensione-avs-inps-2026-errori-comuni/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34556,7 +34556,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attivisti, flotilla, portati, israele',
     ogTitle: 'Due attivisti Flotilla portati in Israele per interrogatorio',
     ogDescription: 'Saif Abu Keshek e Thiago Ávila, attivisti pro-Palestina, saranno interrogati dalle autorità israeliane dopo l\'intercettazione della Flotilla.',
-    canonicalPath: '/articoli-frontaliere/attivisti-flotilla-israele-interrogati',
+    canonicalPath: '/articoli-frontaliere/attivisti-flotilla-israele-interrogati/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34584,7 +34584,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, intervento, polizia, pensilina, lugano',
     ogTitle: 'Intervento di polizia a Lugano in Pensilina',
     ogDescription: 'Massiccio intervento della polizia a Lugano con uso di spray lacrimogeno contro un gruppo di persone esagitate',
-    canonicalPath: '/articoli-frontaliere/massiccio-intervento-polizia-lugano-2026',
+    canonicalPath: '/articoli-frontaliere/massiccio-intervento-polizia-lugano-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34612,7 +34612,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giovani, rematori, protagonisti, ceresio',
     ogTitle: 'Giovani rematori protagonisti sul Ceresio',
     ogDescription: 'La 22ª Regata giovanile organizzata dalla Canottieri Ceresio Castagnola si è tenuta venerdì 1° maggio 2026 sul Lago Ceresio.',
-    canonicalPath: '/articoli-frontaliere/giovani-rematori-ceresio-2026',
+    canonicalPath: '/articoli-frontaliere/giovani-rematori-ceresio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34640,7 +34640,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, permesso, entro, quando, conviene',
     ogTitle: 'Permesso G vs B frontalieri 2026 entro 20 km: quando conviene cambiare',
     ogDescription: 'Confronto tecnico tra Permesso G e B per frontalieri Ticino nel 2026. Focus su \'entro 20 km\' con checklist operativa e scenari concreti.',
-    canonicalPath: '/articoli-frontaliere/permesso-g-b-2026-20km-frontalieri',
+    canonicalPath: '/articoli-frontaliere/permesso-g-b-2026-20km-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34668,7 +34668,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cure, domicilio, lavorato, vita',
     ogTitle: 'Cure a domicilio: chi ha lavorato una vita non può essere penalizzato',
     ogDescription: 'Luca Frasa, Municipale di Quinto, solleva la questione delle cure a domicilio per i pensionati in Ticino, evidenziando il rischio di penalizzazione per chi ha',
-    canonicalPath: '/articoli-frontaliere/cure-domicilio-pensionati-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/cure-domicilio-pensionati-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34696,7 +34696,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, oltre, mille, studenti, gara',
     ogTitle: 'Oltre mille studenti in gara per il concorso Libriamoci a Varese',
     ogDescription: 'La diciottesima edizione del concorso Libriamoci a Varese vede la partecipazione di quasi mille studenti con testi narrativi ed elaborati grafico-pittorici.',
-    canonicalPath: '/articoli-frontaliere/libriamoci-varese-studenti-2026',
+    canonicalPath: '/articoli-frontaliere/libriamoci-varese-studenti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34724,7 +34724,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vino, alto, prodotto, scudellate',
     ogTitle: 'Il vino più alto del Ticino prodotto a Scudellate',
     ogDescription: 'Scopri il vino \'909\', prodotto a 909 metri in Valle di Muggio, e le sue caratteristiche uniche. Presentazione ufficiale il 3 maggio 2026.',
-    canonicalPath: '/articoli-frontaliere/vino-alto-ticino-scudellate-2026',
+    canonicalPath: '/articoli-frontaliere/vino-alto-ticino-scudellate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34752,7 +34752,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, corteo, palestina, invade, lungolago',
     ogTitle: 'Corteo pro Palestina invade il lungolago di Lugano',
     ogDescription: 'Una cinquantina di manifestanti ha sfilato in via Nassa e poi lungo il lungolago, bloccando il traffico e suscitando reazioni contrastanti.',
-    canonicalPath: '/articoli-frontaliere/corteo-pro-palestina-lungolago-lugano',
+    canonicalPath: '/articoli-frontaliere/corteo-pro-palestina-lungolago-lugano/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34780,7 +34780,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, social, media, minori, divieti',
     ogTitle: 'Social media e minori: i divieti non bastano',
     ogDescription: 'Riprogettare le piattaforme per evitare la dipendenza è la soluzione, non limitare l\'accesso',
-    canonicalPath: '/articoli-frontaliere/divieti-social-media-minori',
+    canonicalPath: '/articoli-frontaliere/divieti-social-media-minori/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34808,7 +34808,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, baume-schneider, sanità, immigrazione, centro',
     ogTitle: 'Baume-Schneider: sanità, AVS e immigrazione al centro del discorso del 1° maggio',
     ogDescription: 'Elisabeth Baume-Schneider ha parlato di cure, AVS e rapporti con l\'Europa nel suo discorso del 1° maggio a Liestal. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/primo-maggio-baume-schneider-sanita-avs',
+    canonicalPath: '/articoli-frontaliere/primo-maggio-baume-schneider-sanita-avs/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34836,7 +34836,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, migros, immigrazione, necessaria, garantire',
     ogTitle: 'Migros: Immigrazione necessaria per garantire l\'offerta',
     ogDescription: 'Il CEO di Migros sottolinea l\'importanza dell\'immigrazione per il settore alimentare e del commercio al dettaglio in Svizzera.',
-    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-offerta',
+    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-offerta/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34864,7 +34864,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, tragedia, vico, morcote, bambino',
     ogTitle: 'Tragedia a Vico Morcote: bambino muore in piscina privata',
     ogDescription: 'Un bambino di due anni ha perso la vita in un incidente in piscina a Vico Morcote. La famiglia riceve supporto psicologico.',
-    canonicalPath: '/articoli-frontaliere/vico-morcote-tragedia-bambino-pool',
+    canonicalPath: '/articoli-frontaliere/vico-morcote-tragedia-bambino-pool/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34892,7 +34892,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, limiti, smartphone, social, media',
     ogTitle: 'Limiti età smartphone e social media: Unicef spiega perché non bastano',
     ogDescription: 'Secondo Unicef, i limiti di età per smartphone e social media non sono sufficienti. Ecco perché la regolamentazione deve intervenire sulle piattaforme stesse.',
-    canonicalPath: '/articoli-frontaliere/limiti-eta-smartphone-social-media',
+    canonicalPath: '/articoli-frontaliere/limiti-eta-smartphone-social-media/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34920,7 +34920,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, volandia, battesimo, volo, elicottero',
     ogTitle: 'Volandia: battesimo del volo in elicottero torna nel 2026',
     ogDescription: 'Dal 1 al 3 maggio 2026, Volandia offre voli in elicottero per adulti e bambini, con prezzi fissati a 65 euro per gli adulti e 45 euro per i bambini.',
-    canonicalPath: '/articoli-frontaliere/volandia-battesimo-volo-elicottero-2026',
+    canonicalPath: '/articoli-frontaliere/volandia-battesimo-volo-elicottero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34948,7 +34948,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, banche, svizzere, preparano, accoglienza',
     ogTitle: 'Banche svizzere preparano accoglienza clienti Golfo',
     ogDescription: 'Trasferimenti di fondi in corso verso la Svizzera da Paesi del Golfo a causa della guerra in Iran. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/banche-golfo-preparano-frontalieri',
+    canonicalPath: '/articoli-frontaliere/banche-golfo-preparano-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -34976,7 +34976,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, storia, paperino, passa, cuasso',
     ogTitle: 'La storia di Paperino passa da Cuasso al Monte',
     ogDescription: 'Scopri il legame tra il padre italiano di Paperino e il Ticino durante la Seconda Guerra Mondiale',
-    canonicalPath: '/articoli-frontaliere/papa-paperino-cuasso-monte',
+    canonicalPath: '/articoli-frontaliere/papa-paperino-cuasso-monte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35004,7 +35004,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, venezia, torna, serie, pareggio',
     ogTitle: 'Venezia torna in Serie A con un pareggio contro lo Spezia',
     ogDescription: 'Il Venezia ottiene la promozione in Serie A con un pareggio 2-2 contro lo Spezia, grazie alla sconfitta del Monza',
-    canonicalPath: '/articoli-frontaliere/venezia-serie-a-promozione-2026',
+    canonicalPath: '/articoli-frontaliere/venezia-serie-a-promozione-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35032,7 +35032,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, meloni, governo, secondo, longevo',
     ogTitle: 'Meloni: il mio Governo è il secondo più longevo della Repubblica',
     ogDescription: 'Il Governo Meloni supera i 1.000 giorni di durata, diventando il secondo più longevo della storia repubblicana. Implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/meloni-governo-longevo-2026',
+    canonicalPath: '/articoli-frontaliere/meloni-governo-longevo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35060,7 +35060,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, newsletter, gratuita, iscriviti, aggiornamenti',
     ogTitle: 'Newsletter gratuita: iscriviti per aggiornamenti su Ticino',
     ogDescription: 'Scopri come ricevere notizie quotidiane, settimanali e mensili sulla Svizzera e il Canton Ticino',
-    canonicalPath: '/articoli-frontaliere/abbonamento-newsletter-ticino',
+    canonicalPath: '/articoli-frontaliere/abbonamento-newsletter-ticino/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35088,7 +35088,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, atleti, alla, salewa',
     ogTitle: 'Varese: 100 atleti alla Salewa Cube per la Coppa Italia Lead',
     ogDescription: 'Sabato 2 e domenica 3 maggio, la Salewa Cube di Varese ospita la seconda tappa della Coppa Italia Lead con 109 atleti tra i migliori della nazione.',
-    canonicalPath: '/articoli-frontaliere/varese-arrampicata-salewa-cube-2026',
+    canonicalPath: '/articoli-frontaliere/varese-arrampicata-salewa-cube-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35116,7 +35116,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, migros, immigrazione, necessaria, mario',
     ogTitle: 'Migros: «L\'immigrazione è necessaria per il Ticino»',
     ogDescription: 'Mario Irminger, CEO di Migros, si oppone all\'iniziativa UDC contro l\'immigrazione, sottolineando la sua importanza per il commercio al dettaglio in Ticino.',
-    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-2026',
+    canonicalPath: '/articoli-frontaliere/migros-immigrazione-necessaria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35144,7 +35144,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuova, viabilità, mezzi, pesanti',
     ogTitle: 'Nuova viabilità per mezzi pesanti a Travedona Monate',
     ogDescription: 'Dal 7 maggio 2026, i camion non potranno più circolare nel centro di Travedona Monate. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/nuova-viabilit-travedona-monate-2026',
+    canonicalPath: '/articoli-frontaliere/nuova-viabilit-travedona-monate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35172,7 +35172,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, graudio, flash, maggio, notizie',
     ogTitle: 'GrAudio Flash del 2 maggio 2026: notizie dal Canton Ticino',
     ogDescription: 'Le ultime notizie dal Canton Ticino e dintorni: eventi sportivi, cronaca locale e molto altro.',
-    canonicalPath: '/articoli-frontaliere/graudio-flash-2-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/graudio-flash-2-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35200,7 +35200,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, investimenti, immobiliari, viene, dall',
     ogTitle: 'Il 60% degli investimenti immobiliari in Italia viene dall’estero',
     ogDescription: 'Secondo Roberto Giovenco, COO di RINA Prime, il 60% degli investimenti immobiliari in Italia proviene dall\'estero, segnale di resilienza del Paese.',
-    canonicalPath: '/articoli-frontaliere/investimenti-immobiliari-italia-estero-2026',
+    canonicalPath: '/articoli-frontaliere/investimenti-immobiliari-italia-estero-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35228,7 +35228,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carenza, carburante, rischio, alto',
     ogTitle: 'Carenza carburante Svizzera: rischio alto, ecco perché',
     ogDescription: 'Florence Schurch, Segretaria generale di Suissenégoce, avverte di un rischio elevato di carenza di carburante in Svizzera. Ecco i dettagli.',
-    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35256,7 +35256,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, ermotti, diritto, dibattito, sergio',
     ogTitle: 'Ermotti respinge accuse lobbying UBS: \'Diritto di partecipare al dibattito\'',
     ogDescription: 'Il CEO di UBS Sergio Ermotti respinge le accuse di lobbying aggressivo e difende il diritto della banca a partecipare al dibattito sui fondi propri.',
-    canonicalPath: '/articoli-frontaliere/ermotti-respinge-accuse-lobbying-ubs',
+    canonicalPath: '/articoli-frontaliere/ermotti-respinge-accuse-lobbying-ubs/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35284,7 +35284,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, addio, alex, zanardi, incidente',
     ogTitle: 'Addio ad Alex Zanardi: l\'incidente del 2001 che cambiò la sua vita',
     ogDescription: 'Ripercorriamo la vita straordinaria di Alex Zanardi, dal terribile incidente del 2001 alla sua rinascita sportiva.',
-    canonicalPath: '/articoli-frontaliere/addio-alex-zanardi-2001-incidente-vita',
+    canonicalPath: '/articoli-frontaliere/addio-alex-zanardi-2001-incidente-vita/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35312,7 +35312,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, caronno, varesino, inaugura, nuovo',
     ogTitle: 'Caronno Varesino inaugura il nuovo campetto in memoria di Dante Mercanti',
     ogDescription: 'Sabato 9 maggio alle 16 l\'inaugurazione del nuovo campo sportivo di via Macchi a Caronno Varesino, intitolato a Dante Mercanti.',
-    canonicalPath: '/articoli-frontaliere/caronno-varesino-campetto-dante-mercanti-2026',
+    canonicalPath: '/articoli-frontaliere/caronno-varesino-campetto-dante-mercanti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35340,7 +35340,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, confederazione, valuta, sistemi, difesa',
     ogTitle: 'Confederazione valuta sistemi difesa aerea alternativi',
     ogDescription: 'La Confederazione svizzera valuta sistemi di difesa aerea alternativi a causa dei ritardi nei sistemi Patriot statunitensi.',
-    canonicalPath: '/articoli-frontaliere/confederazione-valuta-sistemi-difesa-aerea',
+    canonicalPath: '/articoli-frontaliere/confederazione-valuta-sistemi-difesa-aerea/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35368,7 +35368,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, penuria, carburante, rischio, molto',
     ogTitle: 'Penuria di carburante in Svizzera: rischio molto elevato',
     ogDescription: 'Florence Schurch di Suissenégoce avverte: le riserve strategiche di carburante potrebbero esaurirsi presto, con conseguenze gravi per la Svizzera.',
-    canonicalPath: '/articoli-frontaliere/penuria-carburante-svizzera-2026',
+    canonicalPath: '/articoli-frontaliere/penuria-carburante-svizzera-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35396,7 +35396,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, christian, bagatin, trionfa, nella',
     ogTitle: 'Christian Bagatin vince la tappa regina del Giro di Turchia',
     ogDescription: 'Christian Bagatin, 23enne di Orino, conquista la prima vittoria da professionista nella sesta tappa del Giro di Turchia, arrivando in solitaria sul traguardo di',
-    canonicalPath: '/articoli-frontaliere/vittoria-bagatin-tappa-turchia',
+    canonicalPath: '/articoli-frontaliere/vittoria-bagatin-tappa-turchia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35424,7 +35424,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, taglio, accise, carburanti, prorogato',
     ogTitle: 'Taglio accise carburanti prorogato al 22 maggio',
     ogDescription: 'Il Consiglio dei ministri ha prorogato il taglio delle accise sui carburanti fino al 22 maggio 2026. Ecco cosa cambia per i frontalieri',
-    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-22-maggio',
+    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-22-maggio/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35452,7 +35452,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, generatori, alla, ricostruzione, maxi',
     ogTitle: 'Dai generatori alla ricostruzione: il maxi piano svizzero per Kiev',
     ogDescription: 'Il delegato del Consiglio federale per l\'Ucraina, Jacques Gerber, illustra il programma di aiuti da 1,5 miliardi di franchi.',
-    canonicalPath: '/articoli-frontaliere/aiuti-svizzera-ucraina-2026',
+    canonicalPath: '/articoli-frontaliere/aiuti-svizzera-ucraina-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35480,7 +35480,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, elettrici, lugano, problemi, ritardi',
     ogTitle: 'Bus elettrici a Lugano: problemi e ritardi',
     ogDescription: 'Scopri i problemi tecnici dei nuovi bus elettrici di Lugano e le soluzioni per migliorare il servizio di trasporto pubblico.',
-    canonicalPath: '/articoli-frontaliere/bus-elettrici-lugano-problemi-utenti',
+    canonicalPath: '/articoli-frontaliere/bus-elettrici-lugano-problemi-utenti/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35508,7 +35508,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, galà, sorriso, incanta, magia',
     ogTitle: 'Galà del Sorriso incanta Varese con magia e solidarietà',
     ogDescription: 'Grande successo per il Galà del Sorriso a Varese, con spettacoli di magia e raccolte fondi per le sale parto dell\'Ospedale Del Ponte',
-    canonicalPath: '/articoli-frontaliere/gala-sorriso-solidarieta-ospedale-del-ponte',
+    canonicalPath: '/articoli-frontaliere/gala-sorriso-solidarieta-ospedale-del-ponte/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35536,7 +35536,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, rogo, ultimo, piano',
     ogTitle: 'Varese, rogo all\'ultimo piano di un palazzo: fiamme domate, nessun ferito',
     ogDescription: 'Incendio in un appartamento al piano sommitale di un palazzo a Varese, nessun ferito grazie all\'intervento tempestivo dei vigili del fuoco',
-    canonicalPath: '/articoli-frontaliere/varese-incendio-palazzo-frontalieri',
+    canonicalPath: '/articoli-frontaliere/varese-incendio-palazzo-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35564,7 +35564,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, carenza, carburante, rischio, concreto',
     ogTitle: 'Carenza carburante Svizzera: rischio concreto per frontalieri',
     ogDescription: 'Florence Schurch di Suissenégoce lancia l\'allarme: prezzo petrolio a 150 dollari al barile e rischi per l\'approvvigionamento energetico',
-    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-frontalieri',
+    canonicalPath: '/articoli-frontaliere/carenza-carburante-svizzera-frontalieri/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35592,7 +35592,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scontro, intervento, polizia, spray',
     ogTitle: 'Scontro e intervento di polizia con spray urticante in centro Lugano',
     ogDescription: 'Due gruppi di ragazzi si sono scontrati in centro Lugano, causando l\'intervento della polizia con spray urticante. Due persone ferite e soccorse.',
-    canonicalPath: '/articoli-frontaliere/scontro-polizia-lugano-spray-urticante',
+    canonicalPath: '/articoli-frontaliere/scontro-polizia-lugano-spray-urticante/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35620,7 +35620,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, saronno, licenza, sospesa, dopo',
     ogTitle: 'Saronno: licenza sospesa per bar dopo rissa',
     ogDescription: 'La licenza di un bar a Saronno è stata sospesa dopo una rissa. Ecco cosa è successo e le implicazioni per la zona.',
-    canonicalPath: '/articoli-frontaliere/saronno-bar-licenza-sospesa-rissa',
+    canonicalPath: '/articoli-frontaliere/saronno-bar-licenza-sospesa-rissa/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35648,7 +35648,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, movieri, azione, domenica, traffico',
     ogTitle: 'Movieri in azione domenica per il traffico record sul Lago di Como',
     ogDescription: 'Servizio straordinario degli osservatori del traffico domenica 3 maggio lungo la SS 340 Regina per gestire l\'afflusso turistico previsto',
-    canonicalPath: '/articoli-frontaliere/movieri-traffico-ss340-2026',
+    canonicalPath: '/articoli-frontaliere/movieri-traffico-ss340-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35676,7 +35676,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, doppietta, sant, antonino, cosa',
     ogTitle: 'Doppietta frontalieri a Sant\'Antonino: cosa cambia',
     ogDescription: 'A Sant\'Antonino, sempre più frontalieri scelgono la doppietta: lavoro in Svizzera e residenza in Italia. Ecco cosa sapere.',
-    canonicalPath: '/articoli-frontaliere/doppietta-frontalieri-santonino-2026',
+    canonicalPath: '/articoli-frontaliere/doppietta-frontalieri-santonino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35704,7 +35704,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, taglio, accise, carburanti, diesel',
     ogTitle: 'Taglio accise carburanti: diesel a sconto pieno, benzina ridotto',
     ogDescription: 'Il governo proroga il taglio delle accise sui carburanti, con sconto pieno sul diesel e ridotto sulla benzina. Scopri cosa cambia e come ti riguarda.',
-    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/taglio-accise-carburanti-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35732,7 +35732,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, yoga, meditazione, passeggiate',
     ogTitle: 'Como: yoga, meditazione e passeggiate nella villa sul lago',
     ogDescription: 'La rassegna \'Coltiviamo l’Energia\' torna a Villa del Grumello con yoga, meditazione e passeggiate nel parco storico affacciato sul lago.',
-    canonicalPath: '/articoli-frontaliere/yoga-meditazione-villa-lago-como',
+    canonicalPath: '/articoli-frontaliere/yoga-meditazione-villa-lago-como/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35760,7 +35760,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, cantù, uniscono, forze',
     ogTitle: 'Como e Cantù uniscono le forze per la Lake Como Creativity Week',
     ogDescription: 'I comuni di Como e Cantù collaborano per la Lake Como Creativity Week, con un accordo triennale firmato il 7 maggio 2026',
-    canonicalPath: '/articoli-frontaliere/como-cantu-creativity-week-2026',
+    canonicalPath: '/articoli-frontaliere/como-cantu-creativity-week-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35788,7 +35788,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, commercio, dettaglio, mini-flessione, ricavi',
     ogTitle: 'Commercio al dettaglio: mini-flessione dei ricavi in marzo',
     ogDescription: 'Marzo 2026: stabilità per i negozi svizzeri, ma calo dello 0,1% del giro d\'affari rispetto al 2025. Dati UST.',
-    canonicalPath: '/articoli-frontaliere/commercio-al-dettaglio-mini-flessione-marzo-2026',
+    canonicalPath: '/articoli-frontaliere/commercio-al-dettaglio-mini-flessione-marzo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35816,7 +35816,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rissa, lugano, feriti, alla',
     ogTitle: 'Rissa a Lugano: due feriti alla Pensilina Botta',
     ogDescription: 'Un tumulto sedato dalla polizia ha coinvolto due persone ferite in un incidente alla Pensilina Botta di Lugano.',
-    canonicalPath: '/articoli-frontaliere/rissa-lugano-pensilina-botta-feriti-2026',
+    canonicalPath: '/articoli-frontaliere/rissa-lugano-pensilina-botta-feriti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35844,7 +35844,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, rissa, lugano, durante, primo',
     ogTitle: 'Rissa a Lugano durante il Primo Maggio: spray urticante per calmare i disordini',
     ogDescription: 'Disordini a Lugano durante il Primo Maggio con due feriti lievi e intervento della polizia con spray urticante.',
-    canonicalPath: '/articoli-frontaliere/rissa-lugano-primo-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/rissa-lugano-primo-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35872,7 +35872,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, attivo, nuovo, servizio, vittime',
     ogTitle: 'Attivo il 142: nuovo servizio per le vittime di violenza',
     ogDescription: 'Dal 1° maggio 2026 è operativo il numero 142 per le vittime di violenza in Ticino. Scopri come funziona e cosa cambia.',
-    canonicalPath: '/articoli-frontaliere/protezione-vittime-142-ticino-2026',
+    canonicalPath: '/articoli-frontaliere/protezione-vittime-142-ticino-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35900,7 +35900,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, golasecca, escursionisti, alla, scoperta',
     ogTitle: 'Golasecca: 140 escursionisti alla scoperta dei luoghi più belli',
     ogDescription: 'Una giornata di cammino di 13 km attraverso i luoghi più suggestivi di Golasecca, con aperitivo, pranzo e merenda. Partecipanti ricevono gadget e defibrillatore',
-    canonicalPath: '/articoli-frontaliere/golasecca-esplorazione-passeggiata-2026',
+    canonicalPath: '/articoli-frontaliere/golasecca-esplorazione-passeggiata-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35928,7 +35928,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, marcia, zurigo, voce, disabilità',
     ogTitle: 'In marcia dal Ticino a Zurigo: la voce della disabilità chiede uguaglianza',
     ogDescription: 'Una ventina di persone dal Ticino partecipano alla manifestazione nazionale per l\'uguaglianza delle persone con disabilità a Zurigo',
-    canonicalPath: '/articoli-frontaliere/marcia-zurigo-disabilita-uguaglianza',
+    canonicalPath: '/articoli-frontaliere/marcia-zurigo-disabilita-uguaglianza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35956,7 +35956,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, nuovi, posti, moto, como',
     ogTitle: 'Nuovi posti moto a Como: sosta vietata durante le partite del Como',
     ogDescription: 'La polizia locale ha attivato il carro attrezzi per rimuovere le moto parcheggiate illegalmente durante le partite del Como.',
-    canonicalPath: '/articoli-frontaliere/nuovi-posti-moto-lago-como',
+    canonicalPath: '/articoli-frontaliere/nuovi-posti-moto-lago-como/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -35984,7 +35984,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, guardia, medica, somma, lombardo',
     ogTitle: 'Guardia medica Somma Lombardo si sposta a Lonate Pozzolo',
     ogDescription: 'Il servizio di continuità assistenziale si trasferisce temporaneamente a Lonate Pozzolo fino a luglio per lavori.',
-    canonicalPath: '/articoli-frontaliere/guardia-medica-somma-lombardo-lonate-pozzolo',
+    canonicalPath: '/articoli-frontaliere/guardia-medica-somma-lombardo-lonate-pozzolo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36012,7 +36012,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, varese, prima, panchina, bianca',
     ogTitle: 'Varese, prima panchina bianca contro abusi minori',
     ogDescription: 'Inaugurata a Varese la prima panchina bianca dedicata al numero 114 per la protezione dei minori, in occasione della Giornata nazionale contro la pedofilia e la',
-    canonicalPath: '/articoli-frontaliere/panchina-bianca-varese-2026',
+    canonicalPath: '/articoli-frontaliere/panchina-bianca-varese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36040,7 +36040,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, furti, chiese, arrestati, rumeni',
     ogTitle: 'Furti in chiese: arrestati due rumeni nel Bellinzonese',
     ogDescription: 'Due cittadini rumeni sono stati arrestati per furti in chiese nel Bellinzonese. Scopri i dettagli dell\'operazione e cosa fare se sei stato vittima di un furto',
-    canonicalPath: '/articoli-frontaliere/furti-chiese-bellinzonese-arresti-2026',
+    canonicalPath: '/articoli-frontaliere/furti-chiese-bellinzonese-arresti-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36068,7 +36068,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, milano-brescia, deviazione, obbligatoria, verso',
     ogTitle: 'A4 Milano-Brescia: deviazione obbligatoria verso Varese dal 5 al 6 maggio 2026',
     ogDescription: 'Dalla notte tra il 5 e il 6 maggio 2026, la A4 Milano-Brescia sarà chiusa per lavori. Ecco cosa cambia per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-diviazione-obbligatoria-2026',
+    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-diviazione-obbligatoria-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36096,7 +36096,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, editto, canonizzazione, roberto, malgesini',
     ogTitle: 'Editto canonizzazione Don Roberto Malgesini: cosa succede ora',
     ogDescription: 'Pubblicato l\'editto per la canonizzazione di Don Roberto Malgesini, ucciso nel 2020. Ecco i prossimi passi e cosa chiede la Diocesi di Como',
-    canonicalPath: '/articoli-frontaliere/editto-canonizzazione-don-roberto-malgesini',
+    canonicalPath: '/articoli-frontaliere/editto-canonizzazione-don-roberto-malgesini/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36124,7 +36124,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beat, jans, iniziativa, milioni',
     ogTitle: 'Beat Jans e l’iniziativa 10 milioni: tutto in regola?',
     ogDescription: 'Il consigliere federale Beat Jans è sotto indagine per presunte violazioni delle regole della comunicazione istituzionale nella campagna contro l’iniziativa',
-    canonicalPath: '/articoli-frontaliere/beat-jans-10-milioni-comunicazione',
+    canonicalPath: '/articoli-frontaliere/beat-jans-10-milioni-comunicazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36152,7 +36152,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, chiusa, sesto, monza, notti',
     ogTitle: 'A4 Milano-Brescia chiusa tra Sesto San Giovanni e Monza: tutte le notti interessate',
     ogDescription: 'Chiusura notturna del tratto tra Sesto San Giovanni e Monza per lavori alle barriere di sicurezza. Percorsi alternativi segnalati.',
-    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-chiusura-notturna-2026',
+    canonicalPath: '/articoli-frontaliere/a4-milano-brescia-chiusura-notturna-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36180,7 +36180,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, giannino, landoni, fagnano, olona',
     ogTitle: 'Via Giannino Landoni a Fagnano Olona: verso l\'inaugurazione',
     ogDescription: 'L\'iter amministrativo per l\'intitolazione della via a Giannino Landoni è concluso. Si attende la data ufficiale della cerimonia.',
-    canonicalPath: '/articoli-frontaliere/via-giannino-landoni-fagnano-olona-inaugurazione',
+    canonicalPath: '/articoli-frontaliere/via-giannino-landoni-fagnano-olona-inaugurazione/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36208,7 +36208,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, scontri, lugano, pensilina, valenzano',
     ogTitle: 'Scontri Lugano Pensilina: Valenzano Rossi, «C\'è molta preoccupazione»',
     ogDescription: 'Due feriti lievi, ma la matrice politica degli scontri preoccupa le autorità luganesi. Karin Valenzano Rossi: «Non c\'entra la movida»',
-    canonicalPath: '/articoli-frontaliere/scontri-lugano-pensilina-2024',
+    canonicalPath: '/articoli-frontaliere/scontri-lugano-pensilina-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36236,7 +36236,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, gordola, nuovo, ricorso, blocca',
     ogTitle: 'Gordola, nuovo ricorso blocca Santa Maria',
     ogDescription: 'Il Municipio di Gordola prepara la difesa contro il ricorso che blocca il piano del comparto Santa Maria, approvato dopo 30 anni',
-    canonicalPath: '/articoli-frontaliere/gordola-santa-maria-ricorso-2026',
+    canonicalPath: '/articoli-frontaliere/gordola-santa-maria-ricorso-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36264,7 +36264,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, vino, amaro, vallese, provins',
     ogTitle: 'Vino amaro in Vallese: Provins SA annuncia perdite e misure drastiche',
     ogDescription: 'Provins SA, azienda chiave della viticoltura vallesana, annuncia una perdita di 6 milioni di franchi per il 2025 e misure drastiche per adattarsi alla crisi del',
-    canonicalPath: '/articoli-frontaliere/vino-amaro-vallese-2026',
+    canonicalPath: '/articoli-frontaliere/vino-amaro-vallese-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36292,7 +36292,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, beatificazione, roberto, malgesini, avvia',
     ogTitle: 'Beatificazione don Roberto Malgesini: avvia l\'iter la Diocesi di Como',
     ogDescription: 'La Diocesi di Como ha avviato il processo per la beatificazione di don Roberto Malgesini, ucciso nel 2020. Scopri come contribuire.',
-    canonicalPath: '/articoli-frontaliere/beatificazione-don-roberto-malgesini-2026',
+    canonicalPath: '/articoli-frontaliere/beatificazione-don-roberto-malgesini-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36320,7 +36320,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, lago, segrino, alle, piazzole',
     ogTitle: 'Lago Segrino: No alle 105 piazzole per camper, distesa d\'asfalto',
     ogDescription: 'Il Circolo Ambiente \'Ilaria Alpi\' si oppone al progetto di 105 piazzole per camper a Canzo vicino al Lago di Segrino, un sito di importanza comunitaria.',
-    canonicalPath: '/articoli-frontaliere/lago-segrino-camper-2026',
+    canonicalPath: '/articoli-frontaliere/lago-segrino-camper-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36348,7 +36348,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, cavalli, esercito, svizzero, costi',
     ogTitle: 'Cavalli esercito svizzero: costi in aumento',
     ogDescription: 'L\'esercito svizzero spenderà 3,8 milioni di franchi per i cavalli dal 2026 al 2028, con critiche alla gestione delle risorse',
-    canonicalPath: '/articoli-frontaliere/cavalli-esercito-svizzero-costi',
+    canonicalPath: '/articoli-frontaliere/cavalli-esercito-svizzero-costi/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36376,7 +36376,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, sconfitta, dalla, finlandia, nell',
     ogTitle: 'Svizzera sconfitta dalla Finlandia nell\'Euro Hockey Tour',
     ogDescription: 'La nazionale svizzera di hockey su ghiaccio perde 5-3 contro la Finlandia. Prossimo avversario la Repubblica Ceca.',
-    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-finlandia',
+    canonicalPath: '/articoli-frontaliere/svizzera-hockey-sconfitta-finlandia/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36404,7 +36404,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, insiste, sulla, sfiducia',
     ogTitle: 'Pd Como insiste sulla sfiducia a Maccabeo: "Mancanza di responsabilità politica"',
     ogDescription: 'Il Partito Democratico di Como non molla sulla mozione di sfiducia all\'assessore Maccabeo, bocciata in consiglio comunale.',
-    canonicalPath: '/articoli-frontaliere/pd-como-sfiducia-maccabeo-2026',
+    canonicalPath: '/articoli-frontaliere/pd-como-sfiducia-maccabeo-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36432,7 +36432,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, patriot, ritardo, berna, valuta',
     ogTitle: 'Patriot in ritardo, Berna valuta altri sistemi',
     ogDescription: 'La Svizzera cerca alternative ai sistemi Patriot in ritardo, interpellando Germania, Francia, Israele e Corea del Sud.',
-    canonicalPath: '/articoli-frontaliere/patriot-ritardo-svizzera-valuta-alternative',
+    canonicalPath: '/articoli-frontaliere/patriot-ritardo-svizzera-valuta-alternative/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36460,7 +36460,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, bambini, elementari, visita, carabinieri',
     ogTitle: 'Bambini in visita dai Carabinieri di Como',
     ogDescription: '38 alunni della scuola primaria Nazario Sauro hanno visitato la caserma dei Carabinieri di Como nell\'ambito della campagna \'Cultura della Legalità\'.',
-    canonicalPath: '/articoli-frontaliere/bambini-carabinieri-como-2026',
+    canonicalPath: '/articoli-frontaliere/bambini-carabinieri-como-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36488,7 +36488,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, incendio, malpensa, terminal, intervento',
     ogTitle: 'Incendio Malpensa Terminal 1: intervento Vigili del Fuoco',
     ogDescription: 'Un corto circuito ha causato un principio di incendio al Terminal 1 di Malpensa il 2 maggio 2026. Nessun ferito. Procedure di sicurezza per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/incendio-malpensa-terminal-1-2-maggio-2026',
+    canonicalPath: '/articoli-frontaliere/incendio-malpensa-terminal-1-2-maggio-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36516,7 +36516,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, como, parcheggio, abusivo, parco',
     ogTitle: 'Parcheggio abusivo a Como nel parco di Villa Olmo',
     ogDescription: 'Numerose auto, tra cui una ticinese, parcheggiate illegalmente nel parco di Villa Olmo e sui marciapiedi di Como.',
-    canonicalPath: '/articoli-frontaliere/parcheggio-abusivo-como-villa-olmo',
+    canonicalPath: '/articoli-frontaliere/parcheggio-abusivo-como-villa-olmo/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36544,7 +36544,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, amplia, caccia, agli, evasori',
     ogTitle: 'Svizzera amplia la caccia agli evasori fiscali: coinvolti 110 Paesi',
     ogDescription: 'Le autorità elvetiche monitorano anche gli svizzeri in Thailandia. Quasi 7mila richieste di assistenza dall\'estero nel 2025.',
-    canonicalPath: '/articoli-frontaliere/svizzera-caccia-evasori-fiscali-2026',
+    canonicalPath: '/articoli-frontaliere/svizzera-caccia-evasori-fiscali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36577,7 +36577,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, landsgemeinde, glarona, austerità, ambiente',
     ogTitle: 'Landsgemeinde di Glarona: austerità e ambiente al voto',
     ogDescription: 'Gli elettori di Glarona decidono su tagli alla spesa pubblica, nuove tasse ambientali e alloggi accessibili nella storica assemblea.',
-    canonicalPath: '/articoli-frontaliere/landsgemeinde-glarona-2026',
+    canonicalPath: '/articoli-frontaliere/landsgemeinde-glarona-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36610,7 +36610,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, interpellanza, municipio, costi, aeroporto',
     ogTitle: 'Interpellanza al Municipio: costi aeroporto Lugano-Agno',
     ogDescription: 'Le consigliere comunali criticano la gestione finanziaria e i ritardi nei piani di sviluppo dello scalo ticinese di Lugano-Agno',
-    canonicalPath: '/articoli-frontaliere/aeroporto-lugano-costi-interpellanza',
+    canonicalPath: '/articoli-frontaliere/aeroporto-lugano-costi-interpellanza/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36643,7 +36643,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, agricoltura, crisi, grido, allarme',
     ogTitle: 'Agricoltura in crisi: il grido d\'allarme degli agricoltori ticinesi',
     ogDescription: 'Cambiamenti climatici, lupi e costi crescenti mettono in ginocchio il settore agricolo ticinese. Ecco cosa sta succedendo',
-    canonicalPath: '/articoli-frontaliere/agricoltura-ticino-allarme-2024',
+    canonicalPath: '/articoli-frontaliere/agricoltura-ticino-allarme-2024/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36676,7 +36676,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, seco, blocca, accesso, atti',
     ogTitle: 'SECO blocca accesso atti trattative con Washington',
     ogDescription: 'La SECO mantiene segreti i documenti sulle trattative con gli USA sui dazi, rischiando una causa in tribunale. Scopri le implicazioni per i frontalieri.',
-    canonicalPath: '/articoli-frontaliere/seco-dazi-segreti-washington',
+    canonicalPath: '/articoli-frontaliere/seco-dazi-segreti-washington/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36709,7 +36709,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, strategia, cambio, chf-eur, simulazione',
     ogTitle: 'Frontalieri: strategia cambio CHF-EUR 2026',
     ogDescription: 'Simulazione pratica per gestire al meglio il cambio CHF-EUR nel 2026 con checklist operativa e confronto scenari',
-    canonicalPath: '/articoli-frontaliere/frontaliere-cambio-chf-eur-strategia-2026-simulazione-pratica',
+    canonicalPath: '/articoli-frontaliere/frontaliere-cambio-chf-eur-strategia-2026-simulazione-pratica/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36742,7 +36742,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, laghi, lombardi, inizio, estate',
     ogTitle: 'Laghi lombardi, inizio estate tragico: sicurezza e consapevolezza',
     ogDescription: 'Un morto nel Comasco e un giovane in condizioni gravissime a Desenzano riaccendono l’allarme sicurezza sui laghi lombardi. ANAB Lombardia lancia un appello.',
-    canonicalPath: '/articoli-frontaliere/laghi-lombardi-sicurezza-estate-2026',
+    canonicalPath: '/articoli-frontaliere/laghi-lombardi-sicurezza-estate-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",
@@ -36775,7 +36775,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
     keywords: 'frontalieri, ticino, svizzera, italia, riforma, commissioni, federali, cosa',
     ogTitle: 'Riforma commissioni federali: cosa cambia per i frontalieri',
     ogDescription: 'Scopri le novità sulla riforma delle commissioni federali svizzere e come potrebbe influenzare i frontalieri che lavorano in Ticino.',
-    canonicalPath: '/articoli-frontaliere/riforma-commissioni-federali-2026',
+    canonicalPath: '/articoli-frontaliere/riforma-commissioni-federali-2026/',
     structuredData: {
       "@context": "https://schema.org",
       "@type": "NewsArticle",

--- a/services/seo/seo-landing.ts
+++ b/services/seo/seo-landing.ts
@@ -71,7 +71,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 40000 chf, calcolo netto frontaliere, simulazione tasse 2026, imposta alla fonte ticino, irpef frontalieri',
  ogTitle: 'Stipendio netto frontaliere 40.000 CHF (2026)',
  ogDescription: 'Con 40.000 CHF lordi/anno, un frontaliere netta circa 2.400–2.600 €/mese dopo AVS, imposta alla fonte e IRPEF (accordo 2026). Simula il tuo netto.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-40000-chf',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-40000-chf/',
  structuredData: [
  {
  '@context': 'https://schema.org',
@@ -90,7 +90,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 60000 chf, calcolo netto frontaliere, simulazione tasse 2026, imposta alla fonte ticino, irpef frontalieri',
  ogTitle: 'Stipendio netto frontaliere 60.000 CHF (2026)',
  ogDescription: 'Con 60.000 CHF lordi/anno, un frontaliere netta circa 3.200–3.500 €/mese dopo AVS, imposta alla fonte e IRPEF (accordo 2026). Simula il tuo netto.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf/',
  structuredData: [
  {
  '@context': 'https://schema.org',
@@ -109,7 +109,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 80000 chf, calcolo netto frontaliere, simulazione tasse 2026, imposta alla fonte ticino, irpef frontalieri',
  ogTitle: 'Stipendio netto frontaliere 80.000 CHF (2026)',
  ogDescription: 'Con 80.000 CHF lordi/anno, un frontaliere netta circa 4.200–4.600 €/mese dopo AVS, LPP, imposta alla fonte e IRPEF (accordo 2026). Simula il tuo netto.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Stipendio netto frontaliere 80.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-80000-chf`, description: 'Simulazione netto per 80.000 CHF/anno (accordo 2026).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -122,7 +122,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 100000 chf, calcolo netto frontaliere, simulazione tasse 2026, imposta alla fonte ticino, irpef frontalieri',
  ogTitle: 'Stipendio netto frontaliere 100.000 CHF (2026)',
  ogDescription: 'Con 100.000 CHF lordi/anno, un frontaliere netta circa 5.100–5.600 €/mese dopo AVS, LPP e imposta alla fonte (accordo 2026). Simula il tuo netto.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Stipendio netto frontaliere 100.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-100000-chf`, description: 'Simulazione netto per 100.000 CHF/anno (accordo 2026).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -135,7 +135,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 120000 chf, calcolo netto frontaliere, simulazione tasse 2026, imposta alla fonte ticino, irpef frontalieri',
  ogTitle: 'Stipendio netto frontaliere 120.000 CHF (2026)',
  ogDescription: 'Con 120.000 CHF lordi/anno, un frontaliere netta circa 5.900–6.500 €/mese dopo AVS, LPP e imposta alla fonte (accordo 2026). Simula il tuo netto.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-120000-chf',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-120000-chf/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Stipendio netto frontaliere 120.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-120000-chf`, description: 'Simulazione netto per 120.000 CHF/anno (accordo 2026).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -148,7 +148,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'vecchio frontaliere 60000 chf, imposta alla fonte ticino, netto frontaliere',
  ogTitle: 'Vecchio frontaliere: netto 60.000 CHF',
  ogDescription: 'Simula il netto per 60.000 CHF nel regime vecchio frontaliere.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-vecchio-frontaliere',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-vecchio-frontaliere/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Vecchio frontaliere: netto 60.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-60000-chf-vecchio-frontaliere`, description: 'Simulazione netto vecchio frontaliere per 60.000 CHF.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -161,7 +161,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'nuovo frontaliere 2026 60000 chf, franchigia 10000, credito imposta, netto frontaliere',
  ogTitle: 'Nuovo frontaliere 2026: netto 60.000 CHF',
  ogDescription: 'Simula il netto per 60.000 CHF nel regime nuovo frontaliere 2026.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-nuovo-frontaliere-2026',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-nuovo-frontaliere-2026/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Nuovo frontaliere 2026: netto 60.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-60000-chf-nuovo-frontaliere-2026`, description: 'Simulazione netto nuovo frontaliere per 60.000 CHF (accordo 2026).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -174,7 +174,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'vecchio frontaliere 80000 chf, imposta alla fonte ticino, netto frontaliere',
  ogTitle: 'Vecchio frontaliere: netto 80.000 CHF',
  ogDescription: 'Simula il netto per 80.000 CHF nel regime vecchio frontaliere.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-vecchio-frontaliere',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-vecchio-frontaliere/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Vecchio frontaliere: netto 80.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-80000-chf-vecchio-frontaliere`, description: 'Simulazione netto vecchio frontaliere per 80.000 CHF.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -187,7 +187,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'nuovo frontaliere 2026 80000 chf, franchigia 10000, credito imposta, netto frontaliere',
  ogTitle: 'Nuovo frontaliere 2026: netto 80.000 CHF',
  ogDescription: 'Simula il netto per 80.000 CHF nel regime nuovo frontaliere 2026.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-nuovo-frontaliere-2026',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-nuovo-frontaliere-2026/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Nuovo frontaliere 2026: netto 80.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-80000-chf-nuovo-frontaliere-2026`, description: 'Simulazione netto nuovo frontaliere per 80.000 CHF (accordo 2026).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -200,7 +200,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'vecchio frontaliere 100000 chf, imposta alla fonte ticino, netto frontaliere',
  ogTitle: 'Vecchio frontaliere: netto 100.000 CHF',
  ogDescription: 'Simula il netto per 100.000 CHF nel regime vecchio frontaliere.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-vecchio-frontaliere',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-vecchio-frontaliere/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Vecchio frontaliere: netto 100.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-100000-chf-vecchio-frontaliere`, description: 'Simulazione netto vecchio frontaliere per 100.000 CHF.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -213,7 +213,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'nuovo frontaliere 2026 100000 chf, franchigia 10000, credito imposta, netto frontaliere',
  ogTitle: 'Nuovo frontaliere 2026: netto 100.000 CHF',
  ogDescription: 'Simula il netto per 100.000 CHF nel regime nuovo frontaliere 2026.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-nuovo-frontaliere-2026',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-nuovo-frontaliere-2026/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Nuovo frontaliere 2026: netto 100.000 CHF', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-100000-chf-nuovo-frontaliere-2026`, description: 'Simulazione netto nuovo frontaliere per 100.000 CHF (accordo 2026).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -226,7 +226,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 60000 chf sposato 2 figli, imposta alla fonte ticino famiglia, irpef frontalieri figli',
  ogTitle: 'Netto 60.000 CHF (sposato, 2 figli)',
  ogDescription: 'Simula il netto per 60.000 CHF con famiglia (2 figli).',
- canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-sposato-2-figli',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-sposato-2-figli/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Netto 60.000 CHF: sposato con 2 figli', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-60000-chf-sposato-2-figli`, description: 'Simulazione netto 60.000 CHF per famiglia (2 figli).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -239,7 +239,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 80000 chf sposato 2 figli, imposta alla fonte ticino famiglia, irpef frontalieri figli',
  ogTitle: 'Netto 80.000 CHF (sposato, 2 figli)',
  ogDescription: 'Simula il netto per 80.000 CHF con famiglia (2 figli).',
- canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-sposato-2-figli',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-sposato-2-figli/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Netto 80.000 CHF: sposato con 2 figli', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-80000-chf-sposato-2-figli`, description: 'Simulazione netto 80.000 CHF per famiglia (2 figli).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -252,7 +252,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 100000 chf sposato 2 figli, imposta alla fonte ticino famiglia, irpef frontalieri figli',
  ogTitle: 'Netto 100.000 CHF (sposato, 2 figli)',
  ogDescription: 'Simula il netto per 100.000 CHF con famiglia (2 figli).',
- canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-sposato-2-figli',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-sposato-2-figli/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Netto 100.000 CHF: sposato con 2 figli', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-100000-chf-sposato-2-figli`, description: 'Simulazione netto 100.000 CHF per famiglia (2 figli).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -265,7 +265,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 80000 chf oltre 20km, distanza residenza frontalieri, simulazione tasse',
  ogTitle: 'Netto 80.000 CHF (oltre 20 km)',
  ogDescription: 'Simula il netto per 80.000 CHF con residenza oltre 20 km.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-residenza-oltre-20km',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-residenza-oltre-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Netto 80.000 CHF: residenza oltre 20 km', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-80000-chf-residenza-oltre-20km`, description: 'Simulazione netto 80.000 CHF con residenza oltre 20 km.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -278,7 +278,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 80000 chf entro 20km, distanza residenza frontalieri, simulazione tasse',
  ogTitle: 'Netto 80.000 CHF (entro 20 km)',
  ogDescription: 'Simula il netto per 80.000 CHF con residenza entro 20 km.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-residenza-entro-20km',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-80000-chf-residenza-entro-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Netto 80.000 CHF: residenza entro 20 km', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-80000-chf-residenza-entro-20km`, description: 'Simulazione netto 80.000 CHF con residenza entro 20 km.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -291,7 +291,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'calcolo tasse frontalieri oltre 20 km, stipendio netto 60000 chf oltre 20km, nuovo frontaliere oltre 20 km, tasse frontaliere distanza confine',
  ogTitle: 'Netto 60.000 CHF (oltre 20 km dal confine)',
  ogDescription: 'Calcolo tasse frontalieri oltre 20 km: simulazione netto per 60.000 CHF/anno con confronto vecchio vs nuovo regime.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-residenza-oltre-20km',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-residenza-oltre-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Calcolo tasse frontaliere 60.000 CHF: residenza oltre 20 km', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-60000-chf-residenza-oltre-20km`, description: 'Simulazione netto frontaliere 60.000 CHF con residenza oltre 20 km dal confine.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -305,7 +305,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 60000 chf frontaliere, calcolo tasse frontalieri entro 20 km, stipendio netto 60000 chf entro 20km, vecchio frontaliere entro 20 km, comuni frontiera 20 km',
  ogTitle: 'Netto 60.000 CHF (entro 20 km dal confine)',
  ogDescription: 'Calcolo tasse frontalieri entro 20 km: simulazione netto per 60.000 CHF/anno con vecchio ordinamento.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-residenza-entro-20km',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-60000-chf-residenza-entro-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Calcolo tasse frontaliere 60.000 CHF: residenza entro 20 km', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-60000-chf-residenza-entro-20km`, description: 'Simulazione netto frontaliere 60.000 CHF con residenza entro 20 km dal confine.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -318,7 +318,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'calcolo tasse frontalieri oltre 20 km, stipendio netto 100000 chf oltre 20km, nuovo frontaliere oltre 20 km, tasse frontaliere alto reddito',
  ogTitle: 'Netto 100.000 CHF (oltre 20 km dal confine)',
  ogDescription: 'Calcolo tasse frontalieri oltre 20 km: simulazione netto per 100.000 CHF/anno. Confronto regimi.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-residenza-oltre-20km',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-residenza-oltre-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Calcolo tasse frontaliere 100.000 CHF: residenza oltre 20 km', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-100000-chf-residenza-oltre-20km`, description: 'Simulazione netto frontaliere 100.000 CHF con residenza oltre 20 km dal confine.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -332,7 +332,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio netto 100000 chf frontaliere, calcolo tasse frontalieri entro 20 km, stipendio netto 100000 chf entro 20km, vecchio frontaliere entro 20 km, tasse frontaliere alto reddito',
  ogTitle: 'Netto 100.000 CHF (entro 20 km dal confine)',
  ogDescription: 'Calcolo tasse frontalieri entro 20 km: simulazione netto per 100.000 CHF/anno. Vecchio ordinamento.',
- canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-residenza-entro-20km',
+ canonicalPath: '/calcola-stipendio/stipendio-netto-100000-chf-residenza-entro-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Calcolo tasse frontaliere 100.000 CHF: residenza entro 20 km', url: `${BASE_URL}/calcola-stipendio/stipendio-netto-100000-chf-residenza-entro-20km`, description: 'Simulazione netto frontaliere 100.000 CHF con residenza entro 20 km dal confine.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -345,7 +345,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'calcolo tasse frontalieri oltre 20 km, nuovi frontalieri oltre 20 km, simulazione tasse oltre 20 km, frontalieri oltre 20 km tasse 2026, calcolo netto oltre 20 km, confronto entro oltre 20 km, nuovo frontaliere oltre 20 km',
  ogTitle: 'Calcolo tasse frontalieri oltre 20 km | Simulazione 2026',
  ogDescription: 'Calcolo tasse frontalieri oltre 20 km: simulazione netto, casi pratici e confronto entro/oltre 20 km.',
- canonicalPath: '/calcola-stipendio/nuovi-frontalieri-oltre-20-km',
+ canonicalPath: '/calcola-stipendio/nuovi-frontalieri-oltre-20-km/',
  structuredData: [
  {
  '@context': 'https://schema.org',
@@ -405,7 +405,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'confronto netto 2025 2026 frontalieri, frontalieri entro 20 km, calcolo tasse frontalieri 2026',
  ogTitle: 'Confronto netto 2025 vs 2026 (entro 20 km)',
  ogDescription: 'Simulazione confronto netto anno su anno per frontalieri entro 20 km.',
- canonicalPath: '/calcola-stipendio/confronto-netto-2025-2026-entro-20km',
+ canonicalPath: '/calcola-stipendio/confronto-netto-2025-2026-entro-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Confronto netto 2025 vs 2026 entro 20 km', url: `${BASE_URL}/calcola-stipendio/confronto-netto-2025-2026-entro-20km`, description: 'Confronto netto frontaliere anno su anno (entro 20 km).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -418,7 +418,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permit g vs b frontalieri, confronto netto permit g permit b, frontalieri entro 20 km',
  ogTitle: 'Permit G vs B (entro 20 km)',
  ogDescription: 'Confronto netto tra Permit G e Permit B per frontalieri entro 20 km.',
- canonicalPath: '/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km',
+ canonicalPath: '/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Confronto Permit G vs B entro 20 km', url: `${BASE_URL}/calcola-stipendio/confronto-permesso-g-vs-b-entro-20km`, description: 'Confronto netto Permit G vs B per frontalieri entro 20 km.' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -431,7 +431,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'confronto netto 2025 2026 frontalieri oltre 20 km, calcolo tasse frontalieri oltre 20 km',
  ogTitle: 'Confronto netto 2025 vs 2026 (oltre 20 km)',
  ogDescription: 'Simulazione confronto netto anno su anno per frontalieri oltre 20 km.',
- canonicalPath: '/calcola-stipendio/confronto-netto-2025-2026-oltre-20km',
+ canonicalPath: '/calcola-stipendio/confronto-netto-2025-2026-oltre-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Confronto netto 2025 vs 2026 oltre 20 km', url: `${BASE_URL}/calcola-stipendio/confronto-netto-2025-2026-oltre-20km`, description: 'Confronto netto frontaliere anno su anno (oltre 20 km).' },
  SALARY_LANDING_FAQ_SCHEMA,
@@ -444,7 +444,7 @@ const LANDING_SEO_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permit g vs b frontalieri oltre 20 km, confronto netto permit g permit b',
  ogTitle: 'Permit G vs B (oltre 20 km)',
  ogDescription: 'Confronto netto tra Permit G e Permit B per frontalieri oltre 20 km.',
- canonicalPath: '/calcola-stipendio/confronto-permesso-g-vs-b-oltre-20km',
+ canonicalPath: '/calcola-stipendio/confronto-permesso-g-vs-b-oltre-20km/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Confronto Permit G vs B oltre 20 km', url: `${BASE_URL}/calcola-stipendio/confronto-permesso-g-vs-b-oltre-20km`, description: 'Confronto netto Permit G vs B per frontalieri oltre 20 km.' },
  SALARY_LANDING_FAQ_SCHEMA,

--- a/services/seo/seo-pages.ts
+++ b/services/seo/seo-pages.ts
@@ -155,7 +155,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'imposta alla fonte ticino, franchigia frontalieri, tabella imposta alla fonte, netto frontalieri',
  ogTitle: 'Imposta alla fonte — Glossario Frontalieri',
  ogDescription: 'Cos\'è l\'imposta alla fonte in Ticino e perché conta per lo stipendio netto dei frontalieri.',
- canonicalPath: '/glossario-frontaliere/imposta-alla-fonte',
+ canonicalPath: '/glossario-frontaliere/imposta-alla-fonte/',
  structuredData: [
  {
  '@context': 'https://schema.org',
@@ -187,7 +187,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'irpef frontalieri, scaglioni irpef 2026, addizionale regionale comunale, credito imposta',
  ogTitle: 'IRPEF — Glossario Frontalieri',
  ogDescription: 'Cos\'è l\'IRPEF e come si applica ai frontalieri con il nuovo accordo.',
- canonicalPath: '/glossario-frontaliere/irpef',
+ canonicalPath: '/glossario-frontaliere/irpef/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'IRPEF', description: 'IRPEF: imposta sul reddito delle persone fisiche in Italia. Per i frontalieri 2026, scaglioni dal 23% al 43% con franchigia di €10.000.', url: `${BASE_URL}/glossario-frontaliere/irpef`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -212,7 +212,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'franchigia 10000 nuovi frontalieri, imponibile irpef, accordo frontalieri 2026',
  ogTitle: 'Franchigia — Glossario Frontalieri',
  ogDescription: 'Cos\'è la franchigia e come influisce sulle tasse dei frontalieri.',
- canonicalPath: '/glossario-frontaliere/franchigia',
+ canonicalPath: '/glossario-frontaliere/franchigia/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'Franchigia', description: 'Franchigia fiscale €10.000 per nuovi frontalieri dal 2024: reddito svizzero esente IRPEF fino a questa soglia. Nuovo accordo CH-IT.', url: `${BASE_URL}/glossario-frontaliere/franchigia`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -237,7 +237,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni frontalieri, comuni confine ticino, tassa salute ristorni',
  ogTitle: 'Ristorni — Glossario Frontalieri',
  ogDescription: 'Cosa sono i ristorni fiscali e perché contano per i frontalieri.',
- canonicalPath: '/glossario-frontaliere/ristorni',
+ canonicalPath: '/glossario-frontaliere/ristorni/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'Ristorni fiscali', description: 'Ristorni fiscali: quota delle imposte alla fonte svizzere retrocessa ai comuni italiani di confine dei lavoratori frontalieri.', url: `${BASE_URL}/glossario-frontaliere/ristorni`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -262,7 +262,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'lamal frontalieri, cassa malati ticino, franchigia assicurazione svizzera',
  ogTitle: 'LAMal — Glossario Frontalieri',
  ogDescription: 'Cos\'è LAMal e come scegliere franchigia e modello assicurativo.',
- canonicalPath: '/glossario-frontaliere/lamal',
+ canonicalPath: '/glossario-frontaliere/lamal/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'LAMal', description: 'LAMal: assicurazione malattia obbligatoria svizzera. Copre cure mediche, ospedaliere e farmaci. I frontalieri scelgono franchigia e modello.', url: `${BASE_URL}/glossario-frontaliere/lamal`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -287,7 +287,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'cmu frontalieri, lamal vs cmu, assicurazione sanitaria frontalieri',
  ogTitle: 'CMU — Glossario Frontalieri',
  ogDescription: 'Cos\'è la CMU e in cosa differisce da LAMal per i frontalieri.',
- canonicalPath: '/glossario-frontaliere/cmu',
+ canonicalPath: '/glossario-frontaliere/cmu/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'CMU', description: 'CMU (Couverture Maladie Universelle): assicurazione sanitaria pubblica francese, alternativa a LAMal per frontalieri in Francia.', url: `${BASE_URL}/glossario-frontaliere/cmu`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -312,7 +312,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso g frontalieri, permesso g vs b, tasse permesso g',
  ogTitle: 'Permesso G — Glossario Frontalieri',
  ogDescription: 'Cos\'è il permesso G e cosa cambia rispetto al permesso B.',
- canonicalPath: '/glossario-frontaliere/permesso-g',
+ canonicalPath: '/glossario-frontaliere/permesso-g/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'Permesso G', description: 'Permesso G: autorizzazione di lavoro per frontalieri che risiedono in un Paese confinante e rientrano quotidianamente. Validità 5 anni.', url: `${BASE_URL}/glossario-frontaliere/permesso-g`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -334,7 +334,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso b frontalieri, residenza svizzera, permesso b vs g',
  ogTitle: 'Permesso B — Glossario Frontalieri',
  ogDescription: 'Cos\'è il permesso B e quando conviene rispetto al permesso G.',
- canonicalPath: '/glossario-frontaliere/permesso-b',
+ canonicalPath: '/glossario-frontaliere/permesso-b/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'Permesso B', description: 'Permesso B: autorizzazione di dimora in Svizzera per cittadini UE/AELS. Consente residenza e lavoro in Svizzera, validità 5 anni.', url: `${BASE_URL}/glossario-frontaliere/permesso-b`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -356,7 +356,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'avs svizzera, contributi avs, pensione frontalieri',
  ogTitle: 'AVS — Glossario Frontalieri',
  ogDescription: 'Cos\'è AVS e come incide su busta paga e pensione.',
- canonicalPath: '/glossario-frontaliere/avs',
+ canonicalPath: '/glossario-frontaliere/avs/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'AVS', description: 'AVS (Assicurazione Vecchiaia e Superstiti): primo pilastro previdenziale svizzero. Contributo del 5,3% sullo stipendio dei frontalieri.', url: `${BASE_URL}/glossario-frontaliere/avs`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -380,7 +380,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'lpp svizzera, secondo pilastro, contributi lpp per età',
  ogTitle: 'LPP — Glossario Frontalieri',
  ogDescription: 'Cos\'è LPP e come influisce su netto e pensione.',
- canonicalPath: '/glossario-frontaliere/lpp',
+ canonicalPath: '/glossario-frontaliere/lpp/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'LPP', description: 'LPP (Previdenza Professionale): secondo pilastro pensionistico svizzero. Contributi crescenti per età, dal 7% al 18% del salario coordinato.', url: `${BASE_URL}/glossario-frontaliere/lpp`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -404,7 +404,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'terzo pilastro 3a, deduzione 3a 2026, previdenza svizzera',
  ogTitle: 'Terzo Pilastro — Glossario Frontalieri',
  ogDescription: 'Cos\'è il terzo pilastro e come si usa per ridurre le tasse.',
- canonicalPath: '/glossario-frontaliere/terzo-pilastro',
+ canonicalPath: '/glossario-frontaliere/terzo-pilastro/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'Terzo Pilastro', description: 'Terzo pilastro (3a/3b): previdenza privata svizzera con vantaggi fiscali. Il pilastro 3a è deducibile fino a CHF 7.258 annui per dipendenti.', url: `${BASE_URL}/glossario-frontaliere/terzo-pilastro`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -428,7 +428,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tasso di cambio chf eur, cambio valuta frontalieri, conversione chf eur',
  ogTitle: 'Tasso di cambio — Glossario Frontalieri',
  ogDescription: 'Cos\'è il tasso di cambio e perché conta per frontalieri e trasferimenti.',
- canonicalPath: '/glossario-frontaliere/tasso-di-cambio',
+ canonicalPath: '/glossario-frontaliere/tasso-di-cambio/',
  structuredData: [
  { '@context': 'https://schema.org', '@type': 'DefinedTerm', name: 'Tasso di cambio CHF/EUR', description: 'Tasso di cambio CHF/EUR: rapporto franco svizzero-euro, fondamentale per calcolare netto in euro e tasse italiane dei frontalieri.', url: `${BASE_URL}/glossario-frontaliere/tasso-di-cambio`, inDefinedTermSet: { '@type': 'DefinedTermSet', name: 'Glossario Frontalieri', url: `${BASE_URL}/glossario-frontaliere` } },
  {
@@ -452,7 +452,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'cambio chf eur, cambio valuta svizzera, wise revolut confronto, operatori mobili svizzera, roaming svizzera italia, trasporti frontalieri, assicurazione sanitaria ticino, banche svizzera italia, traffico valichi doganali',
  ogTitle: 'Comparatori Servizi Frontalieri',
  ogDescription: 'Risparmia 100–300 CHF/mese sui servizi da frontaliere: cambio valuta, operatori mobili con roaming CH-IT, trasporti, assicurazioni sanitarie e conti bancari a confronto.',
- canonicalPath: '/compara-servizi',
+ canonicalPath: '/compara-servizi/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -502,7 +502,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'calcolo stipendio netto svizzera, calcolo stipendio frontaliere, simulatore stipendio netto, busta paga frontaliere, confronto ral svizzera italia, calcolatore imposte alla fonte 2026, etax ticino 2026, imposta alla fonte ticino, bonus frontaliere, congedo parentale frontaliere, permesso g vs b',
  ogTitle: 'Calcolo Stipendio Netto Svizzera 2026 — Simulatore Frontalieri',
  ogDescription: 'Un frontaliere con 60.000 CHF lordi/anno netta circa 3.200–3.500 €/mese dopo contributi svizzeri e tasse italiane. Usa 8 simulatori gratuiti per calcolare il tuo netto esatto (accordo 2026).',
- canonicalPath: '/calcola-stipendio',
+ canonicalPath: '/calcola-stipendio/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -563,7 +563,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri svizzera, guida frontaliere svizzera, permesso g come ottenerlo, nuovo accordo frontalieri 2026, primo giorno frontaliere, dogana svizzera tempi, trasferire auto svizzera, disoccupazione frontaliere, comuni di frontiera svizzera, lamal frontalieri',
  ogTitle: 'Frontalieri Svizzera 2026 — Guida Completa Pillar',
  ogDescription: 'La guida più completa per frontalieri in Svizzera: permesso G (20 km, 5 anni), Nuovo Accordo fiscale 2026, LAMal, dogana, primo giorno, trasferimento auto. 78.000 frontalieri/giorno.',
- canonicalPath: '/guida-frontaliere',
+ canonicalPath: '/guida-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -670,7 +670,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tasse frontalieri 2026, calcolatore imposte alla fonte 2026, etax ticino 2026, dichiarazione redditi frontaliere, ristorni fiscali ticino, pensione frontaliere avs lpp, terzo pilastro 3a frontaliere, scadenze fiscali frontaliere, imposta alla fonte ticino, calcolo stipendio netto svizzera',
  ogTitle: 'Calcolatore Imposte alla Fonte 2026 | Frontaliere Ticino',
  ogDescription: 'Nuovo accordo 2026: calcola imposte alla fonte Ticino (6–15%) + IRPEF con franchigia 10.000 €. Guida completa a tasse, eTax, pensione AVS/LPP e previdenza.',
- canonicalPath: '/tasse-e-pensione',
+ canonicalPath: '/tasse-e-pensione/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -901,7 +901,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'aliquote imposta alla fonte ticino 2026, tabella imposta alla fonte ticino, tabelle A B C H ticino, quellensteuer ticino 2026, imposta alla fonte frontalieri ticino',
  ogTitle: 'Imposta alla Fonte Ticino 2026: Tabelle A B C H',
  ogDescription: 'Tabelle A, B, C e H del Ticino con aliquote 2026, esempi e link ai simulatori per frontalieri.',
- canonicalPath: '/tasse-e-pensione/aliquote-imposta-alla-fonte-ticino-2026',
+ canonicalPath: '/tasse-e-pensione/aliquote-imposta-alla-fonte-ticino-2026/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -999,7 +999,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'simulazione tasse nuovi frontalieri, calcolo tasse nuovi frontalieri 2026, imposta alla fonte nuovi frontalieri, IRPEF frontalieri franchigia 10000, nuovo accordo frontalieri tasse, doppia imposizione nuovi frontalieri, differenza vecchi nuovi frontalieri tasse, franchigia nuovi frontalieri',
  ogTitle: 'Simulazione tasse nuovi frontalieri 2026 — Calcolo netto',
  ogDescription: 'Simulazione tasse nuovi frontalieri 2026: imposta alla fonte CH + IRPEF Italia con franchigia €10.000 e credito d\'imposta. Calcolo gratuito, risultato in EUR.',
- canonicalPath: '/tasse-e-pensione/simulazione-tasse-nuovi-frontalieri',
+ canonicalPath: '/tasse-e-pensione/simulazione-tasse-nuovi-frontalieri/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1101,7 +1101,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'vivere in ticino frontaliere, trasporti frontalieri svizzera, aziende ticino lavoro, scuole svizzera italiana, asili nido ticino, comuni frontiera svizzera italia, vivere svizzera vs italia',
  ogTitle: 'Vita in Ticino per Frontalieri 2026 | Guida Pratica',
  ogDescription: 'Vivere in Ticino costa il 40–60% in più dell\'Italia ma elimina il pendolarismo. Affitto a Lugano da 1.500 CHF vs 600 € a Como. Guida pratica: trasporti, casa, scuole, servizi e confronto permesso B vs G.',
- canonicalPath: '/vivere-in-ticino',
+ canonicalPath: '/vivere-in-ticino/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1148,7 +1148,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'cambio franco euro, cambio chf eur oggi, cambio franco svizzero euro, tasso franco euro 2026, wise tasso cambio, revolut commissioni, spread cambio valuta, postfinance cambio valuta, ubs cambio, n26 trasferimenti, miglior cambio svizzera italia, commissioni cambio valuta, calcolo risparmio cambio',
  ogTitle: 'Cambio Franco Euro 2026 — Tasso Oggi + Confronto Spread',
  ogDescription: '💱 Cambio franco-euro 2026: tasso BNS in tempo reale, spread a confronto tra 6 provider (Wise, Revolut, PostFinance, UBS, Raiffeisen, N26), calcolatore commissioni.',
- canonicalPath: '/compara-servizi/cambio-franco-euro',
+ canonicalPath: '/compara-servizi/cambio-franco-euro/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1201,7 +1201,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'operatori mobili svizzera, roaming svizzera italia, swisscom frontalieri, salt mobile costi, sunrise abbonamenti, yallo wingo confronto, aldi mobile svizzera, roaming illimitato italia',
  ogTitle: 'Operatori Mobili Svizzera | Confronto con Roaming',
  ogDescription: '📱 Confronta 6 operatori mobili svizzeri con roaming illimitato in Italia. Costi reali mensili da CHF 9.95/mese. Trova il piano migliore per frontalieri!',
- canonicalPath: '/compara-servizi/confronta-operatori-mobili',
+ canonicalPath: '/compara-servizi/confronta-operatori-mobili/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1234,7 +1234,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costi trasporto frontalieri, calcolo costi auto, abbonamento treno svizzera, trenitalia frontalieri, ffs ticino, pedaggi autostrada, costo benzina diesel, usura auto, trasporti pubblici frontalieri',
  ogTitle: 'Calcolo Costi Trasporto Frontalieri | Auto vs Treno',
  ogDescription: '🚗 Calcola i costi reali di trasporto per frontalieri. Confronta auto, treno e bus per trovare la soluzione più conveniente!',
- canonicalPath: '/vivere-in-ticino/trasporti-frontalieri',
+ canonicalPath: '/vivere-in-ticino/trasporti-frontalieri/',
  h1: 'Trasporti frontalieri Ticino 2026 — treni TILO, auto, car-sharing e abbonamenti',
  structuredData: {
  "@context": "https://schema.org",
@@ -1255,7 +1255,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'premi lamal frontaliere 2026, casse malati frontaliere ticino, assicurazione sanitaria ticino, premi assicurazione frontalieri, helsana css confronto, swica visana sanitas, franchigia assicurazione svizzera, cassa malati frontalieri, premi lamal ticino',
  ogTitle: 'Premi LAMal Frontaliere Ticino 2026 | Casse Malati',
  ogDescription: 'Premi LAMal frontalieri Ticino 2026: da CHF 200/mese (Assura Telmed) a CHF 600/mese. Scegli tra LAMal e SSN entro 3 mesi dall\'assunzione — confronta 14 casse malati con franchigie da CHF 300 a 2.500.',
- canonicalPath: '/compara-servizi/confronta-casse-malati',
+ canonicalPath: '/compara-servizi/confronta-casse-malati/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1291,7 +1291,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'banche svizzera, conto corrente ticino, ubs credit suisse postfinance, intesa sanpaolo unicredit, costi conto corrente, carte credito svizzera, bonifici internazionali, servizi bancari frontalieri',
  ogTitle: 'Banche per Frontalieri | Confronto Conti CH-IT',
  ogDescription: '🏦 Confronta 8 banche svizzere e italiane. Costi gestione, carte incluse e servizi per frontalieri. Scegli il conto migliore!',
- canonicalPath: '/compara-servizi/confronta-banche',
+ canonicalPath: '/compara-servizi/confronta-banche/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -1311,7 +1311,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'pensione frontalieri, calcolo lpp, avs svizzera, inps italia, secondo pilastro svizzera, contributi pensionistici, totalizzazione pensione, età pensionabile svizzera, previdenza frontalieri, cassa pensione ticino',
  ogTitle: 'Pensione Frontalieri AVS e LPP | Calcolo Previdenza CH-IT',
  ogDescription: 'Pensione frontalieri: AVS (5,3% del lordo) + LPP (5–9%) + INPS italiano. Con 30 anni a 70.000 CHF, la rendita AVS è circa 1.800 CHF/mese. Calcola la tua previdenza combinata CH-IT.',
- canonicalPath: '/tasse-e-pensione/calcola-previdenza',
+ canonicalPath: '/tasse-e-pensione/calcola-previdenza/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1427,7 +1427,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'statistiche frontalieri, lavoro ticino, offerte lavoro ticino, aziende che assumono ticino, trend offerte lavoro, bfs frontalieri, annunci lavoro svizzera italiana, statistiche lavoro ticino 2026',
  ogTitle: 'Statistiche Frontalieri e Lavoro Ticino | BFS e Job Board',
  ogDescription: 'Oltre 78.000 frontalieri in Ticino (BFS 2024) e 4.000+ offerte lavoro attive. Statistiche aggiornate: aziende che assumono, località, settori in crescita e trend giornalieri.',
- canonicalPath: '/statistiche',
+ canonicalPath: '/statistiche/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1475,7 +1475,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'segnalazione bug frontalieri, suggerimenti simulatore, feedback frontalieri, migliorare simulatore tasse, contribuire open source frontalieri',
  ogTitle: 'Aiutaci a Migliorare | Frontaliere Ticino',
  ogDescription: '🐛 Segnala un problema o suggerisci una funzionalità per il simulatore fiscale frontalieri CH-IT. Contribuisci al miglioramento!',
- canonicalPath: '/supporto',
+ canonicalPath: '/supporto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -1494,7 +1494,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'what if frontalieri, simulatore scenari, cosa cambia se figlio, aumento stipendio frontaliere, detrazioni figli frontaliere, cambio stato civile tasse',
  ogTitle: 'Simulatore What-If | Scenari Fiscali per Frontalieri',
  ogDescription: '🔮 Scopri come cambiano le tue tasse con scenari what-if: figlio, stipendio, residenza. Simulazione in tempo reale!',
- canonicalPath: '/calcola-stipendio/cosa-cambia-se',
+ canonicalPath: '/calcola-stipendio/cosa-cambia-se/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1525,7 +1525,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'confronto offerte lavoro svizzera, stipendio netto reale frontaliere, calcolo netto lavoro ticino, costi pendolarismo frontaliere, home office frontaliere, benefit lavoro svizzera',
  ogTitle: 'Confronto Offerte Lavoro Svizzera | Netto Reale Frontalieri',
  ogDescription: '💼 Confronta offerte di lavoro in Svizzera con calcolo netto reale: tasse, trasporto, tempo e benefit inclusi.',
- canonicalPath: '/compara-servizi/confronta-offerte-lavoro',
+ canonicalPath: '/compara-servizi/confronta-offerte-lavoro/',
  h1: 'Confronta offerte di lavoro in Svizzera per frontalieri 2026 — netto reale CHF/EUR',
  structuredData: {
  "@context": "https://schema.org",
@@ -1546,7 +1546,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'scadenze fiscali frontalieri 2026, calendario tasse frontaliere, 730 frontalieri, modello redditi frontaliere, quadro rw svizzera, imposta alla fonte scadenza, irpef frontalieri',
  ogTitle: 'Scadenze Tasse Frontalieri 2026 | Canton Ticino e Italia',
  ogDescription: '📅 Scadenze tasse frontaliero canton Ticino 2026: IRPEF, 730, imposta alla fonte, AVS. Countdown e documenti necessari!',
- canonicalPath: '/tasse-e-pensione/scadenze-fiscali',
+ canonicalPath: '/tasse-e-pensione/scadenze-fiscali/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1614,7 +1614,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso g svizzera, permesso b svizzera, permesso c svizzera, permesso l svizzera, permesso frontaliere requisiti, permesso dimora svizzera, documenti permesso lavoro svizzera',
  ogTitle: 'Permessi Lavoro Svizzera | Guida G, B, C, L per Frontalieri',
  ogDescription: 'Permesso G: residenza entro 20 km, contratto CH, rientro settimanale, durata 5 anni. Permesso B: dimora in Svizzera. Confronta G, B, C e L con requisiti, documenti e costi aggiornati 2026.',
- canonicalPath: '/guida-frontaliere/permessi-di-lavoro',
+ canonicalPath: '/guida-frontaliere/permessi-di-lavoro/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1714,7 +1714,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'terzo pilastro svizzera, pilastro 3a calcolo, pilastro 3b, risparmio fiscale svizzera, previdenza privata svizzera, deduzione fiscale pilastro 3a, investimento pilastro svizzera',
  ogTitle: 'Simulatore 3° Pilastro | Risparmio Fiscale Svizzera',
  ogDescription: '💰 Calcola quanto risparmi con il 3° pilastro: deducibilità fiscale, proiezione rendimento e confronto 3a vs 3b.',
- canonicalPath: '/tasse-e-pensione/simula-terzo-pilastro',
+ canonicalPath: '/tasse-e-pensione/simula-terzo-pilastro/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1814,7 +1814,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'newsletter frontalieri, cambio chf eur settimanale, aggiornamenti frontalieri, email frontalieri svizzera, traffico valichi email, novità tasse frontalieri',
  ogTitle: 'Newsletter Frontalieri | Aggiornamenti Settimanali Gratuiti',
  ogDescription: '📬 Iscriviti alla newsletter per frontalieri: cambio CHF/EUR, traffico ai valichi e novità fiscali ogni settimana!',
- canonicalPath: '/newsletter',
+ canonicalPath: '/newsletter/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -1831,7 +1831,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'prezzi supermercato svizzera vs italia, migros prezzi, coop svizzera caro, spesa frontiera ticino, supermercati confine svizzera italia, esselunga como prezzi, lidl italia vs lidl svizzera, denner prezzi, shopping transfrontaliero, aldi svizzera prezzi, eurospin como, risparmio spesa frontaliere, limite doganale CHF 300, indice convenienza zona confine',
  ogTitle: 'Prezzi Supermercato Svizzera vs Italia | Mappa e Confronto',
  ogDescription: '🛒 Mappa 40+ supermercati di frontiera + confronto prezzi 25 prodotti CH vs IT. Indice di convenienza per zona: risparmio fino al 42%!',
- canonicalPath: '/compara-servizi/confronta-prezzi-spesa',
+ canonicalPath: '/compara-servizi/confronta-prezzi-spesa/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1888,7 +1888,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costo vita svizzera vs italia, costo vita svizzera italia, costo vita lugano, costo vita como, affitto ticino prezzi, costo vita mendrisio chiasso, confronto prezzi svizzera italia, vivere in svizzera costi, costo vita frontiera, costo vita lugano vs como',
  ogTitle: 'Costo Vita Svizzera vs Italia 2026: Affitti e Spesa',
  ogDescription: 'Confronto 2026 tra Lugano e Como: affitto, spesa, LAMal e trasporti per frontalieri ed espatriati.',
- canonicalPath: '/compara-servizi/costo-della-vita',
+ canonicalPath: '/compara-servizi/costo-della-vita/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -1968,7 +1968,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'vivere in svizzera, trasferirsi in svizzera, affitti ticino, costo vita svizzera, lamal assicurazione, scuole svizzera, sistema sanitario svizzera, burocrazia svizzera, residenza svizzera',
  ogTitle: 'Vivere in Svizzera | Guida Completa per Frontalieri',
  ogDescription: '🇨🇭 Guida completa su vivere in Svizzera: affitti, sanità, scuole, trasporti e burocrazia nel Canton Ticino.',
- canonicalPath: '/vivere-in-ticino/vivere-in-svizzera',
+ canonicalPath: '/vivere-in-ticino/vivere-in-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Article",
@@ -1988,7 +1988,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'vivere in italia frontaliere, residenza italia vantaggi, como varese frontalieri, costi vivere italia, detrazioni frontalieri italia, sanità ssn frontalieri, province frontiera',
  ogTitle: 'Vivere in Italia come Frontaliere | Vantaggi e Svantaggi',
  ogDescription: '🇮🇹 Pro e contro di vivere in Italia lavorando in Svizzera: costi, detrazioni, sanità e qualità della vita.',
- canonicalPath: '/vivere-in-ticino/vivere-in-italia',
+ canonicalPath: '/vivere-in-ticino/vivere-in-italia/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Article",
@@ -2008,7 +2008,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'traffico dogana chiasso brogeda, tempi di attesa dogana chiasso, coda dogana chiasso, valichi frontiera svizzera italia, dogana chiasso, tempi attesa dogana, ponte tresa orari, gaggiolo brogeda, stabio valico, percorsi alternativi frontiera, coda brogeda',
  ogTitle: 'Traffico Dogana Chiasso Brogeda | Tempi di Attesa e Code',
  ogDescription: 'Traffico dogana Chiasso e Brogeda: tempi di attesa, code, orari apertura e percorsi alternativi per frontalieri.',
- canonicalPath: '/guida-frontaliere/tempi-attesa-dogana',
+ canonicalPath: '/guida-frontaliere/tempi-attesa-dogana/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2043,7 +2043,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'costi pendolarismo frontaliere, spese viaggio frontaliere, benzina frontaliere, autostrada svizzera costi, parcheggio dogana, treno frontalieri, bus transfrontaliero',
  ogTitle: 'Costi Pendolarismo Frontaliere | Calcolo Spese Viaggio',
  ogDescription: '🚗 Calcola quanto spendi di pendolarismo: auto, treno, bus. Confronta le opzioni per risparmiare!',
- canonicalPath: '/guida-frontaliere/costo-auto-pendolare',
+ canonicalPath: '/guida-frontaliere/costo-auto-pendolare/',
  h1: 'Costo auto pendolare frontaliere Ticino 2026 — casi studio, tabelle km/CHF, treno',
  structuredData: {
  "@context": "https://schema.org",
@@ -2065,7 +2065,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'aziende che assumono in ticino, nomi ditte in svizzera che assumono, aziende canton ticino, aziende ticino lavoro, aziende che assumono svizzera italiana, settori lavoro ticino, opportunità lavoro frontalieri, carriere svizzera, stipendi ticino, lista aziende ticino',
  ogTitle: 'Aziende che Assumono in Ticino 2026 | Lista per Settore',
  ogDescription: '🏢 Aziende che assumono in Ticino nel 2026: lista per settore e città, sedi Lugano/Mendrisio/Chiasso e stipendi medi frontalieri.',
- canonicalPath: '/vivere-in-ticino/aziende-svizzera-italiana',
+ canonicalPath: '/vivere-in-ticino/aziende-svizzera-italiana/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2125,7 +2125,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'comuni di frontiera, elenco comuni frontalieri svizzera 2026, comuni frontalieri svizzera mappa, comuni 20 km confine svizzera, comuni como varese frontiera, distanza valichi frontiera, mappa comuni frontiera',
  ogTitle: '146 Comuni di Frontiera Svizzera — Mappa e Distanze',
  ogDescription: 'Mappa interattiva dei 146 comuni italiani di frontiera. Distanze dai valichi, addizionale IRPEF e trasporti per frontalieri.',
- canonicalPath: '/vivere-in-ticino/comuni-di-frontiera',
+ canonicalPath: '/vivere-in-ticino/comuni-di-frontiera/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2162,7 +2162,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'posti da visitare ticino, cosa fare ticino, lugano attrazioni, monte san salvatore, lago lugano, bellinzona castelli unesco, foxtown mendrisio, swissminiatur, locarno film festival, grotti ticinesi',
  ogTitle: 'Posti da Visitare in Ticino | Natura, Cultura e Famiglia',
  ogDescription: '🏔️ Scopri i posti più belli del Canton Ticino: montagne, laghi, città, eventi e attività per famiglie. Guida per frontalieri!',
- canonicalPath: '/vivere-in-ticino/attrazioni-svizzera-italiana',
+ canonicalPath: '/vivere-in-ticino/attrazioni-svizzera-italiana/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Article",
@@ -2182,7 +2182,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'scuole ticino frontalieri, nido svizzera costi, scuola infanzia ticino, scuola elementare ticino, scuola media mendrisio, liceo lugano, scuole vicino frontiera, costi scuola svizzera, asilo ticino',
  ogTitle: 'Scuole in Ticino per Frontalieri | Guida Completa per Età',
  ogDescription: '🎓 Guida alle scuole del Canton Ticino per frontalieri: tipi per età, costi, orari e scuole vicine ai valichi di frontiera.',
- canonicalPath: '/vivere-in-ticino/scuole-svizzera-italiana',
+ canonicalPath: '/vivere-in-ticino/scuole-svizzera-italiana/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2226,7 +2226,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'disoccupazione frontalieri, naspi frontalieri svizzera, disoccupazione svizzera ALV, PD U1 formulario, indennità disoccupazione frontaliere, naspi italia procedura, assicurazione disoccupazione svizzera, URC ticino, cassa disoccupazione',
  ogTitle: 'Disoccupazione Frontalieri Svizzera: NASpI e PD U1',
  ogDescription: 'Cosa fare dopo il licenziamento in Svizzera: PD U1, NASpI Italia, importi 2026 e tempi pratici.',
- canonicalPath: '/guida-frontaliere/disoccupazione-transfrontaliera',
+ canonicalPath: '/guida-frontaliere/disoccupazione-transfrontaliera/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2316,7 +2316,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  ogTitle: 'Festività Ticino 2026: Calendario e Ponti Ufficiali',
  ogDescription: '15 giorni festivi in Ticino, ponti utili, lavoro festivo e differenze con il calendario italiano.',
  h1: 'Festività Ticino 2026: il calendario ufficiale completo del Canton Ticino',
- canonicalPath: '/tasse-e-pensione/festivita-ticino',
+ canonicalPath: '/tasse-e-pensione/festivita-ticino/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2417,7 +2417,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  ogTitle: 'Feiertage Tessin 2026: Offizieller Kalender und Brückentage für Grenzgänger',
  ogDescription: 'Offizieller Kalender der Tessiner Feiertage 2026: 15 Feiertage, Brückentage, GAV-Zuschläge bei Feiertagsarbeit und Auswirkungen auf den 13. Monatslohn der Grenzgänger.',
  h1: 'Feiertage Tessin 2026: der vollständige offizielle Kalender des Kantons Tessin',
- canonicalPath: '/de/steuern-und-vorsorge/tessin-feiertage',
+ canonicalPath: '/de/steuern-und-vorsorge/tessin-feiertage/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2518,7 +2518,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ral netta italia svizzera, confronto stipendio netto, busta paga frontaliere, imposta alla fonte ticino, irpef vs imposta fonte, stipendio netto svizzera',
  ogTitle: 'Stipendio Frontaliere Svizzera vs Italia | RAL Netta',
  ogDescription: '💰 Stipendio frontaliere Svizzera vs Italia: confronta netto a parità di RAL. Imposta alla fonte, IRPEF e contributi.',
- canonicalPath: '/calcola-stipendio/confronta-retribuzione-ral',
+ canonicalPath: '/calcola-stipendio/confronta-retribuzione-ral/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2552,7 +2552,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'congedo maternità frontalieri, congedo paternità svizzera, IPG svizzera, maternità INPS frontaliere, indennità maternità svizzera italia, congedo parentale frontaliere',
  ogTitle: 'Congedo Maternità/Paternità per Frontalieri',
  ogDescription: '👶 Calcola il congedo maternità e paternità per frontalieri: confronto IPG Svizzera vs INPS Italia, importi e documenti.',
- canonicalPath: '/calcola-stipendio/verifica-congedo-parentale',
+ canonicalPath: '/calcola-stipendio/verifica-congedo-parentale/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2586,7 +2586,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mappa valichi ticino, mappa dogane svizzera italia, valichi confine ticino, chiasso brogeda mappa, gaggiolo ponte tresa mappa, webcam valichi confine, tempi attesa dogane ticino, comuni frontiera svizzera, mappa comuni frontalieri, addizionale irpef comuni confine, dove vivere frontaliere, comuni como varese frontalieri, affitti comuni frontiera',
  ogTitle: 'Mappa Valichi Ticino-Italia | Tempi Attesa + Webcam Live',
  ogDescription: '🗺️ Mappa interattiva dei valichi di confine tra Ticino e Italia con tempi di attesa, webcam, addizionali IRPEF e comuni di frontiera.',
- canonicalPath: '/guida-frontaliere/mappa-confine',
+ canonicalPath: '/guida-frontaliere/mappa-confine/',
  h1: 'Mappa confine Svizzera-Italia 2026 — valichi, comuni 20 km e addizionali IRPEF',
  structuredData: [
  {
@@ -2730,7 +2730,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'meteo frontaliere, traffico valichi mattino, cambio chf eur oggi, previsioni meteo lugano como, buongiorno frontaliere, tempo reale frontiera, dashboard pendolare',
  ogTitle: 'Buongiorno Frontaliere | Meteo + Traffico + Cambio',
  ogDescription: '☀️ Dashboard mattutino per frontalieri: meteo Lugano/Como, traffico valichi e cambio CHF-EUR in tempo reale.',
- canonicalPath: '/buongiorno-frontaliere',
+ canonicalPath: '/buongiorno-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2800,7 +2800,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'trasferire auto svizzera, immatricolare auto ticino, targhe svizzere, cambio patente svizzera, dogana veicolo, MFK collaudo, assicurazione auto svizzera, PRA radiazione',
  ogTitle: 'Trasferire Auto in Svizzera | Guida Completa',
  ogDescription: '🚗 Come immatricolare la tua auto in Svizzera: dogana, targhe TI, cambio patente, assicurazione RC e costi.',
- canonicalPath: '/guida-frontaliere/trasferire-auto-svizzera',
+ canonicalPath: '/guida-frontaliere/trasferire-auto-svizzera/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -2872,7 +2872,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'cambio residenza frontaliere, trasferimento italia svizzera costi, vivere in svizzera costi, traslocare ticino, permesso B svizzera costi, break-even residenza',
  ogTitle: 'Simulatore Cambio Residenza Italia ↔ Svizzera',
  ogDescription: '🏠 Simula costi e risparmi del cambio residenza tra Italia e Svizzera: affitti, spese, break-even point.',
- canonicalPath: '/calcola-stipendio/simula-cambio-residenza',
+ canonicalPath: '/calcola-stipendio/simula-cambio-residenza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -2892,7 +2892,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'quiz stipendio svizzera, quanto guadagnerei in svizzera, stipendio frontaliere per professione, stima stipendio ticino, lavoro svizzera stipendio netto, quanto si guadagna in svizzera',
  ogTitle: 'Quiz Stipendio Svizzera | Quanto Guadagneresti?',
  ogDescription: '🎯 Quiz interattivo: scopri quanto guadagneresti come frontaliere in Svizzera in base alla tua professione e esperienza.',
- canonicalPath: '/calcola-stipendio/quanto-guadagneresti-in-svizzera',
+ canonicalPath: '/calcola-stipendio/quanto-guadagneresti-in-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -2912,7 +2912,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'simulazione tasse nuovi frontalieri, busta paga svizzera, cedolino svizzera frontaliere, calcolo stipendio netto svizzera, deduzioni AVS AC LPP, imposta alla fonte calcolo, stipendio frontaliere dettaglio, calcolatore imposte alla fonte 2026, etax ticino, calcolo imposta fonte ticino, nuovo accordo frontalieri 2026, calcolo tasse frontalieri oltre 20 km',
  ogTitle: 'Calcolatore Imposta alla Fonte 2026 | Busta Paga Frontaliere',
  ogDescription: '📄 Calcolo imposta alla fonte 2026: busta paga frontaliere Svizzera con deduzioni AVS, LPP e netto in dettaglio.',
- canonicalPath: '/calcola-stipendio/simula-busta-paga',
+ canonicalPath: '/calcola-stipendio/simula-busta-paga/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3058,7 +3058,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'permesso G vs B, confronto permesso frontaliere dimora, tasse permesso G, tasse permesso B svizzera, conviene trasferirsi svizzera, frontaliere vs residente',
  ogTitle: 'Confronto Permesso G vs B Costo Vita | Conviene Trasferirsi?',
  ogDescription: '⚖️ Confronto permesso G vs B costo vita: tasse, contributi e spese. Conviene vivere in Svizzera o pendolare?',
- canonicalPath: '/guida-frontaliere/confronta-permesso-g-vs-b',
+ canonicalPath: '/guida-frontaliere/confronta-permesso-g-vs-b/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3126,7 +3126,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'primo giorno frontaliere, checklist frontaliere, guida frontaliere passo passo, permesso G procedura, AIRE iscrizione, conto bancario svizzero, assicurazione LAMal',
  ogTitle: 'Primo Giorno da Frontaliere | Checklist Interattiva',
  ogDescription: '🚀 Checklist gamificata per il primo giorno da frontaliere: tutti i passaggi da seguire passo per passo.',
- canonicalPath: '/guida-frontaliere/primo-giorno-lavoro',
+ canonicalPath: '/guida-frontaliere/primo-giorno-lavoro/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3234,7 +3234,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'forum frontalieri, domande frontaliere, community frontalieri, Q&A frontaliere, aiuto frontalieri Svizzera Italia',
  ogTitle: 'Community Frontalieri - Domande e Risposte',
  ogDescription: '💬 Fai domande e rispondi ad altri frontalieri su tasse, permessi, assicurazioni e molto altro.',
- canonicalPath: '/community',
+ canonicalPath: '/community/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -3255,7 +3255,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dashboard frontaliere, storico simulazioni, confronto simulazioni fiscali, report PDF frontaliere, salva simulazione frontaliere',
  ogTitle: 'Dashboard Personale Frontaliere',
  ogDescription: '📊 Salva, confronta e esporta le tue simulazioni fiscali. Dashboard personale per frontalieri.',
- canonicalPath: '/profilo',
+ canonicalPath: '/profilo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -3276,7 +3276,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'quiz frontalieri, test fiscale, quiz tasse svizzera, quiz permesso G, frontalieri ticino quiz, test conoscenze frontaliere',
  ogTitle: 'Quiz Fiscale Frontalieri | Testa le Tue Conoscenze',
  ogDescription: 'Quiz settimanale sulla fiscalità transfrontaliera! Verifica le tue conoscenze su tasse, deduzioni e permessi per frontalieri in Ticino.',
- canonicalPath: '/tasse-e-pensione/quiz-fiscale',
+ canonicalPath: '/tasse-e-pensione/quiz-fiscale/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Quiz",
@@ -3301,7 +3301,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'credito imposta frontalieri, doppia imposizione svizzera italia, imposta alla fonte credito, IRPEF frontaliere, tasse frontaliere 2026',
  ogTitle: 'Credito d\'Imposta Doppia Imposizione | Frontaliere Ticino',
  ogDescription: 'Calcola il credito d\'imposta per evitare la doppia tassazione come frontaliere. Scopri quanto risparmi con il nostro calcolatore gratuito.',
- canonicalPath: '/tasse-e-pensione/credito-imposta',
+ canonicalPath: '/tasse-e-pensione/credito-imposta/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3369,7 +3369,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'offerte di lavoro ticino, lavoro ticino, offerte lavoro ticino, cerco lavoro ticino, lavoro in svizzera per italiani, posti vacanti ticino, offerte di lavoro frontalieri svizzera, lavoro frontaliere ticino 2026, impiego ticino, lavoro lugano, lavoro mendrisio, offerte lavoro ticino oggi, posti di lavoro ticino, lavoro ticino offerte, offerte di lavoro lugano, lavoro in ticino, offerte di lavoro ticino negli ultimi 3 giorni, lavoro ticino da ieri, lavoro ticino negli ultimi 3 giorni, case anziani ticino offerte di lavoro',
  ogTitle: 'Offerte di Lavoro Ticino 2026 | Lugano, Mendrisio, Bellinzona',
  ogDescription: 'Cerca lavoro in Ticino: 1500+ offerte aggiornate da 100+ aziende a Lugano, Mendrisio e Bellinzona. Banche, IT, pharma, sanità, case anziani. Candidatura diretta — gratis!',
- canonicalPath: '/cerca-lavoro-ticino',
+ canonicalPath: '/cerca-lavoro-ticino/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3447,7 +3447,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'glossario frontaliere, termini fiscali svizzera, avs significato, lpp secondo pilastro, lamal frontaliere, imposta alla fonte spiegazione, irpef frontaliere, glossario lavoro svizzera',
  ogTitle: 'Glossario Frontaliere | 52 Termini Spiegati',
  ogDescription: 'Tutti i termini che un frontaliere deve conoscere: glossario completo con spiegazioni semplici di AVS, LPP, LAMal, imposta alla fonte, IRPEF e altro.',
- canonicalPath: '/glossario-frontaliere',
+ canonicalPath: '/glossario-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "DefinedTermSet",
@@ -3464,7 +3464,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'parole in dialetto ticinese, dialetto ticinese, espressioni ticinesi, vocabolario ticinese, proverbi ticino, lingua ticinese frontalieri, bundi ciau, polenta ticinese, grotto ticino, dialetto lombardo svizzera, modi di dire ticinesi',
  ogTitle: 'Parole in Dialetto Ticinese | Espressioni e Vocabolario',
  ogDescription: 'Parole ed espressioni in dialetto ticinese: 64 vocaboli, saluti, proverbi e modi di dire. Il vocabolario del Ticino spiegato ai frontalieri.',
- canonicalPath: '/dialetto-ticinese',
+ canonicalPath: '/dialetto-ticinese/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "CollectionPage",
@@ -3481,7 +3481,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'domande frequenti frontalieri, faq frontaliere svizzera, tasse frontalieri domande, permesso g domande, lamal frontaliere faq, pensione frontaliere domande, nuovo accordo frontalieri faq',
  ogTitle: 'FAQ Frontalieri 2026 | 30 Domande e Risposte',
  ogDescription: 'Le 30 domande più frequenti sui frontalieri Svizzera-Italia: tasse, permessi, LAMal, pensione e nuovo accordo 2026.',
- canonicalPath: '/domande-frequenti-frontalieri',
+ canonicalPath: '/domande-frequenti-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "FAQPage",
@@ -3542,7 +3542,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mappa del sito frontaliere ticino, strumenti frontalieri svizzera, calcolatori frontaliere, guide frontaliere italia svizzera',
  ogTitle: 'Mappa del Sito | Frontaliere Ticino',
  ogDescription: 'Tutti gli strumenti e risorse per frontalieri Svizzera-Italia in un\'unica pagina.',
- canonicalPath: '/mappa-del-sito',
+ canonicalPath: '/mappa-del-sito/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "CollectionPage",
@@ -3561,7 +3561,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'contratto lavoro svizzera, CCNL ticino, CCL svizzera, diritti lavoratore frontaliere, ore lavoro svizzera, ferie svizzera, tredicesima svizzera, contratti collettivi ticino, GAV tessin',
  ogTitle: 'Contratti Lavoro Svizzera — CCNL e CCL Ticino',
  ogDescription: 'Confronto completo dei contratti collettivi svizzeri e italiani: ore, ferie, tredicesima, preavviso per 5 settori chiave.',
- canonicalPath: '/contratti-lavoro-svizzera',
+ canonicalPath: '/contratti-lavoro-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -3583,7 +3583,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'TFR frontaliere svizzera, liquidazione frontaliere, buonuscita frontaliere, 2 pilastro svizzera, LPP frontaliere, TFR italia vs svizzera, previdenza professionale frontaliere, cassa pensione frontaliere, trattamento fine rapporto svizzera',
  ogTitle: 'TFR e Liquidazione Frontaliere — Svizzera vs Italia',
  ogDescription: 'In Svizzera il TFR non esiste! Confronta il 2° pilastro (LPP) con il TFR italiano. Simulazione su N anni per frontalieri.',
- canonicalPath: '/tfr-liquidazione-frontaliere',
+ canonicalPath: '/tfr-liquidazione-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3637,7 +3637,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'meglio permesso b o g, quiz permesso svizzera, permesso b o g frontaliere, scelta permesso svizzera, permesso b vantaggi, permesso g vantaggi, confronto permesso b g, permesso lavoro svizzera frontaliere',
  ogTitle: 'Quiz: Meglio Permesso B o G? Scoprilo in 2 Minuti',
  ogDescription: 'Rispondi a 8 domande e scopri quale permesso svizzero è più adatto alla tua situazione: Permesso B (residenza) o G (frontaliere).',
- canonicalPath: '/quiz-permesso-b-o-g',
+ canonicalPath: '/quiz-permesso-b-o-g/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3683,7 +3683,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'calcolo tredicesima frontaliere, tredicesima svizzera, 13 stipendio svizzera, quattordicesima frontaliere, mensilità extra frontaliere, 13esima svizzera frontaliere, tredicesima italia vs svizzera',
  ogTitle: 'Calcolatore Tredicesima e Quattordicesima per Frontalieri',
  ogDescription: 'Calcola la tua tredicesima e quattordicesima mensilità come frontaliere. Confronto 13° stipendio svizzero vs tredicesima italiana.',
- canonicalPath: '/calcolo-tredicesima-frontaliere',
+ canonicalPath: '/calcolo-tredicesima-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3717,7 +3717,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'digest settimanale frontaliere, newsletter frontalieri, tasso cambio settimanale, news frontaliere ticino, offerte lavoro ticino, aggiornamenti frontalieri',
  ogTitle: 'Digest Settimanale per Frontalieri',
  ogDescription: 'Ogni lunedì: tasso CHF/EUR, articoli, strumento della settimana e offerte di lavoro in Ticino per frontalieri.',
- canonicalPath: '/digest-settimanale',
+ canonicalPath: '/digest-settimanale/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3738,7 +3738,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'strumento settimana frontaliere, calcolatori frontalieri, comparatori frontalieri, tools frontaliere ticino, strumenti gratuiti frontalieri',
  ogTitle: 'Strumento della Settimana | Frontaliere Ticino',
  ogDescription: 'Ogni settimana uno strumento diverso in evidenza per frontalieri: calcolatori, comparatori e simulatori gratuiti.',
- canonicalPath: '/strumento-della-settimana',
+ canonicalPath: '/strumento-della-settimana/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3759,7 +3759,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dichiarazione redditi frontaliere, 730 frontaliere, credito imposta svizzera, quadro CE, redditi svizzeri italia, modello unico frontaliere, scadenze fiscali frontaliere, imposta alla fonte, rettifica quellensteuer, TDR frontaliere',
  ogTitle: 'Dichiarazione Redditi Frontalieri 2026 | Italia e Svizzera',
  ogDescription: 'Dichiarazione redditi frontalieri 2026: guida Italia (730, quadro CE) e Svizzera (imposta alla fonte, rettifica, TDR). Passo passo con scadenze.',
- canonicalPath: '/tasse-e-pensione/dichiarazione-redditi',
+ canonicalPath: '/tasse-e-pensione/dichiarazione-redditi/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3866,7 +3866,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dichiarazione redditi frontaliere italia, 730 frontaliere, redditi PF frontaliere, credito imposta svizzera, quadro CE, quadro RW, IRPEF frontaliere, franchigia 10000, scadenze fiscali italia 2026',
  ogTitle: 'Dichiarazione Redditi Italia Frontalieri | 730 e Redditi PF',
  ogDescription: 'Guida alla dichiarazione dei redditi in Italia per frontalieri: 730, Redditi PF, IRPEF, credito d\'imposta e scadenze 2026.',
- canonicalPath: '/tasse-e-pensione/dichiarazione-redditi-italia',
+ canonicalPath: '/tasse-e-pensione/dichiarazione-redditi-italia/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -3938,7 +3938,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'dichiarazione fiscale svizzera frontaliere, imposta alla fonte ticino, TDR frontaliere, rettifica quellensteuer, deduzioni cantonali ticino, pillar 3a, LPP, tariffa doganale ridotta frontaliere',
  ogTitle: 'Dichiarazione Fiscale Svizzera Frontalieri',
  ogDescription: 'Guida alla dichiarazione fiscale svizzera per frontalieri: imposta alla fonte, TDR, rettifica e deduzioni cantonali Ticino.',
- canonicalPath: '/tasse-e-pensione/dichiarazione-redditi-svizzera',
+ canonicalPath: '/tasse-e-pensione/dichiarazione-redditi-svizzera/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -4010,7 +4010,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'asili nido ticino, asili nido como, costi asilo svizzera, asili frontalieri, custodia bambini ticino, confronto asili nido, sussidi asilo svizzera italia',
  ogTitle: 'Asili Nido Ticino vs Italia | Confronto per Frontalieri',
  ogDescription: '👶 Confronta costi, orari e sussidi asili nido tra Ticino e Italia per famiglie di frontalieri.',
- canonicalPath: '/vivere-in-ticino/confronta-asili-nido',
+ canonicalPath: '/vivere-in-ticino/confronta-asili-nido/',
  h1: 'Confronta asili nido Ticino vs Italia 2026 — costi, orari e liste d\'attesa',
  structuredData: [
  {
@@ -4098,7 +4098,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'bonus frontaliere, tredicesima frontaliere, tassazione bonus svizzera, gratifica frontaliere, bonus natale frontaliere, tasse bonus ticino',
  ogTitle: 'Calcolo Bonus e Tredicesima Frontalieri',
  ogDescription: '💰 Calcola la tassazione netta del bonus e della tredicesima per frontalieri Svizzera-Italia.',
- canonicalPath: '/calcola-stipendio/stima-bonus-frontaliere',
+ canonicalPath: '/calcola-stipendio/stima-bonus-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4118,7 +4118,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'bonus ristrutturazione frontaliere, detrazioni casa frontaliere, superbonus frontaliere, ecobonus italia, bonus mobili, ristrutturazione casa italia',
  ogTitle: 'Bonus Ristrutturazione Casa per Frontalieri',
  ogDescription: '🏗️ Calcola le detrazioni per ristrutturazione casa disponibili per frontalieri residenti in Italia.',
- canonicalPath: '/compara-servizi/calcola-bonus-ristrutturazione',
+ canonicalPath: '/compara-servizi/calcola-bonus-ristrutturazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4140,7 +4140,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendio medio svizzera per settore, stipendi ticino 2026, salario informatica svizzera, confronto stipendi frontaliere, stipendio svizzera italia, salario settore ticino, stipendio frontaliere 2026, range salariale svizzera, professioni svizzera stipendi, sondaggio stipendi frontalieri',
  ogTitle: 'Stipendi Frontalieri Svizzera | 60 Professioni × 15 Settori',
  ogDescription: 'Confronta stipendi di 60 professioni in 15 settori tra Svizzera e Italia. Range salariali, netti e parità potere d\'acquisto 2026.',
- canonicalPath: '/statistiche/confronta-stipendi',
+ canonicalPath: '/statistiche/confronta-stipendi/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -4181,7 +4181,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'migliori comuni frontiera, comuni frontalieri classifica, vivere como varese, qualità vita frontaliere, comuni vicino svizzera, dove vivere frontaliere',
  ogTitle: 'Migliori Comuni di Frontiera | Classifica 2026',
  ogDescription: '🏡 Classifica dei migliori comuni italiani di frontiera: qualità della vita, distanza dogana e servizi.',
- canonicalPath: '/statistiche/migliori-comuni-frontiera',
+ canonicalPath: '/statistiche/migliori-comuni-frontiera/',
  h1: 'Migliori comuni di frontiera per frontalieri 2026 — classifica qualità e metodologia',
  structuredData: {
  "@context": "https://schema.org",
@@ -4210,7 +4210,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendi ticino, lavori piu cercati ticino, aziende che assumono ticino, offerte lavoro ticino oggi, osservatorio lavoro ticino, stipendi frontalieri ticino',
  ogTitle: 'Osservatorio stipendi e lavori in Ticino',
  ogDescription: 'Dati giornalieri su stipendi osservati negli annunci, ruoli piu pubblicati, aziende che assumono e localita piu attive nel mercato del lavoro ticinese.',
- canonicalPath: '/statistiche/osservatorio-stipendi-lavori-ticino',
+ canonicalPath: '/statistiche/osservatorio-stipendi-lavori-ticino/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -4249,7 +4249,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'storico traffico dogane, traffico valichi svizzera italia, storico code frontiera, tendenze traffico chiasso, traffico gaggiolo stabio, dati traffico frontaliere, orari migliori frontiera',
  ogTitle: 'Storico Traffico Dogane | Dati e Tendenze Frontiera CH-IT',
  ogDescription: '📈 Storico traffico ai valichi Svizzera-Italia: grafici, tendenze e confronto tra dogane per pianificare gli spostamenti.',
- canonicalPath: '/statistiche/storico-traffico-dogane',
+ canonicalPath: '/statistiche/storico-traffico-dogane/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Dataset",
@@ -4277,7 +4277,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'disoccupazione svizzera, tasso disoccupazione SECO, arbeitslosenquote schweiz, unemployment rate switzerland, mercato lavoro svizzero, frontalieri, arbeit.swiss',
  ogTitle: 'Disoccupazione Svizzera — Tasso SECO 10 Anni',
  ogDescription: 'Trend mensile della disoccupazione svizzera dal 2016: grafici interattivi, KPI e confronto annuale. Fonte SECO.',
- canonicalPath: '/statistiche/disoccupazione-svizzera',
+ canonicalPath: '/statistiche/disoccupazione-svizzera/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Dataset",
@@ -4305,7 +4305,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'mutuo frontaliere, mutuo svizzera tasso, mutuo casa frontaliere italia svizzera, confronto mutui, ipoteca svizzera, Tragbarkeit, rata mutuo, tasso ipotecario, SARON, Euribor',
  ogTitle: 'Confronto Mutui Italia vs Svizzera — Simulatore',
  ogDescription: '🏠 Confronta rata mensile, interessi e detrazioni fiscali di un mutuo italiano vs ipoteca svizzera. Simulatore per frontalieri.',
- canonicalPath: '/statistiche/confronto-mutui',
+ canonicalPath: '/statistiche/confronto-mutui/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4323,7 +4323,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'prezzi benzina italia svizzera, dove conviene fare benzina ticino, prezzo benzina como svizzera, prezzo benzina varese ticino, carburanti confine, confronto benzina italia svizzera, mrprezzi confine',
  ogTitle: 'Prezzi Benzina Italia-Svizzera | Dove Conviene Oggi',
  ogDescription: 'Confronta i prezzi benzina nei comuni di confine italiani con le stazioni svizzere vicine e scopri dove conviene fare rifornimento oggi.',
- canonicalPath: '/statistiche/prezzi-benzina-confine',
+ canonicalPath: '/statistiche/prezzi-benzina-confine/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Dataset",
@@ -4351,7 +4351,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'premi malattia svizzera comune, cassa malati confronto comune, premi LAMal 2025, differenze cantonali cassa malati, assicurazione malattia svizzera frontalieri, premi malattia ticino',
  ogTitle: 'Premi Malattia per Comune | Frontaliere Ticino',
  ogDescription: 'Scopri come variano i premi della cassa malati tra comuni svizzeri e quanto potresti risparmiare cambiando comune di residenza.',
- canonicalPath: '/statistiche/premi-malattia-comuni',
+ canonicalPath: '/statistiche/premi-malattia-comuni/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -4413,7 +4413,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ristorni fiscali frontalieri, compensi fiscali svizzera italia, ristorni comuni italiani, ristorni como varese, ristorni frontalieri importo',
  ogTitle: 'Ristorni Fiscali Frontalieri | Statistiche per Comune',
  ogDescription: '💶 Statistiche sui ristorni fiscali: importi per comune, andamento storico e confronto tra province.',
- canonicalPath: '/tasse-e-pensione/ristorni-fiscali',
+ canonicalPath: '/tasse-e-pensione/ristorni-fiscali/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -4491,7 +4491,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'contatti frontaliere, assistenza frontaliere, contattaci frontaliere, supporto simulatore fiscale, segnalazione frontaliere',
  ogTitle: 'Contattaci | Frontaliere Ticino',
  ogDescription: '✉️ Contatta il team di Frontaliere Ticino per domande, suggerimenti o collaborazioni.',
- canonicalPath: '/contattaci',
+ canonicalPath: '/contattaci/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "ContactPage",
@@ -4507,7 +4507,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'consulenza fiscale frontalieri, consulenza frontaliere, consulente fiscale frontaliere, ottimizzazione fiscale svizzera italia, dichiarazione redditi frontaliere, esperto frontaliero, consulenza fiscale frontalieri svizzera',
  ogTitle: 'Consulenza Fiscale per Frontalieri Svizzera',
  ogDescription: '🎯 Consulenza fiscale per frontalieri Svizzera-Italia: ottimizzazione tasse, dichiarazione redditi e pianificazione. Prenota gratis.',
- canonicalPath: '/consulenza',
+ canonicalPath: '/consulenza/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "Service",
@@ -4525,7 +4525,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'servizi frontalieri, commercialista frontaliere, consulente frontaliere, assicurazione frontaliere, partner frontalieri',
  ogTitle: 'Servizi Partner per Frontalieri',
  ogDescription: '🤝 Professionisti selezionati per frontalieri: commercialisti, assicuratori, consulenti fiscali e servizi bancari.',
- canonicalPath: '/servizi-partner',
+ canonicalPath: '/servizi-partner/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "CollectionPage",
@@ -4542,7 +4542,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'gamification frontaliere, obiettivi frontaliere, livelli frontaliere, punti XP frontaliere, impara tasse giocando',
  ogTitle: 'Gamification | Livelli e Obiettivi',
  ogDescription: '🏆 Guadagna XP e sblocca livelli esplorando gli strumenti per frontalieri!',
- canonicalPath: '/gamificazione',
+ canonicalPath: '/gamificazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4559,7 +4559,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'privacy frontaliere, GDPR frontaliere, cookie policy, trattamento dati personali, informativa privacy',
  ogTitle: 'Informativa Privacy Frontalieri 2026 | Frontaliere Ticino',
  ogDescription: '🔒 Informativa sulla privacy: come trattiamo i tuoi dati. Conforme GDPR e LPD.',
- canonicalPath: '/privacy',
+ canonicalPath: '/privacy/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4576,7 +4576,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'termini di servizio frontaliere, condizioni uso, disclaimer frontaliere ticino, termini e condizioni',
  ogTitle: 'Termini di Servizio | Frontaliere Ticino',
  ogDescription: 'Termini e condizioni di utilizzo della piattaforma Frontaliere Ticino.',
- canonicalPath: '/termini-di-servizio',
+ canonicalPath: '/termini-di-servizio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4593,7 +4593,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'benvenuto frontaliere, iscrizione newsletter, conferma email frontaliere, strumenti frontalieri, calcola stipendio svizzera',
  ogTitle: 'Benvenuto, Frontaliere! | Frontaliere Ticino',
  ogDescription: '🎉 La tua email è confermata! Esplora stipendio netto, offerte di lavoro in Ticino e guide pratiche per frontalieri.',
- canonicalPath: '/benvenuto-frontaliere',
+ canonicalPath: '/benvenuto-frontaliere/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4610,7 +4610,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'eliminazione dati, cancellazione dati personali, GDPR diritto oblio, richiesta eliminazione, cancella account frontaliere',
  ogTitle: 'Eliminazione Dati | Frontaliere Ticino',
  ogDescription: '🗑️ Richiedi l\'eliminazione dei tuoi dati personali. Procedura conforme GDPR.',
- canonicalPath: '/eliminazione-dati',
+ canonicalPath: '/eliminazione-dati/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4627,7 +4627,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stato api frontaliere, servizi api, status page frontaliere, disponibilità servizi, uptime frontaliere',
  ogTitle: 'Stato API | Frontaliere Ticino',
  ogDescription: '🔧 Stato in tempo reale dei servizi API: cambio valuta, traffico, Firebase e reCAPTCHA.',
- canonicalPath: '/stato-api',
+ canonicalPath: '/stato-api/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -4651,7 +4651,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'articoli frontalieri, guida frontaliere 2026, blog frontaliere svizzera italia, stipendio netto svizzera, nuovo accordo fiscale, lamal cmi frontaliere, terzo pilastro frontaliere',
  ogTitle: 'Articoli Frontaliere 2026 | Guide Pratiche',
  ogDescription: 'Articoli aggiornati per frontalieri: stipendio netto, tasse, assicurazioni, pensione e vita pratica per chi lavora in Svizzera.',
- canonicalPath: '/articoli-frontaliere',
+ canonicalPath: '/articoli-frontaliere/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -7360,7 +7360,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, borse, rosso, prezzo, petrolio',
  ogTitle: 'Borse in rosso e aumento prezzi petrolio | Frontaliere',
  ogDescription: 'Analisi dell\'impatto dell\'aumento del prezzo del petrolio sui frontalieri in Ticino.',
- canonicalPath: '/articoli-frontaliere/borse-in-rosso-prezzo-petrolio-ticino',
+ canonicalPath: '/articoli-frontaliere/borse-in-rosso-prezzo-petrolio-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7389,7 +7389,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, frontaliers, sabotage, conquista, varese',
  ogTitle: 'Frontaliers Sabotage: un successo oltre confine',
  ogDescription: 'La saga dei frontalieri conquista anche Varese. Scopri di più sul successo di Frontaliers Sabotage',
- canonicalPath: '/articoli-frontaliere/frontaliers-sabotage-varese-successo',
+ canonicalPath: '/articoli-frontaliere/frontaliers-sabotage-varese-successo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7418,7 +7418,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, crescita, cause, cresce',
  ogTitle: 'Disoccupazione in Svizzera: crescita e cause nel 2026',
  ogDescription: 'Nel 2026, la disoccupazione in Svizzera cresce più che nell\'UE, con il settore bancario in difficoltà.',
- canonicalPath: '/articoli-frontaliere/disoccupazione-svizzera-2026',
+ canonicalPath: '/articoli-frontaliere/disoccupazione-svizzera-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7447,7 +7447,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, cerca, infermieri, 137mila, annunci',
  ogTitle: 'Infermieri frontalieri: la sfida del Ticino',
  ogDescription: 'La Svizzera cerca infermieri frontalieri. Scopri le implicazioni per il Ticino e le opportunità per i lavoratori frontalieri nel settore sanitario.',
- canonicalPath: '/articoli-frontaliere/infermieri-svizzera-frontalieri-ticino',
+ canonicalPath: '/articoli-frontaliere/infermieri-svizzera-frontalieri-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7476,7 +7476,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, farmaceutica, successo, globale, preoccupazioni',
  ogTitle: 'Successo farmaceutica in Svizzera: cosa significa per i',
  ogDescription: 'Le due principali aziende farmaceutiche svizzere, Roche e Novartis, registrano risultati record. Scopri le implicazioni per la Svizzera e i frontalieri in',
- canonicalPath: '/articoli-frontaliere/successo-farmaceutica-ticino',
+ canonicalPath: '/articoli-frontaliere/successo-farmaceutica-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7505,7 +7505,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, utile, miliardi, franchi, impatti',
  ogTitle: 'Utile della BNS a 26,1 miliardi di franchi',
  ogDescription: 'Impatto positivo per il Canton Ticino e i frontalieri dopo l\'utile della BNS nel 2025.',
- canonicalPath: '/articoli-frontaliere/utile-bns-2025-ticino',
+ canonicalPath: '/articoli-frontaliere/utile-bns-2025-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7534,7 +7534,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, banche, svizzere, assumono, meno',
  ogTitle: 'Il mercato del lavoro bancario in Svizzera in declino',
  ogDescription: 'Le banche svizzere pubblicano meno annunci di lavoro, mentre la disoccupazione nel settore aumenta. Cosa significa per i frontalieri in Ticino?',
- canonicalPath: '/articoli-frontaliere/banche-ticino-disoccupazione',
+ canonicalPath: '/articoli-frontaliere/banche-ticino-disoccupazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7563,7 +7563,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, medio, vedeggio, nasce, gruppo',
  ogTitle: 'Medio Vedeggio, nasce il gruppo di lavoro per l’aggregazione',
  ogDescription: 'Quattro comuni ticinesi avviano uno studio per la fusione entro il 2028, rafforzando la Valle del Vedeggio nel contesto cantonale.',
- canonicalPath: '/articoli-frontaliere/medio-vedeggio-gruppo-lavoro-aggregazione',
+ canonicalPath: '/articoli-frontaliere/medio-vedeggio-gruppo-lavoro-aggregazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7592,7 +7592,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lugano, airport, salvo, nazionale',
  ogTitle: 'Lugano Airport salva i fondi federali 2026',
  ogDescription: 'Il Consiglio Nazionale boccia il taglio dei fondi per Lugano Airport, assicurando investimenti e sicurezza per il Cantone Ticino e i frontalieri.',
- canonicalPath: '/articoli-frontaliere/lugano-airport-fondi-salvati-2026',
+ canonicalPath: '/articoli-frontaliere/lugano-airport-fondi-salvati-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7621,7 +7621,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, made, italy, revisione, norme',
  ogTitle: 'Made in Italy: revisione doganale e impatti su Ticino 2026',
  ogDescription: 'Scopri come la revisione delle norme doganali UE sul Made in Italy interessa il Canton Ticino e i frontalieri nel 2026.',
- canonicalPath: '/articoli-frontaliere/made-in-italy-doganali-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/made-in-italy-doganali-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7650,7 +7650,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, mercato, lavoro, dati, trend',
  ogTitle: 'Mercato lavoro Ticino Q4 2025 | Frontaliere Ticino',
  ogDescription: 'Analisi dettagliata sul mercato del lavoro ticinese nel Q4 2025, con dati su frontalieri, salari e permessi di lavoro.',
- canonicalPath: '/articoli-frontaliere/mercato-lavoro-ticino-q4-2025',
+ canonicalPath: '/articoli-frontaliere/mercato-lavoro-ticino-q4-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7679,7 +7679,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dichiarazione, imposta, sempre, digitale',
  ogTitle: 'Dichiarazione d’imposta digitale in Ticino oltre 100\'000',
  ogDescription: 'Dal 2026 la dichiarazione imposta ticinese è sempre più digitale con nuove opportunità online per frontalieri e residenti al confine.',
- canonicalPath: '/articoli-frontaliere/dichiarazione-imposta-digitale-ticino-26',
+ canonicalPath: '/articoli-frontaliere/dichiarazione-imposta-digitale-ticino-26/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7708,7 +7708,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tilo, sfonda, quota, milioni',
  ogTitle: 'TILO supera 25 milioni di passeggeri nel 2025',
  ogDescription: 'La rete ferroviaria TILO registra un aumento del 50% dei passeggeri dal 2019, confermando il ruolo chiave per il Canton Ticino e i lavoratori frontalieri.',
- canonicalPath: '/articoli-frontaliere/tilo-25-milioni-passeggeri-2025',
+ canonicalPath: '/articoli-frontaliere/tilo-25-milioni-passeggeri-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7737,7 +7737,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, lombardia, rinvia',
  ogTitle: 'Tassa salute: la Lombardia rinvia, cosa cambia per i',
  ogDescription: 'Scopri come la decisione della Lombardia sulla tassa salute impatta sui frontalieri che lavorano nella regione e vivono in Ticino.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-lombardia-rinvio',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-lombardia-rinvio/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7766,7 +7766,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tilo, raggiunge, milioni, passeggeri',
  ogTitle: 'TILO: 25 milioni di passeggeri nel 2025',
  ogDescription: 'La società ferroviaria TILO raggiunge un nuovo record con 25 milioni di passeggeri nel 2025. L\'incremento è del 3,7% rispetto al 2024.',
- canonicalPath: '/articoli-frontaliere/tilo-record-passeggeri-2025',
+ canonicalPath: '/articoli-frontaliere/tilo-record-passeggeri-2025/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7795,7 +7795,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, trasporti, lombardia-ticino, tilo, batte',
  ogTitle: 'Tilo: record di passeggeri tra Lombardia e Ticino',
  ogDescription: 'I treni Tilo hanno trasportato 25 milioni di passeggeri tra Ticino e Lombardia nel 2025, con un aumento del 3,7% rispetto all\'anno precedente. Scopri di più su',
- canonicalPath: '/articoli-frontaliere/trasporti-lombardia-ticino-record-tilo',
+ canonicalPath: '/articoli-frontaliere/trasporti-lombardia-ticino-record-tilo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7824,7 +7824,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, confusione, politica',
  ogTitle: 'Tassa Salute: Confusione tra Politica e Realtà',
  ogDescription: 'Le recenti dichiarazioni politiche sulla tassa salute creano incertezza tra i frontalieri e gli operatori del settore. Analisi delle posizioni e delle normative',
- canonicalPath: '/articoli-frontaliere/confusione-tassa-salute-frontalieri',
+ canonicalPath: '/articoli-frontaliere/confusione-tassa-salute-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7853,7 +7853,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, costo, carburante, impenna, problema',
  ogTitle: 'Il costo del carburante in Ticino si impenna: un problema',
  ogDescription: 'Aumenti fino a 14 centesimi su diesel e benzina in Ticino, riflesso della crisi energetica mondiale. La politica e il mercato influiscono sui prezzi locali.',
- canonicalPath: '/articoli-frontaliere/carburante-ticino-costo-aumenti',
+ canonicalPath: '/articoli-frontaliere/carburante-ticino-costo-aumenti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7882,7 +7882,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, caso, hospita, richiesta, rivalutazione',
  ogTitle: 'CPI e Caso Hospita: richiesta di rivalutazione dei periti',
  ogDescription: 'La Commissione parlamentare d’inchiesta del Canton Ticino chiede una revisione della nomina dei periti nel caso Hospita, evidenziando possibili conflitti di int',
- canonicalPath: '/articoli-frontaliere/cpi-caso-hospita-rivalutazione-periti',
+ canonicalPath: '/articoli-frontaliere/cpi-caso-hospita-rivalutazione-periti/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7911,7 +7911,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, canton, grigioni, impossibile, richiedere',
  ogTitle: 'Canton Grigioni: Impossibile richiedere il casellario giu',
  ogDescription: 'Il Canton Grigioni chiarisce che non è possibile richiedere sistematicamente il casellario giudiziale per cittadini dell\'UE, sollevando interrogativi sulla sicu',
- canonicalPath: '/articoli-frontaliere/casellario-giudiziale-ue-ticino',
+ canonicalPath: '/articoli-frontaliere/casellario-giudiziale-ue-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7940,7 +7940,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, salario, minimo, controprogetto, discesa',
  ogTitle: 'Salario minimo: il Canton Ticino verso un accordo',
  ogDescription: 'Il Canton Ticino è vicino a un\'intesa sul salario minimo sociale, con una proposta che potrebbe essere discussa in Gran Consiglio ad aprile. L\'accordo prevede',
- canonicalPath: '/articoli-frontaliere/salario-minimo-per-il-controprogetto-la-strada-e-in-discesa',
+ canonicalPath: '/articoli-frontaliere/salario-minimo-per-il-controprogetto-la-strada-e-in-discesa/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7969,7 +7969,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, sulla, salute, lombardia',
  ogTitle: 'Tassa sulla salute: Lombardia non applicherà il contributo?',
  ogDescription: 'Giacomo Zamperini chiarisce che se altre regioni non applicano la tassa sulla salute, la Lombardia seguirà lo stesso esempio.',
- canonicalPath: '/articoli-frontaliere/tassa-salute-lombardia-frontalieri',
+ canonicalPath: '/articoli-frontaliere/tassa-salute-lombardia-frontalieri/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -7998,7 +7998,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, franco, forte, opportunità, sfide',
  ogTitle: 'Il franco forte: opportunità e sfide per il Ticino',
  ogDescription: 'L\'attuale forza del franco svizzero solleva interrogativi sull\'economia ticinese e il futuro dei frontalieri.',
- canonicalPath: '/articoli-frontaliere/franco-forte-problemi-economici',
+ canonicalPath: '/articoli-frontaliere/franco-forte-problemi-economici/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8027,7 +8027,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, aumento, prezzi, benzina, opportunismo',
  ogTitle: 'Aumento Prezzo Benzina in Ticino',
  ogDescription: 'Scopri le cause dell\'aumento dei prezzi della benzina in Ticino e le implicazioni per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/carburante-prezzo-salito-opportunismo',
+ canonicalPath: '/articoli-frontaliere/carburante-prezzo-salito-opportunismo/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8056,7 +8056,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassa, salute, cancellatela, basta',
  ogTitle: 'Frontalieri e tassa salute: cancellatela e basta',
  ogDescription: 'La Lombardia frena sulla tassa salute per i frontalieri, con riflessi sulla gestione politica e sociale del confine.',
- canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-teatro',
+ canonicalPath: '/articoli-frontaliere/frontalieri-tassa-salute-teatro/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8085,7 +8085,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, disoccupazione, stabile, dati, febbraio',
  ogTitle: 'Disoccupazione stabile al 3,2% in Svizzera',
  ogDescription: 'Il mercato del lavoro in Svizzera e Ticino: tassi di disoccupazione e indennità.',
- canonicalPath: '/articoli-frontaliere/disoccupazione-stabile-svizzera-2026',
+ canonicalPath: '/articoli-frontaliere/disoccupazione-stabile-svizzera-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8114,7 +8114,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, dazi, rimborsi, ritardo, cosa',
  ogTitle: 'Dazi USA: Rimborsi in Ritardo per i Frontalieri',
  ogDescription: 'L\'agenzia della Dogana americana sta lavorando a un sistema di rimborsi per i dazi illegali, ma i frontalieri potrebbero dover attendere fino a un mese. Scopri',
- canonicalPath: '/articoli-frontaliere/dazi-usa-rimborsi-ritardi',
+ canonicalPath: '/articoli-frontaliere/dazi-usa-rimborsi-ritardi/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8143,7 +8143,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, votazioni, marzo, incerto, sull',
  ogTitle: 'Votazioni del 8 marzo: l’incerto sull’Iniziativa SSR in T',
  ogDescription: 'Il 8 marzo i cittadini svizzeri si pronunceranno su quattro temi cruciali, con l’Iniziativa SSR ancora in bilico tra sì e no. Analisi e dettagli pratici per i f',
- canonicalPath: '/articoli-frontaliere/votazioni-8-marzo-iniziativa-ssr-aperto',
+ canonicalPath: '/articoli-frontaliere/votazioni-8-marzo-iniziativa-ssr-aperto/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8172,7 +8172,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, spitex, nuove, tariffe, pressione',
  ogTitle: 'Ticino Spitex: Tariffe e Pressioni sul Settore',
  ogDescription: 'Dal 2026 nuove tariffe per le cure a domicilio in Ticino con contributi degli utenti. Crescita rapida del settore mette sotto pressione Cantone e Comuni.',
- canonicalPath: '/articoli-frontaliere/ticino-spitex-contributo-pressione',
+ canonicalPath: '/articoli-frontaliere/ticino-spitex-contributo-pressione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8201,7 +8201,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, stalking, diventa, reato, inserito',
  ogTitle: 'Dal 2026: lo stalking diventa reato in Svizzera e Ticino',
  ogDescription: 'Dal 2026, la Svizzera ha inserito lo stalking tra i reati punibili penalmente. Un cambiamento che interessa anche il Canton Ticino e i frontalieri, con implicaz',
- canonicalPath: '/articoli-frontaliere/stalking-swiss-2026-ticino',
+ canonicalPath: '/articoli-frontaliere/stalking-swiss-2026-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8230,7 +8230,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, automobilisti, italiani, pirati, strada',
  ogTitle: 'Ticino: Due automobilisti italiani tra i pirati della str',
  ogDescription: 'Polizia cantonale di Ticino ferma due automobilisti italiani per violazioni gravi, tra cui velocità oltre il doppio dei limiti, in controlli tra gennaio e febbr',
- canonicalPath: '/articoli-frontaliere/pirati-strada-ticino-italiani-2026',
+ canonicalPath: '/articoli-frontaliere/pirati-strada-ticino-italiani-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8259,7 +8259,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, sette, comuni, locarnese, futuro',
  ogTitle: 'Sette Comuni del Locarnese sul Futuro: Aggregazione o Aut',
  ogDescription: 'Un laboratorio coinvolge Locarno, Losone, Minusio e altri per discutere sulla collaborazione regionale. La sfida: mantenere il benessere o restare indipendenti.',
- canonicalPath: '/articoli-frontaliere/comuni-locarno-futuro-aggregazione',
+ canonicalPath: '/articoli-frontaliere/comuni-locarno-futuro-aggregazione/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8288,7 +8288,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, pagherà, cure, domicilio, aprile',
  ogTitle: 'Ticino: dal 2026 si pagherà per le cure a domicilio',
  ogDescription: 'Dal 1° aprile 2026 in Ticino entra in vigore la partecipazione ai costi per le cure a domicilio, con un contributo massimo di 15 franchi al giorno.',
- canonicalPath: '/articoli-frontaliere/costi-cure-domicilio-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/costi-cure-domicilio-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8317,7 +8317,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, lugano, park, ride, poco',
  ogTitle: 'Lugano: Park and Ride poco usati, bus sovvenzionati in cr',
  ogDescription: 'Nel 2024 Lugano ha speso 1,2 milioni in sovvenzioni per abbonamenti bus, mentre i park and ride registrano scarsa frequentazione e alti costi.',
- canonicalPath: '/articoli-frontaliere/lugano-park-ride-bus-sovvenzioni-2026',
+ canonicalPath: '/articoli-frontaliere/lugano-park-ride-bus-sovvenzioni-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8346,7 +8346,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, crisi, medio, oriente, impatto',
  ogTitle: 'Crisi Medio Oriente: Impatto sul Turismo Svizzero',
  ogDescription: 'La crisi nel Golfo Persico sta modificando le rotte turistiche svizzere. Voli sospesi e carburante alle stelle: scopri l\'impatto economico.',
- canonicalPath: '/articoli-frontaliere/crisi-turismo-golfo-persico',
+ canonicalPath: '/articoli-frontaliere/crisi-turismo-golfo-persico/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8375,7 +8375,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, turisti, ticinesi, bloccati, medio',
  ogTitle: 'Turisti ticinesi bloccati in Medio Oriente',
  ogDescription: 'Circa 400 turisti svizzeri rimangono bloccati in Medio Oriente senza comunicazioni ufficiali. Scopri di più su questa emergenza.',
- canonicalPath: '/articoli-frontaliere/turisti-ticinesi-bloccati-medio-oriente',
+ canonicalPath: '/articoli-frontaliere/turisti-ticinesi-bloccati-medio-oriente/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8404,7 +8404,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, svizzeri, bloccati, medio, oriente',
  ogTitle: 'Svizzeri bloccati in Medio Oriente',
  ogDescription: 'La guerra in Medio Oriente ha bloccato 5.200 cittadini svizzeri. Swiss ha organizzato un volo speciale per il rimpatrio.',
- canonicalPath: '/articoli-frontaliere/svizzeri-bloccati-medio-oriente',
+ canonicalPath: '/articoli-frontaliere/svizzeri-bloccati-medio-oriente/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8433,7 +8433,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rafforza, sicurezza, nelle, scuole',
  ogTitle: 'Ticino rafforza sicurezza scuole | Frontaliere Ticino',
  ogDescription: 'Il DECS lavora su misure antincendio nelle scuole ticinesi dopo Crans-Montana. Consigli pratici e aggiornamenti.',
- canonicalPath: '/articoli-frontaliere/ticino-prevenzione-incendi-scuole-2026',
+ canonicalPath: '/articoli-frontaliere/ticino-prevenzione-incendi-scuole-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8462,7 +8462,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, varese, punta, oriente, export',
  ogTitle: 'Varese: Export India Cresce del 46% | Frontaliere',
  ogDescription: 'Le esportazioni della provincia varesina verso l’India sono aumentate del 46,2% nel 2025, superando i 129 milioni di euro.',
- canonicalPath: '/articoli-frontaliere/varese-india-export-2026',
+ canonicalPath: '/articoli-frontaliere/varese-india-export-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8491,7 +8491,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rincari, carburante, rischio, fermo',
  ogTitle: 'Rincari carburante e rischio fermo autotrasportatori al',
  ogDescription: 'CNA Fita denuncia speculazione: aumento 0,30 €/l in 3 giorni; per 100.000 km/anno aggravio >13.000 euro. Misure richieste al Governo.',
- canonicalPath: '/articoli-frontaliere/autotrasporto-rincari-confine-2026',
+ canonicalPath: '/articoli-frontaliere/autotrasporto-rincari-confine-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8520,7 +8520,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, rincaro, carburanti, impatto, ticinesi',
  ogTitle: 'Rincaro carburanti: impatto sui frontalieri ticinesi',
  ogDescription: 'Prezzi in Italia in rialzo (benzina >1,8 €/l); cosa cambia per chi lavora tra Canton Ticino e Lombardia e come ridurre i costi.',
- canonicalPath: '/articoli-frontaliere/carburanti-rincari-confine-ticino',
+ canonicalPath: '/articoli-frontaliere/carburanti-rincari-confine-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8549,7 +8549,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, voti, marzo, taglio, canone',
  ogTitle: 'Voti 8 marzo: No canone e Sì all\'imposizione individuale',
  ogDescription: 'Primi risultati del voto del 8 marzo 2026: tendenze su canone, imposizione individuale, contante e Fondo clima. Impatti per il Ticino e per i frontalieri.',
- canonicalPath: '/articoli-frontaliere/votazioni-imposizione-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/votazioni-imposizione-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8578,7 +8578,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, tassazione, individuale, cosa, cambia',
  ogTitle: 'Tassazione individuale: impatto Ticino',
  ogDescription: 'Il voto del 08.03.2026 introduce l\'imposizione individuale: guida per frontalieri, Comuni e datori di lavoro in Ticino.',
- canonicalPath: '/articoli-frontaliere/imposizione-individuale-ticino-2026',
+ canonicalPath: '/articoli-frontaliere/imposizione-individuale-ticino-2026/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8607,7 +8607,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontalieri, ticino, svizzera, italia, iniziativa, antidumping, soddisfazione, consiglio',
  ogTitle: 'No all\'iniziativa antidumping | Frontaliere Ticino',
  ogDescription: 'Il Consiglio di Stato del Ticino si soddisfa per il rifiuto dell\'iniziativa antidumping e per il canone SSR.',
- canonicalPath: '/articoli-frontaliere/no-iniziativa-antidumping-ticino',
+ canonicalPath: '/articoli-frontaliere/no-iniziativa-antidumping-ticino/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "NewsArticle",
@@ -8636,7 +8636,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'lavoro frontaliere svizzera 2026, guida completa frontaliere, permesso G svizzera, nuovo accordo frontalieri, imposta alla fonte ticino, frontaliere italia svizzera, lavorare in svizzera dall italia, tassazione frontalieri 2026, assicurazione LAMal frontalieri, pendolare svizzera italia',
  ogTitle: 'Guida Completa al Lavoro Frontaliere in Svizzera 2026',
  ogDescription: 'La guida definitiva per frontalieri Svizzera-Italia: permessi, tasse, previdenza, sanità, trasporti e dichiarazione dei redditi. Aggiornata 2026.',
- canonicalPath: '/guida-frontaliere/guida-completa-lavoro-frontaliere-svizzera-2026',
+ canonicalPath: '/guida-frontaliere/guida-completa-lavoro-frontaliere-svizzera-2026/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -8783,7 +8783,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tassazione svizzera, tassazione frontalieri svizzera, doppia tassazione svizzera, permesso g, nuovo accordo frontalieri, tassazione nuovi frontalieri 2023, aliquote imposta alla fonte ticino 2026, franchigia 10000 euro frontalieri, credito imposta frontalieri, irpef frontalieri',
  ogTitle: 'Tassazione Frontalieri Svizzera 2026 — Guida Completa',
  ogDescription: 'Tutto sulla tassazione dei frontalieri nel 2026: nuovo accordo Italia-Svizzera, doppia imposizione, permesso G vs B, aliquote Ticino, deduzioni fiscali e dichiarazione redditi.',
- canonicalPath: '/guida-tassazione-frontalieri-2026',
+ canonicalPath: '/guida-tassazione-frontalieri-2026/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -8933,7 +8933,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'sindacati frontalieri, unia ticino, ocst, syndicom, sev, sindacato svizzero, contratto collettivo, ccl, diritti lavoratori frontalieri, assistenza legale',
  ogTitle: 'Sindacati per Frontalieri in Ticino — Guida Completa',
  ogDescription: 'UNIA, Syndicom, SEV, OCST: costi, sedi e servizi per frontalieri. Consulenza legale, contratti collettivi e tutela dei diritti.',
- canonicalPath: '/sindacati-frontalieri',
+ canonicalPath: '/sindacati-frontalieri/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -8962,7 +8962,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere ticino, chi siamo, piattaforma frontalieri, lavoratori transfrontalieri svizzera italia',
  ogTitle: 'Chi Siamo — Frontaliere Ticino: La Guida per i Lavoratori Frontalieri',
  ogDescription: 'Piattaforma informativa per frontalieri italiani in Svizzera: tassazione, permessi, lavoro, sanità e aggiornamenti normativi.',
- canonicalPath: '/chi-siamo',
+ canonicalPath: '/chi-siamo/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9008,7 +9008,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'correzioni frontaliere ticino, errata corrige, rettifica articolo, policy correzione, trasparenza editoriale',
  ogTitle: 'Correzioni — Politica di rettifica e registro pubblico',
  ogDescription: 'Come segnaliamo e registriamo le correzioni: SLA 48 ore, tipologie accettate, registro pubblico cronologico.',
- canonicalPath: '/correzioni',
+ canonicalPath: '/correzioni/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9033,7 +9033,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'metodologia editoriale, intelligenza artificiale giornalismo, frontaliere ticino, fonti primarie, fact checking, politica correzioni, trasparenza editoriale',
  ogTitle: 'Metodologia editoriale — Come scriviamo gli articoli | Frontaliere Ticino',
  ogDescription: 'Come usiamo IA generativa, fonti primarie e revisione redazionale per garantire accuratezza e trasparenza.',
- canonicalPath: '/metodologia',
+ canonicalPath: '/metodologia/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9066,7 +9066,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'frontaliere ticino, about us, cross-border workers platform, swiss italian workers',
  ogTitle: 'About Us — Frontaliere Ticino: Cross-Border Workers Guide',
  ogDescription: 'The leading platform for Italian cross-border workers in Switzerland: tax simulation, permits, job board, and more.',
- canonicalPath: '/about',
+ canonicalPath: '/about/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9099,7 +9099,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'contact frontaliere, support frontaliere, cross-border workers support, frontaliere ticino contact',
  ogTitle: 'Contact Us | Frontaliere Ticino',
  ogDescription: '✉️ Contact the Frontaliere Ticino team for questions, suggestions, or collaborations.',
- canonicalPath: '/contact',
+ canonicalPath: '/contact/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "ContactPage",
@@ -9116,7 +9116,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'privacy policy frontaliere, GDPR frontaliere, cookie policy, data processing, privacy information',
  ogTitle: 'Privacy Policy | Frontaliere Ticino',
  ogDescription: '🔒 Privacy policy: how we process your data. Compliant with GDPR and Swiss DPA.',
- canonicalPath: '/privacy-policy',
+ canonicalPath: '/privacy-policy/',
  structuredData: {
  "@context": "https://schema.org",
  "@type": "WebPage",
@@ -9138,7 +9138,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tassa salute frontalieri, contributo sanitario frontalieri, tassa salute ticino, tassa sanitaria frontalieri svizzera, nuovi frontalieri tassa salute, regioni frontaliere salute, trattenuta salute ticino',
  ogTitle: 'Tassa Salute Frontalieri 2026 — Importo e Chi Paga',
  ogDescription: '💰 Guida completa alla tassa salute frontalieri 2026: importo ufficiale, chi è soggetto o esente, come viene trattenuta e rimborsata alle Regioni di confine.',
- canonicalPath: '/guida-frontaliere/tassa-salute-frontalieri',
+ canonicalPath: '/guida-frontaliere/tassa-salute-frontalieri/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9250,7 +9250,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'lamal frontalieri, assicurazione malattia frontalieri, casse malati frontalieri, diritto di opzione lamal, premi lamal ticino, franchigia lamal, SSN o lamal frontalieri',
  ogTitle: 'LAMal Frontalieri 2026 — Guida Completa Diritto d\'Opzione',
  ogDescription: '🏥 Guida pillar alla LAMal per frontalieri: diritto d\'opzione, confronto casse malati Ticino, premi 2026, franchigie e come scegliere tra LAMal e SSN.',
- canonicalPath: '/guida-frontaliere/lamal-frontalieri',
+ canonicalPath: '/guida-frontaliere/lamal-frontalieri/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9329,7 +9329,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'fox town mendrisio, outlet svizzera, outlet mendrisio, outlet ticino, fox town orari, fox town marchi, outlet lusso svizzera, outlet vicino confine italiano, outlet fox town sconti',
  ogTitle: 'Fox Town Mendrisio — Outlet Svizzera di Lusso 2026',
  ogDescription: '🛍️ Oltre 160 marchi di lusso scontati 30-70% a soli 3 km dal confine italiano. Orari, parcheggio, ristoranti e consigli per risparmiare a Fox Town Mendrisio.',
- canonicalPath: '/vita-in-ticino/outlet-svizzera-fox-town-mendrisio',
+ canonicalPath: '/vita-in-ticino/outlet-svizzera-fox-town-mendrisio/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9420,7 +9420,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'ponti 2026 ticino, festività 2026 ticino, calendario frontalieri 2026, ponti svizzera 2026, giorni rossi ticino, long weekend 2026, vacanze frontalieri 2026',
  ogTitle: 'Ponti 2026 Ticino — Calendario Festività + Chiusure Frontiera',
  ogDescription: '📅 Calendario ponti 2026 per frontalieri: festività svizzere e italiane, long weekend, chiusure dogana e info utili per pianificare ferie e rientri.',
- canonicalPath: '/vita-in-ticino/ponti-2026-ticino',
+ canonicalPath: '/vita-in-ticino/ponti-2026-ticino/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9445,7 +9445,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'vacanze scolastiche ticino 2026, calendario scolastico ticino 2026, vacanze scolastiche ticino 2027, DECS ticino, carnevale ticino 2026, estate scuole ticino, vacanze pasqua ticino',
  ogTitle: 'Vacanze Scolastiche Ticino 2026-2027: Date DECS',
  ogDescription: 'Date ufficiali DECS per Carnevale, Pasqua, estate, autunno e Natale. Calendario rapido per famiglie frontaliere.',
- canonicalPath: '/vita-in-ticino/vacanze-scolastiche-ticino-2026',
+ canonicalPath: '/vita-in-ticino/vacanze-scolastiche-ticino-2026/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9470,7 +9470,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'tasse svizzere, tasse frontalieri, imposta alla fonte ticino, nuovo accordo 2026, doppia imposizione italia svizzera, dichiarazione redditi frontaliere, credito imposta frontaliere',
  ogTitle: 'Tasse Svizzere per Frontalieri 2026 — Guida Completa',
  ogDescription: 'Imposta alla fonte Ticino, Nuovo Accordo 2026, doppia imposizione e credito d\'imposta: tutto quello che serve a un frontaliere italiano per capire le tasse svizzere.',
- canonicalPath: '/tasse-e-pensione/tasse-svizzere-frontalieri',
+ canonicalPath: '/tasse-e-pensione/tasse-svizzere-frontalieri/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9556,7 +9556,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'lavoro lugano, lavoro frontalieri lugano, offerte lavoro lugano, stipendi lugano, aziende lugano, lavoro banca lugano, lavoro logistica lugano, lavoro sanità lugano',
  ogTitle: 'Lavoro a Lugano per Frontalieri — Offerte, Stipendi, Aziende',
  ogDescription: 'Cerchi lavoro a Lugano come frontaliere? Settori, stipendi medi, top aziende, come arrivare dai valichi e tutte le posizioni aperte della settimana.',
- canonicalPath: '/vita-in-ticino/lavoro-a-lugano',
+ canonicalPath: '/vita-in-ticino/lavoro-a-lugano/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9626,7 +9626,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'nuova legge frontalieri 2026, nuovo accordo frontalieri, accordo italia svizzera 2026, tasse frontalieri 2026, nuovi frontalieri 2023, vecchi frontalieri, franchigia 10000',
  ogTitle: 'Nuova Legge Frontalieri 2026 — Guida Completa al Nuovo Accordo',
  ogDescription: 'Nuovo Accordo fiscale Italia-Svizzera: cosa cambia nel 2026, chi è nuovo e chi è vecchio frontaliere, tabelle IRPEF, impatto sul netto mensile.',
- canonicalPath: '/tasse-e-pensione/nuova-legge-frontalieri-2026',
+ canonicalPath: '/tasse-e-pensione/nuova-legge-frontalieri-2026/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9712,7 +9712,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'oss svizzera, operatore socio sanitario svizzera, oss ticino, stipendio oss svizzera, riconoscimento titolo oss srk, lavoro oss lugano, lavoro oss bellinzona',
  ogTitle: 'OSS in Svizzera — Stipendi, Riconoscimento SRK, Offerte 2026',
  ogDescription: 'Vuoi lavorare come OSS in Svizzera? Stipendi, riconoscimento titolo SRK, aziende sanitarie che assumono frontalieri italiani, iter pratico.',
- canonicalPath: '/vita-in-ticino/oss-svizzera',
+ canonicalPath: '/vita-in-ticino/oss-svizzera/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9782,7 +9782,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  keywords: 'stipendi svizzera italia, confronto stipendi ticino lombardia, differenza stipendio svizzera italia, stipendi per settore svizzera, costo della vita lugano milano, vale la pena fare il frontaliere',
  ogTitle: 'Stipendi Svizzera vs Italia 2026 — Confronto per Settore',
  ogDescription: 'Quanto si guadagna in più in Svizzera? Tabelle per settore, netto reale post-tasse, costo della vita Lugano vs Milano, matrice di decisione.',
- canonicalPath: '/statistiche/stipendi-svizzera-vs-italia',
+ canonicalPath: '/statistiche/stipendi-svizzera-vs-italia/',
  structuredData: [
  {
  "@context": "https://schema.org",
@@ -9874,7 +9874,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
     keywords: 'marco ferrari, autore, fiscalità frontaliera, 730, dichiarazione redditi, imposta alla fonte, accordo Italia-Svizzera 2026',
     ogTitle: 'Marco Ferrari — Esperto fiscalità frontaliera',
     ogDescription: 'Profilo dell\'autore Marco Ferrari su Frontaliere Ticino: 730, dichiarazione redditi, imposta alla fonte, accordo Italia-Svizzera 2026.',
-    canonicalPath: '/autori/marco-ferrari',
+    canonicalPath: '/autori/marco-ferrari/',
     structuredData: [
       {
         "@context": "https://schema.org",
@@ -9913,7 +9913,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
     keywords: 'laura bianchi, autore, previdenza svizzera, AVS, LPP, LAMal, pensioni frontaliere, terzo pilastro',
     ogTitle: 'Laura Bianchi — Specialista previdenza svizzera',
     ogDescription: 'Profilo dell\'autrice Laura Bianchi su Frontaliere Ticino: AVS, LPP, LAMal, pensioni e assicurazioni sociali svizzere.',
-    canonicalPath: '/autori/laura-bianchi',
+    canonicalPath: '/autori/laura-bianchi/',
     structuredData: [
       {
         "@context": "https://schema.org",
@@ -9952,7 +9952,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
     keywords: 'redazione frontaliere ticino, team editoriale, lavoro frontaliere, salari ticino, trasporti transfrontalieri, dogana',
     ogTitle: 'Redazione Frontaliere Ticino — Team editoriale',
     ogDescription: 'La Redazione editoriale di Frontaliere Ticino: lavoro, salari, trasporti e dogana per i frontalieri italiani in Canton Ticino.',
-    canonicalPath: '/autori/redazione',
+    canonicalPath: '/autori/redazione/',
     structuredData: [
       {
         "@context": "https://schema.org",

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -739,7 +739,7 @@ const BORDER_CROSSING_SEO_OVERRIDES: Record<string, SEOMetadata> = {
    keywords: 'traffico dogana chiasso brogeda, tempi di attesa dogana chiasso, coda dogana chiasso, dogana chiasso centro, valico brogeda tempi, frontaliere ticino, code dogana chiasso',
    ogTitle: 'Traffico Dogana Chiasso Centro e Brogeda | Tempi di Attesa',
    ogDescription: 'Tempi di attesa dogana Chiasso Centro e Brogeda: coda in tempo reale, orari e consigli per frontalieri.',
-   canonicalPath: '/guida-frontaliere/tempi-attesa-dogana/chiasso-centro',
+   canonicalPath: '/guida-frontaliere/tempi-attesa-dogana/chiasso-centro/',
    structuredData: {
      '@context': 'https://schema.org',
      '@type': 'WebPage',


### PR DESCRIPTION
## Summary
Fix root cause of ~2.5% no-slash GSC impressions: 3,734 canonicalPath entries across services/seo/*.ts that emitted `<link rel="canonical">` URLs without trailing slash. Article/guide/vivere/landing pages had their canonical pointing to no-slash form so Google indexed that variant.

## Changes
- 3,734 `canonicalPath: '/...'` literals updated to append `/` (homepage `/` correctly preserved)
- Files: seo-blog.ts (1,293), seo-blog-5.ts (1,178), seo-blog-6.ts (327), seo-blog-7.ts (326), seo-blog-4.ts (187), seo-blog-2.ts (167), seo-pages.ts (162), seo-blog-3.ts (68), seo-landing.ts (25), seoService.ts (1)
- New audit `scripts/audit-canonical-trailing-slash.mjs` walks dist/, fails build if any non-root content page emits canonical without trailing slash
- New npm script `audit:canonical-trailing-slash`
- Wired into `.github/workflows/post-deploy-validate-dist.yml` alongside existing canonical audits

## Impact
- Google will gradually re-index trailing-slash form as canonical
- Future no-slash regressions blocked by CI

## Test plan
- [x] tsc clean
- [ ] CI validate-dist passes new audit on this PR's deploy