### PR TITLE
chore(reviewer): doc + auto-merge 🔴 guard + tier empty-files

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -19,12 +19,19 @@ jobs:
     #   `!contains(body, '🔴')` che generava false negatives quando il bot
     #   scriveva meta-language tipo "Nessun 🔴 Important" per affermare zero
     #   blocker — l'emoji nel testo di negazione bloccava il merge.
+    # - body NON contiene `🔴 Important` (guard belt-and-suspenders contro
+    #   reviewer-error: se il bot scrive `## LGTM` per sbaglio E lascia un
+    #   `🔴 Important` nei findings, l'auto-merge non scatta). Token
+    #   `🔴 Important` (non solo emoji 🔴) per evitare di bloccare merge dove
+    #   l'emoji appare in legend/meta-language. REVIEW.md istruisce comunque
+    #   il reviewer a NON scrivere `## LGTM` con 🔴 aperto.
     # - PR non draft.
     if: |
       github.event.review.user.type == 'Bot' &&
       startsWith(github.event.review.user.login, 'claude') &&
       github.event.review.state == 'commented' &&
       contains(github.event.review.body, '## LGTM') &&
+      !contains(github.event.review.body, '🔴 Important') &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -43,6 +43,17 @@ jobs:
         run: |
           set -euo pipefail
           files=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')
+          # Guard PR vuota (rebase-only, base == head): files vuoto. Default tier
+          # normal + log esplicito, evita di affidarsi al fallback implicito
+          # `grep -q` su input vuoto. Reviewer comunque posta `## LGTM` (no
+          # finding) e auto-merge scatta.
+          if [ -z "$files" ]; then
+            echo "Empty file list (rebase-only or empty PR), tier=normal."
+            echo "tier=normal" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
+            echo "max_turns=15" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if echo "$files" | grep -qE '^(tests/|\.github/workflows/|scripts/|build-plugins/)'; then
             echo "tier=high" >> "$GITHUB_OUTPUT"
             echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"

