### PR TITLE
fix(ci): scope DAYS/MIN_IMP at job level so commit step can expand them

### DIFF
--- a/.github/workflows/refresh-indexed-cluster-urls.yml
+++ b/.github/workflows/refresh-indexed-cluster-urls.yml
@@ -34,6 +34,15 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Job-level env so BOTH the run-script step and the commit step can read
+    # $DAYS / $MIN_IMP. A step-scoped `env:` only on the run-script step
+    # leaves these unset for the commit step, where `--regenerate-cmd
+    # "... $DAYS ..."` is expanded by bash under `set -euo pipefail` and
+    # aborts the push (run 26558153944: local commit OK, push aborted,
+    # runner discarded the commit).
+    env:
+      DAYS: ${{ inputs.days || '90' }}
+      MIN_IMP: ${{ inputs.min_impressions || '1' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -64,9 +73,6 @@ jobs:
         run: node scripts/load-rc-env.mjs
 
       - name: Refresh indexed cluster URL list
-        env:
-          DAYS: ${{ inputs.days || '90' }}
-          MIN_IMP: ${{ inputs.min_impressions || '1' }}
         run: node scripts/refresh-indexed-cluster-urls.mjs --days "$DAYS" --min-impressions "$MIN_IMP"
 
       - name: Commit if changed

--- a/.github/workflows/refresh-noslash-keep.yml
+++ b/.github/workflows/refresh-noslash-keep.yml
@@ -32,6 +32,15 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Job-level env so BOTH the run-script step and the commit step can read
+    # $DAYS / $MIN_IMP. A step-scoped `env:` on just one step leaves these
+    # unset for the commit step, where `--regenerate-cmd "... $DAYS ..."`
+    # is expanded by bash under `set -euo pipefail` and aborts the push
+    # (manifested on the cluster sibling workflow at run 26558153944: local
+    # commit OK, push aborted, runner discarded the commit).
+    env:
+      DAYS: ${{ inputs.days || '90' }}
+      MIN_IMP: ${{ inputs.min_impressions || '1' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -62,9 +71,6 @@ jobs:
         run: node scripts/load-rc-env.mjs
 
       - name: Refresh no-slash keep-list
-        env:
-          DAYS: ${{ inputs.days || '90' }}
-          MIN_IMP: ${{ inputs.min_impressions || '1' }}
         run: node scripts/refresh-noslash-keep.mjs --days "$DAYS" --min-impressions "$MIN_IMP"
 
       - name: Commit if changed


### PR DESCRIPTION
## Bug

Run 26558153944 di \`refresh-indexed-cluster-urls.yml\` ha fallito al push step:
\`\`\`
[main eb1b2858] chore(seo): refresh indexed cluster URLs (GSC+GA4+PostHog union)
 1 file changed, 4924 insertions(+), 6 deletions(-)
.../sh: line 10: DAYS: unbound variable
\`\`\`
Lo script ha scritto correttamente i 4924 path indicizzati, ma il commit step ha abortito perché \`\$DAYS\` non è in scope.

## Causa

\`env:\` step-scoped sul "Refresh ... list" step → \$DAYS visibile solo lì. Il "Commit if changed" step usa \`--regenerate-cmd "... \$DAYS ..."\` (bash espande PRIMA di passare l'arg) sotto \`set -euo pipefail\` → exit 1.

## Fix

Sposto \`env:\` a job level → entrambi gli step vedono \$DAYS/\$MIN_IMP.

Stesso bug latente in \`refresh-noslash-keep.yml\` (sibling che è stato copiato/usato come template per il cluster workflow) → fix in lockstep. Quel workflow non era mai partito quindi non aveva ancora innescato il bug, ma il lunedì 05:00 UTC lo avrebbe rotto allo stesso modo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)