### PR TITLE
chore(ci): riabilita PR review + fix tool permissions

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -14,12 +14,11 @@ jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # DISABILITATO: il run 26586585273 ha registrato total_cost_usd: 0.64 nonostante
-    # claude_code_oauth_token settato. Da chiarire se telemetria informativa
-    # (subscription quota, mostrata in USD equivalente) o consumo reale API credits.
-    # Riabilitare SOLO dopo verifica su console.anthropic.com / claude.ai/usage
-    # che il billing non addebita le run dell'action.
-    if: false && github.event.pull_request.draft == false
+    # Auth via CLAUDE_CODE_OAUTH_TOKEN da subscription Max (consuma quota piano,
+    # non API credits). Verificato zero-cost: nessuna org Anthropic Console,
+    # Usage credits $0.00 spent, "Extra usage not enabled". I total_cost_usd nel
+    # log dell'action sono telemetria informativa equivalente API, non addebiti.
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -41,7 +40,8 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 15 --model claude-sonnet-4-6"
+          show_full_output: true
+          claude_args: "--max-turns 15 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
           prompt: |
             Sei il reviewer automatico per la PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}").
 


### PR DESCRIPTION
## Implementato
- Rimosso `if: false &&` dal job → workflow torna attivo su `pull_request` events.
- Aggiornato commento inline che documenta la verifica zero-cost (Usage credits \$0.00, no org Console, Extra usage not enabled, total_cost_usd = telemetria).
- Aggiunto `--allowedTools 'Bash(gh:*),Read,Grep,Glob'` a `claude_args` → reviewer può eseguire `gh pr view / diff / review`. Il run precedente aveva 22 permission_denials e zero review postate proprio per questa mancanza.
- Aggiunto `show_full_output: true` per esporre il contenuto dell'agent nel log dell'action (debug).

## Non implementato (ancora)
- **Verifica end-to-end review postata**: serve aprire una PR organica con sezioni Implementato/Non implementato dichiarate dopo merge per confermare che il reviewer arrivi davvero a postare un commento. Bloccato dal merge di questa PR.
- **Severity gate / fail su 🔴 Important**: tenuto fuori. Per il workflow attuale autore = me/agent in interattivo, blocco automatico aggiungerebbe friction senza valore.
- **Inline comments per-line**: la review continua a uscire come singolo commento bottom. Non critico per il funnel; follow-up se la UX diventa un blocker.

## Test plan
- [ ] Merge.
- [ ] Aprire una PR organica con le due sezioni dichiarate → verificare review postata con formato caveman.
- [ ] Aprire una PR senza sezioni dichiarate → verificare che reviewer posti SOLO il finding process e termini.
- [ ] Controllare \`/usage\` locale dopo qualche run per vedere il delta cost-equivalent (informativo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)