### PR TITLE
chore(ci): bump upload-artifact v4/v5 → v7 (Node 24)

### DIFF
--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload report artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: adsense-prereview-${{ github.run_number }}
           path: |

--- a/.github/workflows/ai-visibility-check.yml
+++ b/.github/workflows/ai-visibility-check.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload report artifacts
         if: always() && inputs.dry_run != 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ai-visibility-${{ github.run_number }}
           path: reports/ai-visibility-*

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload Report Artifact
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: analytics-report-${{ github.run_number }}
           path: |

--- a/.github/workflows/article-content-canary.yml
+++ b/.github/workflows/article-content-canary.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload canary result artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: article-content-canary-${{ github.run_id }}
           path: |

--- a/.github/workflows/audit-dist-from-run.yml
+++ b/.github/workflows/audit-dist-from-run.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload audit logs + reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: audit-replay-${{ inputs.deploy_run_id }}
           path: |

--- a/.github/workflows/gsc-frontaliere-monitor.yml
+++ b/.github/workflows/gsc-frontaliere-monitor.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload monitor report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gsc-frontaliere-monitor-report
           path: data/gsc-frontaliere-monitor-report.json

--- a/.github/workflows/inspect-dist-composition.yml
+++ b/.github/workflows/inspect-dist-composition.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload composition report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-composition-${{ inputs.deploy_run_id }}
           path: /tmp/composition-report.txt

--- a/.github/workflows/recover-prev-slugs.yml
+++ b/.github/workflows/recover-prev-slugs.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload scan artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: recover-prev-slugs-scan-${{ github.run_id }}
           path: /tmp/prev-slug-recovery/

--- a/.github/workflows/restore-from-artifact.yml
+++ b/.github/workflows/restore-from-artifact.yml
@@ -45,7 +45,7 @@ jobs:
           cd _restore && unzip -q artifact.zip
 
       - name: Re-upload as fresh github-pages artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: github-pages
           path: _restore/artifact.tar

--- a/.github/workflows/rpm-canary.yml
+++ b/.github/workflows/rpm-canary.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload canary result artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rpm-canary-${{ github.run_id }}
           path: |

--- a/.github/workflows/seo-serp-autopilot.yml
+++ b/.github/workflows/seo-serp-autopilot.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload autopilot artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: seo-serp-autopilot-${{ github.run_number }}
           path: |

--- a/.github/workflows/sitemap-shard-size-monitor.yml
+++ b/.github/workflows/sitemap-shard-size-monitor.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sitemap-shard-size-report
           path: data/sitemap-shard-size-report.json

--- a/.github/workflows/smoke-test-ai-models.yml
+++ b/.github/workflows/smoke-test-ai-models.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload smoke-test artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ai-models-smoke-${{ github.run_id }}
           path: |


### PR DESCRIPTION
Completes Node 24 migration trio: #779 (download-artifact) + #792 (checkout/setup-node) + this PR (upload-artifact).\n\nv7 già baseline in deploy.yml ×4 + post-build-matrix-test.yml ×2. Allinea i restanti 13 workflow.\n\nClose #785.