### PR TITLE
feat(canary): RPM crash watch + article-content probe + auto-issue

### DIFF
--- a/.github/workflows/article-content-canary.yml
+++ b/.github/workflows/article-content-canary.yml
@@ -1,0 +1,108 @@
+name: article-content-canary
+
+# Article content canary — catches the article-stub regression class
+# (and any failure mode that reduces an article URL to <5 KB or strips
+# the SPA bundle) by probing 20 random articles from sitemap-blog.xml
+# every 30 minutes.
+#
+# Companion to:
+#   - production-canary.yml (5XX probe, 15 min cadence — catches HTTP errors)
+#   - post-deploy-validate-live.yml (probes after every deploy)
+#   - audit:no-dotfile-html (pre-deploy gate in validate-dist)
+#
+# The unique value here: catches regressions BETWEEN deploys (cache
+# invalidation, CDN routing change, GH Pages quirk, accidental rebuild
+# from an older artifact) AND regressions whose dist/-time fingerprint
+# does not match the existing audits' patterns. If a stub of a different
+# class slips past the dist-time gates, this canary catches it within
+# 30 min.
+#
+# Why 30 min (not 15 like the 5XX canary): the article-content probe
+# downloads ~20 × ~50 KB bodies + sitemap (~500 KB). 30 min is dense
+# enough to keep total RPM loss under 5% of one day's revenue if a
+# regression slips through (worst observed: -56% in 24h from incident
+# 2026-05-28), without doubling the egress of the 5XX canary.
+
+on:
+  schedule:
+    # Every 30 minutes. Cron runs in UTC.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      samples:
+        description: 'Number of random articles to sample (default 20)'
+        required: false
+        default: '20'
+        type: string
+
+concurrency:
+  # Only one canary in flight at a time; cancel an older run if a newer one starts.
+  group: article-content-canary
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Probe article-content on prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write   # open GitHub issue on regression
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run article-content canary
+        id: canary
+        continue-on-error: true
+        env:
+          SAMPLES: ${{ github.event.inputs.samples || '20' }}
+        run: |
+          set -o pipefail
+          node scripts/canary-article-content.mjs --samples="$SAMPLES" --json \
+            > canary-result.json 2> canary.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload canary result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: article-content-canary-${{ github.run_id }}
+          path: |
+            canary-result.json
+            canary.log
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Build issue body from canary result
+        if: steps.canary.outcome == 'failure' || steps.canary.outputs.exit_code != '0'
+        env:
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/build-canary-issue-body.mjs canary-result.json > canary-issue-body.md
+
+      - name: Open GitHub issue on regression
+        if: steps.canary.outcome == 'failure' || steps.canary.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Article content canary: regression detected" \
+            --description "$(cat canary-issue-body.md)" \
+            --priority 1 \
+            --label Bug \
+            --label article-content-canary \
+            --workflow "article-content-canary"
+
+      - name: Fail the workflow if canary failed
+        if: steps.canary.outcome == 'failure' || steps.canary.outputs.exit_code != '0'
+        run: |
+          echo "::error::Article content canary detected regressions — see GitHub issue + artifact"
+          exit 1

--- a/.github/workflows/rpm-canary.yml
+++ b/.github/workflows/rpm-canary.yml
@@ -1,0 +1,135 @@
+name: rpm-canary
+
+# AdSense RPM crash detector — the "watch on the effect" companion to
+# `article-content-canary.yml` (which watches the cause).
+#
+# Runs once a day, pulls daily PAGE_VIEWS_RPM via the AdSense API, and
+# opens a deduplicated GitHub issue if yesterday's RPM is below either
+# of:
+#   - 65% of the trailing 7-day baseline (T-10..T-4), OR
+#   - 1.00 CHF absolute floor
+#
+# Catches ANY revenue-affecting regression within ~24h — article stubs,
+# ads.txt issues, AdSense policy hits, ad slot misconfig, demand drops.
+# Incident 2026-05-28 (3.04 → 1.74 CHF/day) would have triggered the
+# morning of 2026-05-28 with the ratio fired at 56% of baseline.
+#
+# Why daily (not hourly): AdSense daily data is only available ~10h
+# after UTC midnight. Hourly cadence would burn API quota on identical
+# numbers; the goal is "detect within 24h of impact," not real-time.
+
+on:
+  schedule:
+    # Daily at 10:00 UTC — yesterday's AdSense data is settled by then.
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+    inputs:
+      ratio_floor:
+        description: 'Alert if RPM < (ratio_floor × baseline). Default 0.65.'
+        required: false
+        default: '0.65'
+        type: string
+      absolute_floor:
+        description: 'Alert if RPM < absolute_floor CHF. Default 1.0.'
+        required: false
+        default: '1.0'
+        type: string
+
+concurrency:
+  group: rpm-canary
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Probe AdSense RPM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Write Service Account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          fi
+
+      - name: Load secrets from Remote Config (AdSense + GSC tokens)
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
+      - name: Run RPM canary
+        id: canary
+        continue-on-error: true
+        env:
+          RATIO_FLOOR: ${{ github.event.inputs.ratio_floor || '0.65' }}
+          ABSOLUTE_FLOOR: ${{ github.event.inputs.absolute_floor || '1.0' }}
+        run: |
+          set -o pipefail
+          node scripts/canary-rpm.mjs \
+            --json \
+            --ratio-floor="$RATIO_FLOOR" \
+            --absolute-floor="$ABSOLUTE_FLOOR" \
+            > rpm-canary-result.json 2> rpm-canary.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload canary result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-canary-${{ github.run_id }}
+          path: |
+            rpm-canary-result.json
+            rpm-canary.log
+          if-no-files-found: ignore
+          retention-days: 90
+
+      - name: Append summary to job log
+        if: always()
+        run: |
+          if [ -s rpm-canary-result.json ]; then
+            echo "## RPM canary" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat rpm-canary-result.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Build issue body
+        if: steps.canary.outcome == 'failure' || steps.canary.outputs.exit_code == '1'
+        env:
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/build-rpm-canary-issue-body.mjs rpm-canary-result.json > rpm-canary-issue-body.md
+
+      - name: Open GitHub issue on regression
+        if: steps.canary.outcome == 'failure' || steps.canary.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          node scripts/lib/github-issue-creator.mjs \
+            --title "RPM canary: AdSense RPM crash detected" \
+            --description "$(cat rpm-canary-issue-body.md)" \
+            --priority 1 \
+            --label Bug \
+            --label rpm-canary \
+            --label revenue \
+            --workflow "rpm-canary"
+
+      - name: Fail the workflow if RPM regression detected
+        if: steps.canary.outcome == 'failure' || steps.canary.outputs.exit_code == '1'
+        run: |
+          echo "::error::AdSense RPM regression detected — see GitHub issue + artifact"
+          exit 1

