### PR TITLE
feat(jobs-seo): tiered emission for GSC keyword landings (biggest bucket)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -205,9 +205,19 @@ const App: React.FC = () => {
  // by trafficEvidenceFilter. Kept inline (no shared module) since the
  // hourly fetcher classifies server-side via the same prefixes — see
  // scripts/fetch-thin-page-promotions.mjs.
- const urlClass =
- /^(\/(cerca-lavoro-ticino|en\/find-jobs-ticino|de\/jobs-im-tessin|fr\/trouver-emploi-tessin))\//.test(path)
- ? 'previousSlug'
+ //
+ // gsc-keyword-landing URLs live under
+ // `/<canton-section>/(ricerca|search|suche|recherche)-<slug>/` where
+ // <canton-section> is one of cerca-lavoro-X / find-jobs-X / jobs-im-X
+ // / jobs-in-X / trouver-emploi-X. Match before previousSlug so the
+ // search-slug pattern wins (a previousSlug for a job named
+ // `ricerca-X` is rare; the route-prefix check is more specific).
+ const isJobSection = /^\/(?:cerca-lavoro|en\/find-jobs|de\/jobs-(?:in|im)|fr\/trouver-emploi)-[a-z-]+\//;
+ const searchLeaf = /^\/(?:cerca-lavoro|en\/find-jobs|de\/jobs-(?:in|im)|fr\/trouver-emploi)-[a-z-]+\/(?:ricerca|search|suche|recherche)-/;
+ const urlClass = searchLeaf.test(path)
+ ? 'gsc-keyword-landing'
+ : isJobSection.test(path)
+ ? 'previousSlug'  // active/bridge/soft share this shape; tag as previousSlug for promotion routing
  : /^\/(ricerca|en\/search-cluster|de\/such-cluster|fr\/recherche-cluster)\//.test(path)
  ? 'cluster'
  : 'unknown';

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -18,6 +18,7 @@ import { minifyHtml } from './shared/htmlMinify';
 import { getTrafficEvidenceFilter } from './shared/trafficEvidenceFilter';
 import { buildBridgeThinHtml } from './shared/bridgeThinShell';
 import { buildSoftLandingThinHtml } from './shared/softLandingThinShell';
+import { buildGscKeywordThinBody, GSC_KEYWORD_THIN_HEAD_SCRIPT } from './shared/gscKeywordThinShell';
 import { jobDescriptionTextToHtml, inlineTextToHtml } from './shared/jobDescription/toHtml';
 import { markCantonNoindex } from './shared/cantonNoindexRegistry';
 import { WriteCollector } from './batchWrite';
@@ -627,6 +628,16 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  // zero. These two trackers surface that discrepancy in the build log.
  let bridgeBytesSaved = 0;
  let softLandingBytesSaved = 0;
+ // GSC keyword landings (`/cerca-lavoro-X/ricerca-Y/`, `/en/find-jobs-X/
+ // search-Y/`, `/de/jobs-im-X/suche-Y/`, `/fr/trouver-emploi-X/recherche-Y/`)
+ // — auto-generated SEO landings for long-tail search queries. Three
+ // emit sites share this URL shape: predefined keyword landings,
+ // search-stats landings, search-combo landings. The 2026-05-28 dist
+ // showed 517 k of these for ~5.17 GB of jobs-seo (57 % of the
+ // bucket) — by far the largest unattacked target.
+ let gscKeywordFullCount = 0;
+ let gscKeywordThinCount = 0;
+ let gscKeywordBytesSaved = 0;
 
  // `cacheDateStamp` is used as today's stamp throughout the plugin and
  // in the always-run sitemap-index patch below.
@@ -7394,6 +7405,25 @@ ${staticAnalyticsHtml}
  ],
  });
  // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
