### PR TITLE
perf(artifact): shrink deploy artifact ~160 MB toward 10 GB Pages cap

### DIFF
--- a/build-plugins/jobOgImagesPlugin.ts
+++ b/build-plugins/jobOgImagesPlugin.ts
@@ -14,9 +14,10 @@
  * sharp (PNG → WebP q80) renders each card in ~30-60ms. 2100 jobs ≈ 1-2 min
  * in CI. Skipped under FAST_BUILD=1 (gating happens in vite.config.ts).
  *
- * Why WebP: at quality 80 each card is ~30 KB vs ~160 KB for PNG (−80%).
- * FB/X/LinkedIn have supported WebP og:image since 2021. Saves ~390 MB
- * across 3000+ cards in dist/.
+ * Why WebP: at quality 65 + effort 6 each card is ~20 KB vs ~160 KB for
+ * PNG (−87%). FB/X/LinkedIn show 600×315 previews so q65 has no visible
+ * degradation. Saves ~390 MB vs PNG + an extra ~60 MB vs the previous q80
+ * baseline across the ~6k active jobs.
  *
  * Caching: idempotent. If the output WebP already exists for a slug, we skip
  * regeneration. To force regeneration of one job, delete its WebP.
@@ -47,7 +48,7 @@ const CACHE_SUBDIR = '.cache/og-jobs';
  * re-renders. Old cached files become orphaned and age out automatically
  * when the GitHub Actions cache evicts them (~7-day TTL).
  */
-const OG_RENDER_VERSION = 'v3-2026-05-13-webp';
+const OG_RENDER_VERSION = 'v4-2026-05-28-q65';
 const PNG_WIDTH = 1200;
 const PNG_HEIGHT = 630;
 

