### PR TITLE
feat(deploy): bypass deploy-pages 10-min cap via live marker file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -603,6 +603,20 @@ jobs:
       - name: SPA fallback (GitHub Pages serves 404.html for unknown paths)
         run: cp dist/index.html dist/404.html
 
+      # Marker file used by the deploy job's extended-polling step to
+      # verify that the live site has been updated even when
+      # `actions/deploy-pages@v5` aborts its own polling at the hard
+      # 10-minute cap. Filename starts with `__` so it's obvious it is
+      # an infra marker, not user-facing content.
+      - name: Generate live deploy marker
+        run: |
+          built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          printf '{"sha":"%s","run_id":%s,"built_at":"%s"}\n' \
+            "${GITHUB_SHA}" "${GITHUB_RUN_ID}" "${built_at}" \
+            > dist/__deploy_marker.json
+          echo "marker:"
+          cat dist/__deploy_marker.json
+
       - name: Capture pre-deploy sitemap URLs (for IndexNow diff)
         if: github.event.inputs.profile_sequential != 'true'
         continue-on-error: true
@@ -963,6 +977,16 @@ jobs:
       # GitHub Pages allows only one deployment at a time. When concurrent
       # pushes trigger this workflow, the second run can hit "in progress
       # deployment" errors. Retry once after a short wait to handle this.
+      #
+      # `actions/deploy-pages@v5` ALSO caps its internal status polling at
+      # 10 minutes (the `timeout: 1800000` we pass is silently clamped to
+      # 600000 — see the warning emitted at start of the step). For sites
+      # with >1M files the Pages backend's `syncing_files` phase can run
+      # well past 10 minutes, causing the action to abort with
+      # `Timeout reached, aborting!` even though the deployment itself
+      # eventually completes server-side. The marker-based extended
+      # polling below recognises that case and keeps the job green when
+      # the live site actually came up.
       - name: Deploy to GitHub Pages
         id: deployment_first
         uses: actions/deploy-pages@v5
@@ -974,20 +998,53 @@ jobs:
       - name: Wait for previous Pages deployment to finish
         if: steps.deployment_first.outcome == 'failure'
         run: |
-          echo "::warning::First deploy attempt failed (likely Pages busy). Retrying in 30s..."
+          echo "::warning::First deploy attempt failed (likely Pages busy or 10-minute polling cap). Retrying in 30s..."
           sleep 30
 
       - name: Deploy to GitHub Pages (retry)
         id: deployment
         if: steps.deployment_first.outcome == 'failure'
         uses: actions/deploy-pages@v5
+        continue-on-error: true
         with:
           timeout: 1800000
           error_count: 100
 
-      - name: Fail if both deploy attempts failed
-        if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome != 'success'
-        run: exit 1
+      # Extended polling: when deploy-pages times out because backend
+      # `syncing_files` runs past the action's 10-minute cap, the
+      # deployment continues server-side. Verify completion by curling
+      # the marker file (`dist/__deploy_marker.json`, written in the
+      # build job) until the live SHA matches `github.sha`.
+      #
+      # Skipped entirely when either deploy attempt succeeded — the
+      # action's own success signal is authoritative in that case.
+      - name: Verify live deploy via marker file
+        id: marker_check
+        if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome == 'failure'
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+          MARKER_URL: https://frontaliereticino.ch/__deploy_marker.json
+        run: |
+          set -u
+          MAX_TRIES=50      # 50 × 30s = 25 minutes of extended polling
+          INTERVAL=30
+          echo "::notice::Both deploy-pages attempts hit the 10-minute polling cap. Verifying via live marker at ${MARKER_URL} (max $((MAX_TRIES*INTERVAL/60))min)."
+          for i in $(seq 1 ${MAX_TRIES}); do
+            body=$(curl -fsS -m 15 --retry 0 "${MARKER_URL}?cb=$(date +%s)" 2>/dev/null || true)
+            if [ -n "$body" ]; then
+              live_sha=$(printf '%s' "$body" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("sha",""))' 2>/dev/null || true)
+              if [ "$live_sha" = "$EXPECTED_SHA" ]; then
+                echo "::notice::Live marker matches SHA after $((i*INTERVAL))s of extended polling — deploy succeeded server-side."
+                exit 0
+              fi
+              echo "[$i/${MAX_TRIES}] live SHA ${live_sha:0:8} != expected ${EXPECTED_SHA:0:8}"
+            else
+              echo "[$i/${MAX_TRIES}] marker not yet reachable"
+            fi
+            sleep ${INTERVAL}
+          done
+          echo "::error::Live marker never matched SHA ${EXPECTED_SHA:0:8} after ${MAX_TRIES} × ${INTERVAL}s — treating as a real deploy failure."
+          exit 1
 
       - name: Save deploy metadata to Firestore
         if: success()


### PR DESCRIPTION
## Problema

`actions/deploy-pages@v5` ha hard cap **10 minuti** sul polling status — il config `timeout: 1800000` viene silently clamped a 600000ms (warning visibile a start step). Con 1.14M file in `dist/`, la fase `syncing_files` del backend GH Pages routinely dura >10min → action aborts con `Timeout reached, aborting!` anche se il deploy completa server-side subito dopo.

**Net effect**: production stuck (es. site stuck a `last-modified: 05:23 GMT` di stamattina nonostante 3+ deploy successivi).

## Soluzione

Canale di verifica out-of-band via marker file con SHA del commit.

### Implementato

1. **Build job** scrive `dist/__deploy_marker.json` = `{"sha":"<github.sha>","run_id":<id>,"built_at":"<iso>"}`. Shipped at `/__deploy_marker.json` sul site.
2. **Deploy job**: entrambi i tentativi `deploy-pages` ora hanno `continue-on-error: true` (retry prima failavano hard).
3. **NUOVO step** `Verify live deploy via marker file`: gated su `outcome=failure` di entrambi i deploy. Curla il marker live ogni 30s per max 25min. Exit 0 il momento in cui `live_sha == github.sha`.

### Semantica risultante

| Scenario | Job outcome |
|---|---|
| Deploy-pages step success al primo tentativo | success (marker_check skipped) |
| Primo fail (timeout 10min), retry success | success (marker_check skipped) |
| Entrambi i deploy fail, marker appare live entro 25min | success (matched real success server-side) |
| Entrambi i deploy fail, marker mai live in 25min | failure (real backend block) |

Safety net non si è allentata: real failure server-side genera comunque job failure. Solo i "fake fail" da polling cap diventano success corretti.

### Non implementato

- Nessuna riduzione file count
- Nessuna sostituzione di `actions/deploy-pages@v5`
- Nessun cambio retention/concurrency

## Test plan

- [ ] Trigger workflow live su main post-merge
- [ ] Verificare che `dist/__deploy_marker.json` venga emesso (visibile in build log)
- [ ] Se action timeout → `marker_check` step appare nel deploy job
- [ ] Curl manuale `https://frontaliereticino.ch/__deploy_marker.json` post-deploy → contiene SHA corrente
- [ ] `last-modified` header avanza oltre `05:23 GMT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)