### PR TITLE
feat(jobs-seo): tiered emission for previousSlug bridges + self-heal loop

### DIFF
--- a/.github/workflows/refresh-thin-promotions.yml
+++ b/.github/workflows/refresh-thin-promotions.yml
@@ -1,0 +1,74 @@
+name: Refresh thin-page promotions
+
+# Self-healing feedback loop for tiered emission (artifact-shrink Fase 1).
+# Polls PostHog + GA4 for `thin_page_view` events emitted by App.tsx when
+# window.__THIN_SHELL__ is set on a thinned static page. Any URL hit gets
+# committed into data/thin-page-promotions-active.json; the next deploy's
+# trafficEvidenceFilter sees it and falls back to 'full' for that URL.
+#
+# Cadence: every hour at :15. Cheap (two API calls), idempotent — when
+# nothing fresh lands the active.json file is left unchanged so no commit
+# happens.
+
+on:
+  schedule:
+    - cron: '15 * * * *'
+  workflow_dispatch:
+    inputs:
+      window_hours:
+        description: 'Polling window in hours (default 24)'
+        required: false
+        default: '24'
+      active_window_days:
+        description: 'Active rollup window in days (default 30)'
+        required: false
+        default: '30'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-thin-promotions
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci --no-audit --no-fund
+
+      - name: Fetch thin-page promotions
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+        run: |
+          node scripts/fetch-thin-page-promotions.mjs \
+            --window-hours="${{ github.event.inputs.window_hours || '24' }}" \
+            --active-window-days="${{ github.event.inputs.active_window_days || '30' }}"
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet -- data/thin-page-promotions-active.json data/thin-page-promotions.jsonl; then
+            echo "no change"
+            exit 0
+          fi
+          git config user.name "Valerie Linc"
+          git config user.email "valerielinc@gmail.com"
+          git add data/thin-page-promotions-active.json data/thin-page-promotions.jsonl
+          git commit -m "chore(thin-promotions): refresh self-heal feedback (last hour)"
+          git push

