### PR TITLE
fix(thin-shell): filter loads data/gsc-job-urls.json (bridge + soft-landing safety net)

### DIFF
--- a/build-plugins/shared/trafficEvidenceFilter.ts
+++ b/build-plugins/shared/trafficEvidenceFilter.ts
@@ -92,6 +92,13 @@ interface ThinPromotions {
 function normalizePath(p: string): string {
   if (!p) return '';
   let s = p;
+  // Strip protocol + host (some traffic-source files store absolute URLs
+  // with or without `www`, e.g. `gsc-job-urls.json`). Everything we
+  // store in the traffic set is path-only so the comparison is
+  // host-agnostic.
+  if (s.startsWith('http://') || s.startsWith('https://')) {
+    try { s = new URL(s).pathname; } catch { return ''; }
+  }
   const q = s.indexOf('?'); if (q >= 0) s = s.slice(0, q);
   const h = s.indexOf('#'); if (h >= 0) s = s.slice(0, h);
   s = s.replace(/\/index\.html$/, '/');
@@ -126,10 +133,11 @@ export class TrafficEvidenceFilter {
     const promotionsPath = path.join(rootDir, 'data', 'thin-page-promotions-active.json');
     const approvedPath = path.join(rootDir, 'data', 'url-pruning-approved-patterns.json');
     const indexedClusterPath = path.join(rootDir, 'data', 'indexed-cluster-urls.json');
+    const gscJobUrlsPath = path.join(rootDir, 'data', 'gsc-job-urls.json');
 
     // Build a single normalized "has traffic" set from every signal source.
     const trafficSet = new Set<string>();
-    let evGa4 = 0, evPosthog = 0, evGscTop = 0, evIndexed = 0, evPromo = 0;
+    let evGa4 = 0, evPosthog = 0, evGscTop = 0, evIndexed = 0, evGscJobs = 0, evPromo = 0;
     const ev = tryRead<EvidenceIndex>(evidencePath);
     if (ev) {
       for (const path of Object.keys(ev.ga4?.pages ?? {})) {
@@ -165,6 +173,22 @@ export class TrafficEvidenceFilter {
         trafficSet.add(normalizePath(p));
       }
     }
+    // PR #746 follow-up: `data/gsc-job-urls.json` is the job-page analog
+    // of indexed-cluster-urls.json — a flat array of full URLs (with or
+    // without `www`) that GSC has seen for active or expired job-detail
+    // pages. ~2 k entries on 2026-05-28. Without this, bridge +
+    // soft-landing filtering false-negatives on slugs that still get
+    // GSC impressions despite not being top-1 for any query.
+    const gscJobUrls = tryRead<unknown>(gscJobUrlsPath);
+    if (Array.isArray(gscJobUrls)) {
+      for (const u of gscJobUrls) {
+        if (typeof u !== 'string' || !u) continue;
+        const norm = normalizePath(u);
+        if (!norm) continue;
+        if (!trafficSet.has(norm)) evGscJobs++;
+        trafficSet.add(norm);
+      }
+    }
     const promo = tryRead<ThinPromotions>(promotionsPath);
     if (promo?.urls) {
       for (const u of promo.urls) {
@@ -190,7 +214,7 @@ export class TrafficEvidenceFilter {
       const patternCount = approved?.patterns?.length ?? 0;
       console.log(
         `[traffic-evidence-filter] traffic-set=${trafficSet.size} paths, ${patternCount} approved patterns ` +
-        `(sources: ga4=${evGa4} posthog=${evPosthog} gsc-top=${evGscTop} indexed-cluster=${evIndexed} promotions=${evPromo})`
+        `(sources: ga4=${evGa4} posthog=${evPosthog} gsc-top=${evGscTop} indexed-cluster=${evIndexed} gsc-jobs=${evGscJobs} promotions=${evPromo})`
       );
     } else {
       console.log(


### PR DESCRIPTION
## Summary

PR #745 added \`data/indexed-cluster-urls.json\` to the trafficSet for clusters. The job-page analog exists: \`data/gsc-job-urls.json\` is a flat array of ~2 k full URLs that GSC has seen for active or expired job-detail pages. Without this source the filter false-thinned previousSlug bridges and soft-landings whose corresponding job-detail URL ranks for some query but isn't the top-1 landing for any single query.

Also added host-agnostic URL normalization (strip \`http(s)://[www.]?domain/\` prefix) so URLs stored with the full protocol (gsc-job-urls.json format) align with the path-only entries from the other sources.

## Source counter

\`\`\`
[traffic-evidence-filter] traffic-set=N paths, M approved patterns
  (sources: ga4=… posthog=… gsc-top=… indexed-cluster=…
            gsc-jobs=… promotions=…)
\`\`\`

## Re-checked 2% cluster preservation rate

User flagged: only ~5 k cluster URLs preserved out of 180 k = 2 %. Investigated:

\`\`\`
indexed-cluster-urls.json sources (90 d window):
  gsc:     rowsScanned 50 999  clusterSeen 4 515
  ga4:     rowsScanned 14 933  clusterSeen 1 150
  posthog: rowsScanned  1 096  clusterSeen 1 093
\`\`\`

GSC has only seen 4 515 unique cluster URLs in 90 d out of 180 k emitted = **2.5 % indexation rate**. This isn't a filter bug — it's the actual reality of programmatic SEO at long-tail (most auto-generated keyword combinations never get crawled or shown). 2 % preservation matches what Google has touched, which is what we want.

## Test plan

- [ ] Build log: \`gsc-jobs=N\` non-zero
- [ ] Bridge + soft-landing \`full\` counts increase slightly vs PR #745
- [ ] Cluster \`full\` count unchanged (different source)
- [ ] TAR remains well under cap