+ // Tiered emission for GSC keyword landings (urlClass:
+ // 'gsc-keyword-landing'). URL with traffic in evidence-index or
+ // thin-page-promotions stays full; URL without and matching the
+ // approved pattern becomes a thin shell (HEAD identical, body shrunk
+ // to ≥50-word paragraph + link to listing). SPA hydrates the full
+ // filtered listing client-side from the URL slug
+ // (components/community/JobBoard.tsx parseSearchSlugFilter).
+ const __kwDecision = trafficFilter.decide(kwCanonicalPath, 'gsc-keyword-landing');
+ const __kwAction: 'full' | 'thin' = __kwDecision.action === 'thin' ? 'thin' : 'full';
+ const __kwFullBody = `<h1>${esc(itCopy.heading)}</h1>\n <p>${esc(kwDesc)}</p>\n ${kwQueryIntro}\n ${kwIntro}\n <p>${esc(kwCta)}</p>\n <ul class="s-0WjlyL">${kwListHtml}</ul>\n <p><a href="${kwSectionUrl}">${esc(kwOpenAllLabel)}</a></p>\n ${kwMarketSection}\n ${renderJobBoardListingDensityProse(locale, { subject: _kwQuery || kwQueryDisplay || itCopy.heading, location: _kwCity ? _kwCity.charAt(0).toUpperCase() + _kwCity.slice(1) : 'Ticino', resultCount: kwJobs.length, companyCount: kwUniqueCompanies.length, locationCount: kwUniqueLocations.length })}\n ${kwCommuterBlock}`;
+ const __kwBody = __kwAction === 'thin'
+ ? buildGscKeywordThinBody({ locale, query: String(kwQueryDisplay || _kwQuery || itCopy.heading || ''), listingUrl: kwSectionUrl, h1Title: esc(itCopy.heading) })
+ : __kwFullBody;
+ if (__kwAction === 'thin') {
+ gscKeywordThinCount++;
+ gscKeywordBytesSaved += __kwFullBody.length - __kwBody.length;
+ } else {
+ gscKeywordFullCount++;
+ }
  const kwHtml = buildSeoPageHtml({
  locale,
  title: kwTitle,
@@ -7402,7 +7432,8 @@ ${staticAnalyticsHtml}
  ogLocale: localeOg[locale],
  hreflangHtml: kwAlternates,
  jsonLdScripts: [kwBreadcrumbLd, kwCollLd],
- bodyHtml: `<h1>${esc(itCopy.heading)}</h1>\n <p>${esc(kwDesc)}</p>\n ${kwQueryIntro}\n ${kwIntro}\n <p>${esc(kwCta)}</p>\n <ul class="s-0WjlyL">${kwListHtml}</ul>\n <p><a href="${kwSectionUrl}">${esc(kwOpenAllLabel)}</a></p>\n ${kwMarketSection}\n ${renderJobBoardListingDensityProse(locale, { subject: _kwQuery || kwQueryDisplay || itCopy.heading, location: _kwCity ? _kwCity.charAt(0).toUpperCase() + _kwCity.slice(1) : 'Ticino', resultCount: kwJobs.length, companyCount: kwUniqueCompanies.length, locationCount: kwUniqueLocations.length })}\n ${kwCommuterBlock}`,
+ bodyHtml: __kwBody,
+ extraHeadHtml: __kwAction === 'thin' ? GSC_KEYWORD_THIN_HEAD_SCRIPT : undefined,
  distDir,
  });
  const kwOutDir = np.join(distDir, kwCanonicalPath.slice(1));
@@ -7560,6 +7591,22 @@ ${staticAnalyticsHtml}
  // (e.g. `search-lugano-eoc-...` → company hub). Page still emitted at its
  // own path so backlinks resolve.
  const effectiveCanonicalUrl = resolveCanonicalUrl(fullSlug, canonicalUrl);
