### PR TITLE
fix(deploy): classifier absorbs ~200 MB of orphan 'other-*' buckets

### DIFF
--- a/scripts/report-dist-bytes-by-plugin.mjs
+++ b/scripts/report-dist-bytes-by-plugin.mjs
@@ -85,18 +85,63 @@ const PLUGIN_RULES = [
   { plugin: 'hub-faq', prefixes: ['faq/', 'domande/', 'fragen/', 'questions/'] },
   { plugin: 'hub-comparison', prefixes: ['confronti/', 'comparisons/', 'vergleiche/', 'comparaisons/'] },
   { plugin: 'hub-section', prefixes: ['sezioni/', 'sections/', 'abschnitte/'] },
-  // assets bundle
-  { plugin: 'assets', prefixes: ['assets/'] },
+  // Daily-feature SEO plugins (fuelDailyPlugin, healthPremiumsPlugin,
+  // borderWaitPagesPlugin, weatherCommutePlugin, salaryCalculatorPlugin).
+  // Each emits under 4 locale-aware section names — regex catches all.
+  { plugin: 'fuel-daily', regex:
+    /^(prix-essence-suisse|prezzi-benzina|benzinpreis-schweiz|gasoline-price-switzerland|prezzi-diesel|prix-gasoil-suisse|dieselpreis-schweiz|diesel-price-switzerland)\// },
+  { plugin: 'health-premiums', regex:
+    /^(primes-assurance-maladie|premi-cassa-malati|krankenkassenpraemien|health-insurance-premiums)\// },
+  { plugin: 'border-wait', regex:
+    /^(temps-attente-douane|wartezeit-grenze|traffico-dogane|border-wait)\// },
+  { plugin: 'weather-commute', regex:
+    /^(meteo-frontalieri|meteo-frontaliers|pendler-wetter|commute-weather)\// },
+  { plugin: 'salary-calculator', regex:
+    /^(calcola-stipendio|calculate-salary|calculer-salaire|gehalt-berechnen)\// },
+  // Editorial / evergreen sections (companies-hiring, living-in-ticino,
+  // ticino-job-market, glossary, guides, taxes-and-pension, statistics,
+  // service-comparison, faq, alerts/reports).
+  { plugin: 'companies-hiring', regex:
+    /^(aziende-che-assumono|companies-hiring|entreprises-recrutent|unternehmen-einstellen|entreprises-qui-recrutent|firmen-die-einstellen)\// },
+  { plugin: 'living-in-ticino', regex:
+    /^(vivere-in-ticino|living-in-ticino|leben-im-tessin|vivre-au-tessin|vita-in-ticino)\// },
+  { plugin: 'job-market', regex:
+    /^(mercato-lavoro-ticino|ticino-job-market|tessiner-arbeitsmarkt|marche-travail-tessin)\// },
+  { plugin: 'glossary', regex:
+    /^(glossario-frontaliere|cross-border-glossary|grenzgaenger-glossar|glossaire-frontalier)\// },
+  { plugin: 'guides', regex:
+    /^(guida-frontaliere|cross-border-guide|grenzgaenger-ratgeber|guide-frontalier)\// },
+  { plugin: 'taxes-pension', regex:
+    /^(tasse-e-pensione|taxes-and-pension|steuern-und-vorsorge|impots-et-retraite)\// },
+  { plugin: 'statistics', regex:
+    /^(statistiche|statistics|statistiken|statistiques)\// },
+  { plugin: 'service-compare', regex:
+    /^(compara-servizi|service-comparison|service-vergleich|comparaison-services)\// },
+  { plugin: 'faq-pages', regex:
+    /^(domande-frequenti-frontalieri|frequently-asked-questions|haeufige-fragen|questions-frequentes)\// },
+  { plugin: 'alerts', regex:
+    /^(allerte|alerts|warnungen|alertes|report|reports)\// },
+  // Site-search root paths (one .html per locale).
+  { plugin: 'site-search', regex: /^(ricerca|search|suche|recherche)(\/|\.html$)/ },
+  // assets bundle (incl. webfonts)
+  { plugin: 'assets', prefixes: ['assets/', 'fonts/'] },
   // data files shipped
   { plugin: 'data', prefixes: ['dati/', 'data/'] },
-  // sitemaps + robots
-  { plugin: 'sitemap', regex: /^sitemap[^/]*\.xml(\.gz)?$|^robots\.txt$/ },
+  // sitemaps + robots + rss feeds + .well-known
+  { plugin: 'sitemap', regex: /^sitemap[^/]*\.xml(\.gz)?$|^robots\.txt$|^rss(-[a-z]{2})?\.xml$|^\.well-known(\/|$)/ },
   // OG images
   { plugin: 'og-images', prefixes: ['og-images/', 'og/'] },
   // public/ root images
   { plugin: 'images', prefixes: ['images/', 'img/'] },
-  // PDFs
+  // PDFs (whitepapers)
   { plugin: 'pdf', regex: /\.pdf$/ },
+  // LLM-facing prose dumps (llms.txt + llms-full.txt)
+  { plugin: 'llms-txt', regex: /^llms(-full)?\.txt$/ },
+  // Root-level static `.html` redirect aliases: lavoro-ticino-{role}.html,
+  // calcolatore.html, contatti.html, glossary.html, etc. These are emitted
+  // by individual small plugins; bucket together so they don't pollute
+  // `other-*` 50+ times each.
+  { plugin: 'static-aliases', regex: /^[a-z][a-z0-9-]*\.html$/ },
 ];
 
 function classify(relPath) {


### PR DESCRIPTION
## Summary

The 2026-05-28 baseline run (#26565404829, post-#724) showed ~120 distinct \`other-*\` buckets summing to ~200 MB (1.8% of dist) that belong to **well-known SEO plugins** but weren't classified.

New buckets:
- \`fuel-daily\` (~46 MB) — prix-essence-suisse / prezzi-benzina + diesel variants
- \`health-premiums\` (~32 MB) — primes-assurance-maladie / premi-cassa-malati / krankenkassenpraemien / health-insurance-premiums
- \`salary-calculator\` (~26 MB) — calcola-stipendio / calculate-salary / calculer-salaire / gehalt-berechnen
- \`living-in-ticino\` (~22 MB)
- \`companies-hiring\` (~17 MB)
- \`border-wait\` (~7 MB)
- \`weather-commute\` (~1 MB)
- glossary, guides, taxes-pension, statistics, service-compare, faq-pages, alerts, site-search, job-market (~1 MB each)

Plus housekeeping:
- \`assets\` bucket now includes \`fonts/\` (webfont assets)
- \`sitemap\` bucket now includes \`rss(-<locale>)?.xml\` feeds + \`.well-known/\`
- new \`llms-txt\` bucket for \`llms.txt\` + \`llms-full.txt\`
- new \`static-aliases\` bucket for root-level \`<slug>.html\` aliases (lavoro-ticino-cuoco.html, calcolatore.html, glossary.html, …) that previously created ~50 single-file \`other-*\` buckets

All locale variants (IT/EN/DE/FR) captured by a single regex per plugin family. Locally verified against a synthetic dist seeded with one sample per bucket — zero \`other-*\` left in output.

## Why

The filter itself never depended on this classifier (\`jobsSeoPagesPlugin\` passes explicit \`urlClass\` tags to \`TrafficEvidenceFilter.decide()\`). Only the **observability report** consumed it; the report is now actionable.

## Test plan

- [x] Local synthetic dist passes — every sample lands in its proper bucket
- [ ] Next deploy: \`[dist-bytes-report] by plugin\` shows no \`other-*\` for the previously-orphaned categories