### PR TITLE
fix(reviewer): close 3 systemic gaps in PR review contract (process short-circuit, perf-claim gate, funnel ❓ escalation)

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -91,8 +91,11 @@ jobs:
             3. Carica PR: `gh pr view $PR_NUMBER --json title,body,labels`, `gh pr diff $PR_NUMBER`, `gh pr view $PR_NUMBER --json files`.
 
             **Esegui workflow di review come specificato in REVIEW.md:**
-            - completeness contract → Implementato critical thinking → Non implementato filtro scopo → scope drift → cross-file pattern repetition (step 5) → test plan compliance (step 6) → output.
+            - completeness contract → Implementato critical thinking → Non implementato filtro scopo → scope drift → cross-file pattern repetition (step 5) → test plan compliance (step 6) → claim perf non validato (step 7) → output.
             - Tier high: aggiungi sezione `## Adversarial check` con 3 cose NON verificate prima del summary finale.
+            - **Sezioni mancanti + tier high (REVIEW.md step 4): posta il 🔴 process MA NON terminare.** Prosegui con review sostanziale + `## Adversarial check` completi nello stesso pass — il 🔴 blocca solo l'auto-merge, non un merge manuale, quindi la sostanza deferita evapora. Solo tier normal può terminare al process gate.
+            - **Claim perf non validato (REVIEW.md step 7):** PR perf/build/CI che dichiara speedup/regressione attesa senza misura baseline pre-merge (solo "atteso X→Y" / "il profiler misura post-deploy") su tier high → 🔴 Important. Chiedi misura pre/post o revert-risk esplicito.
+            - **Escalation ❓ funnel-critical (REVIEW.md Verification):** un ❓ q (incluso quelli nell'adversarial check) il cui soggetto impatta monetizzazione/traffico (writeJson/persistenza dataset indicizzato, canonical/redirect/previousSlugs, structured data, sitemap, AdSense) → promuovi a 🔴 o apri follow-up issue + linkala. Mai ❓ funnel-critical passivo accanto a `## LGTM`.
 
             **Cross-file pattern probing (REVIEW.md step 5):** quando il diff fix-a un pattern (regex, parsing idiom, assertion shape), usa `rg` per cercare il pattern equivalente nel resto del repo. Pattern presente non toccato in file funnel-critico → 🔴; altrove → 🟡.
 
@@ -104,4 +107,5 @@ jobs:
             - Read-only: no push, no edit file.
             - Zero finding accettabile → chiudi con `## LGTM` (string esatta triggera auto-merge). Non inventare per riempire.
             - 🔴 aperto → NON scrivere `## LGTM`.
+            - ❓ funnel-critical non escalato (né 🔴 né follow-up issue) → NON scrivere `## LGTM`.
             - Incerto → `❓ q:`, no speculazione.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -61,19 +61,26 @@ PR body DEVE avere:
 1. **Implementato item** → critical thinking: diff lo implementa? edge case? logica boundary/null/async/ordering? modo più semplice? buco visibile? Code-smell con maintenance debt anche se non blocca il funnel → 🟡 Nit.
 2. **Non implementato item** → filtro scopo: critico per monetizzazione/traffico? SÌ → 🔴 chiedi impl pre-merge o follow-up issue. NO → ignora.
 3. **Diff fa cose non dichiarate** → 🟡 scope drift: "diff fa X non in scope. PR separata o aggiungi a Implementato."
-4. **Sezioni mancanti** → 🔴 process: "manca Implementato/Non implementato nel PR body. Aggiungere prima review sostanziale." Termina, no altri finding.
+4. **Sezioni mancanti** → 🔴 process: "manca Implementato/Non implementato nel PR body. Aggiungere prima review sostanziale."
+   - **Tier normal**: termina qui, no altri finding (path basso rischio, review sostanziale rimandata al re-push conforme).
+   - **Tier high (`tests/**`, `.github/workflows/**`, `scripts/**`, `build-plugins/**`): NON terminare.** Posta il 🔴 process E prosegui con la review sostanziale + `## Adversarial check` completi nello stesso pass. Motivo: il 🔴 process blocca solo l'auto-merge (`## LGTM`), non un merge manuale; se la sostanza è deferita ("re-review post-update") e l'autore mergia a mano, il probing non avviene mai e i bug si propagano. Caso reale: #814 deferì idempotency-retry-loop + `rebase --abort` autostash → mergiato a mano dopo 40s → diventati le issue #816/#817. #795/#802 fermati al solo process gate → mergiati → entrambi revertati (#822, +17% wall). Non deferire mai il probing su tier high.
 5. **Cross-file pattern repetition** → quando il diff fix-a un pattern (regex, parsing idiom, assertion shape) in 1 file, `rg`/`grep` su pattern equivalente nel resto repo. Se stesso anti-pattern presente altrove non toccato → 🔴 se file funnel-critico (crawler/build-plugin/test gate), 🟡 altrove. Esempio: A3 fix regex `<link rel="canonical"...>` → cerca regex simili su HTML in altri test/crawler.
 6. **Test plan compliance** → PR body con `## Test plan` o checklist `- [ ]`: ogni voce è verificabile pre-merge o richiede live? Se richiede live, ok merged-without-tick MA flag come 🟡 ricorda spunta post-merge. Se verificabile pre-merge + non spuntata + reviewer non può confermare dal diff → 🟡 chiedi conferma o issue follow-up.
+7. **Claim perf/optimization non validato** → PR perf/build/CI che dichiara uno speedup o riduzione regressione (`atteso 65s → 5-10s`, `~60s sparmiati`, `177s → ~110s`) **senza misura baseline pre-merge** — solo "il profiler misura al prossimo deploy" / numeri "attesi" — su path tier high → 🔴 Important: "claim perf non validato pre-merge; mergi su speculazione. Allega misura pre/post oppure dichiara esplicito revert-risk nel `## Non implementato`." Motivo: #795 (IN_FLIGHT 4→8) e #802 (async BFS walkHtml) mergiati su claim attesi non misurati → entrambi regrediti (+17% post-walk wall) → revertati 24h dopo (#822). Parallelismo/IO-tuning su runner condiviso (4-vCPU GitHub) è il caso classico dove il claim atteso diverge dal misurato. Eccezione: ottimizzazione byte-identica banale (es. dedup-early provabile dal diff) o claim già supportato da un run linkato con numeri pre/post.
 
 ### Pre-output adversarial check (tier high)
 
 PR a tier `high` (`tests/**`, `.github/workflows/**`, `scripts/**`, `build-plugins/**`): prima del summary finale, includi sezione `## Adversarial check` con 3 cose NON verificate (regex edge case non testato, exit-code path non esplorato, file related non aperto, idempotency assumption). Surface come ❓ q dove pertinente. Tier normal: skip questa sezione.
+
+**Un ❓ dell'adversarial check il cui soggetto è funnel-critical NON resta sepolto qui.** Se mentre lo scrivi riconosci che, se vero, l'item impatta monetizzazione/traffico (SEO/redirect/structured-data/AdSense/sitemap/indicizzabilità) → promuovilo a 🔴 Important in `## Findings` (vedi Verification → escalation). L'adversarial check è per incertezze residue non-bloccanti, non per parcheggiare bug funnel-critical con un punto di domanda. Caso reale: #829 mise `orphanResult.merged` vs `.mergedCount` (writeJson previousSlugs morto → redirect bridge non persistito) come ❓ qui + `## LGTM` → auto-merge, zero follow-up.
 
 ## Verification
 
 Behavior claims richiedono `file:linea`. No speculazione. Incerto → `❓ q:`.
 
 **Edge case probing via `❓ q:`** anche quando sei sicuro dell'implementazione: input degenere, race condition, default che diventa permanente, refresh manuale dell'autore. Surface come domanda, non assumere che l'autore l'abbia considerato.
+
+**Escalation ❓ funnel-critical → 🔴.** Un `❓ q` resta `❓` solo se l'impatto, fosse anche vero, è non-funnel o cosmetico. Se il soggetto del dubbio — pre-existing o no — impatta monetizzazione/traffico (gate writeJson/persistenza su dataset indicizzato, canonical/redirect/previousSlugs, structured data, sitemap, AdSense placement, indicizzabilità) → NON lasciarlo `❓` passivo accanto a un `## LGTM`. Promuovilo a 🔴 Important (blocca auto-merge) **oppure** apri esplicitamente una follow-up issue e linkala nel finding. Il filtro "pre-existing / out of scope" abbassa la severità del *blocco PR*, non cancella un bug funnel-critical: vale comunque 🔴 o issue. Non affidarti a `post-merge-followup` come rete: può non scattare (storicamente è rimasto fermo) e il finding evapora.
 
 ## Re-review convergence
 
@@ -118,4 +125,4 @@ Prefix: `🔴 Important` / `🟡 Nit` / `🟣 Pre-existing` / `❓ q:`.
 <solo tier high: 3 cose NON verificate>
 ```
 
-Zero 🔴 Important: chiudi con `## LGTM` + frase recap. **Critico:** la stringa esatta `## LGTM` triggera auto-merge in `auto-merge-on-lgtm.yml`. Non scrivere mai `## LGTM` se hai aperto un 🔴 in findings o adversarial check.
+Zero 🔴 Important: chiudi con `## LGTM` + frase recap. **Critico:** la stringa esatta `## LGTM` triggera auto-merge in `auto-merge-on-lgtm.yml`. Non scrivere mai `## LGTM` se hai aperto un 🔴 in findings o adversarial check, **né se hai un ❓ funnel-critical non escalato** (vedi Verification → escalation): o lo promuovi a 🔴, o apri follow-up issue + lo dichiari, prima di poter scrivere `## LGTM`.


### PR DESCRIPTION
## Summary

Audit of recent merged PRs (#829, #828, #802, #795, #822, #814) compared the bot reviewer's output against an independent manual review. The bot is technically accurate (line-cited, cross-file `rg`, no hedging) but three systemic gaps let real defects through — each with a realized consequence in the merge history.

Modifies `REVIEW.md` + `.github/workflows/pr-review-loop.yml` → falls under the AGENTS.md workflow-validation exception (GitHub App blocks the reviewer on its own contract files; auto-merge will not fire). **Merge manually** via `gh pr merge --squash --delete-branch`; validate the new behavior on the next organic PR.

## Implementato

- **Gap 1 — process-gate short-circuit (REVIEW.md step 4 + workflow prompt).** Tier high no longer terminates on missing `## Implementato`/`## Non implementato`: it posts the 🔴 process **and** runs the full substantive review + `## Adversarial check` in the same pass. The 🔴 only blocks auto-merge, not a manual merge, so deferring substance ("re-review post-update") means it never happens. Evidence: #814 deferred idempotency-retry-loop + `rebase --abort` autostash probing → hand-merged 40s later → those exact concerns became follow-up issues #816/#817. #795/#802 stopped at the process gate, got merged, both reverted by #822 (+17% post-walk wall). Tier normal keeps the cheaper terminate behavior.
- **Gap 2 — unvalidated perf-claim gate (REVIEW.md step 7 + prompt).** Perf/build/CI PR claiming a speedup or regression-reduction with no pre-merge baseline measurement (only "atteso X→Y" / "profiler measures next deploy") on tier high → 🔴 Important: attach pre/post measurement or declare explicit revert-risk. #795 (IN_FLIGHT 4→8) and #802 (async BFS walkHtml) merged on expected-not-measured claims; both regressed and were reverted within 24h. Exception: trivially byte-identical opts or claims backed by a linked run with pre/post numbers.
- **Gap 3 — funnel-critical ❓ escalation (REVIEW.md Verification + adversarial-check section + LGTM gate + prompt).** A ❓ q (including ones in `## Adversarial check`) whose subject impacts monetization/traffic — writeJson/persistence on an indexed dataset, canonical/redirect/`previousSlugs`, structured data, sitemap, AdSense — must escalate to 🔴 or a linked follow-up issue, and blocks `## LGTM` either way. The "pre-existing / out of scope" filter lowers the *PR-blocking* severity, not the existence of a funnel-critical bug. #829 buried `orphanResult.merged` vs `.mergedCount` (dead writeJson → `previousSlugs` redirect bridge not persisted) as a ❓ + `## LGTM` → auto-merge, no follow-up. (The underlying code bug is fixed separately in #831.)

## Non implementato (ancora)

- **`post-merge-followup.yml` has not fired since 2026-05-28 23:00** — no triage run for #822/#828/#829, which is why #829's ❓ produced no follow-up issue even though FOLLOWUP.md §32 already covers adversarial-check bullets. Separate infra bug; needs investigation into why the `pull_request: closed` trigger stopped. Flagged here, not fixed — Gap 3's reviewer-level escalation deliberately does NOT depend on this downstream net. Follow-up.
- **Synthetic test for the auto-merge guard** (`## LGTM` suppressed when a funnel-critical ❓ is open) — issue #775 already tracks the 🔴+LGTM guard test; extend there rather than duplicate.
- **FOLLOWUP.md** untouched — it already routes adversarial-check ❓ to candidate issues (§32); the gap was the reviewer burying funnel-critical items as ❓ in the first place, now addressed upstream.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on pr-review-loop.yml — valid
- [ ] Next organic tier-high PR: confirm a missing-sections PR gets 🔴 process **plus** substantive findings in one review (not a bare process gate)
- [ ] Next perf PR without baseline: confirm 🔴 perf-claim finding fires
- [ ] Manual merge required (workflow-validation exception); verify reviewer behavior on the following PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)