### PR TITLE
fix(router): drop staticOverlay on /cerca-lavoro-ticino/ root — restore JobBoard hydration

### DIFF
--- a/services/router.ts
+++ b/services/router.ts
@@ -2877,13 +2877,21 @@ export function parsePath(pathname: string): ParseResult {
  // P7.1 — legacy /cerca-lavoro-ticino/{slug?} → always TI canton filter.
  // Bare hub root (no jobSlug) is a build-time static page emitted by
  // professionLandingsLinksPlugin with `<aside data-ae3-profession-links>`
- // + curated city/sector hub links. Without staticOverlay the SPA replaced
- // the static main with the interactive JobBoard on hydration, producing
- // CLS 0.702 on /cerca-lavoro-ticino/ (Lighthouse 2026-05-28).
- if (!jobSlug) {
- return { route: { activeTab: 'job-board', jobBoardCanton: 'TI', staticOverlay: true }, locale };
- }
- return { route: { activeTab: 'job-board', jobBoardCanton: 'TI', jobSlug }, locale };
+ // + curated city/sector hub links. The CLS 0.702 incident on the bare
+ // root (Lighthouse 2026-05-28) was caused by the OLD HTML shape:
+ // `<div id="root"><main id="main-content">${179KB static body}</main></div>`.
+ // React's `createRoot(...).render(<App/>)` cancelled the 179KB on
+ // hydration → grosso shift. PR #765 fixed the shape: bare root now emits
+ // `<div id="root"></div>` empty + `<main class="seo-static-content">`
+ // OUTSIDE root. React hydrates the empty `#root` with JobBoard and
+ // App.tsx's useLayoutEffect (App.tsx:204-212) flips the sibling
+ // `<main class="seo-static-content">` to `display:none` synchronously
+ // BEFORE paint. Same DOM choreography as every other canton job-board
+ // hub (`/cerca-lavoro-basilea/`, `/cerca-lavoro-zurigo/`, etc.) which
+ // already sit at staticOverlay=false and Lighthouse-pass. Without
+ // staticOverlay here the bare root behaves identically: search bar +
+ // canton filters + interactive job cards visible above the fold.
+ return { route: { activeTab: 'job-board', jobBoardCanton: 'TI', ...(jobSlug ? { jobSlug } : {}) }, locale };
  }
  }
 


### PR DESCRIPTION
## Summary

User report: \`/cerca-lavoro-ticino/\` serves the static page; the SPA
JobBoard (search bar, canton filters, interactive job cards) never
hydrates. Compared against \`/cerca-lavoro-basilea/\` which serves the
exact same DOM shape but hydrates JobBoard correctly:

- Basilea (working): \`staticOverlay = false\`, React main \`flex-grow\`
  inside #root with 3951 chars, 22 job cards, search input visible.
- Ticino root (broken): \`staticOverlay = true\`, no React main rendered,
  only static \`<main class="seo-static-content">\` (14709 chars,
  display:grid) survives.

## Root cause

PR #721 set \`staticOverlay: true\` on the bare TI root to fix CLS 0.702.
That was the right fix when the static HTML had this shape:

\`\`\`
<div id="root"><main id="main-content">${179KB static body}</main></div>
\`\`\`

React's \`createRoot(...).render(<App/>)\` wiped the 179KB on hydration
→ grosso shift above the fold (Lighthouse measured 0.702).

PR #765 fixed the underlying shape:

\`\`\`
<div id="root"></div>
<main class="seo-static-content">${179KB static body}</main>
<div id="footer-root"></div>
\`\`\`

React hydrates the empty \`#root\` with JobBoard. App.tsx:204-212
useLayoutEffect flips the sibling \`<main class="seo-static-content">\`
to \`display:none\` synchronously BEFORE the first paint. This is the
exact choreography every other canton job-board hub uses
(\`/cerca-lavoro-basilea/\`, \`/cerca-lavoro-zurigo/\`, …) — all at
\`staticOverlay: false\` and Lighthouse-pass.

After #765 the staticOverlay flag on the bare TI root is obsolete: it
prevents the React main from rendering at all, leaving users on a
static navigational hub (no search, no filters, no clickable cards).

## Fix

Drop staticOverlay for the bare TI root. Subpaths keep their existing
overlay semantics:
- \`if (rawSecond && resolveEditorialJobLandingDescriptor(rawSecond))\`
  → staticOverlay: true (editorial landings, no SPA replace)
- \`if (rawSecond && isCantonStaticOverlaySlug(rawSecond))\`
  → staticOverlay: true (company hubs, search clusters, pagination)
- \`if (jobSlug)\` → no staticOverlay, SPA renders JobDetail
- **bare root → NO staticOverlay, SPA renders JobBoard (this PR)**

CLS expected to stay 0: DOM choreography is identical to the already-
CLS-clean canton hubs (#765's contribution).

## Implementato

- \`services/router.ts:2877+\`: rimosso \`staticOverlay: true\` dal branch
  bare root (\`if (!jobSlug)\`). Branch collapsato nello stesso shape
  delle altre canton hub via spread \`...(jobSlug ? { jobSlug } : {})\`.
- Aggiornato commento esteso che documenta perché \`staticOverlay\` non
  serve più dopo #765 (DOM shape ora identica alle canton hubs già
  CLS-clean).

## Non implementato (ancora)

- **Fail validate-dist text-html-ratio** (84532 offender pages, regressioni
  job-board 65039>340, spa-other 8581>2, spa-locale 10851>9, career-landings 10>0)
  — bloccato i deploy del 29 maggio, NON causato da questo PR né da #765
  (impatta solo 4 hub URL). Probabili colpevoli PR #723/#740 (tier
  emission). Da affrontare in PR separato.
- **Test cathedral-job-detail-canton.test.ts**: regola la matrix
  multi-canton testata in #772 NON tocca il bare root path
  \`/cerca-lavoro-ticino/\` (testa solo subpath \`/cerca-lavoro-{canton}/<slug>/\`).
- **Lighthouse re-check post-deploy**: CLS \`/cerca-lavoro-ticino/\` deve
  restare ≤ 0.1. Misurato manualmente dopo merge.

## Test plan

- [ ] CI: \`review\` (pr-review-loop) pass
- [ ] Post-deploy: Playwright eval su \`/cerca-lavoro-ticino/\`:
  - \`staticOverlay === false\` nello state React
  - \`<main flex-grow>\` dentro #root con > 1000 chars
  - search input presente, job cards > 0
  - \`<main class="seo-static-content">.computedStyle.display === 'none'\`
- [ ] Lighthouse \`/cerca-lavoro-ticino/\` post-deploy: CLS ≤ 0.1, score ≥ 0.85
- [ ] Confronto visivo Basilea vs Ticino root: same layout, same chrome,
      JobBoard visibile in entrambi

🤖 Generated with [Claude Code](https://claude.com/claude-code)