### PR TITLE
revert(post-walk): roll back #795 IN_FLIGHT 4→8 and #802 async walkHtml

### DIFF
--- a/build-plugins/postWalkCoordinatorPlugin.ts
+++ b/build-plugins/postWalkCoordinatorPlugin.ts
@@ -99,50 +99,26 @@ interface WorkerResult {
 /**
  * Walk every `.html` file under `dir`, skipping static-asset directories.
  *
- * BFS with bounded async concurrency. Each round reads up to
- * WALK_CONCURRENCY directories in parallel via `fs.promises.readdir`, then
- * folds new subdirs back into the queue and continues. Beats the sync
- * recursive generator because (a) each readdir is a syscall that benefits
- * from io_uring + libuv overlap, not a CPU loop, and (b) one slow dir
- * (cold-cache, deep tree) no longer serially blocks every peer.
- *
- * Data point from run 26604491084 ([post-walk-profile] table):
- *   walk-dist  1  65333 ms  ← sync recursive `walkHtml` baseline
- *
- * With 19 k+ directories the C-runtime cost per `readdirSync` (~1-3 ms)
- * dominates wall; concurrent reads amortise the per-call overhead across
- * the libuv thread pool.
- *
- * WALK_CONCURRENCY=8 keeps aggregate open-fd footprint at ≤ 8 simultaneous
- * directory handles, well under any ulimit. Skips the same asset
- * directories (`assets`, `data`, `images`) the sync version did — those
- * dirs hold static files (sprites, JSONs, images) with no SEO HTML to
- * post-process.
+ * Reverted from the async BFS variant (PR #802) back to a sync recursive
+ * generator. Run 26608004451 [post-walk-profile]:
+ *   walk-dist  PR #802 → 85.7 s   (vs 65.3 s sync baseline, +31%)
+ * The 8-way `fs.promises.readdir` BFS contended with the post-walk worker
+ * pool (each worker also issues `fs.promises.readFile` through libuv's
+ * default 4-thread pool) and ended up paying Promise scheduling overhead
+ * + thread-pool serialization that the C-runtime sync recursion avoided.
+ * Re-investigate when the worker pool moves to io_uring native ops or
+ * `UV_THREADPOOL_SIZE` is bumped repo-wide.
  */
-async function walkHtml(dir: string): Promise<string[]> {
-  const out: string[] = [];
-  const WALK_CONCURRENCY = 8;
-  let queue: string[] = [dir];
-  while (queue.length > 0) {
-    const batch = queue.splice(0, WALK_CONCURRENCY);
-    const results = await Promise.all(
-      batch.map((d) => fs.promises.readdir(d, { withFileTypes: true })),
-    );
-    const nextQueue: string[] = queue;
-    for (let i = 0; i < batch.length; i++) {
-      const baseDir = batch[i];
-      for (const entry of results[i]) {
-        if (entry.isDirectory()) {
-          if (entry.name === 'assets' || entry.name === 'data' || entry.name === 'images') continue;
-          nextQueue.push(path.join(baseDir, entry.name));
-        } else if (entry.isFile() && entry.name.endsWith('.html')) {
-          out.push(path.join(baseDir, entry.name));
-        }
-      }
+function* walkHtml(dir: string): Iterable<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'assets' || entry.name === 'data' || entry.name === 'images') continue;
+      yield* walkHtml(p);
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      yield p;
     }
-    queue = nextQueue;
   }
-  return out;
 }
 
 /**
@@ -419,12 +395,12 @@ export function postWalkCoordinatorPlugin(
 
         // ── Phase A: enumerate every emitted HTML file once ──────────
         const __tWalk = profileStart();
-        const allHtmlPaths = await walkHtml(distDir);
-        profileRecord('walk-dist', __tWalk);
+        const allHtmlPaths: string[] = [];
         const processHtmlPaths: string[] = [];
         const existingHtmlSet = new Set<string>();
         let preEmittedFlatBridgesSkipped = 0;
-        for (const file of allHtmlPaths) {
+        for (const file of walkHtml(distDir)) {
+          allHtmlPaths.push(file);
           existingHtmlSet.add(file);
           if (isPreEmittedJobFlatBridgePath(distDir, file)) {
             preEmittedFlatBridgesSkipped++;
@@ -432,6 +408,7 @@ export function postWalkCoordinatorPlugin(
             processHtmlPaths.push(file);
           }
         }
+        profileRecord('walk-dist', __tWalk);
         const filesScanned = allHtmlPaths.length;
         if (filesScanned === 0) {
           // eslint-disable-next-line no-console

--- a/build-plugins/postWalkWorker.mjs
+++ b/build-plugins/postWalkWorker.mjs
@@ -87,30 +87,28 @@ const writeFailures = [];
 
 /**
  * In-flight concurrency limit per worker. The coordinator spawns N=4 workers
- * on the standard 4-vCPU CI runner. Bumped 4 → 8 (commit TBD) after the
- * [post-walk-profile] table on run 26604491084 measured:
- *   - read         976518 files  1620.9 s total  86.0%  ← dominant
- *   - worker-dispatch       1     110.8 s wall          ← Promise.all gate
- *   - hreflang-transform 900491     7.7 s              ← cheap, fast-path
+ * on the standard 4-vCPU CI runner; with 4 in-flight async file ops per
+ * worker the runner can have ~16 concurrent reads/writes, fully saturating
+ * SSD-backed I/O. Sequential profile measured CPU=170s wall=87s (~2× speedup
+ * across 4 workers due to per-worker sync blocking); switching to async
+ * within each worker should overlap I/O wait with peer-file CPU and bring
+ * wall closer to CPU/N.
  *
- * The wall is gated by I/O fan-out: each worker processes ~244 k files at
- * 1.66 ms avg, of which ~1.6 ms is fs.readFile wait (no CPU work). With
- * IN_FLIGHT=4 lanes per worker the kernel readahead pipeline tops out at
- * ~100 s per worker (Promise.all wall = 110 s, dominated by tail latency).
- * Doubling lanes lets each worker overlap 2× more in-flight readFile ops
- * — well within the libuv default thread pool size (UV_THREADPOOL_SIZE=4
- * per worker, but readFile uses the kernel async io_uring path on Node 22+
- * which is not pool-bound). Aggregate fd count stays bounded at
- * 4 workers × 8 IN_FLIGHT = 32 simultaneous open files, two orders of
- * magnitude under the ulimit 65535 ceiling.
+ * Reverted 8 → 4 (was bumped to 8 in PR #795 on the assumption that the
+ * worker-dispatch wall would scale linearly with lane count). Run
+ * 26608004451 [post-walk-profile] disproved that:
+ *   - worker-dispatch wall   PR #795 → 112.5 s (vs 110.8 s baseline, unchanged)
+ *   - read total_ms          PR #795 → 3179 s  (vs 1621 s baseline, +96%)
+ *   - read avg_ms            PR #795 → 3.25 ms (vs 1.66 ms baseline, +96%)
+ * Doubling lanes doubled CPU work without reducing wall — the readahead
+ * pipeline was already saturated at IN_FLIGHT=4 on the standard runner,
+ * and the extra lanes only added scheduler/contention overhead.
  *
- * Output invariant preserved: each filePath is still claimed by exactly one
- * worker and written exactly once. Lane count only changes the order in
- * which a worker dequeues from its assigned chunk — counters mutate
- * worker-local state, no cross-lane race. Byte-identical sitemap content
- * and on-disk HTML.
+ * We avoid going higher to keep aggregate fd count bounded (workers × IN_FLIGHT
+ * ≤ 32 here, well under the 65535 ulimit on ubuntu-latest and the 1024
+ * conservative ulimit honoured elsewhere in the repo, see batchWrite.ts).
  */
