### PR TITLE
feat(reviewer): cross-file probing + post-merge follow-up triage

### DIFF
--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -1,0 +1,72 @@
+name: Post-merge follow-up triage
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  followup:
+    # Trigger condizioni:
+    # - PR merged (non solo chiuso).
+    # - Autore PR = repo owner (skip dependabot/forks).
+    # - Auth via CLAUDE_CODE_OAUTH_TOKEN (subscription Max, zero API cost).
+    # Lo scope è leggere PR body `## Non implementato` + reviewer 🟡/❓ e creare
+    # issue con label `follow-up` quando il filtro scopo passa. Vedi FOLLOWUP.md.
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'valerielinc-ops'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Run Claude follow-up triage
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          claude_args: "--max-turns 15 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
+          prompt: |
+            Triage automatico follow-up per PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}") appena mergiata.
+
+            **Bootstrap:**
+            1. Leggi `FOLLOWUP.md` — contratto operativo completo (parse rules, filtro scopo, dedup, issue format, closing comment).
+            2. Leggi `REVIEW.md → "Scopo progetto"` per il filtro funnel.
+            3. Carica:
+               - `gh pr view $PR_NUMBER --json number,title,body,mergedAt,mergeCommit,url`
+               - `gh api repos/$REPO/pulls/$PR_NUMBER/reviews`
+               - `gh issue list --label follow-up --state all --json number,title,body --limit 50`
+
+            **Esegui workflow come specificato in FOLLOWUP.md:**
+            - Parse PR body `## Non implementato` (skip motivi `out of scope` / `posposto`).
+            - Parse reviewer bot review più recente: estrai 🟡 nit, ❓ q, `## Adversarial check` bullets. Skip 🔴 (già fixed o droppato consapevolmente pre-merge).
+            - Filtro scopo (`REVIEW.md`): item passa se impatta monetizzazione / traffico / funnel.
+            - Dedup vs issue `follow-up` esistenti (titolo >70% similar → skip).
+            - Crea issue per candidate validi, max 10/PR. Label: `follow-up` + UNO funnel-* se inferibile.
+            - Posta `## Post-merge follow-up triage` summary commento sulla PR.
+
+            **Constraint:**
+            - Read-only eccetto `gh issue create`, `gh pr comment`.
+            - Mai modificare PR label/state/title.
+            - Mai chiudere/riaprire issue.
+            - Incerto sul filtro → crea con rationale "needs triage".
+            - Zero candidate → `## Post-merge follow-up triage: zero outstanding items.` e termina.

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -30,6 +30,30 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Determine review tier
+        id: tier
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # Tier high (opus, max-turns 25, adversarial pass): toccato test gate,
+        # workflow CI, script crawler/migrator/validator, build-plugin. Bug in
+        # questi path = falso senso di sicurezza che si propaga su ogni merge,
+        # quindi probing più profondo paga. Tier normal (sonnet, max-turns 15)
+        # per tutto il resto. Vedi REVIEW.md → "Tier review".
+        run: |
+          set -euo pipefail
+          files=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')
+          if echo "$files" | grep -qE '^(tests/|\.github/workflows/|scripts/|build-plugins/)'; then
+            echo "tier=high" >> "$GITHUB_OUTPUT"
+            echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"
+            echo "max_turns=25" >> "$GITHUB_OUTPUT"
+          else
+            echo "tier=normal" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
+            echo "max_turns=15" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Review tier: $(grep tier= "$GITHUB_OUTPUT" | head -1)"
+
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
         env:
@@ -38,19 +62,28 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_TIER: ${{ steps.tier.outputs.tier }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
-          claude_args: "--max-turns 15 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
+          # Tool expansion: aggiunti `Bash(rg:*)`, `Bash(git:*)` per consentire
+          # cross-file pattern search (REVIEW.md → Reviewer behavior step 5) e
+          # navigation history (`git log -L`, `git blame`, `git show`). Tier high
+          # paga il bump opus per probing regex/assertion/idempotency.
+          claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(rg:*),Bash(git:*),Read,Grep,Glob'"
           prompt: |
-            Reviewer automatico PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}").
+            Reviewer automatico PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}"). Tier: ${{ steps.tier.outputs.tier }}.
 
             **Bootstrap:**
