### PR TITLE
fix(cluster): cross-locale candidates in decideMulti (close PR #748 gap)

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2270,7 +2270,30 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         const __clExtraPaths = indexedClusterUrlsByKey.get(__clExtraKey);
         if (__clExtraPaths) for (const p of __clExtraPaths) __clMirrorPaths.add(p);
         __clMirrorPaths.delete(out.urlPath);
-        const __clAllPaths = [out.urlPath, ...__clMirrorPaths];
+        // PR #749: cross-locale safety net for the DECISION ONLY. Each
+        // cluster context is emitted at a single locale, but the same
+        // slug at the same canton in EN/DE/FR is a separate URL with
+        // its own GSC + GA4 footprint. If any locale variant has
+        // indexation evidence the cluster stays full in EVERY locale
+        // (we own the content idea, not the per-locale page).
+        //
+        // CRITICAL: these probe-only paths are NOT added to
+        // __clMirrorPaths because that Set is reused below for the
+        // actual mirror EMIT loop. Adding cross-locale paths there
+        // would write THIS-locale's HTML at OTHER-locales' URLs —
+        // serving DE content at FR routes, etc. We keep emit + decide
+        // payloads separate.
+        const __clCrossLocaleProbes: string[] = [];
+        for (const __clOtherLocale of ['it', 'en', 'de', 'fr'] as const) {
+          if (__clOtherLocale === locale) continue;
+          for (const __clOtherCanton of [ctx.cantonGroup, ctx.legacyCantonGroup, 'TI']) {
+            if (__clOtherCanton === AGGREGATE_KEY) continue;
+            __clCrossLocaleProbes.push(buildClusterPath(__clOtherLocale, ctx.candidate.slug, __clOtherCanton));
+          }
+          const __clOtherExtras = indexedClusterUrlsByKey.get(`${__clOtherLocale}::${ctx.candidate.slug}`);
+          if (__clOtherExtras) for (const p of __clOtherExtras) __clCrossLocaleProbes.push(p);
+        }
+        const __clAllPaths = [out.urlPath, ...__clMirrorPaths, ...__clCrossLocaleProbes];
         const __clDecision = trafficFilter.decideMulti(__clAllPaths, 'gsc-keyword-landing');
         const __clAction: 'full' | 'thin' = __clDecision.action === 'thin' ? 'thin' : 'full';
         const __clHtml = __clAction === 'thin'


### PR DESCRIPTION
## Summary

User caught a gap: PR #748 added cross-locale safety nets to bridges + soft-landings + GSC keyword landings (jobsSeoPagesPlugin), but **missed the equivalent extension in relatedSearchClustersPlugin** — where the bulk of \`gsc-keyword-landing\` pages actually live.

Before this PR, cluster decideMulti at \`relatedSearchClustersPlugin.ts:2274\` checked only THIS locale's variants:
- canonical Svizzera URL
- canton mirrors (legacyCanton + TI)
- \`indexedClusterUrlsByKey\` extras keyed by locale

So an EN cluster with zero EN evidence got thinned even when the IT cluster at the same slug+canton had 200 GSC impressions.

## Fix

Add cross-locale probe paths to the decideMulti candidates: for each OTHER locale (it/en/de/fr), build (a) cantonGroup + legacyCantonGroup + TI mirrors with the other locale's section prefix, and (b) locale-keyed extras from \`indexedClusterUrlsByKey\`.

**CRITICAL design subtlety**: the probe paths are kept in a SEPARATE variable (\`__clCrossLocaleProbes\`), not added to \`__clMirrorPaths\`. The mirror Set is reused below for the actual mirror EMIT loop — adding cross-locale paths there would write THIS-locale's HTML at OTHER-locales' URLs (serving DE content at FR routes). The probes feed only the DECISION; emits remain locale-bound.

Initial commit on this branch confused the two and was force-pushed with the fix.

## Expected impact

Bridge + soft-landing + kw-landing patterns already had cross-locale safety (PR #748). Now clusters do too. \`cluster tier: full\` count should increase by the number of cluster contexts whose other-locale variants have evidence. Likely a 2-4x bump given how IT-skewed the source data is.

## Test plan

- [ ] Build log: \`cluster tier: full\` count significantly higher than ~3-4 k post-#745
- [ ] No emit at unexpected cross-locale path (sample 5 EN clusters, verify they emit at \`/en/find-jobs-…/\` only, not at \`/de/…/\` or \`/fr/…/\`)
- [ ] No regression in TAR (cross-locale extra-fulls add ~50-100 MB, still well under cap)