### PR TITLE
fix(data): refresh canton-aware tracking for 303 stale non-TI entries

### DIFF
--- a/data/all-known-job-slugs.json
+++ b/data/all-known-job-slugs.json
@@ -10177,10 +10177,10 @@
     "fr": "/fr/trouver-emploi-tessin/electrician-efz-100-tz-stromag-brig-glis"
   },
   "electronic-ingegnere-r-d-agie-charmilles-sa-losone": {
-    "it": "/cerca-lavoro-ticino/electronic-ingegnere-r-d-agie-charmilles-sa-losone",
-    "en": "/en/find-jobs-ticino/electronic-engineer-r-d-agie-charmilles-sa-losone",
-    "de": "/de/jobs-im-tessin/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
-    "fr": "/fr/trouver-emploi-tessin/electronic-ingenieur-r-d-agie-charmilles-sa-losone"
+    "it": "/cerca-lavoro-berna/electronic-ingegnere-r-d-agie-charmilles-sa-losone",
+    "en": "/en/find-jobs-bern/electronic-engineer-r-d-agie-charmilles-sa-losone",
+    "de": "/de/jobs-in-bern/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
+    "fr": "/fr/trouver-emploi-berne/electronic-ingenieur-r-d-agie-charmilles-sa-losone"
   },
   "electronic-telecommunications-engineer-f-m-d-80-100-bellinzona-afry-bellinzona": {
     "it": "/cerca-lavoro-ticino/ingegnere-elettronico-telecomunicazione-f-m-d-80-100-bellinzona-afry-bellinzona",
@@ -12107,18 +12107,18 @@
     "fr": "/fr/trouver-emploi-tessin/sage-femme-obstetricien-ne-permette-di-combinare-efficacemente-approccio-locale-e-visione-d-insieme-garantendo-alla-popolazione-un-offerta-o"
   },
   "heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni": {
-    "it": "/cerca-lavoro-ticino/tecnico-di-consegna-di-elettrodomestici-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-delivery-technician-for-electrical-appliances-fust-grigioni",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/technicien-de-livraison-d-appareils-electromenagers-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/tecnico-di-consegna-di-elettrodomestici-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-delivery-technician-for-electrical-appliances-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/technicien-de-livraison-d-appareils-electromenagers-fust-grigioni"
   },
   "heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj": {
     "source": "gsc-404-import",
     "importedAt": "2026-03-31",
-    "it": "/cerca-lavoro-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
-    "en": "/en/find-jobs-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
-    "fr": "/fr/trouver-emploi-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj"
+    "it": "/cerca-lavoro-grigioni/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
+    "en": "/en/find-jobs-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj",
+    "fr": "/fr/trouver-emploi-grisons/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-dk43lj"
   },
   "history-teacher-international-school-of-ticino-lugano": {
     "it": "/cerca-lavoro-ticino/history-teacher-international-school-of-ticino-lugano",
@@ -12147,10 +12147,10 @@
   "home-appliance-installer-fust-grigioni": {
     "source": "gsc-404-import",
     "importedAt": "2026-03-31",
-    "it": "/cerca-lavoro-ticino/home-appliance-installer-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-appliance-installer-fust-grigioni",
-    "de": "/de/jobs-im-tessin/home-appliance-installer-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/home-appliance-installer-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/home-appliance-installer-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-appliance-installer-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/home-appliance-installer-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/home-appliance-installer-fust-grigioni"
   },
   "home-delivery-fitter-of-electrical-household-appliances-fust-grigioni": {
     "source": "gsc-404-import",
@@ -17143,10 +17143,10 @@
     "fr": "/fr/trouver-emploi-tessin/technicien-metrologie-agie-charmilles-sa-losone"
   },
   "metrology-technician-agie-charmilles-sa-losone": {
-    "it": "/cerca-lavoro-ticino/tecnico-laboratorio-metrologia-agie-charmilles-sa-losone",
-    "en": "/en/find-jobs-ticino/metrology-technician-agie-charmilles-sa-losone",
-    "de": "/de/jobs-im-tessin/messtechnik-techniker-agie-charmilles-sa-losone",
-    "fr": "/fr/trouver-emploi-tessin/technicien-metrologie-agie-charmilles-sa-losone"
+    "it": "/cerca-lavoro-berna/tecnico-laboratorio-metrologia-agie-charmilles-sa-losone",
+    "en": "/en/find-jobs-bern/metrology-technician-agie-charmilles-sa-losone",
+    "de": "/de/jobs-in-bern/messtechnik-techniker-agie-charmilles-sa-losone",
+    "fr": "/fr/trouver-emploi-berne/technicien-metrologie-agie-charmilles-sa-losone"
   },
   "metzger-in-fleischfachfrau-fleischfachmann-coop-chur-graubunden-0ndjhs": {
     "source": "gsc-404-import",
@@ -17373,10 +17373,10 @@
     "fr": "/fr/trouver-emploi-tessin/monteur-d-installations-electromenager-fust-grigioni"
   },
   "montatore-di-elettrodomestici-fust-grigioni": {
-    "it": "/cerca-lavoro-ticino/montatore-di-elettrodomestici-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-delivery-technician-for-electrical-appliances-fust-grigioni",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/technicien-de-livraison-a-domicile-d-appareils-electromenagers-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/montatore-di-elettrodomestici-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-delivery-technician-for-electrical-appliances-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/technicien-de-livraison-a-domicile-d-appareils-electromenagers-fust-grigioni"
   },
   "montatore-di-facciate-pemsa-locarno": {
     "it": "/cerca-lavoro-ticino/montatore-di-facciate-pemsa-locarno",
@@ -19337,10 +19337,10 @@
     "fr": "/fr/trouver-emploi-tessin/membre-de-l-equipe-de-controle-hubers-landhendl-gmbh-pfaffstatt"
   },
   "collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-geiser-ag-schlieren": {
-    "it": "/cerca-lavoro-ticino/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-geiser-ag-schlieren",
-    "en": "/en/find-jobs-ticino/technical-and-materials-team-member-geiser-ag-schlieren",
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "fr": "/fr/trouver-emploi-tessin/membre-du-team-technique-et-materiel-geiser-ag-schlieren"
+    "it": "/cerca-lavoro-zurigo/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-geiser-ag-schlieren",
+    "en": "/en/find-jobs-zurich/technical-and-materials-team-member-geiser-ag-schlieren",
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "fr": "/fr/trouver-emploi-zurich/membre-du-team-technique-et-materiel-geiser-ag-schlieren"
   },
   "collaboratore-trice-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht": {
     "it": "/cerca-lavoro-ticino/collaboratore-trice-verladung-versand-m-w-d-bell-deutschland-gmbh-co-kg-edewecht",
@@ -26531,10 +26531,10 @@
     "fr": "/fr/trouver-emploi-tessin/mitarbeiter-steuerung-m-w-d-hilcona-ag-bell-food-group-landquart"
   },
   "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq": {
-    "it": "/cerca-lavoro-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
-    "en": "/en/find-jobs-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq"
+    "it": "/cerca-lavoro-zurigo/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
+    "en": "/en/find-jobs-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq",
+    "fr": "/fr/trouver-emploi-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-ag-bell-food-group-landq"
   },
   "mitarbeiter-verladung-versand-m-w-d-hilcona-ag-bell-food-group-landquart": {
     "it": "/cerca-lavoro-ticino/mitarbeiter-verladung-versand-m-w-d-hilcona-ag-bell-food-group-landquart",
@@ -33401,10 +33401,10 @@
     "fr": "/fr/trouver-emploi-tessin/assistente-di-cura-o-prepose-e-alle-cure-sociosanitarie-eoc-ente-ospedaliero-cantonale-locarno"
   },
   "nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano": {
-    "en": "/en/find-jobs-ticino/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
-    "it": "/cerca-lavoro-ticino/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
-    "de": "/de/jobs-im-tessin/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
-    "fr": "/fr/trouver-emploi-tessin/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano"
+    "en": "/en/find-jobs-basel/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
+    "it": "/cerca-lavoro-basilea/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
+    "de": "/de/jobs-in-basel/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano",
+    "fr": "/fr/trouver-emploi-bale/nurse-in-general-care-currently-in-training-diploma-yet-to-be-obtained-eoc-ente-ospedaliero-cantonale-lugano"
   },
   "krankenpfleger-in-in-allgemeinpflege-derzeit-in-ausbildung-diplom-noch-zu-erwerben-eoc-ente-ospedaliero-cantonale-lugano": {
     "de": "/de/jobs-im-tessin/krankenpfleger-in-in-allgemeinpflege-derzeit-in-ausbildung-diplom-noch-zu-erwerben-eoc-ente-ospedaliero-cantonale-lugano",
@@ -33779,10 +33779,10 @@
     "fr": "/fr/trouver-emploi-tessin/medico-radiologo-eoc-ente-ospedaliero-cantonale-bellinzona-uil4ya"
   },
   "biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona": {
-    "en": "/en/find-jobs-ticino/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "it": "/cerca-lavoro-ticino/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "de": "/de/jobs-im-tessin/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
-    "fr": "/fr/trouver-emploi-tessin/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona"
+    "en": "/en/find-jobs-aargau/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "it": "/cerca-lavoro-argovia/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "de": "/de/jobs-im-aargau/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona",
+    "fr": "/fr/trouver-emploi-argovie/biomedical-analysis-technician-eoc-ente-ospedaliero-cantonale-bellinzona"
   },
   "100-medical-assistant-training-position-eoc-ente-ospedaliero-cantonale-bellinzona": {
     "en": "/en/find-jobs-ticino/100-medical-assistant-training-position-eoc-ente-ospedaliero-cantonale-bellinzona",
@@ -35537,10 +35537,10 @@
     "en": "/en/find-jobs-solothurn/chef-d-equipe-chef-d-equipe-genie-electrique-et-automatisation-bell-schweiz-ag-oensingen"
   },
   "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren": {
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
-    "it": "/cerca-lavoro-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
-    "en": "/en/find-jobs-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren"
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
+    "it": "/cerca-lavoro-zurigo/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
+    "en": "/en/find-jobs-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren",
+    "fr": "/fr/trouver-emploi-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-geiser-ag-schlieren"
   },
   "membre-du-team-technique-et-materiel-geiser-ag-schlieren": {
     "fr": "/fr/trouver-emploi-tessin/membre-du-team-technique-et-materiel-geiser-ag-schlieren",
@@ -35549,16 +35549,16 @@
     "en": "/en/find-jobs-ticino/membre-du-team-technique-et-materiel-geiser-ag-schlieren"
   },
   "collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart": {
-    "it": "/cerca-lavoro-ticino/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
-    "en": "/en/find-jobs-ticino/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
-    "de": "/de/jobs-im-tessin/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
-    "fr": "/fr/trouver-emploi-tessin/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart"
+    "it": "/cerca-lavoro-zurigo/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
+    "en": "/en/find-jobs-zurich/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
+    "de": "/de/jobs-in-zurich/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart",
+    "fr": "/fr/trouver-emploi-zurich/collaboratore-trice-technik-e-materialwirtschaft-mitarbeiterin-technik-e-materialwirtschaft-hilcona-ag-bell-food-group-landquart"
   },
   "mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren": {
-    "it": "/cerca-lavoro-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "en": "/en/find-jobs-ticino/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "de": "/de/jobs-im-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren"
+    "it": "/cerca-lavoro-zurigo/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "en": "/en/find-jobs-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "de": "/de/jobs-in-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren",
+    "fr": "/fr/trouver-emploi-zurich/mitarbeiter-technik-und-materialwirtschaft-mitarbeiterin-technik-und-materialwirtschaft-hilcona-schlieren"
   },
   "bezirksleitung-im-aussendienst-food-service-m-w-d-duesseldorf-krefeld-aachen-hugli-nahrungsmittel-gmbh-radolfzell": {
     "de": "/de/jobs-im-tessin/bezirksleitung-im-aussendienst-food-service-m-w-d-duesseldorf-krefeld-aachen-hugli-nahrungsmittel-gmbh-radolfzell",
@@ -41939,28 +41939,28 @@
     "fr": "/fr/trouver-emploi-tessin/hr-projects-business-management-lead-avaloq-bioggio"
   },
   "electronic-engineer-r-d-agie-charmilles-sa-losone": {
-    "en": "/en/find-jobs-ticino/electronic-engineer-r-d-agie-charmilles-sa-losone",
-    "it": "/cerca-lavoro-ticino/electronic-engineer-r-d-agie-charmilles-sa-losone",
-    "de": "/de/jobs-im-tessin/electronic-engineer-r-d-agie-charmilles-sa-losone",
-    "fr": "/fr/trouver-emploi-tessin/electronic-engineer-r-d-agie-charmilles-sa-losone"
+    "en": "/en/find-jobs-bern/electronic-engineer-r-d-agie-charmilles-sa-losone",
+    "it": "/cerca-lavoro-berna/electronic-engineer-r-d-agie-charmilles-sa-losone",
+    "de": "/de/jobs-in-bern/electronic-engineer-r-d-agie-charmilles-sa-losone",
+    "fr": "/fr/trouver-emploi-berne/electronic-engineer-r-d-agie-charmilles-sa-losone"
   },
   "electronic-ingenieur-r-d-agie-charmilles-sa-losone": {
-    "de": "/de/jobs-im-tessin/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
-    "fr": "/fr/trouver-emploi-tessin/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
-    "it": "/cerca-lavoro-ticino/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
-    "en": "/en/find-jobs-ticino/electronic-ingenieur-r-d-agie-charmilles-sa-losone"
+    "de": "/de/jobs-in-bern/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
+    "fr": "/fr/trouver-emploi-berne/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
+    "it": "/cerca-lavoro-berna/electronic-ingenieur-r-d-agie-charmilles-sa-losone",
+    "en": "/en/find-jobs-bern/electronic-ingenieur-r-d-agie-charmilles-sa-losone"
   },
   "metrology-techniker-agie-charmilles-sa-losone": {
-    "de": "/de/jobs-im-tessin/metrology-techniker-agie-charmilles-sa-losone",
-    "it": "/cerca-lavoro-ticino/metrology-techniker-agie-charmilles-sa-losone",
-    "en": "/en/find-jobs-ticino/metrology-techniker-agie-charmilles-sa-losone",
-    "fr": "/fr/trouver-emploi-tessin/metrology-techniker-agie-charmilles-sa-losone"
+    "de": "/de/jobs-in-bern/metrology-techniker-agie-charmilles-sa-losone",
+    "it": "/cerca-lavoro-berna/metrology-techniker-agie-charmilles-sa-losone",
+    "en": "/en/find-jobs-bern/metrology-techniker-agie-charmilles-sa-losone",
+    "fr": "/fr/trouver-emploi-berne/metrology-techniker-agie-charmilles-sa-losone"
   },
   "metrology-technicien-agie-charmilles-sa-losone": {
-    "fr": "/fr/trouver-emploi-tessin/metrology-technicien-agie-charmilles-sa-losone",
-    "it": "/cerca-lavoro-ticino/metrology-technicien-agie-charmilles-sa-losone",
-    "en": "/en/find-jobs-ticino/metrology-technicien-agie-charmilles-sa-losone",
-    "de": "/de/jobs-im-tessin/metrology-technicien-agie-charmilles-sa-losone"
+    "fr": "/fr/trouver-emploi-berne/metrology-technicien-agie-charmilles-sa-losone",
+    "it": "/cerca-lavoro-berna/metrology-technicien-agie-charmilles-sa-losone",
+    "en": "/en/find-jobs-bern/metrology-technicien-agie-charmilles-sa-losone",
+    "de": "/de/jobs-in-bern/metrology-technicien-agie-charmilles-sa-losone"
   },
   "electrical-installer-efz-50-100-ferrovia-retica-rhb-samedan": {
     "en": "/en/find-jobs-ticino/electrical-installer-efz-50-100-ferrovia-retica-rhb-samedan",
@@ -47093,10 +47093,10 @@
     "fr": "/fr/trouver-emploi-tessin/apprendistato-commercio-al-dettaglio-afc-creazione-di-esperienze-d-acquisto-fust-tenero-contra-ticino-7haru0"
   },
   "heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c": {
-    "it": "/cerca-lavoro-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
-    "en": "/en/find-jobs-ticino/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
-    "de": "/de/jobs-im-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
-    "fr": "/fr/trouver-emploi-tessin/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c"
+    "it": "/cerca-lavoro-grigioni/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
+    "en": "/en/find-jobs-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
+    "de": "/de/jobs-in-graubunden/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c",
+    "fr": "/fr/trouver-emploi-grisons/heimliefermonteur-in-von-elektrohaushaltgeraten-fust-grigioni-pztp1c"
   },
   "einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra": {
     "de": "/de/jobs-in-bern/einzelhandelsspezialist-efz-einkaufserlebnisse-schaffen-fust-swiss-household-services-ag-tenero-contra",
@@ -47597,10 +47597,10 @@
     "fr": "/fr/trouver-emploi-tessin/ingegnere-di-test-80-100-abb-svizzera-sede-ticino-quartino-ticino-quartino-ticino-3"
   },
   "risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus": {
-    "it": "/cerca-lavoro-ticino/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus",
-    "en": "/en/find-jobs-ticino/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus",
-    "de": "/de/jobs-im-tessin/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus",
-    "fr": "/fr/trouver-emploi-tessin/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus"
+    "it": "/cerca-lavoro-glarona/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus",
+    "en": "/en/find-jobs-glarus/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus",
+    "de": "/de/jobs-in-glarus/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus",
+    "fr": "/fr/trouver-emploi-glaris/risorse-umane-generalist-con-projekttatigkeiten-80-100-w-m-d-laderach-schweiz-ag-glarus"
   },
   "responsabilita-della-concorrenza-eoc-ente-ospedaliero-cantonale-bellinzona": {
     "it": "/cerca-lavoro-ticino/responsabilita-della-concorrenza-eoc-ente-ospedaliero-cantonale-bellinzona",
@@ -56039,130 +56039,130 @@
     "fr": "/fr/trouver-emploi-tessin/acheteur-supply-chain-vaxcyte-visp"
   },
   "augenoptiker-w-m-d-fielmann-group-zug": {
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-group-zug",
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-group-zug",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-group-zug",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-group-zug"
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-group-zug",
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-group-zug",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-group-zug",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-group-zug"
   },
   "augenoptico-w-m-d-fielmann-group-wil": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-wil",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-wil",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-wil",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-wil"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-wil",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-wil",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-wil",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-wil"
   },
   "augenoptico-w-m-d-fielmann-group-st": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-st",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-st",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-st",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-st"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-st",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-st",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-st",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-st"
   },
   "augenoptico-w-m-d-fielmann-group-burgdorf": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-burgdorf",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-burgdorf",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-burgdorf",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-burgdorf"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-burgdorf",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-burgdorf",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-burgdorf",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-burgdorf"
   },
   "augenoptico-w-m-d-fielmann-group-buchs": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-buchs",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-buchs",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-buchs",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-buchs"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-buchs",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-buchs",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-buchs",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-buchs"
   },
   "augenoptico-w-m-d-fielmann-group-sursee": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-sursee",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-sursee",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-sursee",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-sursee"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-sursee",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-sursee",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-sursee",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-sursee"
   },
   "augenoptico-w-m-d-fielmann-group-schwyz": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-schwyz",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-schwyz",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-schwyz",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-schwyz"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-schwyz",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-schwyz",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-schwyz",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-schwyz"
   },
   "augenoptico-w-m-d-fielmann-group-bulach": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-bulach",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-bulach",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-bulach",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-bulach"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-bulach",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-bulach",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-bulach",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-bulach"
   },
   "augenoptico-w-m-d-fielmann-group-thun": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-thun",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-thun",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-thun",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-thun"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-thun",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-thun",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-thun",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-thun"
   },
   "augenoptico-w-m-d-fielmann-group-thalwil": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-thalwil",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-thalwil",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-thalwil",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-thalwil"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-thalwil",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-thalwil",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-thalwil",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-thalwil"
   },
   "augenoptiker-w-m-d-fielmann-ch-26": {
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-ch-26",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-ch-26",
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-ch-26",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-26"
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-ch-26",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-ch-26",
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-ch-26",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-ch-26"
   },
   "augenoptico-w-m-d-fielmann-group-uster": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-uster",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-uster",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-uster",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-uster"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-uster",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-uster",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-uster",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-uster"
   },
   "augenoptiker-w-m-d-fielmann-ch-27": {
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-ch-27",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-ch-27",
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-ch-27",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-27"
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-ch-27",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-ch-27",
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-ch-27",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-ch-27"
   },
   "augenoptico-w-m-d-fielmann-group-aarau": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-aarau",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-aarau",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-aarau",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-aarau"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-aarau",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-aarau",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-aarau",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-aarau"
   },
   "augenoptiker-w-m-d-fielmann-ch-28": {
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-ch-28",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-ch-28",
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-ch-28",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-28"
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-ch-28",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-ch-28",
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-ch-28",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-ch-28"
   },
   "augenoptico-w-m-d-fielmann-group-rapperswil": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-rapperswil",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-rapperswil",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-rapperswil",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-rapperswil"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-rapperswil",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-rapperswil",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-rapperswil",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-rapperswil"
   },
   "augenoptiker-w-m-d-fielmann-ch-29": {
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-ch-29",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-ch-29",
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-ch-29",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-29"
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-ch-29",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-ch-29",
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-ch-29",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-ch-29"
   },
   "augenoptico-w-m-d-fielmann-group-olten": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-olten",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-olten",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-olten",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-olten"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-olten",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-olten",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-olten",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-olten"
   },
   "augenoptiker-w-m-d-fielmann-ch-30": {
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-ch-30",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-ch-30",
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-ch-30",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-30"
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-ch-30",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-ch-30",
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-ch-30",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-ch-30"
   },
   "augenoptico-w-m-d-fielmann-group-langenthal": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-langenthal",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-langenthal",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-langenthal",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-langenthal"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-langenthal",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-langenthal",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-langenthal",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-langenthal"
   },
   "augenoptiker-w-m-d-fielmann-ch-31": {
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-ch-31",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-ch-31",
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-ch-31",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-31"
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-ch-31",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-ch-31",
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-ch-31",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-ch-31"
   },
   "audioprotesista-f-m-d-fielmann-group-basel": {
     "it": "/cerca-lavoro-ticino/audioprotesista-f-m-d-fielmann-group-basel",
@@ -56195,22 +56195,22 @@
     "fr": "/fr/trouver-emploi-tessin/augenoptiker-augenoptikermeister-m-w-d-fielmann-group-sion"
   },
   "audioprotesista-f-m-d-fielmann-group-bern": {
-    "it": "/cerca-lavoro-ticino/audioprotesista-f-m-d-fielmann-group-bern",
-    "en": "/en/find-jobs-ticino/audioprotesista-f-m-d-fielmann-group-bern",
-    "de": "/de/jobs-im-tessin/audioprotesista-f-m-d-fielmann-group-bern",
-    "fr": "/fr/trouver-emploi-tessin/audioprotesista-f-m-d-fielmann-group-bern"
+    "it": "/cerca-lavoro-argovia/audioprotesista-f-m-d-fielmann-group-bern",
+    "en": "/en/find-jobs-aargau/audioprotesista-f-m-d-fielmann-group-bern",
+    "de": "/de/jobs-im-aargau/audioprotesista-f-m-d-fielmann-group-bern",
+    "fr": "/fr/trouver-emploi-argovie/audioprotesista-f-m-d-fielmann-group-bern"
   },
   "master-of-hearing-acoustics-f-m-d-fielmann-group-bern": {
-    "en": "/en/find-jobs-ticino/master-of-hearing-acoustics-f-m-d-fielmann-group-bern",
-    "it": "/cerca-lavoro-ticino/master-of-hearing-acoustics-f-m-d-fielmann-group-bern",
-    "de": "/de/jobs-im-tessin/master-of-hearing-acoustics-f-m-d-fielmann-group-bern",
-    "fr": "/fr/trouver-emploi-tessin/master-of-hearing-acoustics-f-m-d-fielmann-group-bern"
+    "en": "/en/find-jobs-aargau/master-of-hearing-acoustics-f-m-d-fielmann-group-bern",
+    "it": "/cerca-lavoro-argovia/master-of-hearing-acoustics-f-m-d-fielmann-group-bern",
+    "de": "/de/jobs-im-aargau/master-of-hearing-acoustics-f-m-d-fielmann-group-bern",
+    "fr": "/fr/trouver-emploi-argovie/master-of-hearing-acoustics-f-m-d-fielmann-group-bern"
   },
   "maitre-audioprothesiste-w-m-d-fielmann-group-bern": {
-    "fr": "/fr/trouver-emploi-tessin/maitre-audioprothesiste-w-m-d-fielmann-group-bern",
-    "it": "/cerca-lavoro-ticino/maitre-audioprothesiste-w-m-d-fielmann-group-bern",
-    "en": "/en/find-jobs-ticino/maitre-audioprothesiste-w-m-d-fielmann-group-bern",
-    "de": "/de/jobs-im-tessin/maitre-audioprothesiste-w-m-d-fielmann-group-bern"
+    "fr": "/fr/trouver-emploi-argovie/maitre-audioprothesiste-w-m-d-fielmann-group-bern",
+    "it": "/cerca-lavoro-argovia/maitre-audioprothesiste-w-m-d-fielmann-group-bern",
+    "en": "/en/find-jobs-aargau/maitre-audioprothesiste-w-m-d-fielmann-group-bern",
+    "de": "/de/jobs-im-aargau/maitre-audioprothesiste-w-m-d-fielmann-group-bern"
   },
   "bachelor-of-science-fhnw-in-optometria-w-m-d-svizzera-fielmann-group-basel-steinenvorstadt": {
     "it": "/cerca-lavoro-ticino/bachelor-of-science-fhnw-in-optometria-w-m-d-svizzera-fielmann-group-basel-steinenvorstadt",
@@ -56261,22 +56261,22 @@
     "fr": "/fr/trouver-emploi-tessin/bachelor-of-science-fhnw-in-optometrie-m-w-d-in-der-gesamten-schweiz-fielmann-group-basel-steinenvorstadt"
   },
   "augenoptico-w-m-d-fielmann-group-wadenswil": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-wadenswil",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-wadenswil",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-wadenswil",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-wadenswil"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-wadenswil",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-wadenswil",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-wadenswil",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-wadenswil"
   },
   "augenoptiker-w-m-d-fielmann-ch-32": {
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-ch-32",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-ch-32",
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-ch-32",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-32"
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-ch-32",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-ch-32",
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-ch-32",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-ch-32"
   },
   "augenoptiker-w-m-d-fielmann-group-zofingen": {
-    "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-group-zofingen",
-    "it": "/cerca-lavoro-ticino/augenoptiker-w-m-d-fielmann-group-zofingen",
-    "en": "/en/find-jobs-ticino/augenoptiker-w-m-d-fielmann-group-zofingen",
-    "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-group-zofingen"
+    "de": "/de/jobs-in-zurich/augenoptiker-w-m-d-fielmann-group-zofingen",
+    "it": "/cerca-lavoro-zurigo/augenoptiker-w-m-d-fielmann-group-zofingen",
+    "en": "/en/find-jobs-zurich/augenoptiker-w-m-d-fielmann-group-zofingen",
+    "fr": "/fr/trouver-emploi-zurich/augenoptiker-w-m-d-fielmann-group-zofingen"
   },
   "augenoptiker-w-m-d-fielmann-group-solothurn": {
     "de": "/de/jobs-im-tessin/augenoptiker-w-m-d-fielmann-group-solothurn",
@@ -56291,22 +56291,22 @@
     "fr": "/fr/trouver-emploi-tessin/augenoptiker-w-m-d-fielmann-ch-3"
   },
   "augenoptico-w-m-d-fielmann-group-bern-i": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-bern-i",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-bern-i",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-bern-i",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-bern-i"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-bern-i",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-bern-i",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-bern-i",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-bern-i"
   },
   "augenoptico-w-m-d-fielmann-group-spreitenbach": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-spreitenbach",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-spreitenbach",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-spreitenbach",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-spreitenbach"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-spreitenbach",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-spreitenbach",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-spreitenbach",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-spreitenbach"
   },
   "augenoptico-w-m-d-fielmann-group-winterthur": {
-    "it": "/cerca-lavoro-ticino/augenoptico-w-m-d-fielmann-group-winterthur",
-    "en": "/en/find-jobs-ticino/augenoptico-w-m-d-fielmann-group-winterthur",
-    "de": "/de/jobs-im-tessin/augenoptico-w-m-d-fielmann-group-winterthur",
-    "fr": "/fr/trouver-emploi-tessin/augenoptico-w-m-d-fielmann-group-winterthur"
+    "it": "/cerca-lavoro-zurigo/augenoptico-w-m-d-fielmann-group-winterthur",
+    "en": "/en/find-jobs-zurich/augenoptico-w-m-d-fielmann-group-winterthur",
+    "de": "/de/jobs-in-zurich/augenoptico-w-m-d-fielmann-group-winterthur",
+    "fr": "/fr/trouver-emploi-zurich/augenoptico-w-m-d-fielmann-group-winterthur"
   },
   "data-center-technician-switzerland-les-acacias-on-site-reboot-monkey-les-acacias-2": {
     "en": "/en/find-jobs-ticino/data-center-technician-switzerland-les-acacias-on-site-reboot-monkey-les-acacias",
@@ -58985,28 +58985,28 @@
     "fr": "/fr/trouver-emploi-tessin/assistenz-oder-fachpsychologe-in-pdgr-ch-2"
   },
   "dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis": {
-    "it": "/cerca-lavoro-ticino/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis",
-    "en": "/en/find-jobs-ticino/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis",
-    "de": "/de/jobs-im-tessin/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis",
-    "fr": "/fr/trouver-emploi-tessin/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis"
+    "it": "/cerca-lavoro-grigioni/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis",
+    "en": "/en/find-jobs-graubunden/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis",
+    "de": "/de/jobs-in-graubunden/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis",
+    "fr": "/fr/trouver-emploi-grisons/dipl-assistente-infermieristico-hf-per-il-turno-di-notte-psychiatrische-dienste-graubunden-cazis"
   },
   "dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis": {
-    "en": "/en/find-jobs-ticino/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis",
-    "it": "/cerca-lavoro-ticino/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis",
-    "de": "/de/jobs-im-tessin/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis",
-    "fr": "/fr/trouver-emploi-tessin/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis"
+    "en": "/en/find-jobs-graubunden/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis",
+    "it": "/cerca-lavoro-grigioni/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis",
+    "de": "/de/jobs-in-graubunden/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis",
+    "fr": "/fr/trouver-emploi-grisons/dipl-nurse-hf-for-night-shift-psychiatrische-dienste-graubunden-cazis"
   },
   "dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis": {
-    "fr": "/fr/trouver-emploi-tessin/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis",
-    "it": "/cerca-lavoro-ticino/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis",
-    "en": "/en/find-jobs-ticino/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis",
-    "de": "/de/jobs-im-tessin/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis"
+    "fr": "/fr/trouver-emploi-grisons/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis",
+    "it": "/cerca-lavoro-grigioni/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis",
+    "en": "/en/find-jobs-graubunden/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis",
+    "de": "/de/jobs-in-graubunden/dipl-infirmier-hf-pour-le-service-de-nuit-psychiatrische-dienste-graubunden-cazis"
   },
   "dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2"
