### PR TITLE
test: unblock no-twitter-meta-dupes timeout + posthog-fetcher mock

### DIFF
--- a/tests/seo/no-twitter-meta-dupes.test.ts
+++ b/tests/seo/no-twitter-meta-dupes.test.ts
@@ -42,10 +42,14 @@ function walkTs(root: string): string[] {
   return out;
 }
 
-function findOffenders(root: string, re: RegExp) {
+function findOffenders(root: string, re: RegExp, fastFilter: string) {
   const offenders: { file: string; lines: string[] }[] = [];
   for (const file of walkTs(root)) {
     const src = readFileSync(file, 'utf8');
+    // Fast substring pre-filter — services/ has ~10k .ts files (146 MB), most
+    // are blog/locale content with no meta code. Skipping them via an
+    // includes() check turns this gate from ~minutes to <1 s.
+    if (!src.includes(fastFilter)) continue;
     re.lastIndex = 0;
     const matches = [...src.matchAll(re)];
     if (matches.length === 0) continue;
@@ -62,7 +66,7 @@ function findOffenders(root: string, re: RegExp) {
 
 describe('no twitter:* meta in source', () => {
   it('forbids static <meta name="twitter:*"> in build-plugins/*.ts', () => {
-    const offenders = findOffenders('build-plugins', STATIC_META_RE);
+    const offenders = findOffenders('build-plugins', STATIC_META_RE, 'twitter:');
     if (offenders.length > 0) {
       const report = offenders.map((o) => `${o.file}:\n  ${o.lines.join('\n  ')}`).join('\n');
       throw new Error(
@@ -74,7 +78,7 @@ describe('no twitter:* meta in source', () => {
   });
 
   it('forbids client-side updateOrCreateMetaTag("name","twitter:*",…) in services/*.ts', () => {
-    const offenders = findOffenders('services', RUNTIME_META_RE);
+    const offenders = findOffenders('services', RUNTIME_META_RE, 'updateOrCreateMetaTag(');
     if (offenders.length > 0) {
       const report = offenders.map((o) => `${o.file}:\n  ${o.lines.join('\n  ')}`).join('\n');
       throw new Error(


### PR DESCRIPTION
## Summary
Origin/main aveva già shippato 4 dei 5 fix (vite.config FAST_BUILD callback, build-plugin-order test isolation, analytics-instrumentation lstatSync + skip symlinks, tracking file canton-refresh). Resta solo il timeout su `tests/seo/no-twitter-meta-dupes.test.ts`.

`services/` ha ~10.6k file `.ts` per 146 MB. Pesanti: `seo-blog*.ts` 2.8 MB, `blog-meta-*.ts` 1.2 MB ciascuno. Il walk + `matchAll` regex su tutti superava il timeout vitest di 15s.

Fix: pre-filtro `src.includes(fastFilter)` (O(n) substring) prima della regex → ~99% dei file viene scartato cheap → ~3s end-to-end.

## Implementato
- [x] Pre-filtro substring in `findOffenders`
- [x] Pass entrambi i casi del filename: `'twitter:'` per static meta, `'updateOrCreateMetaTag('` per runtime
- [x] Verificato locale: 3220ms (vs timeout precedente)

## Non implementato (out-of-scope esplicito)
- ❌ Niente refactor del walk: stesso algoritmo dello stack-based DFS pre-esistente, identical semantics
- ❌ Niente espansione del regex pattern: stessa offensive surface, solo skip cheap dei file innocui
- ❌ Niente parallelizzazione/workerizzazione: non serve, il pre-filter copre 99% dei file
- ❌ Niente cambio di soglia timeout: AGENTS.md vieta abbassare le soglie per passare i build

## Test plan
- [x] `npx vitest run tests/seo/no-twitter-meta-dupes.test.ts` → 2 test passed, 3220ms
- [ ] CI tests.yml su questa branch