### PR TITLE
fix(deploy): classifier catches all canton-aware job sections + OG locale variants

### DIFF
--- a/scripts/report-dist-bytes-by-plugin.mjs
+++ b/scripts/report-dist-bytes-by-plugin.mjs
@@ -60,20 +60,26 @@ function parseArgs(argv) {
 const LOCALES = new Set(['en', 'de', 'fr']);
 
 const PLUGIN_RULES = [
-  // jobs SEO (active + soft-landing + previousSlugs bridges)
-  { plugin: 'jobs-seo', prefixes: [
-    'cerca-lavoro-ticino/', 'find-jobs-ticino/', 'jobs-im-tessin/', 'trouver-emploi-tessin/',
-    'cerca-lavoro-ticino.html', 'find-jobs-ticino.html', 'jobs-im-tessin.html', 'trouver-emploi-tessin.html',
-  ]},
+  // jobs SEO (active + soft-landing + previousSlugs bridges).
+  // jobsSeoPagesPlugin emits under canton-aware sections for every canton
+  // (TI, ZH, BE, GR, BS, VD, VS, LU, AG, GE, SO, SG, FR, TG, NE, …) plus a
+  // pan-Switzerland section. The IT/EN/DE/FR section names diverge per
+  // locale (e.g. cerca-lavoro-zurigo / find-jobs-zurich / jobs-in-zurich /
+  // trouver-emploi-zurich), so we use a regex to catch the whole family
+  // without enumerating every canton × every locale × every prefix.
+  { plugin: 'jobs-seo', regex:
+    /^(cerca-lavoro|find-jobs|jobs-im|jobs-in|trouver-emploi)-[a-z][a-z-]*(\/|\.html$)/ },
   // related search cluster pages
   { plugin: 'cluster', prefixes: [
     'ricerca-cluster/', 'search-cluster/', 'such-cluster/', 'recherche-cluster/',
     'ricerca/', 'cluster-ricerca/',
   ]},
-  // OG / article pages
-  { plugin: 'og-pages', prefixes: [
-    'articoli-frontaliere/', 'articles-frontaliere/', 'artikel-grenzgaenger/', 'articles-frontaliers/',
-  ]},
+  // OG / article pages — paths vary across locales (articoli-frontaliere
+  // / articles-frontalier / grenzgaenger-artikel / cross-border-articles
+  // …). Regex catches the family without enumerating singular/plural and
+  // EN/DE/FR/IT variants.
+  { plugin: 'og-pages', regex:
+    /^(articoli-frontaliere|articles?-frontaliers?|articles?-frontalier|grenzgaenger-artikel|cross-border-articles?)\// },
   // hub plugins
   { plugin: 'hub-salary', prefixes: ['stipendi/', 'salaries/', 'gehaelter/', 'salaires/'] },
   { plugin: 'hub-faq', prefixes: ['faq/', 'domande/', 'fragen/', 'questions/'] },


### PR DESCRIPTION
## Summary

The dist-bytes report was attributing only the Ticino section to \`jobs-seo\`; every other canton (\`cerca-lavoro-zurigo\`, \`find-jobs-bern\`, \`jobs-im-aargau\`, \`trouver-emploi-saint-gall\`, …) fell into \`other-*\` buckets despite being emitted by the same \`jobsSeoPagesPlugin\`.

On the 2026-05-28 build (11.25 GB total), \`jobs-seo\` showed 4.73 GB (42 %), but the **actual jobs-related total** including all \`other-cerca-lavoro-*\` / \`other-find-jobs-*\` / \`other-jobs-in-*\` / \`other-jobs-im-*\` / \`other-trouver-emploi-*\` buckets was ~9.7 GB (~87 %).

Switch the IT/EN/DE/FR job-section prefix list to a single regex catching the whole family. Same for og-pages where article paths diverge per locale (\`articoli-frontaliere\` / \`articles-frontalier\` / \`grenzgaenger-artikel\` / \`cross-border-articles\`).

Note: the filter itself never relied on this classifier — \`jobsSeoPagesPlugin\` passes explicit \`urlClass: 'previousSlug'\` tags to \`TrafficEvidenceFilter.decide()\`. Only the **observability report** was misattributing. This PR fixes the report so we can see thinning impact accurately once \`url-pruning-approved-patterns.json\` activates.

## Test plan

- [x] Local synthetic dist with samples of each canton × locale section verifies the regex catches all the previously-orphaned variants.
- [ ] Next deploy on main: \`[dist-bytes-report] by plugin\` shows \`jobs-seo\` ~9.7 GB instead of 4.73 GB; \`other-*\` buckets shrink correspondingly.