### PR TITLE
perf(post-walk): async parallel dist/ walk (BFS, 8-way concurrent readdir)

### DIFF
--- a/build-plugins/postWalkCoordinatorPlugin.ts
+++ b/build-plugins/postWalkCoordinatorPlugin.ts
@@ -98,17 +98,51 @@ interface WorkerResult {
 
 /**
  * Walk every `.html` file under `dir`, skipping static-asset directories.
+ *
+ * BFS with bounded async concurrency. Each round reads up to
+ * WALK_CONCURRENCY directories in parallel via `fs.promises.readdir`, then
+ * folds new subdirs back into the queue and continues. Beats the sync
+ * recursive generator because (a) each readdir is a syscall that benefits
+ * from io_uring + libuv overlap, not a CPU loop, and (b) one slow dir
+ * (cold-cache, deep tree) no longer serially blocks every peer.
+ *
+ * Data point from run 26604491084 ([post-walk-profile] table):
+ *   walk-dist  1  65333 ms  ← sync recursive `walkHtml` baseline
+ *
+ * With 19 k+ directories the C-runtime cost per `readdirSync` (~1-3 ms)
+ * dominates wall; concurrent reads amortise the per-call overhead across
+ * the libuv thread pool.
+ *
+ * WALK_CONCURRENCY=8 keeps aggregate open-fd footprint at ≤ 8 simultaneous
+ * directory handles, well under any ulimit. Skips the same asset
+ * directories (`assets`, `data`, `images`) the sync version did — those
+ * dirs hold static files (sprites, JSONs, images) with no SEO HTML to
+ * post-process.
  */
-function* walkHtml(dir: string): Iterable<string> {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const p = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (entry.name === 'assets' || entry.name === 'data' || entry.name === 'images') continue;
-      yield* walkHtml(p);
-    } else if (entry.isFile() && entry.name.endsWith('.html')) {
-      yield p;
+async function walkHtml(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const WALK_CONCURRENCY = 8;
+  let queue: string[] = [dir];
+  while (queue.length > 0) {
+    const batch = queue.splice(0, WALK_CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((d) => fs.promises.readdir(d, { withFileTypes: true })),
+    );
+    const nextQueue: string[] = queue;
+    for (let i = 0; i < batch.length; i++) {
+      const baseDir = batch[i];
+      for (const entry of results[i]) {
+        if (entry.isDirectory()) {
+          if (entry.name === 'assets' || entry.name === 'data' || entry.name === 'images') continue;
+          nextQueue.push(path.join(baseDir, entry.name));
+        } else if (entry.isFile() && entry.name.endsWith('.html')) {
+          out.push(path.join(baseDir, entry.name));
+        }
+      }
     }
+    queue = nextQueue;
   }
+  return out;
 }
 
 /**
@@ -385,12 +419,12 @@ export function postWalkCoordinatorPlugin(
 
         // ── Phase A: enumerate every emitted HTML file once ──────────
         const __tWalk = profileStart();
-        const allHtmlPaths: string[] = [];
+        const allHtmlPaths = await walkHtml(distDir);
+        profileRecord('walk-dist', __tWalk);
         const processHtmlPaths: string[] = [];
         const existingHtmlSet = new Set<string>();
         let preEmittedFlatBridgesSkipped = 0;
-        for (const file of walkHtml(distDir)) {
-          allHtmlPaths.push(file);
+        for (const file of allHtmlPaths) {
           existingHtmlSet.add(file);
           if (isPreEmittedJobFlatBridgePath(distDir, file)) {
             preEmittedFlatBridgesSkipped++;
@@ -398,7 +432,6 @@ export function postWalkCoordinatorPlugin(
             processHtmlPaths.push(file);
           }
         }
-        profileRecord('walk-dist', __tWalk);
         const filesScanned = allHtmlPaths.length;
         if (filesScanned === 0) {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
Data-driven follow-up a #776 + #795. `[post-walk-profile] walk-dist` 65.3s wall — recursive sync `readdirSync` su 19k+ subdir serializza ogni syscall. Converto a BFS async con 8-way concurrent `fs.promises.readdir`. Atteso 65s → ~5-10s.\n\nByte-identico: stesso skip set (assets/data/images), stesso filtro estensione, stesso path.join. Set membership invariato; ordine BFS vs DFS non altera output (consumer order-insensitive).\n\nProfiler #776 attivo → next deploy misura delta diretto.