### PR TITLE
fix(tests): diesel canonicalPath expectation with trailing slash (PR #688)

### DIFF
--- a/tests/diesel-pages-seo.test.ts
+++ b/tests/diesel-pages-seo.test.ts
@@ -104,8 +104,9 @@ describe('diesel/carburanti SEO pages — 2026 rewrite', () => {
  it('both articles keep their published canonical paths', () => {
  const dieselMeta = (BLOG_SEO_METADATA_4 as Record<string, { canonicalPath: string }>)[`blog-${DIESEL_ID}`];
  const carburantiMeta = (BLOG_SEO_METADATA_4 as Record<string, { canonicalPath: string }>)[`blog-${CARBURANTI_ID}`];
- expect(dieselMeta.canonicalPath).toBe(`/articoli-frontaliere/${DIESEL_ID}`);
- expect(carburantiMeta.canonicalPath).toBe(`/articoli-frontaliere/${CARBURANTI_ID}`);
+ // PR #688 appended trailing slash to all canonicalPath entries.
+ expect(dieselMeta.canonicalPath).toBe(`/articoli-frontaliere/${DIESEL_ID}/`);
+ expect(carburantiMeta.canonicalPath).toBe(`/articoli-frontaliere/${CARBURANTI_ID}/`);
  });
  });
 });


### PR DESCRIPTION
1-line test fix: PR #688 added trailing slash to all canonicalPath entries; the diesel-pages-seo expectation still asserted the legacy no-slash form.