### PR TITLE
chore(ci): disabilita PR review workflow (sospetto consumo API)

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -14,7 +14,12 @@ jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event.pull_request.draft == false
+    # DISABILITATO: il run 26586585273 ha registrato total_cost_usd: 0.64 nonostante
+    # claude_code_oauth_token settato. Da chiarire se telemetria informativa
+    # (subscription quota, mostrata in USD equivalente) o consumo reale API credits.
+    # Riabilitare SOLO dopo verifica su console.anthropic.com / claude.ai/usage
+    # che il billing non addebita le run dell'action.
+    if: false && github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Implementato
- `.github/workflows/pr-review-loop.yml`: aggiunto `if: false &&` sul job per disabilitarlo. Workflow non parte più su `pull_request` events.
- Commento inline nel file con motivo e link al run sospetto (26586585273).

## Non implementato (ancora)
- **Verifica billing**: l'utente deve controllare manualmente `console.anthropic.com/settings/billing` o `claude.ai/usage` per confermare se il run 26586585273 ha consumato API credits o quota subscription. Critico per decidere se riabilitare.
- **Fix permission denials**: il run ha registrato 22 permission_denials per tentativi di Bash bloccati. Quando riabiliteremo, aggiungere `--allowedTools 'Bash(gh:*),Read,Grep,Glob'` a `claude_args`. Bloccato dalla verifica costi.
- **`show_full_output: true`**: per debug del prompt response, da aggiungere alla riabilitazione.

## Test plan
- [ ] Merge.
- [ ] Verificare che nessun nuovo run parta su PR aperte (questa PR inclusa).
- [ ] Aprire console.anthropic.com → verificare se sono apparsi addebiti dal run del 16:06-16:11 UTC.

## Motivazione urgenza
Vincolo zero-cost del progetto. Run 26586585273 ha `total_cost_usd: 0.64241435` nel telemetry — ambiguo se subscription o API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)