### PR TITLE
fix(seo): exclude card titles from static heading reset

### DIFF
--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -51,7 +51,12 @@ body > #root > main.static-job-page { padding: 26px; }
    stop applying once the SPA owns the page. Any s-* extracted class or
    `.hero-title` (specificity 0,1,0) inside the static main still wins,
    preserving per-job and inline-styled headings. */
-main.seo-static-content h1 {
+/* Card-title atoms (.jc-title / .ec-title) live in @layer components so any
+   unlayered element rule here would silently defeat their Tailwind sizing
+   (`text-sm/font-bold/leading-tight`) and re-introduce big heading margins
+   inside job/employer cards. Exclude them from the heading reset so card
+   titles fall through to the atom CSS and match the SPA-rendered cards. */
+main.seo-static-content h1:not(.jc-title):not(.ec-title) {
   margin: 0 0 12px;
   font-family: "Outfit", sans-serif;
   font-size: clamp(1.75rem, 4vw, 2.5rem);
@@ -59,7 +64,7 @@ main.seo-static-content h1 {
   line-height: 1.15;
   color: var(--color-heading);
 }
-main.seo-static-content h2 {
+main.seo-static-content h2:not(.jc-title):not(.ec-title) {
   margin: 1.5rem 0 0.5rem;
   font-family: "Outfit", sans-serif;
   font-size: clamp(1.25rem, 2.5vw, 1.75rem);
@@ -67,7 +72,7 @@ main.seo-static-content h2 {
   line-height: 1.25;
   color: var(--color-heading);
 }
-main.seo-static-content h3 {
+main.seo-static-content h3:not(.jc-title):not(.ec-title) {
   margin: 1rem 0 0.5rem;
   font-family: "Outfit", sans-serif;
   font-size: 1.125rem;
@@ -75,7 +80,7 @@ main.seo-static-content h3 {
   line-height: 1.3;
   color: var(--color-heading);
 }
-main.seo-static-content h4 { margin: 0; font-family: "Outfit", sans-serif; }
+main.seo-static-content h4:not(.jc-title):not(.ec-title) { margin: 0; font-family: "Outfit", sans-serif; }
 main.seo-static-content { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
 .proposal {
   border: 1px solid var(--color-edge);


### PR DESCRIPTION
## Summary
- Static job/employer card `<h3 class=\"jc-title\">` / `<h3 class=\"ec-title\">` were rendering bigger and with a top margin compared to SPA-rendered JobCards, breaking visual consistency across the site (e.g. \`/cerca-lavoro-ticino/azienda-lis-lugano-istituti-sociali/\` vs \`/cerca-lavoro-ticino/\`).
- Cause: unlayered \`main.seo-static-content h1/h2/h3/h4 { font-size; font-weight; margin }\` in \`public/assets/seo-static.css\` always beats \`@layer components\` where \`.jc-title\`/\`.ec-title\` (\`text-sm font-bold leading-tight\`, no margin) live.
- Fix: add \`:not(.jc-title):not(.ec-title)\` to each heading reset so card titles fall through to the Tailwind atom CSS. Non-card raw headings keep their existing reset.

## Test plan
- [ ] After deploy, fetch \`/cerca-lavoro-ticino/azienda-lis-lugano-istituti-sociali/\` and confirm \`.jc-title\` computed \`font-size\` is \`14px\` (sm) / \`16px\` (≥sm), \`font-weight\` 700, \`margin\` 0 — matching SPA \`<JobCard>\`.
- [ ] Spot-check a non-card hub h2/h3 (e.g. \"Domande frequenti\" on a sector landing) still renders with the SEO heading defaults.
- [ ] No layout regressions on \`/cerca-lavoro-ticino/\`, sector hubs, recency landings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)