-const IN_FLIGHT = 8;
+const IN_FLIGHT = 4;
 
 /**
  * Detect a flat .html that's already a redirect bridge — emitted that way


### PR DESCRIPTION
## Summary

Run 26608004451 (first build post-#795+#802) measured:

| metric | baseline | post-PRs | delta |
|---|---:|---:|---:|
| post-walk wall | 177.1 s | 207.3 s | **+17%** |
| read avg_ms | 1.66 | 3.25 | +96% |
| write avg_ms | 1.53 | 4.50 | +194% |
| walk-dist | 65.3 s | 85.7 s | +31% |
| worker-dispatch | 110.8 s | 112.5 s | flat |

Both PRs regressed measurably. Revert.

## Implementato

- `postWalkWorker.mjs` IN_FLIGHT: 8 → 4 (revert #795).
- `postWalkCoordinatorPlugin.ts` walkHtml: async BFS → sync recursive generator (revert #802). Caller restored to sync iterator.
- Comments updated with the failure data + reason so future re-attempts don't repeat the mistake.

## Root cause

- **#795 (IN_FLIGHT 4→8)**: kernel readahead saturated at lane=4 on standard 4-vCPU runner → doubling lanes added scheduler+contention overhead, doubled CPU work, zero wall reduction.
- **#802 (async BFS walkHtml)**: `fs.promises.readdir` contended with worker pool's `fs.promises.readFile` calls through libuv's default 4-thread pool → Promise scheduling overhead + thread-pool serialization > C-runtime sync recursion fast path.

## Byte invariant

Same file enumeration set, same per-file processing, same write order. Profiler from #776 stays on so next deploy keeps producing `[post-walk-profile]` data.

## Non implementato (future investigation)

Re-attempt parallelism only after addressing the underlying constraints:
- io_uring native ops in the worker (Node 22+ but not default).
- `UV_THREADPOOL_SIZE` bump repo-wide.
- Larger runner SKU (more vCPUs / faster I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)