### PR TITLE
feat(jobs-seo): activate tiered emission + extend to soft-landing pages

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -17,6 +17,7 @@ import { buildSeoPageHtml } from './shared/seoPageShell';
 import { minifyHtml } from './shared/htmlMinify';
 import { getTrafficEvidenceFilter } from './shared/trafficEvidenceFilter';
 import { buildBridgeThinHtml } from './shared/bridgeThinShell';
+import { buildSoftLandingThinHtml } from './shared/softLandingThinShell';
 import { jobDescriptionTextToHtml, inlineTextToHtml } from './shared/jobDescription/toHtml';
 import { markCantonNoindex } from './shared/cantonNoindexRegistry';
 import { WriteCollector } from './batchWrite';
@@ -616,6 +617,8 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const trafficFilter = getTrafficEvidenceFilter(rootDir);
  let bridgeFullCount = 0;
  let bridgeThinCount = 0;
+ let softLandingFullCount = 0;
+ let softLandingThinCount = 0;
 
  // `cacheDateStamp` is used as today's stamp throughout the plugin and
  // in the always-run sitemap-index patch below.
@@ -10582,11 +10585,25 @@ ${staticAnalyticsHtml}
  recordPhase('ejp:jsonld', __tEjpJsonld);
 
  const __tEjpShell = phaseTimer();
