### PR TITLE
fix(seo): bridge dotfile regression crashing article RPM + rollback robustness

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1166,11 +1166,39 @@ jobs:
             "repos/${{ github.repository }}/actions/runs/${{ steps.last-good.outputs.run-id }}/artifacts" \
             --jq '[.artifacts[] | select(.name == "github-pages")] | sort_by(.created_at) | .[0].id // empty')
           if [ -z "$artifact_id" ]; then
-            echo "::error::No github-pages artifact in run ${{ steps.last-good.outputs.run-id }}"
-            exit 1
+            # GitHub Pages artifacts have a 1-hour retention by default;
+            # when the last-known-good is older than that, the artifact is
+            # gone and we cannot fast-rollback by re-uploading. Surface a
+            # warning, leave `id` empty, and let the next step dispatch a
+            # fresh build at the last-known-good SHA as the slow-path
+            # fallback. Incident 2026-05-28 (validation run 10723) wedged
+            # prod for hours because this branch used to `exit 1`.
+            echo "::warning::No github-pages artifact in run ${{ steps.last-good.outputs.run-id }} (likely expired past 1h Pages retention) — will dispatch fresh deploy at last-good SHA"
+            echo "id=" >> "$GITHUB_OUTPUT"
+          else
+            echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
+            echo "Resolved last-good github-pages artifact id: $artifact_id"
           fi
-          echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
-          echo "Resolved last-good github-pages artifact id: $artifact_id"
+
+      # Slow-path rollback: dispatch a fresh `Deploy to GitHub Pages`
+      # workflow_dispatch run pinned to the last-known-good SHA. Used when
+      # the artifact-fast-path above couldn't find the artifact (expired
+      # past Pages' 1-hour retention). Re-runs the full build (~10-15 min)
+      # but produces a guaranteed-good dist that is independent of artifact
+      # retention windows.
+      - name: Dispatch fresh deploy at last-known-good SHA (fallback when artifact expired)
+        if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != '' && steps.last-good-artifact.outputs.id == '' && steps.last-good.outputs.sha != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching deploy.yml at last-known-good SHA ${{ steps.last-good.outputs.sha }}"
+          gh workflow run deploy.yml --ref ${{ steps.last-good.outputs.sha }} \
+            || {
+              echo "::error::Failed to dispatch fresh deploy at last-known-good SHA. Manual recovery required: gh workflow run deploy.yml --ref ${{ steps.last-good.outputs.sha }}"
+              exit 1
+            }
+          echo "Fresh deploy dispatched. Watch: https://github.com/${{ github.repository }}/actions/workflows/deploy.yml"
 
       - name: Download last known good GitHub Pages artifact (by id)
         if: steps.still-live.outputs.still_live == 'true' && steps.last-good.outputs.run-id != '' && steps.last-good-artifact.outputs.id != ''
@@ -1242,9 +1270,14 @@ jobs:
           **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Last good (NOT rolled back):** ${{ steps.last-good.outputs.run-id }}"
           elif [ "${{ steps.rollback_deploy.outcome }}" = "success" ]; then
-            MSG="## Rollback eseguito
+            MSG="## Rollback eseguito (artifact fast-path)
           **Rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})
           **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          elif [ -z "${{ steps.last-good-artifact.outputs.id }}" ] && [ -n "${{ steps.last-good.outputs.sha }}" ]; then
+            MSG="## Rollback via fresh deploy (slow-path: artifact expired)
+          **Dispatched fresh build at sha:** ${{ steps.last-good.outputs.sha }} (last-good run ${{ steps.last-good.outputs.run-id }})
+          **Validation run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          Pages artifact past 1h retention — full rebuild in progress (~10-15 min)."
           else
             MSG="## Rollback fallito
           **Tentato rollback a run:** ${{ steps.last-good.outputs.run-id }} (sha ${{ steps.last-good.outputs.sha }})

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -375,6 +375,15 @@ jobs:
             npm run validate:sitemap-links
           spawn_capped audit:spa-bundle-injection    /tmp/spa-bundle.log \
             npm run audit:spa-bundle-injection