+    "it": "/cerca-lavoro-grigioni/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2",
+    "en": "/en/find-jobs-graubunden/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2",
+    "de": "/de/jobs-in-graubunden/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2",
+    "fr": "/fr/trouver-emploi-grisons/dipl-pflegefachperson-hf-fur-die-nachtwache-pdgr-ch-2"
   },
   "assistenzarztin-assistenzarzt-psychiatrische-dienste-graubunden-cazis-chur": {
     "de": "/de/jobs-im-tessin/assistenzarztin-assistenzarzt-psychiatrische-dienste-graubunden-cazis-chur",
@@ -68711,16 +68711,16 @@
     "en": "/en/find-jobs-ticino/consultant-en-ventes-pour-l-electricite-et-le-multimedia-fust-chur-graubunden"
   },
   "home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni": {
-    "it": "/cerca-lavoro-ticino/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
-    "de": "/de/jobs-im-tessin/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
-    "en": "/en/find-jobs-ticino/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
-    "fr": "/fr/trouver-emploi-tessin/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni"
+    "it": "/cerca-lavoro-grigioni/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni",
+    "fr": "/fr/trouver-emploi-grisons/home-fornitore-negli-elettrodomestici-elettrici-fust-grigioni"
   },
   "fournisseurs-dans-les-appareils-electromenagers-fust-grigioni": {
-    "fr": "/fr/trouver-emploi-tessin/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
-    "it": "/cerca-lavoro-ticino/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
-    "de": "/de/jobs-im-tessin/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
-    "en": "/en/find-jobs-ticino/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni"
+    "fr": "/fr/trouver-emploi-grisons/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
+    "it": "/cerca-lavoro-grigioni/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
+    "de": "/de/jobs-in-graubunden/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni",
+    "en": "/en/find-jobs-graubunden/fournisseurs-dans-les-appareils-electromenagers-fust-grigioni"
   },
   "assistente-contabile-50-giardino-group-champfer": {
     "it": "/cerca-lavoro-ticino/assistente-contabile-50-giardino-group-champfer",
@@ -75293,16 +75293,16 @@
     "fr": "/fr/trouver-emploi-tessin/capofila-dell-istruzione-denner-horw"
   },
   "head-of-branch-in-education-denner-horw": {
-    "en": "/en/find-jobs-ticino/head-of-branch-in-education-denner-horw",
-    "it": "/cerca-lavoro-ticino/head-of-branch-in-education-denner-horw",
-    "de": "/de/jobs-im-tessin/head-of-branch-in-education-denner-horw",
-    "fr": "/fr/trouver-emploi-tessin/head-of-branch-in-education-denner-horw"
+    "en": "/en/find-jobs-lucerne/head-of-branch-in-education-denner-horw",
+    "it": "/cerca-lavoro-lucerna/head-of-branch-in-education-denner-horw",
+    "de": "/de/jobs-in-luzern/head-of-branch-in-education-denner-horw",
+    "fr": "/fr/trouver-emploi-lucerne/head-of-branch-in-education-denner-horw"
   },
   "chef-de-division-en-education-denner-horw": {
-    "fr": "/fr/trouver-emploi-tessin/chef-de-division-en-education-denner-horw",
-    "it": "/cerca-lavoro-ticino/chef-de-division-en-education-denner-horw",
-    "en": "/en/find-jobs-ticino/chef-de-division-en-education-denner-horw",
-    "de": "/de/jobs-im-tessin/chef-de-division-en-education-denner-horw"
+    "fr": "/fr/trouver-emploi-lucerne/chef-de-division-en-education-denner-horw",
+    "it": "/cerca-lavoro-lucerna/chef-de-division-en-education-denner-horw",
+    "en": "/en/find-jobs-lucerne/chef-de-division-en-education-denner-horw",
+    "de": "/de/jobs-in-luzern/chef-de-division-en-education-denner-horw"
   },
   "mediatore-trice-interculturale-60-eoc-ente-ospedaliero-cantonale-mendrisio": {
     "it": "/cerca-lavoro-ticino/mediatore-trice-interculturale-60-eoc-ente-ospedaliero-cantonale-mendrisio",
@@ -76247,10 +76247,10 @@
     "fr": "/fr/trouver-emploi-tessin/tecnico-di-servizio-otis-sa-kriens"
   },
   "tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens": {
-    "it": "/cerca-lavoro-ticino/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens",
-    "en": "/en/find-jobs-ticino/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens",
-    "de": "/de/jobs-im-tessin/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens",
-    "fr": "/fr/trouver-emploi-tessin/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens"
+    "it": "/cerca-lavoro-lucerna/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens",
+    "en": "/en/find-jobs-lucerne/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens",
+    "de": "/de/jobs-in-luzern/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens",
+    "fr": "/fr/trouver-emploi-lucerne/tecnico-montatore-manutentore-ascensori-luzern-m-w-d-otis-sa-kriens"
   },
   "vendita-denner-zurich": {
     "it": "/cerca-lavoro-ticino/vendita-denner-zurich",
@@ -78389,10 +78389,10 @@
     "fr": "/fr/trouver-emploi-tessin/specialista-di-implementazione-servizio-clienti-lastminute-com-chiasso"
   },
   "vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier": {
-    "it": "/cerca-lavoro-ticino/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier",
-    "en": "/en/find-jobs-ticino/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier",
-    "de": "/de/jobs-im-tessin/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier",
-    "fr": "/fr/trouver-emploi-tessin/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier"
+    "it": "/cerca-lavoro-ginevra/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier",
+    "en": "/en/find-jobs-geneva/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier",
+    "de": "/de/jobs-in-genf/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier",
+    "fr": "/fr/trouver-emploi-geneve/vivier-dei-talenti-tecnico-installatore-repairman-otis-sa-vernier"
   },
   "cloud-architect-avaloq-bioggio": {
     "it": "/cerca-lavoro-ticino/cloud-architect-avaloq-bioggio",
@@ -80081,10 +80081,10 @@
     "fr": "/fr/trouver-emploi-tessin/regulatorische-compliance-counsel-vf-international-the-north-face-timberland-stabio"
   },
   "impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona": {
-    "it": "/cerca-lavoro-ticino/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona",
-    "en": "/en/find-jobs-ticino/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona",
-    "de": "/de/jobs-im-tessin/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona",
-    "fr": "/fr/trouver-emploi-tessin/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona"
+    "it": "/cerca-lavoro-berna/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona",
+    "en": "/en/find-jobs-bern/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona",
+    "de": "/de/jobs-in-bern/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona",
+    "fr": "/fr/trouver-emploi-berne/impiegato-a-in-logistica-vorortlager-swiss-armed-forces-vtg-bellinzona"
   },
   "software-ingegnere-python-all-genders-axa-svizzera-60-winterthur-smart-working": {
     "it": "/cerca-lavoro-ticino/software-ingegnere-python-all-genders-axa-svizzera-60-winterthur-smart-working",
@@ -80483,10 +80483,10 @@
     "fr": "/fr/trouver-emploi-tessin/senior-qa-specialista-clean-utilities-and-environmental-monitoring-80-100-f-m-d-lonza-visp"
   },
   "operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona": {
-    "it": "/cerca-lavoro-ticino/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona",
-    "en": "/en/find-jobs-ticino/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona",
-    "de": "/de/jobs-im-tessin/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona",
-    "fr": "/fr/trouver-emploi-tessin/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona"
+    "it": "/cerca-lavoro-berna/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona",
+    "en": "/en/find-jobs-bern/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona",
+    "de": "/de/jobs-in-bern/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona",
+    "fr": "/fr/trouver-emploi-berne/operatore-di-manutenzione-edifici-thusis-swiss-armed-forces-vtg-bellinzona"
   },
   "oss-vallese": {
     "it": "/cerca-lavoro-ticino/oss-vallese",
@@ -81653,10 +81653,10 @@
     "de": "/de/jobs-im-tessin/associe-debut-de-carriere-en-fiscalite-d-entreprise-80-100-pwc-switzerland-luzern"
   },
   "manager-senior-manager-senior-cyber-security-architect-pwc-zurich": {
-    "it": "/cerca-lavoro-ticino/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
-    "en": "/en/find-jobs-ticino/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
-    "de": "/de/jobs-im-tessin/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
-    "fr": "/fr/trouver-emploi-tessin/manager-senior-manager-senior-cyber-security-architect-pwc-zurich"
+    "it": "/cerca-lavoro-ginevra/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
+    "en": "/en/find-jobs-geneva/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
+    "de": "/de/jobs-in-genf/manager-senior-manager-senior-cyber-security-architect-pwc-zurich",
+    "fr": "/fr/trouver-emploi-geneve/manager-senior-manager-senior-cyber-security-architect-pwc-zurich"
   },
   "director-of-basic-education-supsi-dti-direzione-supsi": {
     "en": "/en/find-jobs-ticino/director-of-basic-education-supsi-dti-direzione-supsi",
@@ -82043,16 +82043,16 @@
     "fr": "/fr/trouver-emploi-tessin/mitarbeiter-karriereeinstieg-steuerberatung-80-100-pwc-switzerland-luzern"
   },
   "manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich": {
-    "it": "/cerca-lavoro-ticino/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
-    "en": "/en/find-jobs-ticino/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
-    "de": "/de/jobs-im-tessin/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
-    "fr": "/fr/trouver-emploi-tessin/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich"
+    "it": "/cerca-lavoro-ginevra/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
+    "en": "/en/find-jobs-geneva/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
+    "de": "/de/jobs-in-genf/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich",
+    "fr": "/fr/trouver-emploi-geneve/manager-senior-manager-senior-cyber-security-architetto-pwc-switzerland-zurich"
   },
   "manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
-    "it": "/cerca-lavoro-ticino/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
-    "en": "/en/find-jobs-ticino/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
-    "de": "/de/jobs-im-tessin/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich"
+    "fr": "/fr/trouver-emploi-geneve/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
+    "it": "/cerca-lavoro-ginevra/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
+    "en": "/en/find-jobs-geneva/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich",
+    "de": "/de/jobs-in-genf/manager-senior-manager-senior-cyber-security-architecte-pwc-switzerland-zurich"
   },
   "installateurin-oder-elektroinstallateurin-zu-100-mit-klempnerfunktion-citta-di-mendrisio-mendrisio": {
     "de": "/de/jobs-im-tessin/installateurin-oder-elektroinstallateurin-zu-100-mit-klempnerfunktion-citta-di-mendrisio-mendrisio",
@@ -84089,10 +84089,10 @@
     "fr": "/fr/trouver-emploi-tessin/feldstratege-zukunftige-lebensmittelfabrik-epfl-lausanne"
   },
   "mechanical-engineer-epfl-sion": {
-    "it": "/cerca-lavoro-ticino/mechanical-engineer-epfl-sion",
-    "de": "/de/jobs-im-tessin/mechanical-engineer-epfl-sion",
-    "en": "/en/find-jobs-ticino/mechanical-engineer-epfl-sion",
-    "fr": "/fr/trouver-emploi-tessin/mechanical-engineer-epfl-sion"
+    "it": "/cerca-lavoro-vallese/mechanical-engineer-epfl-sion",
+    "de": "/de/jobs-im-wallis/mechanical-engineer-epfl-sion",
+    "en": "/en/find-jobs-valais/mechanical-engineer-epfl-sion",
+    "fr": "/fr/trouver-emploi-valais/mechanical-engineer-epfl-sion"
   },
   "chef-e-du-service-academique-epfl-lausanne": {
     "it": "/cerca-lavoro-ticino/chef-e-du-service-academique-epfl-lausanne",
@@ -84179,10 +84179,10 @@
     "de": "/de/jobs-im-tessin/global-product-specialiste-dry-type-transformers-mainstream-hitachi-energy-remote-zurich"
   },
   "fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich": {
-    "de": "/de/jobs-im-tessin/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
-    "it": "/cerca-lavoro-ticino/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
-    "en": "/en/find-jobs-ticino/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
-    "fr": "/fr/trouver-emploi-tessin/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich"
+    "de": "/de/jobs-in-zurich/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
+    "it": "/cerca-lavoro-zurigo/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
+    "en": "/en/find-jobs-zurich/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich",
+    "fr": "/fr/trouver-emploi-zurich/fehlerbehebung-prozess-qualitat-techniker-80-100-f-m-d-hitachi-energy-zurich"
   },
   "lead-data-platform-architetto-hitachi-energy-krakow": {
     "it": "/cerca-lavoro-ticino/lead-data-platform-architetto-hitachi-energy-krakow",
@@ -84197,10 +84197,10 @@
     "de": "/de/jobs-im-tessin/lead-data-platform-architecte-hitachi-energy-krakow"
   },
   "lagerspezialist-80-100-w-m-d-hitachi-energy-zurich": {
-    "de": "/de/jobs-im-tessin/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
-    "it": "/cerca-lavoro-ticino/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
-    "en": "/en/find-jobs-ticino/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
-    "fr": "/fr/trouver-emploi-tessin/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich"
+    "de": "/de/jobs-in-zurich/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
+    "it": "/cerca-lavoro-zurigo/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
+    "en": "/en/find-jobs-zurich/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich",
+    "fr": "/fr/trouver-emploi-zurich/lagerspezialist-80-100-w-m-d-hitachi-energy-zurich"
   },
   "gestionnaire-de-projet-d-installation-80-100-f-m-d-hitachi-energy-zurich": {
     "fr": "/fr/trouver-emploi-tessin/gestionnaire-de-projet-d-installation-80-100-f-m-d-hitachi-energy-zurich",
@@ -84545,16 +84545,16 @@
     "fr": "/fr/trouver-emploi-tessin/applikations-manager-in-kantonsspital-winterthur-ksw-winterthur"
   },
   "fachfrau-mann-gesundheit-lindenhofgruppe-bern": {
-    "it": "/cerca-lavoro-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
-    "en": "/en/find-jobs-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
-    "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-bern"
+    "it": "/cerca-lavoro-berna/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
+    "en": "/en/find-jobs-bern/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
+    "de": "/de/jobs-in-bern/fachfrau-mann-gesundheit-lindenhofgruppe-bern",
+    "fr": "/fr/trouver-emploi-berne/fachfrau-mann-gesundheit-lindenhofgruppe-bern"
   },
   "fachfrau-mann-gesundheit-lindenhofgruppe-ch": {
-    "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
-    "en": "/en/find-jobs-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
-    "it": "/cerca-lavoro-ticino/fachfrau-mann-gesundheit-lindenhofgruppe-ch"
+    "de": "/de/jobs-in-bern/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
+    "en": "/en/find-jobs-bern/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
+    "fr": "/fr/trouver-emploi-berne/fachfrau-mann-gesundheit-lindenhofgruppe-ch",
+    "it": "/cerca-lavoro-berna/fachfrau-mann-gesundheit-lindenhofgruppe-ch"
   },
   "leiter-in-medizinische-codierung-lindenhofgruppe-ch": {
     "de": "/de/jobs-im-tessin/leiter-in-medizinische-codierung-lindenhofgruppe-ch",
@@ -86009,10 +86009,10 @@
     "it": "/cerca-lavoro-ticino/dipl-pflegefachmann-frau-palliativstation-stgag-ch"
   },
   "dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-pflegefachmann-frau-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "oberarzt-arztin-neurologie-stgag-ch": {
     "it": "/cerca-lavoro-ticino/oberarzt-arztin-neurologie-stgag-ch",
@@ -86795,10 +86795,10 @@
     "it": "/cerca-lavoro-ticino/dipl-pflegefachmann-frau-medizin-stgag-ch"
   },
   "dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-pflegefachmann-frau-im-pool-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "dipl-pflegefachmann-frau-im-pool-stgag-ch": {
     "de": "/de/jobs-im-tessin/dipl-pflegefachmann-frau-im-pool-stgag-ch",
@@ -87329,22 +87329,22 @@
     "fr": "/fr/trouver-emploi-tessin/medizinische-r-praxisassistent-in-onkologie-unispital-basel-ch"
   },
   "assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel": {
-    "it": "/cerca-lavoro-ticino/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
-    "en": "/en/find-jobs-ticino/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
-    "de": "/de/jobs-im-tessin/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel"
+    "it": "/cerca-lavoro-basilea/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
+    "en": "/en/find-jobs-basel/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
+    "de": "/de/jobs-in-basel/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel",
+    "fr": "/fr/trouver-emploi-bale/assistent-in-gesundheit-e-soziales-lungenstation-universitatsspital-basel"
   },
   "assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel": {
-    "de": "/de/jobs-im-tessin/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
-    "it": "/cerca-lavoro-ticino/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
-    "en": "/en/find-jobs-ticino/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel"
+    "de": "/de/jobs-in-basel/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
+    "it": "/cerca-lavoro-basilea/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
+    "en": "/en/find-jobs-basel/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel",
+    "fr": "/fr/trouver-emploi-bale/assistent-in-gesundheit-und-soziales-lungenstation-universitatsspital-basel-basel"
   },
   "assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch": {
-    "en": "/en/find-jobs-ticino/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
-    "fr": "/fr/trouver-emploi-tessin/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
-    "it": "/cerca-lavoro-ticino/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
-    "de": "/de/jobs-im-tessin/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch"
+    "en": "/en/find-jobs-basel/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
+    "fr": "/fr/trouver-emploi-bale/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
+    "it": "/cerca-lavoro-basilea/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch",
+    "de": "/de/jobs-in-basel/assistent-in-gesundheit-und-soziales-lungenstation-unispital-basel-ch"
   },
   "oberarztin-oberarzt-angiologie-unispital-basel-ch": {
     "it": "/cerca-lavoro-ticino/oberarztin-oberarzt-angiologie-unispital-basel-ch",
@@ -87359,10 +87359,10 @@
     "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-angiologie-universitatsspital-basel-basel"
   },
   "dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch"
+    "it": "/cerca-lavoro-basilea/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
+    "de": "/de/jobs-in-basel/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
+    "fr": "/fr/trouver-emploi-bale/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch",
+    "en": "/en/find-jobs-basel/dipl-pflegefachfrau-pflegefachmann-hf-fh-lungenstation-unispital-basel-ch"
   },
   "fachfrau-fachmann-hr-administration-unispital-basel-ch": {
     "it": "/cerca-lavoro-ticino/fachfrau-fachmann-hr-administration-unispital-basel-ch",
@@ -89405,16 +89405,16 @@
     "fr": "/fr/trouver-emploi-tessin/assicurazione-fornitore-e-consigliere-mortgage-presso-l-agenzia-generale-di-losanna-nord-vaudois-die-mobiliar-conseiller"
   },
   "collaboratore-compliance-office-commercial-clientele-postfinance-bulle": {
-    "it": "/cerca-lavoro-ticino/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
-    "en": "/en/find-jobs-ticino/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
-    "de": "/de/jobs-im-tessin/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
-    "fr": "/fr/trouver-emploi-tessin/collaboratore-compliance-office-commercial-clientele-postfinance-bulle"
+    "it": "/cerca-lavoro-friburgo/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
+    "en": "/en/find-jobs-fribourg/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
+    "de": "/de/jobs-in-freiburg/collaboratore-compliance-office-commercial-clientele-postfinance-bulle",
+    "fr": "/fr/trouver-emploi-fribourg/collaboratore-compliance-office-commercial-clientele-postfinance-bulle"
   },
   "consulente-clienti-privati-carouge-postfinance-carouge": {
-    "it": "/cerca-lavoro-ticino/consulente-clienti-privati-carouge-postfinance-carouge",
-    "en": "/en/find-jobs-ticino/consulente-clienti-privati-carouge-postfinance-carouge",
-    "de": "/de/jobs-im-tessin/consulente-clienti-privati-carouge-postfinance-carouge",
-    "fr": "/fr/trouver-emploi-tessin/consulente-clienti-privati-carouge-postfinance-carouge"
+    "it": "/cerca-lavoro-ginevra/consulente-clienti-privati-carouge-postfinance-carouge",
+    "en": "/en/find-jobs-geneva/consulente-clienti-privati-carouge-postfinance-carouge",
+    "de": "/de/jobs-in-genf/consulente-clienti-privati-carouge-postfinance-carouge",
+    "fr": "/fr/trouver-emploi-geneve/consulente-clienti-privati-carouge-postfinance-carouge"
   },
   "manager-in-rischio-regolatore-conformita-pwc-switzerland-geneve": {
     "it": "/cerca-lavoro-ticino/manager-in-rischio-regolatore-conformita-pwc-switzerland-geneve",
@@ -89447,10 +89447,10 @@
     "fr": "/fr/trouver-emploi-tessin/home-medico-50-100-regionalspital-surselva-ilanz"
   },
   "neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/neurologia-del-medico-senior-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "interni-anno-di-pratica-strutturato-spj-cura-fh-ost-2026-spital-thurgau-stgag-kantonsspital-frauenfeld": {
     "it": "/cerca-lavoro-ticino/interni-anno-di-pratica-strutturato-spj-cura-fh-ost-2026-spital-thurgau-stgag-kantonsspital-frauenfeld",
