### PR TITLE
fix(seo): skip noindex when static overlay serves real content

### DIFF
--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -4345,6 +4345,16 @@ function updateStructuredData(data: Record<string, any> | Record<string, any>[])
  * - removes dynamic structured data (no schema for 404 pages)
  */
 export function applyNotFoundSeo(path: string): void {
+ // Static overlay = authoritative build-emitted page (soft-landing for compat
+ // slugs, renamed jobs, sector/city landings). If present, the static HTML
+ // already carries real title/desc/canonical/JSON-LD — slapping noindex would
+ // de-index a page that ships full content. Router falsely classified the
+ // route as 404 only because the slug isn't in the live jobs index.
+ if (typeof document !== 'undefined'
+   && document.querySelector('main.seo-static-content')) {
+   return;
+ }
+
  const notFoundTitle = 'Pagina non trovata — Frontaliere Ticino';
 
  // Set noindex to prevent Google from indexing this soft-404


### PR DESCRIPTION
## Summary
- `applyNotFoundSeo()` was injecting `<meta robots=noindex>` on every URL the SPA router classified as `notFound` — but build-emitted soft-landing pages (compat-paths / renamed jobs / sector landings) ship full static HTML the router doesn't recognise as live.
- Result: Googlebot rendered the page, saw the SPA-injected `noindex`, and de-indexed pages that already serve valid content.
- Guard: early-return from `applyNotFoundSeo` when `main.seo-static-content` is in the DOM — the static overlay is authoritative.

## Repro
`https://frontaliereticino.ch/cerca-lavoro-ticino/capo-della-stazione-in-akutgeriatrie-kantonsspital-graubunden-walenstadt/`
- HTTP 200, full H1/desc/JSON-LD in static HTML
- `curl` shows no `noindex` (no JS exec)
- Googlebot (JS render) sees `<meta robots=noindex>` injected by `applyNotFoundSeo` → flagged noindex in GSC

## Test plan
- [ ] Live curl after deploy still 200
- [ ] Open page in browser, inspect `<meta name=robots>` → must NOT contain `noindex`
- [ ] Real 404 (e.g. `/this-does-not-exist`) still gets `noindex` (no static overlay → guard doesn't trigger)
- [ ] GSC re-crawl: URL inspection shows "indexable" instead of "Excluded by noindex tag"

🤖 Generated with [Claude Code](https://claude.com/claude-code)