+          # 0-tolerance: dotfile `dist/**\/.html` files mean a plugin produced
+          # `<dir>/.html` via `path + '.html'` where `path` ended in `/`.
+          # GitHub Pages serves these for `/<dir>/` with
+          # content-type=application/octet-stream, masking the real
+          # index.html. See incident 2026-05-28: ogPagesPlugin emitted
+          # ~2 540 of these for articles, AdSense RPM crashed from 3.04 to
+          # 1.74 CHF/day.
+          spawn_capped audit:no-dotfile-html         /tmp/no-dotfile-html.log \
+            npm run audit:no-dotfile-html
           spawn_capped audit:hreflang                /tmp/g14.log \
             npm run audit:hreflang
           spawn_capped audit:sitemap-canonicals      /tmp/g15.log \

--- a/build-plugins/flatHtmlRedirectPlugin.ts
+++ b/build-plugins/flatHtmlRedirectPlugin.ts
@@ -155,6 +155,14 @@ export function transformFlatRedirect(input: FlatRedirectTransformInput): string
   const { filePath, distDir, trimmedBase, readSibling } = input;
   if (path.basename(filePath) === 'index.html') return null;
   if (!filePath.endsWith('.html')) return null;
+  // Defense-in-depth: a dotfile `<dir>/.html` is never a legitimate flat
+  // sibling of `<dir>/index.html`. Some plugins concat `+ '.html'` onto a
+  // path that may end with `/`, producing `<dir>/.html` accidentally; if
+  // we let it pass, transformFlatRedirect would emit a bridge there and
+  // GitHub Pages would serve the bridge for the `/<dir>/` URL with
+  // content-type=application/octet-stream, masking the real index.html.
+  // Skip basenames that start with a dot.
+  if (path.basename(filePath).startsWith('.')) return null;
 
   const stem = filePath.slice(0, -'.html'.length);
   const sibling = path.join(stem, 'index.html');

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -1045,8 +1045,15 @@ ${headTags}
  // Italian (primary)
  const itHtml = html('it', en.path);
  const flatItHtml = itHtml.replace(/\s*<script>location\.replace\([^<]*\)<\/script>/, '');
+ // canonicalPath is captured WITH trailing slash from seo-blog*.ts. The
+ // sibling index.html target wants the trailing slash, but the flat .html
+ // sibling must NOT inherit it — `path.join(distDir, '/foo/' + '.html')`
+ // emits a dotfile `dist/foo/.html` that GitHub Pages serves with
+ // content-type=application/octet-stream for the URL `/foo/`, masking the
+ // real `index.html`. Strip the trailing slash before the `.html` concat.
+ const itFlatPath = en.path.replace(/\/+$/, '');
  collector.add(np.join(distDir, en.path, 'index.html'), itHtml);
- collector.add(np.join(distDir, en.path + '.html'), flatItHtml);
+ collector.add(np.join(distDir, itFlatPath + '.html'), flatItHtml);
  count++;
 
  // EN / DE / FR
@@ -1054,8 +1061,12 @@ ${headTags}
  if (loc === 'it' || !lPath) continue;
  const locHtml = html(loc, lPath);
  const flatLocHtml = locHtml.replace(/\s*<script>location\.replace\([^<]*\)<\/script>/, '');
+ // Defense-in-depth: locale paths are built without trailing slash
+ // (`/${l}/${bs}/${as}`) but normalize anyway in case the source convention
+ // changes.
+ const locFlatPath = lPath.replace(/\/+$/, '');
  collector.add(np.join(distDir, lPath, 'index.html'), locHtml);
- collector.add(np.join(distDir, lPath + '.html'), flatLocHtml);
+ collector.add(np.join(distDir, locFlatPath + '.html'), flatLocHtml);
  count++;
  }
  }