-            1. Leggi `REVIEW.md` — contratto operativo completo (severity, filtro scopo, completeness contract, format, esempi).
+            1. Leggi `REVIEW.md` — contratto operativo completo (tier, severity, filtro scopo, completeness contract, cross-file pattern repetition, test plan compliance, adversarial check, format).
             2. `AGENTS.md` solo come contesto progetto (non-negotiables, architettura) — opzionale, leggi solo se serve.
             3. Carica PR: `gh pr view $PR_NUMBER --json title,body,labels`, `gh pr diff $PR_NUMBER`, `gh pr view $PR_NUMBER --json files`.
 
-            **Esegui workflow di review come specificato in REVIEW.md** (steps: completeness contract → Implementato critical thinking → Non implementato filtro scopo → scope drift → output).
+            **Esegui workflow di review come specificato in REVIEW.md:**
+            - completeness contract → Implementato critical thinking → Non implementato filtro scopo → scope drift → cross-file pattern repetition (step 5) → test plan compliance (step 6) → output.
+            - Tier high: aggiungi sezione `## Adversarial check` con 3 cose NON verificate prima del summary finale.
+
+            **Cross-file pattern probing (REVIEW.md step 5):** quando il diff fix-a un pattern (regex, parsing idiom, assertion shape), usa `rg` per cercare il pattern equivalente nel resto del repo. Pattern presente non toccato in file funnel-critico → 🔴; altrove → 🟡.
 
             **Posta UNA review:**
             `gh pr review $PR_NUMBER --comment --body "<markdown formato REVIEW.md>"`
@@ -58,5 +91,6 @@ jobs:
             **Constraint:**
             - Single-pass, una sola review per run.
             - Read-only: no push, no edit file.
-            - Zero finding accettabile → chiudi con `## LGTM`. Non inventare per riempire.
+            - Zero finding accettabile → chiudi con `## LGTM` (string esatta triggera auto-merge). Non inventare per riempire.
+            - 🔴 aperto → NON scrivere `## LGTM`.
             - Incerto → `❓ q:`, no speculazione.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Iniettato in ogni sessione agent. Detail durevole nei docs, carica on-demand.
 - Parallel/subagent → sempre worktree isolati, mai shared dir.
 - Auto commit+push task successful. PR-as-merge-vehicle: create PR, squash merge, delete remote branch, remove worktree.
 - PR body OBBLIGATORIO con `## Implementato` (cosa fa) + `## Non implementato (ancora)` (scope NON fatto + motivo: out of scope / follow-up / blocked / posposto). Reviewer automatico legge per gating. Vedi `REVIEW.md`.
-- PR ready per `main` → reviewer Claude posta review e il workflow `auto-merge-on-lgtm.yml` mergia automaticamente se review body non contiene `🔴`. L'agent NON deve mergere a mano: aspetta che `gh pr view <N> --json state` ritorni `MERGED`, poi cleanup worktree + branch locale. Gating: `## LGTM` o solo `🟡 Nit` → auto-merge; `🔴 Important` o 🔴 process "missing sections" → no merge automatico, agent legge la review e applica fix in nuovo commit sullo stesso branch (re-review automatica). Altre CI (test/lighthouse/build) NON attese — osserva su `main` post-merge. **Eccezione:** PR che modifica `.github/workflows/pr-review-loop.yml`, `.github/workflows/auto-merge-on-lgtm.yml` o `REVIEW.md` → workflow-validation failure GitHub App, reviewer non posta, auto-merge non scatta → merge manuale via `gh pr merge --squash --delete-branch`; verifica su prossima PR organica.
+- PR ready per `main` → reviewer Claude posta review e il workflow `auto-merge-on-lgtm.yml` mergia automaticamente se review body contiene la stringa esatta `## LGTM`. L'agent NON deve mergere a mano: aspetta che `gh pr view <N> --json state` ritorni `MERGED`, poi cleanup worktree + branch locale. Gating: `## LGTM` → auto-merge; `🔴 Important` o 🔴 process "missing sections" → no `## LGTM`, no auto-merge, agent legge la review e applica fix in nuovo commit sullo stesso branch (re-review automatica). Altre CI (test/lighthouse/build) NON attese — osserva su `main` post-merge. **Eccezione:** PR che modifica `.github/workflows/pr-review-loop.yml`, `.github/workflows/auto-merge-on-lgtm.yml`, `.github/workflows/post-merge-followup.yml`, `REVIEW.md` o `FOLLOWUP.md` → workflow-validation failure GitHub App, reviewer non posta, auto-merge non scatta → merge manuale via `gh pr merge --squash --delete-branch`; verifica su prossima PR organica.
 - Post-merge check/deploy fail → mai fix diretto su `main`; nuovo worktree+branch, fix root cause, nuova PR, merge, riosserva `main`.
 - Pre-task-close: audit worktree/branch. PR merged → delete remote branch + remove worktree immediato. Not merged → lascia + dichiara decisione merge/abandon esplicita.
 - GitHub operations: `gh` CLI only.
