### PR TITLE
fix(posthog-fetcher): also collect pageviews into evidence-index

### DIFF
--- a/build-plugins/shared/trafficEvidenceFilter.ts
+++ b/build-plugins/shared/trafficEvidenceFilter.ts
@@ -9,10 +9,10 @@
 //   data/evidence-index.json
 //     - gsc.queries[query].topLandingPage  → URLs that own a search query
 //     - ga4.pages[path].sessions           → URLs with ≥3 sessions in 90d
-//     - posthog.pages[path].pageviews      → (currently empty in production,
-//                                            kept here so a future fix to
-//                                            scripts/build-evidence-index.mjs
-//                                            picks it up automatically)
+//     - posthog.pages[path]                → either newsletterSignups OR
+//                                            pageviews (or both); key
+//                                            presence alone qualifies as
+//                                            "has traffic"
 //
 //   data/thin-page-promotions-active.json
 //     - { urls: [path, ...], generatedAt }

--- a/scripts/lib/evidence/posthogFetcher.mjs
+++ b/scripts/lib/evidence/posthogFetcher.mjs
@@ -1,10 +1,20 @@
-// PostHog fetcher for the evidence layer — counts `newsletter_signup`
-// events grouped by source page path. Resilient: never throws, returns
-// `{ pages, error? }`.
+// PostHog fetcher for the evidence layer — two signals per page:
 //