@@ -89573,10 +89573,10 @@
     "fr": "/fr/trouver-emploi-tessin/interno-nel-campo-dei-bambini-fabe-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/medico-senior-padiatrie-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "formazione-dipl-expert-in-intensive-care-nds-hf-spital-thurgau-stgag-kantonsspital-frauenfeld": {
     "it": "/cerca-lavoro-ticino/formazione-dipl-expert-in-intensive-care-nds-hf-spital-thurgau-stgag-kantonsspital-frauenfeld",
@@ -90203,10 +90203,10 @@
     "en": "/en/find-jobs-ticino/destination-experience-manager-msc-group-geneva"
   },
   "destinations-experience-manager-msc-geneva": {
-    "en": "/en/find-jobs-ticino/destinations-experience-manager-msc-geneva",
-    "it": "/cerca-lavoro-ticino/destinations-experience-manager-msc-geneva",
-    "de": "/de/jobs-im-tessin/destinations-experience-manager-msc-geneva",
-    "fr": "/fr/trouver-emploi-tessin/destinations-experience-manager-msc-geneva"
+    "en": "/en/find-jobs-geneva/destinations-experience-manager-msc-geneva",
+    "it": "/cerca-lavoro-ginevra/destinations-experience-manager-msc-geneva",
+    "de": "/de/jobs-in-genf/destinations-experience-manager-msc-geneva",
+    "fr": "/fr/trouver-emploi-geneve/destinations-experience-manager-msc-geneva"
   },
   "corporate-communications-senior-manager-msc-geneva": {
     "en": "/en/find-jobs-ticino/corporate-communications-senior-manager-msc-geneva",
@@ -90893,16 +90893,16 @@
     "fr": "/fr/trouver-emploi-tessin/gruppe-eb-uni-beziehung-praktikant-richemont-bellevue"
   },
   "hr-business-partner-piaget-plan-les-ouates": {
-    "fr": "/fr/trouver-emploi-tessin/hr-business-partner-piaget-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/hr-business-partner-piaget-plan-les-ouates",
-    "en": "/en/find-jobs-ticino/hr-business-partner-piaget-plan-les-ouates",
-    "de": "/de/jobs-im-tessin/hr-business-partner-piaget-plan-les-ouates"
+    "fr": "/fr/trouver-emploi-geneve/hr-business-partner-piaget-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/hr-business-partner-piaget-plan-les-ouates",
+    "en": "/en/find-jobs-geneva/hr-business-partner-piaget-plan-les-ouates",
+    "de": "/de/jobs-in-genf/hr-business-partner-piaget-plan-les-ouates"
   },
   "hr-socio-de-negocios-piaget-plan-les-ouates": {
-    "en": "/en/find-jobs-ticino/hr-socio-de-negocios-piaget-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/hr-socio-de-negocios-piaget-plan-les-ouates",
-    "de": "/de/jobs-im-tessin/hr-socio-de-negocios-piaget-plan-les-ouates",
-    "fr": "/fr/trouver-emploi-tessin/hr-socio-de-negocios-piaget-plan-les-ouates"
+    "en": "/en/find-jobs-geneva/hr-socio-de-negocios-piaget-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/hr-socio-de-negocios-piaget-plan-les-ouates",
+    "de": "/de/jobs-in-genf/hr-socio-de-negocios-piaget-plan-les-ouates",
+    "fr": "/fr/trouver-emploi-geneve/hr-socio-de-negocios-piaget-plan-les-ouates"
   },
   "hr-intern-valfleurier-buttes": {
     "en": "/en/find-jobs-ticino/hr-intern-valfleurier-buttes",
@@ -91751,22 +91751,22 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-specialista-di-cura-forense-spital-thurgau-stgag-munsterlingen-7418fa"
   },
   "dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen": {
-    "it": "/cerca-lavoro-ticino/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
-    "en": "/en/find-jobs-ticino/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
-    "de": "/de/jobs-im-tessin/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen"
+    "it": "/cerca-lavoro-turgovia/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
+    "en": "/en/find-jobs-thurgau/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
+    "de": "/de/jobs-im-thurgau/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-cura-professionale-moglie-con-funzione-aggiuntiva-spital-thurgau-stgag-diessenhofen"
   },
   "dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen": {
-    "en": "/en/find-jobs-ticino/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
-    "it": "/cerca-lavoro-ticino/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
-    "de": "/de/jobs-im-tessin/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen"
+    "en": "/en/find-jobs-thurgau/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
+    "it": "/cerca-lavoro-turgovia/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
+    "de": "/de/jobs-im-thurgau/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-care-professional-wife-with-additional-function-spital-thurgau-stgag-diessenhofen"
   },
   "dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen": {
-    "fr": "/fr/trouver-emploi-tessin/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
-    "it": "/cerca-lavoro-ticino/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
-    "en": "/en/find-jobs-ticino/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
-    "de": "/de/jobs-im-tessin/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen"
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
+    "it": "/cerca-lavoro-turgovia/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
+    "en": "/en/find-jobs-thurgau/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen",
+    "de": "/de/jobs-im-thurgau/dipl-professionnel-femme-ayant-une-fonction-supplementaire-spital-thurgau-stgag-diessenhofen"
   },
   "medical-device-technology-medical-device-technology-efz-universitatsspital-basel-basel": {
     "en": "/en/find-jobs-ticino/medical-device-technology-medical-device-technology-efz-universitatsspital-basel-basel",
@@ -91829,22 +91829,22 @@
     "de": "/de/jobs-im-tessin/dipl-specialiste-des-soins-hf-fh-poste-de-plongee-universitatsspital-basel-basel"
   },
   "assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel": {
-    "it": "/cerca-lavoro-ticino/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
-    "en": "/en/find-jobs-ticino/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
-    "de": "/de/jobs-im-tessin/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel"
+    "it": "/cerca-lavoro-basilea/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
+    "en": "/en/find-jobs-basel/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
+    "de": "/de/jobs-in-basel/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel",
+    "fr": "/fr/trouver-emploi-bale/assistente-per-la-salute-e-gli-affari-sociali-universitatsspital-basel-basel"
   },
   "assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel": {
-    "en": "/en/find-jobs-ticino/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
-    "it": "/cerca-lavoro-ticino/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
-    "de": "/de/jobs-im-tessin/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
-    "fr": "/fr/trouver-emploi-tessin/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel"
+    "en": "/en/find-jobs-basel/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
+    "it": "/cerca-lavoro-basilea/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
+    "de": "/de/jobs-in-basel/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel",
+    "fr": "/fr/trouver-emploi-bale/assistant-in-health-and-social-affairs-lungsstation-universitatsspital-basel-basel"
   },
   "assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel": {
-    "fr": "/fr/trouver-emploi-tessin/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
-    "it": "/cerca-lavoro-ticino/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
-    "en": "/en/find-jobs-ticino/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
-    "de": "/de/jobs-im-tessin/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel"
+    "fr": "/fr/trouver-emploi-bale/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
+    "it": "/cerca-lavoro-basilea/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
+    "en": "/en/find-jobs-basel/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel",
+    "de": "/de/jobs-in-basel/assistant-a-la-sante-et-aux-affaires-sociales-lungsstation-universitatsspital-basel-basel"
   },
   "amministrazione-aziendale-universitatsspital-basel-basel": {
     "it": "/cerca-lavoro-ticino/amministrazione-aziendale-universitatsspital-basel-basel",
@@ -92297,16 +92297,16 @@
     "fr": "/fr/trouver-emploi-tessin/junior-lab-techniker-epfl-lausanne"
   },
   "mechanical-ingegnere-epfl-sion": {
-    "it": "/cerca-lavoro-ticino/mechanical-ingegnere-epfl-sion",
-    "en": "/en/find-jobs-ticino/mechanical-ingegnere-epfl-sion",
-    "de": "/de/jobs-im-tessin/mechanical-ingegnere-epfl-sion",
-    "fr": "/fr/trouver-emploi-tessin/mechanical-ingegnere-epfl-sion"
+    "it": "/cerca-lavoro-vallese/mechanical-ingegnere-epfl-sion",
+    "en": "/en/find-jobs-valais/mechanical-ingegnere-epfl-sion",
+    "de": "/de/jobs-im-wallis/mechanical-ingegnere-epfl-sion",
+    "fr": "/fr/trouver-emploi-valais/mechanical-ingegnere-epfl-sion"
   },
   "mechanical-ingenieur-epfl-sion": {
-    "fr": "/fr/trouver-emploi-tessin/mechanical-ingenieur-epfl-sion",
-    "it": "/cerca-lavoro-ticino/mechanical-ingenieur-epfl-sion",
-    "en": "/en/find-jobs-ticino/mechanical-ingenieur-epfl-sion",
-    "de": "/de/jobs-im-tessin/mechanical-ingenieur-epfl-sion"
+    "fr": "/fr/trouver-emploi-valais/mechanical-ingenieur-epfl-sion",
+    "it": "/cerca-lavoro-vallese/mechanical-ingenieur-epfl-sion",
+    "en": "/en/find-jobs-valais/mechanical-ingenieur-epfl-sion",
+    "de": "/de/jobs-im-wallis/mechanical-ingenieur-epfl-sion"
   },
   "head-of-academic-service-epfl-lausanne": {
     "en": "/en/find-jobs-ticino/head-of-academic-service-epfl-lausanne",
@@ -92849,10 +92849,10 @@
     "de": "/de/jobs-im-tessin/assistant-dans-la-gestion-de-la-succursale-denner-gossau-zh"
   },
   "ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems": {
-    "fr": "/fr/trouver-emploi-tessin/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems",
-    "it": "/cerca-lavoro-ticino/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems",
-    "en": "/en/find-jobs-ticino/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems",
-    "de": "/de/jobs-im-tessin/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems"
+    "fr": "/fr/trouver-emploi-grisons/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems",
+    "it": "/cerca-lavoro-grigioni/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems",
+    "en": "/en/find-jobs-graubunden/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems",
+    "de": "/de/jobs-in-graubunden/ingenieur-de-procede-developpement-des-processus-m-f-d-100-ems-chemie-ag-domat-ems"
   },
   "material-testing-laboratory-technician-m-f-d-100-ems-chemie-ag-domat-ems": {
     "en": "/en/find-jobs-ticino/material-testing-laboratory-technician-m-f-d-100-ems-chemie-ag-domat-ems",
@@ -92951,10 +92951,10 @@
     "fr": "/fr/trouver-emploi-tessin/mobile-services-w-m-d-axpo-group-hagenbuch"
   },
   "gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
-    "it": "/cerca-lavoro-ticino/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
-    "en": "/en/find-jobs-ticino/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
-    "de": "/de/jobs-im-tessin/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich"
+    "fr": "/fr/trouver-emploi-zurich/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
+    "it": "/cerca-lavoro-zurigo/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
+    "en": "/en/find-jobs-zurich/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich",
+    "de": "/de/jobs-in-zurich/gestion-globale-de-patrimoine-assistant-banque-privee-zurich-banca-del-sempione-zurich"
   },
   "fornitore-di-servizi-elettrici-per-manutenzione-e-piccoli-ordini-100-elektro-bau-ag-filiale-lenzburg-lenzburg": {
     "it": "/cerca-lavoro-ticino/fornitore-di-servizi-elettrici-per-manutenzione-e-piccoli-ordini-100-elektro-bau-ag-filiale-lenzburg-lenzburg",
@@ -93029,10 +93029,10 @@
     "de": "/de/jobs-im-tessin/gestionnaire-des-prestations-lindenhofgruppe-bern"
   },
   "associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug": {
-    "fr": "/fr/trouver-emploi-tessin/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
-    "it": "/cerca-lavoro-ticino/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
-    "en": "/en/find-jobs-ticino/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
-    "de": "/de/jobs-im-tessin/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug"
+    "fr": "/fr/trouver-emploi-zoug/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
+    "it": "/cerca-lavoro-zugo/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
+    "en": "/en/find-jobs-zug/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug",
+    "de": "/de/jobs-in-zug/associe-principal-gestionnaire-adjoint-verification-commerce-industries-et-services-pwc-switzerland-zug"
   },
   "amministrazione-aziendale-universitatsspital-basel-basel-65d8a1": {
     "it": "/cerca-lavoro-ticino/amministrazione-aziendale-universitatsspital-basel-basel-65d8a1",
@@ -93737,16 +93737,16 @@
     "de": "/de/jobs-im-tessin/montres-de-luxe-omega-sales-associate-dallas-the-swatch-group-u-s-inc-75225-dallas-tx-texas-united-states-company-address-the-swatch-group-u-7uavyr"
   },
   "directeur-des-ventes-cartier-geneva": {
-    "fr": "/fr/trouver-emploi-tessin/directeur-des-ventes-cartier-geneva",
-    "it": "/cerca-lavoro-ticino/directeur-des-ventes-cartier-geneva",
-    "en": "/en/find-jobs-ticino/directeur-des-ventes-cartier-geneva",
-    "de": "/de/jobs-im-tessin/directeur-des-ventes-cartier-geneva"
+    "fr": "/fr/trouver-emploi-geneve/directeur-des-ventes-cartier-geneva",
+    "it": "/cerca-lavoro-ginevra/directeur-des-ventes-cartier-geneva",
+    "en": "/en/find-jobs-geneva/directeur-des-ventes-cartier-geneva",
+    "de": "/de/jobs-in-genf/directeur-des-ventes-cartier-geneva"
   },
   "associe-de-vente-temps-partiel-40-cartier-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/associe-de-vente-temps-partiel-40-cartier-zurich",
