### PR TITLE
fix(blog): backdate stale 2025 office-closure articles to event date

### DIFF
--- a/data/blog-articles-data.ts
+++ b/data/blog-articles-data.ts
@@ -8056,7 +8056,7 @@ export const ARTICLES = [
   {
  id: 'manutenzione-ustat-servizi-chiusure-31-12-2025',
  category: 'pratico',
- date: '2026-04-17T09:45:06.716Z',
+ date: '2025-12-18T09:45:06.716Z',
  image: '/images/blog/manutenzione-ustat-servizi-chiusure-31-12-2025.webp',
  hasCalculator: true,
  authorSlug: 'redazione',
@@ -24899,7 +24899,7 @@ export const ARTICLES = [
  {
  id: 'chiusura-amministrazione-ticino-2025',
  category: 'novita',
- date: '2026-05-28T07:27:40.905Z',
+ date: '2025-12-18T07:27:40.905Z',
  image: '/images/blog/chiusura-amministrazione-ticino-2025.webp',
  hasCalculator: true,
  authorSlug: 'redazione',

--- a/data/blog-articles/chiusura-amministrazione-ticino-2025.json
+++ b/data/blog-articles/chiusura-amministrazione-ticino-2025.json
@@ -1,7 +1,7 @@
 {
   "id": "chiusura-amministrazione-ticino-2025",
   "slug": "chiusura-amministrazione-ticino-2025",
-  "publishedAt": "2026-05-28T07:27:42.473Z",
+  "publishedAt": "2025-12-18T07:27:42.473Z",
   "cluster": "lavoro",
   "_pool": "proven",
   "_pool_source": "ti.ch",

--- a/services/seo/seo-blog-5.ts
+++ b/services/seo/seo-blog-5.ts
@@ -40814,8 +40814,8 @@ const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
         "height": 675,
         "caption": "Vista serale del centro amministrativo di Bellinzona in inverno."
       },
-      "datePublished": "2026-05-28T07:27:40+00:00",
-      "dateModified": "2026-05-28T07:27:40+00:00",
+      "datePublished": "2025-12-18T07:27:40+00:00",
+      "dateModified": "2025-12-18T07:27:40+00:00",
       "inLanguage": "it",
       "author": {
         "@type": "Person",

--- a/services/seo/seo-blog.ts
+++ b/services/seo/seo-blog.ts
@@ -8269,8 +8269,8 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
         "height": 675,
         "caption": "Edificio Ustat a Lugano con neve al crepuscolo"
       },
-      "datePublished": "2026-04-17T09:45:06+00:00",
-      "dateModified": "2026-04-17T09:45:06+00:00",
+      "datePublished": "2025-12-18T09:45:06+00:00",
+      "dateModified": "2025-12-18T09:45:06+00:00",
       "inLanguage": "it",
       "author": {"@id": "https://frontaliereticino.ch/#organization"},
       "publisher": {"@id": "https://frontaliereticino.ch/#organization"},


### PR DESCRIPTION
## Problema

Due articoli che descrivono la chiusura uffici cantonali del **31 dic 2025** erano datati nel futuro rispetto all'evento, quindi comparivano come notizie fresche:

- `chiusura-amministrazione-ticino-2025` → datato `2026-05-28` (5 mesi dopo l'evento)
- `manutenzione-ustat-servizi-chiusure-31-12-2025` → datato `2026-04-17`

(Il primo è quello segnalato; entrato in pipeline via il bug di parsing date ti.ch — vedi PR #830 che lo previene a monte.)

## Implementato

Articoli **mantenuti live**, contenuto invariato. Spostate tutte le date al **2025-12-18** (annuncio della chiusura imminente del 31 dic 2025), su tutti i punti che le espongono:

- `data/blog-articles-data.ts` — campo `date:` (rendering + ordinamento lista → scendono sotto i post recenti)
- `services/seo/seo-blog-5.ts` (chiusura) — JSON-LD `datePublished` + `dateModified`
- `services/seo/seo-blog.ts` (manutenzione) — JSON-LD `datePublished` + `dateModified`
- `data/blog-articles/chiusura-amministrazione-ticino-2025.json` — `publishedAt`

Effetto: structured data e ordinamento riflettono la finestra reale dell'evento; gli articoli leggono come archivio, non come novità.

## Non implementato (ancora)

- **De-listing / redirect** — l'utente ha scelto di lasciarli live, non rimuoverli. Nessun redirect.
- **Riscrittura corpo** — testo invariato; descrive già l'evento al 31 dic 2025 in modo coerente con la data retrodatata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)