### PR TITLE
fix(workflows): add retry loop to 3 remaining unprotected pushes

### DIFF
--- a/.github/workflows/build-evidence-and-tune.yml
+++ b/.github/workflows/build-evidence-and-tune.yml
@@ -51,10 +51,33 @@ jobs:
           git pull --rebase --autostash origin main
           if git diff --cached --quiet; then
             echo "No evidence changes to commit"
-          else
-            git commit -m "chore(evidence): refresh $(date -u +%Y-%m-%d)"
-            git push origin HEAD:main
+            exit 0
           fi
+          git commit -m "chore(evidence): refresh $(date -u +%Y-%m-%d)"
+          # Retry-on-rebase loop — same pattern as #794/#804/#805/#806.
+          # Concurrent producers on main (crawlers + scheduled refreshers
+          # + post-merge auto-commits) regularly out-race a single push;
+          # mirror the loop already proven elsewhere.
+          MAX_ATTEMPTS=5
+          BACKOFF_BASE=3
+          attempt=1
+          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+            if git push origin HEAD:main; then
+              echo "✅ Pushed evidence refresh."
+              exit 0
+            fi
+            echo "⚠️ Push rejected (attempt $attempt/$MAX_ATTEMPTS) — fetch + rebase, then retry…"
+            git fetch origin main || true
+            if ! git -c rebase.autoStash=true rebase origin/main; then
+              echo "⚠️ Rebase conflict on evidence data files — aborting and resetting."
+              git rebase --abort || true
+              exit 1
+            fi
+            sleep $((BACKOFF_BASE * attempt))
+            attempt=$((attempt + 1))
+          done
+          echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving evidence uncommitted."
+          exit 1
 
   tune-quota:
     needs: build-evidence
@@ -83,7 +106,27 @@ jobs:
           git pull --rebase --autostash origin main
           if git diff --cached --quiet; then
             echo "No tune changes to commit"
-          else
-            git commit -m "chore(tune): quota update $(date -u +%Y-%m-%d)"
-            git push origin HEAD:main
+            exit 0
           fi
+          git commit -m "chore(tune): quota update $(date -u +%Y-%m-%d)"
+          # Retry-on-rebase loop — same as the build-evidence job above.
+          MAX_ATTEMPTS=5
+          BACKOFF_BASE=3
+          attempt=1
+          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+            if git push origin HEAD:main; then
+              echo "✅ Pushed tune state."
+              exit 0
+            fi
+            echo "⚠️ Push rejected (attempt $attempt/$MAX_ATTEMPTS) — fetch + rebase, then retry…"
+            git fetch origin main || true
+            if ! git -c rebase.autoStash=true rebase origin/main; then
+              echo "⚠️ Rebase conflict on quota state files — aborting and resetting."
+              git rebase --abort || true
+              exit 1
+            fi
+            sleep $((BACKOFF_BASE * attempt))
+            attempt=$((attempt + 1))
+          done
+          echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving tune uncommitted."
+          exit 1

--- a/.github/workflows/regenerate-visual-baselines.yml
+++ b/.github/workflows/regenerate-visual-baselines.yml
@@ -81,4 +81,26 @@ jobs:
 
           Manually triggered via regenerate-visual-baselines.yml.
           See workflow run for context."
-          git push
+          # Retry-on-rebase loop — same pattern as #794/#804/#805/#806.
+          # workflow_dispatch-only job, but main is busy with concurrent
+          # producers so a non-fast-forward race is still possible.
+          MAX_ATTEMPTS=5
+          BACKOFF_BASE=3
+          attempt=1
+          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+            if git push origin HEAD:main; then
+              echo "✅ Pushed regenerated baselines."
+              exit 0
+            fi
+            echo "⚠️ Push rejected (attempt $attempt/$MAX_ATTEMPTS) — fetch + rebase, then retry…"
+            git fetch origin main || true
+            if ! git -c rebase.autoStash=true rebase origin/main; then
+              echo "⚠️ Rebase conflict on visual baseline files — aborting and resetting."
+              git rebase --abort || true
+              exit 1
+            fi
+            sleep $((BACKOFF_BASE * attempt))
+            attempt=$((attempt + 1))
+          done
+          echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving baselines uncommitted."
+          exit 1


### PR DESCRIPTION
Propaga il rebase-retry pattern (#794/#804/#805/#806) ai 3 push site rimanenti: build-evidence-and-tune × 2 (Commit evidence + Commit tune state) + regenerate-visual-baselines × 1. Stesso 5-attempt loop con `fetch origin main || true` (#800/#807).