### PR TITLE
fix(create-article): date institutional ti.ch/USTAT listings to enforce recency

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2577,7 +2577,7 @@ function extractDateFromUrl(url) {
 }
 
 /** Build a map of URL → date from <time> elements found near <a> links in the HTML */
-function extractDatesFromHtml(html) {
+function extractDatesFromHtml(html, baseUrl) {
   const dateMap = new Map();
   // Match <time datetime="..."> anywhere in HTML — build global date context
   const timeRe = /<time[^>]*datetime=["']([^"']+)["'][^>]*>/gi;
@@ -2595,6 +2595,34 @@ function extractDatesFromHtml(html) {
       } catch { /* skip invalid dates */ }
     }
   }
+
+  // Plain-text DD.MM.YYYY dates nested inside the link — institutional listings
+  // such as Canton Ticino / USTAT (www3.ti.ch …fuseaction=news.dettaglio) render
+  // each row as `<a href=…><div class="data">28.05.2026</div><div class="testo">
+  // title</div></a>`, with no <time> element. Without this, every ti.ch headline
+  // arrives undated and bypasses the MAX_ARTICLE_AGE_DAYS recency filter — that
+  // is how a Dec-2025 office-closure notice was still surfaced on 28.05.2026
+  // (then false-matched into the proven pool). Scope the date to the anchor's
+  // own inner HTML so the link↔date pairing is exact (proximity windows misfire
+  // when the same nwsId appears in multiple sidebars).
+  const anchorRe = /<a\s[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+  let am;
+  while ((am = anchorRe.exec(html)) !== null) {
+    const inner = am[2];
+    const dmy = inner.match(/\b([0-3]?\d)\.(0?[1-9]|1[0-2])\.(20\d{2})\b/);
+    if (!dmy) continue;
+    const day = Number(dmy[1]);
+    const month = Number(dmy[2]);
+    const year = Number(dmy[3]);
+    if (day < 1 || day > 31) continue;
+    // Resolve to the absolute URL so the key matches extractHeadlines' lookup.
+    let href;
+    try { href = new URL(am[1], baseUrl).href; } catch { continue; }
+    if (!href.startsWith('http') || dateMap.has(href)) continue;
+    const d = new Date(year, month - 1, day);
+    if (!isNaN(d.getTime())) dateMap.set(href, d);
+  }
+
   return dateMap;
 }
 
@@ -2609,7 +2637,7 @@ function isWithinDays(date, days) {
 // ── Step 1b: Extract links and headlines from an HTML page ──
 function extractHeadlines(html, baseUrl) {
   const results = [];
-  const htmlDateMap = extractDatesFromHtml(html);
+  const htmlDateMap = extractDatesFromHtml(html, baseUrl);
   // Match <a href="...">text</a> — capture href and inner text
   const linkRe = /<a\s[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
   let m;


### PR DESCRIPTION
## Problema

L'articolo `chiusura-amministrazione-ticino-2025` (notizia chiusura uffici cantonali pomeriggio **31 dic 2025**) è stato pubblicato il **28 mag 2026** — 5 mesi dopo l'evento, già scaduta.

Root cause: le pagine news istituzionali ti.ch/USTAT (`www3.ti.ch …fuseaction=news.dettaglio`) rendono la data di ogni riga come testo `28.05.2026` annidato nel link, non come `<time>`. `extractDatesFromHtml` leggeva solo `<time datetime>`, quindi **ogni headline ti.ch arrivava senza data** → bypassava il filtro `MAX_ARTICLE_AGE_DAYS` (3 giorni) → entrava nel pool fallback `undated` (top 120) → il ranker proven pool l'ha falso-matchata alla query GSC `"offerte di lavoro ticino"` (score 79.66), stesso pattern dell'incidente malpensa documentato a riga ~2840.

## Implementato

- `extractDatesFromHtml(html, baseUrl)`: secondo passaggio che estrae date `DD.MM.YYYY` **dall'inner HTML di ogni `<a>…</a>`** (accoppiamento link↔data esatto, immune ai widget duplicati che sballano la proximity globale). Href relativi risolti con `baseUrl` così la chiave map combacia con la lookup di `extractHeadlines`.
- Call site aggiornato per passare `baseUrl`.
- Verificato end-to-end su HTML reale + sintetico: item recenti (28.05.2026) restano in `recent`; item vecchi (31.12.2025) ricevono data reale → esclusi sia da `recent` che da `undated` → droppati del tutto.

Effetto: ogni futura run che pesca da fonti istituzionali con date testuali `DD.MM.YYYY` applica correttamente la finestra di freschezza. Fix generale, non solo ti.ch.

## Non implementato (ancora)

- **Rimozione articoli già pubblicati** (`chiusura-amministrazione-ticino-2025`, `manutenzione-ustat-servizi-chiusure-31-12-2025`) — fuori scope di questa PR (fix pipeline). Il fix è preventivo, non retroattivo. Follow-up separato se si decide di de-listarli/redirect.
- **Hardening del fallback `undated.slice(0,120)`** — il pool undated resta attivo by-design per cicli di news quieti; non toccato per evitare regressioni su altre fonti. Questo fix chiude il leak ti.ch alla fonte (date reali) senza disabilitare il fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)