### PR TITLE
fix(seo): only reset raw unclassed headings in static SEO body

### DIFF
--- a/public/assets/seo-static.css
+++ b/public/assets/seo-static.css
@@ -38,25 +38,26 @@ body {
 }
 /* Padding only for static pre-hydration content */
 body > #root > main.static-job-page { padding: 26px; }
-/* Heading defaults scoped to the static SEO body (main.seo-static-content).
+/* Heading defaults for the static SEO body (main.seo-static-content).
    Tailwind preflight in the SPA bundle resets
    `h1,h2,h3,h4,h5,h6 { font-size: inherit; font-weight: inherit }`,
-   so raw `<h1>` emitters (jobsSeoPagesPlugin city hubs, page-N, sector/category
-   hubs, company landings) need explicit sizes here or they collapse to body
-   text. Element-selector rules MUST be scoped — unlayered rules win against
-   `@layer utilities` regardless of specificity, so unscoped `h2 { font-size }`
-   silently defeats Tailwind's `text-xs/sm/xl` utilities on every React-rendered
-   heading after hydration. The static `<main class="seo-static-content">` is
-   hidden by `App.tsx` on non-staticOverlay routes, so these rules naturally
-   stop applying once the SPA owns the page. Any s-* extracted class or
-   `.hero-title` (specificity 0,1,0) inside the static main still wins,
-   preserving per-job and inline-styled headings. */
-/* Card-title atoms (.jc-title / .ec-title) live in @layer components so any
-   unlayered element rule here would silently defeat their Tailwind sizing
-   (`text-sm/font-bold/leading-tight`) and re-introduce big heading margins
-   inside job/employer cards. Exclude them from the heading reset so card
-   titles fall through to the atom CSS and match the SPA-rendered cards. */
-main.seo-static-content h1:not(.jc-title):not(.ec-title) {
+   so raw `<h1>`/`<h2>`/`<h3>`/`<h4>` emitters (jobsSeoPagesPlugin city hubs,
+   page-N, sector/category hubs, company landings) need explicit sizes here
+   or they collapse to body text.
+
+   Scope: `:not([class])` — these rules ONLY target raw, unclassed headings.
+   Any heading that already carries a class (`.s-XXXXXX` from the style-to-class
+   codemod, `.hero-title`, `.jc-title`, `.ec-title`, etc.) opts out and keeps
+   its own sizing. Without this, the unlayered element rule beats any class
+   selector regardless of specificity (`main.seo-static-content h1` =
+   specificity 0,1,2 vs `.s-XXX`/`.hero-title` = 0,1,0), which silently
+   overrode every codemod-extracted heading + the card-title atoms
+   (`<h3 class="jc-title">` rendered at 1.125rem/600/with-margin instead of
+   the Tailwind `text-sm font-bold leading-tight` it `@apply`s). The static
+   `<main class="seo-static-content">` is hidden by `App.tsx` on
+   non-staticOverlay routes, so these rules naturally stop applying once the
+   SPA owns the page. */
+main.seo-static-content h1:not([class]) {
   margin: 0 0 12px;
   font-family: "Outfit", sans-serif;
   font-size: clamp(1.75rem, 4vw, 2.5rem);
@@ -64,7 +65,7 @@ main.seo-static-content h1:not(.jc-title):not(.ec-title) {
   line-height: 1.15;
   color: var(--color-heading);
 }
-main.seo-static-content h2:not(.jc-title):not(.ec-title) {
+main.seo-static-content h2:not([class]) {
   margin: 1.5rem 0 0.5rem;
   font-family: "Outfit", sans-serif;
   font-size: clamp(1.25rem, 2.5vw, 1.75rem);
@@ -72,7 +73,7 @@ main.seo-static-content h2:not(.jc-title):not(.ec-title) {
   line-height: 1.25;
   color: var(--color-heading);
 }
-main.seo-static-content h3:not(.jc-title):not(.ec-title) {
+main.seo-static-content h3:not([class]) {
   margin: 1rem 0 0.5rem;
   font-family: "Outfit", sans-serif;
   font-size: 1.125rem;
@@ -80,7 +81,7 @@ main.seo-static-content h3:not(.jc-title):not(.ec-title) {
   line-height: 1.3;
   color: var(--color-heading);
 }
-main.seo-static-content h4:not(.jc-title):not(.ec-title) { margin: 0; font-family: "Outfit", sans-serif; }
+main.seo-static-content h4:not([class]) { margin: 0; font-family: "Outfit", sans-serif; }
 main.seo-static-content { max-width: 1120px; margin: 0 auto; display: grid; gap: 12px; }
 .proposal {
   border: 1px solid var(--color-edge);


### PR DESCRIPTION
## Summary
- Widens the previous card-title exemption (#698) from \`:not(.jc-title):not(.ec-title)\` to \`:not([class])\` on \`main.seo-static-content h{1..4}\`.
- The unlayered element rule had specificity 0,1,2 and silently beat every classed heading: \`.s-XXXXXX\` codemod atoms (e.g. \`.s-0Ns7AE\`/\`.s-e3gkVi\`/\`.s-Wb8ho2\` with explicit font-size + margin), \`.hero-title\` (per-job h1, \`font-size: 23px\` was being clobbered to \`clamp(1.75rem, 4vw, 2.5rem)\`), and \`.jc-title\`/\`.ec-title\`.
- Intent of the rule has always been a *default* for raw headings emitted by plugins that don't carry a class — Tailwind preflight strips \`font-size\`/\`font-weight\` from \`h1-h6\`, so raw \`<h1>\` would otherwise collapse to body text. \`:not([class])\` expresses that intent directly.

## Behavioral impact
- Raw unclassed \`<h1>/<h2>/<h3>/<h4>\` inside \`main.seo-static-content\` keep their current SEO defaults — no change.
- Classed headings (\`s-*\` codemod, \`.hero-title\`, \`.jc-title\`, \`.ec-title\`) now use the size/margin/weight defined by their class. Visible across many landings — this restores the author-intended sizing the comments in the file already described.

## Test plan
- [ ] After deploy, curl \`/cerca-lavoro-ticino/azienda-lis-lugano-istituti-sociali/\` → \`<h3 class=\"jc-title\">\` computed style is \`font-size: 14px\` (or \`16px\` ≥sm) / \`font-weight: 700\` / \`margin: 0\` (card matches SPA).
- [ ] Per-job pages (\`/cerca-lavoro-ticino/<job-slug>/\`) → \`<h1 class=\"hero-title\">\` is \`font-size: 23px\` / \`line-height: 1.18\` (not clamp).
- [ ] Codemod \`s-*\` h1/h2 headings on city/sector hubs render at their own \`font-size\` from \`.s-XXXX\` rules.
- [ ] Pages emitting raw \`<h1>\`/\`<h2>\` (no class) keep current sizing.
- [ ] Spot-check Lighthouse + visual on a sector hub and a recency landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)