-    "it": "/cerca-lavoro-ticino/associe-de-vente-temps-partiel-40-cartier-zurich",
-    "en": "/en/find-jobs-ticino/associe-de-vente-temps-partiel-40-cartier-zurich",
-    "de": "/de/jobs-im-tessin/associe-de-vente-temps-partiel-40-cartier-zurich"
+    "fr": "/fr/trouver-emploi-zurich/associe-de-vente-temps-partiel-40-cartier-zurich",
+    "it": "/cerca-lavoro-zurigo/associe-de-vente-temps-partiel-40-cartier-zurich",
+    "en": "/en/find-jobs-zurich/associe-de-vente-temps-partiel-40-cartier-zurich",
+    "de": "/de/jobs-in-zurich/associe-de-vente-temps-partiel-40-cartier-zurich"
   },
   "interno-finanziario-vacheron-constantin-plan-les-ouates": {
     "it": "/cerca-lavoro-ticino/interno-finanziario-vacheron-constantin-plan-les-ouates",
@@ -94175,10 +94175,10 @@
     "de": "/de/jobs-im-tessin/debut-de-carriere-en-audit-banque-automne-2026-pwc-switzerland-luzern"
   },
   "inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve": {
-    "it": "/cerca-lavoro-ticino/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "en": "/en/find-jobs-ticino/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "de": "/de/jobs-im-tessin/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "fr": "/fr/trouver-emploi-tessin/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve"
+    "it": "/cerca-lavoro-vaud/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "en": "/en/find-jobs-vaud/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "de": "/de/jobs-in-der-waadt/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "fr": "/fr/trouver-emploi-vaud/inizio-carriera-in-audit-commercio-industrie-e-servizi-ginevra-ottobre-2026-pwc-switzerland-geneve"
   },
   "berufseinstieg-in-audit-trade-industries-and-services-genf-oktober-2026-pwc-switzerland-lausanne": {
     "de": "/de/jobs-im-tessin/berufseinstieg-in-audit-trade-industries-and-services-genf-oktober-2026-pwc-switzerland-lausanne",
@@ -94205,10 +94205,10 @@
     "fr": "/fr/trouver-emploi-tessin/intern-practice-integrated-bachelor-s-degree-pibs-industrial-engineering-40-m-f-d-hitachi-energy-wettingen-switzerland"
   },
   "au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland": {
-    "de": "/de/jobs-im-tessin/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
-    "it": "/cerca-lavoro-ticino/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
-    "en": "/en/find-jobs-ticino/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
-    "fr": "/fr/trouver-emploi-tessin/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland"
+    "de": "/de/jobs-in-zurich/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
+    "it": "/cerca-lavoro-zurigo/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
+    "en": "/en/find-jobs-zurich/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland",
+    "fr": "/fr/trouver-emploi-zurich/au-endiensttechniker-w-m-d-hitachi-energy-zurich-switzerland"
   },
   "debut-de-carriere-en-verification-banque-herbst-2026-pwc-switzerland-basel": {
     "fr": "/fr/trouver-emploi-tessin/debut-de-carriere-en-verification-banque-herbst-2026-pwc-switzerland-basel",
@@ -94247,10 +94247,10 @@
     "fr": "/fr/trouver-emploi-tessin/architecture-owner-telephony-and-cop-f-m-d-postfinance-bern"
   },
   "consulente-servizio-clienti-privato-losanna-postfinance-lausanne": {
-    "it": "/cerca-lavoro-ticino/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
-    "en": "/en/find-jobs-ticino/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
-    "de": "/de/jobs-im-tessin/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
-    "fr": "/fr/trouver-emploi-tessin/consulente-servizio-clienti-privato-losanna-postfinance-lausanne"
+    "it": "/cerca-lavoro-vaud/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
+    "en": "/en/find-jobs-vaud/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
+    "de": "/de/jobs-in-der-waadt/consulente-servizio-clienti-privato-losanna-postfinance-lausanne",
+    "fr": "/fr/trouver-emploi-vaud/consulente-servizio-clienti-privato-losanna-postfinance-lausanne"
   },
   "charge-e-de-contestations-postfinance-bern": {
     "fr": "/fr/trouver-emploi-tessin/charge-e-de-contestations-postfinance-bern",
@@ -94733,16 +94733,16 @@
     "fr": "/fr/trouver-emploi-tessin/gruppenprojektleiter-immobilien-masterdatenprojekte-richemont-bellevue"
   },
   "clienteling-data-project-manager-roger-dubuis-meyrin": {
-    "en": "/en/find-jobs-ticino/clienteling-data-project-manager-roger-dubuis-meyrin",
-    "it": "/cerca-lavoro-ticino/clienteling-data-project-manager-roger-dubuis-meyrin",
-    "de": "/de/jobs-im-tessin/clienteling-data-project-manager-roger-dubuis-meyrin",
-    "fr": "/fr/trouver-emploi-tessin/clienteling-data-project-manager-roger-dubuis-meyrin"
+    "en": "/en/find-jobs-geneva/clienteling-data-project-manager-roger-dubuis-meyrin",
+    "it": "/cerca-lavoro-ginevra/clienteling-data-project-manager-roger-dubuis-meyrin",
+    "de": "/de/jobs-in-genf/clienteling-data-project-manager-roger-dubuis-meyrin",
+    "fr": "/fr/trouver-emploi-geneve/clienteling-data-project-manager-roger-dubuis-meyrin"
   },
   "clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin": {
-    "fr": "/fr/trouver-emploi-tessin/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
-    "it": "/cerca-lavoro-ticino/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
-    "en": "/en/find-jobs-ticino/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
-    "de": "/de/jobs-im-tessin/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin"
+    "fr": "/fr/trouver-emploi-geneve/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
+    "it": "/cerca-lavoro-ginevra/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
+    "en": "/en/find-jobs-geneva/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin",
+    "de": "/de/jobs-in-genf/clientele-gestionnaire-de-projet-de-donnees-roger-dubuis-meyrin"
   },
   "ict-senior-system-engineer-safe-team-coach-80-100-w-m-d-ruag-ag-zurich-seebach": {
     "it": "/cerca-lavoro-ticino/ict-senior-system-engineer-safe-team-coach-80-100-w-m-d-ruag-ag-zurich-seebach",
@@ -94763,10 +94763,10 @@
     "fr": "/fr/trouver-emploi-tessin/med-praxisassistentin-oder-fachperson-gesundheit-f-u00fcr-die-fachbereiche-onkologie-h"
   },
   "med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60": {
-    "de": "/de/jobs-im-tessin/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
-    "it": "/cerca-lavoro-ticino/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
-    "en": "/en/find-jobs-ticino/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
-    "fr": "/fr/trouver-emploi-tessin/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60"
+    "de": "/de/jobs-in-zurich/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
+    "it": "/cerca-lavoro-zurigo/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
+    "en": "/en/find-jobs-zurich/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60",
+    "fr": "/fr/trouver-emploi-zurich/med-praxisangestellte-oder-fachangestellte-gesundheit-im-zentralen-belegungsmanagement-60"
   },
   "fachfrau-mann-gesundheit-efz-f-u00fcr-eine-medizinische-oder-chirurgische-bettenstation": {
     "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-efz-f-u00fcr-eine-medizinische-oder-chirurgische-bettenstation",
@@ -95177,10 +95177,10 @@
     "de": "/de/jobs-im-tessin/marchandiser-et-formateur-visuel-cote-est-the-swatch-group-u-s-inc-10017-new-york-ny-new-york-united-states-company"
   },
   "clienting-data-project-manager-roger-dubuis-meyrin": {
-    "de": "/de/jobs-im-tessin/clienting-data-project-manager-roger-dubuis-meyrin",
-    "it": "/cerca-lavoro-ticino/clienting-data-project-manager-roger-dubuis-meyrin",
-    "en": "/en/find-jobs-ticino/clienting-data-project-manager-roger-dubuis-meyrin",
-    "fr": "/fr/trouver-emploi-tessin/clienting-data-project-manager-roger-dubuis-meyrin"
+    "de": "/de/jobs-in-genf/clienting-data-project-manager-roger-dubuis-meyrin",
+    "it": "/cerca-lavoro-ginevra/clienting-data-project-manager-roger-dubuis-meyrin",
+    "en": "/en/find-jobs-geneva/clienting-data-project-manager-roger-dubuis-meyrin",
+    "fr": "/fr/trouver-emploi-geneve/clienting-data-project-manager-roger-dubuis-meyrin"
   },
   "head-of-ai-machine-learning-services-m-w-100-w-m-d-ruag-ag-bern": {
     "it": "/cerca-lavoro-ticino/head-of-ai-machine-learning-services-m-w-100-w-m-d-ruag-ag-bern",
@@ -95855,16 +95855,16 @@
     "fr": "/fr/trouver-emploi-tessin/audit-assistant-manager-financial-services-competence-center-pwc-switzerland-zurich"
   },
   "associate-payroll-consulting-80-100-pwc-switzerland-zurich": {
-    "en": "/en/find-jobs-ticino/associate-payroll-consulting-80-100-pwc-switzerland-zurich",
-    "it": "/cerca-lavoro-ticino/associate-payroll-consulting-80-100-pwc-switzerland-zurich",
-    "de": "/de/jobs-im-tessin/associate-payroll-consulting-80-100-pwc-switzerland-zurich",
-    "fr": "/fr/trouver-emploi-tessin/associate-payroll-consulting-80-100-pwc-switzerland-zurich"
+    "en": "/en/find-jobs-lucerne/associate-payroll-consulting-80-100-pwc-switzerland-zurich",
+    "it": "/cerca-lavoro-lucerna/associate-payroll-consulting-80-100-pwc-switzerland-zurich",
+    "de": "/de/jobs-in-luzern/associate-payroll-consulting-80-100-pwc-switzerland-zurich",
+    "fr": "/fr/trouver-emploi-lucerne/associate-payroll-consulting-80-100-pwc-switzerland-zurich"
   },
   "career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve": {
-    "fr": "/fr/trouver-emploi-tessin/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve",
-    "it": "/cerca-lavoro-ticino/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve",
-    "en": "/en/find-jobs-ticino/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve",
-    "de": "/de/jobs-im-tessin/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve"
+    "fr": "/fr/trouver-emploi-vaud/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve",
+    "it": "/cerca-lavoro-vaud/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve",
+    "en": "/en/find-jobs-vaud/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve",
+    "de": "/de/jobs-in-der-waadt/career-start-in-audit-trade-industries-and-services-geneve-october-2026-pwc-switzerland-geneve"
   },
   "associato-karriereeinstieg-steuerberatung-80-100-pwc-switzerland-luzern": {
     "it": "/cerca-lavoro-ticino/associato-karriereeinstieg-steuerberatung-80-100-pwc-switzerland-luzern",
@@ -95873,10 +95873,10 @@
     "fr": "/fr/trouver-emploi-tessin/associato-karriereeinstieg-steuerberatung-80-100-pwc-switzerland-luzern"
   },
   "manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich": {
-    "en": "/en/find-jobs-ticino/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich",
-    "it": "/cerca-lavoro-ticino/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich",
-    "de": "/de/jobs-im-tessin/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich",
-    "fr": "/fr/trouver-emploi-tessin/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich"
+    "en": "/en/find-jobs-geneva/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich",
+    "it": "/cerca-lavoro-ginevra/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich",
+    "de": "/de/jobs-in-genf/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich",
+    "fr": "/fr/trouver-emploi-geneve/manager-senior-manager-senior-cyber-security-architect-pwc-switzerland-zurich"
   },
   "omega-client-consulente-perth-the-swatch-group-australia-pty-ltd-6000-perth-western-australia-company-address-the-swatch-group-aus-7uaw1j": {
     "it": "/cerca-lavoro-ticino/omega-client-consulente-perth-the-swatch-group-australia-pty-ltd-6000-perth-western-australia-company-address-the-swatch-group-aus-7uaw1j",
@@ -96275,10 +96275,10 @@
     "fr": "/fr/trouver-emploi-tessin/inizio-carriera-in-audit-asset-management-autunno-2026-pwc-switzerland-zurich"
   },
   "inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve": {
-    "it": "/cerca-lavoro-ticino/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "en": "/en/find-jobs-ticino/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "de": "/de/jobs-im-tessin/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
-    "fr": "/fr/trouver-emploi-tessin/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve"
+    "it": "/cerca-lavoro-vaud/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "en": "/en/find-jobs-vaud/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "de": "/de/jobs-in-der-waadt/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve",
+    "fr": "/fr/trouver-emploi-vaud/inizio-carriera-audit-trade-industries-and-services-ginevra-ottobre-2026-pwc-switzerland-geneve"
   },
   "associe-de-vente-tissot-the-swatch-group-u-s-inc-33180-aventura-fl-florida-united-states-company-address-the-swatch-group-u-7uaw28": {
     "fr": "/fr/trouver-emploi-tessin/associe-de-vente-tissot-the-swatch-group-u-s-inc-33180-aventura-fl-florida-united-states-company-address-the-swatch-group-u-7uaw28",
@@ -96797,10 +96797,10 @@
     "fr": "/fr/trouver-emploi-tessin/technician-manutentore-otis-sa-balerna"
   },
   "autista-in-comando-swiss-armed-forces-vtg-bern": {
-    "it": "/cerca-lavoro-ticino/autista-in-comando-swiss-armed-forces-vtg-bern",
-    "en": "/en/find-jobs-ticino/autista-in-comando-swiss-armed-forces-vtg-bern",
-    "de": "/de/jobs-im-tessin/autista-in-comando-swiss-armed-forces-vtg-bern",
-    "fr": "/fr/trouver-emploi-tessin/autista-in-comando-swiss-armed-forces-vtg-bern"
+    "it": "/cerca-lavoro-berna/autista-in-comando-swiss-armed-forces-vtg-bern",
+    "en": "/en/find-jobs-bern/autista-in-comando-swiss-armed-forces-vtg-bern",
+    "de": "/de/jobs-in-bern/autista-in-comando-swiss-armed-forces-vtg-bern",
+    "fr": "/fr/trouver-emploi-berne/autista-in-comando-swiss-armed-forces-vtg-bern"
   },
   "sales-consulente-digital-marketing-localsearch-melide": {
     "it": "/cerca-lavoro-ticino/sales-consulente-digital-marketing-localsearch-melide",
@@ -96839,10 +96839,10 @@
     "fr": "/fr/trouver-emploi-tessin/career-start-in-audit-vorsorgespezialist-in-september-2026-pwc-switzerland-basel"
   },
   "collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern": {
-    "it": "/cerca-lavoro-ticino/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
-    "en": "/en/find-jobs-ticino/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
-    "de": "/de/jobs-im-tessin/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
-    "fr": "/fr/trouver-emploi-tessin/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern"
+    "it": "/cerca-lavoro-lucerna/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
+    "en": "/en/find-jobs-lucerne/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
+    "de": "/de/jobs-in-luzern/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/collaboratore-payroll-consulting-80-100-pwc-switzerland-luzern"
   },
   "consulente-commerciale-in-christ-uhren-schmuck-ag-chur-w2vgxm": {
     "it": "/cerca-lavoro-ticino/consulente-commerciale-in-christ-uhren-schmuck-ag-chur-w2vgxm",
@@ -97181,10 +97181,10 @@
     "it": "/cerca-lavoro-ticino/facharztin-arzt-fur-radiologie-mit-schwerpunkt-muskuloskelettale-radiologie-oa-oder-oambf"
   },
   "assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und": {
-    "de": "/de/jobs-im-tessin/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
-    "en": "/en/find-jobs-ticino/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
-    "fr": "/fr/trouver-emploi-tessin/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
-    "it": "/cerca-lavoro-ticino/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und"
+    "de": "/de/jobs-im-thurgau/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+    "en": "/en/find-jobs-thurgau/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+    "fr": "/fr/trouver-emploi-thurgovie/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und",
+    "it": "/cerca-lavoro-turgovia/assistenzarzt-arztin-in-facharztweiterbildung-kinder-und-jugendpsychiatrie-und"
   },
   "dipl-expertin-experte-intensivpflege-nds-hf-mit-zusatzfunktion-implementierung-ficus": {
     "it": "/cerca-lavoro-ticino/dipl-expertin-experte-intensivpflege-nds-hf-mit-zusatzfunktion-implementierung-ficus",
@@ -97361,10 +97361,10 @@
     "fr": "/fr/trouver-emploi-tessin/manutentore-manutentore-100-rapelli-orior-food-ag-stabio"
   },
   "tecnico-di-servizio-m-f-d-otis-sa-reinach": {
-    "it": "/cerca-lavoro-ticino/tecnico-di-servizio-m-f-d-otis-sa-reinach",
-    "en": "/en/find-jobs-ticino/tecnico-di-servizio-m-f-d-otis-sa-reinach",
-    "de": "/de/jobs-im-tessin/tecnico-di-servizio-m-f-d-otis-sa-reinach",
-    "fr": "/fr/trouver-emploi-tessin/tecnico-di-servizio-m-f-d-otis-sa-reinach"
+    "it": "/cerca-lavoro-basilea/tecnico-di-servizio-m-f-d-otis-sa-reinach",
+    "en": "/en/find-jobs-basel/tecnico-di-servizio-m-f-d-otis-sa-reinach",
+    "de": "/de/jobs-in-basel/tecnico-di-servizio-m-f-d-otis-sa-reinach",
+    "fr": "/fr/trouver-emploi-bale/tecnico-di-servizio-m-f-d-otis-sa-reinach"
   },
   "collaborateur-trice-innendienst-fur-die-hauptagentur-weinfelden-axa-svizzera-arbeitsort-weinfelden": {
     "fr": "/fr/trouver-emploi-tessin/collaborateur-trice-innendienst-fur-die-hauptagentur-weinfelden-axa-svizzera-arbeitsort-weinfelden",
@@ -98111,10 +98111,10 @@
     "de": "/de/jobs-im-tessin/health-safety-stagiaire-prada-group-montevarchi-health-safety-intern"
   },
   "ansprechpartner-fur-das-personal-piaget-plan-les-ouates": {
-    "de": "/de/jobs-im-tessin/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
-    "en": "/en/find-jobs-ticino/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
-    "fr": "/fr/trouver-emploi-tessin/ansprechpartner-fur-das-personal-piaget-plan-les-ouates"
+    "de": "/de/jobs-in-genf/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
+    "en": "/en/find-jobs-geneva/ansprechpartner-fur-das-personal-piaget-plan-les-ouates",
+    "fr": "/fr/trouver-emploi-geneve/ansprechpartner-fur-das-personal-piaget-plan-les-ouates"
   },
   "ai-forschung-ingenieur-pre-training-tether-operations-san-francisco-california": {
     "de": "/de/jobs-im-tessin/ai-forschung-ingenieur-pre-training-tether-operations-san-francisco-california",
@@ -98681,10 +98681,10 @@
     "fr": "/fr/trouver-emploi-tessin/infermiere-a-specializzato-a-in-cure-palliative-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/infermiere-a-dipl-sss-sup-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "formazione-infermiere-a-dipl-sss-3-anni-regolare-settembre-2026-bfgs-spital-thurgau-stgag-kantonsspital-frauenfeld": {
     "it": "/cerca-lavoro-ticino/formazione-infermiere-a-dipl-sss-3-anni-regolare-settembre-2026-bfgs-spital-thurgau-stgag-kantonsspital-frauenfeld",
@@ -101453,16 +101453,16 @@
     "fr": "/fr/trouver-emploi-tessin/laboratoriumsleiter-fur-manner-lifestyle-kleidung-prada-group-montevarchi-responsabile-laboratorio-di-collezione"
   },
   "client-services-project-manager-europe-cis-richemont-geneva": {
-    "it": "/cerca-lavoro-ticino/client-services-project-manager-europe-cis-richemont-geneva",
-    "fr": "/fr/trouver-emploi-tessin/client-services-project-manager-europe-cis-richemont-geneva",
-    "de": "/de/jobs-im-tessin/client-services-project-manager-europe-cis-richemont-geneva",
-    "en": "/en/find-jobs-ticino/client-services-project-manager-europe-cis-richemont-geneva"
+    "it": "/cerca-lavoro-ginevra/client-services-project-manager-europe-cis-richemont-geneva",
+    "fr": "/fr/trouver-emploi-geneve/client-services-project-manager-europe-cis-richemont-geneva",
+    "de": "/de/jobs-in-genf/client-services-project-manager-europe-cis-richemont-geneva",
+    "en": "/en/find-jobs-geneva/client-services-project-manager-europe-cis-richemont-geneva"
   },
   "client-services-project-manager-europe-cis-van-cleef-arpels-geneva": {
-    "en": "/en/find-jobs-ticino/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
-    "it": "/cerca-lavoro-ticino/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
-    "de": "/de/jobs-im-tessin/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
-    "fr": "/fr/trouver-emploi-tessin/client-services-project-manager-europe-cis-van-cleef-arpels-geneva"
+    "en": "/en/find-jobs-geneva/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
+    "it": "/cerca-lavoro-ginevra/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
+    "de": "/de/jobs-in-genf/client-services-project-manager-europe-cis-van-cleef-arpels-geneva",
+    "fr": "/fr/trouver-emploi-geneve/client-services-project-manager-europe-cis-van-cleef-arpels-geneva"
   },
   "lehrstelle-come-commercio-donna-efz-da-agosto-2026-roche-basel": {
     "it": "/cerca-lavoro-ticino/lehrstelle-come-commercio-donna-efz-da-agosto-2026-roche-basel",
@@ -101675,10 +101675,10 @@
     "de": "/de/jobs-im-tessin/chef-de-service-d-angiologie-eoc-ente-ospedaliero-cantonale-lugano"
   },
   "direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva": {
-    "it": "/cerca-lavoro-ticino/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
-    "en": "/en/find-jobs-ticino/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
-    "de": "/de/jobs-im-tessin/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
-    "fr": "/fr/trouver-emploi-tessin/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva"
+    "it": "/cerca-lavoro-ginevra/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
+    "en": "/en/find-jobs-geneva/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
+    "de": "/de/jobs-in-genf/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva",
+    "fr": "/fr/trouver-emploi-geneve/direttore-delle-operazioni-infrastrutture-di-accoglienza-msc-group-geneva"
   },
   "mobile-app-produktspezialist-msc-group-geneva": {
     "de": "/de/jobs-im-tessin/mobile-app-produktspezialist-msc-group-geneva",
@@ -101693,10 +101693,10 @@
     "fr": "/fr/trouver-emploi-tessin/auszubildende-verfahren-procadrans-la-chaux-de-fonds-142a0c"
   },
   "chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva": {
-    "fr": "/fr/trouver-emploi-tessin/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
-    "it": "/cerca-lavoro-ticino/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
-    "en": "/en/find-jobs-ticino/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
-    "de": "/de/jobs-im-tessin/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva"
+    "fr": "/fr/trouver-emploi-geneve/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
+    "it": "/cerca-lavoro-ginevra/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
+    "en": "/en/find-jobs-geneva/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva",
+    "de": "/de/jobs-in-genf/chef-de-projet-des-services-a-la-clientele-europe-cis-van-cleef-arpels-geneva"
   },
   "client-services-projektmanager-europa-cis-van-cleef-arpels-geneva": {
     "de": "/de/jobs-im-tessin/client-services-projektmanager-europa-cis-van-cleef-arpels-geneva",
@@ -101849,10 +101849,10 @@
     "fr": "/fr/trouver-emploi-tessin/insegnamento-come-fornitore-di-logistica-consegna-mista-in-efz-distribution-lettere-e-pacchetti-die-schweizerische-post"
   },
   "advisor-ere-client-en-placement-losanna-postfinance-lausanne": {
-    "it": "/cerca-lavoro-ticino/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
-    "en": "/en/find-jobs-ticino/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
-    "de": "/de/jobs-im-tessin/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
-    "fr": "/fr/trouver-emploi-tessin/advisor-ere-client-en-placement-losanna-postfinance-lausanne"
+    "it": "/cerca-lavoro-vaud/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
+    "en": "/en/find-jobs-vaud/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
+    "de": "/de/jobs-in-der-waadt/advisor-ere-client-en-placement-losanna-postfinance-lausanne",
+    "fr": "/fr/trouver-emploi-vaud/advisor-ere-client-en-placement-losanna-postfinance-lausanne"
   },
   "dr-venditrice-tore-casse-servizi-f-m-d-coop-genossenschaft-caslano": {
     "it": "/cerca-lavoro-ticino/dr-venditrice-tore-casse-servizi-f-m-d-coop-genossenschaft-caslano",
@@ -104237,10 +104237,10 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-ing-pflegefachperson-m-w-hf-fh-center-da-sanadad-savognin-savognin"
   },
   "infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel": {
-    "it": "/cerca-lavoro-ticino/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel",
-    "en": "/en/find-jobs-ticino/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel",
-    "de": "/de/jobs-im-tessin/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel"
+    "it": "/cerca-lavoro-basilea/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel",
+    "en": "/en/find-jobs-basel/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel",
+    "de": "/de/jobs-in-basel/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel",
+    "fr": "/fr/trouver-emploi-bale/infermiere-a-case-manager-pneumologia-chirurgia-toracica-st-claraspital-basel"
   },
   "infirmier-ere-gestionnaire-de-cas-en-pneumologie-chirurgie-thoracique-st-claraspital-basel": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-ere-gestionnaire-de-cas-en-pneumologie-chirurgie-thoracique-st-claraspital-basel",
@@ -104723,28 +104723,28 @@
     "fr": "/fr/trouver-emploi-tessin/globaler-ot-partner-engage-csl-behring-bern"
   },
   "direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern": {
-    "it": "/cerca-lavoro-ticino/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern"
+    "it": "/cerca-lavoro-berna/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
+    "en": "/en/find-jobs-bern/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
+    "de": "/de/jobs-in-bern/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/direttore-senior-programma-clinico-globale-lead-cardiovascular-renal-csl-behring-bern"
   },
   "directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern": {
-    "fr": "/fr/trouver-emploi-tessin/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
-    "it": "/cerca-lavoro-ticino/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern"
+    "fr": "/fr/trouver-emploi-berne/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
+    "it": "/cerca-lavoro-berna/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
+    "en": "/en/find-jobs-bern/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern",
+    "de": "/de/jobs-in-bern/directeur-principal-programme-clinique-mondial-chef-de-file-cardiopathie-et-renale-csl-behring-bern"
   },
   "esperto-senior-ehs-gestione-del-rischio-e-sicurezza-tecnica-f-m-d-csl-behring-bern": {
-    "it": "/cerca-lavoro-ticino/esperto-senior-ehs-gestione-del-rischio-e-sicurezza-tecnica-f-m-d-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
-    "de": "/de/jobs-im-tessin/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
-    "fr": "/fr/trouver-emploi-tessin/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
+    "it": "/cerca-lavoro-berna/esperto-senior-ehs-gestione-del-rischio-e-sicurezza-tecnica-f-m-d-csl-behring-bern",
+    "en": "/en/find-jobs-bern/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
+    "de": "/de/jobs-in-bern/senior-ehs-expert-risk-management-technical-safety-f-m-d-csl-behring-ch",
+    "fr": "/fr/trouver-emploi-berne/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
   },
   "expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern": {
-    "fr": "/fr/trouver-emploi-tessin/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
-    "it": "/cerca-lavoro-ticino/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
+    "fr": "/fr/trouver-emploi-berne/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
+    "it": "/cerca-lavoro-berna/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
+    "en": "/en/find-jobs-bern/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern",
+    "de": "/de/jobs-in-bern/expert-senior-ehs-gestion-des-risques-et-securite-technique-f-m-d-csl-behring-bern"
   },
   "esperto-senior-ehs-f-m-d-csl-behring-bern": {
     "it": "/cerca-lavoro-ticino/esperto-senior-ehs-f-m-d-csl-behring-bern",
@@ -104753,22 +104753,22 @@
     "fr": "/fr/trouver-emploi-tessin/senior-ehs-expert-f-m-d-csl-behring-ch"
   },
   "manutenzione-ecosystem-lead-rimozione-csl-behring-bern": {
-    "it": "/cerca-lavoro-ticino/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
-    "de": "/de/jobs-im-tessin/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/manutenzione-ecosystem-lead-rimozione-csl-behring-bern"
+    "it": "/cerca-lavoro-berna/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
+    "en": "/en/find-jobs-bern/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
+    "de": "/de/jobs-in-bern/manutenzione-ecosystem-lead-rimozione-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/manutenzione-ecosystem-lead-rimozione-csl-behring-bern"
   },
   "maintenance-ecosystem-lead-remote-csl-behring-ch": {
-    "en": "/en/find-jobs-ticino/maintenance-ecosystem-lead-remote-csl-behring-ch",
-    "it": "/cerca-lavoro-ticino/maintenance-ecosystem-lead-remote-csl-behring-ch",
-    "de": "/de/jobs-im-tessin/maintenance-ecosystem-lead-remote-csl-behring-ch",
-    "fr": "/fr/trouver-emploi-tessin/maintenance-ecosystem-lead-remote-csl-behring-ch"
+    "en": "/en/find-jobs-bern/maintenance-ecosystem-lead-remote-csl-behring-ch",
+    "it": "/cerca-lavoro-berna/maintenance-ecosystem-lead-remote-csl-behring-ch",
+    "de": "/de/jobs-in-bern/maintenance-ecosystem-lead-remote-csl-behring-ch",
+    "fr": "/fr/trouver-emploi-berne/maintenance-ecosystem-lead-remote-csl-behring-ch"
   },
   "fuhrender-wartungssystem-manager-remote-csl-behring-bern": {
-    "de": "/de/jobs-im-tessin/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
-    "it": "/cerca-lavoro-ticino/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
-    "en": "/en/find-jobs-ticino/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
-    "fr": "/fr/trouver-emploi-tessin/fuhrender-wartungssystem-manager-remote-csl-behring-bern"
+    "de": "/de/jobs-in-bern/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
+    "it": "/cerca-lavoro-berna/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
+    "en": "/en/find-jobs-bern/fuhrender-wartungssystem-manager-remote-csl-behring-bern",
+    "fr": "/fr/trouver-emploi-berne/fuhrender-wartungssystem-manager-remote-csl-behring-bern"
   },
   "direttore-associato-affidabilita-e-miglioramento-del-prodotto-csl-behring-bern": {
     "it": "/cerca-lavoro-ticino/direttore-associato-affidabilita-e-miglioramento-del-prodotto-csl-behring-bern",
@@ -104963,10 +104963,10 @@
     "fr": "/fr/trouver-emploi-tessin/graduated-physiotherapist-eoc-ente-ospedaliero-cantonale-novaggio-224f42"
   },
   "gestionnaire-de-la-philanthropie-80-100-epfl-lausanne": {
-    "fr": "/fr/trouver-emploi-tessin/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
-    "it": "/cerca-lavoro-ticino/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
-    "en": "/en/find-jobs-ticino/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
-    "de": "/de/jobs-im-tessin/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne"
+    "fr": "/fr/trouver-emploi-vaud/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
+    "it": "/cerca-lavoro-vaud/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
+    "en": "/en/find-jobs-vaud/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne",
+    "de": "/de/jobs-in-der-waadt/gestionnaire-de-la-philanthropie-80-100-epfl-lausanne"
   },
   "health-and-natural-sciences-vocational-maturity-practical-training-in-nursing-gesundheitsnetz-kusnacht-ag-kusnacht": {
     "en": "/en/find-jobs-ticino/health-and-natural-sciences-vocational-maturity-practical-training-in-nursing-gesundheitsnetz-kusnacht-ag-kusnacht",
@@ -104981,22 +104981,22 @@
     "fr": "/fr/trouver-emploi-tessin/initiative-r-abteilungsleiter-in-betreuung-und-pflege-gesundheitsnetz-kuesnacht-kusnacht"
   },
   "aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle": {
-    "it": "/cerca-lavoro-ticino/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "en": "/en/find-jobs-ticino/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "de": "/de/jobs-im-tessin/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "fr": "/fr/trouver-emploi-tessin/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle"
+    "it": "/cerca-lavoro-vaud/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "en": "/en/find-jobs-vaud/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "de": "/de/jobs-in-der-waadt/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "fr": "/fr/trouver-emploi-vaud/aiuto-e-accompagnamento-groupement-hospitalier-de-l-ouest-lemanique-rolle"
   },
   "aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle": {
-    "fr": "/fr/trouver-emploi-tessin/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "it": "/cerca-lavoro-ticino/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "en": "/en/find-jobs-ticino/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "de": "/de/jobs-im-tessin/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle"
+    "fr": "/fr/trouver-emploi-vaud/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "it": "/cerca-lavoro-vaud/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "en": "/en/find-jobs-vaud/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "de": "/de/jobs-in-der-waadt/aide-en-soins-et-accompagnement-groupement-hospitalier-de-l-ouest-lemanique-rolle"
   },
   "care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle": {
-    "en": "/en/find-jobs-ticino/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "it": "/cerca-lavoro-ticino/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "de": "/de/jobs-im-tessin/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
-    "fr": "/fr/trouver-emploi-tessin/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle"
+    "en": "/en/find-jobs-vaud/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "it": "/cerca-lavoro-vaud/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "de": "/de/jobs-in-der-waadt/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle",
+    "fr": "/fr/trouver-emploi-vaud/care-and-support-assistant-groupement-hospitalier-de-l-ouest-lemanique-rolle"
   },
   "apprentice-fachfrau-mann-hotellerie-hauswirtschaft-cfc-m-w-d-from-august-2027-grand-hotel-des-bains-kempinski-st-moritz": {
     "it": "/cerca-lavoro-ticino/apprentice-fachfrau-mann-hotellerie-hauswirtschaft-cfc-m-w-d-from-august-2027-grand-hotel-des-bains-kempinski-st-moritz",
@@ -105047,22 +105047,22 @@
     "fr": "/fr/trouver-emploi-tessin/apprentice-koch-efz-f-m-d-from-august-2027-grand-hotel-des-bains-kempinski-st-moritz-st-moritz"
   },
   "fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf": {
-    "it": "/cerca-lavoro-ticino/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "en": "/en/find-jobs-ticino/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "de": "/de/jobs-im-tessin/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf"
+    "it": "/cerca-lavoro-zurigo/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "en": "/en/find-jobs-zurich/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "de": "/de/jobs-in-zurich/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "fr": "/fr/trouver-emploi-zurich/fachperson-gesundheit-cfc-spitex-gesundheitszentrum-dielsdorf-regensdorf"
   },
   "healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf": {
-    "en": "/en/find-jobs-ticino/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "it": "/cerca-lavoro-ticino/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "de": "/de/jobs-im-tessin/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf",
-    "fr": "/fr/trouver-emploi-tessin/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf"
+    "en": "/en/find-jobs-zurich/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "it": "/cerca-lavoro-zurigo/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "de": "/de/jobs-in-zurich/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf",
+    "fr": "/fr/trouver-emploi-zurich/healthcare-specialist-efz-spitex-gesundheitszentrum-dielsdorf-regensdorf"
   },
   "fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf": {
-    "de": "/de/jobs-im-tessin/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
-    "it": "/cerca-lavoro-ticino/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
-    "en": "/en/find-jobs-ticino/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf"
+    "de": "/de/jobs-in-zurich/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
+    "it": "/cerca-lavoro-zurigo/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
+    "en": "/en/find-jobs-zurich/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf",
+    "fr": "/fr/trouver-emploi-zurich/fachperson-gesundheit-efz-spitex-gz-dielsdorf-regensdorf"
   },
   "candidatura-spontanea-gesundheitszentrum-dielsdorf-dielsdorf-regensdorf": {
     "it": "/cerca-lavoro-ticino/candidatura-spontanea-gesundheitszentrum-dielsdorf-dielsdorf-regensdorf",
@@ -105629,16 +105629,16 @@
     "fr": "/fr/trouver-emploi-tessin/ict-teamleiter-in-identity-access-management-80-100-hoch-health-st-gallen"
   },
   "diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen": {
-    "en": "/en/find-jobs-ticino/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen"
+    "en": "/en/find-jobs-st-gallen/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/diploma-in-nursing-60-100-hoch-health-ostschweiz-st-gallen"
   },
   "diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen": {
-    "fr": "/fr/trouver-emploi-tessin/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen"
+    "fr": "/fr/trouver-emploi-saint-gall/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/diplome-e-en-soins-infirmiers-60-100-hoch-health-ostschweiz-st-gallen"
   },
   "assistente-a-medico-al-100-hoch-health-ostschweiz-st-gallen": {
     "it": "/cerca-lavoro-ticino/assistente-a-medico-al-100-hoch-health-ostschweiz-st-gallen",
@@ -105965,16 +105965,16 @@
     "de": "/de/jobs-im-tessin/employe-e-de-cuisine-100-hoch-health-ostschweiz-st-gallen"
   },
   "diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen": {
-    "en": "/en/find-jobs-ticino/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen"
+    "en": "/en/find-jobs-st-gallen/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/diploma-in-nursing-40-100-hoch-health-ostschweiz-st-gallen"
   },
   "diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen": {
-    "fr": "/fr/trouver-emploi-tessin/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen"
+    "fr": "/fr/trouver-emploi-saint-gall/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/diplome-e-en-soins-infirmiers-40-100-hoch-health-ostschweiz-st-gallen"
   },
   "addetto-a-di-sala-responsabile-di-servizio-100-hoch-health-ostschweiz-st-gallen": {
     "it": "/cerca-lavoro-ticino/addetto-a-di-sala-responsabile-di-servizio-100-hoch-health-ostschweiz-st-gallen",
@@ -106511,34 +106511,34 @@
     "de": "/de/jobs-im-tessin/formation-de-technicien-ne-de-laboratoire-biomedical-hf-hoch-health-ostschweiz-st-gallen"
   },
   "formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen": {
-    "it": "/cerca-lavoro-ticino/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen"
+    "it": "/cerca-lavoro-san-gallo/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/formazione-per-tecnico-di-sala-operatoria-diplomato-hf-hoch-health-ostschweiz-st-gallen"
   },
   "ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach": {
-    "en": "/en/find-jobs-ticino/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach",
-    "it": "/cerca-lavoro-ticino/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach",
-    "de": "/de/jobs-im-tessin/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach",
-    "fr": "/fr/trouver-emploi-tessin/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach"
+    "en": "/en/find-jobs-st-gallen/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach",
+    "it": "/cerca-lavoro-san-gallo/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach",
+    "de": "/de/jobs-in-st-gallen/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach",
+    "fr": "/fr/trouver-emploi-saint-gall/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-ostschweiz-uznach"
   },
   "ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach": {
-    "de": "/de/jobs-im-tessin/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach",
-    "it": "/cerca-lavoro-ticino/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach",
-    "en": "/en/find-jobs-ticino/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach",
-    "fr": "/fr/trouver-emploi-tessin/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach"
+    "de": "/de/jobs-in-st-gallen/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach",
+    "it": "/cerca-lavoro-san-gallo/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach",
+    "en": "/en/find-jobs-st-gallen/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach",
+    "fr": "/fr/trouver-emploi-saint-gall/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-uznach"
   },
   "formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen": {
-    "fr": "/fr/trouver-emploi-tessin/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen"
+    "fr": "/fr/trouver-emploi-saint-gall/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/formation-pour-technicien-en-salle-d-operation-hf-certifie-hoch-health-ostschweiz-st-gallen"
   },
   "ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen": {
-    "it": "/cerca-lavoro-ticino/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen",
-    "en": "/en/find-jobs-ticino/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen",
-    "de": "/de/jobs-im-tessin/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen"
+    "it": "/cerca-lavoro-san-gallo/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen",
+    "en": "/en/find-jobs-st-gallen/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen",
+    "de": "/de/jobs-in-st-gallen/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/ausbildung-zur-dipl-fachperson-operationstechnik-hf-hoch-health-st-gallen"
   },
   "oberarztin-arzt-80-100-hoch-health-st-gallen": {
     "de": "/de/jobs-im-tessin/oberarztin-arzt-80-100-hoch-health-st-gallen",
@@ -106595,88 +106595,88 @@
     "de": "/de/jobs-im-tessin/medecin-en-oncologie-medicale-60-100-hoch-health-ostschweiz-st-gallen"
   },
   "dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs": {
-    "it": "/cerca-lavoro-ticino/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs",
-    "en": "/en/find-jobs-ticino/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs",
-    "de": "/de/jobs-im-tessin/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs",
-    "fr": "/fr/trouver-emploi-tessin/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs"
+    "it": "/cerca-lavoro-san-gallo/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs",
+    "en": "/en/find-jobs-st-gallen/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs",
+    "de": "/de/jobs-in-st-gallen/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs",
+    "fr": "/fr/trouver-emploi-saint-gall/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-ostschweiz-grabs"
   },
   "dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs": {
-    "de": "/de/jobs-im-tessin/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs",
-    "en": "/en/find-jobs-ticino/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs",
-    "fr": "/fr/trouver-emploi-tessin/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs",
-    "it": "/cerca-lavoro-ticino/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs"
+    "de": "/de/jobs-in-st-gallen/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs",
+    "en": "/en/find-jobs-st-gallen/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs",
+    "fr": "/fr/trouver-emploi-saint-gall/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs",
+    "it": "/cerca-lavoro-san-gallo/dipl-fachfrau-mann-operationstechnik-80-100-hoch-health-grabs"
   },
   "infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen": {
-    "it": "/cerca-lavoro-ticino/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen"
+    "it": "/cerca-lavoro-san-gallo/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/infermiere-qualificato-springerpool-50-100-hoch-health-ostschweiz-st-gallen"
   },
   "dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs": {
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs"
+    "en": "/en/find-jobs-st-gallen/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs",
+    "it": "/cerca-lavoro-san-gallo/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs",
+    "de": "/de/jobs-in-st-gallen/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs",
+    "fr": "/fr/trouver-emploi-saint-gall/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-ostschweiz-grabs"
   },
   "dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs": {
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs"
+    "de": "/de/jobs-in-st-gallen/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs",
+    "it": "/cerca-lavoro-san-gallo/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs",
+    "en": "/en/find-jobs-st-gallen/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs",
+    "fr": "/fr/trouver-emploi-saint-gall/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-grabs"
   },
   "infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen": {
-    "fr": "/fr/trouver-emploi-tessin/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen"
+    "fr": "/fr/trouver-emploi-saint-gall/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/infirmiere-diplomee-a-springerpool-50-100-hoch-health-ostschweiz-st-gallen"
   },
   "dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen"
