### PR TITLE
fix(orchestrator): verify dispatch via API instead of trusting gh exit code

### DIFF
--- a/.github/workflows/orchestrate-crawlers.yml
+++ b/.github/workflows/orchestrate-crawlers.yml
@@ -53,6 +53,31 @@ jobs:
           sparse-checkout-cone-mode: false
           fetch-depth: 1
 
+      - name: Reap zombie queued runs (>30 min)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Known GH Actions scheduler bug: occasional runs get stranded in `queued`
+          # forever and block their concurrency group, masking future dispatches as
+          # "no-op" or causing false-failure cascades. Cancel anything queued >30 min
+          # before starting the new wave.
+          cutoff=$(date -u -d '-30 minutes' '+%Y-%m-%dT%H:%M:%SZ')
+          mapfile -t zombies < <(
+            gh api --paginate \
+              "/repos/${GITHUB_REPOSITORY}/actions/runs?status=queued&per_page=100" \
+              --jq ".workflow_runs[] | select(.created_at < \"${cutoff}\") | .id"
+          )
+          if [ ${#zombies[@]} -eq 0 ]; then
+            echo "🧟 No zombie queued runs."
+          else
+            echo "🧟 Cancelling ${#zombies[@]} zombie queued run(s) older than ${cutoff}:"
+            for z in "${zombies[@]}"; do
+              echo "  - run $z"
+              gh run cancel "$z" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+            done
+          fi
+
       - name: Discover and dispatch crawler workflows
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,6 +117,40 @@ jobs:
             echo "20"
           }
 
+          # Verify-by-observation: `gh workflow run` is a fire-and-forget RPC against
+          # the dispatches endpoint (HTTP 204). Its exit code is unreliable — the
+          # client can time out *after* the server already created the run. Trusting
+          # the exit code produced 3 false failures (and `exit 1` on the whole job)
+          # on 2026-05-27 even though all 3 runs existed server-side. Instead, we
+          # ignore the exit code and poll the runs API to confirm the side-effect.
+          STDERR_LOG="${RUNNER_TEMP:-/tmp}/dispatch-stderr.log"
+          : >"$STDERR_LOG"
+
+          dispatch_and_verify() {
+            local filename="$1"
+            local before_iso
+            before_iso=$(date -u -d '-5 seconds' '+%Y-%m-%dT%H:%M:%SZ')
+
+            # Fire-and-forget. Stderr is captured for post-mortem; exit code ignored.
+            gh workflow run "$filename" --ref main -f skip_ai_translation=1 \
+              >/dev/null 2>>"$STDERR_LOG" || true
+
+            # Poll for up to ~15s for a new workflow_dispatch run created after t0.
+            # GitHub normally registers dispatches within 1-3s.
+            local deadline=$(( $(date +%s) + 15 ))
+            while [ "$(date +%s)" -lt "$deadline" ]; do
+              sleep 2
+              local newest
+              newest=$(gh api \
+                "/repos/${GITHUB_REPOSITORY}/actions/workflows/${filename}/runs?per_page=1&event=workflow_dispatch" \
+                --jq '.workflow_runs[0].created_at // ""' 2>/dev/null || echo "")
+              if [ -n "$newest" ] && [[ "$newest" > "$before_iso" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
           # Discover all crawler workflow files
           mapfile -t workflows < <(find .github/workflows -name 'update-jobs-*.yml' -type f | sort)
           total=${#workflows[@]}
@@ -129,11 +188,11 @@ jobs:
               continue
             fi
 
-            if gh workflow run "$filename" --ref main -f skip_ai_translation=1 2>/dev/null; then
+            if dispatch_and_verify "$filename"; then
               echo " — ✅ dispatched"
               dispatched=$((dispatched + 1))
             else
-              echo " — ❌ FAILED"
+              echo " — ❌ FAILED (no run appeared within 15s)"
               failed=$((failed + 1))
             fi
 
@@ -153,6 +212,9 @@ jobs:
 
           if [ "$failed" -gt 0 ]; then
             echo ""
-            echo "⚠️  Some dispatches failed — check individual workflow status"
+            echo "⚠️  Some dispatches failed — captured stderr below for diagnosis:"
+            echo "---- begin gh stderr ----"
+            cat "$STDERR_LOG" || true
+            echo "---- end gh stderr ----"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- `gh workflow run` is fire-and-forget (HTTP 204). Its exit code is unreliable: the client can time out *after* the server already accepted the dispatch. Run [26541141619](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26541141619) marked 3 crawlers as ❌ FAILED even though all 3 runs existed server-side (aarreha-schinznach, spital-thusis, spital-uster).
- Replace exit-code trust with **verify-by-observation**: ignore `gh`'s exit code, capture stderr for diagnosis, then poll `/repos/.../actions/workflows/{file}/runs?event=workflow_dispatch` for ~15s to confirm a new run was actually created after t0. Eliminates false positives **without** blind retries that would multiply dispatches.
- Add a **zombie-queue reaper** as the first step: cancel any run stuck in `queued` for >30 min. Two such zombies (runs 26546815295, 26546829487) were created by yesterday's failure and would otherwise block their concurrency group forever.
- Surface captured stderr in the failure tail so real failures (workflow missing, branch invalid, API down) are diagnosable.

## Test plan

- [ ] Manually dispatch `Orchestrate Job Crawlers` after merge (`gh workflow run orchestrate-crawlers.yml -f dry_run=true`) and confirm the reap step + dispatch helper parse correctly.
- [ ] Real wave: run with `dry_run=false` (or wait for next scheduled cron at 08:00/20:00 UTC) and verify ✅ count ≈ total, ❌ = 0 absent a real outage.
- [ ] Confirm the 2 existing zombies (26546815295 spital-thusis, 26546829487 spital-uster) are reaped on the next run start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)