### PR TITLE
feat(seo): GSC+GA4+PostHog sync for indexed cluster URL mirrors

### DIFF
--- a/.github/workflows/refresh-indexed-cluster-urls.yml
+++ b/.github/workflows/refresh-indexed-cluster-urls.yml
@@ -1,0 +1,84 @@
+name: Refresh indexed cluster URLs
+# Weekly: union of GSC + GA4 + PostHog trafficked related-search cluster URLs
+# under non-aggregator sections. The cluster build plugin reads
+# `data/indexed-cluster-urls.json` and emits byte-identical mirrors at every
+# listed path (in addition to the default TI + legacyCantonGroup mirrors), so
+# every Google-indexed cluster URL stays 200 OK and consolidates into the
+# Svizzera canonical instead of 404-ing.
+#
+# Script: scripts/refresh-indexed-cluster-urls.mjs
+# Sibling: refresh-noslash-keep.yml (same pattern, different filter+output)
+
+on:
+  schedule:
+    - cron: '10 5 * * 1'  # Every Monday at 05:10 UTC (10 min after noslash-keep refresh)
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Lookback window in days'
+        required: false
+        default: '90'
+      min_impressions:
+        description: 'Minimum impressions/views to keep a path'
+        required: false
+        default: '1'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: indexed-cluster-urls-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Write Firebase service-account JSON to /tmp
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "::warning::No FIREBASE_SERVICE_ACCOUNT_JSON — GSC + GA4 will be skipped gracefully."
+          fi
+
+      - name: Load secrets from Remote Config
+        # Maps SERVER_GA4_PROPERTY_ID / SERVER_POSTHOG_* (set in Firebase RC)
+        # to their unprefixed names in $GITHUB_ENV so the script can read them.
+        run: node scripts/load-rc-env.mjs
+
+      - name: Refresh indexed cluster URL list
+        env:
+          DAYS: ${{ inputs.days || '90' }}
+          MIN_IMP: ${{ inputs.min_impressions || '1' }}
+        run: node scripts/refresh-indexed-cluster-urls.mjs --days "$DAYS" --min-impressions "$MIN_IMP"
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/indexed-cluster-urls.json
+          if git diff --cached --quiet; then
+            echo "No change to indexed-cluster-urls.json"
+            exit 0
+          fi
+          git commit -m "chore(seo): refresh indexed cluster URLs (GSC+GA4+PostHog union)"
+          bash scripts/lib/git-push-with-retry.sh \
+            --regenerate-cmd "node scripts/refresh-indexed-cluster-urls.mjs --days $DAYS --min-impressions $MIN_IMP && git add data/indexed-cluster-urls.json"

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -214,6 +214,11 @@ const CACHE_KEY_INPUTS = [
   'data/jobs.json',
   'data/related-search-candidates.json',
   'data/related-search-enriched.json',
+  // GSC/GA4/PostHog-driven mirror set: when the weekly workflow rewrites
+  // this file the build must re-emit so the new mirror paths land in dist.
+  // Missing file is hashed as `missing:<rel>` by computeCacheKey, so
+  // bootstrap stub vs. populated data still produce distinct cache keys.
+  'data/indexed-cluster-urls.json',
   'build-plugins/relatedSearchClustersPlugin.ts',
   'build-plugins/relatedSearchClustersData.ts',
   'build-plugins/shared/seoPageShell.ts',
@@ -484,6 +489,70 @@ function loadJobs(rootDir: string): RawJob[] {
     console.warn('\x1b[33m[related-search-clusters]\x1b[0m failed to parse jobs.json:', err);
     return [];
   }
+}
+
+/**
+ * Parse a cluster URL path into its (locale, slug) key so we can bucket the
+ * GSC-driven mirror paths by the same key the render loop uses.
+ *
+ * Returns null when the path doesn't match the cluster shape — including the
+ * Svizzera aggregator sections, since those ARE the canonical and don't need
+ * a mirror entry.
+ *
+ * Mirrors the `CLUSTER_PATH_RX` regex in scripts/refresh-indexed-cluster-urls.mjs.
+ * If you change one, change the other — keep the de/jobs-im, de/jobs-in,
+ * de/jobs-in-der prefixes in sync because the data file is consumed by this
+ * function unmodified.
+ */
+const CLUSTER_PATH_PARSE_RX = /^\/(?:(en|de|fr)\/)?(?:cerca-lavoro|find-jobs|jobs-im|jobs-in|jobs-in-der|trouver-emploi)-(?!svizzera\b|switzerland\b|schweiz\b|suisse\b)[a-z-]+\/((?:ricerca|search|suche|recherche)-[a-z0-9-]+)\/?$/;
+
+function parseClusterPathKey(p: string): { locale: Locale; slug: string } | null {
+  if (!p) return null;
+  const m = p.toLowerCase().match(CLUSTER_PATH_PARSE_RX);
+  if (!m) return null;
+  const locale = (m[1] || 'it') as Locale;
+  return { locale, slug: m[2] };
+}
+
+/**
+ * Load `data/indexed-cluster-urls.json` and bucket the listed paths by
+ * `${locale}::${slug}` so the render loop can look up additional mirror paths
+ * in O(1) per cluster.
+ *
+ * The file is populated by `scripts/refresh-indexed-cluster-urls.mjs` (run
+ * weekly via `.github/workflows/refresh-indexed-cluster-urls.yml`) — its
+ * union of GSC/GA4/PostHog cluster URLs under non-aggregator sections is the
+ * authoritative list of paths Google / users still hit.
+ *
+ * Missing file or malformed JSON returns an empty map → emit loop falls back
+ * to the default TI + legacyCantonGroup mirrors.
+ */
+function loadIndexedClusterUrls(rootDir: string): Map<string, string[]> {
+  const filePath = path.join(rootDir, 'data', 'indexed-cluster-urls.json');
+  const out = new Map<string, string[]>();
+  if (!fs.existsSync(filePath)) return out;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch (err) {
+    console.warn('\x1b[33m[related-search-clusters]\x1b[0m failed to parse indexed-cluster-urls.json:', err);
+    return out;
+  }
+  const indexedPaths = (raw as { indexedPaths?: unknown })?.indexedPaths;
+  if (!Array.isArray(indexedPaths)) return out;
+  for (const entry of indexedPaths) {
+    if (typeof entry !== 'string') continue;
+    const parsed = parseClusterPathKey(entry);
+    if (!parsed) continue;
+    const key = `${parsed.locale}::${parsed.slug}`;
+    const list = out.get(key) || [];
+    // Normalize to trailing-slash form so the emit-loop dedup against
+    // `out.urlPath` (always slashed) catches collisions with the canonical.
+    const normalized = entry.endsWith('/') ? entry : `${entry}/`;
+    if (!list.includes(normalized)) list.push(normalized);
+    out.set(key, list);
+  }
+  return out;
 }
 
 // ── Filtering & dedupe ──────────────────────────────────────────────────
