### PR TITLE
feat(deploy): per-plugin dist-bytes report + history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -756,22 +756,20 @@ jobs:
           echo "TAR_BYTES=$TAR_BYTES" >> "$GITHUB_ENV"
 
       # ┌────────────────────────────────────────────────────────────────┐
-      # │ Audit dist bytes — attribute size per plugin/locale, append    │
-      # │ to data/dist-size-history.jsonl, and HARD GATE the build       │
-      # │ before upload if tar > 9.5 GB. GitHub Pages enforces a 10 GB   │
-      # │ cap on the artifact tarball; failing here surfaces the         │
-      # │ regression in the build log instead of as an opaque            │
-      # │ "Deployment failed" tail. PR #712 cleared the cap by ~160 MB   │
-      # │ — this gate keeps that headroom enforceable.                   │
+      # │ Audit dist bytes — attribute size per plugin/locale and append │
+      # │ to data/dist-size-history.jsonl. Observability only: the step  │
+      # │ NEVER blocks the upload. If GitHub Pages rejects the tar at    │
+      # │ 10 GB the deploy fails downstream with the canonical error,    │
+      # │ but we always attempt the upload so we can compare "did fit"   │
+      # │ vs "tried and bounced" across runs.                            │
       # │ Cost: stat-only walk, < 30 s on ~470 k files.                  │
       # └────────────────────────────────────────────────────────────────┘
-      - name: Audit dist bytes (per-plugin + 9.5 GB hard gate)
+      - name: Audit dist bytes (per-plugin report)
         if: github.event.inputs.profile_sequential != 'true'
         run: |
           node scripts/report-dist-bytes-by-plugin.mjs \
             --dist=dist \
             --tar-size-bytes="${TAR_BYTES}" \
-            --gate-total-bytes=9500000000 \
             --run-id="${GITHUB_RUN_ID}" \
             --sha="${GITHUB_SHA}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -751,6 +751,29 @@ jobs:
           # (instead of only at the deploy-pages "Deployment failed"
           # tail) — the artifact size is the binding constraint.
           ls -lh "$RUNNER_TEMP/artifact.tar"
+          # Export for downstream report step (Audit dist bytes).
+          TAR_BYTES=$(stat -c %s "$RUNNER_TEMP/artifact.tar")
+          echo "TAR_BYTES=$TAR_BYTES" >> "$GITHUB_ENV"
+
+      # ┌────────────────────────────────────────────────────────────────┐
+      # │ Audit dist bytes — attribute size per plugin/locale, append    │
+      # │ to data/dist-size-history.jsonl, and HARD GATE the build       │
+      # │ before upload if tar > 9.5 GB. GitHub Pages enforces a 10 GB   │
+      # │ cap on the artifact tarball; failing here surfaces the         │
+      # │ regression in the build log instead of as an opaque            │
+      # │ "Deployment failed" tail. PR #712 cleared the cap by ~160 MB   │
+      # │ — this gate keeps that headroom enforceable.                   │
+      # │ Cost: stat-only walk, < 30 s on ~470 k files.                  │
+      # └────────────────────────────────────────────────────────────────┘
+      - name: Audit dist bytes (per-plugin + 9.5 GB hard gate)
+        if: github.event.inputs.profile_sequential != 'true'
+        run: |
+          node scripts/report-dist-bytes-by-plugin.mjs \
+            --dist=dist \
+            --tar-size-bytes="${TAR_BYTES}" \
+            --gate-total-bytes=9500000000 \
+            --run-id="${GITHUB_RUN_ID}" \
+            --sha="${GITHUB_SHA}"
 
       - name: Upload Pages artifact (compression-level 9)
         if: github.event.inputs.profile_sequential != 'true'