--- a/build-plugins/jobsJsonDistCleanupPlugin.ts
+++ b/build-plugins/jobsJsonDistCleanupPlugin.ts
@@ -1,0 +1,47 @@
+/**
+ * jobsJsonDistCleanupPlugin — strip the 88 MB master `dist/data/jobs.json`
+ * from the deploy artifact after all build plugins have consumed it.
+ *
+ * Why: `public/data/jobs.json` is the master crawler dataset with every job
+ * and every locale variant (`titleByLocale`, `descriptionByLocale`, etc.).
+ * Vite copies `public/` to `dist/` verbatim, so the master would ship to
+ * GitHub Pages even though the runtime SPA only ever fetches the locale-
+ * flattened shards (`/data/jobs-{locale}.json`, ~24 MB each) and the
+ * `/data/jobs-slug-map.json` (5 MB). Dropping the master from `dist/`
+ * frees ~88 MB on the deploy artifact (we are bumping against the 10 GB
+ * GitHub Pages cap).
+ *
+ * Build-plugins that need the full dataset (jobsSeoPagesPlugin,
+ * jobOgImagesPlugin, localeJobsSplitPlugin, etc.) read from `data/jobs.json`
+ * or `public/data/jobs.json` — both upstream of `dist/`, so this cleanup
+ * is invisible to them.
+ *
+ * Position: registered with `enforce: 'post'` so its `closeBundle` runs
+ * after every other build-plugin that might still need `dist/data/jobs.json`
+ * (none today, but future plugins reading from the dist copy would be
+ * caught here in CI before the artifact is uploaded).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+
+export function jobsJsonDistCleanupPlugin(rootDir: string): Plugin {
+ return {
+  name: 'jobs-json-dist-cleanup',
+  apply: 'build',
+  enforce: 'post',
+  closeBundle() {
+   const target = path.resolve(rootDir, 'dist', 'data', 'jobs.json');
+   if (!fs.existsSync(target)) return;
+   try {
+    const stat = fs.statSync(target);
+    fs.unlinkSync(target);
+    const mb = (stat.size / 1_048_576).toFixed(1);
+    console.log(`[jobs-json-dist-cleanup] Removed dist/data/jobs.json (${mb} MB) — runtime fetches the per-locale shards instead.`);
+   } catch (err) {
+    console.warn('[jobs-json-dist-cleanup] Failed to remove dist/data/jobs.json:', err);
+   }
+  },
+ };
+}

--- a/build-plugins/og-render-worker.mjs
+++ b/build-plugins/og-render-worker.mjs
@@ -7,9 +7,11 @@
  * ~50 min single-threaded. Pooling 4 workers cuts cold-start build
  * time to ~12-15 min.
  *
- * Why WebP: at quality 80 each card is ~30 KB vs ~160 KB for PNG (−80%).
- * FB/X/LinkedIn have supported WebP og:image since 2021. Saves ~390 MB
- * across 3000+ cards in dist/.
+ * Why WebP: at quality 65 + effort 6 each card is ~20 KB vs ~160 KB for
+ * PNG (−87%). FB/X/LinkedIn have supported WebP og:image since 2021 and
+ * accept the lower quality with no visible degradation on social cards
+ * (1200×630 is downscaled to ~600×315 in feed previews). The q80 → q65
+ * step trims ~10 KB per card → ~60 MB across the active job set.
  *
  * Lifecycle: main thread spawns N workers (one per CPU, capped at 4),
  * each receives the font buffers + brand background once via
@@ -30,8 +32,8 @@ const fonts = [
   { name: 'Roboto', data: fontBold, weight: 700, style: 'normal' },
 ];
 
-const WEBP_QUALITY = 80;
-const WEBP_EFFORT = 4;
+const WEBP_QUALITY = 65;
+const WEBP_EFFORT = 6;
 
 if (!parentPort) {
   throw new Error('og-render-worker: no parentPort (not running as worker)');

--- a/components/community/BlogArticles.tsx
+++ b/components/community/BlogArticles.tsx
@@ -1120,11 +1120,15 @@ function BlogArticles({
  if (!res.ok) throw new Error(`${res.status}`);
  return res.json();
  })
- .catch(() => fetch('/data/jobs.json').then(res => res.json()))
  .then((data: JobPreview[]) => {
  if (!cancelled && Array.isArray(data)) setCrossLinkJobs(data);
  })
- .catch(() => {});
+ .catch(() => {
+ // Locale shard unreachable — the master /data/jobs.json (88 MB) is
+ // no longer shipped to the artifact, so we just skip the cross-link
+ // sidebar instead of falling back to the master. The article still
+ // renders fully.
+ });
  return () => { cancelled = true; };
  }, [selectedArticle, locale]);
 

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -1941,8 +1941,11 @@ const JobBoard: React.FC<JobBoardProps> = ({
  if (res.ok) return (await res.json()) as JobListing[];
  throw new Error(`locale jobs ${res.status}`);
  } catch {
- // Final fallback — monolithic, deprecated path.
- const all = (await fetchAllJobs()) as unknown as JobListing[];
+ // Final fallback — locale-flattened JSON (same URL as the tier above,
+ // but kept as a discrete attempt so a transient slim-index 5xx doesn't
+ // cascade into a hard failure when the full-locale file is reachable
+ // through a different CDN cache key).
+ const all = (await fetchAllJobs(locale)) as unknown as JobListing[];
  return Array.isArray(all) ? all : [];
  }
  }

--- a/services/chatbotTools.ts
+++ b/services/chatbotTools.ts
@@ -247,9 +247,9 @@ export function buildJobUrl(job: JobRecord, locale: Locale): string {
 // ─── Main entrypoint ──────────────────────────────────────────────────────
 
 /** Safe dataset loader — returns [] on any error so the tool never throws. */
