### PR TITLE
fix(thin-shell): filter must check ALL emit paths (mirror + canonical)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -10669,7 +10669,15 @@ ${staticAnalyticsHtml}
  // matching an approved pattern becomes a thin shell (HEAD verbatim,
  // article body replaced by a slim h1+p≥50 words). See
  // build-plugins/shared/softLandingThinShell.ts.
- const __slDecision = trafficFilter.decide(relPath, 'soft-landing-expired');
+ // PR #743 lesson: non-IT locales also emit a legacy-locale bridge
+ // (line ~10700 below) at `legacyRel`. Traffic may land there, so
+ // check both via decideMulti.
+ const __slCandidatePaths: string[] = [relPath];
+ if (locale !== 'it') {
+ const __slLegacyRel = `/${localePrefix[locale]}/${sectionByLocale[locale]}/${slug}`.replace(/\/+/g, '/');
+ if (__slLegacyRel !== relPath) __slCandidatePaths.push(__slLegacyRel);
+ }
+ const __slDecision = trafficFilter.decideMulti(__slCandidatePaths, 'soft-landing-expired');
  const __slAction: 'full' | 'thin' =
  __slDecision.action === 'thin' ? 'thin' : 'full';
  const softLandingHtml =
@@ -11037,8 +11045,17 @@ ${staticAnalyticsHtml}
  // thin-page-promotions-active.json. Decision applies to BOTH the
  // primary emit and the legacy-TI mirror emit below so the bridge
  // pair stays consistent.
+ // PR #743 lesson: GSC + GA4 see traffic at the legacy-TI mirror more
+ // often than the freshly-promoted canton-aware canonical (Google
+ // remembers the pre-PR-159 URL). Check both candidate paths via
+ // decideMulti so a hit at the mirror keeps the bridge full.
  const __brBridgeUrlPath = oldPath.startsWith('/') ? oldPath : `/${oldPath}`;
- const __brDecision = trafficFilter.decide(__brBridgeUrlPath, 'previousSlug');
+ const __brCandidatePaths: string[] = [__brBridgeUrlPath];
+ if (jobCantonForBridge !== 'TI') {
+ const __brLegacyTIPath = `/${localePrefix[locale]}/${buildCantonAwareSection(locale, 'TI')}/${oldSlug}`.replace(/\/+/g, '/');
+ __brCandidatePaths.push(__brLegacyTIPath);
+ }
+ const __brDecision = trafficFilter.decideMulti(__brCandidatePaths, 'previousSlug');
  const __brAction: 'full' | 'thin' =
  __brDecision.action === 'thin' ? 'thin' : 'full';
  if (__brAction === 'thin') bridgeThinCount++; else bridgeFullCount++;

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2254,10 +2254,24 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         // Tiered emission decision per cluster context. The same html
         // payload is reused for the canonical + the flat-bridge source
         // + every legacy-canton mirror, so we decide once and apply
-        // uniformly. byte-saving accumulator counts the delta per
-        // emitted FILE (canonical + mirrors); the flat bridge is
-        // already small and doesn't materially benefit.
-        const __clDecision = trafficFilter.decide(out.urlPath, 'gsc-keyword-landing');
+        // uniformly. PR #743 fix: compute the mirror set BEFORE the
+        // decision and pass every candidate path through
+        // `decideMulti` — GSC + GA4 attribute traffic to the legacy
+        // mirror (typically `/cerca-lavoro-ticino/ricerca-X/`), not
+        // the freshly-promoted Svizzera canonical, so checking only
+        // `out.urlPath` would false-negative on essentially every
+        // cluster with real traffic.
+        const __clMirrorPaths = new Set<string>();
+        for (const mirrorCanton of [ctx.legacyCantonGroup, 'TI']) {
+          if (mirrorCanton === AGGREGATE_KEY) continue;
+          __clMirrorPaths.add(buildClusterPath(locale, ctx.candidate.slug, mirrorCanton));
+        }
+        const __clExtraKey = `${locale}::${ctx.candidate.slug}`;
+        const __clExtraPaths = indexedClusterUrlsByKey.get(__clExtraKey);
+        if (__clExtraPaths) for (const p of __clExtraPaths) __clMirrorPaths.add(p);
+        __clMirrorPaths.delete(out.urlPath);
+        const __clAllPaths = [out.urlPath, ...__clMirrorPaths];
+        const __clDecision = trafficFilter.decideMulti(__clAllPaths, 'gsc-keyword-landing');
         const __clAction: 'full' | 'thin' = __clDecision.action === 'thin' ? 'thin' : 'full';
         const __clHtml = __clAction === 'thin'
           ? buildClusterThinHtml(out.html, locale)
@@ -2313,17 +2327,10 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         // Mirrors are NOT added to sitemapLocs: only the Svizzera canonical
         // appears in sitemap-search-clusters.xml, so audit:sitemap-canonicals
         // continues to pass. Mirrors stay out of the index over time.
