### PR TITLE
chore(ci): bump download-artifact v5 → v7 (Node 24)

### DIFF
--- a/.github/workflows/post-deploy-publish.yml
+++ b/.github/workflows/post-deploy-publish.yml
@@ -76,21 +76,21 @@ jobs:
 
       # Small JSON artifacts only — NO github-pages download here.
       - name: Download pre-deploy sitemap snapshot (optional)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: pre-deploy-snapshot-${{ inputs.deploy_run_id }}
           path: /tmp/pre-deploy-snapshot
 
       - name: Download previous-slug winners (optional)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: winners-${{ inputs.deploy_run_id }}
           path: /tmp/winners
 
       - name: Download sitemaps bundle (pre-deploy + new + build-id)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: sitemaps-${{ inputs.deploy_run_id }}

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -9,7 +9,7 @@ name: Post-deploy Validate (dist)
 #
 # Same-run model:
 #   • github.sha is invariant — no more workflow_run.head_sha drift
-#   • actions/download-artifact@v5 with run-id same-run → no API lag
+#   • actions/download-artifact@v7 with run-id same-run → no API lag
 #   • 1:1 deploy↔validate mapping in the Actions UI by construction;
 #     no more "cancelled" post-deploys for cancelled/skipped deploys
 #     (the parent gates this entire workflow with `if: success()`)
@@ -113,19 +113,19 @@ jobs:
       # Sequential layout: download → tar → run each validator one at a time
       # and emit a per-gate ✅/❌ row. Adds ~10-15s wall vs parallel but is
       # deterministic, easier to reason about, and avoids the race entirely.
-      # Same-run artifact download. `actions/download-artifact@v5` reads
+      # Same-run artifact download. `actions/download-artifact@v7` reads
       # from the current run's artifact storage synchronously — no API
       # propagation lag, no retry, no `gh run download --name` lookup
       # quirks. This is the architectural payoff of unifying deploy +
       # validate in one workflow.
       - name: Download GitHub Pages artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: github-pages
           path: /tmp/github-pages-artifact
 
       - name: Download pre-deploy sitemap snapshot (optional)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true   # snapshot is optional — IndexNow diff falls back gracefully
         with:
           name: pre-deploy-snapshot-${{ inputs.deploy_run_id }}
@@ -138,7 +138,7 @@ jobs:
       # with titleByLocale / descriptionByLocale. We download it back to
       # data/jobs.json so the resolve-data-path lookup picks it up.
       - name: Download master jobs.json (for source validators)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: jobs-master-${{ inputs.deploy_run_id }}
           path: /tmp/jobs-master

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -72,7 +72,7 @@ jobs:
       # serving THIS deploy — so validate-live doesn't need to download
       # the 1.5 GB github-pages artifact just for build-id.
       - name: Download sitemaps bundle (for build-id.txt)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: sitemaps-${{ inputs.deploy_run_id }}


### PR DESCRIPTION
## Summary

GitHub Actions annotation: \`actions/download-artifact@v5\` gira su Node 20 (deprecato; default Node 24 dal 2026-06-02, Node 20 rimosso 2026-09-16). Bump v5 → v7 nei 3 reusable workflows post-deploy.

v7 già usato in:
- \`.github/workflows/post-build-matrix-test.yml\` (righe 123, 245)
- \`.github/workflows/deploy.yml\` upload-artifact@v7 × 4

quindi il formato artifact immutable-per-run è già il baseline corrente del repo. v5→v7 API-compatibile per il same-run download (no \`merge-multiple\`, no \`path\` arrays, no \`pattern\` filter).

## Implementato

5 occorrenze v5 → v7:
- post-deploy-publish.yml × 3 (righe 78, 85, 92)
- post-deploy-validate-dist.yml × 2 (righe 121, 127) + 2 commenti
- post-deploy-validate-live.yml × 1 (riga 74)

Commenti aggiornati da "v5" a "v7" per coerenza.

## Non implementato (separate PRs)

- Bump \`actions/upload-artifact@v4\` (7 use rimanenti) e \`@v5\` (4 use) → v7 per uniformare. PR separato se la deprecation Node20 li tocca specificamente; per ora la deprecation warning era solo su download-artifact.
- Bump \`actions/checkout@v4\`, \`setup-node@v4\`, \`upload-pages-artifact@v5\`, \`deploy-pages@v4\` — non flaggati dalla annotation; separato.
- Lint guardrail GHA actions @ Node24 — tooling separato.

## Test plan

- [ ] Verificare che il deploy successivo NON mostri più la annotation "Node.js 20 actions are deprecated" su download-artifact@v5.
- [ ] Confermare che validate-dist/validate-live/publish scaricano gli artifact same-run correttamente (no "artifact not found" o cambio di nome path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)