@@ -1964,7 +2033,14 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       const __tLoadJobs = profileStart();
       const jobs = loadJobs(rootDir);
       profileRecord('load-jobs', __tLoadJobs);
-      console.log(`\x1b[36m[related-search-clusters]\x1b[0m ${candidates.length} candidates, ${Object.keys(enriched).length} enriched entries, ${jobs.length} jobs`);
+      // GSC/GA4/PostHog-driven mirror paths, keyed by `${locale}::${slug}`.
+      // Empty map when the data file is missing or hasn't been populated yet
+      // (cron `.github/workflows/refresh-indexed-cluster-urls.yml` runs
+      // weekly; first run after deploy populates it). Empty map is safe:
+      // the emit loop still produces the TI + legacyCantonGroup default
+      // mirrors for every cluster.
+      const indexedClusterUrlsByKey = loadIndexedClusterUrls(rootDir);
+      console.log(`\x1b[36m[related-search-clusters]\x1b[0m ${candidates.length} candidates, ${Object.keys(enriched).length} enriched entries, ${jobs.length} jobs, ${indexedClusterUrlsByKey.size} GSC-driven mirror keys`);
 
       // Inverted token index: lazy posting lists per (locale, token), shared
       // across every candidate. Memory budget is dominated by the haystack
@@ -2177,39 +2253,53 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         // legacy per-canton paths that this cluster previously occupied. The
         // mirror's `<link rel="canonical">` already points to Svizzera (it's
         // baked into the rendered HTML), so search engines fold the mirror