-        const mirrorPaths = new Set<string>();
-        for (const mirrorCanton of [ctx.legacyCantonGroup, 'TI']) {
-          if (mirrorCanton === AGGREGATE_KEY) continue; // defensive — never emit canonical as mirror
-          mirrorPaths.add(buildClusterPath(locale, ctx.candidate.slug, mirrorCanton));
-        }
-        const extraIndexedKey = `${locale}::${ctx.candidate.slug}`;
-        const extraIndexedPaths = indexedClusterUrlsByKey.get(extraIndexedKey);
-        if (extraIndexedPaths) {
-          for (const p of extraIndexedPaths) mirrorPaths.add(p);
-        }
-        mirrorPaths.delete(out.urlPath); // never overwrite canonical
+        // Mirror set was collected upstream for the decideMulti call
+        // (PR #743 fix). Reuse it here so canonical-collision dedup
+        // and per-source merging happen in exactly one place.
+        const mirrorPaths = __clMirrorPaths;
         for (const mirrorPath of mirrorPaths) {
           // Mirrors emit ONLY index.html — no flat .html bridge. The slash
           // mirror already canonicalizes to Svizzera (via the rendered

--- a/build-plugins/shared/trafficEvidenceFilter.ts
+++ b/build-plugins/shared/trafficEvidenceFilter.ts
@@ -172,6 +172,24 @@ export class TrafficEvidenceFilter {
   }
 
   decide(urlPath: string, urlClass: UrlClass): FilterDecision {
+    return this.decideMulti([urlPath], urlClass);
+  }
+
+  /**
+   * Multi-path variant: when a single piece of content is emitted at
+   * multiple URLs (canonical + locale mirrors + legacy-canton mirrors),
+   * traffic may land at ANY of them — typically the historically-
+   * indexed mirror, not the freshly-promoted canonical. Check every
+   * candidate path against the traffic-set; if ANY matches we keep the
+   * content full.
+   *
+   * Critical for relatedSearchClustersPlugin: cluster pages
+   * canonicalize to `/cerca-lavoro-svizzera/ricerca-X/` but GSC + GA4
+   * see traffic at the legacy `/cerca-lavoro-ticino/ricerca-X/`
+   * mirrors. A `decide(canonical, …)` call alone would falsely report
+   * zero traffic for ~all clusters.
+   */
+  decideMulti(urlPaths: readonly string[], urlClass: UrlClass): FilterDecision {
     if (!this.active) {
       this.decisionsFull++;
       return { action: 'full', reason: 'filter-dormant' };
@@ -181,16 +199,29 @@ export class TrafficEvidenceFilter {
       this.decisionsFull++;
       return { action: 'full', reason: 'no-pattern' };
     }
-    const norm = normalizePath(urlPath);
-    if (this.trafficSet.has(norm)) {
-      this.decisionsFull++;
-      return { action: 'full', reason: 'has-traffic' };
+    for (const p of urlPaths) {
+      if (this.trafficSet.has(normalizePath(p))) {
+        this.decisionsFull++;
+        return { action: 'full', reason: 'has-traffic' };
+      }
     }
-    // URL has zero traffic AND matches a pattern. First pattern wins.
+    // No path in the candidate set has traffic. Pattern decides.
     const pattern = patterns[0];
     if (pattern.action === 'thin') this.decisionsThin++;
     else if (pattern.action === 'skip') this.decisionsSkip++;
     return { action: pattern.action, reason: pattern.id };
+  }
+
+  /**
+   * Direct traffic-set lookup. Returns true iff the URL appears in the
+   * merged GSC topLandingPage / GA4 sessions / PostHog pages / hourly
+   * thin-page-promotions set. Use only for diagnostic/audit code —
+   * production plugins should call `decide()` or `decideMulti()` to
+   * get a complete tier decision (pattern matching + grace windows
+   * once implemented).
+   */
+  hasTraffic(urlPath: string): boolean {
+    return this.trafficSet.has(normalizePath(urlPath));
   }
 
   summary(): string {


### PR DESCRIPTION
## Summary

Post-merge sanity check on PR #742 (cluster thinning, run 26577742118) showed \`cluster tier: full=1 thin=180778\` — 99.99 % thinning rate. **329 cluster URLs with real GSC + GA4 traffic were wrongly thinned.**

Cluster pages canonicalize to \`/cerca-lavoro-svizzera/ricerca-X/\`, but GSC + GA4 attribute traffic to the legacy \`/cerca-lavoro-ticino/ricerca-X/\` mirror. The filter checked the canonical only → never saw the mirror traffic → thinned everything.

Same single-path bug also affected:
- previousSlug bridges (legacy-TI mirror for non-TI canton jobs)
- expired soft-landings (non-IT-locale legacy slug bridge)

## Fix

- New \`decideMulti(urlPaths[], urlClass)\` on \`TrafficEvidenceFilter\`. Returns \`full\` if **any** candidate path is in the traffic set. \`decide(...)\` is now a 1-element wrapper.
- New \`hasTraffic(path)\` exposed for diagnostic/audit code.
- relatedSearchClustersPlugin: compute mirror set BEFORE the decision, pass \`[canonical, ...mirrors]\`. Same Set reused for the actual mirror emit so we don't compute it twice.
- jobsSeoPagesPlugin previousSlug: \`[oldPath, legacyTIPath]\` (legacy only when canton ≠ TI).
- jobsSeoPagesPlugin soft-landing: \`[relPath, legacyRel]\` (legacy only when locale ≠ IT).
- GSC keyword landings: unchanged (single-URL emit, no mirror).

## Evidence

From \`data/evidence-index.json\`:

\`\`\`
Cluster URLs with traffic, by canton section:
  ticino  220
  tessin  109
  (svizzera) 0  ← canonical, where filter was looking
\`\`\`

## Expected next-deploy delta

\`cluster tier: full=~329 thin=~180k\` (up from \`full=1\`). The 329 reverted pages have negligible tar impact (clusters average 10 KB each → ~3 MB), but they're the ones Google actually ranks — keeping them full removes the medium-term SEO risk that PR #742 introduced.

## Test plan

- [ ] Build log: \`cluster tier: full ≥ 329\` (was 1)
- [ ] \`bridge tier\` + \`soft-landing tier\` \`full\` counts increase slightly (mirror traffic now respected)
- [ ] TAR_BYTES still well under 10 GB cap (delta ≈ 3 MB)
- [ ] \`gsc-position-rolling.json\` 30-day monitor: no regression on cluster traffic