### PR TITLE
perf(build): post-walk profiler + parallel dropOverwrittenLocs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -568,13 +568,14 @@ jobs:
                   }' \
                 | sort -t'|' -k3 -nr
             fi
-            for marker in jobs-seo-profile weekly-employers-profile related-search-profile; do
+            for marker in jobs-seo-profile weekly-employers-profile related-search-profile post-walk-profile; do
               if grep -qE "^\[$marker\]" /tmp/build.log; then
                 echo ""
                 case "$marker" in
                   jobs-seo-profile) echo "## jobsSeoPagesPlugin internal profile" ;;
                   weekly-employers-profile) echo "## weeklyEmployersPlugin internal profile" ;;
                   related-search-profile) echo "## relatedSearchClustersPlugin internal profile" ;;
+                  post-walk-profile) echo "## postWalkCoordinatorPlugin internal profile" ;;
                 esac
                 echo ""
                 echo '```text'

--- a/build-plugins/postWalkCoordinatorPlugin.ts
+++ b/build-plugins/postWalkCoordinatorPlugin.ts
@@ -67,6 +67,13 @@ import {
 import type { BlogLinkLocale } from './blogContextualLinksData';
 import { transformFlatRedirect } from './flatHtmlRedirectPlugin';
 import { transformHreflang } from './hreflangPostprocessPlugin';
+import {
+  startTimer as profileStart,
+  recordEmit as profileRecord,
+  ingestBuckets as profileIngestBuckets,
+  printSummary as printPostWalkProfile,
+  type SerializedBuckets,
+} from './shared/postWalkCoordinatorProfiler';
 
 interface CoordinatorOptions {
   readonly baseUrl: string;
@@ -82,6 +89,11 @@ interface WorkerResult {
   hreflangLinksDropped: number;
   totalWrites: number;
   writeFailures: Array<{ filePath: string; msg: string }>;
+  // Worker-emitted per-phase profiler buckets. Empty array when profiler is
+  // disabled (POST_WALK_PROFILE=0 or BUILD_PROFILE=0). Coordinator folds
+  // these into its own module-level buckets via profileIngestBuckets()
+  // before printPostWalkProfile() emits the unified table.
+  profilerBuckets?: SerializedBuckets;
 }
 
 /**
@@ -197,11 +209,14 @@ function runSingleThreaded(
 
   for (const filePath of allHtmlPaths) {
     let html: string;
+    const __tRead = profileStart();
     try {
       html = fs.readFileSync(filePath, 'utf-8');
     } catch {
+      profileRecord('read', __tRead);
       continue;
     }
+    profileRecord('read', __tRead);
     const original = html;
     let mutated = false;
     let isBridge = false;
@@ -212,21 +227,25 @@ function runSingleThreaded(
       // 45399c0779). Avoids a sync 30 KB sibling read + regex pass that
       // would re-derive the same bridge content. Mirrors the worker fast
       // path in postWalkWorker.mjs (commit 7a00222681).
-      if (
+      const __tCheck = profileStart();
+      const preEmitted =
         html.startsWith('<!DOCTYPE html>\n<html lang="it">\n<head>\n<meta charset="utf-8">') &&
         html.includes('<meta name="robots" content="noindex,follow">') &&
-        html.includes('<script>location.replace(')
-      ) {
+        html.includes('<script>location.replace(');
+      profileRecord('bridge-check', __tCheck);
+      if (preEmitted) {
         isBridge = true;
         result.bridgeConverted++;
         continue;
       }
+      const __tBridge = profileStart();
       const bridge = transformFlatRedirect({
         filePath,
         distDir,
         trimmedBase,
         readSibling,
       });
+      profileRecord('bridge-transform', __tBridge);
       if (bridge !== null) {
         html = bridge;
         mutated = true;
@@ -240,7 +259,9 @@ function runSingleThreaded(
     if (!isBridge) {
       const locale = blogIndexHtmlByPath.get(filePath);
       if (locale !== undefined) {
+        const __tBlog = profileStart();
         const r = injectContextualLinks(html, locale);
+        profileRecord('blog-inject', __tBlog);
         if (r.injected.length > 0 && r.html !== html) {
           html = r.html;
           mutated = true;
@@ -251,9 +272,11 @@ function runSingleThreaded(
     }
 
     if (!isBridge) {
+      const __tHl = profileStart();
       const r = transformHreflang(html, distDir, baseUrl, (absPath) =>
         existingHtmlSet.has(absPath),
       );
+      profileRecord('hreflang-transform', __tHl);
       if (r !== null) {
         html = r.html;
         mutated = true;
@@ -264,6 +287,7 @@ function runSingleThreaded(
     }
 
     if (mutated && html !== original) {
+      const __tWrite = profileStart();
       try {
         fs.writeFileSync(filePath, html, 'utf-8');
         result.totalWrites++;
@@ -271,6 +295,7 @@ function runSingleThreaded(
         const msg = err instanceof Error ? err.message : String(err);
         result.writeFailures.push({ filePath, msg });
       }
+      profileRecord('write', __tWrite);
     }
   }
 
@@ -359,6 +384,7 @@ export function postWalkCoordinatorPlugin(
         const startTotal = Date.now();
 
         // ── Phase A: enumerate every emitted HTML file once ──────────
+        const __tWalk = profileStart();
         const allHtmlPaths: string[] = [];
         const processHtmlPaths: string[] = [];
         const existingHtmlSet = new Set<string>();
@@ -372,6 +398,7 @@ export function postWalkCoordinatorPlugin(
             processHtmlPaths.push(file);
           }
         }
+        profileRecord('walk-dist', __tWalk);
         const filesScanned = allHtmlPaths.length;
         if (filesScanned === 0) {
           // eslint-disable-next-line no-console
@@ -380,6 +407,7 @@ export function postWalkCoordinatorPlugin(
         }
 
         // ── Phase B: load blog-articles target map ONCE ──────────────
+        const __tBlogLoad = profileStart();
         const blogIndexSlugs = readBlogIndexSlugs(rootDir);
         const blogArticles: readonly BlogArticleHtmlFile[] = listBlogArticleHtmlFiles(
           distDir,
@@ -391,6 +419,7 @@ export function postWalkCoordinatorPlugin(
             blogIndexHtmlByPath.set(article.absPath, article.locale);
           }
         }
+        profileRecord('load-blog-articles', __tBlogLoad);
 
         // ── Phase C: dispatch work ─────────────────────────────────
         const workerCount = resolveWorkerCount(processHtmlPaths.length);
@@ -405,9 +434,12 @@ export function postWalkCoordinatorPlugin(
                 trimmedBase,
               )
             : await (async () => {
+                const __tChunk = profileStart();
                 const chunks = chunkRoundRobin(processHtmlPaths, workerCount);
+                profileRecord('chunk-roundrobin', __tChunk);
                 const workerUrl = new URL('./postWalkWorker.mjs', import.meta.url);
                 const blogIndexEntries = Array.from(blogIndexHtmlByPath.entries());
+                const __tDispatch = profileStart();
                 const results = await Promise.all(
                   chunks.map((assignedFiles) =>
                     runInWorker(workerUrl, {
@@ -420,7 +452,16 @@ export function postWalkCoordinatorPlugin(
                     }),
                   ),
                 );
-                return mergeResults(results);
+                profileRecord('worker-dispatch', __tDispatch);
+                const __tMerge = profileStart();
+                for (const r of results) {
+                  if (r.profilerBuckets && r.profilerBuckets.length > 0) {
+                    profileIngestBuckets(r.profilerBuckets);
+                  }
+                }
+                const finalMerged = mergeResults(results);
+                profileRecord('merge-results', __tMerge);
+                return finalMerged;
               })();
 
         for (const f of merged.writeFailures) {
@@ -439,6 +480,11 @@ export function postWalkCoordinatorPlugin(
             `hreflang: ${merged.hreflangFilesRewritten} rewritten / ${merged.hreflangLinksKept} kept / ${merged.hreflangLinksDropped} dropped, ` +
             `total writes: ${merged.totalWrites}`,
         );
+
+        // Unified [post-walk-profile] summary table. No-op when the profiler
+        // is gated off. Mirrors the jobs-seo / related-search summary so the
+        // workflow's Build profile summary step can grep+sed it identically.
+        printPostWalkProfile();
       },
     },
   };

--- a/build-plugins/postWalkWorker.mjs
+++ b/build-plugins/postWalkWorker.mjs
@@ -36,6 +36,15 @@ if (!parentPort) {
 const { transformFlatRedirect } = await import('./flatHtmlRedirectPlugin.ts');
 const { injectContextualLinks } = await import('./blogContextualLinksPlugin.ts');
 const { transformHreflang } = await import('./hreflangPostprocessPlugin.ts');
+// Per-phase profiler — bucketed into the same SerializedBuckets shape the
+// coordinator merges via ingestBuckets() before printing the unified
+// [post-walk-profile] table. tsx loader (execArgv in coordinator) makes
+// this .ts import resolve from the .mjs entry point.
+const {
+  startTimer: profileStart,
+  recordEmit: profileRecord,
+  dumpBuckets: profileDumpBuckets,
+} = await import('./shared/postWalkCoordinatorProfiler.ts');
 
 const {
   distDir,
@@ -116,18 +125,24 @@ function isPreEmittedFlatBridge(html) {
 
 async function processFile(filePath) {
   let html;
+  const __tRead = profileStart();
   try {
     html = await fs.promises.readFile(filePath, 'utf-8');
   } catch {
+    profileRecord('read', __tRead);
     return;
   }
+  profileRecord('read', __tRead);
   const original = html;
   let mutated = false;
   let isBridge = false;
 
   const baseName = path.basename(filePath);
   if (baseName !== 'index.html' && !baseName.startsWith('.')) {
-    if (isPreEmittedFlatBridge(html)) {
+    const __tCheck = profileStart();
+    const preEmitted = isPreEmittedFlatBridge(html);
+    profileRecord('bridge-check', __tCheck);
+    if (preEmitted) {
       // Pre-emitted by the originating plugin and byte-identical to what
       // transformFlatRedirect would produce. Counts as bridgeConverted for
       // the summary line; skips both sibling read + (no-op) write.
@@ -135,12 +150,14 @@ async function processFile(filePath) {
       bridgeConverted++;
       return;
     }
+    const __tBridge = profileStart();
     const bridge = transformFlatRedirect({
       filePath,
       distDir,
       trimmedBase,
       readSibling,
     });
+    profileRecord('bridge-transform', __tBridge);
     if (bridge !== null) {
       html = bridge;
       mutated = true;
@@ -154,7 +171,9 @@ async function processFile(filePath) {
   if (!isBridge) {
     const locale = blogIndexHtmlByPath.get(filePath);
     if (locale !== undefined) {
+      const __tBlog = profileStart();
       const result = injectContextualLinks(html, locale);
+      profileRecord('blog-inject', __tBlog);
       if (result.injected.length > 0 && result.html !== html) {
         html = result.html;
         mutated = true;
@@ -165,7 +184,9 @@ async function processFile(filePath) {
   }
 
   if (!isBridge) {
+    const __tHl = profileStart();
     const hreflangResult = transformHreflang(html, distDir, baseUrl, existsCheck);
+    profileRecord('hreflang-transform', __tHl);
     if (hreflangResult !== null) {
       html = hreflangResult.html;
       mutated = true;
@@ -176,6 +197,7 @@ async function processFile(filePath) {
   }
 
   if (mutated && html !== original) {
+    const __tWrite = profileStart();
     try {
       await fs.promises.writeFile(filePath, html, 'utf-8');
       totalWrites++;
@@ -183,6 +205,7 @@ async function processFile(filePath) {
       const msg = err instanceof Error ? err.message : String(err);
       writeFailures.push({ filePath, msg });
     }
+    profileRecord('write', __tWrite);
   }
 }
 
@@ -210,4 +233,8 @@ parentPort.postMessage({
   hreflangLinksDropped,
   totalWrites,
   writeFailures,
+  // Empty array when POST_WALK_PROFILE/BUILD_PROFILE are off — coordinator
+  // ingestBuckets() is a no-op on empty input and an early no-op when its
+  // own ENABLED gate is false, so the round-trip cost is bounded.
+  profilerBuckets: profileDumpBuckets(),
 });

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -1836,30 +1836,89 @@ function normalizeLocForCanonicalCmp(u: string): string {
     return u.trim();
   }
 }
-function dropOverwrittenLocs(distDir: string, locs: ReadonlyArray<string>): string[] {
+/**
+ * Async parallel variant. Replaced the sync version (180k `fs.readFileSync`
+ * + 360k `fs.existsSync` per build, ~41s under `sitemap-write` in run
+ * 26597194374) with a fixed-size concurrency pool of async readFile attempts.
+ * Order-preserving: each location's decision is recorded into a pre-allocated
+ * Uint8Array indexed by input position, then the output `string[]` is
+ * collected in input order — byte-identical sitemap content vs sync path.
+ *
+ * The async pool overlaps SSD reads across N in-flight ops per main-thread
+ * lane (no worker_threads needed since the work is pure I/O). With
+ * IN_FLIGHT=32 on a 4-vCPU runner the kernel readahead pipeline stays
+ * saturated; higher values returned diminishing gains in microbenchmarks
+ * and risk fd contention with concurrent plugins still flushing writes.
+ *
+ * Missing-HTML semantics preserved: the original code silently skipped a
+ * loc when neither `<urlPath>/index.html` nor `<urlPath>.html` existed
+ * (no counter); this path collapses both `existsSync` probes into the
+ * `readFile` attempts and flags `DROP_MISSING` only for logging-skip — the
+ * net output is identical (loc absent from result, no log line).
+ */
+async function dropOverwrittenLocs(
+  distDir: string,
+  locs: ReadonlyArray<string>,
+): Promise<string[]> {
+  const KEEP = 1;
+  const DROP_NOINDEX = 2;
+  const DROP_NONCANON = 3;
+  const DROP_MISSING = 4;
+  const flags = new Uint8Array(locs.length);
+
+  // Concurrency cap for in-flight async readFile attempts. 32 matches the
+  // postWalkWorker IN_FLIGHT × workers budget (4 workers × 8 in-flight) and
+  // stays well under the ulimit guard (see batchWrite.ts conservative 1024).
+  const IN_FLIGHT = 32;
+  let cursor = 0;
+
+  const lane = async (): Promise<void> => {
+    while (cursor < locs.length) {
+      const i = cursor++;
+      const loc = locs[i];
+      const urlPath = new URL(loc).pathname.replace(/\/+$/, '');
+      const indexPath = path.join(distDir, urlPath, 'index.html');
+      const flatPath = path.join(distDir, urlPath + '.html');
+      let html: string | null = null;
+      try {
+        html = await fs.promises.readFile(indexPath, 'utf-8');
+      } catch {
+        try {
+          html = await fs.promises.readFile(flatPath, 'utf-8');
+        } catch {
+          flags[i] = DROP_MISSING;
+          continue;
+        }
+      }
+      if (NOINDEX_RE.test(html)) {
+        flags[i] = DROP_NOINDEX;
+        continue;
+      }
+      const canonMatch =
+        html.match(CANONICAL_HREF_RE) || html.match(CANONICAL_HREF_REVERSED_RE);
+      if (canonMatch && canonMatch[1]) {
+        const canonHref = canonMatch[1].trim();
+        if (normalizeLocForCanonicalCmp(canonHref) !== normalizeLocForCanonicalCmp(loc)) {
+          flags[i] = DROP_NONCANON;
+          continue;
+        }
+      }
+      flags[i] = KEEP;
+    }
+  };
+
+  const lanes: Promise<void>[] = [];
+  for (let l = 0; l < Math.min(IN_FLIGHT, locs.length); l++) lanes.push(lane());
+  await Promise.all(lanes);
+
   const out: string[] = [];
   let droppedNoindex = 0;
   let droppedNonCanonical = 0;
-  for (const loc of locs) {
-    const urlPath = new URL(loc).pathname.replace(/\/+$/, '');
-    const indexPath = path.join(distDir, urlPath, 'index.html');
-    const flatPath = path.join(distDir, urlPath + '.html');
-    const target = fs.existsSync(indexPath) ? indexPath : flatPath;
-    if (!fs.existsSync(target)) continue; // missing HTML — skip silently
-    const html = fs.readFileSync(target, 'utf-8');
-    if (NOINDEX_RE.test(html)) {
-      droppedNoindex++;
-      continue;
-    }
-    const canonMatch = html.match(CANONICAL_HREF_RE) || html.match(CANONICAL_HREF_REVERSED_RE);
-    if (canonMatch && canonMatch[1]) {
-      const canonHref = canonMatch[1].trim();
-      if (normalizeLocForCanonicalCmp(canonHref) !== normalizeLocForCanonicalCmp(loc)) {
-        droppedNonCanonical++;
-        continue;
-      }
-    }
-    out.push(loc);
+  for (let i = 0; i < locs.length; i++) {
+    const f = flags[i];
+    if (f === KEEP) out.push(locs[i]);
+    else if (f === DROP_NOINDEX) droppedNoindex++;
+    else if (f === DROP_NONCANON) droppedNonCanonical++;
   }
   if (droppedNoindex > 0 || droppedNonCanonical > 0) {
     console.log(
@@ -1881,28 +1940,38 @@ async function writeSitemap(
   // without this barrier the cluster sitemap is written while bridge files
   // are still buffered and bridge URLs whose canonical points elsewhere
   // leak into sitemap-search-clusters.xml — audit:sitemap-canonicals fails.
+  const __tFlushWait = profileStart();
   await jobsSeoPagesFlushed;
-  const locs = dropOverwrittenLocs(distDir, allLocs);
+  profileRecord('sw:wait-jobs-flush', __tFlushWait);
+  const __tDrop = profileStart();
+  const locs = await dropOverwrittenLocs(distDir, allLocs);
+  profileRecord('sw:drop-overwritten', __tDrop);
   if (locs.length === 0) return [];
 
   // Clear any stale single-file legacy sitemap or shard residue from a
   // previous run that produced more shards than this one. Without this,
   // a shrinking corpus would leave dangling sitemap-search-clusters-NNN.xml
   // files referenced by the auto-discovered sitemap.xml index.
+  const __tClearStale = profileStart();
   clearStaleClusterSitemaps(distDir);
+  profileRecord('sw:clear-stale', __tClearStale);
 
   const totalShards = Math.max(1, Math.ceil(locs.length / SITEMAP_SHARD_CAP));
   const written: string[] = [];
   try {
     fs.mkdirSync(distDir, { recursive: true });
     for (let i = 0; i < totalShards; i++) {
+      const __tSerialize = profileStart();
       const slice = locs.slice(i * SITEMAP_SHARD_CAP, (i + 1) * SITEMAP_SHARD_CAP);
       const entries = slice.map((loc) =>
         `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${dateStamp}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.6</priority>\n  </url>`,
       ).join('\n');
       const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+      profileRecord('sw:serialize-xml', __tSerialize);
+      const __tWriteShard = profileStart();
       const file = shardFilename(i + 1);
       fs.writeFileSync(path.join(distDir, file), xml, 'utf-8');
+      profileRecord('sw:write-shard', __tWriteShard);
       written.push(file);
     }
   } catch (err) {
@@ -1912,7 +1981,9 @@ async function writeSitemap(
   console.log(
     `\x1b[36m[related-search-clusters]\x1b[0m sharded ${locs.length} URLs into ${written.length} file(s) at ${SITEMAP_SHARD_CAP}/shard`,
   );
+  const __tPatchMaster = profileStart();
   patchMasterSitemap(distDir, dateStamp, written);
+  profileRecord('sw:patch-master', __tPatchMaster);
   return written;
 }
 

--- a/build-plugins/shared/postWalkCoordinatorProfiler.ts
+++ b/build-plugins/shared/postWalkCoordinatorProfiler.ts
@@ -1,0 +1,245 @@
+/**
+ * postWalkCoordinatorProfiler — per-category instrumentation for
+ * postWalkCoordinatorPlugin. Mirrors the format of jobsSeoProfiler /
+ * relatedSearchClustersProfiler so the workflow summary parser can apply
+ * the same grep/sed pipeline (marker prefix `[post-walk-profile]`).
+ *
+ * Activated by default with build profiling. Set `POST_WALK_PROFILE=0` or
+ * `BUILD_PROFILE=0` to opt out, or `POST_WALK_PROFILE=1` to force this table
+ * on in a one-off local/profile run.
+ *
+ * Categories the coordinator + worker emit:
+ *   Coordinator (closeBundle main thread):
+ *     - walk-dist            → recursive walk of dist/ to enumerate HTML
+ *     - load-blog-articles   → readBlogIndexSlugs + listBlogArticleHtmlFiles
+ *     - chunk-roundrobin     → split processHtmlPaths into worker chunks
+ *     - worker-dispatch      → Promise.all over workers
+ *     - merge-results        → fold per-worker result objects
+ *   Worker (postWalkWorker.mjs per-file phases):
+ *     - read                 → fs.promises.readFile of the source HTML
+ *     - bridge-check         → cheap pre-emitted-bridge prefix discriminator
+ *     - bridge-transform     → transformFlatRedirect (sibling read + render)
+ *     - blog-inject          → injectContextualLinks on blog index files
+ *     - hreflang-transform   → transformHreflang (strip broken hreflang)
+ *     - write                → fs.promises.writeFile when mutated
+ *
+ * Worker merge model: each Worker thread instantiates its own module copy
+ * (per-process state, identical to how `jobs-seo-profile` works during the
+ * canonical-fallback pre-pass). The worker exports `dumpBuckets()` which the
+ * coordinator postMessages back; the coordinator merges samples with
+ * `ingestBuckets()` and calls `printSummary()` once at the end. Reservoir
+ * sampling is preserved on merge (per-category cap = SAMPLE_CAP).
+ *
+ * Output format (sorted by totalMs DESC) — IDENTICAL columns to jobs-seo:
+ *
+ *   [post-walk-profile] category                  count    total_ms   %  avg_ms  p50_ms  p99_ms  min_ms  max_ms
+ *   [post-walk-profile] hreflang-transform        118432   65003.8    36   0.55    0.49    1.22    0.10    14.5
+ *   [post-walk-profile] read                      118432   42100.1    23   0.36    0.31    0.92    0.04     9.8
+ *   ...
+ */
+
+const ENABLED = process.env.POST_WALK_PROFILE === '1'
+  || (process.env.POST_WALK_PROFILE !== '0' && process.env.BUILD_PROFILE !== '0');
+
+type CategoryStats = {
+  count: number;
+  totalNs: bigint;
+  minNs: bigint;
+  maxNs: bigint;
+  // Reservoir of sample durations in ns for percentile estimation. We keep
+  // up to 10k samples per category (random replacement) to bound memory.
+  samplesNs: number[];
+};
+
+const buckets = new Map<string, CategoryStats>();
+const SAMPLE_CAP = 10_000;
+
+/**
+ * Returns a token usable with recordEmit(). Caller should bracket exactly the
+ * work that produces the next emit and pass the token back. When the
+ * profiler is disabled, returns 0n and recordEmit is a no-op.
+ */
+export function startTimer(): bigint {
+  if (!ENABLED) return 0n;
+  return process.hrtime.bigint();
+}
+
+/**
+ * Record one emit in the named category. `start` MUST be the value returned
+ * by a paired `startTimer()` call. Safe to call when disabled (no-op).
+ */
+export function recordEmit(category: string, start: bigint): void {
+  if (!ENABLED || start === 0n) return;
+  const elapsed = process.hrtime.bigint() - start;
+  let b = buckets.get(category);
+  if (!b) {
+    b = {
+      count: 0,
+      totalNs: 0n,
+      minNs: elapsed,
+      maxNs: elapsed,
+      samplesNs: [],
+    };
+    buckets.set(category, b);
+  }
+  b.count++;
+  b.totalNs += elapsed;
+  if (elapsed < b.minNs) b.minNs = elapsed;
+  if (elapsed > b.maxNs) b.maxNs = elapsed;
+  const elapsedNum = Number(elapsed);
+  if (b.samplesNs.length < SAMPLE_CAP) {
+    b.samplesNs.push(elapsedNum);
+  } else {
+    const idx = Math.floor(Math.random() * b.count);
+    if (idx < SAMPLE_CAP) b.samplesNs[idx] = elapsedNum;
+  }
+}
+
+/** Convenience helper: time a synchronous closure and record the result. */
+export function timed<T>(category: string, fn: () => T): T {
+  if (!ENABLED) return fn();
+  const t = startTimer();
+  try {
+    return fn();
+  } finally {
+    recordEmit(category, t);
+  }
+}
+
+/**
+ * Serializable snapshot of this process' buckets. Designed to cross
+ * `parentPort.postMessage` cheaply — `bigint` is converted to `string` for
+ * structured-clone compatibility (workerData is fine with bigint but
+ * postMessage to the main thread is not in all Node versions; use string
+ * for safety).
+ */
+export type SerializedBuckets = Array<{
+  category: string;
+  count: number;
+  totalNs: string;
+  minNs: string;
+  maxNs: string;
+  samplesNs: number[];
+}>;
+
+export function dumpBuckets(): SerializedBuckets {
+  const out: SerializedBuckets = [];
+  for (const [category, b] of buckets) {
+    out.push({
+      category,
+      count: b.count,
+      totalNs: b.totalNs.toString(),
+      minNs: b.minNs.toString(),
+      maxNs: b.maxNs.toString(),
+      samplesNs: b.samplesNs,
+    });
+  }
+  return out;
+}
+
+/**
+ * Merge a serialized snapshot (from a worker thread) into this process'
+ * buckets. Reservoir cap is re-applied after merge so the final sample set
+ * stays bounded regardless of worker count.
+ */
+export function ingestBuckets(snap: SerializedBuckets): void {
+  if (!ENABLED) return;
+  for (const entry of snap) {
+    let b = buckets.get(entry.category);
+    const entryTotalNs = BigInt(entry.totalNs);
+    const entryMinNs = BigInt(entry.minNs);
+    const entryMaxNs = BigInt(entry.maxNs);
+    if (!b) {
+      b = {
+        count: entry.count,
+        totalNs: entryTotalNs,
+        minNs: entryMinNs,
+        maxNs: entryMaxNs,
+        samplesNs: entry.samplesNs.slice(),
+      };
+      buckets.set(entry.category, b);
+    } else {
+      b.count += entry.count;
+      b.totalNs += entryTotalNs;
+      if (entryMinNs < b.minNs) b.minNs = entryMinNs;
+      if (entryMaxNs > b.maxNs) b.maxNs = entryMaxNs;
+      b.samplesNs.push(...entry.samplesNs);
+    }
+    if (b.samplesNs.length > SAMPLE_CAP) {
+      // Down-sample uniformly to the cap so percentiles stay representative.
+      const step = b.samplesNs.length / SAMPLE_CAP;
+      const reduced: number[] = new Array(SAMPLE_CAP);
+      for (let i = 0; i < SAMPLE_CAP; i++) {
+        reduced[i] = b.samplesNs[Math.floor(i * step)];
+      }
+      b.samplesNs = reduced;
+    }
+  }
+}
+
+function nsToMs(ns: bigint | number): number {
+  const n = typeof ns === 'bigint' ? Number(ns) : ns;
+  return n / 1_000_000;
+}
+
+function percentile(sortedSamplesMs: number[], p: number): number {
+  if (sortedSamplesMs.length === 0) return 0;
+  const idx = Math.min(
+    sortedSamplesMs.length - 1,
+    Math.max(0, Math.floor((p / 100) * sortedSamplesMs.length)),
+  );
+  return sortedSamplesMs[idx];
+}
+
+/**
+ * Print a sorted summary table to stdout. No-op when the profiler is
+ * disabled. Each row is prefixed with `[post-walk-profile]` so the
+ * workflow summary step can grep+sed it identically to jobs-seo / related.
+ */
+export function printSummary(): void {
+  if (!ENABLED) return;
+  const rows = Array.from(buckets.entries()).map(([category, b]) => {
+    const sorted = b.samplesNs.slice().sort((a, b) => a - b);
+    const sortedMs = sorted.map((n) => n / 1_000_000);
+    return {
+      category,
+      count: b.count,
+      totalMs: nsToMs(b.totalNs),
+      avgMs: nsToMs(b.totalNs) / b.count,
+      p50Ms: percentile(sortedMs, 50),
+      p99Ms: percentile(sortedMs, 99),
+      minMs: nsToMs(b.minNs),
+      maxMs: nsToMs(b.maxNs),
+    };
+  });
+  rows.sort((a, b) => b.totalMs - a.totalMs);
+
+  const totalMsAll = rows.reduce((s, r) => s + r.totalMs, 0);
+  const totalCountAll = rows.reduce((s, r) => s + r.count, 0);
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[post-walk-profile] ${'category'.padEnd(28)} ${'count'.padStart(7)} ${'total_ms'.padStart(10)} ${'%'.padStart(5)} ${'avg_ms'.padStart(8)} ${'p50_ms'.padStart(8)} ${'p99_ms'.padStart(8)} ${'min_ms'.padStart(7)} ${'max_ms'.padStart(8)}`,
+  );
+  for (const r of rows) {
+    const pct = totalMsAll > 0 ? (r.totalMs / totalMsAll) * 100 : 0;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[post-walk-profile] ${r.category.padEnd(28)} ${String(r.count).padStart(7)} ${r.totalMs.toFixed(1).padStart(10)} ${pct.toFixed(1).padStart(5)} ${r.avgMs.toFixed(2).padStart(8)} ${r.p50Ms.toFixed(2).padStart(8)} ${r.p99Ms.toFixed(2).padStart(8)} ${r.minMs.toFixed(2).padStart(7)} ${r.maxMs.toFixed(2).padStart(8)}`,
+    );
+  }
+  // eslint-disable-next-line no-console
+  console.log(
+    `[post-walk-profile] ${'TOTAL'.padEnd(28)} ${String(totalCountAll).padStart(7)} ${totalMsAll.toFixed(1).padStart(10)}`,
+  );
+}
+
+/** Reset all collected stats. Mainly useful for tests. */
+export function resetProfiler(): void {
+  buckets.clear();
+}
+
+/** True if the profiler is active for this process. */
+export function isEnabled(): boolean {
+  return ENABLED;
+}


### PR DESCRIPTION
## Summary

Top-3 plugin internal-profiler coverage + sitemap-write hotspot fix, based on run [26597194374](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26597194374) (38m26s deploy job; Build step 25m41s ≈ 67% of job).

Plugin profiler status before this PR:

| Plugin | Wall | Internal profiler? |
|---|---:|---|
| jobs-seo-pages | 676.85s | YES `[jobs-seo-profile]` |
| related-search-clusters | 372.28s | YES `[related-search-profile]` |
| post-walk-coordinator | 180.33s | **NO** ← added |

Top sub-categories observed:
- jobs-seo-pages → `expired-soft-landing` 105.8s (24%) + `canonical-fallback-pre-pass` 126.7s (already 4-core saturated)
- related-search-clusters → `render-cluster-page` 213.5s (180k × 1.18ms) + `sitemap-write` 41.4s (single op) ← **attacked**

## Implementato

- **NEW `build-plugins/shared/postWalkCoordinatorProfiler.ts`** — mirror of `jobsSeoProfiler` / `relatedSearchClustersProfiler` shape: same column layout (`category count total_ms % avg_ms p50_ms p99_ms min_ms max_ms`), reservoir-sampled percentiles, sortable by `totalMs DESC`. Marker prefix `[post-walk-profile]`. Gated by `POST_WALK_PROFILE=0` / `BUILD_PROFILE=0` (zero overhead when off).
- **`postWalkWorker.mjs`** — instrumented `processFile` per-phase: `read`, `bridge-check`, `bridge-transform`, `blog-inject`, `hreflang-transform`, `write`. Returns serialized buckets to coordinator via `postMessage`.
- **`postWalkCoordinatorPlugin.ts`** — instrumented coordinator phases: `walk-dist`, `load-blog-articles`, `chunk-roundrobin`, `worker-dispatch`, `merge-results`. Single-threaded fallback path identically instrumented. Coordinator ingests per-worker buckets and prints unified `[post-walk-profile]` table at end of `closeBundle`.
- **`relatedSearchClustersPlugin.ts` — `dropOverwrittenLocs` parallelized**: 180k `fs.readFileSync` + 360k `fs.existsSync` → 32-lane async `fs.promises.readFile` pool. Order-preserving via `Uint8Array` flags indexed by input position so sitemap content is byte-identical. Missing-HTML semantics preserved (silent skip, no log line). Sub-profilers added inside `writeSitemap` (`sw:wait-jobs-flush`, `sw:drop-overwritten`, `sw:clear-stale`, `sw:serialize-xml`, `sw:write-shard`, `sw:patch-master`) under the existing `[related-search-profile]` table to attribute the remaining ~33s of sitemap-write wall-clock.
- **`.github/workflows/deploy.yml`** — added `post-walk-profile` to the marker loop in the `Build profile summary` step so the new table renders in every job summary.

### Expected gains

| Item | Wall now | Estimated after |
|---|---:|---:|
| `sitemap-write` (related-search) | 41.4s | ~10–12s (-30s) |
| `post-walk-coordinator` headline | 180.3s | unchanged this PR; profiler exposes the next optimization target |

The `[post-walk-profile]` table will reveal whether the 180s is dominated by `read` (I/O), `hreflang-transform` (regex), or `write` (fs flush) per-file — direct input to the next perf PR.

## Non implementato (out of scope, deferred PRs)

- **`expired-soft-landing` 105.8s (jobs-seo, 195k pages × 0.54ms)** — worker-pool split blocked by render-state serialization risk + byte-identity contract. Needs profile-first phase-level decomposition (`ph:ejp:*`) before splitting; per `feedback_seo_content_first_for_proposals` and `feedback_speed_only_no_behavior_change` we won't risk a parallel rewrite without a clear single-page hotspot identified.
- **`render-cluster-page` 213.5s (related-search, 180k × 1.18ms)** — PR #382 attempted worker_threads; failed in CI with `ERR_MODULE_NOT_FOUND` because `tsx --import` can't resolve extension-less relative imports across ~15 transitive `.ts` deps (worker_thread_ts_imports rule). Proper fix = extracting `renderClusterPage` into a standalone `.ts` module with explicit `.ts` imports — separate PR.
- **`canonical-fallback-pre-pass` 126.7s** — already saturates 4 cores (`worker_work_avg=124.8s` on `wall=126.7s`); no parallelism headroom left, only work-reduction opportunities (cache reuse across builds — separate PR).
- **Pack dist→tar 5m08s overlap with Audit dist bytes 2m06s** — both read-only on `dist/`; running tar in BG during audit would save ~2m. Workflow restructure, separate PR.
- **Upload Pages compression-level 9 (2m46s)** — A/B test 9 → 6 would save ~50–70s at cost of ~80 MB artifact size. Separate measure-and-flip PR.

## Byte invariant

- `dropOverwrittenLocs` preserves input order via `flags[i]` set in the lane loop, then output is collected in input order on a final pass → sitemap shard content identical to the sync version.
- Missing-HTML branch collapses two `existsSync` probes into the `readFile` attempts; when both `readFile` reject, the loc is silently dropped (same as sync code's `if (!fs.existsSync(target)) continue`).
- Worker counters and write order unchanged in `postWalkWorker`; only timing samples added.

## Profiler gating

`POST_WALK_PROFILE=0` or `BUILD_PROFILE=0` ⇒ zero overhead (`startTimer` returns `0n`, `recordEmit` early-returns, `dumpBuckets` returns `[]`, `ingestBuckets` no-ops, `printSummary` no-ops). `BUILD_PROFILE=1` is set unconditionally in `deploy.yml`, so the new table will appear in every CI build summary.

## Test plan

- [ ] Merge + observe `main` deploy run: confirm `[post-walk-profile] TOTAL` line in `/tmp/build.log` and `postWalkCoordinatorPlugin internal profile` section in the job summary.
- [ ] Confirm `[related-search-profile] sw:*` rows appear under the related-search profile table.
- [ ] Diff `[related-search-profile] sitemap-write` total before/after this PR (target: -25 to -30s).
- [ ] Confirm `sitemap-search-clusters-NNN.xml` shard count + first/last shard sizes unchanged across the merge boundary (byte-identity check).
- [ ] Confirm validate-build-profile-markers PASS (existing required markers unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)