@@ -39,6 +39,14 @@ Iniettato in ogni sessione agent. Detail durevole nei docs, carica on-demand.
 - E2E: Playwright CLI o Codex Browser. No preview-only tools.
 - Touch function/class/method → GitNexus impact analysis prima. Pre-commit → GitNexus detect changes.
 - Mai full build locale; trigger/validate via GitHub Actions.
+
+## Post-merge feedback handling
+
+- Reviewer bot posta 🔴/🟡/❓ in review body. **Mai silent ignore di 🟡/❓.** Workflow `post-merge-followup.yml` triagia automaticamente post-merge: legge PR body `## Non implementato` + reviewer 🟡/❓/adversarial-check, applica filtro scopo (`REVIEW.md`), crea issue `follow-up` + summary commento sulla PR. Contratto in `FOLLOWUP.md`.
+- 🔴 Important blocca merge (auto-merge richiede `## LGTM`). Se compare 🔴 → fix in nuovo commit sullo stesso branch, re-review automatica.
+- Agent inizio task DEVE controllare `gh issue list --label follow-up --state open` se tocca area correlata. Issue follow-up esistente per scope corrente → linkare nel PR body (`## Implementato` chiude issue con `Closes #N`) o aggiornare l'issue con rationale.
+- Test plan PR body con `- [ ]` non spuntate post-merge → spunta dopo verifica live, oppure converti in issue follow-up. Reviewer flagga come 🟡 quelle non verificabili pre-merge (vedi `REVIEW.md → "Test plan compliance"`).
+- Eccezione drop senza issue: nit puro stilistico-deferibile (non funnel) → reply inline sulla PR review thread con motivo "deferred — non funnel-critical". `post-merge-followup.yml` lo include automaticamente nella sezione "Dropped" del summary.
 
 ## Build And Test
 

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -1,0 +1,92 @@
+# Follow-up Triage Instructions
+
+Contratto operativo per `post-merge-followup.yml`. Triage automatico post-merge: estrae lavoro residuo da PR body + reviewer comments, crea issue con label `follow-up` per evitare evaporazione dello scope deferred.
+
+## Scopo
+
+Ogni 🟡 nit, ❓ q del reviewer bot e voce `## Non implementato` del PR body DEVE risultare in: (a) issue con label `follow-up`, o (b) drop motivato. Nessun silent ignore. Filtra via scopo progetto (vedi `REVIEW.md` → "Scopo progetto").
+
+## Input
+
+- PR merged: `gh pr view $PR_NUMBER --json number,title,body,mergedAt,mergeCommit,url`
+- Reviewer bot reviews: `gh api repos/$REPO/pulls/$PR_NUMBER/reviews` (filtra `user.type == "Bot"` + `user.login` starts `claude`)
+- Issue esistenti collegate: `gh issue list --label follow-up --state all --search "PR #$PR_NUMBER" --json number,title,body`
+
+## Parse rules
+
+### Da PR body
+
+Estrai sezione `## Non implementato (ancora)`. Ogni bullet `- **X** — Y` → candidate item.
+
+- Voci con motivo `out of scope` o `posposto` → skip (esplicitamente droppate).
+- Voci con motivo `follow-up`, `blocked`, `deferred`, o senza motivo → candidate issue.
+
+### Da reviewer bot reviews
+
+Parse il body markdown della review più recente. Per ogni riga:
+
+- `🔴 Important: ...` → SKIP. 🔴 blocca merge, se la PR è merged significa che è stato fixato in-PR o droppato consapevolmente. Non creare follow-up per 🔴 retroattivi.
+- `🟡 Nit: ...` → candidate issue.
+- `❓ q: ...` → candidate issue (rephrase come "Verifica: <q>").
+- `🟣 Pre-existing: ...` → candidate issue solo se file ancora presente nel diff (`gh pr diff`).
+- `## Adversarial check` bullets → candidate issue per ogni voce (3 typical).
+
+## Filtro scopo
+
+Applica `REVIEW.md → "Scopo progetto"`. Item passa SE impatta monetizzazione / traffico organico / funnel reale. Altrimenti drop con rationale loggato nel commento di chiusura sulla PR.
+
+## Dedup
+
+Prima di creare issue:
+- `gh issue list --label follow-up --state all --search "<keyword from item>"` — se match titolo >70% similar → skip + log "duplicate of #N".
+- Cerca link a issue/PR nel testo dell'item (`#NNN`) → se referenziato issue/PR open → skip.
+
+## Issue format
+
+```markdown
+Title: follow-up(#<PR>): <one-line item>
+
+Body:
+## Origine
+- PR: #<PR_NUMBER> <PR_TITLE> (merged <mergedAt>)
+- Source: <PR body Non implementato | reviewer 🟡 nit | reviewer ❓ q | adversarial check>
+- Original text:
+  > <verbatim>
+
+## Scope filter
+- Funnel impact: <monetizzazione | traffico | funnel | none>
+- Rationale: <perché passa il filtro>
+
+## Suggested action
+<concrete next step se ovvio dal contesto; altrimenti "investigate + decide drop or impl">
+```
+
+Labels: `follow-up`, e UNO tra `funnel-monetization` / `funnel-seo` / `funnel-ux` se inferibile dal scope filter.
+
+## Closing comment
+
+Dopo aver creato issue (o droppato item), posta UN commento sulla PR riepilogativo:
+
+```markdown
+## Post-merge follow-up triage
+
+Created: N issue
+- #<id1> <title1>
+- #<id2> <title2>
+
+Dropped: M item
+- "<verbatim>" — <reason: out-of-scope | dup-of-#X | non-funnel>
+
+Skipped: P item (🔴 pre-merge or duplicate active follow-up)
+```
+
+Se zero issue create + zero drop → posta `## Post-merge follow-up triage: zero outstanding items.`
+
+## Constraint
+
+- Read-only su tutto eccetto: `gh issue create`, `gh pr comment`.
+- Mai modificare label/state/title della PR.
+- Mai chiudere/riaprire issue.
+- Zero finding accettabile (PR LGTM puro senza Non implementato). NON inventare.
+- Incerto sul filtro scopo → crea issue comunque, rationale "needs triage". Drop è più costoso di una issue extra.
+- Limite hard: max 10 issue create per PR. Oltre → posta commento "throttled, manual triage needed" e termina.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -32,6 +32,17 @@ Non passa nessuno → drop. Non importante per questo progetto.
 - "Aggiungi test" generico senza target+motivo funnel
 - Cavilli architetturali se la soluzione attuale funziona
 