- const softLandingHtml = buildSoftLandingHtml(
+ const __slFullHtml = buildSoftLandingHtml(
  locale, pageTitle, pageDesc, expiredRobotsTag,
  selfUrl, hreflangLinks, jsonLdScripts, expiredWindowData,
  staticBody
  );
+ // Tiered emission for soft-landings. Same filter + evidence flow as
+ // previousSlug bridges: URL with traffic stays full; URL without and
+ // matching an approved pattern becomes a thin shell (HEAD verbatim,
+ // article body replaced by a slim h1+p≥50 words). See
+ // build-plugins/shared/softLandingThinShell.ts.
+ const __slDecision = trafficFilter.decide(relPath, 'soft-landing-expired');
+ const __slAction: 'full' | 'thin' =
+ __slDecision.action === 'thin' ? 'thin' : 'full';
+ const softLandingHtml =
+ __slAction === 'thin'
+ ? buildSoftLandingThinHtml(__slFullHtml, locale)
+ : __slFullHtml;
+ if (__slAction === 'thin') softLandingThinCount++;
+ else softLandingFullCount++;
  recordPhase('ejp:shell', __tEjpShell);
 
  // Dedup membership: __slPathKey is computed and checked at the top of
@@ -11238,6 +11255,12 @@ ${staticAnalyticsHtml}
  console.log(
  `\x1b[36m[jobs-seo-pages]\x1b[0m bridge tier: ` +
  `full=${bridgeFullCount} thin=${bridgeThinCount}`
+ );
+ }
+ if (softLandingThinCount > 0 || softLandingFullCount > 0) {
+ console.log(
+ `\x1b[36m[jobs-seo-pages]\x1b[0m soft-landing tier: ` +
+ `full=${softLandingFullCount} thin=${softLandingThinCount}`
  );
  }
  console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m ${trafficFilter.summary()}`);

--- a/build-plugins/shared/softLandingThinShell.ts
+++ b/build-plugins/shared/softLandingThinShell.ts
@@ -1,0 +1,111 @@
+// softLandingThinShell.ts
+//
+// Convert a full expired-job soft-landing HTML page into a thin shell by
+// replacing only the `<article class="ft-static-article">` block with a
+// slim h1 + paragraph (≥50 words). HEAD is preserved verbatim — every
+// JSON-LD block, canonical, hreflang, OG meta, and the
+// `window.__EXPIRED_JOB_DATA__` blob the SPA's JobOrphanView reads on
+// mount survive byte-identical. Net saving: ~5-8 KB per soft-landing
+// page (with STRIP_EXPIRED_JOB_PROSE on; more when prose is in).
+//
+// One script is added to the head: `window.__THIN_SHELL__ = 1`. The
+// App.tsx mount effect fires `thin_page_view` via PostHog + Firebase
+// Analytics; the hourly workflow lifts hit URLs into
+// data/thin-page-promotions-active.json so the next build's filter
+// returns 'full' for them. Self-heal latency: ≤25 h.
+//
+// SPA-side rendering: unlike previousSlug bridges, soft-landings emit
+// their content INSIDE `<div id="root">` so React replaces it on mount
+// anyway (the static body is a crawler-only first-paint). The thinning
+// shrinks that first-paint payload; user UX after hydration is
+// identical to today.
+
+const LOCALE_LISTING_PATH: Record<string, string> = {
+  it: '/cerca-lavoro-ticino/',
+  en: '/en/find-jobs-ticino/',
+  de: '/de/jobs-im-tessin/',
+  fr: '/fr/trouver-emploi-tessin/',
+};
+
+const SOFT_LANDING_PROSE: Record<string, (canonicalPath: string, listingPath: string) => string> = {
+  it: (canonicalPath, listingPath) =>
+    `Questa offerta di lavoro non è più attiva. Per vedere le posizioni aperte equivalenti e i dettagli aggiornati su stipendio, sede e contratto, consulta tutte le <a href="${listingPath}">offerte di lavoro in Ticino</a>. Sul nostro job board indicizziamo ogni giorno migliaia di posizioni presso aziende svizzere per frontalieri italiani, con filtri per canton, settore, contratto e fascia di stipendio. La pagina attuale mantiene il riferimento storico per il motore di ricerca e si aggiorna automaticamente quando ricarichi la lista completa.`,
+  en: (canonicalPath, listingPath) =>
+    `This job listing is no longer active. To browse equivalent open positions with up-to-date salary, location and contract details, see all the <a href="${listingPath}">jobs in Ticino</a>. Our job board indexes thousands of positions at Swiss companies for Italian cross-border workers every day, with filters by canton, sector, contract type and salary band. This page is preserved as a historical reference and updates automatically when you reload the full listing.`,
+  de: (canonicalPath, listingPath) =>
+    `Dieses Stellenangebot ist nicht mehr aktiv. Um gleichwertige offene Stellen mit aktuellen Angaben zu Gehalt, Arbeitsort und Vertrag zu sehen, schauen Sie sich alle <a href="${listingPath}">Stellen im Tessin</a> an. Unser Job Board indiziert täglich tausende Positionen bei Schweizer Unternehmen für italienische Grenzgänger, mit Filtern nach Kanton, Branche, Vertragsart und Lohnband. Diese Seite bleibt als historische Referenz erhalten und aktualisiert sich automatisch, wenn Sie die vollständige Liste neu laden.`,
+  fr: (canonicalPath, listingPath) =>
+    `Cette offre d'emploi n'est plus active. Pour parcourir les postes ouverts équivalents avec les détails à jour sur le salaire, le lieu et le contrat, consultez toutes les <a href="${listingPath}">offres d'emploi au Tessin</a>. Notre job board indexe quotidiennement des milliers de postes auprès d'entreprises suisses pour les travailleurs frontaliers italiens, avec des filtres par canton, secteur, type de contrat et fourchette salariale. Cette page reste comme référence historique et se met à jour automatiquement lorsque vous rechargez la liste complète.`,
+};
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function extractH1(html: string): string {
+  const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (!m) return '';
+  return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function extractCanonicalUrl(html: string): string {
+  const m = html.match(/<link\s+rel=["']?canonical["']?\s+href=["']([^"']+)["']/i);
+  return m ? m[1] : '';
+}
+
+function canonicalPathFromUrl(url: string): string {
+  if (!url) return '/';
+  if (url.startsWith('/')) return url;
+  try {
+    const u = new URL(url);
+    return u.pathname + (u.search || '');
+  } catch {
+    return '/';
+  }
+}
+
+/**
+ * Build a thin variant of the soft-landing HTML.
+ *
+ * @param fullHtml  The output of buildSoftLandingHtml for this page.
+ * @param locale    'it' | 'en' | 'de' | 'fr'.
+ * @returns         Thin HTML (~3-5 KB instead of ~10-15 KB).
+ */
+export function buildSoftLandingThinHtml(fullHtml: string, locale: string): string {
+  const h1Text = htmlEscape(extractH1(fullHtml));
+  const canonicalUrl = extractCanonicalUrl(fullHtml);
+  const canonicalPath = canonicalPathFromUrl(canonicalUrl);
+  const listingPath = LOCALE_LISTING_PATH[locale] || LOCALE_LISTING_PATH.it;
+  const proseFn = SOFT_LANDING_PROSE[locale] || SOFT_LANDING_PROSE.it;
+  const prose = proseFn(canonicalPath, listingPath);
+
+  // Same `ft-static-article` class so the inline snapshot script
+  // (last line of soft-landing body) still finds an element to read.
+  // Its content is now the thin block — that's fine, JobOrphanView's
+  // SPA mount path doesn't rely on this snapshot for data (it reads
+  // `__EXPIRED_JOB_DATA__` from head).
+  const thinArticle =
+    `<article class="ft-static-article">` +
+    `<h1>${h1Text}</h1>` +
+    `<p>${prose}</p>` +
+    `</article>`;
+
+  // Replace the entire heavy article with the thin one.
+  const withThinBody = fullHtml.replace(
+    /<article\s+class=["']ft-static-article["'][^>]*>[\s\S]*?<\/article>/i,
+    thinArticle,
+  );
+
+  if (withThinBody === fullHtml) return fullHtml;
+
+  // Add the thin-shell signal in head so App.tsx fires thin_page_view.
+  return withThinBody.replace(
+    '</head>',
+    ` <script>window.__THIN_SHELL__=1;</script>\n </head>`,
+  );
+}

--- a/data/url-pruning-approved-patterns.json
+++ b/data/url-pruning-approved-patterns.json
@@ -1,5 +1,16 @@
 {
-  "_doc": "Approved URL-pruning patterns consumed by build-plugins/shared/trafficEvidenceFilter.ts. Empty array = filter dormant (every emit is 'full'). To activate: add one entry per URL class you want to tier-2 thin. Required: { id, urlClass: 'previousSlug'|'soft-landing-expired'|'cluster'|..., action: 'thin' }. The filter checks data/evidence-index.json (90d GSC/GA4 traffic) + data/thin-page-promotions-active.json (hourly self-heal): URLs in either set stay 'full', the rest get the pattern's action.",
+  "_doc": "Approved URL-pruning patterns consumed by build-plugins/shared/trafficEvidenceFilter.ts. URL with traffic in data/evidence-index.json (GSC topLandingPage / GA4 sessions >=3 / PostHog pageviews) OR data/thin-page-promotions-active.json (hourly self-heal) stays 'full'; URL not in either set and matching a pattern here gets the pattern's action.",
   "version": 1,
-  "patterns": []
+  "patterns": [
+    {
+      "id": "zero-traffic-previous-slug",
+      "urlClass": "previousSlug",
+      "action": "thin"
+    },
+    {
+      "id": "zero-traffic-soft-landing-expired",
+      "urlClass": "soft-landing-expired",
+      "action": "thin"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Two changes that go together so we see end-to-end the Fase 1 effect on the next deploy:

1. **Activate the previousSlug pattern** (introduced dormant in #723). The filter starts thinning previousSlug bridges with zero traffic per \`evidence-index.json\`. URL with GSC topLandingPage OR GA4 sessions ≥3 OR PostHog pageviews stays full. Coverage spans **all canton sections**, not just Ticino — the filter is class-gated, the plugin passes canton-aware URLs through.

2. **Extend tiered emission to expired-job soft-landings**. New \`build-plugins/shared/softLandingThinShell.ts\` mirrors \`bridgeThinShell.ts\`: replaces only the heavy \`<article class=\"ft-static-article\">\` block with a slim h1 + ≥50-word paragraph linking to the canonical listing. HEAD preserved verbatim (JSON-LD, canonical, hreflang, \`__EXPIRED_JOB_DATA__\` blob all survive byte-identical). Adds \`__THIN_SHELL__=1\` so App.tsx feedback loop fires \`thin_page_view\` on hydration.

## Plugin wiring

Same pattern as bridges:

\`\`\`ts
const __slDecision = trafficFilter.decide(relPath, 'soft-landing-expired');
const softLandingHtml = __slDecision.action === 'thin'
  ? buildSoftLandingThinHtml(__slFullHtml, locale)
  : __slFullHtml;
\`\`\`

New counters in build log:

\`\`\`
[jobs-seo-pages] bridge tier:       full=N thin=M
[jobs-seo-pages] soft-landing tier: full=N thin=M
\`\`\`

## Self-heal

Unchanged: thinned URL gets a hit → fires \`thin_page_view\` (PostHog + Firebase Analytics) → hourly workflow lifts into \`thin-page-promotions-active.json\` → next deploy returns 'full'. ≤25 h.

## Expected saving (on 2026-05-28 baseline of 11.25 GB dist)

Stimate:
- previousSlug bridges across all cantons (~7-9 KB delta × ~250k pages): **~2 GB**
- soft-landing expired (~5-8 KB delta × ~600k pages): **~3-4 GB**
- **Cumulative: ~5-6 GB** → dist drops from 11.25 GB to ~5-6 GB

Actual numbers will surface in the post-merge \`[dist-bytes-report]\` line.

## Test plan

- [ ] Build log shows \`bridge tier: full=N thin=M\` AND \`soft-landing tier: full=N thin=M\` with M > 0
- [ ] \`dist-bytes-report\` jobs-seo bucket drops materially
- [ ] Spot-check 5 thinned URLs (3 bridges + 2 soft-landings): \`curl\` shows JSON-LD intact, canonical correct, ≥50 visible words; loading in browser shows full SPA-hydrated job page
- [ ] Hourly \`refresh-thin-promotions\` workflow runs without 401/403
- [ ] \`gsc-position-rolling.json\` monitored for 30 days post-merge — no regression

## Out of scope

Cluster pages (\`relatedSearchClustersPlugin\`) — separate PR.