-// Total tolerance: winner-def is traffic-only, so a PostHog outage doesn't
-// block selection — the `posthog` block becomes `{}` and downstream consumers
-// treat it as "no signal".
+//   - `newsletterSignups`: count of `newsletter_signup` events grouped by
+//     source page path. Conversion signal (winner-def historic use).
+//   - `pageviews`: count of `$pageview` events grouped by `$pathname`.
+//     General traffic signal (artifact-shrink Fase 1 use): any URL with
+//     a pageview in the window is treated as "has traffic" by
+//     build-plugins/shared/trafficEvidenceFilter.ts and stays 'full'.
+//
+// Both signals merge into the same `pages` map keyed by pathname so
+// downstream consumers that only check key-presence (the filter) and
+// consumers that read `newsletterSignups` (winner-def, marquee) keep
+// working with no schema change.
+//
+// Resilient: never throws, returns `{ pages, error? }`. If a sub-query
+// fails its signal is omitted but the other one still lands; both
+// errors collapse into a single `error` string.
 
 /**
  * @param {object} options
@@ -24,19 +34,40 @@ export async function fetchPosthogPages({
   endDate,
   fetchImpl = fetch,
 } = {}) {
+  const key = apiKey || process.env.POSTHOG_PERSONAL_API_KEY;
+  const project = projectId || process.env.POSTHOG_PROJECT_ID;
+  const hostBase = (host || process.env.POSTHOG_HOST || 'https://eu.posthog.com').replace(/\/$/, '');
+  if (!key || !project) {
+    return { pages: {}, error: 'no POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID' };
+  }
+
+  const queryUrl = `${hostBase}/api/projects/${project}/query/`;
+  const runQuery = async (hogql) => {
+    const res = await fetchImpl(queryUrl, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: { kind: 'HogQLQuery', query: hogql } }),
+    });
+    if (!res.ok) throw new Error(`posthog ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = await res.json();
+    return data?.results || [];
+  };
+
+  const normalizePath = (raw) => {
+    if (!raw) return null;
+    let p = String(raw);
+    if (p.startsWith('http')) {
+      try { p = new URL(p).pathname; } catch { return null; }
+    }
+    return p;
+  };
+
+  const pages = {};
+  const errors = [];
+
+  // ─── newsletter_signup (conversion signal — winner-def consumer) ──
   try {
-    const key = apiKey || process.env.POSTHOG_PERSONAL_API_KEY;
-    const project = projectId || process.env.POSTHOG_PROJECT_ID;
-    const hostBase = (host || process.env.POSTHOG_HOST || 'https://eu.posthog.com').replace(/\/$/, '');
-    if (!key || !project) throw new Error('no POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID');
-
-    const url = `${hostBase}/api/projects/${project}/query/`;
-
-    // HogQL: count newsletter_signup events grouped by source page path.
-    // We use $current_url first (set on the event itself) and fall back to
-    // the most-recent prior $pageview's $pathname when the signup event
-    // doesn't carry a URL property.
-    const query = `
+    const signupQ = `
       SELECT coalesce(properties.$pathname, properties.$current_url) AS path,
              count() AS signups
       FROM events
@@ -47,36 +78,48 @@ export async function fetchPosthogPages({
       GROUP BY path
       LIMIT 5000
     `.trim();
-
-    const res = await fetchImpl(url, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
-    });
-    if (!res.ok) throw new Error(`posthog ${res.status}: ${await res.text()}`);
-    const data = await res.json();
-    const rows = data?.results || [];
-
-    const pages = {};
-    for (const row of rows) {
-      const [rawPath, signups] = row;
-      if (!rawPath) continue;
-      // Normalise to pathname only (strip host if a full URL slipped in).
-      let path = rawPath;
-      if (path.startsWith('http')) {
-        try {
-          path = new URL(path).pathname;
-        } catch {
-          continue;
-        }
-      }
-      const n = Number(signups) || 0;
+    for (const row of await runQuery(signupQ)) {
+      const path = normalizePath(row[0]);
+      if (!path) continue;
+      const n = Number(row[1]) || 0;
       if (n < 1) continue;
-      pages[path] = { newsletterSignups: n };
+      pages[path] = { ...(pages[path] || {}), newsletterSignups: n };
     }
-    return { pages };
   } catch (err) {
-    const reason = err && err.message ? err.message : String(err);
-    return { pages: {}, error: reason };
+    errors.push(`signups: ${err.message}`);
   }
+
+  // ─── $pageview (general traffic signal — filter consumer) ─────────
+  // High-cardinality on a 200k-URL site so we cap at 100k rows; threshold
+  // ≥1 view filters out crawler-only paths that the bot detection didn't
+  // strip.
+  try {
+    const pageviewQ = `
+      SELECT properties.$pathname AS path,
+             count() AS pv
+      FROM events
+      WHERE event = '$pageview'
+        AND properties.$pathname IS NOT NULL
+        AND timestamp >= toDateTime('${startDate} 00:00:00')
+        AND timestamp <= toDateTime('${endDate} 23:59:59')
+      GROUP BY path
+      ORDER BY pv DESC
+      LIMIT 100000
+    `.trim();
+    for (const row of await runQuery(pageviewQ)) {
+      const path = normalizePath(row[0]);
+      if (!path) continue;
+      const n = Number(row[1]) || 0;
+      if (n < 1) continue;
+      pages[path] = { ...(pages[path] || {}), pageviews: n };
+    }
+  } catch (err) {
+    errors.push(`pageviews: ${err.message}`);
+  }
+
+  if (errors.length === 0) return { pages };
+  if (errors.length === 2) return { pages: {}, error: errors.join(' | ') };
+  // Partial: one feed worked, the other didn't. Return what we have +
+  // surface the failure so the caller can decide whether to commit.
+  return { pages, error: errors.join(' | ') };
 }


### PR DESCRIPTION
## Summary

\`posthog.pages\` was being populated only with \`newsletter_signup\` counts (the historic winner-def consumer). The artifact-shrink \`trafficEvidenceFilter\` treats key-presence in \`posthog.pages\` as \"has traffic\", so empty pages meant **PostHog contributed zero protective signal** — URLs with PostHog pageviews but no GSC impressions / GA4 sessions could be wrongly classified as zero-traffic and thinned by PR #725.

## Fix

Extend \`fetchPosthogPages\` to issue a **second HogQL query** against \`$pageview\` grouped by \`$pathname\` (90d window), merging into the same \`pages\` map. The schema is additive:

\`\`\`json
\"posthog\": {
  \"pages\": {
    \"/some/url\": { \"newsletterSignups\": 3, \"pageviews\": 142 }
  }
}
\`\`\`

- Existing consumers reading \`newsletterSignups\` (winner-def, marquee identification) keep working — the field is unchanged when present.
- The filter (which only checks key-presence) now sees every URL with any PostHog signal.
- The two sub-queries fail independently: one errored → the other still lands. Both errored → empty pages + combined \`error\` string (preserves existing behaviour).

## Cardinality

Cap \`$pageview\` query at 100 k rows ordered by pageview count desc. Production traffic typically shows 10-20 k unique paths in 90d.

## Test plan

- [ ] Next \`build-evidence-index.mjs\` run shows \`posthog.pages\` populated with ~10-50 k entries (vs 0 today)
- [ ] \`trafficEvidenceFilter\` traffic-set grows correspondingly; thin counters in deploy log drop slightly (correct — fewer false-thin decisions)
- [ ] No regression in winner-def / marquee scripts that read \`newsletterSignups\` (presence unchanged for those paths)