### PR TITLE
fix(thin-shell): filter loads data/indexed-cluster-urls.json (4.9k cluster URLs)

### DIFF
--- a/build-plugins/shared/trafficEvidenceFilter.ts
+++ b/build-plugins/shared/trafficEvidenceFilter.ts
@@ -125,24 +125,52 @@ export class TrafficEvidenceFilter {
     const evidencePath = path.join(rootDir, 'data', 'evidence-index.json');
     const promotionsPath = path.join(rootDir, 'data', 'thin-page-promotions-active.json');
     const approvedPath = path.join(rootDir, 'data', 'url-pruning-approved-patterns.json');
+    const indexedClusterPath = path.join(rootDir, 'data', 'indexed-cluster-urls.json');
 
     // Build a single normalized "has traffic" set from every signal source.
     const trafficSet = new Set<string>();
+    let evGa4 = 0, evPosthog = 0, evGscTop = 0, evIndexed = 0, evPromo = 0;
     const ev = tryRead<EvidenceIndex>(evidencePath);
     if (ev) {
       for (const path of Object.keys(ev.ga4?.pages ?? {})) {
+        if (!trafficSet.has(normalizePath(path))) evGa4++;
         trafficSet.add(normalizePath(path));
       }
       for (const path of Object.keys(ev.posthog?.pages ?? {})) {
+        if (!trafficSet.has(normalizePath(path))) evPosthog++;
         trafficSet.add(normalizePath(path));
       }
       for (const q of Object.values(ev.gsc?.queries ?? {})) {
-        if (q?.topLandingPage) trafficSet.add(normalizePath(q.topLandingPage));
+        if (q?.topLandingPage) {
+          if (!trafficSet.has(normalizePath(q.topLandingPage))) evGscTop++;
+          trafficSet.add(normalizePath(q.topLandingPage));
+        }
+      }
+    }
+    // PR #743 follow-up: `data/indexed-cluster-urls.json` is the merged
+    // GSC + GA4 + PostHog union of cluster URLs Google has indexed in
+    // the last 90 d, populated by .github/workflows/refresh-indexed-
+    // cluster-urls.yml. It carries ~4.9 k URLs vs the ~300 cluster
+    // URLs that surface as GSC `topLandingPage` in evidence-index.json
+    // (which thresholds at min 5 impressions and keeps only the
+    // top-1 landing per query). Without this source the cluster
+    // filter false-thinned ~all cluster pages that rank #2+ for any
+    // query — the cluster's own `indexedClusterUrlsByKey` lookup uses
+    // the same file for mirror promotion, so the data is already
+    // production-trusted.
+    const indexedCluster = tryRead<{ indexedPaths?: string[] }>(indexedClusterPath);
+    if (Array.isArray(indexedCluster?.indexedPaths)) {
+      for (const p of indexedCluster.indexedPaths) {
+        if (!trafficSet.has(normalizePath(p))) evIndexed++;
+        trafficSet.add(normalizePath(p));
       }
     }
     const promo = tryRead<ThinPromotions>(promotionsPath);
     if (promo?.urls) {
-      for (const u of promo.urls) trafficSet.add(normalizePath(u));
+      for (const u of promo.urls) {
+        if (!trafficSet.has(normalizePath(u))) evPromo++;
+        trafficSet.add(normalizePath(u));
+      }
     }
     this.trafficSet = trafficSet;
 
@@ -161,7 +189,8 @@ export class TrafficEvidenceFilter {
     if (this.active) {
       const patternCount = approved?.patterns?.length ?? 0;
       console.log(
-        `[traffic-evidence-filter] traffic-set=${trafficSet.size} paths, ${patternCount} approved patterns`
+        `[traffic-evidence-filter] traffic-set=${trafficSet.size} paths, ${patternCount} approved patterns ` +
+        `(sources: ga4=${evGa4} posthog=${evPosthog} gsc-top=${evGscTop} indexed-cluster=${evIndexed} promotions=${evPromo})`
       );
     } else {
       console.log(


### PR DESCRIPTION
## Summary

User noted: 329 cluster URLs preserved out of 180 k seems too few. Investigation:

\`data/evidence-index.json\` uses **GSC \`topLandingPage\` per query (top-1 only, min 5 imp)** → only ~300 cluster URLs ever surface. Clusters ranking #2+ for any query are invisible.

**\`data/indexed-cluster-urls.json\` already exists in the repo** (refreshed daily by \`refresh-indexed-cluster-urls.yml\`) — it's the merged **GSC + GA4 + PostHog union** of cluster URLs Google indexed in the last 90 d:

\`\`\`
sources:
  gsc:     rowsScanned 50 999  clusterSeen 4 515  kept 4 515
  ga4:     rowsScanned 14 933  clusterSeen 1 150  kept 1 150
  posthog: rowsScanned  1 096  clusterSeen 1 093  kept 1 093

indexedPaths: 4 902
\`\`\`

The cluster plugin already trusts this file for mirror promotion via \`indexedClusterUrlsByKey\` — production-grade data.

## Fix

\`TrafficEvidenceFilter\` constructor reads it as a 4th traffic-set source alongside the existing 4 (evidence-index ga4.pages + posthog.pages + gsc topLandingPage + thin-page-promotions). Adds per-source counters to the startup log so future under-counting surfaces immediately:

\`\`\`
[traffic-evidence-filter] traffic-set=N paths, M approved patterns
  (sources: ga4=… posthog=… gsc-top=… indexed-cluster=… promotions=…)
\`\`\`

## Expected next-deploy delta

\`cluster tier: full ≈ 3-4 k thin ≈ 176 k\` (up from \`full=329\` after PR #743). Artifact saving stays ~the same (those extra 3.5 k clusters total ~30-40 MB). SEO impact: every cluster URL Google has ever indexed with traffic keeps its full HTML; only the long-tail (~175 k pages with zero indexation signal) gets thinned.

## Test plan

- [ ] Build log: \`(sources: ga4=… posthog=… gsc-top=… indexed-cluster=4900+ promotions=…)\`
- [ ] \`cluster tier: full ≥ 3000\` (was 329)
- [ ] TAR still well under 10 GB cap
- [ ] No code change in plugins — only the filter constructor