+## Tier review (effort + adversarial depth)
+
+Determina tier dai file toccati. Reviewer regola depth+probing in base a tier.
+
+| Tier | Trigger files | Adversarial depth |
+|---|---|---|
+| **high** | `tests/**`, `.github/workflows/**`, `scripts/**` (validators, migrators, crawlers), `build-plugins/**` | Bug nel test/CI/build = falso senso sicurezza che si propaga su ogni merge. Probe regex/assertion/exit-code/idempotency. Lista 3 cose NON verificate prima dell'output (`## Adversarial check`). |
+| **normal** | tutto il resto | Single-pass standard. No adversarial step obbligatorio. |
+
+High-tier non implica più 🔴 — implica più probing. Filtro scopo identico.
+
 ## Completeness contract
 
 PR body DEVE avere:
@@ -50,6 +61,12 @@ PR body DEVE avere:
 2. **Non implementato item** → filtro scopo: critico per monetizzazione/traffico? SÌ → 🔴 chiedi impl pre-merge o follow-up issue. NO → ignora.
 3. **Diff fa cose non dichiarate** → 🟡 scope drift: "diff fa X non in scope. PR separata o aggiungi a Implementato."
 4. **Sezioni mancanti** → 🔴 process: "manca Implementato/Non implementato nel PR body. Aggiungere prima review sostanziale." Termina, no altri finding.
