### PR TITLE
fix(ci): GitHub Issues reporter — perms+env on 13 workflows + harden 2 tests

### DIFF
--- a/.github/workflows/cathedral-noindex-flip.yml
+++ b/.github/workflows/cathedral-noindex-flip.yml
@@ -39,6 +39,7 @@ on:
 
 permissions:
   contents: write
+  issues: write     # for github-issue-creator on failure
 
 concurrency:
   group: cathedral-noindex-flip
@@ -116,7 +117,7 @@ jobs:
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/cathedral-noindex-flip.mjs --no-dry-run --threshold=${{ steps.mode.outputs.threshold }} && git add data/cathedral-flip-log.json"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/deploy-cloud-functions.yml
+++ b/.github/workflows/deploy-cloud-functions.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write     # for github-issue-creator on failure
 
 concurrency:
   group: deploy-cloud-functions
@@ -55,7 +56,7 @@ jobs:
       - name: Deploy Firestore indexes
         run: firebase deploy --only firestore:indexes --project frontaliere-ticino
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write     # for github-issue-creator on failure
 
 concurrency:
   group: deploy-firestore-rules
@@ -51,7 +52,7 @@ jobs:
       - name: Deploy Firestore security rules
         run: firebase deploy --only firestore:rules --project frontaliere-ticino
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write     # for github-issue-creator on build/deploy failure
 
 jobs:
   build:
@@ -896,9 +897,11 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      - name: Report failure to Linear (build)
+      - name: Report failure to GitHub Issues (build)
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure (build): ${{ github.workflow }} — run ${{ github.run_number }}" \
@@ -1077,9 +1080,11 @@ jobs:
             --og-image="${OG_IMAGE}" \
             --article-category="${ARTICLE_CATEGORY}"
 
-      - name: Report failure to Linear (deploy)
+      - name: Report failure to GitHub Issues (deploy)
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure (deploy): ${{ github.workflow }} — run ${{ github.run_number }}" \
@@ -1403,9 +1408,11 @@ jobs:
           timeout: 1800000
           error_count: 100
 
-      - name: Report rollback to Linear
+      - name: Report rollback to GitHub Issues
         if: always()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ steps.still-live.outputs.still_live }}" != "true" ]; then
             MSG="## Rollback skippato (newer deploy already live)

--- a/.github/workflows/persist-job-stats.yml
+++ b/.github/workflows/persist-job-stats.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  issues: write     # for github-issue-creator on failure
 
 concurrency:
   group: persist-job-stats
@@ -59,7 +60,7 @@ jobs:
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/assemble-jobs-dataset.mjs --stats && git add data/jobs-stats-history.json data/jobs-keys-snapshot.json"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       contents: write   # for git push in sync-previous-slug-winners
       actions: read     # for download-artifact same-run
+      issues: write     # for github-issue-creator on publish failure
     steps:
       - name: Checkout (same SHA as deploy — invariant in workflow_call)
         uses: actions/checkout@v5
@@ -246,9 +247,11 @@ jobs:
             --run-id="${{ github.run_id }}" \
             --sha="${{ github.sha }}"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Publish post-deploy fallita — run ${{ github.run_number }}" \

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read     # for download-artifact same-run (github-pages, sitemaps)
+      issues: write     # for github-issue-creator on validation failure (run 26592389280 surfaced "Resource not accessible by integration (createIssue)")
     steps:
       - name: Checkout (same SHA as deploy — invariant in workflow_call)
         uses: actions/checkout@v5
@@ -536,9 +537,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "Validation Failure (dist): post-deploy — run ${{ github.run_number }}" \

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: read    # read-only — winners git push moved to publish.yml
       actions: read     # for download-artifact same-run
+      issues: write     # for github-issue-creator on validation failure (run 26592389280 surfaced "Resource not accessible by integration (createIssue)")
     steps:
       - name: Checkout (same SHA as deploy — invariant in workflow_call)
         uses: actions/checkout@v5
@@ -175,7 +176,7 @@ jobs:
           path: test-results/
           retention-days: 14
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/refresh-article-trending.yml
+++ b/.github/workflows/refresh-article-trending.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  issues: write     # for github-issue-creator on failure
 
 concurrency:
   group: refresh-article-trending
@@ -69,7 +70,7 @@ jobs:
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/fetch-article-trending.mjs && git add public/article-trending.json"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/refresh-bfs-stats.yml
+++ b/.github/workflows/refresh-bfs-stats.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   actions: write
+  issues: write     # for github-issue-creator on failure
 
 concurrency:
   group: refresh-bfs-stats
