### PR TITLE
fix(workflows): tolerate transient git-fetch failure in retry loops

### DIFF
--- a/.github/workflows/crawler-health-monitor.yml
+++ b/.github/workflows/crawler-health-monitor.yml
@@ -81,7 +81,7 @@ jobs:
               # data/crawler-health.json so conflicts are extremely rare,
               # but rebase keeps us safe even when a parallel push lands
               # between our fetch and push.
-              git fetch origin main
+              git fetch origin main || true  # tolerate transient net failure; rebase below will signal staleness
               if ! git rebase origin/main; then
                 echo "⚠️ Rebase conflict — aborting and resetting."
                 git rebase --abort 2>/dev/null || true
@@ -92,7 +92,7 @@ jobs:
                 # Reset our commit, re-add the file (latest remote may have
                 # touched it), then loop.
                 git reset --mixed HEAD~1 || true
-                git fetch origin main
+                git fetch origin main || true  # tolerate transient net failure; rebase below will signal staleness
                 git reset --hard origin/main
                 # Re-run the script so the state file reflects the new
                 # remote baseline plus today's observations.

--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -209,7 +209,7 @@ jobs:
           source scripts/lib/resolve-append-conflicts.sh
 
           # ── Sync with remote BEFORE committing ──
-          git fetch origin main
+          git fetch origin main || true  # tolerate transient net failure; rebase below will signal staleness
           LOCAL=$(git rev-parse HEAD)
           REMOTE=$(git rev-parse origin/main)
 

--- a/.github/workflows/gsc-frontaliere-monitor.yml
+++ b/.github/workflows/gsc-frontaliere-monitor.yml
@@ -111,7 +111,7 @@ jobs:
               exit 0
             fi
             echo "⚠️ Push rejected (attempt $attempt/$MAX_ATTEMPTS) — fetch + rebase, then retry…"
-            git fetch origin main
+            git fetch origin main || true  # tolerate transient net failure; rebase below will signal staleness
             if ! git rebase origin/main; then
               echo "⚠️ Rebase conflict on data/gsc-frontaliere-baseline.json — aborting and resetting."
               git rebase --abort || true

--- a/.github/workflows/refresh-thin-promotions.yml
+++ b/.github/workflows/refresh-thin-promotions.yml
@@ -99,7 +99,7 @@ jobs:
               exit 0
             fi
             echo "⚠️ Push rejected (attempt $attempt/$MAX_ATTEMPTS) — fetch + rebase, then retry…"
-            git fetch origin main
+            git fetch origin main || true  # tolerate transient net failure; rebase below will signal staleness
             if ! git rebase origin/main; then
               echo "⚠️ Rebase conflict on data/thin-page-promotions-*.json — aborting and resetting."
               git rebase --abort || true

--- a/.github/workflows/update-weather.yml
+++ b/.github/workflows/update-weather.yml
@@ -63,7 +63,7 @@ jobs:
               exit 0
             fi
             echo "push failed (attempt $attempt), rebasing..."
-            git fetch origin main
+            git fetch origin main || true  # tolerate transient net failure; rebase below will signal staleness
             git rebase origin/main || { git rebase --abort; sleep 2; continue; }
             sleep $((attempt * 2))
           done


### PR DESCRIPTION
Closes #800. GH Actions `run:` default `bash -eo pipefail` esce su `git fetch origin main` fail (net transient). Aggiungo `|| true` ai 6 fetch sites in 5 workflow retry loops (crawler-health-monitor ×2, gsc, generate-article, refresh-thin-promotions, update-weather).