### PR TITLE
fix(crawlers): unbrick logitech + zivi filter + heineken HTTP fallback

### DIFF
--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -77,6 +77,14 @@ const EMPTY_OK_CRAWLERS = new Set([
   // Dedicated regional Zurich Insurance search can legitimately return zero
   // TI/GR openings while the crawler and source are healthy.
   'zurich-insurance-sede-ticino',
+  // Manor sitemap currently lists 160+ jobs across CH but none in Ticino
+  // (Lugano/Locarno/Biasca). Manor has effectively withdrawn from TI hiring
+  // for now; parser is healthy and will re-arm when TI listings reappear.
+  'manor',
+  // Zambon Cadempino (TI) production site: the ncoreplat careers API
+  // (https://www.zambon.com/it/api/careers-api) returns jobs across
+  // BR/DE/IT/FR/ES/CO but currently 0 CH listings. Parser is healthy.
+  'zambon',
 ]);
 
 /** Read JSON file, return null on any error. */

--- a/scripts/lib/ats-clients/workday-client.mjs
+++ b/scripts/lib/ats-clients/workday-client.mjs
@@ -286,7 +286,12 @@ export async function* fetchWorkdayJobs(apiBase, options = {}) {
     }
 
     const postings = Array.isArray(data?.jobPostings) ? data.jobPostings : [];
-    if (typeof data?.total === 'number' && Number.isFinite(data.total)) {
+    // Some Workday tenants (e.g. logitech.wd5) return `total: 0` on every
+    // page after the first, which would otherwise trip the
+    // `yielded >= total` early-exit below after page 1. Trust only the
+    // first page's total; rely on `postings.length < pageSize` / empty
+    // payload to detect the genuine end of pagination.
+    if (page === 0 && typeof data?.total === 'number' && Number.isFinite(data.total)) {
       total = data.total;
     }
 

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -700,6 +700,26 @@ export function getCompanyBoilerplateIT(company = '') {
  * Returns true if the text is a short boilerplate template that should be cleared.
  * Patterns: recruiter portal notices, "full description available at", etc.
  */
+/**
+ * True if the title/description points to a Swiss compulsory civil-service
+ * (Zivildienst / "Zivi") position rather than a regular job opening.
+ *
+ * Zivi positions are reserved for Swiss conscripts performing alternative
+ * service in lieu of military duty — they require Swiss citizenship and a
+ * conscription waiver, so they are never accessible to cross-border workers.
+ * Their listings are also typically thin (a few lines describing the
+ * placement type), which tends to trip the boilerplate guard when present
+ * alongside only one or two real openings.
+ */
+export function isCivilServiceListing(title = '', description = '') {
+  const haystack = `${String(title || '')}\n${String(description || '')}`.toLowerCase();
+  // German: Zivi / Zivildienst / Zivildienstleistender
+  // Italian / French: servizio civile / service civil
+  // Be specific enough to avoid false positives on legitimate roles
+  // (Civilingenieur, Civicare, etc.).
+  return /\b(zivi|zivildienst(?:leistend(?:er|e))?|servizio civile|service civil)\b/i.test(haystack);
+}
+
 export function isPlaceholderDescription(text = '') {
   const clean = String(text || '').trim();
   if (!clean || clean.length >= 500) return false; // Long texts likely have real content

--- a/scripts/lib/heineken-ch-job-parser.mjs
+++ b/scripts/lib/heineken-ch-job-parser.mjs
@@ -398,6 +398,61 @@ async function fetchListingRows(context) {
 }
 
 /**
+ * Plain-HTTP fallback for the Heineken Switzerland listing.
+ *
+ * Cloudflare on the new Drupal careers site challenges Playwright's browser
+ * fingerprint from GH Actions IPs roughly half the time (the listing renders
+ * a "Just a moment…" interstitial that never resolves before our 20s wait,
+ * leaving us with 0 rows discovered — see issue #655). A bare GET with a
+ * realistic Safari UA bypasses the JS challenge for the listing page, which
+ * is server-rendered HTML containing the same `/job/heineken-switzerland/`
+ * anchors that the Playwright path scrapes. We only need to dedupe by href
+ * (each row has a titled link plus an "Ansicht"/"View" CTA pointing at the
+ * same URL).
+ */
+async function fetchListingRowsHttp() {
+  let html;
+  try {
+    const res = await fetch(LISTING_URL, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'de,de-CH;q=0.9,en;q=0.8',
+      },
+    });
+    if (!res.ok) {
+      console.warn(`⚠️ Heineken HTTP listing fallback: HTTP ${res.status}`);
+      return [];
+    }
+    html = await res.text();
+  } catch (err) {
+    console.warn(`⚠️ Heineken HTTP listing fallback failed: ${err?.message || err}`);
+    return [];
+  }
+
+  const rows = [];
+  const seen = new Set();
+  // Anchors look like:
+  //   <a href="/job/heineken-switzerland/switzerland/<slug>" ...>Title</a>
+  //   <a href="/job/heineken-switzerland/<slug>" ...>Ansicht</a> (legacy)
+  const anchorRe = /<a[^>]+href="(\/job\/heineken-switzerland\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = anchorRe.exec(html)) !== null) {
+    const href = m[1];
+    if (!href || seen.has(href)) continue;
+    seen.add(href);
+    const title = m[2].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+    // Skip the "Ansicht"/"View"/"Voir" CTAs that share the same href as the
+    // titled anchor — the seen-set above already dedupes by href, so when we
+    // hit one of these first we'd lose the title. Filter to entries with a
+    // meaningful (non-CTA) title.
+    if (!title || /^(ansicht|view|voir|leggi|details?)$/i.test(title)) continue;
+    rows.push({ href, title });
+  }
+  return rows;
+}
+
+/**
  * Open one detail page and extract title, location, function, description,
  * and apply URL.
  *
@@ -527,12 +582,22 @@ export async function fetchAllHeinekenChJobs() {
     browser = await createBrowser({ userAgent: BROWSER_UA });
     const context = await createPoliteContext(browser, { userAgent: BROWSER_UA });
 
-    const rows = await fetchListingRows(context);
-    console.log(`  📋 Discovered ${rows.length} job links`);
+    let rows = await fetchListingRows(context);
+    console.log(`  📋 Discovered ${rows.length} job links (Playwright)`);
 
     if (rows.length === 0) {
-      console.warn('⚠️ No Heineken Switzerland job links found on listing page.');
-      return [];
+      // Cloudflare on the new Drupal careers site occasionally challenges
+      // Playwright's fingerprint from GH Actions IPs, leaving the listing
+      // empty (see issue #655). The listing page is server-rendered HTML
+      // and bypasses the challenge under a bare GET with a realistic Safari
+      // UA — retry once via plain HTTP before giving up.
+      const httpRows = await fetchListingRowsHttp();
+      if (httpRows.length === 0) {
+        console.warn('⚠️ No Heineken Switzerland job links found on listing page (Playwright + HTTP fallback both empty).');
+        return [];
+      }
+      console.log(`  📋 Discovered ${httpRows.length} job links (HTTP fallback)`);
+      rows = httpRows;
     }
 
     const jobs = [];

--- a/scripts/lib/rehab-basel-job-parser.mjs
+++ b/scripts/lib/rehab-basel-job-parser.mjs
@@ -10,7 +10,7 @@
  * with the title link, posted date, and reference number.
  */
 import { createHash } from 'node:crypto';