@@ -109,9 +110,11 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Dispatched with \`url=$URL\` for new quarter \`$NEW_QUARTER\`." >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/lib/github-issue-creator.mjs \
             --title "CI Failure: Refresh BFS Stats — run ${{ github.run_number }}" \

--- a/.github/workflows/refresh-job-popularity.yml
+++ b/.github/workflows/refresh-job-popularity.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  issues: write     # for github-issue-creator on failure
 
 concurrency:
   group: refresh-job-popularity
@@ -66,7 +67,7 @@ jobs:
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/fetch-job-popularity.mjs && git add data/job-popularity.json"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/send-job-alerts.yml
+++ b/.github/workflows/send-job-alerts.yml
@@ -17,6 +17,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write     # for github-issue-creator on failure
 
 jobs:
   send-alerts:
@@ -65,7 +66,7 @@ jobs:
           SKIP_NEWSLETTER_COOLDOWN: ${{ inputs.target_email != '' && '1' || '' }}
         run: node scripts/send-job-alerts.mjs
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: steps.send-alerts.outcome == 'failure'
         continue-on-error: true
         env:

--- a/.github/workflows/translate-pending.yml
+++ b/.github/workflows/translate-pending.yml
@@ -37,6 +37,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write     # for github-issue-creator on failure
 
 env:
   NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
@@ -232,7 +233,7 @@ jobs:
             echo "   The next cron run will retry and trigger deploy once all jobs are translated."
           fi
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-a-plus-plus-group.yml
+++ b/.github/workflows/update-jobs-a-plus-plus-group.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update A++ Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-aarreha-schinznach.yml
+++ b/.github/workflows/update-jobs-aarreha-schinznach.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update aarReha Schinznach jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-abb.yml
+++ b/.github/workflows/update-jobs-abb.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "⚡ Auto-update ABB jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-abbott.yml
+++ b/.github/workflows/update-jobs-abbott.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ABBOTT jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-adullam.yml
+++ b/.github/workflows/update-jobs-adullam.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ADULLAM jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-adus-klinik.yml
+++ b/.github/workflows/update-jobs-adus-klinik.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ADUS Klinik jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-afry.yml
+++ b/.github/workflows/update-jobs-afry.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update AFRY jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-agie-charmilles.yml
+++ b/.github/workflows/update-jobs-agie-charmilles.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "Auto-update AGIE Charmilles jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-agroscope.yml
+++ b/.github/workflows/update-jobs-agroscope.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "Auto-update Agroscope jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ail.yml
+++ b/.github/workflows/update-jobs-ail.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update AIL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-air-zermatt.yml
+++ b/.github/workflows/update-jobs-air-zermatt.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "Auto-update Air Zermatt AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-alcon.yml
+++ b/.github/workflows/update-jobs-alcon.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ALCON jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-aldi-suisse.yml
+++ b/.github/workflows/update-jobs-aldi-suisse.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🛒 Auto-update ALDI Suisse jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-allianz.yml
+++ b/.github/workflows/update-jobs-allianz.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Allianz Suisse jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-alpiq.yml
+++ b/.github/workflows/update-jobs-alpiq.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "⚡ Auto-update Alpiq jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-alprose.yml
+++ b/.github/workflows/update-jobs-alprose.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Alprose jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-alten.yml
+++ b/.github/workflows/update-jobs-alten.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: \${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🧩 Auto-update ALTEN jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-amag.yml
+++ b/.github/workflows/update-jobs-amag.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update AMAG Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ameos-ch.yml
+++ b/.github/workflows/update-jobs-ameos-ch.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update AMEOS Schweiz jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-apg-sga.yml
+++ b/.github/workflows/update-jobs-apg-sga.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update APG|SGA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ardentis.yml
+++ b/.github/workflows/update-jobs-ardentis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ARDENTIS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ariston.yml
+++ b/.github/workflows/update-jobs-ariston.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🔥 Auto-update Ariston Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-arosa-lenzerheide.yml
+++ b/.github/workflows/update-jobs-arosa-lenzerheide.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Arosa Lenzerheide jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-arsante-clinique-de-carouge.yml
+++ b/.github/workflows/update-jobs-arsante-clinique-de-carouge.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Arsanté jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-artificialy.yml
+++ b/.github/workflows/update-jobs-artificialy.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "Auto-update Artificialy jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-artisa.yml
+++ b/.github/workflows/update-jobs-artisa.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Artisa Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-arxada.yml
+++ b/.github/workflows/update-jobs-arxada.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Arxada jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-asana-spital.yml
+++ b/.github/workflows/update-jobs-asana-spital.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ASANA_SPITAL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-avaloq.yml
+++ b/.github/workflows/update-jobs-avaloq.yml
@@ -82,7 +82,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🛠️ Auto-update Avaloq jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-axa.yml
+++ b/.github/workflows/update-jobs-axa.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "Auto-update AXA Svizzera jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-axpo.yml
+++ b/.github/workflows/update-jobs-axpo.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "⚡ Auto-update Axpo Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bachem.yml
+++ b/.github/workflows/update-jobs-bachem.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BACHEM jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bachtelen.yml
+++ b/.github/workflows/update-jobs-bachtelen.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Bachtelen jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-badrutts-palace.yml
+++ b/.github/workflows/update-jobs-badrutts-palace.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Badrutt's Palace Hotel jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-balgrist.yml
+++ b/.github/workflows/update-jobs-balgrist.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BALGRIST jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bally.yml
+++ b/.github/workflows/update-jobs-bally.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Bally jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-banca-sempione.yml
+++ b/.github/workflows/update-jobs-banca-sempione.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏦 Auto-update Banca del Sempione jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bcvs.yml
+++ b/.github/workflows/update-jobs-bcvs.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Banque Cantonale du Valais jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-benteler.yml
+++ b/.github/workflows/update-jobs-benteler.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Benteler jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-berit-klinik.yml
+++ b/.github/workflows/update-jobs-berit-klinik.yml
@@ -84,7 +84,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BERIT_KLINIK jobs (dedicated crawler)" data/jobs-crawler-adapters/adapters/berit-klinik.json
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-berner-klinik-montana.yml
+++ b/.github/workflows/update-jobs-berner-klinik-montana.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BERNER_KLINIK_MONTANA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-berner-montage.yml
+++ b/.github/workflows/update-jobs-berner-montage.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Montagetechnik BERNER AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bethesda-spital.yml
+++ b/.github/workflows/update-jobs-bethesda-spital.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BETHESDA_SPITAL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bitfinex.yml
+++ b/.github/workflows/update-jobs-bitfinex.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Bitfinex jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bls.yml
+++ b/.github/workflows/update-jobs-bls.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BLS AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bms-building.yml
+++ b/.github/workflows/update-jobs-bms-building.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BMS Building Materials jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-board.yml
+++ b/.github/workflows/update-jobs-board.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💻 Auto-update Board International jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bobst.yml
+++ b/.github/workflows/update-jobs-bobst.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Bobst jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bosch.yml
+++ b/.github/workflows/update-jobs-bosch.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🔴 Auto-update Bosch jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bps-suisse.yml
+++ b/.github/workflows/update-jobs-bps-suisse.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏦 Auto-update BPS Suisse jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-bracco.yml
+++ b/.github/workflows/update-jobs-bracco.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update Bracco Suisse jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-buergenstock-hotels.yml
+++ b/.github/workflows/update-jobs-buergenstock-hotels.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update BUERGENSTOCK_HOTELS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-burkhalter.yml
+++ b/.github/workflows/update-jobs-burkhalter.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Burkhalter Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cambiavalute.yml
+++ b/.github/workflows/update-jobs-cambiavalute.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💱 Auto-update CambiaValute.ch jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-canton-ticino-osc.yml
+++ b/.github/workflows/update-jobs-canton-ticino-osc.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CANTON_TICINO_OSC jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-canton-valais.yml
+++ b/.github/workflows/update-jobs-canton-valais.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Canton du Valais jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-capri-holdings.yml
+++ b/.github/workflows/update-jobs-capri-holdings.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "👜 Auto-update Capri Holdings jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-caritas-schweiz.yml
+++ b/.github/workflows/update-jobs-caritas-schweiz.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Caritas Schweiz jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-casale.yml
+++ b/.github/workflows/update-jobs-casale.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "⚗️ Auto-update Casale SA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-caseificio-gottardo.yml
+++ b/.github/workflows/update-jobs-caseificio-gottardo.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🧀 Auto-update Caseificio del Gottardo jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cds-savognin.yml
+++ b/.github/workflows/update-jobs-cds-savognin.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CDS SAVOGNIN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cedes.yml
+++ b/.github/workflows/update-jobs-cedes.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "📡 Auto-update CEDES jobs (dedicated crawler)" data/jobs-crawler-adapters/
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-centiel.yml
+++ b/.github/workflows/update-jobs-centiel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "⚡ Auto-update Centiel jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cerbios-pharma.yml
+++ b/.github/workflows/update-jobs-cerbios-pharma.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💊 Auto-update Cerbios-Pharma jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cereneo.yml
+++ b/.github/workflows/update-jobs-cereneo.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CERENEO jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-chicco-doro.yml
+++ b/.github/workflows/update-jobs-chicco-doro.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Chicco d'Oro jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-citta-di-bellinzona.yml
+++ b/.github/workflows/update-jobs-citta-di-bellinzona.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏛️ Auto-update Città di Bellinzona jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-citta-di-locarno.yml
+++ b/.github/workflows/update-jobs-citta-di-locarno.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏛️ Auto-update Città di Locarno jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-citta-di-lugano.yml
+++ b/.github/workflows/update-jobs-citta-di-lugano.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏛️ Auto-update Città di Lugano jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-claraspital.yml
+++ b/.github/workflows/update-jobs-claraspital.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLARASPITAL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cler.yml
+++ b/.github/workflows/update-jobs-cler.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏦 Auto-update Cler jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clienia-ag.yml
+++ b/.github/workflows/update-jobs-clienia-ag.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLIENIA_AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinica-hildebrand.yml
+++ b/.github/workflows/update-jobs-clinica-hildebrand.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLINICA_HILDEBRAND jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinica-holistica-engiadina.yml
+++ b/.github/workflows/update-jobs-clinica-holistica-engiadina.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLINICA_HOLISTICA_ENGIADINA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinica-varini.yml
+++ b/.github/workflows/update-jobs-clinica-varini.yml
@@ -88,7 +88,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLINICA_VARINI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-cic.yml
+++ b/.github/workflows/update-jobs-clinique-cic.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique CIC jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-de-genolier.yml
+++ b/.github/workflows/update-jobs-clinique-de-genolier.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique de Genolier jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-de-la-plaine.yml
+++ b/.github/workflows/update-jobs-clinique-de-la-plaine.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique de la Plaine jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-de-montchoisi.yml
+++ b/.github/workflows/update-jobs-clinique-de-montchoisi.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique de Montchoisi jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-de-valere.yml
+++ b/.github/workflows/update-jobs-clinique-de-valere.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique de Valère jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-generale-beaulieu.yml
+++ b/.github/workflows/update-jobs-clinique-generale-beaulieu.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique Générale-Beaulieu jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-generale-ste-anne.yml
+++ b/.github/workflows/update-jobs-clinique-generale-ste-anne.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique Générale Ste-Anne jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-la-source.yml
+++ b/.github/workflows/update-jobs-clinique-la-source.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Clinique de La Source jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-clinique-le-noirmont.yml
+++ b/.github/workflows/update-jobs-clinique-le-noirmont.yml
@@ -84,7 +84,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CLINIQUE_LE_NOIRMONT jobs (dedicated crawler)" data/jobs-crawler-adapters/adapters/clinique-le-noirmont.json
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cnp.yml
+++ b/.github/workflows/update-jobs-cnp.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CNP jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-colin-cie.yml
+++ b/.github/workflows/update-jobs-colin-cie.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Colin&Cie jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-concara.yml
+++ b/.github/workflows/update-jobs-concara.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CONCARA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-confederazione.yml
+++ b/.github/workflows/update-jobs-confederazione.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏛️ Auto-update Confederazione Ticino jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-constellium.yml
+++ b/.github/workflows/update-jobs-constellium.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Constellium Valais jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-convit.yml
+++ b/.github/workflows/update-jobs-convit.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Convit Holding jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-coop.yml
+++ b/.github/workflows/update-jobs-coop.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Coop jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-coopers.yml
+++ b/.github/workflows/update-jobs-coopers.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Coopers Group AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-corner.yml
+++ b/.github/workflows/update-jobs-corner.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏦 Auto-update Corner jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-crr-suva-sion.yml
+++ b/.github/workflows/update-jobs-crr-suva-sion.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CRR Suva jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cs-bregaglia.yml
+++ b/.github/workflows/update-jobs-cs-bregaglia.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CS_BREGAGLIA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-csc-costruzioni.yml
+++ b/.github/workflows/update-jobs-csc-costruzioni.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update CSC Costruzioni jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-csd-engineers.yml
+++ b/.github/workflows/update-jobs-csd-engineers.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CSD ENGINEERS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-cseb.yml
+++ b/.github/workflows/update-jobs-cseb.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Center da Sanadad Engiadina Bassa jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-csl-behring.yml
+++ b/.github/workflows/update-jobs-csl-behring.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CSL_BEHRING jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-csvm-mustair.yml
+++ b/.github/workflows/update-jobs-csvm-mustair.yml
@@ -91,7 +91,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CSVM_MUSTAIR jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-csvp-poschiavo.yml
+++ b/.github/workflows/update-jobs-csvp-poschiavo.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update CSVP_POSCHIAVO jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-daler-hopital.yml
+++ b/.github/workflows/update-jobs-daler-hopital.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Daler jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-damiani.yml
+++ b/.github/workflows/update-jobs-damiani.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💎 Auto-update Damiani jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-davos-klosters-bergbahnen.yml
+++ b/.github/workflows/update-jobs-davos-klosters-bergbahnen.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏔️ Auto-update Davos Klosters Bergbahnen jobs (dedicated crawler)" data/jobs-crawler-adapters/
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-debiopharm.yml
+++ b/.github/workflows/update-jobs-debiopharm.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update DEBIOPHARM jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-decathlon.yml
+++ b/.github/workflows/update-jobs-decathlon.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏃 Auto-update Decathlon jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-delvitech.yml
+++ b/.github/workflows/update-jobs-delvitech.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🔴 Auto-update Delvitech jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-denner.yml
+++ b/.github/workflows/update-jobs-denner.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏪 Auto-update Denner jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-diakoniewerk-neumuenster.yml
+++ b/.github/workflows/update-jobs-diakoniewerk-neumuenster.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Diakoniewerk Neumünster jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-dxt.yml
+++ b/.github/workflows/update-jobs-dxt.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update DXT Commodities jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-efg.yml
+++ b/.github/workflows/update-jobs-efg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update EFG jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ehc-vd.yml
+++ b/.github/workflows/update-jobs-ehc-vd.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update EHC jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ehnv.yml
+++ b/.github/workflows/update-jobs-ehnv.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update EHNV jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-elettra-1938.yml
+++ b/.github/workflows/update-jobs-elettra-1938.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Elettra 1938 jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ems-chemie.yml
+++ b/.github/workflows/update-jobs-ems-chemie.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🧪 Auto-update EMS-Chemie jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-engadin-tourismus.yml
+++ b/.github/workflows/update-jobs-engadin-tourismus.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "Auto-update Engadin Tourismus AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-engelvoelkers.yml
+++ b/.github/workflows/update-jobs-engelvoelkers.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Engel & Völkers jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-entero.yml
+++ b/.github/workflows/update-jobs-entero.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update entero jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-eoc.yml
+++ b/.github/workflows/update-jobs-eoc.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update EOC jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-epfl.yml
+++ b/.github/workflows/update-jobs-epfl.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update EPFL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-epi-stiftung.yml
+++ b/.github/workflows/update-jobs-epi-stiftung.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update EPI STIFTUNG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ergolz-klinik.yml
+++ b/.github/workflows/update-jobs-ergolz-klinik.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Ergolz Klinik jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-eth-zurich.yml
+++ b/.github/workflows/update-jobs-eth-zurich.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ETH Zürich jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fart.yml
+++ b/.github/workflows/update-jobs-fart.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🚂 Auto-update FART jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-faulhaber.yml
+++ b/.github/workflows/update-jobs-faulhaber.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Faulhaber jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ferrovia-retica.yml
+++ b/.github/workflows/update-jobs-ferrovia-retica.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🚂 Auto-update Ferrovia Retica jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fhgr.yml
+++ b/.github/workflows/update-jobs-fhgr.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Fachhochschule Graubünden jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fielmann.yml
+++ b/.github/workflows/update-jobs-fielmann.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Fielmann Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fincons.yml
+++ b/.github/workflows/update-jobs-fincons.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update Fincons jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-flury-stiftung.yml
+++ b/.github/workflows/update-jobs-flury-stiftung.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Flury Stiftung jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fmi.yml
+++ b/.github/workflows/update-jobs-fmi.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update FMI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fnz.yml
+++ b/.github/workflows/update-jobs-fnz.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update FNZ jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fondation-domus.yml
+++ b/.github/workflows/update-jobs-fondation-domus.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Fondation Domus jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-forel-klinik.yml
+++ b/.github/workflows/update-jobs-forel-klinik.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update FOREL_KLINIK jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-franklin-university.yml
+++ b/.github/workflows/update-jobs-franklin-university.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Franklin University Switzerland jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fusalp.yml
+++ b/.github/workflows/update-jobs-fusalp.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Fusalp jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-fust.yml
+++ b/.github/workflows/update-jobs-fust.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏪 Auto-update Fust jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-galenica.yml
+++ b/.github/workflows/update-jobs-galenica.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💊 Auto-update Galenica jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-gemeinde-st-moritz.yml
+++ b/.github/workflows/update-jobs-gemeinde-st-moritz.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Gemeinde St. Moritz jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-gesundheitsnetz-kuesnacht.yml
+++ b/.github/workflows/update-jobs-gesundheitsnetz-kuesnacht.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update GESUNDHEITSNETZ_KUESNACHT jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-gesundheitszentrum-fricktal.yml
+++ b/.github/workflows/update-jobs-gesundheitszentrum-fricktal.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update GESUNDHEITSZENTRUM_FRICKTAL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ghol.yml
+++ b/.github/workflows/update-jobs-ghol.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update GHOL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-giardino.yml
+++ b/.github/workflows/update-jobs-giardino.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Giardino Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-giorgio-armani.yml
+++ b/.github/workflows/update-jobs-giorgio-armani.yml
@@ -90,7 +90,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "👔 Auto-update Giorgio Armani jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-givaudan.yml
+++ b/.github/workflows/update-jobs-givaudan.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Givaudan jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-gkb.yml
+++ b/.github/workflows/update-jobs-gkb.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Graubündner Kantonalbank jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-goline.yml
+++ b/.github/workflows/update-jobs-goline.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update GOLINE jobs (dedicated crawler)" data/jobs-crawler-adapters/adapters/goline.json
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-grace.yml
+++ b/.github/workflows/update-jobs-grace.yml
@@ -82,7 +82,7 @@ jobs:
           SKIP_AI_TRANSLATION: \${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏨 Auto-update Grace La Margna jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-groupe-mutuel.yml
+++ b/.github/workflows/update-jobs-groupe-mutuel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Groupe Mutuel jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-guess.yml
+++ b/.github/workflows/update-jobs-guess.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Guess jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-gz-dielsdorf.yml
+++ b/.github/workflows/update-jobs-gz-dielsdorf.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update GZ_DIELSDORF jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-gzo-wetzikon.yml
+++ b/.github/workflows/update-jobs-gzo-wetzikon.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update GZO Wetzikon jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-h-ju-hopital-du-jura.yml
+++ b/.github/workflows/update-jobs-h-ju-hopital-du-jura.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update H_JU jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hamilton.yml
+++ b/.github/workflows/update-jobs-hamilton.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏭 Auto-update Hamilton Bonaduz AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-has-healthcare.yml
+++ b/.github/workflows/update-jobs-has-healthcare.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update HAS Healthcare jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-heineken-ch.yml
+++ b/.github/workflows/update-jobs-heineken-ch.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Heineken Switzerland jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-helsinn.yml
+++ b/.github/workflows/update-jobs-helsinn.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💊 Auto-update Helsinn Healthcare SA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hes-so-valais.yml
+++ b/.github/workflows/update-jobs-hes-so-valais.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HES-SO Valais-Wallis jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hfr-hopital-fribourgeois.yml
+++ b/.github/workflows/update-jobs-hfr-hopital-fribourgeois.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HFR jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hib.yml
+++ b/.github/workflows/update-jobs-hib.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HIB jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hilcona.yml
+++ b/.github/workflows/update-jobs-hilcona.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🥗 Auto-update Hilcona jobs (dedicated crawler)" data/jobs-crawler-adapters/
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hirslanden.yml
+++ b/.github/workflows/update-jobs-hirslanden.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hirslanden Klinik jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hitachi-energy.yml
+++ b/.github/workflows/update-jobs-hitachi-energy.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Hitachi Energy jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hoch-health.yml
+++ b/.github/workflows/update-jobs-hoch-health.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HOCH_HEALTH jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hochgebirgsklinik-davos.yml
+++ b/.github/workflows/update-jobs-hochgebirgsklinik-davos.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hochgebirgsklinik Davos jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hofweissbad.yml
+++ b/.github/workflows/update-jobs-hofweissbad.yml
@@ -92,7 +92,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hof Weissbad jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-holcim.yml
+++ b/.github/workflows/update-jobs-holcim.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Holcim Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hopital-de-lavaux.yml
+++ b/.github/workflows/update-jobs-hopital-de-lavaux.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hôpital de Lavaux jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hopital-de-moutier.yml
+++ b/.github/workflows/update-jobs-hopital-de-moutier.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hôpital de Moutier jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hopital-du-valais.yml
+++ b/.github/workflows/update-jobs-hopital-du-valais.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hôpital du Valais jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hopital-la-tour.yml
+++ b/.github/workflows/update-jobs-hopital-la-tour.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HOPITAL_LA_TOUR jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hoval.yml
+++ b/.github/workflows/update-jobs-hoval.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Hoval jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hrc.yml
+++ b/.github/workflows/update-jobs-hrc.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HRC jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hug.yml
+++ b/.github/workflows/update-jobs-hug.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update HUG — Hôpitaux Universitaires de Genève jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-hugo-boss.yml
+++ b/.github/workflows/update-jobs-hugo-boss.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "👔 Auto-update Hugo Boss jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-huntsman.yml
+++ b/.github/workflows/update-jobs-huntsman.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Huntsman Corporation jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ibsa.yml
+++ b/.github/workflows/update-jobs-ibsa.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🧬 Auto-update IBSA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-igs-bern.yml
+++ b/.github/workflows/update-jobs-igs-bern.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update IGS_BERN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ikea.yml
+++ b/.github/workflows/update-jobs-ikea.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update IKEA Svizzera jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-imad.yml
+++ b/.github/workflows/update-jobs-imad.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update IMAD jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-imerys.yml
+++ b/.github/workflows/update-jobs-imerys.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Imerys jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-institution-lavigny.yml
+++ b/.github/workflows/update-jobs-institution-lavigny.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Institution de Lavigny jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-integra-biosciences.yml
+++ b/.github/workflows/update-jobs-integra-biosciences.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update INTEGRA Biosciences jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-interdiscount.yml
+++ b/.github/workflows/update-jobs-interdiscount.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Interdiscount jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-interroll.yml
+++ b/.github/workflows/update-jobs-interroll.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏭 Auto-update Interroll Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ipw.yml
+++ b/.github/workflows/update-jobs-ipw.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update IPW jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ist.yml
+++ b/.github/workflows/update-jobs-ist.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update IST jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-julius-baer.yml
+++ b/.github/workflows/update-jobs-julius-baer.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏦 Auto-update Julius Baer jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-jumbo.yml
+++ b/.github/workflows/update-jobs-jumbo.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update JUMBO jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-jysk.yml
+++ b/.github/workflows/update-jobs-jysk.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🛋️ Auto-update JYSK jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kanton-gr.yml
+++ b/.github/workflows/update-jobs-kanton-gr.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kantonale Verwaltung Graubünden jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kantonsspital-uri.yml
+++ b/.github/workflows/update-jobs-kantonsspital-uri.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KANTONSSPITAL-URI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kempinski.yml
+++ b/.github/workflows/update-jobs-kempinski.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏨 Auto-update Kempinski Switzerland jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kispi-sg.yml
+++ b/.github/workflows/update-jobs-kispi-sg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KISPI_SG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kispi-zurich.yml
+++ b/.github/workflows/update-jobs-kispi-zurich.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KISPI_ZURICH jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kispi.yml
+++ b/.github/workflows/update-jobs-kispi.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KISPI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-aadorf.yml
+++ b/.github/workflows/update-jobs-klinik-aadorf.yml
@@ -88,7 +88,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_AADORF jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-adelheid.yml
+++ b/.github/workflows/update-jobs-klinik-adelheid.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK-ADELHEID jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-arlesheim.yml
+++ b/.github/workflows/update-jobs-klinik-arlesheim.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_ARLESHEIM jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-barmelweid.yml
+++ b/.github/workflows/update-jobs-klinik-barmelweid.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Klinik Barmelweid jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-gut.yml
+++ b/.github/workflows/update-jobs-klinik-gut.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_GUT jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-im-hasel.yml
+++ b/.github/workflows/update-jobs-klinik-im-hasel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_IM_HASEL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-lengg.yml
+++ b/.github/workflows/update-jobs-klinik-lengg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_LENGG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-schloss-mammern.yml
+++ b/.github/workflows/update-jobs-klinik-schloss-mammern.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK-SCHLOSS-MAMMERN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-schoenberg.yml
+++ b/.github/workflows/update-jobs-klinik-schoenberg.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_SCHOENBERG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-schuetzen.yml
+++ b/.github/workflows/update-jobs-klinik-schuetzen.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Klinik Schützen jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-seeschau.yml
+++ b/.github/workflows/update-jobs-klinik-seeschau.yml
@@ -88,7 +88,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_SEESCHAU jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-sgm.yml
+++ b/.github/workflows/update-jobs-klinik-sgm.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_SGM jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-siloah.yml
+++ b/.github/workflows/update-jobs-klinik-siloah.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_SILOAH jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-sonnenhalde.yml
+++ b/.github/workflows/update-jobs-klinik-sonnenhalde.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_SONNENHALDE jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-susenberg.yml
+++ b/.github/workflows/update-jobs-klinik-susenberg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Klinik Susenberg jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-klinik-wyssholzli.yml
+++ b/.github/workflows/update-jobs-klinik-wyssholzli.yml
@@ -84,7 +84,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIK_WYSSHOLZLI jobs (dedicated crawler)" data/jobs-crawler-adapters/adapters/klinik-wyssholzli.json
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kliniken-valens.yml
+++ b/.github/workflows/update-jobs-kliniken-valens.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KLINIKEN_VALENS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-knowledge-lab.yml
+++ b/.github/workflows/update-jobs-knowledge-lab.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Knowledge Lab jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kone.yml
+++ b/.github/workflows/update-jobs-kone.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KONE jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kronenhof.yml
+++ b/.github/workflows/update-jobs-kronenhof.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏨 Auto-update Grand Hotel Kronenhof jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ksa.yml
+++ b/.github/workflows/update-jobs-ksa.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kantonsspital Aarau (KSA) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ksb.yml
+++ b/.github/workflows/update-jobs-ksb.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KSB jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ksbl.yml
+++ b/.github/workflows/update-jobs-ksbl.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KSBL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ksgl.yml
+++ b/.github/workflows/update-jobs-ksgl.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kantonsspital Glarus (KSGL) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ksgr.yml
+++ b/.github/workflows/update-jobs-ksgr.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏥 Auto-update KSGR jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ksow.yml
+++ b/.github/workflows/update-jobs-ksow.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kantonsspital Obwalden jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kssg.yml
+++ b/.github/workflows/update-jobs-kssg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kantonsspital St. Gallen (KSSG / HOCH) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ksw.yml
+++ b/.github/workflows/update-jobs-ksw.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kantonsspital Winterthur (KSW) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kudelski-nagra.yml
+++ b/.github/workflows/update-jobs-kudelski-nagra.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kudelski NAGRA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kulm-hotel.yml
+++ b/.github/workflows/update-jobs-kulm-hotel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Kulm Hotel St. Moritz jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-kzu.yml
+++ b/.github/workflows/update-jobs-kzu.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update KZU jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-laderach.yml
+++ b/.github/workflows/update-jobs-laderach.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🍫 Auto-update Läderach jobs (dedicated crawler)" data/jobs-crawler-adapters/
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lafonte.yml
+++ b/.github/workflows/update-jobs-lafonte.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update La Fonte jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lastminute.yml
+++ b/.github/workflows/update-jobs-lastminute.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "✈️ Auto-update lastminute.com jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-leukerbad-clinic.yml
+++ b/.github/workflows/update-jobs-leukerbad-clinic.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update LEUKERBAD_CLINIC jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lhm-luzerner-hohenklinik-montana.yml
+++ b/.github/workflows/update-jobs-lhm-luzerner-hohenklinik-montana.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update LHM jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lidl.yml
+++ b/.github/workflows/update-jobs-lidl.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🛒 Auto-update Lidl jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lindenhofgruppe.yml
+++ b/.github/workflows/update-jobs-lindenhofgruppe.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Lindenhofgruppe jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-linnea.yml
+++ b/.github/workflows/update-jobs-linnea.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update Linnea SA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lis.yml
+++ b/.github/workflows/update-jobs-lis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update LIS jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-livingcircle.yml
+++ b/.github/workflows/update-jobs-livingcircle.yml
@@ -84,7 +84,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update The Living Circle jobs (dedicated crawler)" data/jobs-crawler-adapters/adapters/the-living-circle.json
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-localsearch.yml
+++ b/.github/workflows/update-jobs-localsearch.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update localsearch jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-logitech.yml
+++ b/.github/workflows/update-jobs-logitech.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Logitech jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lombard-odier.yml
+++ b/.github/workflows/update-jobs-lombard-odier.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Lombard Odier jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lombardi.yml
+++ b/.github/workflows/update-jobs-lombardi.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Lombardi Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lonza.yml
+++ b/.github/workflows/update-jobs-lonza.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Lonza jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-luks.yml
+++ b/.github/workflows/update-jobs-luks.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Luzerner Kantonsspital (LUKS) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lups.yml
+++ b/.github/workflows/update-jobs-lups.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Luzerner Psychiatrie (LUPS) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-lwphr.yml
+++ b/.github/workflows/update-jobs-lwphr.yml
@@ -83,7 +83,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update LWPHR jobs (dedicated crawler)" data/jobs-crawler-adapters/adapters/lwphr.json
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-mabetex.yml
+++ b/.github/workflows/update-jobs-mabetex.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Mabetex Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-manor.yml
+++ b/.github/workflows/update-jobs-manor.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏬 Auto-update Manor jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-marriott.yml
+++ b/.github/workflows/update-jobs-marriott.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Marriott International jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-matterhorn-gotthard-bahn.yml
+++ b/.github/workflows/update-jobs-matterhorn-gotthard-bahn.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Matterhorn Gotthard Bahn jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-medacta.yml
+++ b/.github/workflows/update-jobs-medacta.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏥 Auto-update Medacta jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-medartis.yml
+++ b/.github/workflows/update-jobs-medartis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MEDARTIS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-medics-labor.yml
+++ b/.github/workflows/update-jobs-medics-labor.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MEDICS_LABOR jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-medtronic.yml
+++ b/.github/workflows/update-jobs-medtronic.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MEDTRONIC jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-mendrisio.yml
+++ b/.github/workflows/update-jobs-mendrisio.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏛️ Auto-update Città di Mendrisio jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-merian-iselin.yml
+++ b/.github/workflows/update-jobs-merian-iselin.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MERIAN_ISELIN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-michel-gruppe.yml
+++ b/.github/workflows/update-jobs-michel-gruppe.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Michel Gruppe AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-migros-hq.yml
+++ b/.github/workflows/update-jobs-migros-hq.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Migros HQ Zürich jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-migros.yml
+++ b/.github/workflows/update-jobs-migros.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Migros jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-mikron.yml
+++ b/.github/workflows/update-jobs-mikron.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🔧 Auto-update Mikron jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-mkspamp.yml
+++ b/.github/workflows/update-jobs-mkspamp.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update MKS PAMP jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-mobiliar.yml
+++ b/.github/workflows/update-jobs-mobiliar.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update die Mobiliar jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-modellstation-somosa.yml
+++ b/.github/workflows/update-jobs-modellstation-somosa.yml
@@ -88,7 +88,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MODELLSTATION_SOMOSA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-moncucco.yml
+++ b/.github/workflows/update-jobs-moncucco.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Gruppo Ospedaliero Moncucco jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-msc-cargo.yml
+++ b/.github/workflows/update-jobs-msc-cargo.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update MSC Cargo jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-mtic.yml
+++ b/.github/workflows/update-jobs-mtic.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update MTIC Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-nant.yml
+++ b/.github/workflows/update-jobs-nant.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Fondation de Nant jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-nestle.yml
+++ b/.github/workflows/update-jobs-nestle.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Nestlé jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-novartis.yml
+++ b/.github/workflows/update-jobs-novartis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Novartis jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-novelis.yml
+++ b/.github/workflows/update-jobs-novelis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Novelis jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-nsn-medical.yml
+++ b/.github/workflows/update-jobs-nsn-medical.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update NSN Medical jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-octapharma.yml
+++ b/.github/workflows/update-jobs-octapharma.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update OCTAPHARMA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-oerlikon.yml
+++ b/.github/workflows/update-jobs-oerlikon.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Oerlikon jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-omega.yml
+++ b/.github/workflows/update-jobs-omega.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update OMEGA SA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ophtalmique.yml
+++ b/.github/workflows/update-jobs-ophtalmique.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Hôpital ophtalmique jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-oscam-castelrotto.yml
+++ b/.github/workflows/update-jobs-oscam-castelrotto.yml
@@ -90,7 +90,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update OSCAM_CASTELROTTO jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-oscam.yml
+++ b/.github/workflows/update-jobs-oscam.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏥 Auto-update OSCAM jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-otis.yml
+++ b/.github/workflows/update-jobs-otis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🛗 Auto-update Otis jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pallas-kliniken.yml
+++ b/.github/workflows/update-jobs-pallas-kliniken.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Pallas Kliniken jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-palliativklinik.yml
+++ b/.github/workflows/update-jobs-palliativklinik.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Palliativklinik im Park jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-paraplegie.yml
+++ b/.github/workflows/update-jobs-paraplegie.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PARAPLEGIE jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pbl.yml
+++ b/.github/workflows/update-jobs-pbl.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PBL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pdag.yml
+++ b/.github/workflows/update-jobs-pdag.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PDAG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pdgr.yml
+++ b/.github/workflows/update-jobs-pdgr.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Psychiatrische Dienste Graubünden jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pemsa.yml
+++ b/.github/workflows/update-jobs-pemsa.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update PEMSA jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pictet.yml
+++ b/.github/workflows/update-jobs-pictet.yml
@@ -93,7 +93,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Pictet Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pigna.yml
+++ b/.github/workflows/update-jobs-pigna.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Pigna jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pizzarotti.yml
+++ b/.github/workflows/update-jobs-pizzarotti.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Impresa Pizzarotti jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pole-sante-pays-enhaut.yml
+++ b/.github/workflows/update-jobs-pole-sante-pays-enhaut.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update POLE_SANTE_PAYS_ENHAUT jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-postch.yml
+++ b/.github/workflows/update-jobs-postch.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "📮 Auto-update Post.ch jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-postfinance.yml
+++ b/.github/workflows/update-jobs-postfinance.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏦 Auto-update PostFinance jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-prada.yml
+++ b/.github/workflows/update-jobs-prada.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "👜 Auto-update Prada Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-privatklinik-bethanien.yml
+++ b/.github/workflows/update-jobs-privatklinik-bethanien.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Privatklinik Bethanien jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-privatklinik-hohenegg.yml
+++ b/.github/workflows/update-jobs-privatklinik-hohenegg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Privatklinik Hohenegg jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-privatklinik-meiringen.yml
+++ b/.github/workflows/update-jobs-privatklinik-meiringen.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Privatklinik Meiringen jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-privatklinik-obach.yml
+++ b/.github/workflows/update-jobs-privatklinik-obach.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Privatklinik Obach jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-privatklinik-wyss.yml
+++ b/.github/workflows/update-jobs-privatklinik-wyss.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PRIVATKLINIK_WYSS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-prosenectute-ti.yml
+++ b/.github/workflows/update-jobs-prosenectute-ti.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PROSENECTUTE_TI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-psgn.yml
+++ b/.github/workflows/update-jobs-psgn.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PSGN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-puk-zuerich.yml
+++ b/.github/workflows/update-jobs-puk-zuerich.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PUK_ZUERICH jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pwc.yml
+++ b/.github/workflows/update-jobs-pwc.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "Auto-update PwC jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-pzm-muensingen.yml
+++ b/.github/workflows/update-jobs-pzm-muensingen.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update PZM_MUENSINGEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-raiffeisen-vc.yml
+++ b/.github/workflows/update-jobs-raiffeisen-vc.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏦 Auto-update Raiffeisen VC jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rapelli.yml
+++ b/.github/workflows/update-jobs-rapelli.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '1' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🍖 Auto-update Rapelli jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-reboot-monkey.yml
+++ b/.github/workflows/update-jobs-reboot-monkey.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Reboot Monkey jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-reha-andeer.yml
+++ b/.github/workflows/update-jobs-reha-andeer.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update REHA_ANDEER jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-reha-bellikon.yml
+++ b/.github/workflows/update-jobs-reha-bellikon.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Reha Bellikon jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rehab-basel.yml
+++ b/.github/workflows/update-jobs-rehab-basel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update REHAB_BASEL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rehaklinik-hasliberg.yml
+++ b/.github/workflows/update-jobs-rehaklinik-hasliberg.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Rehaklinik Hasliberg jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-relewant.yml
+++ b/.github/workflows/update-jobs-relewant.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update ReleWant jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rennbahnklinik.yml
+++ b/.github/workflows/update-jobs-rennbahnklinik.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update RENNBAHNKLINIK jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rfsm-fribourg.yml
+++ b/.github/workflows/update-jobs-rfsm-fribourg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update RFSM - Réseau fribourgeois santé mentale jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rhne-reseau-hospitalier-neuchatelois.yml
+++ b/.github/workflows/update-jobs-rhne-reseau-hospitalier-neuchatelois.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update RHNE jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-richemont.yml
+++ b/.github/workflows/update-jobs-richemont.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Richemont jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-riri.yml
+++ b/.github/workflows/update-jobs-riri.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Riri Group jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rittmeyer.yml
+++ b/.github/workflows/update-jobs-rittmeyer.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💧 Auto-update Rittmeyer jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-riveneuve.yml
+++ b/.github/workflows/update-jobs-riveneuve.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Rive-Neuve jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-roche.yml
+++ b/.github/workflows/update-jobs-roche.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Roche jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rsbj.yml
+++ b/.github/workflows/update-jobs-rsbj.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update RSBJ jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-rss-surselva.yml
+++ b/.github/workflows/update-jobs-rss-surselva.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Regionalspital Surselva jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ruag.yml
+++ b/.github/workflows/update-jobs-ruag.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🛠️ Auto-update RUAG jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-salina-reha.yml
+++ b/.github/workflows/update-jobs-salina-reha.yml
@@ -90,7 +90,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Salina Rehaklinik Rheinfelden jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sanatorium-kilchberg.yml
+++ b/.github/workflows/update-jobs-sanatorium-kilchberg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Sanatorium Kilchberg jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sbb.yml
+++ b/.github/workflows/update-jobs-sbb.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SBB jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-schindler.yml
+++ b/.github/workflows/update-jobs-schindler.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Schindler jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-schulthess-klinik.yml
+++ b/.github/workflows/update-jobs-schulthess-klinik.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SCHULTHESS KLINIK jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-see-spital.yml
+++ b/.github/workflows/update-jobs-see-spital.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update See-Spital jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-senevita.yml
+++ b/.github/workflows/update-jobs-senevita.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Senevita jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-siegfried.yml
+++ b/.github/workflows/update-jobs-siegfried.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Siegfried jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-siemens-healthineers.yml
+++ b/.github/workflows/update-jobs-siemens-healthineers.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Siemens Healthineers jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sika.yml
+++ b/.github/workflows/update-jobs-sika.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Sika AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sintetica.yml
+++ b/.github/workflows/update-jobs-sintetica.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💉 Auto-update Sintetica SA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-skyguide.yml
+++ b/.github/workflows/update-jobs-skyguide.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🛫 Auto-update Skyguide jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sobi.yml
+++ b/.github/workflows/update-jobs-sobi.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SOBI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-soh-solothurner-spitaeler.yml
+++ b/.github/workflows/update-jobs-soh-solothurner-spitaeler.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SOH jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-solina.yml
+++ b/.github/workflows/update-jobs-solina.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Solina jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-solothurner-spitaeler.yml
+++ b/.github/workflows/update-jobs-solothurner-spitaeler.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Solothurner Spitäler (soH) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-somedia.yml
+++ b/.github/workflows/update-jobs-somedia.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Somedia AG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sonnweid.yml
+++ b/.github/workflows/update-jobs-sonnweid.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Sonnweid jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spitaeler-schaffhausen.yml
+++ b/.github/workflows/update-jobs-spitaeler-schaffhausen.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITAELER_SCHAFFHAUSEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-affoltern.yml
+++ b/.github/workflows/update-jobs-spital-affoltern.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Affoltern jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-buelach.yml
+++ b/.github/workflows/update-jobs-spital-buelach.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Bülach jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-davos.yml
+++ b/.github/workflows/update-jobs-spital-davos.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Davos jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-emmental.yml
+++ b/.github/workflows/update-jobs-spital-emmental.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITAL_EMMENTAL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-lachen.yml
+++ b/.github/workflows/update-jobs-spital-lachen.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITAL-LACHEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-limmattal.yml
+++ b/.github/workflows/update-jobs-spital-limmattal.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Limmattal jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-maennedorf.yml
+++ b/.github/workflows/update-jobs-spital-maennedorf.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Männedorf jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-muri.yml
+++ b/.github/workflows/update-jobs-spital-muri.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITAL_MURI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-nidwalden.yml
+++ b/.github/workflows/update-jobs-spital-nidwalden.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Nidwalden jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-oberengadin.yml
+++ b/.github/workflows/update-jobs-spital-oberengadin.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Oberengadin jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-schwyz.yml
+++ b/.github/workflows/update-jobs-spital-schwyz.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITAL-SCHWYZ jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-sts.yml
+++ b/.github/workflows/update-jobs-spital-sts.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital STS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-thurgau.yml
+++ b/.github/workflows/update-jobs-spital-thurgau.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Thurgau (STGAG) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-thusis.yml
+++ b/.github/workflows/update-jobs-spital-thusis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Thusis jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-uster.yml
+++ b/.github/workflows/update-jobs-spital-uster.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Uster jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-zofingen.yml
+++ b/.github/workflows/update-jobs-spital-zofingen.yml
@@ -90,7 +90,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITAL_ZOFINGEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spital-zollikerberg.yml
+++ b/.github/workflows/update-jobs-spital-zollikerberg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spital Zollikerberg jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spitex-basel.yml
+++ b/.github/workflows/update-jobs-spitex-basel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITEX BASEL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spitex-ch.yml
+++ b/.github/workflows/update-jobs-spitex-ch.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spitex Schweiz jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spitex-zuerich.yml
+++ b/.github/workflows/update-jobs-spitex-zuerich.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPITEX_ZUERICH jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-spz.yml
+++ b/.github/workflows/update-jobs-spz.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SPZ jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-srg-ssr.yml
+++ b/.github/workflows/update-jobs-srg-ssr.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SRG SSR jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sro.yml
+++ b/.github/workflows/update-jobs-sro.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SRO jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-stadler-rail.yml
+++ b/.github/workflows/update-jobs-stadler-rail.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Stadler Rail jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-stadt-chur.yml
+++ b/.github/workflows/update-jobs-stadt-chur.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏛️ Auto-update Stadt Chur jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-stadtspital-zuerich.yml
+++ b/.github/workflows/update-jobs-stadtspital-zuerich.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Stadtspital Zürich jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-stgag.yml
+++ b/.github/workflows/update-jobs-stgag.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update STGAG jobs (dedicated Umantis crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-stiftung-diaconis.yml
+++ b/.github/workflows/update-jobs-stiftung-diaconis.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Stiftung Diaconis jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-stiftung-kind-autismus.yml
+++ b/.github/workflows/update-jobs-stiftung-kind-autismus.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update STIFTUNG_KIND_AUTISMUS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-stryker.yml
+++ b/.github/workflows/update-jobs-stryker.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update STRYKER jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-suchtfachstelle-zuerich.yml
+++ b/.github/workflows/update-jobs-suchtfachstelle-zuerich.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Suchtfachstelle Zürich jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-suchthilfe-region-basel.yml
+++ b/.github/workflows/update-jobs-suchthilfe-region-basel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Suchthilfe Region Basel jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-suedhang.yml
+++ b/.github/workflows/update-jobs-suedhang.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SUEDHANG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sulzer.yml
+++ b/.github/workflows/update-jobs-sulzer.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Sulzer jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sune-egge.yml
+++ b/.github/workflows/update-jobs-sune-egge.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Fachspital Sune-Egge jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-sunrise.yml
+++ b/.github/workflows/update-jobs-sunrise.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🌅 Auto-update Sunrise jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-supsi.yml
+++ b/.github/workflows/update-jobs-supsi.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🎓 Auto-update SUPSI jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-svar-spitalverbund-ar.yml
+++ b/.github/workflows/update-jobs-svar-spitalverbund-ar.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update SVAR jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-swatchgroup.yml
+++ b/.github/workflows/update-jobs-swatchgroup.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "⌚ Auto-update Swatch Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-swiss-life.yml
+++ b/.github/workflows/update-jobs-swiss-life.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Swiss Life jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-swiss-medical-network.yml
+++ b/.github/workflows/update-jobs-swiss-medical-network.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏥 Auto-update Swiss Medical Network jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-swiss-re.yml
+++ b/.github/workflows/update-jobs-swiss-re.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Swiss Re jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-swisscom.yml
+++ b/.github/workflows/update-jobs-swisscom.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏢 Auto-update Swisscom jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-szb-chb.yml
+++ b/.github/workflows/update-jobs-szb-chb.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Spitalzentrum Biel / Centre hospitalier Bienne jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tally-weijl.yml
+++ b/.github/workflows/update-jobs-tally-weijl.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update TALLY WEiJL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tarchini-group.yml
+++ b/.github/workflows/update-jobs-tarchini-group.yml
@@ -71,7 +71,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏗️ Auto-update Tarchini Group jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tecan.yml
+++ b/.github/workflows/update-jobs-tecan.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update TECAN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tertianum.yml
+++ b/.github/workflows/update-jobs-tertianum.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Tertianum jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tether.yml
+++ b/.github/workflows/update-jobs-tether.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Tether Operations jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-therapiezentrum-meggen.yml
+++ b/.github/workflows/update-jobs-therapiezentrum-meggen.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update THERAPIEZENTRUM_MEGGEN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-thurklinik.yml
+++ b/.github/workflows/update-jobs-thurklinik.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Thurklinik jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tich.yml
+++ b/.github/workflows/update-jobs-tich.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Ti.CH jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tinext.yml
+++ b/.github/workflows/update-jobs-tinext.yml
@@ -88,7 +88,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🧩 Auto-update Tinext jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tpl-lugano.yml
+++ b/.github/workflows/update-jobs-tpl-lugano.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🚌 Auto-update TPL Lugano jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-transgourmet.yml
+++ b/.github/workflows/update-jobs-transgourmet.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Transgourmet jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-triaplus.yml
+++ b/.github/workflows/update-jobs-triaplus.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update TRIAPLUS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-trumpf.yml
+++ b/.github/workflows/update-jobs-trumpf.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🔧 Auto-update TRUMPF Schweiz jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tschuggen.yml
+++ b/.github/workflows/update-jobs-tschuggen.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Tschuggen Collection jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-tsmg.yml
+++ b/.github/workflows/update-jobs-tsmg.yml
@@ -83,7 +83,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update TSMG jobs (dedicated crawler)" data/jobs-crawler-adapters/adapters/tsmg.json
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ubp.yml
+++ b/.github/workflows/update-jobs-ubp.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Union Bancaire Privée jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ubs.yml
+++ b/.github/workflows/update-jobs-ubs.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update UBS jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-ukbb.yml
+++ b/.github/workflows/update-jobs-ukbb.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update UKBB jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-unispital-basel.yml
+++ b/.github/workflows/update-jobs-unispital-basel.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Universitätsspital Basel jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-upd.yml
+++ b/.github/workflows/update-jobs-upd.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update UPD jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-uroviva.yml
+++ b/.github/workflows/update-jobs-uroviva.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update UROVIVA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-usi.yml
+++ b/.github/workflows/update-jobs-usi.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🎓 Auto-update USI jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-usz.yml
+++ b/.github/workflows/update-jobs-usz.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Universitätsspital Zürich (USZ) jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-vaudoise.yml
+++ b/.github/workflows/update-jobs-vaudoise.yml
@@ -89,7 +89,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Vaudoise Assurances jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-vaxcyte.yml
+++ b/.github/workflows/update-jobs-vaxcyte.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Vaxcyte jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-vf.yml
+++ b/.github/workflows/update-jobs-vf.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update VF jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-villa-im-park.yml
+++ b/.github/workflows/update-jobs-villa-im-park.yml
@@ -87,7 +87,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Privatklinik Villa im Park jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-vir-biotechnology.yml
+++ b/.github/workflows/update-jobs-vir-biotechnology.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🧬 Auto-update Vir Biotechnology jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-vista.yml
+++ b/.github/workflows/update-jobs-vista.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Vista jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-vitrea-gesundheit.yml
+++ b/.github/workflows/update-jobs-vitrea-gesundheit.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update VITREA_GESUNDHEIT jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-viva-luzern.yml
+++ b/.github/workflows/update-jobs-viva-luzern.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update VIVA_LUZERN jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-volg.yml
+++ b/.github/workflows/update-jobs-volg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏪 Auto-update Volg / fenaco jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-vtg.yml
+++ b/.github/workflows/update-jobs-vtg.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🎖️ Auto-update VTG jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-wagerenhof.yml
+++ b/.github/workflows/update-jobs-wagerenhof.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Wagerenhof jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-weisse-arena.yml
+++ b/.github/workflows/update-jobs-weisse-arena.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Weisse Arena Gruppe jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-wuerth-international.yml
+++ b/.github/workflows/update-jobs-wuerth-international.yml
@@ -85,7 +85,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Würth International jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-zambon.yml
+++ b/.github/workflows/update-jobs-zambon.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🧪 Auto-update Zambon Svizzera SA jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-zegna.yml
+++ b/.github/workflows/update-jobs-zegna.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Zegna jobs (dedicated crawler)"
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-zermatt-bergbahnen.yml
+++ b/.github/workflows/update-jobs-zermatt-bergbahnen.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update Zermatt Bergbahnen jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-zuger-kantonsspital.yml
+++ b/.github/workflows/update-jobs-zuger-kantonsspital.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ZUGER-KANTONSSPITAL jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-zurich.yml
+++ b/.github/workflows/update-jobs-zurich.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "🏛️ Auto-update Zurich Insurance jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/.github/workflows/update-jobs-zurzach-care.yml
+++ b/.github/workflows/update-jobs-zurzach-care.yml
@@ -86,7 +86,7 @@ jobs:
           SKIP_AI_TRANSLATION: ${{ github.event.inputs.skip_ai_translation || '0' }}
         run: bash scripts/lib/git-commit-data.sh --slice-only "💼 Auto-update ZURZACH Care jobs (dedicated crawler)" data/jobs-crawler-adapters/
 
-      - name: Report failure to Linear
+      - name: Report failure to GitHub Issues
         if: failure()
         continue-on-error: true
         env:

--- a/tests/seo/cathedral-job-detail-canton.test.ts
+++ b/tests/seo/cathedral-job-detail-canton.test.ts
@@ -2,54 +2,94 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { resolveCantonSection } from '../../build-plugins/shared/cantonSection';
+
 const DIST = path.resolve(__dirname, '../../dist');
+const JOBS_PATH = path.resolve(__dirname, '../../data/jobs.json');
+
+// Cantons sampled by the behavioural matrix below. Each is mapped to its
+// IT section slug via the canonical `resolveCantonSection` helper (same
+// path-derivation logic the build plugins use) so the test stays in sync
+// with the build emit without duplicating the dePrefix / group-merge rules.
+// Coverage across multiple cantons catches regressions where a single
+// canton's section slug drifts (group-merge, dePrefix override, etc.)
+// without requiring a separate test per canton.
+const SAMPLED_NON_TI_CANTONS = ['ZH', 'VD', 'BE', 'GR', 'LU', 'GE', 'BS'] as const;
+
+interface Job {
+  canton?: string;
+  location?: string;
+  slug?: string;
+  slugByLocale?: Record<string, string>;
+}
+
+function readJobs(): Job[] | null {
+  if (!fs.existsSync(JOBS_PATH)) return null;
+  return JSON.parse(fs.readFileSync(JOBS_PATH, 'utf8')) as Job[];
+}
+
+function pickItSlug(job: Job): string | undefined {
+  return job.slugByLocale?.it ?? job.slug;
+}
+
+// Read the <link rel="canonical"> href out of an emitted HTML page.
+// Uses the DOM parser provided by vitest's jsdom environment so the
+// assertion survives every flavour of HTML-minify output (stripped quotes,
+// reordered attributes, surrounding whitespace) — the regex variant was
+// fragile and silently false-negatived minified bridges in post-deploy run
+// 26592389280.
+function extractCanonicalHref(html: string): string | null {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const link = doc.querySelector('link[rel~="canonical" i]');
+  return link?.getAttribute('href') ?? null;
+}
 
 describe('job-detail URLs route per job.canton (Phase 1)', () => {
-  it('a Zurich job in jobs.json emits at /cerca-lavoro-zurigo/<slug>/ with canton-aware canonical', () => {
+  it('TI invariance: a Lugano job stays at /cerca-lavoro-ticino/<slug>/', () => {
     if (!fs.existsSync(DIST)) return;
-    const jobsPath = path.resolve(__dirname, '../../data/jobs.json');
-    if (!fs.existsSync(jobsPath)) return;
-    const jobs = JSON.parse(fs.readFileSync(jobsPath, 'utf8'));
-    const zhJob = jobs.find((j: { canton?: string }) => j.canton === 'ZH');
-    if (!zhJob) return; // skip if dataset has no ZH job
-    const slug = zhJob.slugByLocale?.it || zhJob.slug;
-    // Phase 1: the canonical canton-aware page MUST exist. This is the URL the
-    // SPA navigates to, the URL in the sitemap, and the canonical target every
-    // bridge points at.
-    expect(fs.existsSync(path.join(DIST, 'cerca-lavoro-zurigo', slug, 'index.html'))).toBe(true);
-    // Phase 8b/c (cross-canton legacy TI bridge — see jobsSeoPagesPlugin.ts:3236-3265):
-    // the legacy /cerca-lavoro-ticino/<slug>/ MAY exist for non-TI jobs as a
-    // soft-landing for Google-indexed pre-cathedral URLs. When it exists, its
-    // canonical MUST point back to the canton-aware URL so link equity
-    // consolidates on the cathedral target instead of cannibalising the new
-    // section. The behavioural assertion in
-    // cathedral-previous-slug-canton.test.ts already enforces this for
-    // previousSlugs; here we extend the same contract to the current slug.
-    const legacyBridge = path.join(DIST, 'cerca-lavoro-ticino', slug, 'index.html');
-    if (fs.existsSync(legacyBridge)) {
-      const html = fs.readFileSync(legacyBridge, 'utf8');
-      // The HTML minifier strips quotes around simple attribute values
-      // (`rel=canonical href=...`), so the regex must tolerate quoted +
-      // unquoted forms in either attribute order.
-      const m = html.match(/<link\b[^>]*\brel=["']?canonical["']?[^>]*\bhref=["']?([^"'\s>]+)/i)
-        ?? html.match(/<link\b[^>]*\bhref=["']?([^"'\s>]+)[^>]*\brel=["']?canonical["']?/i);
-      expect(m, `legacy TI bridge for ZH job ${slug} has no <link rel=canonical>`).toBeTruthy();
-      expect(m![1], `legacy TI bridge for ZH job ${slug} canonicalises to TI instead of /cerca-lavoro-zurigo/: ${m![1]}`)
-        .toMatch(/\/cerca-lavoro-zurigo\//);
-    }
-  });
-
-  it('a Lugano job stays at /cerca-lavoro-ticino/<slug>/ (TI invariance)', () => {
-    if (!fs.existsSync(DIST)) return;
-    const jobsPath = path.resolve(__dirname, '../../data/jobs.json');
-    if (!fs.existsSync(jobsPath)) return;
-    const jobs = JSON.parse(fs.readFileSync(jobsPath, 'utf8'));
+    const jobs = readJobs();
+    if (!jobs) return;
     const tiJob = jobs.find(
-      (j: { canton?: string; location?: string }) =>
-        j.canton === 'TI' || /lugano|mendrisio|bellinzona/i.test(j.location || ''),
+      (j) => j.canton === 'TI' || /lugano|mendrisio|bellinzona/i.test(j.location || ''),
     );
     if (!tiJob) return;
-    const slug = tiJob.slugByLocale?.it || tiJob.slug;
+    const slug = pickItSlug(tiJob);
+    if (!slug) return;
     expect(fs.existsSync(path.join(DIST, 'cerca-lavoro-ticino', slug, 'index.html'))).toBe(true);
   });
+
+  // ── Behavioural matrix: for every non-TI canton sampled, pick a job and
+  //    assert
+  //      (1) the canton-aware page MUST exist (Phase 1 routing contract),
+  //      (2) if the legacy /cerca-lavoro-ticino/<slug>/ bridge ALSO exists
+  //          (Phase 8c cross-canton legacy TI bridge,
+  //          jobsSeoPagesPlugin.ts:3236-3265), its <link rel="canonical">
+  //          MUST point back at the canton-aware URL so link equity
+  //          consolidates instead of cannibalising the new section.
+  for (const cantonCode of SAMPLED_NON_TI_CANTONS) {
+    const sectionSlug = resolveCantonSection('it', cantonCode);
+    it(`non-TI ${cantonCode}: emits at /${sectionSlug}/<slug>/ + legacy TI bridge canonicalises to it`, () => {
+      if (!fs.existsSync(DIST)) return;
+      const jobs = readJobs();
+      if (!jobs) return;
+      const job = jobs.find((j) => j.canton === cantonCode);
+      if (!job) return; // canton not represented in current dataset — skip
+      const slug = pickItSlug(job);
+      if (!slug) return;
+
+      // (1) Canonical canton-aware page MUST exist.
+      const canonPage = path.join(DIST, sectionSlug, slug, 'index.html');
+      expect(fs.existsSync(canonPage), `canton-aware page missing for ${cantonCode} job ${slug} at /${sectionSlug}/`).toBe(true);
+
+      // (2) Legacy TI bridge MAY exist; when it does, canonical → canton-aware.
+      const legacyBridge = path.join(DIST, 'cerca-lavoro-ticino', slug, 'index.html');
+      if (!fs.existsSync(legacyBridge)) return;
+      const href = extractCanonicalHref(fs.readFileSync(legacyBridge, 'utf8'));
+      expect(href, `legacy TI bridge for ${cantonCode} job ${slug} has no <link rel=canonical>`).toBeTruthy();
+      expect(href!, `legacy TI bridge for ${cantonCode} job ${slug} canonicalises to TI instead of /${sectionSlug}/: ${href}`)
+        .toMatch(new RegExp(`/${sectionSlug}/`));
+      expect(href!, `legacy TI bridge for ${cantonCode} job ${slug} canonicalises to legacy TI section: ${href}`)
+        .not.toMatch(/\/cerca-lavoro-ticino\//);
+    });
+  }
 });

--- a/tests/seo/cathedral-previous-slug-canton.test.ts
+++ b/tests/seo/cathedral-previous-slug-canton.test.ts
@@ -150,24 +150,26 @@ describe('cathedral Phase 8b — previousSlugs bridges canton-aware', () => {
         // Bridge IS for this job. Its <link rel="canonical"> must point to the
         // canton-aware URL — not to /cerca-lavoro-ticino/ — so Google folds
         // equity into the new canton section.
-        // The HTML minifier strips quotes around simple attribute values
-        // (`rel=canonical href=https://…`) so the regex must tolerate both
-        // quoted and unquoted forms in either attribute order. Pre-2026-05-28
-        // the strict double-quoted form falsely flagged minified bridges as
-        // "no canonical" (post-deploy run 26592389280) even though the tag
-        // was present and pointing at the canton-aware URL.
-        const canonicalMatch =
-          html.match(/<link\b[^>]*\brel=["']?canonical["']?[^>]*\bhref=["']?([^"'\s>]+)/i)
-          ?? html.match(/<link\b[^>]*\bhref=["']?([^"'\s>]+)[^>]*\brel=["']?canonical["']?/i);
-        if (!canonicalMatch) {
+        // Use the DOM parser provided by vitest's jsdom environment so the
+        // assertion survives every flavour of HTML-minify output (stripped
+        // quotes, reordered attributes). The previous regex variant
+        // false-negatived minified bridges on post-deploy run 26592389280
+        // (`<link rel=canonical href="...">` with the quotes stripped from
+        // the rel value), reporting "no canonical" on bridges whose
+        // canonical was actually present and correctly pointing canton-aware.
+        const canonicalHref = new DOMParser()
+          .parseFromString(html, 'text/html')
+          .querySelector('link[rel~="canonical" i]')
+          ?.getAttribute('href') ?? null;
+        if (!canonicalHref) {
           mismatches.push(
             `non-TI job ${canonicalSlug} (canton=${job.canton}) legacy TI bridge has no canonical: cerca-lavoro-ticino/${oldSlug}/`,
           );
           continue;
         }
-        if (/\/cerca-lavoro-ticino\//.test(canonicalMatch[1])) {
+        if (/\/cerca-lavoro-ticino\//.test(canonicalHref)) {
           mismatches.push(
-            `non-TI job ${canonicalSlug} (canton=${job.canton}) legacy TI bridge canonicalises to TI: ${canonicalMatch[1]}`,
+            `non-TI job ${canonicalSlug} (canton=${job.canton}) legacy TI bridge canonicalises to TI: ${canonicalHref}`,
           );
         }
       }


### PR DESCRIPTION
## Summary

Two independent fixes bundled; both surfaced as side-effects of the same
post-deploy 26592389280 canton-gate failure.

### Issue reporter pipeline (#2)

Every workflow with `Report failure to Linear` (438) actually invokes
`scripts/lib/github-issue-creator.mjs` — a GitHub Issues creator (the
script docstring already says "Drop-in replacement for the legacy Linear
creator"). The "Linear" label in step names was misleading and the steps
were silently failing because:

1. **9 workflows lacked `permissions: issues: write`** → default
   `GITHUB_TOKEN` is read-only for issues. Failure mode on validate-live
   run 26592389280: `GraphQL: Resource not accessible by integration (createIssue)`.
2. **5 workflows lacked `env: GH_TOKEN`** on the report step → gh CLI
   couldn't authenticate. Failure mode on validate-dist: `gh: To use
   GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment
   variable`.

Both manifested as `[github-issue-creator] Failed to create issue` → no
issue → no signal that the validation pipeline saw a failure.

### Test hardening (#3 + #4)

- **#3**: `cathedral-job-detail-canton.test.ts` only sampled ZH. A
  regression on another canton's section slug (group-merge BS/BL → BASILEA,
  dePrefix `im Aargau` / `in der Waadt`) would slip through. Now
  parameterised over ZH/VD/BE/GR/LU/GE/BS via `resolveCantonSection('it',
  code)` so the matrix tracks the build emit without per-canton hardcodes.
- **#4**: both canton tests now read `<link rel="canonical">` via the DOM
  parser (vitest jsdom env), replacing the regex variant that
  relaxed-passed in #767 but stayed fragile to future minifier drift.

## Implementato

### Issue reporter
- `permissions: issues: write` aggiunto a **9 workflow**: deploy.yml,
  post-deploy-publish.yml, post-deploy-validate-dist.yml,
  post-deploy-validate-live.yml, refresh-bfs-stats.yml,
  deploy-cloud-functions.yml, deploy-firestore-rules.yml,
  cathedral-noindex-flip.yml, refresh-article-trending.yml,
  persist-job-stats.yml, refresh-job-popularity.yml, send-job-alerts.yml,
  translate-pending.yml.
- `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` aggiunto sui report step
  in 5 workflow: post-deploy-validate-dist.yml, post-deploy-publish.yml,
  refresh-bfs-stats.yml, deploy.yml (build + deploy + rollback).
- Rename `Report failure to Linear` → `Report failure to GitHub Issues`
  (+ varianti build/deploy/rollback) su **438 file** workflow.
- Post-fix audit: 438/438 workflow hanno sia perm sia env sul report step.

### Test hardening
- `cathedral-job-detail-canton.test.ts`: matrix multi-canton
  (ZH/VD/BE/GR/LU/GE/BS) via `resolveCantonSection`; ogni canton asserisce
  (1) canton-aware page esiste, (2) se legacy TI bridge esiste, canonical
  canton-aware (no riferimento TI).
- `cathedral-previous-slug-canton.test.ts`: regex `<link rel=canonical>`
  sostituita con `DOMParser().querySelector('link[rel~="canonical" i]')`.
- `cathedral-job-detail-canton.test.ts`: stessa DOMParser extraction usata
  per il legacy TI bridge canonical check.

## Non implementato (ancora)

- **#5 visual regression baseline refresh post-B**: N/A — il job-board hub
  TI NON è nei snapshot stabili (`tests/e2e/seo-visual-regression.spec.ts`
  esclude job-board perché contenuti cambiano daily da crawler). Nessuna
  baseline esiste per `/cerca-lavoro-ticino/` quindi nessun refresh.
- **Rollback step `Dispatch fresh deploy at last-known-good SHA`** che
  fallisce quando artifact last-good è scaduto — separato dal reporter,
  fuori scope.
- **`recover-prev-slugs.yml`**: già OK (env + perm presenti). Nessuna modifica.
- **Estensione canton matrix oltre 7 sample**: tutti i 26 cantoni saturano
  il test (canton-merge AI/AR, BS/BL, LB/etc. richiedono casi specifici).
  Sample copre i top-7 per volume; estensione full-canton in PR separato.

## Test plan

- [ ] CI: `review` (pr-review-loop) check pass
- [ ] Post-merge: prossimo `post-deploy-validate-dist`/`-live` su main →
      issue GH creata correttamente in caso di failure
- [ ] Confronto pre/post-PR delle prossime validation failure: issue body
      contiene workflow name + run URL + label `priority:urgent` + `Bug`
- [ ] `gate:seo-source` continua a passare su `cathedral-job-detail-canton`
      e `cathedral-previous-slug-canton` con la nuova DOM extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)