### PR TITLE
fix(assemble): reconcile guard read mergedCount not merged — dead writeJson dropped previousSlugs persistence

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -1764,8 +1764,8 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
             ? JSON.parse(fs.readFileSync(enrichedFile, 'utf8'))
             : {};
           const orphanResult = reconcileOrphanSlugs(assembled, orphanSlugs, enrichedData, { dryRun: false, writeSlices: true });
-          if (orphanResult.merged > 0) {
-            console.log(`  🔗 Orphan reconciliation: ${orphanResult.merged} slugs merged into active jobs' previousSlugs`);
+          if (orphanResult.mergedCount > 0) {
+            console.log(`  🔗 Orphan reconciliation: ${orphanResult.mergedCount} slugs merged into active jobs' previousSlugs`);
             writeJson(DATA_JOBS, assembled);
             writeJson(PUBLIC_JOBS, assembled);
           }
@@ -1773,8 +1773,8 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
 
         // Reconcile expired slugs → merge into active jobs' previousSlugs
         const expResult = reconcileExpiredSlugs(assembled, cleanedExpired, { dryRun: false, writeSlices: true });
-        if (expResult.merged > 0) {
-          console.log(`  🔗 Expired reconciliation: ${expResult.merged} slugs merged into active jobs' previousSlugs`);
+        if (expResult.mergedCount > 0) {
+          console.log(`  🔗 Expired reconciliation: ${expResult.mergedCount} slugs merged into active jobs' previousSlugs`);
           writeJson(DATA_JOBS, assembled);
           writeJson(PUBLIC_JOBS, assembled);
           writeJson(DATA_EXPIRED, cleanedExpired);

--- a/tests/reconcile-slugs-merged-count-contract.test.ts
+++ b/tests/reconcile-slugs-merged-count-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+// @ts-expect-error — .mjs ESM module, no type declarations
+import { reconcileOrphanSlugs, reconcileExpiredSlugs } from '../scripts/reconcile-job-slugs.mjs';
+
+const root = path.resolve(__dirname, '..');
+
+// Regression guard for the silently-dead writeJson gate in
+// assemble-jobs-dataset.mjs: the reconcile functions return `mergedCount`,
+// but the assemble caller read `orphanResult.merged` / `expResult.merged`
+// (always undefined → `undefined > 0` false), so the post-reconcile
+// writeJson(DATA_JOBS/PUBLIC_JOBS) never fired and the merged previousSlugs
+// (the redirect bridge for indexed orphan/expired slugs) were never persisted
+// to the canonical dataset. previousSlugs preservation is funnel-critical:
+// without it, previously-indexed job URLs 404 instead of bridging.
+
+describe('reconcile slug functions — mergedCount return contract', () => {
+  it('reconcileOrphanSlugs returns numeric `mergedCount`, never `merged`', () => {
+    const res = reconcileOrphanSlugs([], [], {}, { dryRun: true });
+    expect(typeof res.mergedCount).toBe('number');
+    expect('merged' in res).toBe(false);
+  });
+
+  it('reconcileExpiredSlugs returns numeric `mergedCount`, never `merged`', () => {
+    const res = reconcileExpiredSlugs([], [], { dryRun: true });
+    expect(typeof res.mergedCount).toBe('number');
+    expect('merged' in res).toBe(false);
+  });
+});
+
+describe('assemble-jobs-dataset reconcile guards read the correct property', () => {
+  const source = fs.readFileSync(
+    path.resolve(root, 'scripts/assemble-jobs-dataset.mjs'),
+    'utf-8',
+  );
+
+  it('gates the post-reconcile writeJson on `.mergedCount`, not `.merged`', () => {
+    expect(source).toContain('orphanResult.mergedCount > 0');
+    expect(source).toContain('expResult.mergedCount > 0');
+    // The dead-gate property must not reappear on either result object.
+    expect(source).not.toMatch(/orphanResult\.merged\b(?!Count)/);
+    expect(source).not.toMatch(/expResult\.merged\b(?!Count)/);
+  });
+});


### PR DESCRIPTION
## Summary

Funnel-critical bug surfaced (but never tracked) by the PR #829 reviewer's adversarial-check `❓ q`. The `post-merge-followup` triage that should have opened a follow-up issue has not fired since 2026-05-28 23:00, so the finding evaporated. Fixing directly.

`reconcileOrphanSlugs` / `reconcileExpiredSlugs` (`scripts/reconcile-job-slugs.mjs:672,808`) return `{ mergedCount, ... }`. The assemble caller (`scripts/assemble-jobs-dataset.mjs:1767,1776`) gated the post-reconcile `writeJson` on `orphanResult.merged` / `expResult.merged` — a property that does not exist → `undefined > 0` is always `false`.

Consequence: the `writeJson(DATA_JOBS, assembled)` + `writeJson(PUBLIC_JOBS, assembled)` (and expired equivalents) that persist the merged `previousSlugs` into the **canonical** dataset never executed. `previousSlugs` is the redirect bridge that keeps previously-indexed orphan/expired job URLs serving full-content pages instead of 404 — i.e. organic-traffic preservation. The in-place merge into `assembled` (functions mutate `activeJobs` in place, per their JSDoc) was computed each run and then dropped on the floor for the canonical files. Partial mitigation existed via `writeSlices: true`, but the canonical-file gate was provably dead.

## Implementato

- `scripts/assemble-jobs-dataset.mjs:1767,1776`: guard + log interpolation read `.mergedCount` instead of the nonexistent `.merged`. The previously-unreachable `writeJson(DATA_JOBS/PUBLIC_JOBS[/DATA_EXPIRED/PUBLIC_EXPIRED])` now fires exactly when merges happen.
- `tests/reconcile-slugs-merged-count-contract.test.ts`: regression guard. Locks (a) the return contract — both reconcile fns return numeric `mergedCount` and no `merged` key — and (b) the assemble guard property name via static source assertion. Either half would have caught this bug.

## Non implementato (ancora)

- **End-to-end reconcile→assemble integration test** (real orphan/expired fixtures → assert canonical `data/jobs.json` gains `previousSlugs`) — heavier fixture setup, follow-up. The contract + static guards added here close the specific regression.
- **Backfill of merges missed while the gate was dead** — `writeSlices: true` wrote slices each run, so the next assemble run after this fix re-runs reconciliation and persists canonically; no manual backfill scripted. Verify on next deploy that `data/jobs.json` `previousSlugs` counts move.

## Test plan

- [x] `npx vitest run tests/reconcile-slugs-merged-count-contract.test.ts` — 3 passing
- [x] `node --check scripts/assemble-jobs-dataset.mjs` — syntax OK
- [ ] Post-deploy: confirm the assemble step logs `🔗 Orphan/Expired reconciliation: N slugs merged` (previously silent) and `previousSlugs` coverage rises

🤖 Generated with [Claude Code](https://claude.com/claude-code)