### PR TITLE
feat(cluster): tiered emission for related-search cluster pages (the real bulk)

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -51,6 +51,8 @@ import { BASE_URL } from './constants';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
 import { buildSeoPageHtml } from './shared/seoPageShell';
 import { buildTitleWithBrand, TITLE_MAX_CHARS } from './shared/titleSuffix';
+import { getTrafficEvidenceFilter } from './shared/trafficEvidenceFilter';
+import { buildClusterThinHtml } from './shared/clusterThinShell';
 import {
   renderJobBoardCommuterContext,
   renderSearchQueryIntro,
@@ -1979,6 +1981,22 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       const startedAt = Date.now();
       const dateStamp = new Date().toISOString().slice(0, 10);
 
+      // Tiered emission for cluster pages (urlClass: 'gsc-keyword-landing').
+      // 2026-05-28 dist: 517 k pages = 5.17 GB = 57 % of jobs-seo bucket;
+      // sample shows `<main class=cluster-seo-prose>` block accounts for
+      // 77 % of each page's bytes. Filter consults
+      // data/evidence-index.json + data/thin-page-promotions-active.json
+      // + data/url-pruning-approved-patterns.json. URL with traffic stays
+      // full; URL without and matching the approved pattern becomes a
+      // thin shell (HEAD preserved verbatim; main block replaced with a
+      // slim h1 + ≥50-word paragraph linking back to the canonical hub).
+      // SPA hydrates the filtered listing client-side from the URL.
+      // See build-plugins/shared/clusterThinShell.ts.
+      const trafficFilter = getTrafficEvidenceFilter(rootDir);
+      let clusterFullCount = 0;
+      let clusterThinCount = 0;
+      let clusterBytesSaved = 0;
+
       // Cache fast path. If inputs haven't changed since the last emit,
       // restore the cluster + hub HTML + sitemap fragment from disk, run
       // the cross-plugin patches (master sitemap + hub-link injection)
@@ -2233,16 +2251,31 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           dateStamp,
         });
 
+        // Tiered emission decision per cluster context. The same html
+        // payload is reused for the canonical + the flat-bridge source
+        // + every legacy-canton mirror, so we decide once and apply
+        // uniformly. byte-saving accumulator counts the delta per
+        // emitted FILE (canonical + mirrors); the flat bridge is
+        // already small and doesn't materially benefit.
+        const __clDecision = trafficFilter.decide(out.urlPath, 'gsc-keyword-landing');
+        const __clAction: 'full' | 'thin' = __clDecision.action === 'thin' ? 'thin' : 'full';
+        const __clHtml = __clAction === 'thin'
+          ? buildClusterThinHtml(out.html, locale)
+          : out.html;
+        const __clDelta = __clAction === 'thin' ? out.html.length - __clHtml.length : 0;
+        if (__clAction === 'thin') clusterThinCount++; else clusterFullCount++;
+
         const indexPath = path.join(distDir, out.urlPath, 'index.html');
         const flatPath = path.join(distDir, out.urlPath.replace(/\/+$/, '') + '.html');
-        collector.add(indexPath, out.html);
+        collector.add(indexPath, __clHtml);
+        clusterBytesSaved += __clDelta;
         // Emit the flat .html as a redirect bridge directly: postWalkCoordinator
         // would otherwise read this file (~30 KB), build the same bridge from
         // the sibling, and rewrite (~500 B). Pre-emitting the bridge cuts
         // ~52k × 30 KB writes here AND post-walk's `html === original` guard
         // skips the rewrite. Trims ~30-50 s off closeBundle.
         const slashUrl = `${BASE_URL}${out.urlPath.replace(/\/+$/, '')}/`;
-        const flatBridge = buildFlatBridgeFromSibling(out.html, slashUrl);
+        const flatBridge = buildFlatBridgeFromSibling(__clHtml, slashUrl);
         collector.add(flatPath, flatBridge);
         emittedFiles.push(path.relative(distDir, indexPath));
         emittedFiles.push(path.relative(distDir, flatPath));
@@ -2302,7 +2335,8 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
           // via flat bridges would add hundreds of thousands of files for a
           // negligible UX gain.
           const mirrorIndexPath = path.join(distDir, mirrorPath, 'index.html');
