### PR TITLE
fix(grace-window): historical initial seed + working dist-history push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -832,14 +832,24 @@ jobs:
           git config user.email "dist-history-bot@frontaliereticino.ch"
           git add data/dist-size-history.jsonl data/url-first-seen.json
           git commit -m "chore(dist-history): append run ${GITHUB_RUN_ID} (${GITHUB_SHA::8})"
+          # The build job leaves dist/ and other generated files dirty
+          # in the working tree. `git pull --rebase` refuses to run
+          # while unstaged changes exist (`cannot pull with rebase: You
+          # have unstaged changes`), so we ran the retry loop three
+          # times for nothing on every deploy and the url-first-seen
+          # update never landed on origin. `rebase.autoStash=true`
+          # stashes those untracked/unstaged files before rebase and
+          # pops them back after — purely scoped to this command, no
+          # leftover stash state.
           for i in 1 2 3; do
-            if git pull --rebase origin main && git push origin HEAD:main; then
+            if git -c rebase.autoStash=true pull --rebase origin main \
+                && git push origin HEAD:main; then
               echo "[dist-history] pushed on attempt $i"
               exit 0
             fi
             sleep 5
           done
-          echo "[dist-history] push failed after 3 attempts (continuing anyway)"
+          echo "::warning::[dist-history] push failed after 3 attempts — url-first-seen.json will not be available to the next build's grace-window check"
 
       - name: Upload Pages artifact (compression-level 9)
         if: github.event.inputs.profile_sequential != 'true'

--- a/scripts/refresh-url-first-seen.mjs
+++ b/scripts/refresh-url-first-seen.mjs
@@ -31,16 +31,32 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
+// Initial seed date — used the FIRST time this script runs against an
+// empty url-first-seen.json. Backfills every URL discovered in dist
+// sitemaps with a historical date so the 15-day grace window does not
+// retroactively mark every existing URL as `full` for two weeks.
+// Effective semantics:
+//   - File empty (initial seed)  → stamp all current URLs with this date
+//                                  (past the longest grace window in any
+//                                  approved pattern → no grace → thinning
+//                                  decisions match current behaviour)
+//   - File non-empty (steady state) → stamp NEW URLs with today's date
+//                                     (15-day grace protects them)
+// Override with `--initial-seed-date=YYYY-MM-DD` for local backfills.
+const DEFAULT_INITIAL_SEED_DATE = '2026-04-01';
+
 function parseArgs(argv) {
   const out = {
     dist: 'dist',
     out: 'data/url-first-seen.json',
     dryRun: false,
+    initialSeedDate: DEFAULT_INITIAL_SEED_DATE,
   };
   for (const a of argv) {
     if (a === '--dry-run') out.dryRun = true;
     else if (a.startsWith('--dist=')) out.dist = a.slice(7);
     else if (a.startsWith('--out=')) out.out = a.slice(6);
+    else if (a.startsWith('--initial-seed-date=')) out.initialSeedDate = a.slice(20);
   }
   return out;
 }
@@ -117,15 +133,28 @@ async function main() {
     }
   }
 
+  // Initial seed = empty file. Without special-casing, every URL would
+  // get stamped with today's date, putting the entire emit set inside
+  // the 15-day grace window and effectively disabling thinning until
+  // those entries age out. Use a historical seed date (well past every
+  // approved pattern's `minAgeDays`) so existing URLs behave as
+  // "already old" and only URLs added in FUTURE runs receive today's
+  // stamp + real 15-day protection.
+  const isInitialSeed = Object.keys(existing).length === 0;
   const today = new Date().toISOString().slice(0, 10);
+  const stampDate = isInitialSeed ? args.initialSeedDate : today;
+  console.log(
+    `[url-first-seen] mode: ${isInitialSeed ? 'INITIAL-SEED' : 'incremental'} ` +
+    `(stampDate=${stampDate})`
+  );
   let added = 0;
   for (const u of allUrls) {
     if (!existing[u]) {
-      existing[u] = today;
+      existing[u] = stampDate;
       added++;
     }
   }