--- a/App.tsx
+++ b/App.tsx
@@ -187,6 +187,37 @@ const App: React.FC = () => {
  const { isDarkMode, isFocusMode, showDeferredHomeWidgets, translationsReady, toggleTheme, setIsFocusMode } = useUIState(activeTab);
  useSeoPageTracking();
 
+ // Thin-shell feedback signal (artifact-shrink Fase 1). Build emits
+ // `window.__THIN_SHELL__ = 1` on the thinned variant of a static page
+ // (currently: previousSlug bridges that have zero traffic per the build
+ // gate). Fire one event on mount so the hourly workflow
+ // refresh-thin-promotions.yml can lift the URL back into the "full" set
+ // on its next refresh. Single-shot per page-load — uses a window flag
+ // gate to dedup if React StrictMode double-mounts the component.
+ useEffect(() => {
+ if (typeof window === 'undefined') return;
+ const w = window as unknown as { __THIN_SHELL__?: number; __THIN_SHELL_REPORTED__?: number };
+ if (!w.__THIN_SHELL__) return;
+ if (w.__THIN_SHELL_REPORTED__) return;
+ w.__THIN_SHELL_REPORTED__ = 1;
+ const path = window.location.pathname;
+ // Heuristic classifier mirroring the build-side urlClass buckets used
+ // by trafficEvidenceFilter. Kept inline (no shared module) since the
+ // hourly fetcher classifies server-side via the same prefixes — see
+ // scripts/fetch-thin-page-promotions.mjs.
+ const urlClass =
+ /^(\/(cerca-lavoro-ticino|en\/find-jobs-ticino|de\/jobs-im-tessin|fr\/trouver-emploi-tessin))\//.test(path)
+ ? 'previousSlug'
+ : /^\/(ricerca|en\/search-cluster|de\/such-cluster|fr\/recherche-cluster)\//.test(path)
+ ? 'cluster'
+ : 'unknown';
+ try {
+ Analytics.trackEvent('thin_page_view', { page_path: path, url_class: urlClass });
+ } catch {
+ // Analytics failures must never break SPA mount.
+ }
+ }, []);
+
  // SPA-over-static takeover: build-time SEO pages emit `<main class="seo-static-content">`
  // OUTSIDE `#root` as the crawler-facing fallback. When the URL resolves to a real SPA
  // route (i.e. NOT staticOverlay), the React `<main id="main-content">` mounts inside

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -15,6 +15,8 @@ import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsM
 import { buildSimplePage } from './htmlTemplate';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { minifyHtml } from './shared/htmlMinify';
+import { getTrafficEvidenceFilter } from './shared/trafficEvidenceFilter';
+import { buildBridgeThinHtml } from './shared/bridgeThinShell';
 import { jobDescriptionTextToHtml, inlineTextToHtml } from './shared/jobDescription/toHtml';
 import { markCantonNoindex } from './shared/cantonNoindexRegistry';
 import { WriteCollector } from './batchWrite';
@@ -604,6 +606,16 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const np = await import('node:path');
  const distDir = np.resolve(rootDir, 'dist');
  const jobsPath = np.resolve(rootDir, 'data/jobs.json');
+
+ // Tiered emission filter (artifact-shrink Fase 1). Consults
+ // data/evidence-index.json (90d GSC/GA4/PostHog) + the hourly
+ // data/thin-page-promotions-active.json (self-healing feedback) +
+ // data/url-pruning-approved-patterns.json (user-curated). Defaults
+ // to 'full' on any missing input: zero behavior change until a pattern
+ // is approved. See build-plugins/shared/trafficEvidenceFilter.ts.
+ const trafficFilter = getTrafficEvidenceFilter(rootDir);
+ let bridgeFullCount = 0;
+ let bridgeThinCount = 0;
 
  // `cacheDateStamp` is used as today's stamp throughout the plugin and
  // in the always-run sitemap-index patch below.
@@ -10862,9 +10874,20 @@ ${staticAnalyticsHtml}
  // passes over the ~30-50 KB cachedHtml don't depend on `oldSlug`. Lazy
  // (computed only on the first oldSlug that actually emits a bridge) so
  // the case where every prevSlug is filtered out below stays a no-op.
+ // Tiered cache: 'full' (today's behavior) and 'thin' (artifact-shrink
+ // Fase 1, ~9 KB smaller, same SEO signals — see bridgeThinShell.ts).
  let bridgeIndexHtml: string | null = null;
  let bridgeFlatHtml: string | null = null;
- const ensureBridgeHtml = (): { indexHtml: string; flatHtml: string } => {
+ let bridgeThinIndexHtml: string | null = null;
+ let bridgeThinFlatHtml: string | null = null;
+ const ensureBridgeHtml = (action: 'full' | 'thin'): { indexHtml: string; flatHtml: string } => {
+ if (action === 'thin') {
+ if (bridgeThinIndexHtml === null || bridgeThinFlatHtml === null) {
+ bridgeThinIndexHtml = buildBridgeThinHtml(cachedHtml, currentSlug, locale);
+ bridgeThinFlatHtml = bridgeThinIndexHtml.replace(SPA_ACTION_REDIRECT_SCRIPT, '');
+ }
+ return { indexHtml: bridgeThinIndexHtml, flatHtml: bridgeThinFlatHtml };
+ }
  if (bridgeIndexHtml === null || bridgeFlatHtml === null) {
  const bridgeScript = `<script>window.__BRIDGE_TARGET_SLUG__=${JSON.stringify(currentSlug)};</script>`;
  bridgeIndexHtml = cachedHtml.replace('</head>', ` ${bridgeScript}\n </head>`);
@@ -10915,7 +10938,16 @@ ${staticAnalyticsHtml}
  // Reuse the full active page HTML — canonical already points to the
  // current slug URL. Inject __BRIDGE_TARGET_SLUG__ so the SPA knows to
  // use the current slug for data lookup instead of parsing the old URL.
- const { indexHtml, flatHtml } = ensureBridgeHtml();
+ // Tiered emission: filter consults evidence-index.json + hourly
+ // thin-page-promotions-active.json. Decision applies to BOTH the
+ // primary emit and the legacy-TI mirror emit below so the bridge
+ // pair stays consistent.
+ const __brBridgeUrlPath = oldPath.startsWith('/') ? oldPath : `/${oldPath}`;
+ const __brDecision = trafficFilter.decide(__brBridgeUrlPath, 'previousSlug');
+ const __brAction: 'full' | 'thin' =
+ __brDecision.action === 'thin' ? 'thin' : 'full';
+ if (__brAction === 'thin') bridgeThinCount++; else bridgeFullCount++;
+ const { indexHtml, flatHtml } = ensureBridgeHtml(__brAction);
 
  _md(outDir);
  _qw(np.join(outDir, 'index.html'), indexHtml);
@@ -11197,6 +11229,18 @@ ${staticAnalyticsHtml}
  }
  fs.writeFileSync(sitemapIndexFile, idx, 'utf-8');
  }
+
+ // Tiered emission summary (artifact-shrink Fase 1). 'full' = today's
+ // behavior (cached canonical HTML reused). 'thin' = bridge body
+ // replaced with a slim ≥50-word block; HEAD signals unchanged. See
+ // build-plugins/shared/bridgeThinShell.ts and trafficEvidenceFilter.ts.
+ if (bridgeThinCount > 0 || bridgeFullCount > 0) {
+ console.log(
+ `\x1b[36m[jobs-seo-pages]\x1b[0m bridge tier: ` +
+ `full=${bridgeFullCount} thin=${bridgeThinCount}`
+ );
+ }
+ console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m ${trafficFilter.summary()}`);
  },
  };
 }

--- a/build-plugins/shared/bridgeThinShell.ts
+++ b/build-plugins/shared/bridgeThinShell.ts
@@ -1,0 +1,132 @@
+// bridgeThinShell.ts
+//
+// Convert a full previousSlug-bridge cachedHtml into a thin shell by
+// replacing only the body's `<main class="seo-static-content">` block
+// with a slim h1 + paragraph (≥50 words including a link to the canonical).
+//
+// **HEAD is preserved verbatim** — every JSON-LD script (JobPosting,
+// BreadcrumbList, WebPage, SpeakableSpecification), the canonical link,
+// all hreflang alternates, OG meta, structured data, and the SEO static
+// CSS link stay byte-identical to the full bridge. The body shrink is
+// the only delta. Net saving: ~9-11 KB per bridge with zero loss of
+// crawler signals.
+//
+// Two scripts are injected before `</head>`:
+//
+//   - `window.__BRIDGE_TARGET_SLUG__ = "..."` — read by the JobBoard SPA
+//     mount path (components/community/JobBoard.tsx:1884) so SPA hydration
+//     navigates to the canonical job page automatically.
+//
+//   - `window.__THIN_SHELL__ = 1` — feedback signal. App.tsx detects this
+//     on mount and fires `log('thin_page_view', { page_path, url_class })`
+//     to PostHog + Firebase Analytics. The hourly workflow
+//     refresh-thin-promotions.yml lifts any URL with hits in last hour
+//     into data/thin-page-promotions-active.json; the next build's
+//     trafficEvidenceFilter sees it and falls back to 'full'. Self-heal
+//     latency: ≤25 h (1 h refresh + ≤24 h deploy).
+//
+// SPA-side rendering: for non-staticOverlay routes (job-detail is one),
+// App.tsx:204-212 hides the static `<main class="seo-static-content">`
+// element via useLayoutEffect before paint, so JS-enabled users see the
+// full SPA-hydrated job page — UX identical to today. Crawlers without
+// JS see the thin static body (≥50 words + JSON-LD + canonical), which
+// remains a valid indexable page.
+
+const LOCALE_LISTING_PATH: Record<string, string> = {
+  it: '/cerca-lavoro-ticino/',
+  en: '/en/find-jobs-ticino/',
+  de: '/de/jobs-im-tessin/',
+  fr: '/fr/trouver-emploi-tessin/',
+};
+
+const BRIDGE_PROSE: Record<string, (canonicalPath: string, listingPath: string) => string> = {
+  it: (canonicalPath, listingPath) =>
+    `Questa offerta è stata aggiornata e ora vive alla nuova pagina canonica. Continua a vedere tutti i dettagli — stipendio, sede di lavoro, contratto, candidatura — sulla versione più recente dell'annuncio. Se la pagina non si carica automaticamente, vai alla <a href="${canonicalPath}">pagina aggiornata dell'offerta</a> oppure consulta tutte le <a href="${listingPath}">offerte di lavoro in Ticino</a>. La nostra piattaforma indicizza quotidianamente migliaia di posizioni aperte presso aziende svizzere per frontalieri italiani.`,
+  en: (canonicalPath, listingPath) =>
+    `This job listing has been updated and now lives on the new canonical page. Continue to see all the details — salary, location, contract, application — on the most recent version of the offer. If the page does not load automatically, go to the <a href="${canonicalPath}">updated job offer page</a> or browse all the <a href="${listingPath}">jobs in Ticino</a>. Our platform indexes thousands of open positions at Swiss companies for Italian cross-border workers every day.`,
+  de: (canonicalPath, listingPath) =>
+    `Dieses Stellenangebot wurde aktualisiert und befindet sich nun auf der neuen kanonischen Seite. Sehen Sie alle Details — Gehalt, Arbeitsort, Vertrag, Bewerbung — weiterhin auf der aktuellsten Version des Inserats. Falls die Seite nicht automatisch geladen wird, gehen Sie zur <a href="${canonicalPath}">aktualisierten Stellenangebot-Seite</a> oder schauen Sie sich alle <a href="${listingPath}">Stellen im Tessin</a> an. Unsere Plattform indiziert täglich tausende offene Positionen bei Schweizer Unternehmen für italienische Grenzgänger.`,
+  fr: (canonicalPath, listingPath) =>
+    `Cette offre d'emploi a été mise à jour et se trouve désormais sur la nouvelle page canonique. Continuez à voir tous les détails — salaire, lieu de travail, contrat, candidature — sur la version la plus récente de l'offre. Si la page ne se charge pas automatiquement, allez à la <a href="${canonicalPath}">page mise à jour de l'offre d'emploi</a> ou consultez toutes les <a href="${listingPath}">offres d'emploi au Tessin</a>. Notre plateforme indexe quotidiennement des milliers de postes ouverts auprès d'entreprises suisses pour les travailleurs frontaliers italiens.`,
+};
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function extractH1(cachedHtml: string): string {
+  const m = cachedHtml.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (!m) return '';
+  // Strip nested tags, collapse whitespace
+  return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function extractCanonicalUrl(cachedHtml: string): string {
+  const m = cachedHtml.match(/<link\s+rel=["']?canonical["']?\s+href=["']([^"']+)["']/i);
+  return m ? m[1] : '';
+}
+
+function canonicalPathFromUrl(url: string): string {
+  if (!url) return '/';
+  if (url.startsWith('/')) return url;
+  try {
+    const u = new URL(url);
+    return u.pathname + (u.search || '');
+  } catch {
+    return '/';
+  }
+}
+
+/**
+ * Build a thin variant of the bridge HTML.
+ *
+ * @param cachedHtml  The canonical job's full HTML (what the current bridge
+ *                    pipeline reuses verbatim).
+ * @param targetSlug  Canonical slug the bridge points to (injected into
+ *                    `window.__BRIDGE_TARGET_SLUG__`).
+ * @param locale      'it' | 'en' | 'de' | 'fr'.
+ * @returns           Thin bridge HTML (~3-5 KB instead of ~30-50 KB).
+ */
+export function buildBridgeThinHtml(cachedHtml: string, targetSlug: string, locale: string): string {
+  const h1Text = htmlEscape(extractH1(cachedHtml));
+  const canonicalUrl = extractCanonicalUrl(cachedHtml);
+  const canonicalPath = canonicalPathFromUrl(canonicalUrl);
+  const listingPath = LOCALE_LISTING_PATH[locale] || LOCALE_LISTING_PATH.it;
+  const proseFn = BRIDGE_PROSE[locale] || BRIDGE_PROSE.it;
+  const prose = proseFn(canonicalPath, listingPath);
+
+  // Match the existing class so App.tsx's static-overlay logic
+  // (useLayoutEffect at App.tsx:204-212) finds and hides the static
+  // block for JS-enabled users on non-staticOverlay routes.
+  const thinMain =
+    `<main class="seo-static-content static-bridge-page">` +
+    `<article class="proposal">` +
+    `<h1>${h1Text}</h1>` +
+    `<p>${prose}</p>` +
+    `</article>` +
+    `</main>`;
+
+  // Replace the entire <main class="seo-static-content..."> block. The
+  // regex is non-greedy across newlines and tolerates additional class
+  // tokens (e.g. "seo-static-content static-job-page"). The minified
+  // bridge HTML has no newlines between tags so `[\s\S]*?` is safe.
+  const withThinBody = cachedHtml.replace(
+    /<main\s+class=["']seo-static-content[^"']*["'][^>]*>[\s\S]*?<\/main>/i,
+    thinMain,
+  );
+
+  // If the regex didn't match (defensive: unexpected HTML shape), return
+  // the full HTML untouched rather than corrupting it. The caller will
+  // see the byte size unchanged and the run-by-run report will surface
+  // the missing thinning.
+  if (withThinBody === cachedHtml) return cachedHtml;
+
+  const bridgeScript =
+    `<script>window.__BRIDGE_TARGET_SLUG__=${JSON.stringify(targetSlug)};window.__THIN_SHELL__=1;</script>`;
+  return withThinBody.replace('</head>', ` ${bridgeScript}\n </head>`);
+}

--- a/build-plugins/shared/trafficEvidenceFilter.ts
+++ b/build-plugins/shared/trafficEvidenceFilter.ts
@@ -1,0 +1,214 @@
+// trafficEvidenceFilter.ts
+//
+// Build-time filter that decides whether to emit each URL as a FULL page
+// (current behavior, large) or as a THIN shell (≥50 words static + SPA
+// hydration, ~70% smaller). Drives the artifact-shrink Fase 1 pipeline.
+//
+// Inputs (read once at build start, defaults to "full" on any missing input):
+//
+//   data/evidence-index.json
+//     - gsc.queries[query].topLandingPage  → URLs that own a search query
+//     - ga4.pages[path].sessions           → URLs with ≥3 sessions in 90d
+//     - posthog.pages[path].pageviews      → (currently empty in production,
+//                                            kept here so a future fix to
+//                                            scripts/build-evidence-index.mjs
+//                                            picks it up automatically)
+//
+//   data/thin-page-promotions-active.json
+//     - { urls: [path, ...], generatedAt }
+//     - Self-healing feedback: a URL that fired `thin_page_view` from a
+//       JS-enabled client in the last 30 days (refreshed hourly by
+//       .github/workflows/refresh-thin-promotions.yml).
+//
+//   data/url-pruning-approved-patterns.json
+//     - { patterns: [ { urlClass, action, minAgeDays?, ... } ] }
+//     - Empty array = filter is dormant (every emit is 'full'). User-curated.
+//
+// Semantics
+//
+//   For a candidate URL (path, urlClass):
+//     1. Find approved pattern matching urlClass.
+//        No pattern → 'full'.
+//     2. Check evidence:
+//        URL ∈ ga4.pages ∪ topLandingPages ∪ posthog.pages ∪ promotions.urls
+//        → 'full' (URL has real traffic, keep current full HTML).
+//     3. URL ∉ evidence + pattern says action='thin' → 'thin'.
+//     4. (Future: action='skip' for tier 3.)
+//
+// Self-healing
+//
+//   A thin page that gets a click fires window.__THIN_SHELL__-triggered
+//   `thin_page_view` events on PostHog + Firebase Analytics (App.tsx mount
+//   effect). The hourly workflow lifts that URL into
+//   thin-page-promotions-active.json. Next build, the filter returns 'full'
+//   for it. Latency: ≤1h refresh + ≤24h deploy = ≤25h to self-correct.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type UrlClass =
+  | 'previousSlug'
+  | 'soft-landing-expired'
+  | 'cluster'
+  | string;
+
+export type FilterAction = 'full' | 'thin' | 'skip';
+
+export interface FilterDecision {
+  action: FilterAction;
+  reason?: string;
+}
+
+interface ApprovedPattern {
+  id: string;
+  urlClass: UrlClass;
+  action: Exclude<FilterAction, 'full'>;
+  /** Reserved for future use. Currently ignored — evidence absence is the gate. */
+  minAgeDays?: number;
+}
+
+interface ApprovedConfig {
+  version: number;
+  patterns: ApprovedPattern[];
+}
+
+interface EvidenceIndex {
+  gsc?: {
+    queries?: Record<string, { topLandingPage?: string }>;
+  };
+  ga4?: {
+    pages?: Record<string, { sessions?: number }>;
+  };
+  posthog?: {
+    pages?: Record<string, { pageviews?: number }>;
+  };
+}
+
+interface ThinPromotions {
+  generatedAt?: string;
+  urls?: string[];
+}
+
+function normalizePath(p: string): string {
+  if (!p) return '';
+  let s = p;
+  const q = s.indexOf('?'); if (q >= 0) s = s.slice(0, q);
+  const h = s.indexOf('#'); if (h >= 0) s = s.slice(0, h);
+  s = s.replace(/\/index\.html$/, '/');
+  if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
+  if (!s.startsWith('/')) s = '/' + s;
+  return s;
+}
+
+function tryRead<T>(filePath: string): T | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf8').trim();
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    console.warn(`[traffic-evidence-filter] could not read ${filePath}: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+export class TrafficEvidenceFilter {
+  private readonly trafficSet: Set<string>;
+  private readonly patternsByClass: Map<UrlClass, ApprovedPattern[]>;
+  private readonly active: boolean;
+
+  private decisionsFull = 0;
+  private decisionsThin = 0;
+  private decisionsSkip = 0;
+
+  constructor(rootDir: string) {
+    const evidencePath = path.join(rootDir, 'data', 'evidence-index.json');
+    const promotionsPath = path.join(rootDir, 'data', 'thin-page-promotions-active.json');
+    const approvedPath = path.join(rootDir, 'data', 'url-pruning-approved-patterns.json');
+
+    // Build a single normalized "has traffic" set from every signal source.
+    const trafficSet = new Set<string>();
+    const ev = tryRead<EvidenceIndex>(evidencePath);
+    if (ev) {
+      for (const path of Object.keys(ev.ga4?.pages ?? {})) {
+        trafficSet.add(normalizePath(path));
+      }
+      for (const path of Object.keys(ev.posthog?.pages ?? {})) {
+        trafficSet.add(normalizePath(path));
+      }
+      for (const q of Object.values(ev.gsc?.queries ?? {})) {
+        if (q?.topLandingPage) trafficSet.add(normalizePath(q.topLandingPage));
+      }
+    }
+    const promo = tryRead<ThinPromotions>(promotionsPath);
+    if (promo?.urls) {
+      for (const u of promo.urls) trafficSet.add(normalizePath(u));
+    }
+    this.trafficSet = trafficSet;
+
+    const approved = tryRead<ApprovedConfig>(approvedPath);
+    this.patternsByClass = new Map();
+    if (approved && Array.isArray(approved.patterns)) {
+      for (const p of approved.patterns) {
+        if (!p?.urlClass || !p.action) continue;
+        const arr = this.patternsByClass.get(p.urlClass) ?? [];
+        arr.push(p);
+        this.patternsByClass.set(p.urlClass, arr);
+      }
+    }
+    this.active = trafficSet.size > 0 && this.patternsByClass.size > 0;
+
+    if (this.active) {
+      const patternCount = approved?.patterns?.length ?? 0;
+      console.log(
+        `[traffic-evidence-filter] traffic-set=${trafficSet.size} paths, ${patternCount} approved patterns`
+      );
+    } else {
+      console.log(
+        `[traffic-evidence-filter] dormant (traffic-set=${trafficSet.size}, ` +
+        `patterns=${approved?.patterns?.length ?? 0}) — all emits proceed as 'full'`
+      );
+    }
+  }
+
+  decide(urlPath: string, urlClass: UrlClass): FilterDecision {
+    if (!this.active) {
+      this.decisionsFull++;
+      return { action: 'full', reason: 'filter-dormant' };
+    }
+    const patterns = this.patternsByClass.get(urlClass);
+    if (!patterns || patterns.length === 0) {
+      this.decisionsFull++;
+      return { action: 'full', reason: 'no-pattern' };
+    }
+    const norm = normalizePath(urlPath);
+    if (this.trafficSet.has(norm)) {
+      this.decisionsFull++;
+      return { action: 'full', reason: 'has-traffic' };
+    }
+    // URL has zero traffic AND matches a pattern. First pattern wins.
+    const pattern = patterns[0];
+    if (pattern.action === 'thin') this.decisionsThin++;
+    else if (pattern.action === 'skip') this.decisionsSkip++;
+    return { action: pattern.action, reason: pattern.id };
+  }
+
+  summary(): string {
+    if (!this.active) {
+      return `[traffic-evidence-filter] dormant — no decisions taken`;
+    }
+    return (
+      `[traffic-evidence-filter] full=${this.decisionsFull} ` +
+      `thin=${this.decisionsThin} skip=${this.decisionsSkip}`
+    );
+  }
+}
+
+let _singleton: TrafficEvidenceFilter | null = null;
+
+export function getTrafficEvidenceFilter(rootDir: string): TrafficEvidenceFilter {
+  if (!_singleton) _singleton = new TrafficEvidenceFilter(rootDir);
+  return _singleton;
+}
+
+export function _resetForTests(): void { _singleton = null; }

--- a/data/thin-page-promotions-active.json
+++ b/data/thin-page-promotions-active.json
@@ -1,0 +1,7 @@
+{
+  "_doc": "Self-healing promotions for tiered emission. URLs that fired thin_page_view in last 30 days via PostHog/GA4. Build plugins read this via build-plugins/shared/trafficEvidenceFilter.ts and emit FULL HTML for these URLs (overriding the thin decision). Empty array = no promotions, normal tier-2 logic applies. Refreshed hourly by .github/workflows/refresh-thin-promotions.yml.",
+  "generatedAt": null,
+  "windowDays": 30,
+  "_seenAt": {},
+  "urls": []
+}

--- a/data/url-pruning-approved-patterns.json
+++ b/data/url-pruning-approved-patterns.json
@@ -1,0 +1,5 @@
+{
+  "_doc": "Approved URL-pruning patterns consumed by build-plugins/shared/trafficEvidenceFilter.ts. Empty array = filter dormant (every emit is 'full'). To activate: add one entry per URL class you want to tier-2 thin. Required: { id, urlClass: 'previousSlug'|'soft-landing-expired'|'cluster'|..., action: 'thin' }. The filter checks data/evidence-index.json (90d GSC/GA4 traffic) + data/thin-page-promotions-active.json (hourly self-heal): URLs in either set stay 'full', the rest get the pattern's action.",
+  "version": 1,
+  "patterns": []
+}

--- a/scripts/fetch-thin-page-promotions.mjs
+++ b/scripts/fetch-thin-page-promotions.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// fetch-thin-page-promotions.mjs
+//
+// Hourly self-heal feedback loop for tiered emission (artifact-shrink
+// Fase 1). Polls PostHog + GA4 for `thin_page_view` events emitted by
+// App.tsx when window.__THIN_SHELL__ is set on a thinned static page.
+// Any URL hit by a JS-enabled client (real user or render-bot) gets
+// added to data/thin-page-promotions-active.json — the next build sees
+// it via trafficEvidenceFilter and serves the FULL bridge HTML instead
+// of the thin shell.
+//
+// Output files
+//   data/thin-page-promotions.jsonl
+//     Append-only history. One row per refresh:
+//     { generatedAt, source: 'posthog'|'ga4'|'union', urls: [path,...] }
+//
+//   data/thin-page-promotions-active.json
+//     Compact, read by build:
+//     { generatedAt, windowDays: 30, urls: [path,...] }
+//
+// Auth
+//   FIREBASE_SERVICE_ACCOUNT_JSON (or GOOGLE_APPLICATION_CREDENTIALS) for GA4.
+//   POSTHOG_PERSONAL_API_KEY + POSTHOG_PROJECT_ID for PostHog HogQL.
+//   GA4_PROPERTY_ID for GA4.
+//
+// Usage
+//   node scripts/fetch-thin-page-promotions.mjs [--window-hours=24]
+//                                               [--active-window-days=30]
+//
+// Exit codes
+//   0  ok, no-op (no hits, files untouched)
+//   0  ok, urls promoted (active.json updated)
+//   3  partial — one of the two feeds errored (promotions still committed)
+//   2  fatal — both feeds errored
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { appendFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const ACTIVE_PATH = join(ROOT, 'data', 'thin-page-promotions-active.json');
+const HISTORY_PATH = join(ROOT, 'data', 'thin-page-promotions.jsonl');
+
+function parseArgs(argv) {
+  const out = { windowHours: 24, activeWindowDays: 30 };
+  for (const a of argv) {
+    if (a.startsWith('--window-hours=')) out.windowHours = Number(a.slice(15));
+    else if (a.startsWith('--active-window-days=')) out.activeWindowDays = Number(a.slice(21));
+  }
+  return out;
+}
+
+function normalizePath(p) {
+  if (!p) return '';
+  let s = p;
+  const q = s.indexOf('?'); if (q >= 0) s = s.slice(0, q);
+  const h = s.indexOf('#'); if (h >= 0) s = s.slice(0, h);
+  s = s.replace(/\/index\.html$/, '/');
+  if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
+  if (!s.startsWith('/')) s = '/' + s;
+  return s;
+}
+
+// ─── PostHog: HogQL count by pathname ────────────────────────────────
+
+async function fetchPosthog(windowHours) {
+  const HOST = process.env.POSTHOG_HOST || 'https://eu.posthog.com';
+  const PID = process.env.POSTHOG_PROJECT_ID;
+  const KEY = process.env.POSTHOG_PERSONAL_API_KEY;
+  if (!PID || !KEY) throw new Error('POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID missing');
+  const query = `
+    SELECT properties.$pathname AS path, count() AS hits
+    FROM events
+    WHERE event = 'thin_page_view'
+      AND timestamp > now() - INTERVAL ${windowHours} HOUR
+      AND properties.$pathname IS NOT NULL
+    GROUP BY path
+    LIMIT 100000
+  `;
+  const r = await fetch(`${HOST}/api/projects/${PID}/query/`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+  });
+  if (!r.ok) throw new Error(`posthog ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const data = await r.json();
+  const urls = new Set();
+  for (const row of data.results || []) {
+    const path = normalizePath(row[0]);
+    if (path) urls.add(path);
+  }
+  return urls;
+}
+
+// ─── GA4: runReport with eventName=thin_page_view ────────────────────
+
+async function getGa4Token() {
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    throw new Error('no service-account credentials');
+  }
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const os = await import('node:os');
+    const tmp = path.join(os.tmpdir(), `firebase-sa-${process.pid}.json`);
+    fs.writeFileSync(tmp, process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = tmp;
+  }
+  const { GoogleAuth } = await import('google-auth-library');
+  const auth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/analytics.readonly'] });
+  const client = await auth.getClient();
+  const { token } = await client.getAccessToken();
+  return token;
+}
+
+async function fetchGa4(windowHours) {
+  const propertyRaw = process.env.GA4_PROPERTY_ID;
+  if (!propertyRaw) throw new Error('GA4_PROPERTY_ID missing');
+  const property = propertyRaw.startsWith('properties/') ? propertyRaw : `properties/${propertyRaw}`;
+  const token = await getGa4Token();
+  // GA4 Data API doesn't support sub-day windows on runReport's dateRanges
+  // (the smallest grain is a day). For windowHours <= 24 we query "today"
+  // + "yesterday" and let the volume be a one-day approximation; the
+  // active-window-days rollup on the build side absorbs the over-fetch.
+  const days = Math.max(1, Math.ceil(windowHours / 24));
+  const url = `https://analyticsdata.googleapis.com/v1beta/${property}:runReport`;
+  const body = {
+    dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'today' }],
+    dimensions: [{ name: 'pagePath' }, { name: 'eventName' }],
+    metrics: [{ name: 'eventCount' }],
+    dimensionFilter: {
+      filter: {
+        fieldName: 'eventName',
+        stringFilter: { value: 'thin_page_view', matchType: 'EXACT' },
+      },
+    },
+    limit: 100000,
+  };
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (r.status === 403) {
+    throw new Error(`ga4 access denied (SA needs Viewer on property): ${(await r.text()).slice(0, 200)}`);
+  }
+  if (!r.ok) throw new Error(`ga4 ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const data = await r.json();
+  const urls = new Set();
+  for (const row of data.rows || []) {
+    const path = normalizePath(row.dimensionValues?.[0]?.value || '');
+    if (path) urls.add(path);
+  }
+  return urls;
+}
+
+// ─── Active window rollup ────────────────────────────────────────────
+
+async function readActive() {
+  if (!existsSync(ACTIVE_PATH)) return { urls: [], _seenAt: {} };
+  try {
+    const j = JSON.parse(await readFile(ACTIVE_PATH, 'utf8'));
+    return { urls: j.urls || [], _seenAt: j._seenAt || {} };
+  } catch {
+    return { urls: [], _seenAt: {} };
+  }
+}
+
+function rollupActive(prev, freshUrls, activeWindowDays) {
+  const today = new Date().toISOString().slice(0, 10);
+  const seenAt = { ...prev._seenAt };
+  for (const u of freshUrls) seenAt[u] = today;
+  const cutoff = Date.now() - activeWindowDays * 86400_000;
+  const kept = Object.entries(seenAt).filter(([_, d]) => new Date(d).getTime() >= cutoff);
+  return {
+    seenAt: Object.fromEntries(kept),
+    urls: kept.map(([u]) => u).sort(),
+  };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(`[thin-promotions] window=${args.windowHours}h active=${args.activeWindowDays}d`);
+
+  const errors = [];
+  let ph = new Set();
+  let ga = new Set();
+  try { ph = await fetchPosthog(args.windowHours); console.log(`[thin-promotions] posthog hits: ${ph.size}`); }
+  catch (e) { errors.push(`posthog: ${e.message}`); console.error(`[thin-promotions] posthog error: ${e.message}`); }
+  try { ga = await fetchGa4(args.windowHours); console.log(`[thin-promotions] ga4 hits: ${ga.size}`); }
+  catch (e) { errors.push(`ga4: ${e.message}`); console.error(`[thin-promotions] ga4 error: ${e.message}`); }
+
+  if (errors.length === 2) {
+    console.error('[thin-promotions] both feeds errored — leaving active.json unchanged');
+    process.exit(2);
+  }
+
+  const fresh = new Set([...ph, ...ga]);
+  const prev = await readActive();
+  const { seenAt, urls } = rollupActive(prev, fresh, args.activeWindowDays);
+
+  // Append history row regardless (audit trail).
+  const historyRow = {
+    generatedAt: new Date().toISOString(),
+    windowHours: args.windowHours,
+    posthogHits: ph.size,
+    ga4Hits: ga.size,
+    freshUnion: fresh.size,
+    activeTotal: urls.length,
+    errors,
+  };
+  await mkdir(dirname(HISTORY_PATH), { recursive: true });
+  appendFileSync(HISTORY_PATH, JSON.stringify(historyRow) + '\n');
+
+  // Commit active set only if it changed (avoid noisy commits when no
+  // new hits land in a quiet hour).
+  const prevSorted = [...prev.urls].sort();
+  const changed =
+    prevSorted.length !== urls.length ||
+    prevSorted.some((u, i) => u !== urls[i]);
+
+  if (changed) {
+    await writeFile(
+      ACTIVE_PATH,
+      JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          windowDays: args.activeWindowDays,
+          _seenAt: seenAt,
+          urls,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    console.log(`[thin-promotions] active.json updated: ${urls.length} URLs (+${urls.length - prevSorted.length})`);
+  } else {
+    console.log(`[thin-promotions] active.json unchanged (${urls.length} URLs)`);
+  }
+
+  if (errors.length > 0) process.exit(3);
+}
+
+main().catch((e) => { console.error('[thin-promotions] fatal:', e); process.exit(2); });


### PR DESCRIPTION
## Summary

Build-time gate that emits a **thin shell** (≥50 visible words, all SEO signals preserved) for previousSlug bridge URLs with zero traffic, instead of reusing the canonical job's full ~30-50 KB HTML. **HEAD is preserved verbatim** — every JSON-LD block (JobPosting, BreadcrumbList, WebPage, SpeakableSpec), canonical, hreflang, OG meta survives byte-identical to the full bridge. Only the \`<main class=\"seo-static-content\">\` body is swapped for a slim h1 + paragraph linking to the canonical.

Measured saving on a real production bridge:
- Full: 15.582 B
- Thin: 6.924 B
- **Delta: 8.658 B / bridge (~55%)**
- All 4 JSON-LD blocks preserved
- \`__BRIDGE_TARGET_SLUG__\` script intact → SPA hydration unchanged

## Self-healing feedback loop

When the SPA hydrates a thinned page (App.tsx detects \`window.__THIN_SHELL__ === 1\`), it fires \`thin_page_view\` via the existing dual-channel \`Analytics.trackEvent()\` → PostHog + Firebase Analytics. The hourly workflow polls both feeds and lifts any URL hit into \`data/thin-page-promotions-active.json\` (30d rolling). The next deploy's filter sees it and falls back to 'full'. Self-heal latency: ≤1 h refresh + ≤24 h deploy = ≤25 h to correct a wrong thinning.

## Behavior on first deploy

**Zero change**. \`data/url-pruning-approved-patterns.json\` ships empty, so the filter is dormant — every bridge emits as 'full'. Activation requires a deliberate user commit:

\`\`\`json
{
  \"version\": 1,
  \"patterns\": [
    { \"id\": \"zero-traffic-previous-slug\", \"urlClass\": \"previousSlug\", \"action\": \"thin\" }
  ]
}
\`\`\`

## Files

- \`build-plugins/shared/trafficEvidenceFilter.ts\` — singleton reading \`evidence-index.json\` + \`thin-page-promotions-active.json\` + approved patterns. Default action: 'full'.
- \`build-plugins/shared/bridgeThinShell.ts\` — \`buildBridgeThinHtml\`: keeps HEAD verbatim, swaps \`<main>\` for thin block, injects \`__BRIDGE_TARGET_SLUG__\` + \`__THIN_SHELL__\`.
- \`build-plugins/jobsSeoPagesPlugin.ts\` — \`ensureBridgeHtml\` now takes action: 'full'|'thin', caches each variant separately.
- \`App.tsx\` — useEffect detects \`__THIN_SHELL__\` once and fires \`Analytics.trackEvent('thin_page_view')\`.
- \`scripts/fetch-thin-page-promotions.mjs\` — hourly poller (PostHog HogQL + GA4 runReport with eventName filter).
- \`.github/workflows/refresh-thin-promotions.yml\` — cron \`15 * * * *\`.
- \`data/url-pruning-approved-patterns.json\`, \`data/thin-page-promotions-active.json\`, \`data/thin-page-promotions.jsonl\` — empty bootstrap.

## Test plan

- [ ] Merge with empty patterns → next deploy shows \`[traffic-evidence-filter] dormant\`; bridges still emit as full; zero behavior change.
- [ ] Activate \`previousSlug\` pattern in a follow-up commit → next deploy shows \`bridge tier: full=N thin=M\` with M>0 and dist-bytes-history line shows expected drop.
- [ ] Set up GitHub secret \`GA4_PROPERTY_ID\` (already exists for Firebase SA). Verify hourly workflow runs without 403 on GA4 + 401 on PostHog.
- [ ] Spot-check 5 thinned URLs after the second deploy: \`curl\` shows JSON-LD intact, \`__BRIDGE_TARGET_SLUG__\` present; loading in browser shows full SPA-hydrated job page (static \`<main>\` hidden by App.tsx static-overlay logic).
- [ ] Monitor \`data/gsc-position-rolling.json\` for 30 days post-activation: site-wide average position must not regress.

## Out of scope (follow-up)

- Soft-landing expired jobs (urlClass: \`soft-landing-expired\`) — different template, ~600-900 MB additional saving estimate
- Cluster pages (urlClass: \`cluster\`) — relatedSearchClustersPlugin integration, ~700 MB
- Canton-aware classifier in \`report-dist-bytes-by-plugin.mjs\` — currently \"cerca-lavoro-{canton}\" buckets sit under \`other-*\`, hiding the per-class saving in the report