### PR TITLE
fix(router): keep tassazione-hub pillar as static overlay on SPA hydration

### DIFF
--- a/services/router.ts
+++ b/services/router.ts
@@ -2290,6 +2290,26 @@ export function parsePath(pathname: string): ParseResult {
    }
  }
 
+ // Taxation hub pillar — /guida-tassazione-frontalieri-2026/ + locale variants.
+ // Standalone editorial SEO landing emitted by build-plugins/editorialContent.ts
+ // outside #root. Without staticOverlay the SPA hydration mapped the route to
+ // `activeTab: 'tassazione-hub'`, for which App.tsx has no rendering branch —
+ // it fell through to the FeedbackSection fallback (the "report a bug" page),
+ // wiping the static pillar content on first paint. Route to the fisco tab so
+ // back-nav lands on a usable view, and keep staticOverlay so the SSG HTML
+ // stays visible.
+ {
+   const normalized = pathname.endsWith('/') ? pathname : `${pathname}/`;
+   if (
+     normalized === '/guida-tassazione-frontalieri-2026/' ||
+     normalized === '/en/cross-border-taxation-guide-2026/' ||
+     normalized === '/de/grenzgaenger-besteuerung-leitfaden-2026/' ||
+     normalized === '/fr/guide-imposition-frontaliers-2026/'
+   ) {
+     return { route: { activeTab: 'fisco', staticOverlay: true }, locale };
+   }
+ }
+
  // Border-municipality static SEO pages — one page per Italian comune under
  // the municipalities hub. The build emits the actual page body outside
  // #root; staticOverlay keeps SPA navigation from replacing it with the


### PR DESCRIPTION
## Summary

- URL `/guida-tassazione-frontalieri-2026/` (+ EN/DE/FR variants) is a standalone SEO pillar landing emitted by `build-plugins/editorialContent.ts` outside `#root`. The SSG HTML is correct (curl confirms title + h1 + full editorial body + Article/FAQPage JSON-LD), but SPA hydration parsed the route to `activeTab: 'tassazione-hub'` for which `App.tsx` has **no rendering branch** — it fell through to the `<FeedbackSection />` fallback (the "report a bug" page), wiping the pillar content on first paint.
- Mirror the border-wait / border-municipality pattern: early-return from `parsePath` with `{ activeTab: 'fisco', staticOverlay: true }` so `App.tsx:2170` skips the React `<main>` render and the SSG HTML stays visible. `fisco` is the natural parent tab so back-nav lands on a usable view.

## Test plan

- [ ] Live curl: `/guida-tassazione-frontalieri-2026/` returns 200 with title "Guida Tassazione Frontalieri 2026" (already does — purely SPA hydration regression)
- [ ] Open page in browser post-deploy; pillar content stays visible after hydration (no flash → FeedbackSection)
- [ ] Same check on `/en/cross-border-taxation-guide-2026/`, `/de/grenzgaenger-besteuerung-leitfaden-2026/`, `/fr/guide-imposition-frontaliers-2026/`
- [ ] CI: `tests/router.test.ts` + `tests/seo-completeness.test.ts` (the 'tassazione-hub' tab entry in seo-completeness still routes via `getSeoSection`/`buildPath`, untouched)

## Notes

- No PII in diff; canonical author identity preserved.
- Risk: `parsePath` is HIGH-risk per GitNexus (8 upstream symbols), but change is purely additive — new early-return for 4 specific URLs that previously hit a no-op tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)