--- a/build-plugins/postWalkCoordinatorPlugin.ts
+++ b/build-plugins/postWalkCoordinatorPlugin.ts
@@ -206,7 +206,8 @@ function runSingleThreaded(
     let mutated = false;
     let isBridge = false;
 
-    if (path.basename(filePath) !== 'index.html') {
+    const baseName = path.basename(filePath);
+    if (baseName !== 'index.html' && !baseName.startsWith('.')) {
       // Fast-path: pre-emitted bridge from cluster/jobs-seo plugins (commit
       // 45399c0779). Avoids a sync 30 KB sibling read + regex pass that
       // would re-derive the same bridge content. Mirrors the worker fast

--- a/build-plugins/postWalkWorker.mjs
+++ b/build-plugins/postWalkWorker.mjs
@@ -125,7 +125,8 @@ async function processFile(filePath) {
   let mutated = false;
   let isBridge = false;
 
-  if (path.basename(filePath) !== 'index.html') {
+  const baseName = path.basename(filePath);
+  if (baseName !== 'index.html' && !baseName.startsWith('.')) {
     if (isPreEmittedFlatBridge(html)) {
       // Pre-emitted by the originating plugin and byte-identical to what
       // transformFlatRedirect would produce. Counts as bridgeConverted for

--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     "audit:max-bfs-depth:rebaseline": "node scripts/audit-bfs-depth.mjs --write-baseline=data/bfs-depth-baseline.json",
     "audit:footer-root-presence": "node scripts/audit-footer-root-presence.mjs",
     "audit:no-merge-markers": "node scripts/audit-no-merge-markers.mjs",
+    "audit:no-dotfile-html": "node scripts/audit-no-dotfile-html.mjs",
     "audit:active-jobs-regression": "node scripts/check-active-jobs-regression.mjs",
     "audit:active-jobs-regression:rebaseline": "node scripts/check-active-jobs-regression.mjs --rebaseline",
     "recover:conflict-markers": "node scripts/recover-conflict-marker-slices.mjs",

--- a/scripts/audit-no-dotfile-html.mjs
+++ b/scripts/audit-no-dotfile-html.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * audit-no-dotfile-html.mjs
+ *
+ * 0-tolerance gate: fails if any HTML file emitted under `dist/` has a
+ * basename that starts with `.` (e.g. `dist/articoli-frontaliere/<slug>/.html`).
+ *
+ * Why exists: incident 2026-05-28 — `ogPagesPlugin` concatenated `+ '.html'`
+ * onto a canonicalPath that already ended in `/`, producing a dotfile
+ * `<slug>/.html` instead of the intended flat sibling `<slug>.html`. The
+ * post-walk coordinator then rewrote it into a redirect bridge. GitHub
+ * Pages served that dotfile for the trailing-slash URL with
+ * `content-type=application/octet-stream`, masking the real
+ * `<slug>/index.html` (full article) and reducing the served body to a
+ * 1.7 KB infinite-redirect stub. ~2 540 articles affected; AdSense RPM
+ * collapsed from 3.04 to 1.74 CHF in a single day because the stubs
+ * carry no SPA bundle and no AdSense tags.
+ *
+ * Wired into `post-deploy-validate-dist.yml` as a strict gate (count must
+ * stay at zero — there is no legitimate use case for a `dist/**\/.html`
+ * dotfile).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const distDir = path.resolve(process.cwd(), "dist");
+
+if (!fs.existsSync(distDir)) {
+  console.error("[audit-no-dotfile-html] dist/ not found — nothing to audit");
+  process.exit(0);
+}
+
+const offenders = [];
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip static-asset directories that may legitimately ship dotfiles
+      // (none currently, but matches the post-walk coordinator convention).
+      if (entry.name === "assets" || entry.name === "data" || entry.name === "images") continue;
+      walk(p);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".html")) continue;
+    if (entry.name.startsWith(".")) {
+      const rel = path.relative(distDir, p);
+      const size = fs.statSync(p).size;
+      offenders.push({ rel, size });
+    }
+  }
+}
+
+walk(distDir);
+
+if (offenders.length === 0) {
+  console.log("\x1b[32m[audit-no-dotfile-html]\x1b[0m PASS — no dotfile .html under dist/");
+  process.exit(0);
+}
+
+console.error(
+  `\x1b[31m[audit-no-dotfile-html]\x1b[0m FAIL — ${offenders.length} dotfile .html files under dist/`,
+);
+const sample = offenders.slice(0, 20);
+for (const o of sample) {
+  console.error(`  - dist/${o.rel} (${o.size} bytes)`);
+}
+if (offenders.length > sample.length) {
+  console.error(`  … ${offenders.length - sample.length} more`);
+}
+console.error(
+  "Hint: a build plugin likely concatenated `+ '.html'` onto a path ending in `/`. " +
+    "Strip the trailing slash before the concat (see ogPagesPlugin.ts:1049 fix).",
+);
+process.exit(1);

--- a/tests/flat-html-redirect.test.ts
+++ b/tests/flat-html-redirect.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
-import { flatHtmlRedirectPlugin } from '../build-plugins/flatHtmlRedirectPlugin';
+import { flatHtmlRedirectPlugin, transformFlatRedirect } from '../build-plugins/flatHtmlRedirectPlugin';
 
 /**
  * Verifies the redirect bridge emitted by `flatHtmlRedirectPlugin` after
@@ -132,6 +132,41 @@ describe('flatHtmlRedirectPlugin redirect bridge', () => {
     expect(bridge).toContain('og:image:height');
     expect(bridge).toContain('og:image:type');
     expect(bridge).not.toContain('twitter:title');
+  });
+
+  it('skips dotfile basenames like <dir>/.html so they never get rewritten as a bridge', () => {
+    // Regression: ogPagesPlugin used to concat `+ '.html'` onto a path that
+    // already ended in `/` (from canonicalPath), producing
+    // `dist/articoli-frontaliere/<slug>/.html`. transformFlatRedirect would
+    // then read the sibling `<slug>/index.html` (the real article), build a
+    // self-referencing bridge, and write it to the dotfile. GitHub Pages
+    // served that dotfile for the `/<slug>/` URL with content-type=
+    // application/octet-stream, masking the real article and crashing
+    // AdSense RPM. Skip basenames starting with `.` defensively.
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'flat-html-dotfile-'));
+    try {
+      const distDir = path.join(tmpRoot, 'dist');
+      const fooDir = path.join(distDir, 'foo');
+      fs.mkdirSync(fooDir, { recursive: true });
+      const dotfile = path.join(fooDir, '.html');
+      const siblingFile = path.join(fooDir, 'index.html');
+      fs.writeFileSync(dotfile, 'should not be touched');
+      fs.writeFileSync(
+        siblingFile,
+        '<!DOCTYPE html><html><head><title>Real</title></head><body>full</body></html>',
+      );
+      const readSibling = (p: string): string | null =>
+        fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null;
+      const result = transformFlatRedirect({
+        filePath: dotfile,
+        distDir,
+        trimmedBase: 'https://frontaliereticino.ch',
+        readSibling,
+      });
+      expect(result).toBeNull();
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it('falls back to a per-URL string when the sibling has no parsable title', async () => {


### PR DESCRIPTION
## Summary
Three coordinated fixes after **incident 2026-05-28** (AdSense RPM crashed **3.04 → 1.74 CHF/day** in <48h because ~2,540 of ~2,607 articles started serving a 1.7 KB infinite-redirect stub with no SPA bundle, no AdSense tags, and `noindex,follow`).

## Root cause (#2)

`canonicalPath` in `services/seo/seo-blog*.ts` is `'/articoli-frontaliere/<slug>/'` (WITH trailing slash). `ogPagesPlugin.ts:1049` then did:

```ts
collector.add(np.join(distDir, en.path + '.html'), flatItHtml);
//                              ^^^^^^^^^^^^^^^^
// '/articoli-frontaliere/<slug>/' + '.html'
//   → path.join → 'dist/articoli-frontaliere/<slug>/.html'   ← DOTFILE
```

That dotfile gets converted to a redirect bridge by the post-walk coordinator. GitHub Pages then serves the dotfile for the URL `/articoli-frontaliere/<slug>/` with `content-type=application/octet-stream` (no extension match), masking the real `<slug>/index.html` (19 KB full article).

Diagnostic side-by-side:
| URL | Bytes | Content-Type | etag |
|---|---:|---|---|
| `/<slug>/index.html` (explicit) | 19,420 | text/html | `6a17d0ce-4bdc` |
| `/<slug>/` | 1,733 | **application/octet-stream** | `6a17d0dd-6c5` |
| `/<slug>.html` | 1,733 | text/html | `6a17d0d1-6c5` |

AdSense impact 26→27 May:
- Targeting=None PV: 481 → **1,052** (+118%)
- Unmatched ad requests: 3,482 → **5,847** (+68%)
- Coverage: 60% → **45%**
- Desktop PV-RPM: 2.11 → **0.76** CHF (-64%)

## Changes

### #2 Source bug — `build-plugins/ogPagesPlugin.ts`
Strip trailing slash from the path before concatenating `.html`. Applied to both IT and EN/DE/FR emit branches (DE/EN/FR were not hit in the wild because `lPath` is built without trailing slash, but normalize defensively).

### #2 Defense-in-depth — bridge transform
- `flatHtmlRedirectPlugin.ts:transformFlatRedirect`: skip files whose basename starts with `.`
- `postWalkCoordinatorPlugin.ts` (single-threaded path): same skip on the fast-path
- `postWalkWorker.mjs`: same skip on the worker fast-path

Test: `tests/flat-html-redirect.test.ts` adds a regression case asserting `transformFlatRedirect` returns `null` for a `<dir>/.html` dotfile.

### #3 Rollback robustness — `.github/workflows/deploy.yml`
GitHub Pages artifacts have **1-hour retention**. When the last-known-good run is older than that, the rollback's `gh api .../artifacts` returns empty and the workflow used to `exit 1`. Incident 2026-05-28 (run 10723) wedged prod because the last-known-good (run 26389021146 from 25/5 07:31 UTC) was already past retention.

Fix:
- Don't `exit 1` when the artifact is missing — emit a `::warning::` and leave `id` empty.
- New step: when the artifact is empty AND we have a SHA, dispatch a fresh `deploy.yml` `workflow_dispatch` run pinned to the last-known-good SHA. Rebuild takes ~10-15 min but is independent of artifact retention.
- Linear report distinguishes artifact-fast-path vs fresh-deploy slow-path.

### #4 Dist gate — `scripts/audit-no-dotfile-html.mjs` (new)
0-tolerance walker: fails the build if ANY `dist/**/.html` dotfile exists. Wired into `post-deploy-validate-dist.yml` parallel pool. The existing `audit:spa-bundle-injection` is a ratchet that scans `index.html` only, so it never saw the dotfile bridges — this new audit closes the gap **before** publish.

## Test plan
- [x] `tsc` + esbuild parse clean (verified via worktree diff review)
- [x] `tests/flat-html-redirect.test.ts` adds dotfile-skip regression case
- [ ] Post-merge: `npm run audit:no-dotfile-html` step is GREEN on the new build (was missing dotfiles before this PR; should stay at 0)
- [ ] Post-deploy live curl: `/articoli-frontaliere/<slug>/` returns 19,420-byte article (text/html), not the 1,733-byte octet-stream bridge
- [ ] RPM recovers ≥3 CHF/day within 24-48h of redeploy (track via `scripts/revenue-monitor.mjs`)
- [ ] Future "artifact expired" rollback path tested live by waiting >1h after a deploy then forcing a validate-live failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)