+5. **Cross-file pattern repetition** → quando il diff fix-a un pattern (regex, parsing idiom, assertion shape) in 1 file, `rg`/`grep` su pattern equivalente nel resto repo. Se stesso anti-pattern presente altrove non toccato → 🔴 se file funnel-critico (crawler/build-plugin/test gate), 🟡 altrove. Esempio: A3 fix regex `<link rel="canonical"...>` → cerca regex simili su HTML in altri test/crawler.
+6. **Test plan compliance** → PR body con `## Test plan` o checklist `- [ ]`: ogni voce è verificabile pre-merge o richiede live? Se richiede live, ok merged-without-tick MA flag come 🟡 ricorda spunta post-merge. Se verificabile pre-merge + non spuntata + reviewer non può confermare dal diff → 🟡 chiedi conferma o issue follow-up.
+
+### Pre-output adversarial check (tier high)
+
+PR a tier `high` (`tests/**`, `.github/workflows/**`, `scripts/**`, `build-plugins/**`): prima del summary finale, includi sezione `## Adversarial check` con 3 cose NON verificate (regex edge case non testato, exit-code path non esplorato, file related non aperto, idempotency assumption). Surface come ❓ q dove pertinente. Tier normal: skip questa sezione.
 
 ## Verification
 
@@ -82,17 +99,22 @@ Prefix: `🔴 Important` / `🟡 Nit` / `🟣 Pre-existing` / `❓ q:`.
 - `services/router.ts:L42: 🔴 Important: parsePath() ritorna null per /lavoro/ticino, route non hydrata. Aggiungere case prima del fallback.`
 - `build-plugins/job-page.ts:L88: 🔴 Important: jobLocation omesso da JSON-LD quando city null. Google rifiuta structured data → de-index. Defaultare "Ticino"/"Switzerland".`
 - `components/AdSlot.tsx:L23: 🔴 Important: container senza min-height, Auto Ads anchor → CLS 0.18 mobile. min-height: 90px.`