+    "it": "/cerca-lavoro-san-gallo/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen",
+    "en": "/en/find-jobs-st-gallen/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen",
+    "de": "/de/jobs-in-st-gallen/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/dipl-pflegefachfrau-mann-springerpool-50-100-hoch-health-st-gallen"
   },
   "logistiker-in-100-hoch-health-ostschweiz-grabs": {
-    "it": "/cerca-lavoro-ticino/logistiker-in-100-hoch-health-ostschweiz-grabs",
-    "en": "/en/find-jobs-ticino/logistiker-in-100-hoch-health-ostschweiz-grabs",
-    "de": "/de/jobs-im-tessin/logistiker-in-100-hoch-health-ostschweiz-grabs",
-    "fr": "/fr/trouver-emploi-tessin/logistiker-in-100-hoch-health-ostschweiz-grabs"
+    "it": "/cerca-lavoro-san-gallo/logistiker-in-100-hoch-health-ostschweiz-grabs",
+    "en": "/en/find-jobs-st-gallen/logistiker-in-100-hoch-health-ostschweiz-grabs",
+    "de": "/de/jobs-in-st-gallen/logistiker-in-100-hoch-health-ostschweiz-grabs",
+    "fr": "/fr/trouver-emploi-saint-gall/logistiker-in-100-hoch-health-ostschweiz-grabs"
   },
   "logistiker-in-100-hoch-health-grabs": {
-    "de": "/de/jobs-im-tessin/logistiker-in-100-hoch-health-grabs",
-    "en": "/en/find-jobs-ticino/logistiker-in-100-hoch-health-grabs",
-    "fr": "/fr/trouver-emploi-tessin/logistiker-in-100-hoch-health-grabs",
-    "it": "/cerca-lavoro-ticino/logistiker-in-100-hoch-health-grabs"
+    "de": "/de/jobs-in-st-gallen/logistiker-in-100-hoch-health-grabs",
+    "en": "/en/find-jobs-st-gallen/logistiker-in-100-hoch-health-grabs",
+    "fr": "/fr/trouver-emploi-saint-gall/logistiker-in-100-hoch-health-grabs",
+    "it": "/cerca-lavoro-san-gallo/logistiker-in-100-hoch-health-grabs"
   },
   "logistiker-in-100-hoch-health-ostschweiz-uznach": {
-    "it": "/cerca-lavoro-ticino/logistiker-in-100-hoch-health-ostschweiz-uznach",
-    "en": "/en/find-jobs-ticino/logistiker-in-100-hoch-health-ostschweiz-uznach",
-    "de": "/de/jobs-im-tessin/logistiker-in-100-hoch-health-ostschweiz-uznach",
-    "fr": "/fr/trouver-emploi-tessin/logistiker-in-100-hoch-health-ostschweiz-uznach"
+    "it": "/cerca-lavoro-san-gallo/logistiker-in-100-hoch-health-ostschweiz-uznach",
+    "en": "/en/find-jobs-st-gallen/logistiker-in-100-hoch-health-ostschweiz-uznach",
+    "de": "/de/jobs-in-st-gallen/logistiker-in-100-hoch-health-ostschweiz-uznach",
+    "fr": "/fr/trouver-emploi-saint-gall/logistiker-in-100-hoch-health-ostschweiz-uznach"
   },
   "logistiker-in-100-hoch-health-uznach": {
-    "de": "/de/jobs-im-tessin/logistiker-in-100-hoch-health-uznach",
-    "en": "/en/find-jobs-ticino/logistiker-in-100-hoch-health-uznach",
-    "fr": "/fr/trouver-emploi-tessin/logistiker-in-100-hoch-health-uznach",
-    "it": "/cerca-lavoro-ticino/logistiker-in-100-hoch-health-uznach"
+    "de": "/de/jobs-in-st-gallen/logistiker-in-100-hoch-health-uznach",
+    "en": "/en/find-jobs-st-gallen/logistiker-in-100-hoch-health-uznach",
+    "fr": "/fr/trouver-emploi-saint-gall/logistiker-in-100-hoch-health-uznach",
+    "it": "/cerca-lavoro-san-gallo/logistiker-in-100-hoch-health-uznach"
   },
   "health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen": {
-    "en": "/en/find-jobs-ticino/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen"
+    "en": "/en/find-jobs-st-gallen/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/health-care-specialist-80-100-hoch-health-ostschweiz-st-gallen"
   },
   "fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5": {
-    "it": "/cerca-lavoro-ticino/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5",
-    "en": "/en/find-jobs-ticino/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5",
-    "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5"
+    "it": "/cerca-lavoro-san-gallo/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5",
+    "en": "/en/find-jobs-st-gallen/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5",
+    "de": "/de/jobs-in-st-gallen/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5",
+    "fr": "/fr/trouver-emploi-saint-gall/fachfrau-mann-gesundheit-80-100-hoch-health-st-gallen-5"
   },
   "fachfrau-mann-gesundheit-80-100-hoch-health-wil-2": {
-    "it": "/cerca-lavoro-ticino/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2",
-    "en": "/en/find-jobs-ticino/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2",
-    "de": "/de/jobs-im-tessin/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2"
+    "it": "/cerca-lavoro-san-gallo/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2",
+    "en": "/en/find-jobs-st-gallen/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2",
+    "de": "/de/jobs-in-st-gallen/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2",
+    "fr": "/fr/trouver-emploi-saint-gall/fachfrau-mann-gesundheit-80-100-hoch-health-wil-2"
   },
   "assistente-i-di-base-2027-hoch-health-ostschweiz-st-gallen": {
     "it": "/cerca-lavoro-ticino/assistente-i-di-base-2027-hoch-health-ostschweiz-st-gallen",
@@ -106715,16 +106715,16 @@
     "de": "/de/jobs-im-tessin/medicin-specialiste-en-neurologie-80-hoch-health-ostschweiz-st-gallen"
   },
   "candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen": {
-    "it": "/cerca-lavoro-ticino/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen",
-    "fr": "/fr/trouver-emploi-tessin/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen"
+    "it": "/cerca-lavoro-san-gallo/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen",
+    "fr": "/fr/trouver-emploi-saint-gall/candidatura-spontanea-dipartimento-cure-e-servizi-terapeutici-40-100-hoch-health-ostschweiz-st-gallen"
   },
   "candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen": {
-    "fr": "/fr/trouver-emploi-tessin/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen",
-    "it": "/cerca-lavoro-ticino/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen",
-    "en": "/en/find-jobs-ticino/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen",
-    "de": "/de/jobs-im-tessin/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen"
+    "fr": "/fr/trouver-emploi-saint-gall/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen",
+    "it": "/cerca-lavoro-san-gallo/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen",
+    "en": "/en/find-jobs-st-gallen/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen",
+    "de": "/de/jobs-in-st-gallen/candidature-spontanee-departement-soins-et-services-therapeutiques-40-100-hoch-health-ostschweiz-st-gallen"
   },
   "case-manager-gestione-pazienti-centrale-zpm-100-hoch-health-ostschweiz-st-gallen": {
     "it": "/cerca-lavoro-ticino/case-manager-gestione-pazienti-centrale-zpm-100-hoch-health-ostschweiz-st-gallen",
@@ -107735,106 +107735,106 @@
     "de": "/de/jobs-im-tessin/infirmier-ere-diplome-e-hf-fh-60-100-klinik-gut-ag-st-moritz"
   },
   "healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich": {
-    "en": "/en/find-jobs-ticino/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich"
+    "en": "/en/find-jobs-zurich/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/healthcare-specialist-neurorehabilitation-a-in-early-and-late-shifts-klinik-lengg-zurich"
   },
   "fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg": {
-    "de": "/de/jobs-im-tessin/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
-    "it": "/cerca-lavoro-ticino/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
-    "en": "/en/find-jobs-ticino/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg"
+    "de": "/de/jobs-in-zurich/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
+    "it": "/cerca-lavoro-zurigo/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
+    "en": "/en/find-jobs-zurich/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg",
+    "fr": "/fr/trouver-emploi-zurich/fachfrau-fachmann-gesundheit-neurorehabilitation-a-im-fruh-und-spatdienst-klinik-lengg"
   },
   "dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich": {
-    "it": "/cerca-lavoro-ticino/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich"
+    "it": "/cerca-lavoro-zurigo/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/dipl-infermiere-come-early-bird-o-night-owl-klinik-lengg-zurich"
   },
   "dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich": {
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich"
+    "en": "/en/find-jobs-zurich/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/dipl-pflegefachperson-als-early-bird-oder-night-owl-a-klinik-lengg-zurich"
   },
   "diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich"
+    "fr": "/fr/trouver-emploi-zurich/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/diplome-e-en-soins-infirmiers-en-tant-qu-oiseau-de-nuit-ou-matinal-klinik-lengg-zurich"
   },
   "dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich"
+    "it": "/cerca-lavoro-zurigo/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/dipl-pflegefachperson-als-fruhaufsteher-oder-nachteule-a-klinik-lengg-zurich"
   },
   "formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich": {
-    "it": "/cerca-lavoro-ticino/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich"
+    "it": "/cerca-lavoro-zurigo/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/formatore-sanitario-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich"
   },
   "healthcare-educator-in-a-klinik-lengg-zurich": {
-    "en": "/en/find-jobs-ticino/healthcare-educator-in-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/healthcare-educator-in-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/healthcare-educator-in-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/healthcare-educator-in-a-klinik-lengg-zurich"
+    "en": "/en/find-jobs-zurich/healthcare-educator-in-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/healthcare-educator-in-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/healthcare-educator-in-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/healthcare-educator-in-a-klinik-lengg-zurich"
   },
   "berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich": {
-    "de": "/de/jobs-im-tessin/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich"
+    "de": "/de/jobs-in-zurich/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/berufsbildner-in-fachfrau-fachmann-gesundheit-a-klinik-lengg-zurich"
   },
   "formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich"
