### PR TITLE
fix(validate-dist): restore master jobs.json via dedicated artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -683,6 +683,23 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+      # Master jobs.json for post-deploy validators. The deploy artifact
+      # strips dist/data/jobs.json (jobsJsonDistCleanupPlugin, PR #712) to
+      # stay under the 10 GB GH Pages cap — runtime SPA fetches the
+      # per-locale shards instead. Validators like
+      # validate:translation-completeness still need the master file with
+      # titleByLocale / descriptionByLocale, so we upload it as a small
+      # dedicated artifact (retention 1d) that post-deploy-validate-dist
+      # downloads back into data/.
+      - name: Upload master jobs.json for post-deploy validators
+        if: github.event.inputs.profile_sequential != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: jobs-master-${{ github.run_id }}
+          path: data/jobs.json
+          retention-days: 1
+          if-no-files-found: error
+
       # Post-build dist shrinker REMOVED 2026-05-22 (PR #480).
       # Originally added (PRs #473+#475+#476+#478) to recover ~190 MB
       # of HTML byte slop. After Round-2 source fixes:

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -130,6 +130,18 @@ jobs:
           name: pre-deploy-snapshot-${{ inputs.deploy_run_id }}
           path: /tmp/pre-deploy-snapshot
 
+      # Master jobs.json artifact (uploaded by deploy.yml). The deploy
+      # pipeline strips dist/data/jobs.json via jobsJsonDistCleanupPlugin
+      # (PR #712) to stay under the 10 GB GH Pages cap, but validators
+      # like validate:translation-completeness still need the master file
+      # with titleByLocale / descriptionByLocale. We download it back to
+      # data/jobs.json so the resolve-data-path lookup picks it up.
+      - name: Download master jobs.json (for source validators)
+        uses: actions/download-artifact@v5
+        with:
+          name: jobs-master-${{ inputs.deploy_run_id }}
+          path: /tmp/jobs-master
+
       - name: Download previous-slug winners (optional)
         # The build job only uploads `winners-${RUN_ID}` when
         # `data/previous-slug-winners.json` actually changed in the
@@ -157,10 +169,15 @@ jobs:
           rm -rf dist && mkdir -p dist
           tar -xf /tmp/github-pages-artifact/artifact.tar -C dist
 
-          # Expose jobs.json to scripts that expect public/data/jobs.json
-          # (the file is gitignored; dist/data/jobs.json is the built copy).
+          # Restore master data/jobs.json from the dedicated artifact
+          # (jobsJsonDistCleanupPlugin strips it from dist/ to clear the
+          # 10 GB GH Pages cap — validators still need the master copy
+          # with titleByLocale / descriptionByLocale).
+          mkdir -p data
+          cp -f /tmp/jobs-master/jobs.json data/jobs.json
+          # Expose jobs.json to scripts that expect public/data/jobs.json.
           mkdir -p public/data
-          cp -f dist/data/jobs.json public/data/jobs.json 2>/dev/null || true
+          cp -f data/jobs.json public/data/jobs.json
           # validate:crawler-summaries reads data/jobs-crawler-summaries.json,
           # gitignored and produced by `assemble-jobs-dataset.mjs` during
           # build (then copied into dist/data/ by vite). Same pattern.


### PR DESCRIPTION
## Summary
- `jobsJsonDistCleanupPlugin` (PR #712) strips `dist/data/jobs.json` post-build to clear the 10 GB GH Pages cap, but `validate:translation-completeness` in `post-deploy-validate-dist.yml` still needs the master file with `titleByLocale` / `descriptionByLocale`.
- Failing on every deploy (run 26577742118 → rc=2 "no dataset 'jobs.json' found"), non-blocking but noisy.
- Fix: upload `data/jobs.json` as a dedicated `jobs-master-<run_id>` artifact in `deploy.yml`, download it back into `data/` in `post-deploy-validate-dist.yml`. GH Pages artifact stays unchanged; translation-completeness gate stays intact.

## Test plan
- [ ] Merge → observe `validate-dist` job on the post-merge deploy run.
- [ ] Confirm `Upload master jobs.json` step succeeds in build job.
- [ ] Confirm `Download master jobs.json` step succeeds in validate-dist job.
- [ ] Confirm `validate:translation-completeness` now passes (or fails with a real translation issue, not "file not found").

🤖 Generated with [Claude Code](https://claude.com/claude-code)