-  console.log(`[url-first-seen] ${added} new URLs stamped with ${today}; ${Object.keys(existing).length} total entries`);
+  console.log(`[url-first-seen] ${added} new URLs stamped with ${stampDate}; ${Object.keys(existing).length} total entries`);
 
   if (args.dryRun) {
     console.log(`[url-first-seen] dry-run — file not written`);


### PR DESCRIPTION
## Problema

Doppia bug nel grace window 15-day del `trafficEvidenceFilter`:

### Bug 1 — push silenziosamente fallito

`data/url-first-seen.json` non finiva mai su origin/main. Build job log:
\`\`\`
2026-05-28T17:56:25 [main f60da209] chore(dist-history): append run...
2026-05-28T17:56:25 error: cannot pull with rebase: You have unstaged changes.
2026-05-28T17:56:30 error: cannot pull with rebase: You have unstaged changes.
2026-05-28T17:56:35 error: cannot pull with rebase: You have unstaged changes.
2026-05-28T17:56:40 [dist-history] push failed after 3 attempts (continuing anyway)
\`\`\`

`git pull --rebase` rifiuta perché dist/ e generated files sono dirty nel working tree. Retry loop fallisce 3 volte. `continue-on-error: true` maschera il problema. → Su origin/main il file resta \`{}\` per sempre → filter log mostra costante \`0 first-seen timestamps\` → grace mai applicata.

### Bug 2 — initial seed con data di oggi

Anche con push funzionante, refresh script stampava OGNI URL con data di oggi al primo run su file vuoto. Risultato: 600k+ URL stampati 2026-05-28 → `seenAt > cutoffMs (oggi - 15gg)` TRUE per tutti → return `'full' reason 'grace'` per tutti → **thinning disattivato per 15 giorni**.

## Soluzione

### Fix 1 — `rebase.autoStash=true`

```diff
- if git pull --rebase origin main && git push origin HEAD:main; then
+ if git -c rebase.autoStash=true pull --rebase origin main \
+     && git push origin HEAD:main; then
```

Stash unstaged → rebase → pop. Atomico, scoped solo a questa command. Push log final elevato a `::warning::` per visibilità.

### Fix 2 — initial-seed mode con data storica

```js
const isInitialSeed = Object.keys(existing).length === 0;
const stampDate = isInitialSeed ? args.initialSeedDate : today;
```

- File vuoto (initial seed) → tutti URL → `2026-04-01` (58gg fa, oltre ogni `minAgeDays` approvato)
- File popolato (incremental) → solo URL NUOVI → today
- Monotonic preservato in entrambi i modi (URL esistenti mai sovrascritti)

Default seed overridabile via `--initial-seed-date=YYYY-MM-DD`.

## Verifica locale

Tested con tmp sitemap:

| Run | Esistente | Output |
|---|---|---|
| 1 (file vuoto) | `{}` | mode=INITIAL-SEED, 2 URLs → `2026-04-01` |
| 2 (file popolato + 1 URL nuovo) | 2 entries | mode=incremental, solo URL nuovo → `2026-05-28`, esistenti preservati |

## Impatto deploy

Post-merge:
1. Prossimo run build legge file ancora vuoto su main → INITIAL-SEED stampa ~600k URL con `2026-04-01`
2. Refresh step committa il file (ora con autoStash, push funziona)
3. Run successivi leggono file popolato → grace 15gg attiva solo per URL NUOVI
4. Thinning continua su URL esistenti (~600k stampati storici, oltre cutoff)

## Non implementato

- Backfill `firstSeenAt` reali da `data/jobs/by-crawler/*.json` (avrebbe dato date accurate per job-derived URL, ma 2026-04-01 storico è sufficiente: thinning decisions identical, e nuovi URL ancora protetti correttamente da quando entrano nel file)
- Backfill da git log su data files (overkill per il bisogno attuale)
- Test vitest dedicato (script CLI semplice + verifica manuale due-pass coprono i path)

## Test plan

- [ ] Merge → osserva prossimo deploy run su main
- [ ] Build log: `[url-first-seen] mode: INITIAL-SEED (stampDate=2026-04-01)`
- [ ] Build log: `[url-first-seen] N new URLs stamped with 2026-04-01; N total entries`
- [ ] Commit step: `[dist-history] pushed on attempt 1` (no più "push failed")
- [ ] Verifica su origin/main dopo deploy: `git show origin/main:data/url-first-seen.json | wc -l` > 100k
- [ ] Run successivo: filter log `traffic-set=... patterns, N first-seen timestamps` con N > 0
- [ ] Run successivo: tier counters dovrebbero rimanere ~91% thinned (storici non graced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)