+    "fr": "/fr/trouver-emploi-zurich/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/formateur-trice-en-soins-de-sante-a-klinik-lengg-zurich"
   },
   "medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich": {
-    "it": "/cerca-lavoro-ticino/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich"
+    "it": "/cerca-lavoro-zurigo/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/medico-assistente-neurorehabilitazione-a-klinik-lengg-zurich"
   },
   "assistant-physician-neurorehabilitation-a-klinik-lengg-zurich": {
-    "en": "/en/find-jobs-ticino/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich"
+    "en": "/en/find-jobs-zurich/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/assistant-physician-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich": {
-    "de": "/de/jobs-im-tessin/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich"
+    "de": "/de/jobs-in-zurich/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/assistenzarztin-assistenzarzt-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich"
+    "fr": "/fr/trouver-emploi-zurich/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/medecin-assistant-en-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich": {
-    "it": "/cerca-lavoro-ticino/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich"
+    "it": "/cerca-lavoro-zurigo/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/medico-neurorehabilitazione-a-capo-dipartimento-klinik-lengg-zurich"
   },
   "oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich": {
-    "de": "/de/jobs-im-tessin/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
-    "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich"
+    "de": "/de/jobs-in-zurich/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich",
+    "fr": "/fr/trouver-emploi-zurich/oberarztin-oberarzt-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich": {
-    "fr": "/fr/trouver-emploi-tessin/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich",
-    "it": "/cerca-lavoro-ticino/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich",
-    "en": "/en/find-jobs-ticino/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich",
-    "de": "/de/jobs-im-tessin/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich"
+    "fr": "/fr/trouver-emploi-zurich/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich",
+    "it": "/cerca-lavoro-zurigo/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich",
+    "en": "/en/find-jobs-zurich/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich",
+    "de": "/de/jobs-in-zurich/medecin-chef-en-neurorehabilitation-a-klinik-lengg-zurich"
   },
   "infermiere-diplomato-hf-fh-w-m-d-80-100-klinik-schonberg-ag-gunten": {
     "it": "/cerca-lavoro-ticino/infermiere-diplomato-hf-fh-w-m-d-80-100-klinik-schonberg-ag-gunten",
@@ -109169,10 +109169,10 @@
     "fr": "/fr/trouver-emploi-tessin/nursing-intern-80-100-luzerner-kantonsspital-luks-wolhusen"
   },
   "fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern": {
-    "de": "/de/jobs-im-tessin/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
-    "it": "/cerca-lavoro-ticino/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
-    "en": "/en/find-jobs-ticino/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern"
+    "de": "/de/jobs-in-luzern/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
+    "en": "/en/find-jobs-lucerne/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/fachfrau-gesundheit-fachmann-gesundheit-viszeral-und-gefasschirurgie-80-100-luks-luzern"
   },
   "healthcare-specialist-visceral-and-vascular-surgery-80-100-luzerner-kantonsspital-luks-luzern": {
     "en": "/en/find-jobs-ticino/healthcare-specialist-visceral-and-vascular-surgery-80-100-luzerner-kantonsspital-luks-luzern",
@@ -109205,10 +109205,10 @@
     "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-fur-radiologie-interventional-radiology-fellowship-100-befristet-auf-2-jahre-luzerner-kantonsspital"
   },
   "facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet": {
-    "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
-    "it": "/cerca-lavoro-ticino/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
-    "en": "/en/find-jobs-ticino/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
-    "de": "/de/jobs-im-tessin/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet"
+    "fr": "/fr/trouver-emploi-lucerne/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
+    "it": "/cerca-lavoro-lucerna/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
+    "en": "/en/find-jobs-lucerne/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet",
+    "de": "/de/jobs-in-luzern/facharztin-facharzt-fur-radiologie-fellowship-interventionelle-radiologie-100-befristet"
   },
   "facharztin-facharzt-radiology-fellowship-abdominal-radiology-100-befristet-auf-1-jahr-luzerner-kantonsspital-luks-luzern": {
     "de": "/de/jobs-im-tessin/facharztin-facharzt-radiology-fellowship-abdominal-radiology-100-befristet-auf-1-jahr-luzerner-kantonsspital-luks-luzern",
@@ -109217,10 +109217,10 @@
     "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-radiology-fellowship-abdominal-radiology-100-befristet-auf-1-jahr-luzerner-kantonsspital-luks-luzern"
   },
   "facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr": {
-    "fr": "/fr/trouver-emploi-tessin/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
-    "it": "/cerca-lavoro-ticino/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
-    "en": "/en/find-jobs-ticino/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
-    "de": "/de/jobs-im-tessin/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr"
+    "fr": "/fr/trouver-emploi-lucerne/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
+    "it": "/cerca-lavoro-lucerna/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
+    "en": "/en/find-jobs-lucerne/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr",
+    "de": "/de/jobs-in-luzern/facharztin-facharzt-radiologie-fellowship-abdominale-radiologie-100-befristet-auf-1-jahr"
   },
   "insegnante-di-cura-in-ambito-operatorio-50-luzerner-kantonsspital-luks-luzern": {
     "it": "/cerca-lavoro-ticino/insegnante-di-cura-in-ambito-operatorio-50-luzerner-kantonsspital-luks-luzern",
@@ -109229,10 +109229,10 @@
     "fr": "/fr/trouver-emploi-tessin/insegnante-di-cura-in-ambito-operatorio-50-luzerner-kantonsspital-luks-luzern"
   },
   "lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern": {
-    "de": "/de/jobs-im-tessin/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
-    "it": "/cerca-lavoro-ticino/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
-    "en": "/en/find-jobs-ticino/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern"
+    "de": "/de/jobs-in-luzern/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
+    "en": "/en/find-jobs-lucerne/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/lehrperson-fur-pflege-in-der-praxis-operationstechnik-50-luks-luzern"
   },
   "educateur-en-soins-pratiques-en-chirurgie-50-luzerner-kantonsspital-luks-luzern": {
     "fr": "/fr/trouver-emploi-tessin/educateur-en-soins-pratiques-en-chirurgie-50-luzerner-kantonsspital-luks-luzern",
@@ -109247,10 +109247,10 @@
     "fr": "/fr/trouver-emploi-tessin/consulente-specializzato-in-diabete-70-80-luzerner-kantonsspital-luks-sursee"
   },
   "diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee": {
-    "de": "/de/jobs-im-tessin/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
-    "it": "/cerca-lavoro-ticino/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
-    "en": "/en/find-jobs-ticino/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
-    "fr": "/fr/trouver-emploi-tessin/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee"
+    "de": "/de/jobs-in-luzern/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
+    "it": "/cerca-lavoro-lucerna/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
+    "en": "/en/find-jobs-lucerne/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee",
+    "fr": "/fr/trouver-emploi-lucerne/diabetesfachberaterin-diabetesfachberater-70-80-luks-sursee"
   },
   "diabetes-specialist-advisor-70-80-luzerner-kantonsspital-luks-sursee": {
     "en": "/en/find-jobs-ticino/diabetes-specialist-advisor-70-80-luzerner-kantonsspital-luks-sursee",
@@ -109271,10 +109271,10 @@
     "fr": "/fr/trouver-emploi-tessin/addetta-o-alle-pulizie-50-80-a-tempo-determinato-fino-al-31-08-2026-luzerner-kantonsspital-luks-luzern"
   },
   "mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern": {
-    "de": "/de/jobs-im-tessin/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
-    "it": "/cerca-lavoro-ticino/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
-    "en": "/en/find-jobs-ticino/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern"
+    "de": "/de/jobs-in-luzern/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
+    "en": "/en/find-jobs-lucerne/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/mitarbeiterin-mitarbeiter-reinigungsdienst-50-80-befristet-bis-31-08-2026-luks-luzern"
   },
   "cleaning-staff-50-80-fixed-term-until-31-08-2026-luzerner-kantonsspital-luks-luzern": {
     "en": "/en/find-jobs-ticino/cleaning-staff-50-80-fixed-term-until-31-08-2026-luzerner-kantonsspital-luks-luzern",
@@ -109289,10 +109289,10 @@
     "de": "/de/jobs-im-tessin/employe-e-de-nettoyage-50-80-en-contrat-temporaire-jusqu-au-31-08-2026-luzerner-kantonsspital-luks-luzern"
   },
   "medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern": {
-    "de": "/de/jobs-im-tessin/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
-    "it": "/cerca-lavoro-ticino/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
-    "en": "/en/find-jobs-ticino/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern"
+    "de": "/de/jobs-in-luzern/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
+    "en": "/en/find-jobs-lucerne/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/medizinische-fachperson-gesundheitsleitstelle-50-100-luks-luzern"
   },
   "healthcare-professional-for-health-hub-50-100-luzerner-kantonsspital-luks-luzern": {
     "en": "/en/find-jobs-ticino/healthcare-professional-for-health-hub-50-100-luzerner-kantonsspital-luks-luzern",
@@ -109313,10 +109313,10 @@
     "fr": "/fr/trouver-emploi-tessin/capo-della-fisioterapia-possibilita-di-lavoro-condiviso-100-luzerner-kantonsspital-luks-stans"
   },
   "leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2": {
-    "it": "/cerca-lavoro-ticino/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
-    "en": "/en/find-jobs-ticino/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
-    "de": "/de/jobs-im-tessin/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
-    "fr": "/fr/trouver-emploi-tessin/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2"
+    "it": "/cerca-lavoro-nidvaldo/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
+    "en": "/en/find-jobs-nidwalden/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
+    "de": "/de/jobs-in-nidwalden/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2",
+    "fr": "/fr/trouver-emploi-nidwald/leiter-in-physiotherapie-auch-jobsharing-moglich-100-luks-stans-2"
   },
   "infermiere-a-interdisciplinare-reparto-madre-bambino-100-luzerner-kantonsspital-luks-sursee": {
     "it": "/cerca-lavoro-ticino/infermiere-a-interdisciplinare-reparto-madre-bambino-100-luzerner-kantonsspital-luks-sursee",
@@ -109343,16 +109343,16 @@
     "fr": "/fr/trouver-emploi-tessin/capo-it-sicurezza-80-100-luzerner-kantonsspital-luks-luzern"
   },
   "leiterin-leiter-it-security-80-100-luks-luzern": {
-    "de": "/de/jobs-im-tessin/leiterin-leiter-it-security-80-100-luks-luzern",
-    "it": "/cerca-lavoro-ticino/leiterin-leiter-it-security-80-100-luks-luzern",
-    "en": "/en/find-jobs-ticino/leiterin-leiter-it-security-80-100-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/leiterin-leiter-it-security-80-100-luks-luzern"
+    "de": "/de/jobs-in-luzern/leiterin-leiter-it-security-80-100-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/leiterin-leiter-it-security-80-100-luks-luzern",
+    "en": "/en/find-jobs-lucerne/leiterin-leiter-it-security-80-100-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/leiterin-leiter-it-security-80-100-luks-luzern"
   },
   "head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern": {
-    "en": "/en/find-jobs-ticino/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
-    "it": "/cerca-lavoro-ticino/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
-    "de": "/de/jobs-im-tessin/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern"
+    "en": "/en/find-jobs-lucerne/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
+    "it": "/cerca-lavoro-lucerna/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
+    "de": "/de/jobs-in-luzern/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/head-of-it-security-80-100-luzerner-kantonsspital-luks-luzern"
   },
   "impiego-di-servizio-civile-come-assistente-alla-cura-al-100-luzerner-psychiatrie-lups-luzern-16": {
     "it": "/cerca-lavoro-ticino/impiego-di-servizio-civile-come-assistente-alla-cura-al-100-luzerner-psychiatrie-lups-luzern-16",
@@ -109751,28 +109751,28 @@
     "de": "/de/jobs-im-tessin/collaborateur-trice-kuche-allrounder-in-80-100-michel-gruppe-ag-hasliberg-hohfluh"
   },
   "kv-apprendistato-cfc-2027-agenzia-generale-bern-west-die-mobiliar-bern": {
-    "it": "/cerca-lavoro-ticino/kv-apprendistato-cfc-2027-agenzia-generale-bern-west-die-mobiliar-bern",
-    "de": "/de/jobs-im-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "en": "/en/find-jobs-ticino/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "fr": "/fr/trouver-emploi-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
+    "it": "/cerca-lavoro-berna/kv-apprendistato-cfc-2027-agenzia-generale-bern-west-die-mobiliar-bern",
+    "de": "/de/jobs-in-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "en": "/en/find-jobs-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "fr": "/fr/trouver-emploi-berne/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
   },
   "kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch": {
-    "de": "/de/jobs-im-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "it": "/cerca-lavoro-ticino/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "en": "/en/find-jobs-ticino/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
-    "fr": "/fr/trouver-emploi-tessin/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
+    "de": "/de/jobs-in-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "it": "/cerca-lavoro-berna/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "en": "/en/find-jobs-bern/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch",
+    "fr": "/fr/trouver-emploi-berne/kv-lehrstelle-efz-2027-generalagentur-bern-west-mobiliar-ch"
   },
   "kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern": {
-    "en": "/en/find-jobs-ticino/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
-    "it": "/cerca-lavoro-ticino/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
-    "de": "/de/jobs-im-tessin/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
-    "fr": "/fr/trouver-emploi-tessin/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern"
+    "en": "/en/find-jobs-bern/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
+    "it": "/cerca-lavoro-berna/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
+    "de": "/de/jobs-in-bern/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern",
+    "fr": "/fr/trouver-emploi-berne/kv-apprenticeship-efz-2027-general-agency-bern-west-die-mobiliar-bern"
   },
   "apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern": {
-    "fr": "/fr/trouver-emploi-tessin/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
-    "it": "/cerca-lavoro-ticino/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
-    "en": "/en/find-jobs-ticino/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
-    "de": "/de/jobs-im-tessin/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern"
+    "fr": "/fr/trouver-emploi-berne/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
+    "it": "/cerca-lavoro-berna/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
+    "en": "/en/find-jobs-bern/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern",
+    "de": "/de/jobs-in-bern/apprentissage-kv-efz-2027-agence-generale-berne-ouest-die-mobiliar-bern"
   },
   "koch-w-m-d-kita-mikado-80-mobiliar-ch": {
     "it": "/cerca-lavoro-ticino/koch-w-m-d-kita-mikado-80-mobiliar-ch",
@@ -111371,10 +111371,10 @@
     "de": "/de/jobs-im-tessin/infirmier-ere-hf-fh-sanatorium-kilchberg-kilchberg"
   },
   "gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur": {
-    "it": "/cerca-lavoro-ticino/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
-    "en": "/en/find-jobs-ticino/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
-    "de": "/de/jobs-im-tessin/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
-    "fr": "/fr/trouver-emploi-tessin/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur"
+    "it": "/cerca-lavoro-argovia/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
+    "en": "/en/find-jobs-aargau/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
+    "de": "/de/jobs-im-aargau/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur",
+    "fr": "/fr/trouver-emploi-argovie/gestionnaire-pour-les-autorisations-de-cookies-schindler-winterthur"
   },
   "aufzugsmonteur-in-m-w-d-80-100-schindler-wettswil": {
     "it": "/cerca-lavoro-ticino/aufzugsmonteur-in-m-w-d-80-100-schindler-wettswil",
@@ -113057,10 +113057,10 @@
     "de": "/de/jobs-im-tessin/assistant-en-soins-et-social-50-80-senevita-islikon-tg"
   },
   "esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach": {
-    "it": "/cerca-lavoro-ticino/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "en": "/en/find-jobs-ticino/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "de": "/de/jobs-im-tessin/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "fr": "/fr/trouver-emploi-tessin/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach"
+    "it": "/cerca-lavoro-soletta/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "en": "/en/find-jobs-solothurn/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "de": "/de/jobs-in-solothurn/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "fr": "/fr/trouver-emploi-soleure/esperta-o-di-anestesia-infermieristica-pool-uomo-donna-solothurner-spitaler-ag-soh-dornach"
   },
   "expert-anesthesia-nurse-pool-male-female-solothurner-spitaler-ag-soh-dornach": {
     "en": "/en/find-jobs-ticino/expert-anesthesia-nurse-pool-male-female-solothurner-spitaler-ag-soh-dornach",
@@ -113081,10 +113081,10 @@
     "de": "/de/jobs-im-tessin/expert-en-soins-anesthesiques-pool-homme-femme-solothurner-spitaler-ag-soh-dornach"
   },
   "diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i": {
-    "it": "/cerca-lavoro-ticino/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i",
-    "en": "/en/find-jobs-ticino/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i",
-    "de": "/de/jobs-im-tessin/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i",
-    "fr": "/fr/trouver-emploi-tessin/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i"
+    "it": "/cerca-lavoro-soletta/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i",
+    "en": "/en/find-jobs-solothurn/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i",
+    "de": "/de/jobs-in-solothurn/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i",
+    "fr": "/fr/trouver-emploi-soleure/diplomata-in-assistenza-infermieristica-specializzati-in-unita-di-stroke-con-monitoraggio-incluso-medicina-u-m-i"
   },
   "diploma-in-nursing-specialized-in-stroke-unit-with-monitoring-included-medicine-m-f-d-solothurner-spitaler-ag-soh": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-specialized-in-stroke-unit-with-monitoring-included-medicine-m-f-d-solothurner-spitaler-ag-soh",
@@ -113117,10 +113117,10 @@
     "de": "/de/jobs-im-tessin/medecin-senior-en-psychiatrie-de-l-enfant-et-de-l-adolescent-h-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/collaboratore-volontario-per-assistenza-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
     "de": "/de/jobs-im-tessin/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113135,10 +113135,10 @@
     "de": "/de/jobs-im-tessin/collaborateur-volontaire-en-soins-h-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-pflege-w-m-d-soh-solothurner-spitaeler"
   },
   "dipl-nursing-specialist-nursing-specialist-acute-geriatrics-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/dipl-nursing-specialist-nursing-specialist-acute-geriatrics-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113153,10 +113153,10 @@
     "de": "/de/jobs-im-tessin/infirmier-diplome-infirmiere-diplomee-en-geriatrie-aigue-h-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/infermiera-infermiere-dipl-cliniche-chirurgiche-w-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "dipl-nurse-surgical-clinics-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/dipl-nurse-surgical-clinics-w-m-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113177,10 +113177,10 @@
     "de": "/de/jobs-im-tessin/infirmier-infirmiere-dipl-cliniques-chirurgicales-w-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/dipl-pflegefachfrau-pflegefachmann-chirurgische-kliniken-w-m-d-soh-solothurner-spitaeler"
   },
   "health-professional-stationary-services-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/health-professional-stationary-services-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113219,10 +113219,10 @@
     "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-pool-de-soins-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh": {
-    "it": "/cerca-lavoro-ticino/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh",
-    "en": "/en/find-jobs-ticino/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh",
-    "de": "/de/jobs-im-tessin/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh",
-    "fr": "/fr/trouver-emploi-tessin/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh"
+    "it": "/cerca-lavoro-soletta/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh",
+    "en": "/en/find-jobs-solothurn/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh",
+    "de": "/de/jobs-in-solothurn/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh",
+    "fr": "/fr/trouver-emploi-soleure/diplomata-di-assistenza-infermieristica-specializzati-in-chirurgia-e-ostetricia-uomini-donne-solothurner-spitaler-ag-soh"
   },
   "diploma-in-nursing-chirurgische-und-frauenklinik-wochnerinnenabteilung-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-chirurgische-und-frauenklinik-wochnerinnenabteilung-solothurner-spitaler-ag-soh-solothurn",
@@ -113249,10 +113249,10 @@
     "fr": "/fr/trouver-emploi-tessin/bachelor-of-science-in-nursing-practice-module-b-completion-stage-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-i-specializzato-i-di-notte-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "diploma-in-nursing-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -113273,16 +113273,16 @@
     "de": "/de/jobs-im-tessin/infirmier-ere-diplome-e-de-nuit-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/dipl-pflegefachfrau-pflegefachmann-im-nachtdienst-w-m-d-soh-solothurner-spitaeler"
   },
   "diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach": {
-    "it": "/cerca-lavoro-ticino/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach",
-    "en": "/en/find-jobs-ticino/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach",
-    "de": "/de/jobs-im-tessin/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach",
-    "fr": "/fr/trouver-emploi-tessin/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach"
+    "it": "/cerca-lavoro-soletta/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach",
+    "en": "/en/find-jobs-solothurn/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach",
+    "de": "/de/jobs-in-solothurn/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach",
+    "fr": "/fr/trouver-emploi-soleure/diplomata-o-infermiere-a-o-tecnico-a-della-salute-con-esperienza-in-reparto-acuto-solothurner-spitaler-ag-soh-dornach"
   },
   "diploma-in-nursing-or-health-care-with-experience-in-acute-ward-solothurner-spitaler-ag-soh-dornach": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-or-health-care-with-experience-in-acute-ward-solothurner-spitaler-ag-soh-dornach",
@@ -113303,10 +113303,10 @@
     "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-ou-en-sante-avec-experience-en-service-d-urgence-solothurner-spitaler-ag-soh-dornach"
   },
   "medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-in-medicina-intensiva-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "oberarztin-oberarzt-intensivstation-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-intensivstation-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -113327,10 +113327,10 @@
     "fr": "/fr/trouver-emploi-tessin/emergency-medical-technician-male-female-solothurner-spitaler-ag-soh-solothurn"
   },
   "medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken": {
-    "it": "/cerca-lavoro-ticino/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken",
-    "en": "/en/find-jobs-ticino/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken",
-    "de": "/de/jobs-im-tessin/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken",
-    "fr": "/fr/trouver-emploi-tessin/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken"
+    "it": "/cerca-lavoro-soletta/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken",
+    "en": "/en/find-jobs-solothurn/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken",
+    "de": "/de/jobs-in-solothurn/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken",
+    "fr": "/fr/trouver-emploi-soleure/medico-di-base-uomo-donna-solothurner-spitaler-ag-soh-daniken"
   },
   "general-practitioner-male-female-solothurner-spitaler-ag-soh-daniken": {
     "en": "/en/find-jobs-ticino/general-practitioner-male-female-solothurner-spitaler-ag-soh-daniken",
@@ -113363,10 +113363,10 @@
     "de": "/de/jobs-im-tessin/infirmier-ere-de-positionnement-en-salle-d-operation-h-f-solothurner-spitaler-ag-soh-olten"
   },
   "diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner": {
-    "it": "/cerca-lavoro-ticino/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner",
-    "en": "/en/find-jobs-ticino/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner",
-    "de": "/de/jobs-im-tessin/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner",
-    "fr": "/fr/trouver-emploi-tessin/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner"
+    "it": "/cerca-lavoro-soletta/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner",
+    "en": "/en/find-jobs-solothurn/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner",
+    "de": "/de/jobs-in-solothurn/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner",
+    "fr": "/fr/trouver-emploi-soleure/diplomata-della-cura-infermieristica-diplomati-della-cura-infermieristica-e-specialisti-della-salute-u-m-d-solothurner"
   },
   "diploma-in-nursing-health-care-specialist-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-health-care-specialist-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113387,10 +113387,10 @@
     "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-specialiste-en-sante-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/impiegato-a-servizio-trasporti-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "employee-publisher-service-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/employee-publisher-service-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -113411,10 +113411,10 @@
     "de": "/de/jobs-im-tessin/employe-e-service-de-transport-homme-femme-solothurner-spitaler-ag-soh-solothurn"
   },
   "infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag": {
-    "it": "/cerca-lavoro-ticino/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag",
-    "en": "/en/find-jobs-ticino/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag",
-    "de": "/de/jobs-im-tessin/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag",
-    "fr": "/fr/trouver-emploi-tessin/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag"
+    "it": "/cerca-lavoro-soletta/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag",
+    "en": "/en/find-jobs-solothurn/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag",
+    "de": "/de/jobs-in-solothurn/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag",
+    "fr": "/fr/trouver-emploi-soleure/infermiera-infermiere-specializzato-in-medicina-operativa-con-focus-su-chirurgia-ortopedia-w-m-d-solothurner-spitaler-ag"
   },
   "nurse-specialized-in-operative-medicine-with-a-focus-on-surgery-orthopedics-w-m-d-solothurner-spitaler-ag-soh-olten": {
     "en": "/en/find-jobs-ticino/nurse-specialized-in-operative-medicine-with-a-focus-on-surgery-orthopedics-w-m-d-solothurner-spitaler-ag-soh-olten",
@@ -113429,10 +113429,10 @@
     "de": "/de/jobs-im-tessin/infirmier-infirmiere-specialise-e-en-medecine-operatoire-avec-un-accent-sur-la-chirurgie-orthopedie-w-m-d-solothurner"
   },
   "medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-capoclinica-in-medicina-interna-generale-f-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "oberarztin-oberarzt-allgemeine-innere-medizin-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-allgemeine-innere-medizin-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -113447,10 +113447,10 @@
     "de": "/de/jobs-im-tessin/medecin-cadre-en-medecine-interne-generale-f-h-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "dietista-m-f-d-solothurner-spitaler-ag-soh-dornach": {
-    "it": "/cerca-lavoro-ticino/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach",
-    "en": "/en/find-jobs-ticino/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach",
-    "de": "/de/jobs-im-tessin/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach",
-    "fr": "/fr/trouver-emploi-tessin/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach"
+    "it": "/cerca-lavoro-soletta/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach",
+    "en": "/en/find-jobs-solothurn/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach",
+    "de": "/de/jobs-in-solothurn/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach",
+    "fr": "/fr/trouver-emploi-soleure/dietista-m-f-d-solothurner-spitaler-ag-soh-dornach"
   },
   "nutritionist-dietitian-m-f-d-solothurner-spitaler-ag-soh-dornach": {
     "en": "/en/find-jobs-ticino/nutritionist-dietitian-m-f-d-solothurner-spitaler-ag-soh-dornach",
@@ -113477,10 +113477,10 @@
     "fr": "/fr/trouver-emploi-tessin/emergency-medical-technician-emt-with-or-without-anesthesia-care-specialist-acs-certification-solothurner-spitaler-ag"
   },
   "medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/medico-urologo-w-m-d-solothurner-spitaler-ag-soh-olten"
   },
   "assistenzarztin-assistenzarzt-urologie-w-m-d-soh-solothurner-spitaeler-olten": {
     "de": "/de/jobs-im-tessin/assistenzarztin-assistenzarzt-urologie-w-m-d-soh-solothurner-spitaeler-olten",
@@ -113495,10 +113495,10 @@
     "de": "/de/jobs-im-tessin/medical-urologie-w-m-d-solothurner-spitaler-ag-soh-olten"
   },
   "cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh": {
-    "it": "/cerca-lavoro-ticino/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh",
-    "en": "/en/find-jobs-ticino/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh",
-    "de": "/de/jobs-im-tessin/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh",
-    "fr": "/fr/trouver-emploi-tessin/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh"
+    "it": "/cerca-lavoro-soletta/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh",
+    "en": "/en/find-jobs-solothurn/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh",
+    "de": "/de/jobs-in-solothurn/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh",
+    "fr": "/fr/trouver-emploi-soleure/cuoco-cuoca-efz-o-addetto-di-cucina-assistente-di-cucina-eba-in-formazione-uomo-donna-solothurner-spitaler-ag-soh"
   },
   "cook-efz-or-kitchen-assistant-eba-in-training-m-f-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/cook-efz-or-kitchen-assistant-eba-in-training-m-f-solothurner-spitaler-ag-soh-solothurn",
@@ -113519,10 +113519,10 @@
     "de": "/de/jobs-im-tessin/cuisinier-cuisiniere-efz-ou-employe-e-de-cuisine-eba-en-formation-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "en": "/en/find-jobs-ticino/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "de": "/de/jobs-im-tessin/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach"
+    "it": "/cerca-lavoro-soletta/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "en": "/en/find-jobs-solothurn/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "de": "/de/jobs-in-solothurn/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-in-medicina-interna-e-endocrinologia-uomo-donna-solothurner-spitaler-ag-soh-dornach"
   },
   "oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-solothurner-spitaler-ag-soh-dornach": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-solothurner-spitaler-ag-soh-dornach",
@@ -113537,10 +113537,10 @@
     "de": "/de/jobs-im-tessin/medecin-specialiste-en-medecine-interne-et-endocrinologie-h-f-solothurner-spitaler-ag-soh-dornach"
   },
   "oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/oberarztin-oberarzt-innere-medizin-und-endokrinologie-w-m-d-soh-solothurner-spitaeler"
   },
   "civilian-service-hospital-assistant-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/civilian-service-hospital-assistant-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -113573,22 +113573,22 @@
     "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-operationstechnik-im-pool-w-m-d-soh-solothurner-spitaeler-dornach"
   },
   "capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/capo-del-team-di-assistenza-al-trasporto-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/corso-post-diploma-hf-di-cure-intensive-uomo-donna-solothurner-spitaler-ag-soh-olten"
   },
   "nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten": {
-    "de": "/de/jobs-im-tessin/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
-    "it": "/cerca-lavoro-ticino/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
-    "en": "/en/find-jobs-ticino/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
-    "fr": "/fr/trouver-emploi-tessin/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten"
+    "de": "/de/jobs-in-solothurn/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
+    "it": "/cerca-lavoro-soletta/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
+    "en": "/en/find-jobs-solothurn/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten",
+    "fr": "/fr/trouver-emploi-soleure/nachdiplomstudium-hf-intensivpflege-w-m-d-soh-solothurner-spitaeler-olten"
   },
   "formation-postgrade-hf-en-soins-intensifs-h-f-solothurner-spitaler-ag-soh-olten": {
     "fr": "/fr/trouver-emploi-tessin/formation-postgrade-hf-en-soins-intensifs-h-f-solothurner-spitaler-ag-soh-olten",
@@ -113597,10 +113597,10 @@
     "de": "/de/jobs-im-tessin/formation-postgrade-hf-en-soins-intensifs-h-f-solothurner-spitaler-ag-soh-olten"
   },
   "medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-in-medicina-interna-ipr-medicina-interna-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113615,16 +113615,16 @@
     "de": "/de/jobs-im-tessin/medecin-specialiste-en-medecine-interne-ipr-medecine-interne-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/oberarztin-oberarzt-medizinbereich-ipr-innere-medizin-w-m-d-soh-solothurner-spitaeler"
   },
   "diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh": {
-    "it": "/cerca-lavoro-ticino/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh",
-    "en": "/en/find-jobs-ticino/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh",
-    "de": "/de/jobs-im-tessin/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh",
-    "fr": "/fr/trouver-emploi-tessin/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh"
+    "it": "/cerca-lavoro-soletta/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh",
+    "en": "/en/find-jobs-solothurn/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh",
+    "de": "/de/jobs-in-solothurn/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh",
+    "fr": "/fr/trouver-emploi-soleure/diplomato-a-della-cura-infermieristica-infermiere-a-del-pool-di-cura-chirurgia-uomo-donna-solothurner-spitaler-ag-soh"
   },
   "dipl-pflegefachfrau-pflegefachmann-pflegepool-chirurgie-w-m-d-soh-solothurner-spitaeler": {
     "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-pflegepool-chirurgie-w-m-d-soh-solothurner-spitaeler",
@@ -113657,16 +113657,16 @@
     "de": "/de/jobs-im-tessin/assistant-en-hotellerie-et-services-generaux-h-f-solothurner-spitaler-ag-soh-dornach"
   },
   "fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/fachfrau-fachmann-hotellerie-hauswirtschaft-in-ausbildung-m-w-d-soh-solothurner-spitaeler"
   },
   "formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/formatore-formatrice-di-professione-tecnica-di-sala-operatoria-uomo-donna-solothurner-spitaler-ag-soh-olten"
   },
   "berufsbildnerin-berufsbildner-fachfrau-fachmann-operationstechnik-w-m-d-soh-solothurner": {
     "de": "/de/jobs-im-tessin/berufsbildnerin-berufsbildner-fachfrau-fachmann-operationstechnik-w-m-d-soh-solothurner",
@@ -113681,10 +113681,10 @@
     "de": "/de/jobs-im-tessin/formateur-formatrice-en-technique-de-salle-d-operation-h-f-solothurner-spitaler-ag-soh-olten"
   },
   "esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach": {
-    "it": "/cerca-lavoro-ticino/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach",
-    "en": "/en/find-jobs-ticino/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach",
-    "de": "/de/jobs-im-tessin/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach",
-    "fr": "/fr/trouver-emploi-tessin/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach"
+    "it": "/cerca-lavoro-soletta/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach",
+    "en": "/en/find-jobs-solothurn/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach",
+    "de": "/de/jobs-in-solothurn/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach",
+    "fr": "/fr/trouver-emploi-soleure/esperta-o-in-anestesia-infermieristica-l-m-solothurner-spitaler-ag-soh-dornach"
   },
   "expert-anesthesia-nurse-m-f-solothurner-spitaler-ag-soh-dornach": {
     "en": "/en/find-jobs-ticino/expert-anesthesia-nurse-m-f-solothurner-spitaler-ag-soh-dornach",
@@ -113705,16 +113705,16 @@
     "fr": "/fr/trouver-emploi-tessin/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/freiwillige-mitarbeiterin-freiwilliger-mitarbeiter-w-m-d-soh-solothurner-spitaeler"
   },
   "medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-di-area-interdisciplinare-di-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113729,16 +113729,16 @@
     "de": "/de/jobs-im-tessin/medecin-specialiste-en-station-d-urgences-interdisciplinaire-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/oberarztin-oberarzt-interdisziplinare-notfallstation-w-m-d-soh-solothurner-spitaeler"
   },
   "esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/esperta-o-di-infermieristica-intensiva-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "expertin-experte-intensivpflege-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/expertin-experte-intensivpflege-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -113753,10 +113753,10 @@
     "de": "/de/jobs-im-tessin/expert-en-soins-intensifs-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/formatore-a-di-professione-sanita-servizi-ospedalieri-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "healthcare-professional-trainer-inpatient-services-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/healthcare-professional-trainer-inpatient-services-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -113777,10 +113777,10 @@
     "de": "/de/jobs-im-tessin/formateur-trice-en-sante-services-hospitaliers-homme-femme-solothurner-spitaler-ag-soh-solothurn"
   },
   "medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-responsabile-di-reparto-angiologia-u-m-d-solothurner-spitaler-ag-soh-olten"
   },
   "oberarztin-oberarzt-oder-leitende-arztin-leitender-arzt-angiologie-w-m-d-soh-solothurner": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-oder-leitende-arztin-leitender-arzt-angiologie-w-m-d-soh-solothurner",
@@ -113807,10 +113807,10 @@
     "de": "/de/jobs-im-tessin/mpa-clinique-d-orthopedie-m-w-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler": {
-    "it": "/cerca-lavoro-ticino/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler",
-    "en": "/en/find-jobs-ticino/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler",
-    "de": "/de/jobs-im-tessin/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler",
-    "fr": "/fr/trouver-emploi-tessin/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler"
+    "it": "/cerca-lavoro-soletta/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler",
+    "en": "/en/find-jobs-solothurn/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler",
+    "de": "/de/jobs-in-solothurn/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler",
+    "fr": "/fr/trouver-emploi-soleure/diplomata-di-assistenza-infermieristica-operativa-specializzati-in-chirurgia-ortopedia-uomini-donne-solothurner-spitaler"
   },
   "diploma-in-nursing-operative-medicine-specialty-in-surgery-orthopedics-male-female-solothurner-spitaler-ag-soh-olten": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-operative-medicine-specialty-in-surgery-orthopedics-male-female-solothurner-spitaler-ag-soh-olten",