--- a/package.json
+++ b/package.json
@@ -271,6 +271,7 @@
     "audit:news-sitemap": "node scripts/cleanup-news-sitemap.mjs --dry-run",
     "sanitize:news-sitemap": "node scripts/cleanup-news-sitemap.mjs --apply",
     "probe:5xx": "node scripts/probe-5xx.mjs",
+    "canary:article-content": "node scripts/canary-article-content.mjs",
     "prepush": "true",
     "jobs:update:buergenstock-hotels": "node scripts/update-buergenstock-hotels-jobs.mjs",
     "jobs:update:klinik-siloah": "node scripts/update-klinik-siloah-jobs.mjs",

--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "sanitize:news-sitemap": "node scripts/cleanup-news-sitemap.mjs --apply",
     "probe:5xx": "node scripts/probe-5xx.mjs",
     "canary:article-content": "node scripts/canary-article-content.mjs",
+    "canary:rpm": "node scripts/canary-rpm.mjs",
     "prepush": "true",
     "jobs:update:buergenstock-hotels": "node scripts/update-buergenstock-hotels-jobs.mjs",
     "jobs:update:klinik-siloah": "node scripts/update-klinik-siloah-jobs.mjs",

--- a/scripts/build-canary-issue-body.mjs
+++ b/scripts/build-canary-issue-body.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * build-canary-issue-body.mjs — Format the article-content canary JSON
+ * output as a Markdown body for the auto-created GitHub issue.
+ *
+ * Pulled out of the workflow YAML so the (multi-line, backtick-heavy)
+ * template is shell-quote-safe and easy to unit-test.
+ *
+ * Usage:
+ *   node scripts/build-canary-issue-body.mjs canary-result.json
+ *
+ * Env:
+ *   RUN_URL — workflow run URL injected into the issue body. Optional.
+ */
+
+import fs from "node:fs";
+import process from "node:process";
+
+const inputPath = process.argv[2];
+if (!inputPath) {
+  console.error("usage: build-canary-issue-body.mjs <canary-result.json>");
+  process.exit(2);
+}
+
+const runUrl = process.env.RUN_URL || "(unknown)";
+
+let report = null;
+try {
+  if (fs.existsSync(inputPath) && fs.statSync(inputPath).size > 0) {
+    report = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+  }
+} catch (err) {
+  console.error(`[build-canary-issue-body] could not parse ${inputPath}: ${err.message}`);
+}
+
+if (!report) {
+  process.stdout.write(
+    [
+      "## Article content regression detected",
+      "",
+      "The canary script failed before producing a JSON result. Inspect `canary.log` in the workflow run artifacts.",
+      "",
+      `**Workflow run:** ${runUrl}`,
+      "",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+const ts = report.timestamp || new Date().toISOString();
+const lines = [];
+lines.push("## Article content regression detected");
+lines.push("");
+lines.push(`**When:** ${ts}`);
+lines.push(`**Sample:** ${report.sampleSize} random articles from sitemap-blog.xml`);
+lines.push(`**Result:** ${report.pass} pass, ${report.fail} fail`);
+lines.push(`**Workflow run:** ${runUrl}`);
+lines.push("");
+lines.push("### Failing URLs");
+const failures = Array.isArray(report.failures) ? report.failures : [];
+for (const f of failures.slice(0, 25)) {
+  lines.push(`- ${f.url}`);
+  const detail = f.reason + (f.bytes !== undefined ? ` (body=${f.bytes} bytes)` : "");
+  lines.push(`  - reason: ${detail}`);
+}
+if (failures.length > 25) {
+  lines.push(`- … ${failures.length - 25} more (see canary-result.json artifact)`);
+}
+lines.push("");
+lines.push("### Likely root causes");
+lines.push(
+  "1. Plugin emitting `<dir>/.html` dotfile (`path + '.html'` over a slash-terminated path). Pre-deploy gate `audit:no-dotfile-html` should catch this — if it slipped through, inspect recent ogPagesPlugin / jobsSeoPagesPlugin / staticPagesPlugin changes.",
+);
+lines.push("2. Validate-live ratchet drift (SPA bundle injection baseline raised too high to catch new regressions).");
+lines.push("3. GitHub Pages routing quirk for a newly-emitted URL class.");
+lines.push("4. Accidental redeploy of an older artifact via the rollback fallback path.");
+lines.push("");
+lines.push("### Next steps");
+lines.push("1. Curl a failing URL: `curl -sI <url>` — confirm content-type / content-length match the canary report.");
+lines.push("2. `curl -sI <url>index.html` — if `/index.html` returns a different (larger) body, this is the dotfile-bridge class.");
+lines.push("3. `gh run view <recent-deploy-run-id> --log | grep audit-no-dotfile-html` — verify the pre-deploy gate ran on the build that shipped.");
+lines.push("4. If RPM is degrading, rollback via `gh workflow run deploy.yml --ref $(node scripts/deploy-registry.mjs get-good | jq -r .sha)`.");
+lines.push("");
+
+process.stdout.write(lines.join("\n"));

--- a/scripts/build-rpm-canary-issue-body.mjs
+++ b/scripts/build-rpm-canary-issue-body.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * build-rpm-canary-issue-body.mjs — Format the RPM canary JSON output
+ * as a Markdown body for the auto-created GitHub issue.
+ *
+ * Usage:
+ *   node scripts/build-rpm-canary-issue-body.mjs rpm-canary-result.json
+ *
+ * Env:
+ *   RUN_URL — workflow run URL injected into the issue body. Optional.
+ */
+
+import fs from "node:fs";
+import process from "node:process";
+
+const inputPath = process.argv[2];
+if (!inputPath) {
+  console.error("usage: build-rpm-canary-issue-body.mjs <rpm-canary-result.json>");
+  process.exit(2);
+}
+
+const runUrl = process.env.RUN_URL || "(unknown)";
+
+let r = null;
+try {
+  if (fs.existsSync(inputPath) && fs.statSync(inputPath).size > 0) {
+    r = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+  }
+} catch (err) {
+  console.error(`[build-rpm-canary-issue-body] parse error: ${err.message}`);
+}
+
+if (!r || !r.current) {
+  process.stdout.write(
+    [
+      "## RPM canary alert",
+      "",
+      "The RPM canary failed before producing a usable JSON result. See `rpm-canary.log` artifact.",
+      "",
+      `**Workflow run:** ${runUrl}`,
+      "",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+const lines = [];
+lines.push("## AdSense RPM crash detected");
+lines.push("");
+lines.push(`**When detected:** ${r.timestamp || "(unknown)"}`);
+lines.push(`**Account:** ${r.account || "(unknown)"}`);
+lines.push(`**Workflow run:** ${runUrl}`);
+lines.push("");
+lines.push("### Numbers");
+lines.push("");
+lines.push(`| Metric | Current (${r.current.date}) | Baseline (${r.baseline.from}..${r.baseline.to}) |`);
+lines.push("|---|---:|---:|");
+lines.push(`| PV-RPM (CHF) | **${r.current.rpm.toFixed(2)}** | ${r.baseline.rpm.toFixed(2)} |`);
+lines.push(`| Earnings (CHF) | ${r.current.earnings.toFixed(2)} | ${r.baseline.earnings.toFixed(2)} |`);
+lines.push(`| Page views | ${r.current.pageViews} | — |`);
+lines.push("");
+lines.push(`**Ratio current/baseline:** ${(r.ratio * 100).toFixed(0)}%`);
+lines.push(`**Thresholds:** ratio < ${(r.floors.ratio * 100).toFixed(0)}% OR absolute < ${r.floors.absoluteCHF.toFixed(2)} CHF`);
+lines.push("");
+lines.push("### Triggered conditions");
+for (const reason of r.reasons || []) {
+  lines.push(`- ${reason}`);
+}
+lines.push("");
+if (Array.isArray(r.rows) && r.rows.length > 0) {
+  lines.push("### Daily history (last 14 days)");
+  lines.push("");
+  lines.push("| Date | RPM (CHF) | Earnings (CHF) | Page views |");
+  lines.push("|---|---:|---:|---:|");
+  for (const row of r.rows) {
+    lines.push(`| ${row.date} | ${row.rpm.toFixed(2)} | ${row.earnings.toFixed(2)} | ${row.pageViews} |`);
+  }
+  lines.push("");
+}
+lines.push("### Diagnostic checklist (in priority order)");
+lines.push("");
+lines.push("1. **Article-content canary status** — check the latest run of `article-content-canary.yml`. If it also failed, the cause is upstream HTML (stubs, missing SPA bundle, etc.) and the fix lives in build plugins. If it passed, the cause is downstream of the served HTML.");
+lines.push("2. **Recent deploys** — `gh run list --branch main --limit 20 --workflow=233284293`. A failed `validate-live` + failed `rollback` is the incident-2026-05-28 signature.");
+lines.push("3. **AdSense console** — Sites tab for ads.txt / policy issues; Performance tab for reach by ad format (Auto Ads disabled? Anchor ads serving?).");
+lines.push("4. **Unmatched ad requests + coverage** — pull a 14-day daily report dimensioned by `TARGETING_TYPE_NAME` and look for spike in `None` / `(Unmatched ad requests)`. A spike here is the article-stub fingerprint.");
+lines.push("5. **PostHog $web_vitals** — CLS regression can suppress vignettes and anchor ads; check the last few daily snapshots.");
+lines.push("");
+lines.push("### Manual rollback (if needed)");
+lines.push("");
+lines.push("```bash");
+lines.push("gh workflow run deploy.yml --ref $(node scripts/deploy-registry.mjs get-good | jq -r .sha)");
+lines.push("```");
+lines.push("");
+
+process.stdout.write(lines.join("\n"));

--- a/scripts/canary-article-content.mjs
+++ b/scripts/canary-article-content.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * canary-article-content.mjs — Live article-content canary.
+ *
+ * Catches the article-stub regression class proactively, BETWEEN deploys.
+ *
+ * Why exists: incident 2026-05-28 — `ogPagesPlugin` emitted a dotfile
+ * `dist/articoli-frontaliere/<slug>/.html` for ~2,540 articles. GitHub
+ * Pages served the dotfile for `/<slug>/` URLs with content-type=
+ * application/octet-stream (no extension match), masking the real
+ * `<slug>/index.html`. The served body was a 1.7 KB infinite-redirect
+ * stub with no SPA bundle, no AdSense tags, and `noindex,follow`.
+ * AdSense RPM crashed 3.04 → 1.74 CHF/day in 48h because the stubs
+ * carry zero monetization inventory.
+ *
+ * The fix in PR #713 (a) strips trailing slashes from the path before
+ * `+ '.html'` concat in ogPagesPlugin, (b) skips dotfile basenames in
+ * `transformFlatRedirect`, (c) added `audit:no-dotfile-html` as a
+ * pre-deploy gate, and (d) repaired the rollback workflow's
+ * artifact-expired path. This canary is the LAST line of defense:
+ * a scheduled probe that catches any future regression of this class
+ * (or any other failure mode that reduces an article URL to a stub)
+ * by checking the LIVE site every 30 min.
+ *
+ * Checks per article (any failure → fail the URL):
+ *   1. HTTP status == 200
+ *   2. content-type starts with `text/html`  — guards against the
+ *      dotfile-served-as-octet-stream case
+ *   3. content-length >= MIN_BYTES (default 5000)  — real articles are
+ *      15-110 KB, stubs are 1.7 KB
+ *   4. body contains `src="/assets/index-`  — SPA bundle injected
+ *   5. body does NOT contain `location.replace("<own URL>"` — no
+ *      self-redirect loop (the stub's defining signature)
+ *
+ * Sample strategy: 20 random URLs from sitemap-blog.xml. With 97%
+ * regression rate (incident baseline), 20 samples catches ≥1 broken
+ * URL with probability >99.9%.
+ *
+ * Exit codes:
+ *   0 — every sampled article passed all checks
+ *   1 — at least one article failed; details on stdout for the workflow
+ *       to consume and turn into a GitHub issue
+ *
+ * Usage:
+ *   node scripts/canary-article-content.mjs              # default: 20 samples
+ *   node scripts/canary-article-content.mjs --samples=10 # custom sample size
+ *   node scripts/canary-article-content.mjs --json       # JSON summary on stdout
+ */
+
+import process from "node:process";
+
+const SITE = "https://frontaliereticino.ch";
+const SITEMAP_URL = `${SITE}/sitemap-blog.xml`;
+const DEFAULT_SAMPLES = 20;
+const MIN_BYTES = 5000;
+const FETCH_TIMEOUT_MS = 15000;
+const PROBE_CONCURRENCY = 5;
+
+const args = process.argv.slice(2);
+const samples = (() => {
+  const f = args.find((a) => a.startsWith("--samples="));
+  if (!f) return DEFAULT_SAMPLES;
+  const n = Number.parseInt(f.slice("--samples=".length), 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_SAMPLES;
+})();
+const wantsJson = args.includes("--json");
+
+function log(line) {
+  if (!wantsJson) console.log(line);
+  else console.error(line);
+}
+
+async function fetchWithTimeout(url, init = {}) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function loadArticleUrls() {
+  const res = await fetchWithTimeout(SITEMAP_URL);
+  if (!res.ok) throw new Error(`sitemap fetch ${res.status}`);
+  const xml = await res.text();
+  const urls = [];
+  const rx = /<loc>([^<]+)<\/loc>/g;
+  let m;
+  while ((m = rx.exec(xml)) !== null) urls.push(m[1]);
+  return urls;
+}
+
+function pickSample(urls, n) {
+  // Fisher-Yates partial shuffle for a uniformly random sample.
+  const a = urls.slice();
+  const k = Math.min(n, a.length);
+  for (let i = 0; i < k; i += 1) {
+    const j = i + Math.floor(Math.random() * (a.length - i));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a.slice(0, k);
+}
+
+async function probe(url) {
+  let res;
+  try {
+    res = await fetchWithTimeout(url, { redirect: "manual" });
+  } catch (err) {
+    return { url, ok: false, reason: `fetch error: ${err.message || err}` };
+  }
+  if (res.status !== 200) {
+    return { url, ok: false, reason: `HTTP ${res.status}` };
+  }
+  const ct = res.headers.get("content-type") || "";
+  if (!ct.toLowerCase().startsWith("text/html")) {
+    return { url, ok: false, reason: `content-type=${ct || "(none)"}` };
+  }
+  const body = await res.text();
+  const bytes = Buffer.byteLength(body, "utf8");
+  if (bytes < MIN_BYTES) {
+    return { url, ok: false, reason: `body=${bytes}B < ${MIN_BYTES}B (stub?)`, bytes };
+  }
+  if (!body.includes('src="/assets/index-')) {
+    return { url, ok: false, reason: "missing SPA bundle <script src=/assets/index-*.js>", bytes };
+  }
+  // Self-redirect loop detector: bridges contain `location.replace("<self URL>"`.
+  // Real articles ship a location.replace ONLY in their flat-sibling shell, not
+  // the index.html shell — so any location.replace WHOSE TARGET equals the
+  // current URL is the stub signature.
+  const selfLoopRx = new RegExp(
+    `location\\.replace\\(\\s*"${url.replace(/[/.?$^*+()|[\]\\{}]/g, "\\$&")}"`,
+  );
+  if (selfLoopRx.test(body)) {
+    return { url, ok: false, reason: "self-redirect loop (location.replace to own URL)", bytes };
+  }
+  return { url, ok: true, bytes };
+}
+
+async function probeWithPool(urls, concurrency) {
+  const results = [];
+  let cursor = 0;
+  const lanes = Array.from({ length: concurrency }, async () => {
+    while (cursor < urls.length) {
+      const i = cursor++;
+      const r = await probe(urls[i]);
+      results.push(r);
+    }
+  });
+  await Promise.all(lanes);
+  return results;
+}
+
+async function main() {
+  log(`[canary-article-content] sitemap=${SITEMAP_URL}`);
+  const all = await loadArticleUrls();
+  log(`[canary-article-content] sitemap=${all.length} URLs`);
+  if (all.length === 0) {
+    console.error("[canary-article-content] FAIL — sitemap empty");
+    process.exit(1);
+  }
+  const sample = pickSample(all, samples);
+  log(`[canary-article-content] sampling ${sample.length} URLs at concurrency=${PROBE_CONCURRENCY}`);
+  const results = await probeWithPool(sample, PROBE_CONCURRENCY);
+  const failures = results.filter((r) => !r.ok);
+  const passes = results.filter((r) => r.ok);
+  const summary = {
+    site: SITE,
+    sampleSize: sample.length,
+    pass: passes.length,
+    fail: failures.length,
+    failures: failures.map((f) => ({ url: f.url, reason: f.reason, bytes: f.bytes })),
+    timestamp: new Date().toISOString(),
+  };
+  if (wantsJson) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    log("");
+    log(`Results: ${passes.length} pass, ${failures.length} fail (sample=${sample.length})`);
+    for (const f of failures) {
+      log(`  FAIL ${f.url} — ${f.reason}${f.bytes !== undefined ? ` (body=${f.bytes}B)` : ""}`);
+    }
+  }
+  if (failures.length > 0) {
+    console.error(
+      `\x1b[31m[canary-article-content]\x1b[0m FAIL — ${failures.length}/${sample.length} articles regressed`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `\x1b[32m[canary-article-content]\x1b[0m PASS — ${passes.length}/${sample.length} articles healthy`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`[canary-article-content] error: ${err.message || err}`);
+  process.exit(2);
+});

--- a/scripts/canary-rpm.mjs
+++ b/scripts/canary-rpm.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * canary-rpm.mjs — AdSense RPM crash detector.
+ *
+ * Pulls daily AdSense PAGE_VIEWS_RPM for the last 14 days, computes a
+ * trailing 7-day baseline (days T-10..T-4), compares yesterday (T-1)
+ * against it, and exits non-zero if yesterday's RPM is below either of:
+ *   - `--ratio-floor` × baseline (default 0.65 → alert when RPM < 65% of baseline)
+ *   - `--absolute-floor` CHF (default 1.0 CHF, regardless of baseline)
+ *
+ * Why exists: incident 2026-05-28 — AdSense RPM crashed 3.04 → 1.74
+ * CHF/day in 48h because ~2,540 of ~2,607 articles started serving a
+ * 1.7 KB infinite-redirect stub (no SPA bundle, no ad slots). The
+ * upstream cause is caught at dist-time by `audit:no-dotfile-html` and
+ * at content-time by `article-content-canary.yml`. This RPM canary is
+ * the LAST line of defense: catches ANY revenue-affecting regression
+ * (article stubs, AdSense policy hit, ad slot misconfig, ads.txt
+ * issues, demand-side market drops) within ~24h of impact by watching
+ * the EFFECT (revenue) rather than any particular CAUSE.
+ *
+ * Auth: same as scripts/revenue-monitor.mjs — uses ADSENSE_REFRESH_TOKEN
+ * + GSC_CLIENT_ID/SECRET (the OAuth client is shared with GSC), loaded
+ * from Firebase Remote Config via scripts/load-rc-env.mjs.
+ *
+ * Exit codes:
+ *   0 — RPM is healthy (above all thresholds, or insufficient data)
+ *   1 — RPM regression detected; details on stdout (JSON when --json)
+ *   2 — Auth / API failure (do not treat as a real regression)
+ *
+ * Usage:
+ *   node scripts/canary-rpm.mjs
+ *   node scripts/canary-rpm.mjs --json
+ *   node scripts/canary-rpm.mjs --ratio-floor=0.7 --absolute-floor=1.5
+ */
+
+import process from "node:process";
+
+const args = process.argv.slice(2);
+const wantsJson = args.includes("--json");
+const parseFlag = (name, fallback) => {
+  const f = args.find((a) => a.startsWith(`--${name}=`));
+  if (!f) return fallback;
+  const n = Number.parseFloat(f.slice(`--${name}=`.length));
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const RATIO_FLOOR = parseFlag("ratio-floor", 0.65);
+const ABSOLUTE_FLOOR = parseFlag("absolute-floor", 1.0);
+const BASELINE_DAYS = 7;
+const BASELINE_LAG_DAYS = 3; // baseline ends at T-4 (skips noisy last 3 days)
+const REQUIRED_BASELINE_SAMPLES = 5; // need at least 5 days of baseline data
+
+const log = (line) => {
+  if (wantsJson) console.error(line);
+  else console.log(line);
+};
+
+async function refreshAccessToken({ clientId, clientSecret, refreshToken }) {
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+  if (!res.ok) throw new Error(`token refresh ${res.status}: ${await res.text()}`);
+  return (await res.json()).access_token;
+}
+
+function fmtDate(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+async function fetchDailyRpm() {
+  const refreshToken = process.env.ADSENSE_REFRESH_TOKEN;
+  const clientId = process.env.ADSENSE_CLIENT_ID || process.env.GSC_CLIENT_ID;
+  const clientSecret = process.env.ADSENSE_CLIENT_SECRET || process.env.GSC_CLIENT_SECRET;
+  if (!refreshToken || !clientId || !clientSecret) {
+    throw new Error("missing AdSense OAuth credentials (ADSENSE_REFRESH_TOKEN / *_CLIENT_ID / *_CLIENT_SECRET)");
+  }
+  const token = await refreshAccessToken({ clientId, clientSecret, refreshToken });
+  const acctRes = await fetch("https://adsense.googleapis.com/v2/accounts", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!acctRes.ok) throw new Error(`adsense accounts ${acctRes.status}: ${await acctRes.text()}`);
+  const acctData = await acctRes.json();
+  const account = acctData.accounts?.[0]?.name;
+  if (!account) throw new Error("no AdSense account on this token");
+
+  const end = new Date();
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 14);
+  const startStr = fmtDate(start);
+  const endStr = fmtDate(end);
+
+  const params = new URLSearchParams();
+  params.append("dateRange", "CUSTOM");
+  params.append("startDate.year", startStr.slice(0, 4));
+  params.append("startDate.month", String(Number(startStr.slice(5, 7))));
+  params.append("startDate.day", String(Number(startStr.slice(8, 10))));
+  params.append("endDate.year", endStr.slice(0, 4));
+  params.append("endDate.month", String(Number(endStr.slice(5, 7))));
+  params.append("endDate.day", String(Number(endStr.slice(8, 10))));
+  params.append("metrics", "PAGE_VIEWS_RPM");
+  params.append("metrics", "ESTIMATED_EARNINGS");
+  params.append("metrics", "PAGE_VIEWS");
+  params.append("dimensions", "DATE");
+
+  const url = `https://adsense.googleapis.com/v2/${account}/reports:generate?${params}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`adsense daily ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  const rows = (data.rows || []).map((r) => ({
+    date: r.cells[0]?.value || "",
+    rpm: Number(r.cells[1]?.value ?? 0),
+    earnings: Number(r.cells[2]?.value ?? 0),
+    pageViews: Number(r.cells[3]?.value ?? 0),
+  }));
+  // Defensive sort by date ascending (the API does this but don't assume).
+  rows.sort((a, b) => a.date.localeCompare(b.date));
+  return { account, rows };
+}
+
+function classify(rows) {
+  if (rows.length < BASELINE_LAG_DAYS + REQUIRED_BASELINE_SAMPLES) {
+    return {
+      verdict: "insufficient-data",
+      reason: `need ≥${BASELINE_LAG_DAYS + REQUIRED_BASELINE_SAMPLES} days of data, got ${rows.length}`,
+    };
+  }
+  // Latest fully-closed day = the most recent row whose pageViews looks
+  // "complete" (≥ 60% of the prior day's PV). AdSense daily data is
+  // sometimes truncated for the current UTC day until ~10am UTC the next
+  // day, so we drop trailing rows whose PV looks incomplete.
+  let latestClosedIdx = rows.length - 1;
+  if (rows.length >= 2) {
+    const prior = rows[rows.length - 2].pageViews;
+    const last = rows[rows.length - 1].pageViews;
+    if (prior > 0 && last < prior * 0.5) {
+      // The last row is probably still being collected — skip it.
+      latestClosedIdx = rows.length - 2;
+    }
+  }
+  const currentRow = rows[latestClosedIdx];
+  const baselineEnd = latestClosedIdx - (BASELINE_LAG_DAYS - 1);
+  const baselineStart = baselineEnd - BASELINE_DAYS;
+  if (baselineStart < 0 || baselineEnd <= baselineStart) {
+    return { verdict: "insufficient-data", reason: "baseline window underflowed" };
+  }
+  const baselineRows = rows.slice(baselineStart, baselineEnd);
+  if (baselineRows.length < REQUIRED_BASELINE_SAMPLES) {
+    return {
+      verdict: "insufficient-data",
+      reason: `baseline window has ${baselineRows.length} samples, need ${REQUIRED_BASELINE_SAMPLES}`,
+    };
+  }
+  const baselineRpm =
+    baselineRows.reduce((s, r) => s + (r.rpm || 0), 0) / baselineRows.length;
+  const baselineEarnings =
+    baselineRows.reduce((s, r) => s + (r.earnings || 0), 0) / baselineRows.length;
+  const ratio = baselineRpm > 0 ? currentRow.rpm / baselineRpm : 1;
+
+  const reasons = [];
+  if (currentRow.rpm < ABSOLUTE_FLOOR) {
+    reasons.push(`RPM ${currentRow.rpm.toFixed(2)} < absolute floor ${ABSOLUTE_FLOOR.toFixed(2)}`);
+  }
+  if (baselineRpm > 0 && ratio < RATIO_FLOOR) {
+    reasons.push(
+      `RPM ${currentRow.rpm.toFixed(2)} = ${(ratio * 100).toFixed(0)}% of baseline ${baselineRpm.toFixed(2)} (floor ${(RATIO_FLOOR * 100).toFixed(0)}%)`,
+    );
+  }
+  return {
+    verdict: reasons.length > 0 ? "regression" : "healthy",
+    current: { date: currentRow.date, rpm: currentRow.rpm, earnings: currentRow.earnings, pageViews: currentRow.pageViews },
+    baseline: {
+      from: baselineRows[0].date,
+      to: baselineRows[baselineRows.length - 1].date,
+      rpm: Number(baselineRpm.toFixed(3)),
+      earnings: Number(baselineEarnings.toFixed(2)),
+      samples: baselineRows.length,
+    },
+    ratio: Number((ratio || 0).toFixed(3)),
+    floors: { ratio: RATIO_FLOOR, absoluteCHF: ABSOLUTE_FLOOR },
+    reasons,
+  };
+}
+
+async function main() {
+  let result;
+  try {
+    const { account, rows } = await fetchDailyRpm();
+    log(`[canary-rpm] account=${account}, ${rows.length} daily rows`);
+    result = classify(rows);
+    result.account = account;
+    result.rows = rows;
+  } catch (err) {
+    console.error(`[canary-rpm] auth/API failure: ${err.message || err}`);
+    process.exit(2);
+  }
+  result.timestamp = new Date().toISOString();
+  if (wantsJson) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    log("");
+    log(`verdict=${result.verdict}`);
+    if (result.current) {
+      log(`current: ${result.current.date} RPM=${result.current.rpm.toFixed(2)} earnings=${result.current.earnings.toFixed(2)} pv=${result.current.pageViews}`);
+    }
+    if (result.baseline) {
+      log(`baseline ${result.baseline.from}..${result.baseline.to}: RPM=${result.baseline.rpm.toFixed(2)} earnings=${result.baseline.earnings.toFixed(2)} (${result.baseline.samples} samples)`);
+      log(`ratio=${(result.ratio * 100).toFixed(0)}%   floors: ratio=${(RATIO_FLOOR * 100).toFixed(0)}%, absolute=${ABSOLUTE_FLOOR.toFixed(2)} CHF`);
+    }
+    for (const r of result.reasons || []) log(`  ALERT: ${r}`);
+  }
+  if (result.verdict === "regression") {
+    console.error(`\x1b[31m[canary-rpm]\x1b[0m FAIL — RPM regression`);
+    process.exit(1);
+  }
+  if (result.verdict === "insufficient-data") {
+    console.error(`\x1b[33m[canary-rpm]\x1b[0m SKIP — ${result.reason}`);
+    process.exit(0);
+  }
+  console.log(`\x1b[32m[canary-rpm]\x1b[0m PASS — RPM healthy`);
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary
Two new scheduled canaries that would have caught **incident 2026-05-28** (AdSense RPM crashed 3.04 → 1.74 CHF/day in 48h) within ~24h instead of days. Both open deduplicated GitHub issues via the project's `github-issue-creator.mjs` helper.

## What's new

### 1. `rpm-canary.yml` (daily, 10:00 UTC) — watches the EFFECT
Pulls 14 days of daily `PAGE_VIEWS_RPM` from AdSense, computes trailing 7-day baseline (T-10..T-4), compares the most recent fully-closed day. Fails if:
- RPM < 65% of baseline (configurable via `--ratio-floor`), OR
- RPM < 1.00 CHF absolute (configurable via `--absolute-floor`)

**Calibration on the actual incident:** morning of 2026-05-28 the canary would have seen May 27 RPM 1.74 vs baseline ~3.13 (May 18-24) = **55% ratio**, well below 65% → alert opened by ~10:00 UTC the morning of the crash.

The issue body includes a full 14-day RPM table plus a diagnostic checklist (article-content canary status, recent deploys, AdSense console, unmatched-ad-requests spike, manual rollback command).

Catches ANY revenue-affecting regression — not just article stubs. Ads.txt break, AdSense policy hit, ad slot misconfig, demand-side market drop all surface within ~24h regardless of root cause.

### 2. `article-content-canary.yml` (every 30 min) — watches the CAUSE
Samples 20 random articles from `sitemap-blog.xml`, fails any URL where:
- HTTP != 200
- content-type ≠ `text/html` (guards against the dotfile-served-as-octet-stream case)
- body < 5,000 bytes (real articles are 15-110 KB, stubs are 1.7 KB)
- body missing `src="/assets/index-` (no SPA bundle)
- body contains `location.replace("<self URL>"` (self-redirect loop)

With 97% regression rate (incident baseline), sampling 20 catches ≥1 broken URL with probability >99.9%. Issue body includes the failing URLs + reasons + diagnostic checklist + manual rollback command.

The CAUSE canary fires within 30 min and points to the specific URLs and failure mode. The EFFECT canary fires within 24h and proves the RPM impact. Together they bracket any future incident of this class.

## Files
- `scripts/canary-rpm.mjs` (new) — AdSense daily RPM probe + classifier
- `scripts/canary-article-content.mjs` (new) — sitemap-blog.xml sampler + per-URL probe
- `scripts/build-rpm-canary-issue-body.mjs` (new) — Markdown issue body for RPM canary
- `scripts/build-canary-issue-body.mjs` (new) — Markdown issue body for article-content canary
- `.github/workflows/rpm-canary.yml` (new) — daily cron + issue-on-failure
- `.github/workflows/article-content-canary.yml` (new) — 30-min cron + issue-on-failure
- `package.json` — `canary:article-content` + `canary:rpm` npm scripts

## How it composes with existing defenses

| Layer | When | What |
|---|---|---|
| `audit:no-dotfile-html` (PR #713) | pre-deploy gate | catches `dist/**\/.html` dotfiles before they ship |
| `audit:spa-bundle-injection` ratchet | pre-deploy gate | catches bundle-less `index.html` regressions |
| `post-deploy-validate-live.yml` | every deploy | Playwright probe of critical URLs |
| `production-canary.yml` (existing) | every 15 min | 5XX HTTP probe |
| **`article-content-canary.yml` (this PR)** | every 30 min | content-quality probe of random articles |
| **`rpm-canary.yml` (this PR)** | daily 10:00 UTC | revenue-impact probe via AdSense API |
| `revenue-monitor.yml` (existing, weekly) | Mondays | full revenue+SEO+CLS dashboard |

The two new canaries fill the gap between "per-deploy validation" and "weekly digest" — the window where the May 28 incident was able to fester unnoticed.

## Test plan
- [ ] `workflow_dispatch` `rpm-canary.yml` after merge → confirm it pulls AdSense data without auth errors and reports either PASS or FAIL with a usable JSON artifact
- [ ] `workflow_dispatch` `article-content-canary.yml` after merge → confirm it samples 20 URLs and reports per-URL status; on the still-broken prod state (pre-PR-#713-deploy) this should FAIL and open an issue (validates the issue-creator wiring)
- [ ] After PR #713 deploy lands and articles return to 19 KB content, re-trigger both canaries → both should PASS
- [ ] Verify the deduplicated issue helper: trigger 2 failing runs back-to-back; the second should comment on the first issue instead of opening a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)