--- a/scripts/report-dist-bytes-by-plugin.mjs
+++ b/scripts/report-dist-bytes-by-plugin.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+// report-dist-bytes-by-plugin.mjs
+//
+// Walks dist/ and attributes bytes per emitting plugin/category and per
+// locale. Output is one JSONL line appended to data/dist-size-history.jsonl
+// + a stdout summary table.
+//
+// Usage:
+//   node scripts/report-dist-bytes-by-plugin.mjs [--dist=dist] [--no-append]
+//                                                [--gate-total-bytes=10200000000]
+//                                                [--run-id=<id>] [--sha=<sha>]
+//                                                [--tar-size-bytes=<n>]
+//
+// Exit codes:
+//   0  ok
+//   1  --gate-total-bytes set AND total exceeded → block deploy
+//   2  dist dir missing / unreadable
+//
+// Design constraints (from CI-cost history, PR #480 dist-shrink rollback):
+//   - Pure fs.stat walk, no file content reads.
+//   - Sequential readdir w/ withFileTypes — already I/O-bound on EXT4, worker
+//     parallelism added <2 % wall-clock in spike test and 12 MB peak RSS.
+//   - Target: < 30 s on ~470 k files.
+//
+// Classification is prefix-based. Unknown prefixes are bucketed under
+// "other-<top-segment>" so a new plugin path is visible the first build.
+
+import { readdir, stat } from 'node:fs/promises';
+import { join, dirname, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appendFileSync, existsSync, writeFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+function parseArgs(argv) {
+  const out = {
+    dist: 'dist',
+    append: true,
+    gateTotalBytes: null,
+    runId: process.env.GITHUB_RUN_ID || null,
+    sha: process.env.GITHUB_SHA || null,
+    tarSizeBytes: null,
+  };
+  for (const arg of argv) {
+    if (arg === '--no-append') out.append = false;
+    else if (arg.startsWith('--dist=')) out.dist = arg.slice(7);
+    else if (arg.startsWith('--gate-total-bytes=')) out.gateTotalBytes = Number(arg.slice(19));
+    else if (arg.startsWith('--run-id=')) out.runId = arg.slice(9);
+    else if (arg.startsWith('--sha=')) out.sha = arg.slice(6);
+    else if (arg.startsWith('--tar-size-bytes=')) out.tarSizeBytes = Number(arg.slice(17));
+  }
+  return out;
+}
+
+// Classifier: ordered. First match wins. Locale is detected separately.
+// Locale-prefixed paths (en/, de/, fr/) are stripped before matching, so
+// `en/find-jobs-ticino/...` and `cerca-lavoro-ticino/...` map to the same
+// plugin bucket. Root (no locale prefix) is IT.
+const LOCALES = new Set(['en', 'de', 'fr']);
+
+const PLUGIN_RULES = [
+  // jobs SEO (active + soft-landing + previousSlugs bridges)
+  { plugin: 'jobs-seo', prefixes: [
+    'cerca-lavoro-ticino/', 'find-jobs-ticino/', 'jobs-im-tessin/', 'trouver-emploi-tessin/',
+    'cerca-lavoro-ticino.html', 'find-jobs-ticino.html', 'jobs-im-tessin.html', 'trouver-emploi-tessin.html',
+  ]},
+  // related search cluster pages
+  { plugin: 'cluster', prefixes: [
+    'ricerca-cluster/', 'search-cluster/', 'such-cluster/', 'recherche-cluster/',
+    'ricerca/', 'cluster-ricerca/',
+  ]},
+  // OG / article pages
+  { plugin: 'og-pages', prefixes: [
+    'articoli-frontaliere/', 'articles-frontaliere/', 'artikel-grenzgaenger/', 'articles-frontaliers/',
+  ]},
+  // hub plugins
+  { plugin: 'hub-salary', prefixes: ['stipendi/', 'salaries/', 'gehaelter/', 'salaires/'] },
+  { plugin: 'hub-faq', prefixes: ['faq/', 'domande/', 'fragen/', 'questions/'] },
+  { plugin: 'hub-comparison', prefixes: ['confronti/', 'comparisons/', 'vergleiche/', 'comparaisons/'] },
+  { plugin: 'hub-section', prefixes: ['sezioni/', 'sections/', 'abschnitte/'] },
+  // assets bundle
+  { plugin: 'assets', prefixes: ['assets/'] },
+  // data files shipped
+  { plugin: 'data', prefixes: ['dati/', 'data/'] },
+  // sitemaps + robots
+  { plugin: 'sitemap', regex: /^sitemap[^/]*\.xml(\.gz)?$|^robots\.txt$/ },
+  // OG images
+  { plugin: 'og-images', prefixes: ['og-images/', 'og/'] },
+  // public/ root images
+  { plugin: 'images', prefixes: ['images/', 'img/'] },
+  // PDFs
+  { plugin: 'pdf', regex: /\.pdf$/ },
+];
+
+function classify(relPath) {
+  // Detect locale (top-level segment)
+  let locale = 'it';
+  let remainder = relPath;
+  const firstSlash = relPath.indexOf('/');
+  if (firstSlash > 0) {
+    const head = relPath.slice(0, firstSlash);
+    if (LOCALES.has(head)) {
+      locale = head;
+      remainder = relPath.slice(firstSlash + 1);
+    }
+  } else if (LOCALES.has(relPath)) {
+    // bare 'en' file? shouldn't happen, but be safe
+    locale = relPath;
+    remainder = '';
+  }
+
+  for (const rule of PLUGIN_RULES) {
+    if (rule.prefixes) {
+      for (const p of rule.prefixes) {
+        if (remainder.startsWith(p) || remainder === p.replace(/\/$/, '')) {
+          return { plugin: rule.plugin, locale };
+        }
+      }
+    }
+    if (rule.regex && rule.regex.test(remainder)) {
+      return { plugin: rule.plugin, locale };
+    }
+  }
+  // Unknown — bucket by top segment of remainder (or 'root' if none)
+  const idx = remainder.indexOf('/');
+  const topSeg = idx > 0 ? remainder.slice(0, idx) : remainder;
+  return { plugin: `other-${topSeg || 'root'}`, locale };
+}
+
+async function walk(distDir) {
+  const totals = {
+    totalBytes: 0,
+    totalFiles: 0,
+    byPlugin: {},      // plugin → { bytes, files }
+    byLocale: {},      // locale → { bytes, files }
+    byPluginLocale: {},// "plugin/locale" → { bytes, files }
+  };
+
+  async function recurse(absDir, relDir) {
+    let entries;
+    try {
+      entries = await readdir(absDir, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') return;
+      throw err;
+    }
+    for (const e of entries) {
+      const abs = join(absDir, e.name);
+      const rel = relDir ? `${relDir}/${e.name}` : e.name;
+      if (e.isDirectory()) {
+        await recurse(abs, rel);
+      } else if (e.isFile()) {
+        let st;
+        try { st = await stat(abs); } catch { continue; }
+        const bytes = st.size;
+        const { plugin, locale } = classify(rel);
+
+        totals.totalBytes += bytes;
+        totals.totalFiles += 1;
+
+        const pb = totals.byPlugin[plugin] ||= { bytes: 0, files: 0 };
+        pb.bytes += bytes; pb.files += 1;
+
+        const lb = totals.byLocale[locale] ||= { bytes: 0, files: 0 };
+        lb.bytes += bytes; lb.files += 1;
+
+        const key = `${plugin}/${locale}`;
+        const plb = totals.byPluginLocale[key] ||= { bytes: 0, files: 0 };
+        plb.bytes += bytes; plb.files += 1;
+      }
+    }
+  }
+
+  await recurse(distDir, '');
+  return totals;
+}
+
+function fmtBytes(n) {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)}GB`;
+}
+
+function printSummary(totals) {
+  const rows = Object.entries(totals.byPlugin)
+    .sort((a, b) => b[1].bytes - a[1].bytes);
+  console.log('\n[dist-bytes-report] by plugin:');
+  for (const [plugin, { bytes, files }] of rows) {
+    const pct = ((bytes / totals.totalBytes) * 100).toFixed(1);
+    console.log(`  ${plugin.padEnd(22)} ${fmtBytes(bytes).padStart(10)}  ${pct.padStart(5)}%  (${files} files)`);
+  }
+  console.log('\n[dist-bytes-report] by locale:');
+  for (const [locale, { bytes, files }] of Object.entries(totals.byLocale).sort((a, b) => b[1].bytes - a[1].bytes)) {
+    const pct = ((bytes / totals.totalBytes) * 100).toFixed(1);
+    console.log(`  ${locale.padEnd(4)} ${fmtBytes(bytes).padStart(10)}  ${pct.padStart(5)}%  (${files} files)`);
+  }
+  console.log(`\n[dist-bytes-report] TOTAL: ${fmtBytes(totals.totalBytes)}  (${totals.totalFiles} files)\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const distDir = isAbsolute(args.dist) ? args.dist : join(ROOT, args.dist);
+  if (!existsSync(distDir)) {
+    console.error(`[dist-bytes-report] dist not found: ${distDir}`);
+    process.exit(2);
+  }
+
+  const t0 = Date.now();
+  const totals = await walk(distDir);
+  const elapsedMs = Date.now() - t0;
+
+  printSummary(totals);
+  console.log(`[dist-bytes-report] walk: ${(elapsedMs / 1000).toFixed(1)}s`);
+
+  const row = {
+    timestamp: new Date().toISOString(),
+    runId: args.runId,
+    sha: args.sha,
+    totalBytes: totals.totalBytes,
+    totalFiles: totals.totalFiles,
+    tarSizeBytes: args.tarSizeBytes,
+    byPlugin: totals.byPlugin,
+    byLocale: totals.byLocale,
+    byPluginLocale: totals.byPluginLocale,
+  };
+
+  if (args.append) {
+    const historyPath = join(ROOT, 'data', 'dist-size-history.jsonl');
+    if (!existsSync(historyPath)) writeFileSync(historyPath, '');
+    appendFileSync(historyPath, JSON.stringify(row) + '\n');
+    console.log(`[dist-bytes-report] appended to data/dist-size-history.jsonl`);
+  }
+
+  // Gate
+  if (args.gateTotalBytes != null && Number.isFinite(args.gateTotalBytes)) {
+    const subject = args.tarSizeBytes ?? totals.totalBytes;
+    const label = args.tarSizeBytes != null ? 'tar' : 'dist';
+    if (subject > args.gateTotalBytes) {
+      console.error(
+        `\n[dist-bytes-report] GATE FAIL: ${label} size ${fmtBytes(subject)} ` +
+        `exceeds ${fmtBytes(args.gateTotalBytes)}. ` +
+        `GitHub Pages artifact hard cap is 10 GB — blocking deploy ` +
+        `before it fails downstream.`
+      );
+      process.exit(1);
+    }
+    console.log(`[dist-bytes-report] gate OK: ${label} ${fmtBytes(subject)} < ${fmtBytes(args.gateTotalBytes)}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('[dist-bytes-report] error:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Observability step in the deploy build that attributes dist/ bytes per
emitting plugin/category + per locale, and appends a JSONL row to
`data/dist-size-history.jsonl` every run. Lets us see exactly what
moves the artifact size before we keep hitting the GitHub Pages 10 GB
cap.

- New: \`scripts/report-dist-bytes-by-plugin.mjs\` — stat-only walk,
  prefix-based classifier, target < 30 s on ~470 k files. Unknown
  prefixes bucket under \`other-<top-segment>\` so a new plugin path
  is immediately visible.
- New: \`data/dist-size-history.jsonl\` — append-only accumulator.
- \`.github/workflows/deploy.yml\` — new \"Audit dist bytes\" step after
  the tar-pack step. **Does NOT block upload** — observability only.
  If GitHub Pages rejects at 10 GB the downstream deploy-pages step
  still fails with the canonical error, but we always attempt the
  upload to record fit/bounce in the run log.

## Scope

This is a 2-commit branch focused on artifact-size visibility. The
larger artifact-shrink work (traffic-evidence pruning, thin-static +
SPA hydration) lives on a separate branch — kept out of this PR so
the observability tooling can land independently.

## Test plan

- [ ] CI deploy run logs the per-plugin breakdown after the tar-pack step
- [ ] \`data/dist-size-history.jsonl\` gets a new row at HEAD after merge
- [ ] No regression in build duration (step is sub-30 s)
- [ ] Upload always attempted regardless of dist size