+ // Tiered emission: shares 'gsc-keyword-landing' urlClass with the
+ // predefined-keyword + search-combo emit sites — same URL shape
+ // (`/cerca-lavoro-X/ricerca-Y/`), same SPA hydration path. Build
+ // both variants and pick based on filter decision.
+ const __ssFullBody = `<h1>${esc(copy.heading(name))}</h1>\n <p>${esc(description)}</p>\n${searchBodyParts.join('\n')}`;
+ const __ssDecision = trafficFilter.decide(canonicalPath, 'gsc-keyword-landing');
+ const __ssAction: 'full' | 'thin' = __ssDecision.action === 'thin' ? 'thin' : 'full';
+ const __ssBody = __ssAction === 'thin'
+ ? buildGscKeywordThinBody({ locale, query: String(name || key || ''), listingUrl: _sListUrl, h1Title: esc(copy.heading(name)) })
+ : __ssFullBody;
+ if (__ssAction === 'thin') {
+ gscKeywordThinCount++;
+ gscKeywordBytesSaved += __ssFullBody.length - __ssBody.length;
+ } else {
+ gscKeywordFullCount++;
+ }
  // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
  const searchHtml = buildSeoPageHtml({
  locale,
@@ -7580,7 +7627,8 @@ ${staticAnalyticsHtml}
  ogLocale: localeOg[locale],
  hreflangHtml: alternates,
  jsonLdScripts: [searchBreadcrumbLd],
- bodyHtml: `<h1>${esc(copy.heading(name))}</h1>\n <p>${esc(description)}</p>\n${searchBodyParts.join('\n')}`,
+ bodyHtml: __ssBody,
+ extraHeadHtml: __ssAction === 'thin' ? GSC_KEYWORD_THIN_HEAD_SCRIPT : undefined,
  distDir,
  });
 
@@ -7722,6 +7770,21 @@ ${staticAnalyticsHtml}
  { '@type': 'ListItem', position: 3, name: copy.heading, item: canonicalUrl },
  ],
  });
+ // Tiered emission: same 'gsc-keyword-landing' urlClass as the
+ // predefined-keyword + search-stats emit sites — they share the URL
+ // shape (`/cerca-lavoro-X/ricerca-Y/`) and SPA hydration path.
+ const __cmFullBody = `<h1>${esc(copy.heading)}</h1>\n <p>${esc(description)}</p>\n${comboBodyParts.join('\n')}`;
+ const __cmDecision = trafficFilter.decide(canonicalPath, 'gsc-keyword-landing');
+ const __cmAction: 'full' | 'thin' = __cmDecision.action === 'thin' ? 'thin' : 'full';
+ const __cmBody = __cmAction === 'thin'
+ ? buildGscKeywordThinBody({ locale, query: String(copy.heading || comboTitle || ''), listingUrl: _cListUrl, h1Title: esc(copy.heading) })
+ : __cmFullBody;
+ if (__cmAction === 'thin') {
+ gscKeywordThinCount++;
+ gscKeywordBytesSaved += __cmFullBody.length - __cmBody.length;
+ } else {
+ gscKeywordFullCount++;
+ }
  // buildSeoPageHtml (hydration-safe shell). See city-hub fix at line ~5420.
  const comboHtml = buildSeoPageHtml({
  locale,
@@ -7730,9 +7793,12 @@ ${staticAnalyticsHtml}
  canonicalUrl,
  ogLocale: localeOg[locale],
  hreflangHtml: alternates,
- extraHeadHtml: comboOgImage,
+ // Preserve OG image override; append thin-shell signal when applicable.
+ extraHeadHtml: __cmAction === 'thin'
+ ? `${comboOgImage || ''}${GSC_KEYWORD_THIN_HEAD_SCRIPT}`
+ : comboOgImage,
  jsonLdScripts: [comboBreadcrumbLd],
- bodyHtml: `<h1>${esc(copy.heading)}</h1>\n <p>${esc(description)}</p>\n${comboBodyParts.join('\n')}`,
+ bodyHtml: __cmBody,
  distDir,
  });
 
@@ -11293,6 +11359,13 @@ ${staticAnalyticsHtml}
  `bytes_saved=${fmtBytes(softLandingBytesSaved)}`
  );
  }
+ if (gscKeywordThinCount > 0 || gscKeywordFullCount > 0) {
+ console.log(
+ `\x1b[36m[jobs-seo-pages]\x1b[0m gsc-keyword-landing tier: ` +
+ `full=${gscKeywordFullCount} thin=${gscKeywordThinCount} ` +
+ `bytes_saved=${fmtBytes(gscKeywordBytesSaved)}`
+ );
+ }
  // Total real dist saving from tiered emission. PR #729 lesson: the
  // tier counters above record FILTER DECISIONS, not byte deltas. A
  // build where the thin-shell regex misses (e.g. unquoted-class bug