-import { detectLang } from './dedicated-crawler-common.mjs';
+import { detectLang, isCivilServiceListing } from './dedicated-crawler-common.mjs';
 import { slugify } from './crawler-template.mjs';
 import {
   fetchHtml,
@@ -83,8 +83,18 @@ export async function fetchAllRehabBaselJobs() {
 
   const todayIso = new Date().toISOString().slice(0, 10);
   const jobs = [];
+  let skippedCivilService = 0;
   for (const it of items) {
     const title = it.title;
+    // Skip Swiss compulsory civil-service (Zivildienst) placements — they
+    // require Swiss citizenship and a conscription waiver, so they are
+    // never accessible to cross-border workers. Their thin descriptions
+    // also tend to trip the boilerplate guard when the listing pool is
+    // small (see issue #685).
+    if (isCivilServiceListing(title, it.fullTitle)) {
+      skippedCivilService++;
+      continue;
+    }
     const intro = `${title} bei REHAB Basel — Klinik für Neurorehabilitation und Paraplegiologie, Basel (4055, BS), Schweiz.`;
     const bullets = [];
     if (it.ref) bullets.push(`• Referenz: ${it.ref}`);
@@ -136,6 +146,9 @@ export async function fetchAllRehabBaselJobs() {
       requirements: [],
       requirementsByLocale: { [sourceLang]: [] },
     });
+  }
+  if (skippedCivilService > 0) {
+    console.log(`  ⏭️  Skipped ${skippedCivilService} Zivildienst/civil-service listing(s) (not relevant for cross-border workers)`);
   }
   console.log(`📋 Total ${REHAB_BASEL_COMPANY_NAME} jobs discovered: ${jobs.length}`);
   return jobs;

--- a/scripts/lib/umantis-listing-common.mjs
+++ b/scripts/lib/umantis-listing-common.mjs
@@ -35,7 +35,7 @@
  * raw umantis.com subdomain always works regardless.
  */
 import { createHash } from 'node:crypto';
-import { detectLang } from './dedicated-crawler-common.mjs';
+import { detectLang, isCivilServiceListing } from './dedicated-crawler-common.mjs';
 import { slugify, stripHtml } from './crawler-template.mjs';
 import { inferSwissTargetCanton } from './target-swiss-locations.mjs';
 
@@ -510,8 +510,18 @@ export function createUmantisListingParser(config) {
     const jobs = [];
     let detailHits = 0;
 
+    let skippedCivilService = 0;
     for (const entry of entries) {
       const title = entry.title;
+      // Skip Swiss compulsory civil-service (Zivildienst) placements — they
+      // require Swiss citizenship and a conscription waiver, so they are
+      // never accessible to cross-border workers. Their thin descriptions
+      // also tend to trip the boilerplate guard when the listing pool is
+      // small (see issues #683/#685/#693).
+      if (isCivilServiceListing(title, entry.snippet)) {
+        skippedCivilService++;
+        continue;
+      }
       const detailUrl = `${BASE_URL}/Vacancies/${entry.id}/Description/${langCode}`;
       const applyUrl = `${BASE_URL}/Vacancies/${entry.id}/Application/CheckLogin/${langCode}`;
       const jobUrl = canonicalUrlMode === 'application' ? applyUrl : detailUrl;
@@ -610,6 +620,9 @@ export function createUmantisListingParser(config) {
       });
     }
 
+    if (skippedCivilService > 0) {
+      console.log(`  ⏭️  Skipped ${skippedCivilService} Zivildienst/civil-service listing(s) (not relevant for cross-border workers)`);
+    }
     console.log(`\n📋 Total ${companyName} jobs discovered: ${jobs.length} (${detailHits}/${entries.length} with rich detail content)`);
     return jobs;
   }