-          collector.add(mirrorIndexPath, out.html);
+          collector.add(mirrorIndexPath, __clHtml);
+          clusterBytesSaved += __clDelta;
           emittedFiles.push(path.relative(distDir, mirrorIndexPath));
         }
         profileRecord('render-cluster-page', __tRenderCluster);
@@ -2391,6 +2425,25 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
       console.log(
         `\x1b[36m[related-search-clusters]\x1b[0m emitted ${ctxCount} cluster pages + ${hubCount} hubs (${written} files) in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
       );
+      // Tiered emission summary. Counter records FILTER DECISIONS;
+      // bytes_saved is the REAL delta (full html length − thin html
+      // length) accumulated per emitted file (canonical + every legacy
+      // mirror that reused the html). See PR #729 / #734 lesson:
+      // counter ≠ saving when the regex misses.
+      if (clusterThinCount > 0 || clusterFullCount > 0) {
+        const fmtBytes = (n: number): string => {
+          if (n < 1024) return `${n}B`;
+          if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+          if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+          return `${(n / (1024 * 1024 * 1024)).toFixed(2)}GB`;
+        };
+        console.log(
+          `\x1b[36m[related-search-clusters]\x1b[0m cluster tier: ` +
+          `full=${clusterFullCount} thin=${clusterThinCount} ` +
+          `bytes_saved=${fmtBytes(clusterBytesSaved)}`,
+        );
+        console.log(`\x1b[36m[related-search-clusters]\x1b[0m ${trafficFilter.summary()}`);
+      }
       printRelatedSearchProfile();
     },
   };

--- a/build-plugins/shared/clusterThinShell.ts
+++ b/build-plugins/shared/clusterThinShell.ts
@@ -1,0 +1,123 @@
+// clusterThinShell.ts
+//
+// Thin-shell post-processor for cluster pages emitted by
+// relatedSearchClustersPlugin (the `/cerca-lavoro-X/ricerca-Y/` family
+// and locale equivalents — by far the largest jobs-seo sub-bucket,
+// 517 k pages = 5.17 GB / 57 % on the 2026-05-28 dist).
+//
+// Operates on the rendered HTML returned by `renderClusterPage`. The
+// page structure is:
+//
+//   <head>…</head>
+//   <body>
+//     <div id="root"></div>
+//     <main class=cluster-seo-prose>
+//       <div class=related-search-cluster>
+//         <h1>…</h1>
+//         <ul class=cluster-seo-jobs>… 30 job links …</ul>
+//         <section>…related searches…</section>
+//         <section>…commuter context…</section>
+//         …
+//       </div>
+//     </main>
+//     <div id=footer-root></div>
+//     <script type=module src=/assets/index-X.js></script>
+//   </body>
+//
+// Real artifact sample (cerca-lavoro-ticino/ricerca-mansioni-lingerie-80/):
+//   total 10 306 B; `<main class=cluster-seo-prose>` block = 7 920 B (77 %).
+//
+// HEAD is preserved verbatim (canonical, hreflang, OG meta, JSON-LD
+// BreadcrumbList) — every Google-visible signal stays identical. Only
+// the `<main>` block shrinks to a slim h1 + ≥50-word paragraph linking
+// back to the canonical hub.
+//
+// SPA hydration: the cluster URL routes through the SPA's
+// JobBoard component which reads the slug + canton from the URL via
+// `parsePath`/`parseSearchSlugFilter` and renders the filtered listing
+// dynamically. App.tsx's static-overlay hider drops the thin static
+// body for non-staticOverlay routes (cluster URLs resolve to a SPA
+// view), so JS-enabled users see the full hydrated listing identical
+// to today.
+//
+// Adds `window.__THIN_SHELL__=1` in head so App.tsx fires
+// `thin_page_view` on PostHog + Firebase Analytics → hourly workflow
+// lifts hit URLs into thin-page-promotions-active.json → next deploy
+// returns 'full' for them. ≤25 h self-heal.
+
+const LOCALE_LISTING_PATH: Record<string, string> = {
+  it: '/cerca-lavoro-svizzera/',
+  en: '/en/find-jobs-switzerland/',
+  de: '/de/jobs-in-schweiz/',
+  fr: '/fr/trouver-emploi-suisse/',
+};
+
+const PROSE: Record<string, (query: string, listingUrl: string) => string> = {
+  it: (q, l) =>
+    `Sul nostro job board indicizziamo ogni giorno migliaia di posizioni aperte presso aziende svizzere. Per esplorare tutte le offerte disponibili — comprese quelle pertinenti a "${q}" — apri la <a href="${l}">job board completa</a> con filtri per cantone, settore, contratto, fascia di stipendio e località. Gli annunci sono aggiornati quotidianamente dai datori di lavoro in Ticino, Grigioni, Zurigo, Berna, Basilea, Vaud e altri cantoni. Ogni offerta mostra stipendio, contratto, sede di lavoro e link diretto al sito dell'azienda. Le ricerche correlate ti aiutano a scoprire posizioni simili nello stesso settore o nella stessa zona geografica.`,
+  en: (q, l) =>
+    `Our job board indexes thousands of open positions at Swiss companies every day. To browse all available openings — including those relevant to "${q}" — open the <a href="${l}">complete job board</a> with filters by canton, sector, contract type, salary band and location. Listings are updated daily by employers across Ticino, Graubünden, Zurich, Bern, Basel, Vaud and other cantons. Each posting shows salary, contract type, work location, and a direct link to the employer's site. Related searches help you discover similar positions in the same sector or geographic area.`,
+  de: (q, l) =>
+    `Unser Job Board indiziert täglich tausende offene Stellen bei Schweizer Unternehmen. Um alle verfügbaren Angebote zu durchsuchen — auch jene, die zu "${q}" passen — öffnen Sie das <a href="${l}">vollständige Job Board</a> mit Filtern nach Kanton, Branche, Vertragsart, Lohnband und Arbeitsort. Die Angebote werden täglich von Arbeitgebern aus Tessin, Graubünden, Zürich, Bern, Basel, Waadt und weiteren Kantonen aktualisiert. Jedes Inserat zeigt Lohn, Vertragsart, Arbeitsort und einen direkten Link zur Webseite des Arbeitgebers. Verwandte Suchanfragen helfen Ihnen, ähnliche Positionen in derselben Branche oder geographischen Region zu finden.`,
+  fr: (q, l) =>
+    `Notre job board indexe quotidiennement des milliers de postes ouverts auprès d'entreprises suisses. Pour parcourir toutes les offres disponibles — y compris celles qui correspondent à "${q}" — ouvrez le <a href="${l}">job board complet</a> avec des filtres par canton, secteur, type de contrat, fourchette salariale et lieu. Les offres sont mises à jour quotidiennement par des employeurs au Tessin, dans les Grisons, à Zurich, Berne, Bâle, Vaud et d'autres cantons. Chaque annonce affiche le salaire, le type de contrat, le lieu de travail et un lien direct vers le site de l'employeur. Les recherches associées vous aident à découvrir des postes similaires dans le même secteur ou la même région.`,
+};
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function extractH1(html: string): string {
+  const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (!m) return '';
+  return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Convert a full cluster-prose HTML into its thin variant. HEAD is
+ * preserved verbatim; the `<main class=cluster-seo-prose>` block is
+ * replaced with a slim h1 + ≥50-word paragraph linking back to the
+ * canonical Swiss-section hub.
+ *
+ * Defensive: if the regex doesn't match (unexpected HTML shape),
+ * returns the input unchanged so the build can't corrupt a page —
+ * the deploy log's `cluster tier: bytes_saved=0B` will surface the
+ * miss.
+ */
+export function buildClusterThinHtml(fullHtml: string, locale: string): string {
+  const h1Text = htmlEscape(extractH1(fullHtml));
+  const listingPath = LOCALE_LISTING_PATH[locale] || LOCALE_LISTING_PATH.it;
+  const proseFn = PROSE[locale] || PROSE.it;
+  const prose = proseFn(h1Text || 'offerte di lavoro', listingPath);
+
+  // Match the `<main class=cluster-seo-prose...>...</main>` block. The
+  // class attribute is single-token (`cluster-seo-prose`), so the
+  // upstream minifier (PR #478 removeAttributeQuotes) strips its
+  // quotes. Tolerate both quoted and unquoted forms via the same
+  // pattern PR #729 introduced for ft-static-article.
+  const thinMain =
+    `<main class="seo-static-content static-cluster">` +
+    `<article class="proposal">` +
+    `<h1>${h1Text}</h1>` +
+    `<p>${prose}</p>` +
+    `</article>` +
+    `</main>`;
+
+  const withThinBody = fullHtml.replace(
+    /<main\s+class=["']?cluster-seo-prose(?=[\s>"'])[^>]*>[\s\S]*?<\/main>/i,
+    thinMain,
+  );
+
+  if (withThinBody === fullHtml) return fullHtml;
+
+  // Inject the thin-shell signal so App.tsx fires thin_page_view.
+  return withThinBody.replace(
+    '</head>',
+    ` <script>window.__THIN_SHELL__=1;</script>\n </head>`,
+  );
+}


### PR DESCRIPTION
## Summary

PR #740 wired \`jobsSeoPagesPlugin\`'s 3 emit sites for the \`gsc-keyword-landing\` urlClass — but a post-merge sanity-check on the production artifact showed **30/30 sampled \`ricerca-*\` pages are actually emitted by \`relatedSearchClustersPlugin\`** (class \`cluster-seo-prose\`). The cluster plugin runs first and claims the URLs in \`activeJobDirs\`; jobsSeoPagesPlugin then skips them. So #740 only thinned a tiny minority.

This PR wires the same pipeline into the cluster plugin — **where the 517k pages = 5.17 GB bulk lives**.

## Real-artifact validation

Sample: \`cerca-lavoro-ticino/ricerca-mansioni-lingerie-80/index.html\`
- Total: 10.306 B
- \`<main class=cluster-seo-prose>\` block: **7.920 B (77 %)**
- After thinning: **3.002 B (saved 7.304 B / page)**

Across 517k cluster pages × ~70 % zero-traffic share = **~2.6 GB tar saving**.

## Pipeline (identical to bridges/soft-landings/GSC-keyword)

1. \`TrafficEvidenceFilter\` consults \`data/evidence-index.json\` + \`data/thin-page-promotions-active.json\` + \`data/url-pruning-approved-patterns.json\`.
2. URL with traffic → \`full\`. URL without + approved pattern → \`thin\`.
3. Thin shell preserves HEAD verbatim (canonical, hreflang, OG, JSON-LD BreadcrumbList). Only \`<main class=cluster-seo-prose>\` is replaced with \`<main class=seo-static-content static-cluster>\` containing h1 + ≥50-word paragraph + link to canonical Swiss-section hub.
4. SPA hydration: cluster URLs resolve to JobBoard's filtered-listing view; App.tsx's static-overlay useLayoutEffect hides the thin body for JS-enabled users → end UX identical to today.
5. Self-heal: \`__THIN_SHELL__=1\` → \`thin_page_view\` event → hourly workflow → next deploy returns \`full\`. ≤25 h.

## Files

- \`build-plugins/shared/clusterThinShell.ts\` — \`buildClusterThinHtml(fullHtml, locale)\`. Regex tolerates unquoted \`class=cluster-seo-prose\` (PR #729 lesson: minifier strips quotes from single-token classes).
- \`build-plugins/relatedSearchClustersPlugin.ts\` — filter instantiated once at \`closeBundle\` top; decision taken per cluster context (one HTML, reused for canonical + flat-bridge source + every legacy-canton mirror).

## Build-log additions

\`\`\`
[related-search-clusters] cluster tier: full=N thin=M bytes_saved=XGB
[related-search-clusters] [traffic-evidence-filter] full=… thin=… skip=…
\`\`\`

## Combined impact (after merge)

| Run | TAR | jobs-seo |
|-----|----:|--:|
| 26565404829 (pre-thin baseline) | 12.79 GB | 9.94 GB |
| 26569025264 (PR #725+#729 bridges+soft) | 11.94 GB | 9.10 GB |
| **Post-this-PR (expected)** | **~9.4 GB** | **~6.5 GB** |

→ TAR under the 10 GB GitHub Pages cap with ~600 MB headroom.

## Test plan

- [ ] Build log: \`cluster tier: thin=M\` with M > 0 (no regex miss)
- [ ] \`bytes_saved=XGB\` non-zero (PR #729 lesson)
- [ ] TAR_BYTES < 10 737 418 240 (10 GiB)
- [ ] Spot-check 5 thinned cluster URLs: HEAD JSON-LD intact, canonical correct, body slim; browser loads full listing via SPA hydration
- [ ] \`gsc-position-rolling.json\` 30-day monitor: no regression on cluster traffic