@@ -11300,8 +11373,8 @@ ${staticAnalyticsHtml}
  // line is the ground truth.
  console.log(
  `\x1b[36m[jobs-seo-pages]\x1b[0m tiered emission saved ` +
- `${fmtBytes(bridgeBytesSaved + softLandingBytesSaved)} ` +
- `(bridges=${fmtBytes(bridgeBytesSaved)}, soft-landings=${fmtBytes(softLandingBytesSaved)})`
+ `${fmtBytes(bridgeBytesSaved + softLandingBytesSaved + gscKeywordBytesSaved)} ` +
+ `(bridges=${fmtBytes(bridgeBytesSaved)}, soft-landings=${fmtBytes(softLandingBytesSaved)}, gsc-keyword=${fmtBytes(gscKeywordBytesSaved)})`
  );
  console.log(`\x1b[36m[jobs-seo-pages]\x1b[0m ${trafficFilter.summary()}`);
  },

--- a/build-plugins/shared/gscKeywordThinShell.ts
+++ b/build-plugins/shared/gscKeywordThinShell.ts
@@ -1,0 +1,72 @@
+// gscKeywordThinShell.ts
+//
+// Thin-shell body for GSC keyword landing pages (the
+// `/cerca-lavoro-X/ricerca-Y/`, `/en/find-jobs-X/search-Y/`, etc.
+// family — emitted by 3 sites in jobsSeoPagesPlugin: predefined-keyword
+// landings, search-stats landings, search-combo landings — all share
+// the same URL shape and SPA route).
+//
+// SPA-side rendering: the JobBoard component reads the leaf slug from
+// the URL via `parseSearchSlugFilter` (components/community/JobBoard.tsx
+// ~line 1881) and renders the filtered listing dynamically. The static
+// `<main class="seo-static-content">` payload is only the crawler-facing
+// fallback — App.tsx's useLayoutEffect at App.tsx:204-212 hides it for
+// non-staticOverlay routes (search routes resolve to a SPA view), so
+// JS-enabled users see the full hydrated listing identical to the
+// pre-thin behaviour.
+//
+// HEAD (canonical, hreflang, OG meta, JSON-LD BreadcrumbList +
+// CollectionPage, og:image) is built by buildSeoPageHtml unchanged.
+// Only the bodyHtml shrinks: full version is ~10 KB (intro + cta + job
+// list + market section + commuter context); thin version is ~700 B
+// (h1 + ≥50-word paragraph + link to the canonical listing).
+//
+// Adds `window.__THIN_SHELL__=1` via the caller's extraHeadHtml so
+// App.tsx fires `thin_page_view` on mount → hourly workflow lifts the
+// URL into thin-page-promotions-active.json → next deploy returns
+// 'full' for it. Self-heal latency ≤25 h.
+
+interface ThinBodyOpts {
+  locale: string;
+  /** Display string for the query, e.g. "infermieri turno notte". */
+  query: string;
+  /** Canonical hub URL (target of the "browse all" link), e.g.
+   *  `https://frontaliereticino.ch/cerca-lavoro-ticino/`. */
+  listingUrl: string;
+  /** Title text already escaped for HTML interpolation. */
+  h1Title: string;
+}
+
+const PROSE: Record<string, (q: string, listingUrl: string) => string> = {
+  it: (q, l) =>
+    `Sul nostro job board indicizziamo ogni giorno migliaia di posizioni aperte presso aziende svizzere. Per esplorare tutte le offerte disponibili — incluse quelle che corrispondono a "${q}" — apri la <a href="${l}">job board completa</a> con filtri per cantone, settore, contratto, fascia di stipendio e località. Le offerte vengono aggiornate quotidianamente dai datori di lavoro nei cantoni di Ticino, Grigioni, Zurigo, Berna, Basilea, Vaud e altri. Ogni annuncio mostra stipendio, contratto, sede di lavoro e link diretto al sito dell'azienda.`,
+  en: (q, l) =>
+    `Our job board indexes thousands of open positions at Swiss companies every day. To browse all available openings — including those matching "${q}" — open the <a href="${l}">complete job board</a> with filters by canton, sector, contract type, salary band and location. Listings are updated daily by employers across Ticino, Graubünden, Zurich, Bern, Basel, Vaud and other cantons. Each posting shows salary, contract type, work location, and a direct link to the employer's site.`,
+  de: (q, l) =>
+    `Unser Job Board indiziert täglich tausende offene Stellen bei Schweizer Unternehmen. Um alle verfügbaren Angebote zu durchsuchen — auch jene, die zu "${q}" passen — öffnen Sie das <a href="${l}">vollständige Job Board</a> mit Filtern nach Kanton, Branche, Vertragsart, Lohnband und Arbeitsort. Die Angebote werden täglich von Arbeitgebern aus Tessin, Graubünden, Zürich, Bern, Basel, Waadt und weiteren Kantonen aktualisiert. Jedes Inserat zeigt Lohn, Vertragsart, Arbeitsort und einen direkten Link zur Webseite des Arbeitgebers.`,
+  fr: (q, l) =>
+    `Notre job board indexe quotidiennement des milliers de postes ouverts auprès d'entreprises suisses. Pour parcourir toutes les offres disponibles — y compris celles qui correspondent à "${q}" — ouvrez le <a href="${l}">job board complet</a> avec des filtres par canton, secteur, type de contrat, fourchette salariale et lieu. Les offres sont mises à jour quotidiennement par des employeurs au Tessin, dans les Grisons, à Zurich, Berne, Bâle, Vaud et d'autres cantons. Chaque annonce affiche le salaire, le type de contrat, le lieu de travail et un lien direct vers le site de l'employeur.`,
+};
+
+/**
+ * Slim bodyHtml for a GSC keyword landing page. Returns a ≥50-word
+ * paragraph wrapped in `<main class="seo-static-content static-search-landing">`
+ * — the same class shape used by bridges/soft-landings so App.tsx's
+ * static-overlay hider catches it for JS-enabled users.
+ */
+export function buildGscKeywordThinBody(opts: ThinBodyOpts): string {
+  const proseFn = PROSE[opts.locale] || PROSE.it;
+  const prose = proseFn(opts.query, opts.listingUrl);
+  return (
+    `<h1>${opts.h1Title}</h1>` +
+    `<p>${prose}</p>`
+  );
+}
+
+/**
+ * Inline `<script>` to add to `extraHeadHtml`. Sets `__THIN_SHELL__=1`
+ * so App.tsx's mount effect fires `thin_page_view` on PostHog + Firebase
+ * Analytics. Pair with buildGscKeywordThinBody() — they go together.
+ */
+export const GSC_KEYWORD_THIN_HEAD_SCRIPT =
+  `<script>window.__THIN_SHELL__=1;</script>`;