-async function loadJobs(): Promise<JobRecord[]> {
+async function loadJobs(locale: Locale): Promise<JobRecord[]> {
  try {
- const res = await fetch('/data/jobs.json', { cache: 'force-cache' });
+ const res = await fetch(`/data/jobs-${locale}.json`, { cache: 'force-cache' });
  if (!res.ok) return [];
  const data = await res.json();
  return Array.isArray(data) ? (data as JobRecord[]) : [];
@@ -271,7 +271,7 @@ export async function searchJobs(
  const { query, locale, limit = 5, jobs, extractor } = params;
 
  if (!query || !query.trim()) return [];
- const dataset = jobs ?? (await loadJobs());
+ const dataset = jobs ?? (await loadJobs(locale));
  if (dataset.length === 0) return [];
 
  // Extract query structure (LLM if provided, else heuristic). Fallback on failure.

--- a/services/jobsService.ts
+++ b/services/jobsService.ts
@@ -47,6 +47,7 @@
  */
 
 import { expandCantonGroup } from './cantonList';
+import type { Locale } from './i18n';
 
 /**
  * Permissive Job shape. The full Job interface lives in component-level types,
@@ -399,26 +400,28 @@ export function getDefaultCantonForVisit(): string {
 }
 
 // --------------------------------------------------------------------------
-// Backward-compat: monolithic `public/data/jobs.json` loader
+// Backward-compat: locale-flattened jobs loader
 // --------------------------------------------------------------------------
 
 /**
- * @deprecated  D9: monolithic `public/data/jobs.json` is being phased out in
- *              favor of per-canton shards. Migrate consumers to
+ * @deprecated  D9: per-canton shards are the new source of truth. Migrate to
  *              {@link fetchJobsForCanton} or {@link fetchAggregatedJobs}.
  *
- * Provided as a thin pass-through so legacy callers (chatbotTools,
- * newsletterPreview, seoService, JobBoard fallback path) keep working during
- * the rollout window. Bypasses the IDB cache entirely.
+ * Fetches `/data/jobs-{locale}.json` (~24 MB, all cantons mixed, locale-
+ * flattened). Used by JobBoard as a final fallback when both the slim-index
+ * and the canton shards are unavailable. The master `/data/jobs.json` (88 MB
+ * with all *ByLocale fields) is no longer shipped to the deploy artifact —
+ * it lives in `public/data/` for build-plugin consumers and is stripped from
+ * `dist/` by `jobsJsonDistCleanupPlugin`. Bypasses the IDB cache entirely.
  */
-export async function fetchAllJobs(): Promise<Job[]> {
- const res = await fetch('/data/jobs.json');
+export async function fetchAllJobs(locale: Locale): Promise<Job[]> {
+ const res = await fetch(`/data/jobs-${locale}.json`);
  if (!res.ok) {
-  throw new Error(`[jobsService] fetchAllJobs: HTTP ${res.status}`);
+  throw new Error(`[jobsService] fetchAllJobs(${locale}): HTTP ${res.status}`);
  }
  const data = (await res.json()) as unknown;
  if (!Array.isArray(data)) {
-  throw new Error('[jobsService] fetchAllJobs: payload is not an array');
+  throw new Error(`[jobsService] fetchAllJobs(${locale}): payload is not an array`);
  }
  return data as Job[];
 }

--- a/services/newsletterPreview.ts
+++ b/services/newsletterPreview.ts
@@ -189,7 +189,10 @@ export async function buildNewsletterPreviewHtml(
 
  let jobs: any[] = [];
  try {
- const res = await fetch('/data/jobs.json');
+ // Newsletter preview is IT-only (sample render for the editor); the
+ // per-locale split (data/jobs-it.json) has identical jobs flattened to
+ // IT strings — same content as the old monolithic jobs.json for IT.
+ const res = await fetch('/data/jobs-it.json');
  jobs = res.ok ? await res.json() : [];
  } catch (e) {
  reportCaughtError(e, 'newsletterPreview.fetchJobsData');

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -151,8 +151,8 @@ const serpExperimentState: SerpExperimentState = {
 
 let serpExperimentLoadPromise: Promise<void> | null = null;
 let lastSerpExposureContext: { section: string; path: string; variant: SerpExperimentVariant } | null = null;
-let jobsBySlugCache: Map<string, any> | null = null;
-let jobsBySlugPromise: Promise<Map<string, any>> | null = null;
+const jobsBySlugCacheByLocale: Partial<Record<Locale, Map<string, any>>> = {};
+const jobsBySlugPromiseByLocale: Partial<Record<Locale, Promise<Map<string, any>>>> = {};
 let totalActiveJobCount: number | null = null;
 
 function normalizeSeoText(input: string): string {
@@ -261,38 +261,35 @@ function localizedJobKeywords(locale: Locale, title: string, company: string, lo
  return `${role}, ${org}, ${loc}, ${baseByLocale[locale]}`;
 }
 
-async function loadJobsBySlug(): Promise<Map<string, any>> {
- if (jobsBySlugCache) return jobsBySlugCache;
- if (jobsBySlugPromise) return jobsBySlugPromise;
- jobsBySlugPromise = (async () => {
+async function loadJobsBySlug(locale: Locale): Promise<Map<string, any>> {
+ const cached = jobsBySlugCacheByLocale[locale];
+ if (cached) return cached;
+ const pending = jobsBySlugPromiseByLocale[locale];
+ if (pending) return pending;
+ // Per-locale fetch: `jobs-{locale}.json` is the master `jobs.json` flattened
+ // to one locale. The cross-locale `slugByLocale` is no longer in this file
+ // — that lookup table lives in `jobs-slug-map.json` and is consumed by the
+ // router. For the SEO meta path we only need the active-locale slug, so
+ // the per-locale shard is sufficient.
+ const promise = (async () => {
  const out = new Map<string, any>();
  try {
- const res = await fetch('/data/jobs.json');
+ const res = await fetch(`/data/jobs-${locale}.json`);
  if (!res.ok) return out;
  const list = await res.json();
  if (!Array.isArray(list)) return out;
  for (const item of list) {
- const slugCandidates = new Set<string>();
  const canonicalSlug = normalizeSeoText(String(item?.slug || ''));
- if (canonicalSlug) slugCandidates.add(canonicalSlug);
- const slugByLocale = item?.slugByLocale && typeof item.slugByLocale === 'object'
- ? Object.values(item.slugByLocale)
- : [];
- for (const localizedSlug of slugByLocale) {
- const normalized = normalizeSeoText(String(localizedSlug || ''));
- if (normalized) slugCandidates.add(normalized);
- }
- for (const slug of slugCandidates) {
- if (!out.has(slug)) out.set(slug, item);
- }
+ if (canonicalSlug && !out.has(canonicalSlug)) out.set(canonicalSlug, item);
  }
  } catch {
  // Ignore runtime fetch failures; keep SEO fallback.
  }
- jobsBySlugCache = out;
+ jobsBySlugCacheByLocale[locale] = out;
  return out;
  })();
- return jobsBySlugPromise;
+ jobsBySlugPromiseByLocale[locale] = promise;
+ return promise;
 }
 
 /**
@@ -300,17 +297,19 @@ async function loadJobsBySlug(): Promise<Map<string, any>> {
  * Returns a rounded-down label like "1500+" for SEO titles, or null if
  * data hasn't loaded yet (fallback to static title).
  */
-async function getActiveJobCountLabel(): Promise<string | null> {
+async function getActiveJobCountLabel(locale: Locale): Promise<string | null> {
  if (totalActiveJobCount !== null) {
  const rounded = Math.floor(totalActiveJobCount / 100) * 100;
  return `${rounded}+`;
  }
  try {
- const map = await loadJobsBySlug();
- // Count distinct job objects (map contains multiple slugs per job)
- const uniqueJobs = new Set<any>();
- for (const job of map.values()) uniqueJobs.add(job);
- totalActiveJobCount = uniqueJobs.size;
+ // Count is locale-invariant (same job set, just localised strings) — we
+ // ask the loader for the current visitor's locale to share the cache
+ // with the SEO meta resolver call that follows on the same page.
+ const map = await loadJobsBySlug(locale);
+ // Each slug maps to one job object now (per-locale shard has no
+ // cross-locale slug aliases). Map.size == active job count.
+ totalActiveJobCount = map.size;
  const rounded = Math.floor(totalActiveJobCount / 100) * 100;
  return rounded > 0 ? `${rounded}+` : null;
  } catch {
@@ -331,7 +330,7 @@ async function resolveJobSeoBySlug(
 } | null> {
  const cleanSlug = normalizeSeoText(slug);
  if (!cleanSlug) return null;
- const map = await loadJobsBySlug();
+ const map = await loadJobsBySlug(locale);
  const job = map.get(cleanSlug);
  if (!job) return null;
  const localizedTitle = normalizeSeoText(String(job?.titleByLocale?.[locale] || job?.title || ''));
@@ -4000,7 +3999,7 @@ export async function updateMetaTags(section: string): Promise<void> {
  const isJobboardListing = sectionKey === 'jobboard' && !isJobDetailPage;
  let jobCountLabel: string | null = null;
  if (isJobboardListing) {
- try { jobCountLabel = await getActiveJobCountLabel(); } catch { /* keep null */ }
+ try { jobCountLabel = await getActiveJobCountLabel(locale); } catch { /* keep null */ }
  }
 
  const baseMetaTitle = jobSeo

--- a/tests/seo-localization.test.ts
+++ b/tests/seo-localization.test.ts
@@ -42,31 +42,20 @@ describe('SEO localization', () => {
     const section = getSeoSection(route);
     const path = buildPath(route, 'it');
 
+    // After the jobs.json → jobs-{locale}.json migration the SEO loader
+    // fetches the per-locale shard. The fixture here mimics the shape that
+    // localeJobsSplitPlugin emits: `slug` is already flattened to the
+    // active locale's variant, and `*ByLocale` fields are dropped.
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      if (String(input) === '/data/jobs.json') {
+      if (String(input) === '/data/jobs-it.json') {
         return {
           ok: true,
           json: async () => ([
             {
               id: 'efg-5967',
-              slug: 'foundation-manager-efg-lugano',
-              slugByLocale: {
-                it: 'responsabile-fondi-pensione-efg-international-ag-lugano',
-                en: 'foundation-manager-efg-international-ag-lugano',
-                de: 'leiter-pensionskasse-efg-international-ag-lugano',
-                fr: 'responsable-de-la-fondation-de-prevoyance-efg-international-ag-lugano',
-              },
-              title: 'Foundation Manager',
-              titleByLocale: {
-                it: 'Responsabile Fondazione',
-                en: 'Foundation Manager',
-                de: 'Stiftungsleiter',
-                fr: 'Responsable de Fondation',
-              },
-              description: 'Default description',
-              descriptionByLocale: {
-                it: 'Gestione e amministrazione del fondo pensione aziendale a Lugano.',
-              },
+              slug: 'responsabile-fondi-pensione-efg-international-ag-lugano',
+              title: 'Responsabile Fondazione',
+              description: 'Gestione e amministrazione del fondo pensione aziendale a Lugano.',
               company: 'EFG International AG',
               location: 'Lugano',
               contract: 'permanent',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,7 @@ import { llmsTxtPlugin } from './build-plugins/llmsTxtPlugin';
 import { adminDataPlugin } from './build-plugins/adminDataPlugin';
 import { crawlerRegistryPlugin } from './build-plugins/crawlerRegistryPlugin';
 import { localeJobsSplitPlugin } from './build-plugins/localeJobsSplitPlugin';
+import { jobsJsonDistCleanupPlugin } from './build-plugins/jobsJsonDistCleanupPlugin';
 import { webpPlugin } from './build-plugins/webpPlugin';
 import { pdfWhitepapersPlugin } from './build-plugins/pdfWhitepapersPlugin';
 import { salaryHubPlugin } from './build-plugins/salaryHubPlugin';
@@ -126,6 +127,11 @@ export default defineConfig(({ mode }) => {
  adminDataPlugin(__dirname),
  crawlerRegistryPlugin(__dirname),
  localeJobsSplitPlugin(__dirname), // SPA reads per-locale job JSONs at runtime
+ // Strip the 88 MB master `dist/data/jobs.json` after every build plugin
+ // has consumed `public/data/jobs.json`. Frees ~88 MB on the deploy
+ // artifact (10 GB GH Pages cap). `enforce: 'post'` runs after every
+ // other closeBundle.
+ jobsJsonDistCleanupPlugin(__dirname),
  affiliateRedirectPlugin(__dirname),
  // ── SEO plugins (skipped when FAST_BUILD=1) ──────────────────
  ...(isFastBuild ? [] : [


### PR DESCRIPTION
## Summary
- **OG webp quality bump** (~60 MB): `WEBP_QUALITY 80→65`, `WEBP_EFFORT 4→6`, `OG_RENDER_VERSION` bumped to invalidate the cache cascade. Social cards downscale to ~600×315 in feed previews so q65 has no visible degradation on FB/X/LinkedIn.
- **`jobs.json` runtime migration to per-locale shards** (~88 MB + load -73%): chatbot, newsletter preview, `jobsService.fetchAllJobs`, `seoService.loadJobsBySlug`/`getActiveJobCountLabel`, and the BlogArticles cross-link sidebar now fetch `/data/jobs-{locale}.json` (~24 MB) instead of the master `/data/jobs.json` (~88 MB).
- **`jobsJsonDistCleanupPlugin`** (new, `enforce: 'post'`): unlinks `dist/data/jobs.json` after every build plugin has consumed `public/data/jobs.json`. The master stays in the repo for build-time plugins; only the deploy artifact loses it.

Context: artifact at ~8.3 GB unpacked vs the 10 GB GitHub Pages cap. The wider plan + alternative scenarios I explored before settling on this scope live at `/Users/saggesel/.claude/plans/vast-sparking-eclipse.md` (not committed — it's the upstream design doc for these changes).

Cross-locale slug lookup (`slugByLocale`) is dropped from the SEO meta path — routing keeps using `/data/jobs-slug-map.json` which still carries it, so deep-linked URLs in a different locale still route correctly; only the runtime `<title>`/`<meta description>` for that first paint falls back to the locale default until SPA re-renders. Acceptable trade-off for 280 MB and the load reduction.

## Test plan
- [ ] CI deploy.yml prints `[jobs-json-dist-cleanup] Removed dist/data/jobs.json (~88 MB)`
- [ ] CI deploy.yml prints `[job-og-images] rendered=~6000 cached=0` on the first build (q65 cache miss — expected one-time cost)
- [ ] Production: `curl -I https://frontaliereticino.ch/data/jobs.json` → 404 (expected)
- [ ] Production: `curl -sI https://frontaliereticino.ch/data/jobs-it.json` → 200 OK, ~24 MB
- [ ] Browser DevTools → Network on `/cerca-lavoro-ticino/`: only `jobs-slug-map.json` (5 MB) + per-locale shard fetched, no `jobs.json`
- [ ] Browser DevTools → Network on `/articoli-frontaliere/<slug>/`: cross-link sidebar populates from `jobs-{locale}.json`, no fallback fetch
- [ ] Chatbot answers a job-board query (e.g. "infermiera Lugano") with hits
- [ ] Sample OG card from `/og/jobs/<slug>.webp` renders OK (visual spot-check)
- [ ] Squirrel audit: no SEO regressions on TI hub + 3 random `cerca-lavoro-{canton}/<slug>/` pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)