### PR TITLE
fix(thin-shell): tolerate unquoted class= (minifier strips quotes from single-token classes)

### DIFF
--- a/build-plugins/shared/bridgeThinShell.ts
+++ b/build-plugins/shared/bridgeThinShell.ts
@@ -115,8 +115,16 @@ export function buildBridgeThinHtml(cachedHtml: string, targetSlug: string, loca
   // regex is non-greedy across newlines and tolerates additional class
   // tokens (e.g. "seo-static-content static-job-page"). The minified
   // bridge HTML has no newlines between tags so `[\s\S]*?` is safe.
+  //
+  // The class attribute may be quoted or unquoted depending on token
+  // count: a multi-token value like `seo-static-content static-job-page`
+  // has a space and PR #478 (removeAttributeQuotes) keeps its quotes,
+  // but a single-token `seo-static-content` would be unquoted. Today the
+  // bridge always emits the multi-token form, but the regex tolerates
+  // both shapes so a future change to the class list doesn't silently
+  // disable thinning.
   const withThinBody = cachedHtml.replace(
-    /<main\s+class=["']seo-static-content[^"']*["'][^>]*>[\s\S]*?<\/main>/i,
+    /<main\s+class=["']?seo-static-content(?=[\s>"'])[^>]*>[\s\S]*?<\/main>/i,
     thinMain,
   );
 

--- a/build-plugins/shared/softLandingThinShell.ts
+++ b/build-plugins/shared/softLandingThinShell.ts
@@ -96,8 +96,15 @@ export function buildSoftLandingThinHtml(fullHtml: string, locale: string): stri
     `</article>`;
 
   // Replace the entire heavy article with the thin one.
+  //
+  // PR #478 (removeAttributeQuotes) strips quotes from single-token class
+  // values, so the minified output is `<article class=ft-static-article>`
+  // (no quotes) NOT `<article class="ft-static-article">`. The verified
+  // artifact on 2026-05-28 confirmed the unquoted form is in dist. The
+  // lookahead `(?=[\s>"'])` asserts the token ends cleanly (no accidental
+  // match against `ft-static-article-xyz` if such a class is ever added).
   const withThinBody = fullHtml.replace(
-    /<article\s+class=["']ft-static-article["'][^>]*>[\s\S]*?<\/article>/i,
+    /<article\s+class=["']?ft-static-article(?=[\s>"'])[^>]*>[\s\S]*?<\/article>/i,
     thinArticle,
   );
 


### PR DESCRIPTION
## Summary

Verified against the real dist artifact from run #26565404829 (sha 10e69fad, downloaded post-merge of #725):

\`\`\`
BRIDGE match: YES bytes=11630, full 18.206 → thin 6.587 (−11.619 B)
SOFT   match: NO  ← BUG, full 9.965 → thin 9.965 (no change!)
\`\`\`

\`buildSoftLandingThinHtml\` was emitting **zero thinned soft-landings** because the regex \`<article class=\"ft-static-article\">\` doesn't match the minified output \`<article class=ft-static-article>\` (PR #478 \`removeAttributeQuotes\` strips quotes from single-token class values).

\`buildBridgeThinHtml\` worked by accident because the bridge \`<main>\` has two class tokens (\`seo-static-content static-job-page\`) → the space prevented quote removal. Fragile.

## Fix

Both regexes:
- \`class=[\"']?\` (optional quotes — handles both forms)
- \`(?=[\\s>\"'])\` lookahead asserting the token ends cleanly (no accidental match on \`ft-static-article-extended\` or similar)

## Validation (real artifact, /tmp/art/sample/)

\`\`\`
BRIDGE  18.206 B → 6.587 B  (-11.619)
SOFT     9.965 B → 6.383 B  ( -3.582)
\`\`\`

## Unlock estimate

Soft-landings: ~428k pages × 3.6 KB delta × ~70 % thinnable share = **~1.1 GB** that PR #725 was emitting unchanged due to the regex miss. Now unlocked.

## Test plan

- [x] Real artifact regex validation (this PR description)
- [ ] Next deploy: \`[jobs-seo-pages] soft-landing tier:\` shows \`thin > 0\` (was reported as \`thin=0\` even with patterns active, because regex was misfiring)