-        // into the canonical instead of treating it as a duplicate. Two
-        // mirror cantons are covered:
-        //   1. `ctx.legacyCantonGroup` — the canton of `matchingJobs[0]`,
-        //      which is where the pre-refactor build emitted the cluster
-        //      AND where the sitemap-search-clusters shards still advertise
-        //      it from previous deploys (every URL Google has crawled).
-        //   2. `'TI'` — the legacy default section. The JobBoard related-
-        //      search widget (components/community/JobBoard.tsx:5776) used
-        //      `buildPath` without `jobBoardCanton`, which falls back to
+        // into the canonical instead of treating it as a duplicate.
+        //
+        // Three mirror sources are merged into a single Set of absolute
+        // paths (deduped + collision-guarded against the canonical):
+        //   1. `ctx.legacyCantonGroup` — canton of `matchingJobs[0]`, the
+        //      URL the pre-refactor build emitted AND where the
+        //      sitemap-search-clusters shards still advertise the cluster
+        //      from previous deploys (definitely crawled by Google).
+        //   2. `'TI'` — legacy default section. The JobBoard related-search
+        //      widget (components/community/JobBoard.tsx:5776) used
+        //      `buildPath` without `jobBoardCanton`, falling back to
         //      `table.jobBoard` (cerca-lavoro-ticino / find-jobs-ticino /
-        //      jobs-im-tessin / trouver-emploi-tessin) — so Googlebot
+        //      jobs-im-tessin / trouver-emploi-tessin), so Googlebot
         //      followed those internal links and indexed the TI variant
         //      across all locales.
+        //   3. `data/indexed-cluster-urls.json` — GSC + GA4 + PostHog union
+        //      of cluster URLs under any non-aggregator section that still
+        //      receives traffic. Populated weekly by
+        //      `.github/workflows/refresh-indexed-cluster-urls.yml`. Lets
+        //      us preserve URLs Google indexed back when the top-match was
+        //      a now-stale canton (e.g. cluster pinned to BL last month,
+        //      pinned to ZH this month — GSC's BL impressions keep the BL
+        //      mirror alive even after legacyCantonGroup moved to ZH).
+        //
         // Mirrors are NOT added to sitemapLocs: only the Svizzera canonical
         // appears in sitemap-search-clusters.xml, so audit:sitemap-canonicals
         // continues to pass. Mirrors stay out of the index over time.
