### PR TITLE
fix(deploy): grant issues:write to reusable workflow callers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1114,6 +1114,7 @@ jobs:
     permissions:
       contents: read    # checkout
       actions: read     # download-artifact same-run
+      issues: write     # github-issue-creator on validation failure (PR #772 added to the called job; must be declared at this caller too or the reusable workflow startup_failures)
 
   # ───────────────────────────────────────────────────────────────────────
   # validate-live: live smoke + social posting + indexing submission.
@@ -1132,6 +1133,7 @@ jobs:
     permissions:
       contents: write   # sync previous-slug winners (git push)
       actions: read     # download small artifacts (sitemaps, winners)
+      issues: write     # github-issue-creator on validation failure (PR #772 added to the called job; must be declared at this caller too or the reusable workflow startup_failures)
 
   # ───────────────────────────────────────────────────────────────────────
   # publish: side-effects + mark last_known_good. Runs ONLY when build,
@@ -1166,6 +1168,7 @@ jobs:
     permissions:
       contents: write   # sync previous-slug winners (git push)
       actions: read     # download small artifacts (sitemaps, winners)
+      issues: write     # github-issue-creator on publish failure (PR #772 added to the called job; must be declared at this caller too or the reusable workflow startup_failures)
 
   # ───────────────────────────────────────────────────────────────────────
   # rollback: revert Pages to last_known_good if either validate fails.


### PR DESCRIPTION
## Summary

Fix `startup_failure` su ogni deploy run da #772 (4 ore fa). Root cause: PR #772 ha aggiunto `issues: write` ai job dentro `post-deploy-validate-dist/live/publish.yml` (reusable), ma i caller `validate-dist` / `validate-live` / `publish` in `deploy.yml` non l'hanno aggiunto al loro blocco `permissions:`. Semantica reusable workflow: il caller deve dichiarare tutti i permessi che il called job richiede.

## Evidenza

Runs affetti (event=push o workflow_dispatch):

| Run | SHA | Trigger | Conclusion |
|---|---|---|---|
| 26601252138 | b66e3d0b | push | `startup_failure` |
| 26601456939 | 32ab5ed3 | push | `startup_failure` |
| 26604068831 | 14db5eaa | workflow_dispatch | `startup_failure` |

Tutti `run_duration_ms=1000, billable={}`, nessun job schedulato.

`run_duration_ms=1000` + `billable={}` è la firma di un workflow che fallisce al **load** (prima di schedulare qualsiasi job) — coerente con Actions che rigetta una reusable workflow che richiede permessi non concessi dal caller.

## Impatto

Da #772 (2026-05-28 22:46): **ogni push a main fa startup_failure del deploy**. Bloccati:
- SEO refresh (sitemap, link-graph closer, redirects)
- Jobs assemble + crawler-dataset stream
- IndexNow + Google Indexing submissions
- Auto-update job board stats
- Le 3 PR merged dopo #772 hanno run di deploy mancante/falliti: #773, #776 (perf-post-walk-profiler), #777.

## Fix

3 righe in `deploy.yml`, una per caller. Stesso wording adottato per chiarezza ("PR #772 added to the called job; must be declared at this caller too or the reusable workflow startup_failures"):

```yaml
permissions:
  ...
  issues: write     # github-issue-creator on validation failure (PR #772 added to the called job; must be declared at this caller too or the reusable workflow startup_failures)
```

`rollback` non è un reusable-workflow caller (inline steps); il top-level `permissions: issues: write` già aggiunto da #772 (riga 73) basta.

## Implementato

- `validate-dist` caller: + `issues: write`
- `validate-live` caller: + `issues: write`
- `publish` caller: + `issues: write`

## Non implementato (separate PRs)

- Test/lint guardrail che verifichi parity caller-vs-callee permissions block (eviterebbe ricorrenza). Separato perché tooling-only.
- Re-trigger dispatch dei deploy mancati per #776, #777, #773. Da fare manualmente dopo che questa PR merga.

## Test plan

- [ ] Merge fix → verifica che il prossimo push (o un `gh workflow run deploy.yml --ref main`) NON faccia startup_failure.
- [ ] Confermare che validate-dist, validate-live, publish job partano (non startup_failure).
- [ ] Re-trigger deploy per il merge ebc889e15e (PR #776 perf) per raccogliere il `[post-walk-profile]` nel summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)