--- a/data/url-pruning-approved-patterns.json
+++ b/data/url-pruning-approved-patterns.json
@@ -11,6 +11,11 @@
       "id": "zero-traffic-soft-landing-expired",
       "urlClass": "soft-landing-expired",
       "action": "thin"
+    },
+    {
+      "id": "zero-traffic-gsc-keyword-landing",
+      "urlClass": "gsc-keyword-landing",
+      "action": "thin"
     }
   ]
 }

--- a/scripts/report-dist-bytes-by-plugin.mjs
+++ b/scripts/report-dist-bytes-by-plugin.mjs
@@ -160,6 +160,12 @@ const PLUGIN_RULES = [
 // canton-section prefix has been stripped) so the same rule fires for
 // IT/EN/DE/FR locale variants.
 const URL_CLASS_RULES = [
+  // GSC-derived search/keyword landing pages — by far the largest
+  // jobs-seo sub-bucket (517k pages, ~5.2 GB on the 2026-05-28 dist).
+  // Three emit sites in jobsSeoPagesPlugin.ts share this URL shape:
+  // recordEmit('gsc-keyword-landing'), recordEmit('search-stats-landing'),
+  // recordEmit('search-combo-landing').
+  { urlClass: 'gsc-keyword-landing',     regex: /^(?:ricerca|search|suche|recherche)-/ },
   { urlClass: 'paginated-listing',       regex: /(?:^|\/)(?:page|pagina|seite)-[0-9]+(?:\/|$)/ },
   { urlClass: 'category-listing-all',    regex: /(?:^|\/)(?:tutti|tutte|alle|all|tous)(?:\/|$)/ },
   { urlClass: 'company-canton-hub',      regex: /(?:^|\/)(?:per-azienda|by-company|nach-firma|par-entreprise)(?:\/|$)/ },


### PR DESCRIPTION
## Summary

The 2026-05-28 dist showed **517 k pages = 5.17 GB (57 % of jobs-seo bucket)** under \`/cerca-lavoro-X/ricerca-Y/\` (IT) + locale equivalents (\`search-Y/\`, \`suche-Y/\`, \`recherche-Y/\`). These are auto-generated GSC keyword landing pages — long-tail SEO landings for search queries. Three emit sites in \`jobsSeoPagesPlugin\` share this URL shape: \`recordEmit('gsc-keyword-landing')\`, \`recordEmit('search-stats-landing')\`, \`recordEmit('search-combo-landing')\`.

**By far the largest unattacked saving target** in the artifact-shrink series.

## Pattern

Same as bridges + soft-landings:

1. Filter (\`build-plugins/shared/trafficEvidenceFilter.ts\`) consults \`evidence-index.json\` + hourly \`thin-page-promotions-active.json\` + approved patterns.
2. URL with traffic → \`full\`. URL without + approved pattern → \`thin\`.
3. Thin shell preserves HEAD verbatim (canonical, hreflang, OG, JSON-LD BreadcrumbList + CollectionPage). Only \`bodyHtml\` shrinks: ~10 KB → ~700 B.
4. SPA hydration: JobBoard's \`parseSearchSlugFilter\` reads the leaf slug → renders the filtered listing client-side. End user sees zero change.
5. Self-heal: thin page sets \`window.__THIN_SHELL__=1\` → \`thin_page_view\` event → hourly workflow → next deploy lifts back to full. ≤25 h.

## Files

- \`build-plugins/shared/gscKeywordThinShell.ts\` — new helper with \`buildGscKeywordThinBody()\` (4-locale prose, ≥50 words) + \`GSC_KEYWORD_THIN_HEAD_SCRIPT\`
- \`build-plugins/jobsSeoPagesPlugin.ts\` — 3 emit sites wired (lines ~7414, ~7610, ~7783); each builds full body for byte-saving metric, picks thin when filter says so, preserves any per-page \`og:image\` in extraHeadHtml
- \`data/url-pruning-approved-patterns.json\` — new pattern \`zero-traffic-gsc-keyword-landing\` activates thinning
- \`scripts/report-dist-bytes-by-plugin.mjs\` — URL_CLASS_RULES gains a \`gsc-keyword-landing\` rule so the bucket appears in the build log
- \`App.tsx\` — thin_page_view classifier recognises \`/<canton-section>/(ricerca|search|suche|recherche)-\` paths

## New build-log counters

\`\`\`
[jobs-seo-pages] gsc-keyword-landing tier: full=N thin=M bytes_saved=XMB
[jobs-seo-pages] tiered emission saved YGB
  (bridges=…, soft-landings=…, gsc-keyword=…)
\`\`\`

## Expected impact

517 k pages × ~70 % zero-traffic × 6-8 KB body delta = **~2.5 GB saving**.

Pushes the artifact tar from current 11.94 GB → **~9.5 GB → under the 10 GB cap with ~500 MB headroom**.

## Test plan

- [ ] Next deploy log: \`gsc-keyword-landing tier: full=N thin=M\` with M > 0
- [ ] \`bytes_saved=XMB\` is non-zero (PR #729 lesson — counter ≠ saving until regex actually matches)
- [ ] TAR_BYTES drops below 10 GB (10737418240)
- [ ] Spot-check 5 thinned URLs: HEAD intact (JSON-LD CollectionPage, canonical, hreflang); body slim; browser loads full listing via SPA hydration
- [ ] \`gsc-position-rolling.json\` 30-day monitor: no regression on keyword-landing traffic