### PR TITLE
fix(auto-merge): use '## LGTM' header signal (no false negative su meta-🔴)

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -11,17 +11,20 @@ permissions:
 jobs:
   auto-merge:
     # Trigger condizioni:
-    # - review autore = GitHub App con login "claude[bot]" (verificato via API:
-    #   user.login == "claude[bot]", user.type == "Bot", user.id == 209825114).
-    #   Usiamo type == 'Bot' + startsWith come safety net se il login cambia.
-    # - review.state = "commented" (gh pr review --comment)
-    # - body senza 🔴 (LGTM o solo 🟡 Nit)
-    # - PR non draft
+    # - review autore = GitHub App "claude[bot]" (user.type=='Bot' + startsWith
+    #   safety net).
+    # - review.state = "commented" (gh pr review --comment).
+    # - body contiene `## LGTM` (signal esplicito da REVIEW.md: "Zero 🔴
+    #   Important: chiudi con `## LGTM`"). Sostituisce il check precedente
+    #   `!contains(body, '🔴')` che generava false negatives quando il bot
+    #   scriveva meta-language tipo "Nessun 🔴 Important" per affermare zero
+    #   blocker — l'emoji nel testo di negazione bloccava il merge.
+    # - PR non draft.
     if: |
       github.event.review.user.type == 'Bot' &&
       startsWith(github.event.review.user.login, 'claude') &&
       github.event.review.state == 'commented' &&
-      !contains(github.event.review.body, '🔴') &&
+      contains(github.event.review.body, '## LGTM') &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Implementato
- `.github/workflows/auto-merge-on-lgtm.yml`: sostituita condition `!contains(github.event.review.body, '🔴')` con `contains(github.event.review.body, '## LGTM')`.
- Aggiornato commento inline: documenta il false negative caso (bot scrive "Nessun 🔴 Important" come negazione → emoji nel testo blocca merge), il fix, e il riferimento al contract REVIEW.md.

## Non implementato (ancora)
- **Validazione su body senza `## LGTM` ma comunque positivo**: REVIEW.md richiede `## LGTM` esplicito quando zero Important. Se il reviewer dimentica → merge non scatta (preferibile: false negative > false positive su un sistema di auto-merge). Verificare su 5+ run successivi che il bot inserisca sempre `## LGTM` quando dovuto.
- **Severity gate parsing strutturato**: il check rimane substring match. Un parser che legge `## Findings (Important: N, Nit: M)` ed estrae N sarebbe più robusto. Costo: più codice nello YAML; valore: marginale finché il bot rispetta REVIEW.md.
- **Retry post-fix per PR #762**: la review è stata postata con la vecchia condition; l'evento non si re-trigga in automatico. Va mergeata manualmente dopo questo fix (o pusha empty commit per nuovo review event).

## Test plan
- [ ] Merge questa PR (modifica auto-merge-on-lgtm.yml → workflow-validation della GitHub App → reviewer non posta sul PR → merge manuale per eccezione).
- [ ] Merge manuale di PR #762 (review già LGTM, ma auto-merge era skipped → recupero manuale).
- [ ] Prossima PR organica con review LGTM: verificare che auto-merge ora scatti correttamente.
- [ ] Prossima PR con review che contiene `🟡 Nit` e `## LGTM`: verificare che auto-merge scatti (Nit non blocca).

🤖 Generated with [Claude Code](https://claude.com/claude-code)