### PR TITLE
fix(tests): diesel canonicalPath expects trailing slash (re-apply PR #689)

### DIFF
--- a/tests/diesel-pages-seo.test.ts
+++ b/tests/diesel-pages-seo.test.ts
@@ -104,8 +104,8 @@ describe('diesel/carburanti SEO pages — 2026 rewrite', () => {
  it('both articles keep their published canonical paths', () => {
  const dieselMeta = (BLOG_SEO_METADATA_4 as Record<string, { canonicalPath: string }>)[`blog-${DIESEL_ID}`];
  const carburantiMeta = (BLOG_SEO_METADATA_4 as Record<string, { canonicalPath: string }>)[`blog-${CARBURANTI_ID}`];
- expect(dieselMeta.canonicalPath).toBe(`/articoli-frontaliere/${DIESEL_ID}`);
- expect(carburantiMeta.canonicalPath).toBe(`/articoli-frontaliere/${CARBURANTI_ID}`);
+ expect(dieselMeta.canonicalPath).toBe(`/articoli-frontaliere/${DIESEL_ID}/`);
+ expect(carburantiMeta.canonicalPath).toBe(`/articoli-frontaliere/${CARBURANTI_ID}/`);
  });
  });
 });


### PR DESCRIPTION
## Summary
- PR #688 introduced trailing slashes on canonical paths.
- PR #689 updated `tests/diesel-pages-seo.test.ts` to expect them, but that commit was lost in the 2026-05-27 `origin/main` history rewrite.
- This re-applies the two-line assertion change so vitest goes green again on main.

## Test plan
- [x] vitest CI runs `tests/diesel-pages-seo.test.ts` and passes