@@ -113831,10 +113831,10 @@
     "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-en-medecine-operationnelle-specialise-e-en-chirurgie-orthopedie-h-f-solothurner-spitaler"
   },
   "infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/infermiera-infermiere-in-formazione-somatica-3-anni-ridotto-2-anni-m-f-solothurner-spitaler-ag-soh-olten"
   },
   "healthcare-professional-in-training-somatic-nursing-3-years-shortened-2-years-m-f-solothurner-spitaler-ag-soh-olten": {
     "en": "/en/find-jobs-ticino/healthcare-professional-in-training-somatic-nursing-3-years-shortened-2-years-m-f-solothurner-spitaler-ag-soh-olten",
@@ -113843,10 +113843,10 @@
     "fr": "/fr/trouver-emploi-tessin/healthcare-professional-in-training-somatic-nursing-3-years-shortened-2-years-m-f-solothurner-spitaler-ag-soh-olten"
   },
   "infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-infermiere-di-formazione-hf-in-psichiatria-4-anni-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "infirmier-infirmier-en-formation-hf-en-psychiatrie-4-ans-homme-femme-solothurner-spitaler-ag-soh-solothurn": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-infirmier-en-formation-hf-en-psychiatrie-4-ans-homme-femme-solothurner-spitaler-ag-soh-solothurn",
@@ -113855,10 +113855,10 @@
     "de": "/de/jobs-im-tessin/infirmier-infirmier-en-formation-hf-en-psychiatrie-4-ans-homme-femme-solothurner-spitaler-ag-soh-solothurn"
   },
   "infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner": {
-    "it": "/cerca-lavoro-ticino/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner",
-    "en": "/en/find-jobs-ticino/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner",
-    "de": "/de/jobs-im-tessin/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner"
+    "it": "/cerca-lavoro-soletta/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner",
+    "en": "/en/find-jobs-solothurn/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner",
+    "de": "/de/jobs-in-solothurn/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-infermiere-specializzato-a-in-formazione-in-psichiatria-corso-abbreviato-di-2-5-anni-uomo-donna-solothurner"
   },
   "infirmier-infirmier-specialise-en-formation-en-psychiatrie-cours-raccourci-de-2-5-ans-h-f-solothurner-spitaler-ag-soh": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-infirmier-specialise-en-formation-en-psychiatrie-cours-raccourci-de-2-5-ans-h-f-solothurner-spitaler-ag-soh",
@@ -113873,10 +113873,10 @@
     "fr": "/fr/trouver-emploi-tessin/healthcare-professional-hf-in-training-somatic-4-years-male-female-solothurner-spitaler-ag-soh-olten"
   },
   "infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-infermiere-specializzanda-o-hf-somatica-4-anni-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "nursing-specialist-m-f-d-in-training-4-years-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/nursing-specialist-m-f-d-in-training-4-years-solothurner-spitaler-ag-soh-solothurn",
@@ -113891,10 +113891,10 @@
     "de": "/de/jobs-im-tessin/infirmier-infirmier-specialise-e-hf-en-formation-somatique-4-ans-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-infermiere-di-formazione-in-psichiatria-3-anni-abbreviato-2-anni-u-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "infirmier-infirmier-en-formation-en-psychiatrie-3-ans-raccourci-2-ans-h-f-solothurner-spitaler-ag-soh-solothurn": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-infirmier-en-formation-en-psychiatrie-3-ans-raccourci-2-ans-h-f-solothurner-spitaler-ag-soh-solothurn",
@@ -113903,10 +113903,10 @@
     "de": "/de/jobs-im-tessin/infirmier-infirmier-en-formation-en-psychiatrie-3-ans-raccourci-2-ans-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/esperta-esperto-di-cure-d-emergenza-l-m-g-solothurner-spitaler-ag-soh-solothurn"
   },
   "expertin-experte-notfallpflege-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/expertin-experte-notfallpflege-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -113921,10 +113921,10 @@
     "de": "/de/jobs-im-tessin/expert-en-soins-d-urgence-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/ex-in-accompagnatore-a-della-ripresa-stazione-c1-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "ex-in-recovery-companion-station-c1-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/ex-in-recovery-companion-station-c1-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -113945,16 +113945,16 @@
     "de": "/de/jobs-im-tessin/ex-in-accompagnateur-trice-en-retablissement-station-c1-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/ex-in-genesungsbegleiterin-genesungsbegleiter-station-c1-w-m-d-soh-solothurner-spitaeler"
   },
   "dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/dipl-infermiere-a-interdisciplinare-stazione-privata-u-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "diploma-in-nursing-interdisciplinary-private-ward-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-interdisciplinary-private-ward-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -113975,10 +113975,10 @@
     "de": "/de/jobs-im-tessin/infirmier-ere-diplome-e-service-prive-interdisciplinaire-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh",
-    "en": "/en/find-jobs-ticino/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh",
-    "de": "/de/jobs-im-tessin/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh"
+    "it": "/cerca-lavoro-soletta/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh",
+    "en": "/en/find-jobs-solothurn/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh",
+    "de": "/de/jobs-in-solothurn/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-di-medicina-interna-con-specializzazione-in-cure-palliative-uomo-donna-solothurner-spitaler-ag-soh"
   },
   "oberarztin-oberarzt-innere-medizin-mit-schwerpunkttitel-palliative-care-w-m-d-soh": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-innere-medizin-mit-schwerpunkttitel-palliative-care-w-m-d-soh",
@@ -114005,10 +114005,10 @@
     "fr": "/fr/trouver-emploi-tessin/fachgruppenleiterin-fachgruppenleiter-medizintechnik-w-m-d-soh-solothurner-spitaeler-olten"
   },
   "medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-di-psichiatria-e-psicoterapia-kppp-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "oberarztin-oberarzt-kppp-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-kppp-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -114035,10 +114035,10 @@
     "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-operationstechnik-toa-w-m-d-soh-solothurner-spitaeler-olten"
   },
   "medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "en": "/en/find-jobs-ticino/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "de": "/de/jobs-im-tessin/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach"
+    "it": "/cerca-lavoro-soletta/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "en": "/en/find-jobs-solothurn/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "de": "/de/jobs-in-solothurn/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-di-area-internistica-uomo-donna-solothurner-spitaler-ag-soh-dornach"
   },
   "oberarztin-oberarzt-medizin-w-m-d-soh-solothurner-spitaeler-dornach": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-medizin-w-m-d-soh-solothurner-spitaeler-dornach",
@@ -114053,10 +114053,10 @@
     "de": "/de/jobs-im-tessin/medecin-specialiste-en-medecine-interne-h-f-solothurner-spitaler-ag-soh-dornach"
   },
   "impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/impiegato-a-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten"
   },
   "employee-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten": {
     "en": "/en/find-jobs-ticino/employee-aemp-zsva-m-f-d-solothurner-spitaler-ag-soh-olten",
@@ -114095,10 +114095,10 @@
     "fr": "/fr/trouver-emploi-tessin/intern-occupational-therapy-male-female-solothurner-spitaler-ag-soh-olten"
   },
   "infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh": {
-    "it": "/cerca-lavoro-ticino/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh",
-    "en": "/en/find-jobs-ticino/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh",
-    "de": "/de/jobs-im-tessin/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh"
+    "it": "/cerca-lavoro-soletta/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh",
+    "en": "/en/find-jobs-solothurn/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh",
+    "de": "/de/jobs-in-solothurn/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-infermiere-specializzanda-o-in-psichiatria-corso-abbreviato-2-3-4-anni-uomo-donna-solothurner-spitaler-ag-soh"
   },
   "infirmier-infirmiere-en-formation-en-psychiatrie-cours-raccourci-de-2-3-4-ans-h-f-solothurner-spitaler-ag-soh-solothurn": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-infirmiere-en-formation-en-psychiatrie-cours-raccourci-de-2-3-4-ans-h-f-solothurner-spitaler-ag-soh-solothurn",
@@ -114119,10 +114119,10 @@
     "de": "/de/jobs-im-tessin/assistant-en-soins-de-sante-en-formation-cours-raccourci-de-2-3-4-ans-homme-femme-solothurner-spitaler-ag-soh-olten"
   },
   "infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh": {
-    "it": "/cerca-lavoro-ticino/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh",
-    "en": "/en/find-jobs-ticino/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh",
-    "de": "/de/jobs-im-tessin/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh"
+    "it": "/cerca-lavoro-soletta/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh",
+    "en": "/en/find-jobs-solothurn/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh",
+    "de": "/de/jobs-in-solothurn/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-infermiere-specializzanda-a-somatico-a-corso-abbreviato-2-anni-e-3-4-l-m-solothurner-spitaler-ag-soh"
   },
   "healthcare-professional-hf-in-training-somatic-shortened-2-3-4-years-m-f-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/healthcare-professional-hf-in-training-somatic-shortened-2-3-4-years-m-f-solothurner-spitaler-ag-soh-solothurn",
@@ -114137,10 +114137,10 @@
     "de": "/de/jobs-im-tessin/infirmier-infirmier-en-formation-somatique-formation-raccourcie-de-2-ans-et-3-4-h-f-solothurner-spitaler-ag-soh"
   },
   "impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/impiegato-a-di-assistenza-psichiatrica-1-1-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
     "de": "/de/jobs-im-tessin/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114155,10 +114155,10 @@
     "de": "/de/jobs-im-tessin/assistante-en-soins-psychiatriques-1-1-homme-femme-solothurner-spitaler-ag-soh-solothurn"
   },
   "mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/mitarbeiterin-mitarbeiter-psychiatrische-1-1-betreuung-w-m-d-soh-solothurner-spitaeler"
   },
   "diploma-in-nursing-imc-m-f-d-solothurner-spitaler-ag-soh-solothurn-72bf35": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-imc-m-f-d-solothurner-spitaler-ag-soh-solothurn-72bf35",
@@ -114179,10 +114179,10 @@
     "fr": "/fr/trouver-emploi-tessin/lagerungspflegerin-lagerungspfleger-w-m-d-soh-solothurner-spitaeler-solothurn"
   },
   "ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/ergoterapista-ergoterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "ergotherapeutin-ergotherapeut-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/ergotherapeutin-ergotherapeut-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -114197,10 +114197,10 @@
     "de": "/de/jobs-im-tessin/ergotherapeute-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/dipl-pflegefachfrau-pflegefachmann-orthopala-hno-plastische-chirurgie-w-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "diploma-in-nursing-orthopedics-ent-plastic-surgery-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/diploma-in-nursing-orthopedics-ent-plastic-surgery-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114221,10 +114221,10 @@
     "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-en-orthopedie-orl-chirurgie-plastique-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner": {
-    "it": "/cerca-lavoro-ticino/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner",
-    "en": "/en/find-jobs-ticino/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner",
-    "de": "/de/jobs-im-tessin/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner",
-    "fr": "/fr/trouver-emploi-tessin/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner"
+    "it": "/cerca-lavoro-soletta/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner",
+    "en": "/en/find-jobs-solothurn/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner",
+    "de": "/de/jobs-in-solothurn/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner",
+    "fr": "/fr/trouver-emploi-soleure/diplomata-infermiera-o-specializzata-o-in-ortopedia-otorinolaringoiatria-chirurgia-plastica-uomo-donna-solothurner"
   },
   "junior-assistant-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/junior-assistant-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114239,10 +114239,10 @@
     "de": "/de/jobs-im-tessin/assistant-e-junior-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-assistente-in-psichiatria-infantile-e-giovanile-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "assistant-physician-in-child-and-adolescent-psychiatry-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/assistant-physician-in-child-and-adolescent-psychiatry-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114263,16 +114263,16 @@
     "de": "/de/jobs-im-tessin/medecin-assistant-en-psychiatrie-de-l-enfant-et-de-l-adolescent-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/assistenzarztin-assistenzarzt-kinder-und-jugendpsychiatrie-w-m-d-soh-solothurner-spitaeler"
   },
   "medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-in-ematologia-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "lead-physician-in-hematology-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/lead-physician-in-hematology-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114293,10 +114293,10 @@
     "de": "/de/jobs-im-tessin/medecin-specialiste-en-hematologie-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/medico-specialista-oss-medicina-m-f-d-solothurner-spitaler-ag-soh-olten"
   },
   "oberarztin-oberarzt-medizin-w-m-d-soh-solothurner-spitaeler-olten": {
     "de": "/de/jobs-im-tessin/oberarztin-oberarzt-medizin-w-m-d-soh-solothurner-spitaeler-olten",
@@ -114311,10 +114311,10 @@
     "de": "/de/jobs-im-tessin/medecin-specialiste-en-medecine-interne-h-f-solothurner-spitaler-ag-soh-olten"
   },
   "infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh": {
-    "it": "/cerca-lavoro-ticino/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh",
-    "en": "/en/find-jobs-ticino/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh",
-    "de": "/de/jobs-im-tessin/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh"
+    "it": "/cerca-lavoro-soletta/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh",
+    "en": "/en/find-jobs-solothurn/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh",
+    "de": "/de/jobs-in-solothurn/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-a-operativa-stazione-di-degenza-specializzazione-chirurgia-ortopedia-uomo-donna-solothurner-spitaler-ag-soh"
   },
   "infirmier-ere-en-salle-d-operation-service-de-chirurgie-orthopedie-specialisation-h-f-solothurner-spitaler-ag-soh-olten": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-ere-en-salle-d-operation-service-de-chirurgie-orthopedie-specialisation-h-f-solothurner-spitaler-ag-soh-olten",
@@ -114323,10 +114323,10 @@
     "de": "/de/jobs-im-tessin/infirmier-ere-en-salle-d-operation-service-de-chirurgie-orthopedie-specialisation-h-f-solothurner-spitaler-ag-soh-olten"
   },
   "esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/esperta-o-di-cure-d-urgenza-m-f-d-solothurner-spitaler-ag-soh-olten"
   },
   "expertin-experte-notfallpflege-w-m-d-soh-solothurner-spitaeler-olten": {
     "de": "/de/jobs-im-tessin/expertin-experte-notfallpflege-w-m-d-soh-solothurner-spitaeler-olten",
@@ -114353,10 +114353,10 @@
     "de": "/de/jobs-im-tessin/diplome-e-en-soins-infirmiers-medecine-hf-h-f-solothurner-spitaler-ag-soh-olten"
   },
   "esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/esperta-o-di-anestesia-m-f-d-solothurner-spitaler-ag-soh-olten"
   },
   "expert-in-anesthesia-nursing-m-f-d-solothurner-spitaler-ag-soh-olten": {
     "en": "/en/find-jobs-ticino/expert-in-anesthesia-nursing-m-f-d-solothurner-spitaler-ag-soh-olten",
@@ -114383,10 +114383,10 @@
     "de": "/de/jobs-im-tessin/electricien-ne-d-exploitation-specialiste-de-systeme-electrique-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/addetto-a-alle-pulizie-speciali-con-focus-sull-area-di-pulizia-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "housekeeping-specialist-with-a-focus-on-special-areas-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/housekeeping-specialist-with-a-focus-on-special-areas-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -114407,10 +114407,10 @@
     "de": "/de/jobs-im-tessin/employe-e-de-maison-specialise-e-dans-les-zones-speciales-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/anno-di-preparazione-professionale-bvj-casa-pulizia-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-solothurner-spitaler-ag-soh-solothurn": {
     "de": "/de/jobs-im-tessin/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114425,10 +114425,10 @@
     "de": "/de/jobs-im-tessin/annee-de-preparation-professionnelle-bvj-maison-nettoyage-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/berufsvorbereitungsjahr-bvj-hauswirtschaft-reinigung-m-w-d-soh-solothurner-spitaeler"
   },
   "anno-di-preparazione-professionale-bvj-cucina-u-m-d-solothurner-spitaler-ag-soh-oltean": {
     "it": "/cerca-lavoro-ticino/anno-di-preparazione-professionale-bvj-cucina-u-m-d-solothurner-spitaler-ag-soh-oltean",
@@ -114539,16 +114539,16 @@
     "fr": "/fr/trouver-emploi-tessin/diplome-e-en-soins-infirmiers-en-gastroenterologie-h-f-solothurner-spitaler-ag-soh-schweiz"
   },
   "fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/fisioterapista-fisioterapista-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/farmacista-ospedaliera-rappresentante-di-maternita-f-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "hospital-pharmacist-maternity-representative-f-m-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/hospital-pharmacist-maternity-representative-f-m-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114557,10 +114557,10 @@
     "fr": "/fr/trouver-emploi-tessin/hospital-pharmacist-maternity-representative-f-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/fisioterapista-fisioterapista-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "healthcare-specialist-in-the-care-pool-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/healthcare-specialist-in-the-care-pool-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -114599,10 +114599,10 @@
     "de": "/de/jobs-im-tessin/employe-e-de-maison-d-hospital-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/cuoco-cuoca-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "cook-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/cook-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114623,10 +114623,10 @@
     "de": "/de/jobs-im-tessin/cuisinier-cuisiniere-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel": {
-    "it": "/cerca-lavoro-ticino/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel",
-    "en": "/en/find-jobs-ticino/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel",
-    "de": "/de/jobs-im-tessin/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel",
-    "fr": "/fr/trouver-emploi-tessin/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel"
+    "it": "/cerca-lavoro-soletta/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel",
+    "en": "/en/find-jobs-solothurn/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel",
+    "de": "/de/jobs-in-solothurn/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel",
+    "fr": "/fr/trouver-emploi-soleure/capo-di-reparto-interdisciplinare-clinica-diurna-uomo-donna-solothurner-spitaler-ag-soh-basel"
   },
   "interdisciplinary-day-clinic-head-nurse-male-female-solothurner-spitaler-ag-soh-basel": {
     "en": "/en/find-jobs-ticino/interdisciplinary-day-clinic-head-nurse-male-female-solothurner-spitaler-ag-soh-basel",
@@ -114641,10 +114641,10 @@
     "de": "/de/jobs-im-tessin/chef-d-unite-interdisciplinaire-de-clinique-de-jour-h-f-solothurner-spitaler-ag-soh-basel"
   },
   "medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/medico-specializzando-orl-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "assistenzarztin-assistenzarzt-hno-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/assistenzarztin-assistenzarzt-hno-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -114665,10 +114665,10 @@
     "fr": "/fr/trouver-emploi-tessin/oberarztin-oberarzt-endokrinologie-w-m-d-soh-solothurner-spitaeler-solothurn"
   },
   "esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/esperta-di-settore-esperto-di-settore-ssm-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "fachexpertin-fachexperte-ll-medizin-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/fachexpertin-fachexperte-ll-medizin-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -114683,10 +114683,10 @@
     "de": "/de/jobs-im-tessin/expert-e-specialise-e-en-soins-infirmiers-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/diplomata-infermiera-o-specializzata-o-in-cure-palliative-e-medicina-uomo-donna-solothurner-spitaler-ag-soh-olten"
   },
   "dipl-pflegefachfrau-pflegefachmann-palliative-care-amp-medizin-w-m-d-soh-solothurner": {
     "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-palliative-care-amp-medizin-w-m-d-soh-solothurner",
@@ -114731,10 +114731,10 @@
     "fr": "/fr/trouver-emploi-tessin/arztsekretarin-arztsekretar-urologie-w-m-d-soh-solothurner-spitaeler-solothurn"
   },
   "mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/mpa-o-tecnico-a-della-salute-vascolare-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "mpa-or-health-care-assistant-vascular-center-m-f-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/mpa-or-health-care-assistant-vascular-center-m-f-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114755,10 +114755,10 @@
     "de": "/de/jobs-im-tessin/mpa-ou-assistant-e-en-soins-de-sante-vasculaire-h-f-solothurner-spitaler-ag-soh-solothurn"
   },
   "mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler": {
-    "it": "/cerca-lavoro-ticino/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler",
-    "en": "/en/find-jobs-ticino/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler",
-    "de": "/de/jobs-im-tessin/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler",
-    "fr": "/fr/trouver-emploi-tessin/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler"
+    "it": "/cerca-lavoro-soletta/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler",
+    "en": "/en/find-jobs-solothurn/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler",
+    "de": "/de/jobs-in-solothurn/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler",
+    "fr": "/fr/trouver-emploi-soleure/mpa-oder-fachfrau-fachmann-gesundheit-gefasszentrum-w-m-d-soh-solothurner-spitaeler"
   },
   "healthcare-specialist-radiology-mpa-male-female-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/healthcare-specialist-radiology-mpa-male-female-solothurner-spitaler-ag-soh-solothurn",
@@ -114773,10 +114773,10 @@
     "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-gesundheit-oder-mpa-radiologie-w-m-d-soh-solothurner-spitaeler-solothurn"
   },
   "impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/impiegato-a-drg-support-w-m-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "drg-support-specialist-w-m-d-solothurner-spitaler-ag-soh-solothurn": {
     "en": "/en/find-jobs-ticino/drg-support-specialist-w-m-d-solothurner-spitaler-ag-soh-solothurn",
@@ -114791,10 +114791,10 @@
     "fr": "/fr/trouver-emploi-tessin/mitarbeiterin-mitarbeiter-drg-support-w-m-d-soh-solothurner-spitaeler-solothurn"
   },
   "chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/chirurgia-plastica-mpa-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "mpa-plastische-chirurgie-w-m-d-soh-solothurner-spitaeler-solothurn": {
     "de": "/de/jobs-im-tessin/mpa-plastische-chirurgie-w-m-d-soh-solothurner-spitaeler-solothurn",
@@ -114827,10 +114827,10 @@
     "fr": "/fr/trouver-emploi-tessin/medical-project-manager-and-data-manager-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn": {
-    "it": "/cerca-lavoro-ticino/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "en": "/en/find-jobs-ticino/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "de": "/de/jobs-im-tessin/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
-    "fr": "/fr/trouver-emploi-tessin/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
+    "it": "/cerca-lavoro-soletta/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "en": "/en/find-jobs-solothurn/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "de": "/de/jobs-in-solothurn/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn",
+    "fr": "/fr/trouver-emploi-soleure/addetto-a-all-accettazione-dei-pazienti-in-emergenza-uomo-donna-solothurner-spitaler-ag-soh-solothurn"
   },
   "employe-e-d-accueil-des-patients-en-urgence-solothurner-spitaler-ag-soh-solothurn": {
     "fr": "/fr/trouver-emploi-tessin/employe-e-d-accueil-des-patients-en-urgence-solothurner-spitaler-ag-soh-solothurn",
@@ -114839,10 +114839,10 @@
     "de": "/de/jobs-im-tessin/employe-e-d-accueil-des-patients-en-urgence-solothurner-spitaler-ag-soh-solothurn"
   },
   "mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/mpa-o-segretaria-o-di-studio-medico-uomo-donna-solothurner-spitaler-ag-soh-olten"
   },
   "medical-secretary-pool-m-f-d-solothurner-spitaler-ag-soh-olten": {
     "en": "/en/find-jobs-ticino/medical-secretary-pool-m-f-d-solothurner-spitaler-ag-soh-olten",
@@ -114905,10 +114905,10 @@
     "fr": "/fr/trouver-emploi-tessin/child-and-adolescent-psychiatry-psychologist-m-f-d-solothurner-spitaler-ag-soh-solothurn"
   },
   "infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten": {
-    "it": "/cerca-lavoro-ticino/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten",
-    "en": "/en/find-jobs-ticino/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten",
-    "de": "/de/jobs-im-tessin/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten",
-    "fr": "/fr/trouver-emploi-tessin/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten"
+    "it": "/cerca-lavoro-soletta/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten",
+    "en": "/en/find-jobs-solothurn/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten",
+    "de": "/de/jobs-in-solothurn/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten",
+    "fr": "/fr/trouver-emploi-soleure/infermiere-infermiere-hf-in-formazione-ridotto-2-anni-u-m-d-solothurner-spitaler-ag-soh-olten"
   },
   "healthcare-professional-hf-in-training-reduced-2-years-m-f-d-solothurner-spitaler-ag-soh-olten": {
     "en": "/en/find-jobs-ticino/healthcare-professional-hf-in-training-reduced-2-years-m-f-d-solothurner-spitaler-ag-soh-olten",
@@ -114965,10 +114965,10 @@
     "fr": "/fr/trouver-emploi-tessin/civilian-service-technician-spitaler-schaffhausen-schaffhausen"
   },
   "dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen"
+    "it": "/cerca-lavoro-sciaffusa/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
+    "en": "/en/find-jobs-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
+    "de": "/de/jobs-in-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
+    "fr": "/fr/trouver-emploi-schaffhouse/dipl-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen"
   },
   "dipl-ing-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen": {
     "de": "/de/jobs-im-tessin/dipl-ing-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen",
@@ -114977,10 +114977,10 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-ing-pflegefachfrau-pflegefachmann-hf-spitaler-schaffhausen-schaffhausen"
   },
   "dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen"