-        const mirrorCantons = new Set<string>([ctx.legacyCantonGroup, 'TI']);
-        // The canonical was already written under AGGREGATE_KEY → don't
-        // re-emit at the same path even if legacyCantonGroup somehow
-        // collapses to AGGREGATE (currently impossible: resolveJobCanton
-        // never returns it). Defensive only.
-        mirrorCantons.delete(AGGREGATE_KEY);
-        for (const mirrorCanton of mirrorCantons) {
-          const mirrorPath = buildClusterPath(locale, ctx.candidate.slug, mirrorCanton);
-          if (mirrorPath === out.urlPath) continue; // never overwrite canonical
+        const mirrorPaths = new Set<string>();
+        for (const mirrorCanton of [ctx.legacyCantonGroup, 'TI']) {
+          if (mirrorCanton === AGGREGATE_KEY) continue; // defensive — never emit canonical as mirror
+          mirrorPaths.add(buildClusterPath(locale, ctx.candidate.slug, mirrorCanton));
+        }
+        const extraIndexedKey = `${locale}::${ctx.candidate.slug}`;
+        const extraIndexedPaths = indexedClusterUrlsByKey.get(extraIndexedKey);
+        if (extraIndexedPaths) {
+          for (const p of extraIndexedPaths) mirrorPaths.add(p);
+        }
+        mirrorPaths.delete(out.urlPath); // never overwrite canonical
+        for (const mirrorPath of mirrorPaths) {
           // Mirrors emit ONLY index.html — no flat .html bridge. The slash
           // mirror already canonicalizes to Svizzera (via the rendered
           // HTML's `<link rel="canonical">`), so a flat .html bridge would
           // be a second redirect hop for a low-value URL form (visitors
           // typing the URL without trailing slash). Cuts mirror file count
-          // in half — relevant because ~70% of clusters emit 2 mirrors
-          // (legacyCanton + TI when legacy ≠ TI) so doubling mirrors via
-          // flat bridges would add hundreds of thousands of files for a
+          // in half — relevant because ~70% of clusters emit 2+ mirrors
+          // (legacyCanton + TI + any GSC-flagged extras) so doubling mirrors
+          // via flat bridges would add hundreds of thousands of files for a
           // negligible UX gain.
           const mirrorIndexPath = path.join(distDir, mirrorPath, 'index.html');
           collector.add(mirrorIndexPath, out.html);

--- a/data/indexed-cluster-urls.json
+++ b/data/indexed-cluster-urls.json
@@ -1,0 +1,12 @@
+{
+  "refreshedAt": "1970-01-01T00:00:00.000Z",
+  "lookbackDays": 90,
+  "minImpressions": 1,
+  "sources": {
+    "gsc": { "ok": false, "reason": "not yet populated — first run pending" },
+    "ga4": { "ok": false, "reason": "not yet populated — first run pending" },
+    "posthog": { "ok": false, "reason": "not yet populated — first run pending" }
+  },
+  "indexedCount": 0,
+  "indexedPaths": []
+}

--- a/scripts/refresh-indexed-cluster-urls.mjs
+++ b/scripts/refresh-indexed-cluster-urls.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+/**
+ * Refresh data/indexed-cluster-urls.json — the union of related-search cluster
+ * URL paths that any traffic source reports as still active under a NON-canonical
+ * (non-aggregator) section. Sourced from:
+ *   1. Google Search Console (impressions)
+ *   2. Google Analytics 4 (pageviews)
+ *   3. PostHog (pageviews)
+ *
+ * Background:
+ *   `build-plugins/relatedSearchClustersPlugin.ts` canonicalizes every cluster
+ *   under the Switzerland-wide aggregator section
+ *   (`/cerca-lavoro-svizzera/ricerca-{slug}/` and per-locale equivalents) since
+ *   PR #704. Per-canton URLs Google had crawled before that refactor are kept
+ *   alive as byte-identical mirrors at TI + the legacy top-match canton by
+ *   default. This script extends the mirror set with EVERY cluster URL that
+ *   any traffic source reports as still receiving impressions / views — so
+ *   sections beyond TI + legacyCanton (e.g. /cerca-lavoro-zurigo/ricerca-...
+ *   that Google indexed back when the top-match was elsewhere) stay 200 OK
+ *   instead of 404 once their canton stops being the build-time pin.
+ *
+ * Auth:
+ *   - GSC: Firebase Service Account
+ *   - GA4: GA4_PROPERTY_ID env + GOOGLE_APPLICATION_CREDENTIALS or FIREBASE_SERVICE_ACCOUNT_JSON
+ *   - PostHog: POSTHOG_PERSONAL_API_KEY + POSTHOG_PROJECT_ID env
+ *
+ *   Missing sources are silently skipped (best-effort union — mirrors the
+ *   refresh-noslash-keep.mjs sibling).
+ *
+ * Output (data/indexed-cluster-urls.json):
+ *   {
+ *     "refreshedAt": "2026-05-28T...",
+ *     "lookbackDays": 90,
+ *     "minImpressions": 1,
+ *     "sources": {
+ *       "gsc":     { "ok": true,  "rowsScanned": 12000, "clusterSeen": 580, "kept": 412 },
+ *       "ga4":     { "ok": false, "reason": "missing creds" },
+ *       "posthog": { "ok": false, "reason": "missing creds" }
+ *     },
+ *     "indexedCount": 412,
+ *     "indexedPaths": [ "/cerca-lavoro-zurigo/ricerca-data-center-technician/", ... ]
+ *   }
+ *
+ * Usage:
+ *   node scripts/refresh-indexed-cluster-urls.mjs                # 90 days, threshold 1
+ *   node scripts/refresh-indexed-cluster-urls.mjs --days 180
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const OUT_PATH = path.join(ROOT, 'data', 'indexed-cluster-urls.json');
+const SITE = 'sc-domain:frontaliereticino.ch';
+
+const argv = process.argv.slice(2);
+function arg(name, def) {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : def;
+}
+const days = parseInt(arg('--days', '90'), 10);
+const minImpressions = parseInt(arg('--min-impressions', '1'), 10);
+
+// Match cluster-page paths under a NON-aggregator section. Captures:
+//   group 1: optional locale prefix (en|de|fr) — IT has no prefix
+//   group 2: canton section slug (cerca-lavoro-{canton} / find-jobs-{canton} /
+//            jobs-im-{canton} / jobs-in-{canton} / trouver-emploi-{canton})
+//   group 3: cluster slug (ricerca-... / search-... / suche-... / recherche-...)
+// The svizzera/switzerland/schweiz/suisse aggregator sections are explicitly
+// excluded — those URLs ARE the canonical and don't need a mirror.
+const CLUSTER_PATH_RX = /^\/(?:(en|de|fr)\/)?((?:cerca-lavoro|find-jobs|jobs-im|jobs-in|jobs-in-der|trouver-emploi)-(?!svizzera\/|switzerland\/|schweiz\/|suisse\/)[a-z-]+)\/((?:ricerca|search|suche|recherche)-[a-z0-9-]+)\/?$/i;
+
+function loadServiceAccount() {
+  const envPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (envPath && fs.existsSync(envPath)) {
+    return JSON.parse(fs.readFileSync(envPath, 'utf8'));
+  }
+  if (process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    return JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+  }
+  const local = path.join(ROOT, 'mcp-gsc-main', 'service_account_credentials.json');
+  if (fs.existsSync(local)) {
+    return JSON.parse(fs.readFileSync(local, 'utf8'));
+  }
+  return null;
+}
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+async function getAccessToken(sa, scopes) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT', kid: sa.private_key_id };
+  const claims = {
+    iss: sa.client_email,
+    scope: scopes,
+    aud: 'https://oauth2.googleapis.com/token',
+    iat: now,
+    exp: now + 3600,
+  };
+  const unsigned = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(claims))}`;
+  const signer = crypto.createSign('RSA-SHA256');
+  signer.update(unsigned);
+  signer.end();
+  const jwt = `${unsigned}.${base64url(signer.sign(sa.private_key))}`;
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    }),
+  });
+  if (!res.ok) throw new Error(`Token exchange failed: ${res.status}`);
+  const data = await res.json();
+  if (!data.access_token) throw new Error('no access_token');
+  return data.access_token;
+}
+
+function pathFromUrl(u) {
+  try {
+    return new URL(u).pathname;
+  } catch {
+    if (typeof u === 'string' && u.startsWith('/')) return u;
+    return null;
+  }
+}
+
+// Canonicalize cluster path: ensure trailing slash, lowercase. Returns the
+// normalized path on match, null otherwise. Filters out svizzera/aggregator
+// variants (those ARE the canonical and don't need a mirror).
+function normalizeClusterPath(p) {
+  if (!p) return null;
+  const trimmed = p.endsWith('/') ? p : `${p}/`;
+  const lower = trimmed.toLowerCase();
+  if (!CLUSTER_PATH_RX.test(lower)) return null;
+  return lower;
+}
+
+async function fetchGsc(sa, startDate, endDate) {
+  const token = await getAccessToken(sa, 'https://www.googleapis.com/auth/webmasters.readonly');
+  const rows = [];
+  let startRow = 0;
+  for (let i = 0; i < 10; i++) {
+    const body = { startDate, endDate, dimensions: ['page'], rowLimit: 25000, startRow, type: 'web' };
+    const url = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(SITE)}/searchAnalytics/query`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`GSC ${res.status}: ${await res.text()}`);
+    const data = await res.json();
+    if (!data.rows || data.rows.length === 0) break;
+    rows.push(...data.rows);
+    if (data.rows.length < 25000) break;
+    startRow += data.rows.length;
+  }
+  return rows;
+}
+
+async function fetchGa4(sa, startDate, endDate) {
+  const propertyIdRaw = process.env.GA4_PROPERTY_ID;
+  if (!propertyIdRaw) throw new Error('GA4_PROPERTY_ID unset');
+  const propertyId = propertyIdRaw.startsWith('properties/') ? propertyIdRaw : `properties/${propertyIdRaw}`;
+  const token = await getAccessToken(sa, 'https://www.googleapis.com/auth/analytics.readonly');
+  const url = `https://analyticsdata.googleapis.com/v1beta/${propertyId}:runReport`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      dateRanges: [{ startDate, endDate }],
+      dimensions: [{ name: 'pagePath' }],
+      metrics: [{ name: 'screenPageViews' }],
+      limit: 100000,
+    }),
+  });
+  if (!res.ok) throw new Error(`GA4 ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return (data.rows || []).map((r) => ({
+    path: r.dimensionValues?.[0]?.value || '',
+    views: parseInt(r.metricValues?.[0]?.value || '0', 10),
+  }));
+}
+
+async function fetchPosthog(startDate, endDate) {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || 'https://eu.posthog.com').replace(/\/$/, '');
+  if (!apiKey || !projectId) throw new Error('POSTHOG_PERSONAL_API_KEY/POSTHOG_PROJECT_ID unset');
+  // Restrict to cluster prefixes (ricerca/search/suche/recherche) under any
+  // job-section root, so the HogQL query stays under PostHog's 60s timeout
+  // on the full pageview firehose.
+  const query = `
+    SELECT properties.$pathname AS path, count() AS views
+    FROM events
+    WHERE event = '$pageview'
+      AND properties.$pathname IS NOT NULL
+      AND (
+        properties.$pathname LIKE '/cerca-lavoro-%/ricerca-%'
+        OR properties.$pathname LIKE '/en/find-jobs-%/search-%'
+        OR properties.$pathname LIKE '/de/jobs-im-%/suche-%'
+        OR properties.$pathname LIKE '/de/jobs-in-%/suche-%'
+        OR properties.$pathname LIKE '/fr/trouver-emploi-%/recherche-%'
+      )
+      AND timestamp >= toDateTime('${startDate} 00:00:00')
+      AND timestamp <= toDateTime('${endDate} 23:59:59')
+    GROUP BY path
+    LIMIT 10000
+  `.trim();
+  const url = `${host}/api/projects/${projectId}/query/`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+  });
+  if (!res.ok) throw new Error(`PostHog ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return (data.results || []).map((row) => ({ path: row[0], views: row[1] }));
+}
+
+async function main() {
+  const today = new Date();
+  const endDate = today.toISOString().slice(0, 10);
+  const startD = new Date(today);
+  startD.setDate(startD.getDate() - days);
+  const startDate = startD.toISOString().slice(0, 10);
+
+  console.error(`[indexed-cluster-urls] lookback ${startDate} → ${endDate} (${days} days), min impressions/views = ${minImpressions}`);
+
+  const indexed = new Set();
+  const sources = { gsc: { ok: false }, ga4: { ok: false }, posthog: { ok: false } };
+  const sa = loadServiceAccount();
+
+  // ─── GSC ───────────────────────────────────────────────────────────────
+  if (sa) {
+    try {
+      const rows = await fetchGsc(sa, startDate, endDate);
+      let clusterSeen = 0, kept = 0;
+      for (const row of rows) {
+        const raw = pathFromUrl(row.keys?.[0]);
+        const normalized = normalizeClusterPath(raw);
+        if (!normalized) continue;
+        clusterSeen += 1;
+        if (row.impressions < minImpressions) continue;
+        indexed.add(normalized);
+        kept += 1;
+      }
+      sources.gsc = { ok: true, rowsScanned: rows.length, clusterSeen, kept };
+      console.error(`[indexed-cluster-urls] GSC: ${kept} non-aggregator cluster paths kept from ${clusterSeen} cluster URLs (${rows.length} rows scanned)`);
+    } catch (err) {
+      sources.gsc = { ok: false, reason: err.message };
+      console.error(`[indexed-cluster-urls] GSC: ${err.message}`);
+    }
+  } else {
+    sources.gsc = { ok: false, reason: 'no service account' };
+    console.error('[indexed-cluster-urls] GSC: no service account');
+  }
+
+  // ─── GA4 ───────────────────────────────────────────────────────────────
+  if (sa && process.env.GA4_PROPERTY_ID) {
+    try {
+      const rows = await fetchGa4(sa, startDate, endDate);
+      let clusterSeen = 0, kept = 0;
+      for (const row of rows) {
+        const normalized = normalizeClusterPath(row.path);
+        if (!normalized) continue;
+        clusterSeen += 1;
+        if (row.views < minImpressions) continue;
+        indexed.add(normalized);
+        kept += 1;
+      }
+      sources.ga4 = { ok: true, rowsScanned: rows.length, clusterSeen, kept };
+      console.error(`[indexed-cluster-urls] GA4: ${kept} non-aggregator cluster paths kept from ${clusterSeen} cluster URLs (${rows.length} rows)`);
+    } catch (err) {
+      sources.ga4 = { ok: false, reason: err.message };
+      console.error(`[indexed-cluster-urls] GA4: ${err.message}`);
+    }
+  } else {
+    sources.ga4 = { ok: false, reason: 'missing GA4_PROPERTY_ID or service account' };
+    console.error('[indexed-cluster-urls] GA4: skipped (missing credentials)');
+  }
+
+  // ─── PostHog ───────────────────────────────────────────────────────────
+  if (process.env.POSTHOG_PERSONAL_API_KEY && process.env.POSTHOG_PROJECT_ID) {
+    try {
+      const rows = await fetchPosthog(startDate, endDate);
+      let clusterSeen = 0, kept = 0;
+      for (const row of rows) {
+        const normalized = normalizeClusterPath(row.path);
+        if (!normalized) continue;
+        clusterSeen += 1;
+        if (row.views < minImpressions) continue;
+        indexed.add(normalized);
+        kept += 1;
+      }
+      sources.posthog = { ok: true, rowsScanned: rows.length, clusterSeen, kept };
+      console.error(`[indexed-cluster-urls] PostHog: ${kept} non-aggregator cluster paths kept from ${clusterSeen} cluster URLs (${rows.length} rows)`);
+    } catch (err) {
+      sources.posthog = { ok: false, reason: err.message };
+      console.error(`[indexed-cluster-urls] PostHog: ${err.message}`);
+    }
+  } else {
+    sources.posthog = { ok: false, reason: 'missing POSTHOG_* env' };
+    console.error('[indexed-cluster-urls] PostHog: skipped (missing credentials)');
+  }
+
+  // Merge previous indexed list so a temporarily-unavailable source can't
+  // shrink the mirror set. Same UNION policy as refresh-noslash-keep.mjs:
+  // paths only disappear when all sources agree they're dead AND we
+  // re-publish the same file — for safety we keep them forever in the
+  // current revision (cheap: file scales with traffic, not corpus).
+  let prev = null;
+  if (fs.existsSync(OUT_PATH)) {
+    try {
+      prev = JSON.parse(fs.readFileSync(OUT_PATH, 'utf8'));
+    } catch {
+      prev = null;
+    }
+  }
+  if (prev && Array.isArray(prev.indexedPaths)) {
+    for (const p of prev.indexedPaths) {
+      const normalized = normalizeClusterPath(p);
+      if (normalized) indexed.add(normalized);
+    }
+  }
+
+  const indexedPaths = Array.from(indexed).sort();
+  const output = {
+    refreshedAt: new Date().toISOString(),
+    lookbackDays: days,
+    minImpressions,
+    sources,
+    indexedCount: indexedPaths.length,
+    indexedPaths,
+  };
+  fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
+  fs.writeFileSync(OUT_PATH, JSON.stringify(output, null, 2) + '\n');
+  console.error(`[indexed-cluster-urls] Wrote ${OUT_PATH} — ${indexedPaths.length} indexed cluster paths total (union of GSC/GA4/PostHog + previous list)`);
+}
+
+main().catch((err) => {
+  console.error('[indexed-cluster-urls] Fatal:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Cosa

Estende il pattern del workflow `refresh-noslash-keep` (settimanale, union di GSC + GA4 + PostHog) al mirror set dei cluster orphans introdotti in PR #704.

## Perché

PR #704 emette mirror per ogni cluster a 2 path di default: `TI` + `legacyCantonGroup` (canton del top-match al build corrente). Ma se Google ha indicizzato in passato un cluster su un cantone diverso (es. cluster pinnato a BL un mese fa, oggi pinnato a ZH), quella URL BL non è coperta dai default e diventa 404. Questo PR aggiunge un terzo input per il mirror set: l'union dei path che ANCORA ricevono traffico secondo GSC/GA4/PostHog.

## Pezzi

1. `scripts/refresh-indexed-cluster-urls.mjs` — modellato 1:1 su `refresh-noslash-keep.mjs`:
   - Stesso loader Firebase SA, stesso JWT/getAccessToken, stesso pattern fetch GSC/GA4/PostHog.
   - Filtro: regex `CLUSTER_PATH_RX` accetta `/[locale/]?(cerca-lavoro|find-jobs|jobs-im|jobs-in|jobs-in-der|trouver-emploi)-{canton}/(ricerca|search|suche|recherche)-{slug}/` ESCLUSO svizzera/switzerland/schweiz/suisse (sono il canonico).
   - Union con la versione precedente del file, normalizzata trailing-slash + lowercase.
   - Output: `data/indexed-cluster-urls.json` con stesso schema (`refreshedAt`, `lookbackDays`, `sources`, `indexedCount`, `indexedPaths`).

2. `.github/workflows/refresh-indexed-cluster-urls.yml` — gemello speculare:
   - Cron `10 5 * * 1` (lunedì 05:10 UTC, 10 min dopo `refresh-noslash-keep` per evitare lock concorrenti su origin).
   - Stesse step: checkout, setup-node, npm ci, Firebase SA → /tmp, `load-rc-env.mjs` per `GA4_PROPERTY_ID` + `POSTHOG_*`, run script, commit-if-changed con `git-push-with-retry.sh`.
   - `workflow_dispatch` con input `days` + `min_impressions` per refresh manuali.

3. `build-plugins/relatedSearchClustersPlugin.ts`:
   - `loadIndexedClusterUrls(rootDir)`: legge il JSON, parsa ogni path via `parseClusterPathKey()` (regex tenuta in lockstep con quella dello script), bucket per `${locale}::${slug}` → `Map<string, string[]>`.
   - Emit loop dei mirror: unisce 3 sorgenti in un Set di path assoluti (legacyCantonGroup, TI, indexed extras) + guard `mirrorPaths.delete(out.urlPath)` contro collisione con canonico.
   - `CACHE_KEY_INPUTS` include il nuovo JSON → refresh settimanale invalida correttamente la cache cluster.

4. `data/indexed-cluster-urls.json` — stub vuoto bootstrap. Il primo run del workflow dopo merge lo popola con dati reali.

## Test plan

- [x] Stub vuoto: build legge il JSON, `indexedClusterUrlsByKey.size === 0`, emit loop produce solo i 2 default mirror (TI + legacyCantonGroup). No cambio comportamento vs PR #704.
- [ ] Post-merge: `gh workflow run refresh-indexed-cluster-urls.yml --ref main` per popolare il JSON, verifica auto-commit del file.
- [ ] Post-deploy successivo: verificare che URL GSC-indicizzate fuori da TI+legacyCanton ora ritornino 200 con canonical → Svizzera.

## Note

- Il regex `CLUSTER_PATH_PARSE_RX` nel plugin e `CLUSTER_PATH_RX` nello script DEVONO restare in lockstep — c'è un commento di warning nel plugin. Se aggiungi una nuova locale o un nuovo prefisso job-section, aggiorna entrambi.
- Costo build addizionale: dipende dal numero di path che GSC restituisce. Per un sito che ha ~120k cluster non-svizzera potenzialmente indicizzati, GSC ne riporta probabilmente <10k come realmente attivi (impressioni ≥1 negli ultimi 90 giorni). Mirror extra stimati: ~10k file (≈ ~3-5% in più rispetto al baseline post-#704).

🤖 Generated with [Claude Code](https://claude.com/claude-code)