### PR TITLE
fix(crawlers): archive removed jobs to per-crawler expired slice

### DIFF
--- a/scripts/lib/crawler-template.mjs
+++ b/scripts/lib/crawler-template.mjs
@@ -150,6 +150,7 @@ import {
   detectLang,
   deriveLocalizedSlug,
 } from './dedicated-crawler-common.mjs';
+import { archiveRemovedJobsToSlice } from './expired-jobs-archive.mjs';
 
 /* ── Shared Utilities (re-exported for parser convenience) ──────────── */
 
@@ -592,6 +593,22 @@ export async function runStandardCrawlerPipeline(config) {
   writeCrawlChangeSummaryToGH(diff, companyLabel);
   printPublishedJobUrls(clean, companyLabel);
   writeJobsSummary(clean, companyLabel);
+
+  // ─── Step 4b: Archive removed jobs to per-crawler expired slice ──
+  // mergePreserveLocaleData drops entries not present in the fresh fetch
+  // (it iterates only freshJobs). Without this archival those drops leave
+  // indexed Google URLs returning 404 instead of JobExpiredView. Captures
+  // `diff.removedJobs` (full job objects, with slug + locale data) into
+  // `data/jobs/expired/by-crawler/<companyKey>.json` so the build plugin
+  // can emit the soft-landing page.
+  if (diff.removedJobs && diff.removedJobs.length > 0) {
+    const archived = archiveRemovedJobsToSlice(diff.removedJobs, companyKey);
+    if (archived > 0) {
+      console.log(
+        `📦 Archived ${archived} removed jobs → data/jobs/expired/by-crawler/${companyKey}.json`,
+      );
+    }
+  }
 
   // ─── Step 5: AI Localization ────────────────────────────────
   // Translates titles + descriptions to all 4 locales via AI.

--- a/scripts/lib/expired-jobs-archive.mjs
+++ b/scripts/lib/expired-jobs-archive.mjs
@@ -1,0 +1,132 @@
+/**
+ * Per-crawler expired-jobs archival.
+ *
+ * Dedicated crawlers refetch the upstream ATS each run and overwrite their
+ * `data/jobs/by-crawler/<key>.json` slice with the current vacancies. When a
+ * job disappears from upstream (vacancy filled, listing removed) it is
+ * dropped from the slice silently — `mergePreserveLocaleData` iterates only
+ * the fresh batch, so any prior entry not present in the new fetch is gone.
+ *
+ * Without archival, indexed-by-Google detail URLs (and their previousSlug
+ * bridges) 404 on the next deploy instead of rendering JobExpiredView. This
+ * module captures those drops into `data/jobs/expired/by-crawler/<key>.json`
+ * so the build plugin can emit the soft-landing page.
+ *
+ * Shape of an expired entry mirrors `cleanup-jobs.mjs:buildExpiredEntry`
+ * so both code paths produce the same on-disk format.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULT_EXPIRED_SLICES_DIR = path.join(ROOT, 'data', 'jobs', 'expired', 'by-crawler');
+
+/**
+ * Build an expired-job archive entry from a job object. Preserves the fields
+ * the build plugin needs to render an enriched JobExpiredView under any
+ * locale prefix (slugByLocale, descriptionByLocale, previousSlugs, salary +
+ * address). Mirrors `scripts/cleanup-jobs.mjs:buildExpiredEntry` byte for byte.
+ *
+ * @param {object} job
+ * @returns {object} expired entry
+ */
+export function buildExpiredEntry(job) {
+  const entry = {
+    slug: job.slug,
+    title: job.title || '',
+    titleByLocale: job.titleByLocale || {},
+    company: job.company || '',
+    companyKey: job.companyKey || '',
+    location: job.location || '',
+    addressLocality: job.addressLocality || '',
+    descriptionByLocale: job.descriptionByLocale || {},
+    slugByLocale: job.slugByLocale || {},
+    sector: job.sector || '',
+    expiredAt: new Date().toISOString(),
+    previousSlugs:
+      Array.isArray(job.previousSlugs) && job.previousSlugs.length > 0
+        ? [...job.previousSlugs]
+        : undefined,
+    previousSlugsByLocale:
+      job.previousSlugsByLocale &&
+      typeof job.previousSlugsByLocale === 'object' &&
+      Object.keys(job.previousSlugsByLocale).length > 0
+        ? JSON.parse(JSON.stringify(job.previousSlugsByLocale))
+        : undefined,
+    postalCode: job.postalCode || '',
+    streetAddress: job.streetAddress || '',
+    salaryMin: job.salaryMin || null,
+    salaryMax: job.salaryMax || null,
+    salaryCurrency: job.salaryCurrency || 'CHF',
+    salaryPeriod: job.salaryPeriod || 'YEAR',
+    dedupArchive: job.dedupArchive === true ? true : undefined,
+  };
+  if (!entry.postalCode) delete entry.postalCode;
+  if (!entry.streetAddress) delete entry.streetAddress;
+  if (!entry.salaryMin) delete entry.salaryMin;
+  if (!entry.salaryMax) delete entry.salaryMax;
+  if (entry.dedupArchive !== true) delete entry.dedupArchive;
+  return entry;
+}
+
+/**
+ * Archive removed jobs to a per-crawler expired slice file.
+ *
+ * Merges with any existing entries by `slug`, keeping the most-recently
+ * expired entry per slug. Skips jobs without a slug (no static page to land
+ * on). Returns the number of newly-added entries; zero means the on-disk
+ * file is unchanged.
+ *
+ * @param {object[]} removedJobs - Full job objects (NOT `{ id }` refs)
+ * @param {string} crawlerKey
+ * @param {object} [opts]
+ * @param {string} [opts.dir] - Override directory (default: data/jobs/expired/by-crawler)
+ * @returns {number} added count
+ */
+export function archiveRemovedJobsToSlice(removedJobs, crawlerKey, opts = {}) {
+  if (!crawlerKey) return 0;
+  if (!Array.isArray(removedJobs) || removedJobs.length === 0) return 0;
+
+  const dir = opts.dir || DEFAULT_EXPIRED_SLICES_DIR;
+  fs.mkdirSync(dir, { recursive: true });
+  const slicePath = path.join(dir, `${crawlerKey}.json`);
+
+  let existing = [];
+  try {
+    existing = JSON.parse(fs.readFileSync(slicePath, 'utf-8'));
+    if (!Array.isArray(existing)) existing = [];
+  } catch {
+    existing = [];
+  }
+
+  const bySlug = new Map();
+  for (const ej of existing) {
+    if (ej?.slug) bySlug.set(ej.slug, ej);
+  }
+  const sizeBefore = bySlug.size;
+
+  let added = 0;
+  for (const job of removedJobs) {
+    if (!job?.slug) continue;
+    const entry = buildExpiredEntry(job);
+    const prev = bySlug.get(entry.slug);
+    if (!prev) {
+      bySlug.set(entry.slug, entry);
+      added++;
+    } else if ((entry.expiredAt || '') >= (prev.expiredAt || '')) {
+      bySlug.set(entry.slug, entry);
+    }
+  }
+
+  if (added === 0 && bySlug.size === sizeBefore) return 0;
+
+  const archived = [...bySlug.values()].sort((a, b) =>
+    (b.expiredAt || '').localeCompare(a.expiredAt || ''),
+  );
+  fs.writeFileSync(slicePath, `${JSON.stringify(archived, null, 2)}\n`, 'utf-8');
+  return added;
+}

--- a/tests/regression/crawler-archive-removed-to-expired.test.ts
+++ b/tests/regression/crawler-archive-removed-to-expired.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression: when a dedicated crawler refetches and a previously-known job
+ * is no longer in the upstream ATS, the drop must be captured into
+ * `data/jobs/expired/by-crawler/<crawler>.json` instead of being lost.
+ *
+ * Without this, `mergePreserveLocaleData` (iterates only freshJobs) silently
+ * drops the entry, the next deploy stops emitting the static detail page,
+ * and Google-indexed URLs (plus their previousSlugs bridges) return 404
+ * instead of rendering JobExpiredView.
+ *
+ * The UPD crawler hit this on 2026-05-27 when job `upd-c1ad47e6563e`
+ * (psychology-assistant) vanished from the Umantis source between runs —
+ * `data/jobs/expired/by-crawler/upd.json` never existed because the
+ * crawler-template pipeline lacked an archival step.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  archiveRemovedJobsToSlice,
+  buildExpiredEntry,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — .mjs has no type declarations
+} from '../../scripts/lib/expired-jobs-archive.mjs';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'expired-archive-'));
+}
+
+function readSlice(dir: string, crawlerKey: string): unknown[] {
+  const p = path.join(dir, `${crawlerKey}.json`);
+  if (!fs.existsSync(p)) return [];
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+const removedUpdJob = {
+  id: 'upd-c1ad47e6563e',
+  slug: 'assistente-psicologa-assistente-psicologo-o-psicologa-specializzata-psicologo-specializzato-universitare-psychiatrische',
+  title: 'Assistenzpsychologin / Assistenzpsychologe oder Fachpsychologin / Fachpsychologe',
+  titleByLocale: {
+    it: 'Assistente Psicologa / Assistente Psicologo',
+    en: 'Psychology Assistant / Specialized Psychologist',
+    de: 'Assistenzpsychologin / Assistenzpsychologe',
+    fr: 'Psychologue assistant·e',
+  },
+  company: 'Universitäre Psychiatrische Dienste Bern (UPD)',
+  companyKey: 'upd',
+  location: 'Bern',
+  addressLocality: 'Bern',
+  canton: 'BE',
+  postalCode: '3000',
+  slugByLocale: {
+    it: 'assistente-psicologa-assistente-psicologo-o-psicologa-specializzata-psicologo-specializzato-universitare-psychiatrische',
+    en: 'psychology-assistant-specialized-psychologist-assistant-universitare-psychiatrische-dienste-bern-upd-bern',
+    de: 'assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-upd-bern',
+    fr: 'psychologue-assistant-e-ou-psychologue-specialise-e-universitare-psychiatrische-dienste-bern-upd-bern',
+  },
+  descriptionByLocale: {
+    it: 'Lorem ipsum '.repeat(40),
+    en: 'Lorem ipsum '.repeat(40),
+    de: 'Lorem ipsum '.repeat(40),
+    fr: 'Lorem ipsum '.repeat(40),
+  },
+  previousSlugs: [
+    'assistenzpsychologin-assistenzpsychologe-oder-fachpsychologin-fachpsychologe-upd-bern',
+    'psicologo-a-assistente-o-a-psicologo-a-specializzato-a-universitare-psychiatrische-dienste-bern-upd-bern',
+  ],
+  previousSlugsByLocale: {
+    en: ['assistant-psychologist-or-specialist-psychologist-universitare-psychiatrische-dienste-bern-upd-bern'],
+  },
+  sector: 'Sanità / Ospedali',
+  salaryMin: 49500,
+  salaryMax: 75000,
+  currency: 'CHF',
+};
+
+describe('archiveRemovedJobsToSlice', () => {
+  it('writes a new slice file when no prior archive exists', () => {
+    const dir = makeTmpDir();
+    const added = archiveRemovedJobsToSlice([removedUpdJob], 'upd', { dir });
+    expect(added).toBe(1);
+
+    const slice = readSlice(dir, 'upd') as Array<Record<string, unknown>>;
+    expect(slice).toHaveLength(1);
+    expect(slice[0].slug).toBe(removedUpdJob.slug);
+    expect(slice[0].slugByLocale).toEqual(removedUpdJob.slugByLocale);
+    expect(slice[0].previousSlugs).toEqual(removedUpdJob.previousSlugs);
+    expect(slice[0].previousSlugsByLocale).toEqual(removedUpdJob.previousSlugsByLocale);
+    expect(typeof slice[0].expiredAt).toBe('string');
+  });
+
+  it('merges with existing entries instead of overwriting', () => {
+    const dir = makeTmpDir();
+    // Seed: prior expired entry from a different upstream removal
+    const prior = {
+      slug: 'old-removed-job',
+      title: 'Old Job',
+      company: 'UPD',
+      slugByLocale: { it: 'old-removed-job' },
+      expiredAt: '2026-05-01T00:00:00.000Z',
+    };
+    fs.writeFileSync(path.join(dir, 'upd.json'), JSON.stringify([prior], null, 2) + '\n');
+
+    archiveRemovedJobsToSlice([removedUpdJob], 'upd', { dir });
+    const slice = readSlice(dir, 'upd') as Array<Record<string, unknown>>;
+    expect(slice).toHaveLength(2);
+    const slugs = slice.map((e) => e.slug).sort();
+    expect(slugs).toContain('old-removed-job');
+    expect(slugs).toContain(removedUpdJob.slug);
+  });
+
+  it('keeps the most-recently-expired entry when a slug is re-archived', () => {
+    const dir = makeTmpDir();
+    archiveRemovedJobsToSlice([removedUpdJob], 'upd', { dir });
+    const first = readSlice(dir, 'upd') as Array<Record<string, unknown>>;
+    const firstExpiredAt = first[0].expiredAt as string;
+
+    // Pause a hair to guarantee a later ISO timestamp on the second archive
+    const after = new Date(Date.now() + 5).toISOString();
+    archiveRemovedJobsToSlice(
+      [{ ...removedUpdJob, _bumpExpiredAt: after }],
+      'upd',
+      { dir },
+    );
+    const second = readSlice(dir, 'upd') as Array<Record<string, unknown>>;
+    expect(second).toHaveLength(1);
+    expect((second[0].expiredAt as string) >= firstExpiredAt).toBe(true);
+  });
+
+  it('skips jobs without a slug (no static page to land on)', () => {
+    const dir = makeTmpDir();
+    const noSlug = { ...removedUpdJob, slug: undefined };
+    const added = archiveRemovedJobsToSlice([noSlug as never], 'upd', { dir });
+    expect(added).toBe(0);
+    expect(fs.existsSync(path.join(dir, 'upd.json'))).toBe(false);
+  });
+
+  it('is a no-op when removedJobs is empty', () => {
+    const dir = makeTmpDir();
+    expect(archiveRemovedJobsToSlice([], 'upd', { dir })).toBe(0);
+    expect(fs.existsSync(path.join(dir, 'upd.json'))).toBe(false);
+  });
+
+  it('refuses to run without a crawlerKey', () => {
+    const dir = makeTmpDir();
+    expect(archiveRemovedJobsToSlice([removedUpdJob], '', { dir })).toBe(0);
+  });
+
+  it('sorts the on-disk archive by expiredAt descending', () => {
+    const dir = makeTmpDir();
+    const older = {
+      ...removedUpdJob,
+      slug: 'older-removed-job',
+      slugByLocale: { it: 'older-removed-job' },
+    };
+    fs.writeFileSync(
+      path.join(dir, 'upd.json'),
+      JSON.stringify(
+        [{ slug: 'older-removed-job', expiredAt: '2026-04-01T00:00:00.000Z' }],
+        null,
+        2,
+      ) + '\n',
+    );
+    archiveRemovedJobsToSlice([removedUpdJob], 'upd', { dir });
+    const slice = readSlice(dir, 'upd') as Array<Record<string, string>>;
+    expect(slice[0].slug).toBe(removedUpdJob.slug); // newer first
+    expect(slice[1].slug).toBe('older-removed-job');
+  });
+});
+
+describe('buildExpiredEntry', () => {
+  it('preserves locale-aware slug + previousSlugs for cross-locale bridges', () => {
+    const entry = buildExpiredEntry(removedUpdJob);
+    expect(entry.slug).toBe(removedUpdJob.slug);
+    expect(entry.slugByLocale).toEqual(removedUpdJob.slugByLocale);
+    expect(entry.previousSlugs).toEqual(removedUpdJob.previousSlugs);
+    expect(entry.previousSlugsByLocale).toEqual(removedUpdJob.previousSlugsByLocale);
+    expect(entry.descriptionByLocale).toEqual(removedUpdJob.descriptionByLocale);
+    expect(entry.salaryMin).toBe(removedUpdJob.salaryMin);
+    expect(entry.salaryMax).toBe(removedUpdJob.salaryMax);
+    expect(typeof entry.expiredAt).toBe('string');
+  });
+
+  it('strips empty optional fields', () => {
+    const entry = buildExpiredEntry({
+      slug: 'x',
+      title: 'X',
+      company: 'X',
+      location: 'X',
+    });
+    expect(entry).not.toHaveProperty('postalCode');
+    expect(entry).not.toHaveProperty('streetAddress');
+    expect(entry).not.toHaveProperty('salaryMin');
+    expect(entry).not.toHaveProperty('salaryMax');
+    expect(entry).not.toHaveProperty('dedupArchive');
+  });
+});


### PR DESCRIPTION
## Summary

Dedicated crawlers built on `runStandardCrawlerPipeline` overwrite their `data/jobs/by-crawler/<key>.json` slice each run. When a vacancy disappears upstream, `mergePreserveLocaleData` (which iterates only `freshJobs`) silently drops it. The `diff.removedJobs` was computed and printed in the crawl summary, but never archived. Result: Google-indexed detail URLs and their `previousSlugs` bridges 404 on the next deploy instead of rendering `JobExpiredView`.

### Reproduction

UPD job `upd-c1ad47e6563e` (psychology-assistant-specialized-...) was present in `data/jobs/by-crawler/upd.json` at commit `7a0323cfb1` (2026-05-19), gone at the next UPD crawl `98cccfa423` (2026-05-27). `data/jobs/expired/by-crawler/upd.json` doesn't exist. The user's reported [404 URL](https://frontaliereticino.ch/en/find-jobs-bern/psychology-assistant-specialized-psychologist-assistant-universitare-psychiatrische-dienste-bern-upd-bern/) was the visible symptom.

The same gap affects every dedicated crawler using this template (~300 of them). Some crawlers still have populated expired slices on disk (artisa-group 126 KB, abb-svizzera 146 KB, axa-svizzera 275 KB) — leftover from the old pre-slice workflow where `cleanup-jobs.mjs` operated on the monolithic `data/jobs.json` and could see prior state. Post-migration the slice-mode cleanup only sees the just-overwritten slice, so no drops are archived.

### Fix

After `computeCrawlDiff` in `scripts/lib/crawler-template.mjs`, archive `diff.removedJobs` (full job objects with slug + locale data) to `data/jobs/expired/by-crawler/<companyKey>.json` via a new shared helper `scripts/lib/expired-jobs-archive.mjs`. The expired-entry shape mirrors `cleanup-jobs.mjs:buildExpiredEntry` byte-for-byte so both code paths produce the same on-disk format. Idempotent; merges with existing entries by slug.

## Test plan

- [x] New regression test `tests/regression/crawler-archive-removed-to-expired.test.ts` — 9 cases, all pass:
  - writes new slice when no prior archive
  - merges with existing entries (no overwrite)
  - keeps most-recently-expired on slug re-archive
  - skips slugless jobs (no static page to land on)
  - no-op on empty input
  - refuses to run without a crawlerKey
  - sorts on-disk archive by `expiredAt` descending
  - `buildExpiredEntry` preserves locale slug + previousSlugs for cross-locale bridges
  - `buildExpiredEntry` strips empty optional fields
- [x] Existing crawler tests still pass (`bally`, `kanton-gr` — 44/44 cases)
- [ ] Post-merge: next UPD crawl run should produce `data/jobs/expired/by-crawler/upd.json` with the next dropped vacancies; verify by inspecting the auto-commit diff.

## Out of scope

- The specific URL the user reported (`upd-c1ad47e6563e`) was already lost before this fix lands. Recovering it would require fetching the historical job data from commit `7a0323cfb1` and seeding the expired slice — separate cleanup task.
- `cleanup-jobs.mjs` still has its own copy of `buildExpiredEntry` + `archiveExpiredJobsPerCrawler` (operates on `{ id }` refs). Could be DRY'd against the new shared module in a follow-up — kept untouched here to minimize blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)