--- a/docs/CI-CD-PIPELINE.md
+++ b/docs/CI-CD-PIPELINE.md
@@ -174,6 +174,39 @@ After dispatching, **does not wait**. All crawlers run concurrently. `translate-
 
 ---
 
+### PR review + auto-merge + follow-up triage (PR #769)
+
+> Operational contracts live in `REVIEW.md` (review tiers, signal grammar, scope filter) and `FOLLOWUP.md` (follow-up issue contract). This section is just the workflow surface — do not duplicate contract content here.
+
+| Workflow | Trigger | Role |
+|---|---|---|
+| `.github/workflows/pr-review-loop.yml` | `pull_request` (sync/open) | Tiered Claude review; emits structured `REVIEW.md` signals + `## LGTM` when green |
+| `.github/workflows/auto-merge-on-lgtm.yml` | `pull_request_review` submitted by the review bot | Squash-merges the PR when the review body contains the literal `## LGTM` marker |
+| `.github/workflows/post-merge-followup.yml` | `pull_request` `closed` + `merged == true` | Reads PR body `## Non implementato` + reviewer 🟡 / ❓ / adversarial bullets, applies the scope filter, dedups against open follow-up issues, files new issues (labels `follow-up` + `funnel-*`, cap 10/PR) and posts a summary comment on the merged PR |
+
+**`pr-review-loop.yml` — tiered review (PR #769)**
+
+- `Determine review tier` step inspects the PR's changed paths and computes `model` + `max_turns` dynamically:
+  - **high tier** — triggered by changes under `tests/`, `.github/workflows/`, `scripts/`, or `build-plugins/`. Uses Opus, `max_turns: 25`, runs the adversarial-check sweep on top of the baseline review.
+  - **normal tier** — everything else. Uses Sonnet, `max_turns: 15`.
+- Tool whitelist widened to include `Bash(rg:*)` and `Bash(git:*)` so the reviewer can do cross-file pattern probing (`REVIEW.md` step 5) and PR-history checks.
+- Test plan compliance is enforced by `REVIEW.md` step 6 — the reviewer cross-checks the PR body's test plan against the diff.
+- Green output ends with the literal `## LGTM` marker; that is the single signal `auto-merge-on-lgtm.yml` watches for. See `REVIEW.md` for what scenarios are allowed to emit `## LGTM`.
+
+**`post-merge-followup.yml` — scope-filtered follow-up issues (PR #769)**
+
+- Runs only on merged PRs (`pull_request.closed && merged == true`).
+- Parses two sources: the PR description's `## Non implementato` block (author-declared deferred work) and the reviewer's 🟡 / ❓ / adversarial bullets from the latest `pr-review-loop` review.
+- Applies the `REVIEW.md` scope filter (monetization / traffic / SEO funnel impact); cosmetic or out-of-scope bullets are dropped.
+- Dedups candidates against currently open issues labelled `follow-up` before opening anything new.
+- Creates at most **10 issues per merged PR**, all labelled `follow-up` plus the relevant `funnel-*` label, and posts a summary comment back on the merged PR linking each new issue.
+- Issue body contract (titles, sections, linkbacks) is defined in `FOLLOWUP.md`.
+
+**`auto-merge-on-lgtm.yml`**
+
+- Fires on `pull_request_review` events where the review author is the Claude review bot.
+- If the review body contains the exact marker `## LGTM`, squash-merges the PR via `gh pr merge --squash --delete-branch`. Any other body content is a no-op. See `REVIEW.md` for which review outcomes are allowed to emit `## LGTM`.
+
 ### GITHUB_TOKEN Limitation
 
 Pushes made with the default `GITHUB_TOKEN` **do not trigger other workflows** (GitHub anti-loop rule). Only `translate-pending` and `article-generation` trigger deploy — they use `GITHUB_PAT` (from Firebase Remote Config) via `scripts/lib/trigger-deploy.sh`.


### PR DESCRIPTION
## Summary

Follow-up a #769 che chiude i 3 gap minori segnalati post-merge: doc drift, auto-merge edge case, tier-step empty-files implicito.

## Implementato

- **`docs/CI-CD-PIPELINE.md`** — nuova sezione "PR review + auto-merge + follow-up triage (PR #769)" prima di "GITHUB_TOKEN Limitation". Documenta i 3 workflow (`pr-review-loop.yml`, `auto-merge-on-lgtm.yml`, `post-merge-followup.yml`) come surface, rimanda a `REVIEW.md` + `FOLLOWUP.md` come single source of truth dei contratti. No duplicazione.
- **`.github/workflows/auto-merge-on-lgtm.yml`** — belt-and-suspenders guard: aggiunto `!contains(github.event.review.body, '🔴 Important')` alla `if:` condition. Edge case neutralizzato: se reviewer scrive `## LGTM` per errore E lascia un `🔴 Important` nei findings (process error), auto-merge non scatta. Token esatto `🔴 Important` non solo emoji, per evitare di bloccare merge dove l'emoji appare in legend/meta-language. REVIEW.md già istruisce il reviewer a non scrivere `## LGTM` con 🔴 aperto — questo è il check di sicurezza secondo livello.
- **`.github/workflows/pr-review-loop.yml`** — tier step ora ha guard esplicito per PR senza file (rebase-only, branch identico a base): `if [ -z "$files" ]` → default `tier=normal` + log esplicito + `exit 0`. Sostituisce il fallback implicito su `grep -q` con input vuoto. Comportamento finale invariato, solo più leggibile + log diagnostico.

## Non implementato (ancora)

- **Workflow_dispatch su `post-merge-followup.yml`** per backfill manuale su PR vecchie (es. #767) — non aggiunto. Trade-off: aggiunge superficie di triggering accidentale + secret usage. Possibile follow-up se serve backfill.
- **Re-run `pr-review-loop` con il nuovo step empty-guard su PR vuota reale** — nessuna PR vuota corrente per validare live.
- **Test sintetico per `## LGTM` con 🔴 Important** — non implementato. La logica è una `if:` GitHub Actions, testabile solo live. Validation = osservare il comportamento sulla prossima review.

## Test plan

- [ ] CI: `review` check (probabile workflow-validation failure perché modifica i workflow stessi → merge manuale come da AGENTS.md exception)
- [ ] Post-merge: prossima PR organica → step "Determine review tier" logga tier corretto
- [ ] Post-merge: se il reviewer dovesse mai scrivere `## LGTM` con `🔴 Important` (process error), `auto-merge-on-lgtm.yml` deve restare silent (no trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)