### PR TITLE
fix(rpm-canary): install npm deps so load-rc-env can import firebase-admin

### DIFF
--- a/.github/workflows/rpm-canary.yml
+++ b/.github/workflows/rpm-canary.yml
@@ -57,6 +57,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+
+      # load-rc-env.mjs imports `firebase-admin` to talk to Remote Config;
+      # without npm deps it falls back to "no secrets loaded" and the
+      # AdSense call later errors with "missing OAuth credentials". Same
+      # install pattern as revenue-monitor.yml (`--ignore-scripts` since
+      # we don't need postinstall hooks for this read-only canary).
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
 
       - name: Write Service Account credentials
         env:


### PR DESCRIPTION
## Summary
Manual `workflow_dispatch` of `rpm-canary.yml` (run 26560326818) failed with `Cannot find package 'firebase-admin'` from `scripts/load-rc-env.mjs`. Without RC secrets, the AdSense API call later exits with "missing OAuth credentials" — the canary can't tell healthy from regressed.

Same pattern `revenue-monitor.yml` uses successfully: `npm ci --ignore-scripts` between Setup Node and Remote Config load, plus npm caching to keep cold-start under 30s.

## Test plan
- [ ] After merge: `gh workflow run rpm-canary.yml --ref main` and confirm the run reports a real verdict (PASS or FAIL with the JSON body filled), not `auth/API failure`.