+    "it": "/cerca-lavoro-sciaffusa/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
+    "en": "/en/find-jobs-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
+    "de": "/de/jobs-in-schaffhausen/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen",
+    "fr": "/fr/trouver-emploi-schaffhouse/dipl-pflegefachfrau-pflegefachmann-hf-spitaeler-schaffhausen-schaffhausen"
   },
   "accompagnatore-a-della-ripresa-peer-in-day-hospital-spitaler-schaffhausen-schaffhausen": {
     "it": "/cerca-lavoro-ticino/accompagnatore-a-della-ripresa-peer-in-day-hospital-spitaler-schaffhausen-schaffhausen",
@@ -115013,22 +115013,22 @@
     "fr": "/fr/trouver-emploi-tessin/interdisciplinary-emergency-center-manager-spitaler-schaffhausen-schaffhausen"
   },
   "intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am": {
-    "en": "/en/find-jobs-ticino/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
-    "it": "/cerca-lavoro-ticino/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
-    "de": "/de/jobs-im-tessin/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
-    "fr": "/fr/trouver-emploi-tessin/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am"
+    "en": "/en/find-jobs-zurich/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
+    "it": "/cerca-lavoro-zurigo/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
+    "de": "/de/jobs-in-zurich/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am",
+    "fr": "/fr/trouver-emploi-zurich/intern-intern-psychiatric-care-geriatric-and-adult-psychiatry-fixed-term-6-12-months-spital-affoltern-ag-affoltern-am"
   },
   "abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach": {
-    "de": "/de/jobs-im-tessin/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
-    "it": "/cerca-lavoro-ticino/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
-    "en": "/en/find-jobs-ticino/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
-    "fr": "/fr/trouver-emploi-tessin/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach"
+    "de": "/de/jobs-in-zurich/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
+    "it": "/cerca-lavoro-zurigo/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
+    "en": "/en/find-jobs-zurich/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach",
+    "fr": "/fr/trouver-emploi-zurich/abteilungsleitung-oder-co-leitung-pflegeabteilung-medizin-spital-buelach-bulach"
   },
   "head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach": {
-    "en": "/en/find-jobs-ticino/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach",
-    "it": "/cerca-lavoro-ticino/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach",
-    "de": "/de/jobs-im-tessin/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach",
-    "fr": "/fr/trouver-emploi-tessin/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach"
+    "en": "/en/find-jobs-zurich/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach",
+    "it": "/cerca-lavoro-zurigo/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach",
+    "de": "/de/jobs-in-zurich/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach",
+    "fr": "/fr/trouver-emploi-zurich/head-of-or-co-lead-nursing-department-medical-spital-bulach-bulach"
   },
   "capo-del-reparto-pronto-soccorso-spital-emmental-langnau": {
     "it": "/cerca-lavoro-ticino/capo-del-reparto-pronto-soccorso-spital-emmental-langnau",
@@ -115403,16 +115403,16 @@
     "it": "/cerca-lavoro-ticino/co-teamleitung-pflege-80-100-spitex-ch-thalwil"
   },
   "infermiere-dipl-hf-50-80-formatore-per-hf-fh-spitex-aare-selzach": {
-    "it": "/cerca-lavoro-ticino/infermiere-dipl-hf-50-80-formatore-per-hf-fh-spitex-aare-selzach",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "en": "/en/find-jobs-ticino/registered-nurse-hf-50-80-trainer-for-hf-fh-spitex-aare-selzach",
-    "fr": "/fr/trouver-emploi-tessin/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach"
+    "it": "/cerca-lavoro-soletta/infermiere-dipl-hf-50-80-formatore-per-hf-fh-spitex-aare-selzach",
+    "de": "/de/jobs-in-solothurn/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "en": "/en/find-jobs-solothurn/registered-nurse-hf-50-80-trainer-for-hf-fh-spitex-aare-selzach",
+    "fr": "/fr/trouver-emploi-soleure/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach"
   },
   "dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach": {
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach"
+    "de": "/de/jobs-in-solothurn/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "it": "/cerca-lavoro-soletta/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "en": "/en/find-jobs-solothurn/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach",
+    "fr": "/fr/trouver-emploi-soleure/dipl-pflegefachperson-hf-50-bis-80-berufsbildner-in-fur-hf-fh-spitex-ch-selzach"
   },
   "infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach": {
     "fr": "/fr/trouver-emploi-tessin/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach",
@@ -115421,10 +115421,10 @@
     "de": "/de/jobs-im-tessin/infirmier-dipl-hf-50-80-formateur-trice-pour-hf-fh-spitex-aare-selzach"
   },
   "infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen": {
-    "fr": "/fr/trouver-emploi-tessin/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
-    "it": "/cerca-lavoro-ticino/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
-    "en": "/en/find-jobs-ticino/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
-    "de": "/de/jobs-im-tessin/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen"
+    "fr": "/fr/trouver-emploi-soleure/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
+    "it": "/cerca-lavoro-soletta/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
+    "en": "/en/find-jobs-solothurn/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen",
+    "de": "/de/jobs-in-solothurn/infirmier-ere-hf-fh-avec-specialisation-en-demence-40-80-spitex-gau-oensingen"
   },
   "infermiere-infermiera-professionale-efz-60-90-spitex-region-bulach-bulach": {
     "it": "/cerca-lavoro-ticino/infermiere-infermiera-professionale-efz-60-90-spitex-region-bulach-bulach",
@@ -115541,28 +115541,28 @@
     "fr": "/fr/trouver-emploi-tessin/administration-internship-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil": {
-    "it": "/cerca-lavoro-ticino/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "en": "/en/find-jobs-ticino/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "de": "/de/jobs-im-tessin/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "fr": "/fr/trouver-emploi-tessin/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil"
+    "it": "/cerca-lavoro-lucerna/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "en": "/en/find-jobs-lucerne/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "de": "/de/jobs-in-luzern/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "fr": "/fr/trouver-emploi-lucerne/addetto-a-alla-ristorazione-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil": {
-    "en": "/en/find-jobs-ticino/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "it": "/cerca-lavoro-ticino/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "de": "/de/jobs-im-tessin/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "fr": "/fr/trouver-emploi-tessin/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil"
+    "en": "/en/find-jobs-lucerne/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "it": "/cerca-lavoro-lucerna/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "de": "/de/jobs-in-luzern/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "fr": "/fr/trouver-emploi-lucerne/gastronomy-staff-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "mitarbeiter-in-gastronomie-spz-nottwil": {
-    "de": "/de/jobs-im-tessin/mitarbeiter-in-gastronomie-spz-nottwil",
-    "it": "/cerca-lavoro-ticino/mitarbeiter-in-gastronomie-spz-nottwil",
-    "en": "/en/find-jobs-ticino/mitarbeiter-in-gastronomie-spz-nottwil",
-    "fr": "/fr/trouver-emploi-tessin/mitarbeiter-in-gastronomie-spz-nottwil"
+    "de": "/de/jobs-in-luzern/mitarbeiter-in-gastronomie-spz-nottwil",
+    "it": "/cerca-lavoro-lucerna/mitarbeiter-in-gastronomie-spz-nottwil",
+    "en": "/en/find-jobs-lucerne/mitarbeiter-in-gastronomie-spz-nottwil",
+    "fr": "/fr/trouver-emploi-lucerne/mitarbeiter-in-gastronomie-spz-nottwil"
   },
   "employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil": {
-    "fr": "/fr/trouver-emploi-tessin/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "it": "/cerca-lavoro-ticino/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "en": "/en/find-jobs-ticino/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
-    "de": "/de/jobs-im-tessin/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil"
+    "fr": "/fr/trouver-emploi-lucerne/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "it": "/cerca-lavoro-lucerna/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "en": "/en/find-jobs-lucerne/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil",
+    "de": "/de/jobs-in-luzern/employe-e-de-la-restauration-schweizer-paraplegiker-zentrum-spz-nottwil"
   },
   "medico-capo-ginecologia-60-100-sro-ag-spital-region-oberaargau-divers": {
     "it": "/cerca-lavoro-ticino/medico-capo-ginecologia-60-100-sro-ag-spital-region-oberaargau-divers",
@@ -115595,16 +115595,16 @@
     "fr": "/fr/trouver-emploi-tessin/infermiere-di-soccorso-diplomato-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
   },
   "dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal": {
-    "en": "/en/find-jobs-ticino/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
-    "it": "/cerca-lavoro-ticino/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
-    "de": "/de/jobs-im-tessin/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
-    "fr": "/fr/trouver-emploi-tessin/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
+    "en": "/en/find-jobs-bern/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
+    "it": "/cerca-lavoro-berna/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
+    "de": "/de/jobs-in-bern/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
+    "fr": "/fr/trouver-emploi-berne/dipl-emergency-medical-technician-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
   },
   "dipl-rettungssanitater-in-hf-60-100-sro-langenthal": {
-    "de": "/de/jobs-im-tessin/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
-    "it": "/cerca-lavoro-ticino/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
-    "en": "/en/find-jobs-ticino/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
-    "fr": "/fr/trouver-emploi-tessin/dipl-rettungssanitater-in-hf-60-100-sro-langenthal"
+    "de": "/de/jobs-in-bern/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
+    "it": "/cerca-lavoro-berna/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
+    "en": "/en/find-jobs-bern/dipl-rettungssanitater-in-hf-60-100-sro-langenthal",
+    "fr": "/fr/trouver-emploi-berne/dipl-rettungssanitater-in-hf-60-100-sro-langenthal"
   },
   "dipl-assistant-sanitaire-hf-60-100-sro-ag-spital-region-oberaargau-langenthal": {
     "fr": "/fr/trouver-emploi-tessin/dipl-assistant-sanitaire-hf-60-100-sro-ag-spital-region-oberaargau-langenthal",
@@ -115613,22 +115613,22 @@
     "de": "/de/jobs-im-tessin/dipl-assistant-sanitaire-hf-60-100-sro-ag-spital-region-oberaargau-langenthal"
   },
   "dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2": {
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2"
+    "it": "/cerca-lavoro-berna/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
+    "en": "/en/find-jobs-bern/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
+    "fr": "/fr/trouver-emploi-berne/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2",
+    "de": "/de/jobs-in-bern/dipl-pflegefachperson-hf-fh-40-100-br-medizin-palliativ-care-sro-langenthal-2"
   },
   "field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch": {
-    "en": "/en/find-jobs-ticino/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
-    "it": "/cerca-lavoro-ticino/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
-    "de": "/de/jobs-im-tessin/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
-    "fr": "/fr/trouver-emploi-tessin/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch"
+    "en": "/en/find-jobs-solothurn/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
+    "it": "/cerca-lavoro-soletta/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
+    "de": "/de/jobs-in-solothurn/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch",
+    "fr": "/fr/trouver-emploi-soleure/field-clinical-specialist-northern-new-jersey-area-peripheral-vascular-stryker-ch"
   },
   "feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach": {
-    "de": "/de/jobs-im-tessin/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
-    "it": "/cerca-lavoro-ticino/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
-    "en": "/en/find-jobs-ticino/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
-    "fr": "/fr/trouver-emploi-tessin/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach"
+    "de": "/de/jobs-in-solothurn/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
+    "it": "/cerca-lavoro-soletta/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
+    "en": "/en/find-jobs-solothurn/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach",
+    "fr": "/fr/trouver-emploi-soleure/feldklinischer-spezialist-nord-new-jersey-gebiet-periphere-gefa-e-stryker-selzach"
   },
   "assistente-medico-klinik-sudhang-ambulatorium-biel-bienne": {
     "it": "/cerca-lavoro-ticino/assistente-medico-klinik-sudhang-ambulatorium-biel-bienne",
@@ -119489,10 +119489,10 @@
     "de": "/de/jobs-im-tessin/expert-e-en-soins-d-urgence-diplome-ou-infirmier-ere-expert-e-en-soins-spital-emmental-langnau"
   },
   "interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5": {
-    "it": "/cerca-lavoro-ticino/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
-    "en": "/en/find-jobs-ticino/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
-    "de": "/de/jobs-im-tessin/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
-    "fr": "/fr/trouver-emploi-tessin/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5"
+    "it": "/cerca-lavoro-turgovia/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
+    "en": "/en/find-jobs-thurgau/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
+    "de": "/de/jobs-im-thurgau/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5",
+    "fr": "/fr/trouver-emploi-thurgovie/interns-1-4-weeks-spital-thurgau-stgag-munsterlingen-35b3e5"
   },
   "tissot-sales-associate-the-swatch-group-u-s-inc-ticino": {
     "it": "/cerca-lavoro-ticino/tissot-sales-associate-the-swatch-group-u-s-inc-ticino",
@@ -119507,10 +119507,10 @@
     "fr": "/fr/trouver-emploi-tessin/swatch-tempo-pieno-keyholder-ny-ny-hotel-las-vegas-the-swatch-group-u-s-inc-ticino"
   },
   "tecnico-di-ascensori-m-f-d-otis-sa-kriens": {
-    "it": "/cerca-lavoro-ticino/tecnico-di-ascensori-m-f-d-otis-sa-kriens",
-    "en": "/en/find-jobs-ticino/tecnico-di-ascensori-m-f-d-otis-sa-kriens",
-    "de": "/de/jobs-im-tessin/tecnico-di-ascensori-m-f-d-otis-sa-kriens",
-    "fr": "/fr/trouver-emploi-tessin/tecnico-di-ascensori-m-f-d-otis-sa-kriens"
+    "it": "/cerca-lavoro-lucerna/tecnico-di-ascensori-m-f-d-otis-sa-kriens",
+    "en": "/en/find-jobs-lucerne/tecnico-di-ascensori-m-f-d-otis-sa-kriens",
+    "de": "/de/jobs-in-luzern/tecnico-di-ascensori-m-f-d-otis-sa-kriens",
+    "fr": "/fr/trouver-emploi-lucerne/tecnico-di-ascensori-m-f-d-otis-sa-kriens"
   },
   "omega-client-advisor-perth-the-swatch-group-australia-pty-ltd-ticino": {
     "it": "/cerca-lavoro-ticino/omega-client-advisor-perth-the-swatch-group-australia-pty-ltd-ticino",
@@ -119591,10 +119591,10 @@
     "fr": "/fr/trouver-emploi-tessin/fachfrau-fachmann-gesundheit-cfc-a-interdisziplinare-rehabilitation-innere-medizin-klinik-barmelweid-barmelweid"
   },
   "fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern": {
-    "it": "/cerca-lavoro-ticino/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
-    "en": "/en/find-jobs-ticino/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
-    "de": "/de/jobs-im-tessin/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
-    "fr": "/fr/trouver-emploi-tessin/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern"
+    "it": "/cerca-lavoro-lucerna/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
+    "en": "/en/find-jobs-lucerne/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
+    "de": "/de/jobs-in-luzern/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern",
+    "fr": "/fr/trouver-emploi-lucerne/fage-cfc-ambulatorium-gastroenterologie-hepatologie-100-luzerner-kantonsspital-luks-luzern"
   },
   "cc-place-d-apprentissage-cfc-2027-agence-generale-berne-ouest-die-mobiliar-bern": {
     "it": "/cerca-lavoro-ticino/cc-place-d-apprentissage-cfc-2027-agence-generale-berne-ouest-die-mobiliar-bern",
@@ -119645,46 +119645,46 @@
     "fr": "/fr/trouver-emploi-tessin/assistente-a-alla-salute-e-al-sociale-40-100-turni-diurni-o-notturni-tertianum-rich-d80pq1"
   },
   "high-watchmaking-client-relationship-manager-richemont-plan-les-ouates": {
-    "en": "/en/find-jobs-ticino/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
-    "it": "/cerca-lavoro-ticino/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
-    "de": "/de/jobs-im-tessin/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
-    "fr": "/fr/trouver-emploi-tessin/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates"
+    "en": "/en/find-jobs-geneva/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
+    "it": "/cerca-lavoro-ginevra/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
+    "de": "/de/jobs-in-genf/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates",
+    "fr": "/fr/trouver-emploi-geneve/high-watchmaking-client-relationship-manager-richemont-plan-les-ouates"
   },
   "boutique-assistant-intern-cartier-zurich": {
-    "en": "/en/find-jobs-ticino/boutique-assistant-intern-cartier-zurich",
-    "it": "/cerca-lavoro-ticino/boutique-assistant-intern-cartier-zurich",
-    "de": "/de/jobs-im-tessin/boutique-assistant-intern-cartier-zurich",
-    "fr": "/fr/trouver-emploi-tessin/boutique-assistant-intern-cartier-zurich"
+    "en": "/en/find-jobs-zurich/boutique-assistant-intern-cartier-zurich",
+    "it": "/cerca-lavoro-zurigo/boutique-assistant-intern-cartier-zurich",
+    "de": "/de/jobs-in-zurich/boutique-assistant-intern-cartier-zurich",
+    "fr": "/fr/trouver-emploi-zurich/boutique-assistant-intern-cartier-zurich"
   },
   "boutique-assistant-intern-richemont-zurich": {
-    "en": "/en/find-jobs-ticino/boutique-assistant-intern-cartier-zurich",
-    "it": "/cerca-lavoro-ticino/boutique-assistant-intern-richemont-zurich",
-    "de": "/de/jobs-im-tessin/boutique-assistant-intern-richemont-zurich",
-    "fr": "/fr/trouver-emploi-tessin/boutique-assistant-intern-richemont-zurich"
+    "en": "/en/find-jobs-zurich/boutique-assistant-intern-cartier-zurich",
+    "it": "/cerca-lavoro-zurigo/boutique-assistant-intern-richemont-zurich",
+    "de": "/de/jobs-in-zurich/boutique-assistant-intern-richemont-zurich",
+    "fr": "/fr/trouver-emploi-zurich/boutique-assistant-intern-richemont-zurich"
   },
   "dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern": {
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
+    "de": "/de/jobs-in-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "en": "/en/find-jobs-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "fr": "/fr/trouver-emploi-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "it": "/cerca-lavoro-zurigo/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
   },
   "dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-e-nachtschicht-spital-affoltern-ag-affoltern-am-albis": {
-    "de": "/de/jobs-im-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "it": "/cerca-lavoro-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-e-nachtschicht-spital-affoltern-ag-affoltern-am-albis",
-    "en": "/en/find-jobs-ticino/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
-    "fr": "/fr/trouver-emploi-tessin/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
+    "de": "/de/jobs-in-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "it": "/cerca-lavoro-zurigo/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-e-nachtschicht-spital-affoltern-ag-affoltern-am-albis",
+    "en": "/en/find-jobs-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern",
+    "fr": "/fr/trouver-emploi-zurich/dipl-pflegefachperson-hf-fh-palliative-care-fruh-spat-und-nachtschicht-spital-affoltern"
   },
   "fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf": {
-    "de": "/de/jobs-im-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "en": "/en/find-jobs-ticino/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "it": "/cerca-lavoro-ticino/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
+    "de": "/de/jobs-in-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "en": "/en/find-jobs-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "fr": "/fr/trouver-emploi-berne/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "it": "/cerca-lavoro-berna/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
   },
   "fachperson-per-neurophysiologische-diagnostik-a-spital-emmental-burgdorf": {
-    "de": "/de/jobs-im-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "it": "/cerca-lavoro-ticino/fachperson-per-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "en": "/en/find-jobs-ticino/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
-    "fr": "/fr/trouver-emploi-tessin/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
+    "de": "/de/jobs-in-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "it": "/cerca-lavoro-berna/fachperson-per-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "en": "/en/find-jobs-bern/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf",
+    "fr": "/fr/trouver-emploi-berne/fachperson-fur-neurophysiologische-diagnostik-a-spital-emmental-burgdorf"
   },
   "fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil": {
     "de": "/de/jobs-im-tessin/fachperson-gesundheit-efz-arbeitspensum-40-80-spitex-ch-wattwil",
@@ -119699,10 +119699,10 @@
     "fr": "/fr/trouver-emploi-tessin/brand-creative-senior-designer-100-swatch-ltd-job-location-rue-nicolas-g-hayek-strasse-2502-biel-bienne-ber-7uaw3z"
   },
   "berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt": {
-    "it": "/cerca-lavoro-ticino/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
-    "en": "/en/find-jobs-ticino/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
-    "de": "/de/jobs-im-tessin/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
-    "fr": "/fr/trouver-emploi-tessin/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt"
+    "it": "/cerca-lavoro-argovia/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
+    "en": "/en/find-jobs-aargau/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
+    "de": "/de/jobs-im-aargau/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt",
+    "fr": "/fr/trouver-emploi-argovie/berechnungsingenieur-strukturmechanik-m-w-d-kernkraftwerk-leibstadt-ag-leibstadt"
   },
   "alle": {
     "it": "/cerca-lavoro-ticino/alle",
@@ -119717,10 +119717,10 @@
     "fr": "/fr/trouver-emploi-tessin/swatch-part-time-keyholder-garden-state-plaza-nj-the-swatch-group-u-s-inc-ticino"
   },
   "cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve": {
-    "it": "/cerca-lavoro-ticino/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve",
-    "en": "/en/find-jobs-ticino/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve",
-    "de": "/de/jobs-im-tessin/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve",
-    "fr": "/fr/trouver-emploi-tessin/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve"
+    "it": "/cerca-lavoro-ginevra/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve",
+    "en": "/en/find-jobs-geneva/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve",
+    "de": "/de/jobs-in-genf/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve",
+    "fr": "/fr/trouver-emploi-geneve/cis-specialista-onboarding-periodic-reviews-compliance-officer-efg-international-ag-geneve"
   },
   "branchen": {
     "it": "/cerca-lavoro-ticino/branchen",
@@ -119741,10 +119741,10 @@
     "fr": "/fr/trouver-emploi-tessin/educatori-vallese"
   },
   "hris-specialista-cdd-richemont-meyrin": {
-    "it": "/cerca-lavoro-ticino/hris-specialista-cdd-richemont-meyrin",
-    "en": "/en/find-jobs-ticino/hris-specialista-cdd-richemont-meyrin",
-    "de": "/de/jobs-im-tessin/hris-specialista-cdd-richemont-meyrin",
-    "fr": "/fr/trouver-emploi-tessin/hris-specialista-cdd-richemont-meyrin"
+    "it": "/cerca-lavoro-ginevra/hris-specialista-cdd-richemont-meyrin",
+    "en": "/en/find-jobs-geneva/hris-specialista-cdd-richemont-meyrin",
+    "de": "/de/jobs-in-genf/hris-specialista-cdd-richemont-meyrin",
+    "fr": "/fr/trouver-emploi-geneve/hris-specialista-cdd-richemont-meyrin"
   },
   "swatch-part-time-keyholder-valley-fair-ca-the-swatch-group-u-s-inc-ticino": {
     "it": "/cerca-lavoro-ticino/swatch-part-time-keyholder-valley-fair-ca-the-swatch-group-u-s-inc-ticino",
@@ -119825,10 +119825,10 @@
     "fr": "/fr/trouver-emploi-tessin/infermiere-a-diplomato-a-50-100-hoch-health-ostschweiz-st-gallen"
   },
   "anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil": {
-    "it": "/cerca-lavoro-ticino/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil",
-    "en": "/en/find-jobs-ticino/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil",
-    "de": "/de/jobs-im-tessin/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil",
-    "fr": "/fr/trouver-emploi-tessin/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil"
+    "it": "/cerca-lavoro-san-gallo/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil",
+    "en": "/en/find-jobs-st-gallen/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil",
+    "de": "/de/jobs-in-st-gallen/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil",
+    "fr": "/fr/trouver-emploi-saint-gall/anno-di-pratica-strutturato-maturita-specialistica-salute-2026-hoch-health-ostschweiz-wil"
   },
   "infermiere-a-in-riabilitazione-neurologica-m-f-a-80-100-kliniken-valens-valens": {
     "it": "/cerca-lavoro-ticino/infermiere-a-in-riabilitazione-neurologica-m-f-a-80-100-kliniken-valens-valens",
@@ -120215,10 +120215,10 @@
     "fr": "/fr/trouver-emploi-tessin/dipl-specialista-di-cura-hf-fh-medicina-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen": {
-    "it": "/cerca-lavoro-ticino/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "en": "/en/find-jobs-ticino/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "de": "/de/jobs-im-tessin/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
-    "fr": "/fr/trouver-emploi-tessin/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
+    "it": "/cerca-lavoro-turgovia/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "en": "/en/find-jobs-thurgau/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "de": "/de/jobs-im-thurgau/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen",
+    "fr": "/fr/trouver-emploi-thurgovie/dipl-specialista-di-cura-hf-fh-spital-thurgau-stgag-kantonsspital-munsterlingen"
   },
   "dipl-medicina-specialistica-spital-thurgau-stgag-kantonsspital-frauenfeld": {
     "it": "/cerca-lavoro-ticino/dipl-medicina-specialistica-spital-thurgau-stgag-kantonsspital-frauenfeld",


### PR DESCRIPTION
## Summary
Re-runs `scripts/migrate-all-known-job-slugs-canton-aware.mjs` to rewrite 303 non-TI tracking rows in `data/all-known-job-slugs.json` that had drifted back to `/cerca-lavoro-ticino/` paths since the prior migration commit (`857c3156`). Idempotent.

## Root cause
`tests/seo/cathedral-expired-tracking-canton.test.ts > data: non-TI tracking entries no longer reference the TI section path` was red on the committed snapshot (origin/main still contained e.g. `advisor-ere-client-en-placement-losanna-postfinance-lausanne (VD)` mapped to `/cerca-lavoro-ticino/...`). CI doesn't fail on it only because its test gate runs the migration script first; this commit makes the snapshot match the post-migrate state.

Note: an earlier draft (#737) bundled an equivalent `vite.config.ts` + `tests/build-plugin-order.test.ts` fix, but origin/main already carries that patch — left out here. PR #737 has been closed.

## Test plan
- [x] `npx vitest run tests/seo/cathedral-expired-tracking-canton.test.ts` → both tests pass
- [x] Migration output: `rewritten (non-TI job): 303; kept (TI job): 694; kept (orphan): 19003`
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)