+- `scripts/lib/bls-job-parser.mjs:L182: 🔴 Important: regex `<span class="info">` quote-strict, stesso anti-pattern fixato in `tests/seo/cathedral-previous-slug-canton.test.ts:L153` di questa PR. Crawler funnel-critico → silent zero-match su class variant. Allarga a `class=["']?[^"'>]*\binfo\b`.`
 - `lib/locale.ts:L17: 🟡 Nit: switch 4 rami → map literal. -12 righe.`
 - `pages/SoftLandingPage.tsx:L156: ❓ q: check staticOverlay dopo parsePath() — corretto vs feedback router_preserve_search?`
+- `PR body Test plan L3: 🟡 Nit: checkbox "post-deploy gate verde" richiede live, ok merge ma flagga spunta o crea issue follow-up post-deploy.`
 
 ## Summary body
 
 ```markdown
 ## Scope
-<una frase: scopo PR>
+<una frase: scopo PR> (tier: high|normal)
 
 ## Findings (Important: N, Nit: M)
 <lista>
+
+## Adversarial check
+<solo tier high: 3 cose NON verificate>
 ```
 
-Zero 🔴 Important: chiudi con `## LGTM` + frase recap.
+Zero 🔴 Important: chiudi con `## LGTM` + frase recap. **Critico:** la stringa esatta `## LGTM` triggera auto-merge in `auto-merge-on-lgtm.yml`. Non scrivere mai `## LGTM` se hai aperto un 🔴 in findings o adversarial check.


### PR DESCRIPTION
## Summary

Bundle che chiude 3 gap del reviewer + agent feedback loop, partendo dal post-mortem di PR #767 dove il bot ha mancato (a) regex `class=\"info\"` BLS che ripeteva esattamente il bug A3 sui canonical test, (b) test plan checklist non verificata pre-merge, (c) nessun follow-up per `## Non implementato`.

## Implementato

### A — Reviewer signal expansion (`REVIEW.md` + `pr-review-loop.yml`)

- **Tier review high|normal** dai file toccati. Trigger high: `tests/**`, `.github/workflows/**`, `scripts/**`, `build-plugins/**`. High = bump a `claude-opus-4-7` + `--max-turns 25` + adversarial pass obbligatorio. Normal resta sonnet 15.
- **Step 5 — Cross-file pattern repetition**: quando il diff fixa un pattern (regex, parsing idiom, assertion shape), reviewer cerca pattern equivalente nel resto del repo con `rg`. Stesso anti-pattern in file funnel-critico (crawler/build-plugin/test gate) = 🔴, altrove = 🟡.
- **Step 6 — Test plan compliance**: checkbox `- [ ]` in PR body → se verificabili pre-merge ma non spuntate = 🟡 + richiesta conferma; se richiedono live = 🟡 reminder spunta post-deploy o issue follow-up.
- **`## Adversarial check`** (tier high only): reviewer DEVE listare 3 cose NON verificate prima del summary finale. Surface come ❓ q dove pertinente.
- **Tool whitelist allargata**: aggiunti `Bash(rg:*)`, `Bash(git:*)` (era solo `Bash(gh:*),Read,Grep,Glob`) per consentire cross-file search + history navigation.
- **Auto-merge guard**: REVIEW.md ora dichiara esplicitamente che la stringa `## LGTM` triggera `auto-merge-on-lgtm.yml` e va omessa se c'è 🔴 in findings o adversarial check.
- Step "Determine review tier" computa tier + model + max_turns via `gh pr view --files` e li espone in `steps.tier.outputs.*`.

### B — Post-merge follow-up automation (nuovo `post-merge-followup.yml` + `FOLLOWUP.md`)

- Workflow nuovo trigger `pull_request: closed` + `merged == true` + autore owner.
- Agent legge: PR body `## Non implementato`, ultima review del bot (🟡/❓/adversarial bullets), issue `follow-up` esistenti.
- Filtra via scopo progetto (`REVIEW.md`), dedup vs issue esistenti (titolo >70% similar), crea issue con label `follow-up` + uno tra `funnel-monetization`/`funnel-seo`/`funnel-ux`.
- Posta summary commento sulla PR con Created/Dropped/Skipped + rationale per ogni drop.
- Hard cap: 10 issue/PR (throttle anti-runaway). Auth subscription Max → zero API cost.

### C — Agent contract (`AGENTS.md`)

- Sezione nuova "Post-merge feedback handling": **mai silent ignore di 🟡/❓** del bot reviewer.
- Agent inizio task DEVE controllare `gh issue list --label follow-up --state open` se tocca area correlata.
- Eccezione drop senza issue: nit puro stilistico-deferibile via reply inline con motivo "deferred — non funnel-critical".
- Workflow-validation exception list aggiornata: aggiunti `post-merge-followup.yml` e `FOLLOWUP.md` ai file che richiedono merge manuale.
- Sezione Workflow allineata al fatto che auto-merge richiede letteralmente `## LGTM` (era ambigua "review body non contiene 🔴").

## Non implementato (ancora)

- **MCP gitnexus nel reviewer** — richiede daemon in CI runner, non disponibile. Aggiunto `Bash(git:*)` + `Bash(rg:*)` come fallback funzionale.
- **Issue dedup semantico** (titolo >70% similar) — implementazione lasciata all'agent runtime via prompt, no embedding/fuzzy match deterministico. Drift possibile → throttle 10 issue/PR caps il blast.
- **Migration issue follow-up vecchie PR** (pre questa change) — non rebuildiamo storico. Solo PR future triagiate.
- **Conditional model per PR mista** (alcuni file high, alcuni normal) → trigger conservativo a high se *anche un solo* file matcha. Possibile over-spend opus su PR cross-area. Accettato (sicurezza > costo).
- **Adversarial check non parsato da `post-merge-followup.yml`** come fonte separata — incluso implicitamente come "🟡/❓ in review body" via parsing markdown. Se la sezione `## Adversarial check` non viene emessa, nessun item perso (il reviewer surface-a comunque come ❓ q nel findings list).

## Test plan

- [ ] CI: review check pass (workflow-validation potrebbe fallire come da AGENTS.md → merge manuale)
- [ ] Post-merge: prossima PR organica → reviewer logga tier corretto in step "Determine review tier"
- [ ] Post-merge: PR organica con `tests/`/`.github/workflows/` → review body include `## Adversarial check`
- [ ] Post-merge: PR organica con `## Non implementato` → `post-merge-followup.yml` triggera + summary commento appare sulla PR + issue create con label `follow-up`
- [ ] Verifica `gh workflow run post-merge-followup.yml --ref main` non più necessario dopo prima organica (workflow on `pull_request` non `workflow_dispatch`)

## Reference

- Gap analysis su PR #767 (regex BLS↔canonical, test plan non spuntato, scope deferred non issue-ato)
- Auto-merge gating preserved: `## LGTM` rimane stringa esatta richiesta

🤖 Generated with [Claude Code](https://claude.com/claude-code)