### PR TITLE
test(posthog-fetcher): route mock by HogQL body after PR #726 added pageviews

### DIFF
--- a/tests/scripts/lib/evidence/posthogFetcher.test.ts
+++ b/tests/scripts/lib/evidence/posthogFetcher.test.ts
@@ -15,15 +15,21 @@ function jsonRes(body: unknown, { ok = true, status = 200 }: { ok?: boolean; sta
 
 describe('fetchPosthogPages', () => {
   it('aggregates newsletter_signup events per page path', async () => {
-    const fetchImpl = vi.fn(async () =>
-      jsonRes({
-        results: [
-          ['/articoli-frontaliere/stipendio/', 7],
-          ['/articoli-frontaliere/lamal/', 3],
-          ['/calcola-stipendio/', 0], // dropped (n < 1)
-        ],
-      }),
-    );
+    // PR #726 added a 2nd HogQL query for `$pageview`. Route by body so the
+    // signup assertion stays focused; pageview query returns empty here.
+    const fetchImpl = vi.fn(async (_url: string, init: { body: string }) => {
+      const hogql = JSON.parse(init.body).query.query as string;
+      if (hogql.includes("event = 'newsletter_signup'")) {
+        return jsonRes({
+          results: [
+            ['/articoli-frontaliere/stipendio/', 7],
+            ['/articoli-frontaliere/lamal/', 3],
+            ['/calcola-stipendio/', 0], // dropped (n < 1)
+          ],
+        });
+      }
+      return jsonRes({ results: [] });
+    });
 
     const result = await fetchPosthogPages({
       apiKey: 'k',
@@ -41,11 +47,13 @@ describe('fetchPosthogPages', () => {
   });
 
   it('normalises absolute URLs to pathname', async () => {
-    const fetchImpl = vi.fn(async () =>
-      jsonRes({
-        results: [['https://frontaliereticino.ch/articoli-frontaliere/foo/', 2]],
-      }),
-    );
+    const fetchImpl = vi.fn(async (_url: string, init: { body: string }) => {
+      const hogql = JSON.parse(init.body).query.query as string;
+      if (hogql.includes("event = 'newsletter_signup'")) {
+        return jsonRes({ results: [['https://frontaliereticino.ch/articoli-frontaliere/foo/', 2]] });
+      }
+      return jsonRes({ results: [] });
+    });
     const result = await fetchPosthogPages({
       apiKey: 'k',
       projectId: '123',


### PR DESCRIPTION
## Summary
Fix vitest fail su \`tests/scripts/lib/evidence/posthogFetcher.test.ts\` introdotta da PR #726 (\"posthog-fetcher: also collect pageviews so evidence-index covers traffic\").

PR #726 ha aggiunto una seconda query HogQL (\`\$pageview\`) che viene merged sullo stesso \`pages\` map per pathname. Il mock del test restituiva la stessa fixture per entrambe le query → ogni path otteneva sia \`newsletterSignups: 7\` sia \`pageviews: 7\` → \`toEqual({ newsletterSignups: 7 })\` rompe.

Fix: il mock \`fetchImpl\` ora ispeziona il body HogQL della richiesta. Signup-query → fixture originale, pageview-query → \`[]\`. Intent del test (aggregazione signup) preservato, niente espansione di scope.

## Implementato
- [x] \`fetchImpl\` route by \`hogql.includes(\"event = 'newsletter_signup'\")\`
- [x] Applicato a entrambi i test che usano la fixture (signup aggregation + URL normalization)
- [x] Test locale: 4/4 pass, 6ms

## Non implementato (out-of-scope esplicito)
- ❌ Niente nuova copertura per il branch pageviews: la PR #726 dovrebbe avere il suo test dedicato; qui solo unblock dell'esistente
- ❌ Niente refactor di \`posthogFetcher.mjs\`: impl di PR #726 è giusta, era il mock obsoleto

## Test plan
- [x] \`npx vitest run tests/scripts/lib/evidence/posthogFetcher.test.ts\` → 4 passed
- [ ] CI tests.yml verde su questa branch