### PR DESCRIPTION
## Summary

Resolves seven crawler issues in one bundle:

- **#656 logitech** — Workday API regression: `total: 0` on later pages tripped the early-exit in `fetchWorkdayJobs()` after page 1, dropping 80%+ of listings. Trust only page 0's total. Logitech now returns 7 CH jobs (was 0 for 3+ runs). Likely unbricks several other Workday-based crawlers too (Roche, Novartis, Stryker, Alcon, Abbott, CSL, KSB, Lombard Odier, Medtronic, Sulzer).
- **#683 #685 #693 (Schweizer Paraplegiker-Gruppe, REHAB Basel, Adullam/EHC)** — boilerplate-guard tripped at 50% with `1/2 jobs` thin descriptions, all of which were Zivi (Swiss compulsory civil-service) placements. Filter Zivildienst/"Zivi"/"servizio civile" at parser level (not relevant for cross-border workers). REHAB Basel: 14 parsed → 1 Zivi skipped → 13 jobs (well above guard threshold).
- **#655 heineken-ch** — Cloudflare challenges Playwright's fingerprint from GH Actions IPs, leaving listing empty for 3+ runs. Listing page is server-rendered HTML; bare GET with Safari UA bypasses the challenge. Added HTTP fallback when Playwright returns 0.
- **#657 manor**, **#658 zambon** — sources are healthy but currently have 0 Ticino / 0 CH listings respectively (Manor has 160+ jobs, none in Lugano/Locarno/Biasca; Zambon's ncoreplat API returns BR/DE/IT/FR/ES/CO only). Added to `EMPTY_OK_CRAWLERS` (same treatment as existing `csvp-poschiavo`, `zurich-insurance-sede-ticino`). Crawlers keep running and will re-arm automatically when listings reappear.

## Test plan

- [x] `tests/scripts/check-crawler-health.test.ts` (13/13)
- [x] `tests/parsers/umantis-listing-parser.test.ts` (24/24)
- [x] `tests/heineken-ch-crawler.test.ts` (59/59)
- [x] Live REHAB Basel parser: 14 → 13 jobs (1 Zivi skipped)
- [x] Live Logitech parser: 7 jobs (was 0)
- [x] Live Heineken parser: 10 jobs (Playwright path succeeded locally; HTTP fallback exercised separately)
- [ ] Post-merge: confirm next workflow_dispatch on rehab-basel/paraplegie/adullam crawlers clears the boilerplate guard
- [ ] Post-merge: confirm next scheduled run of logitech / heineken returns non-zero jobs

Closes #655 #656 #657 #658 #683 #685 #693