### PR TITLE
fix(auto-merge): dispatch post-merge-followup via GH_PAT after LGTM merge

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -45,3 +45,26 @@ jobs:
             --squash \
             --delete-branch \
             --repo "${{ github.repository }}"
+
+      # Il merge sopra usa GITHUB_TOKEN: per design GitHub, eventi generati dal
+      # GITHUB_TOKEN (qui il `pull_request: closed`) NON triggerano altri
+      # workflow. Conseguenza storica: ogni PR auto-mergiata su `## LGTM`
+      # saltava `post-merge-followup.yml` (triage 🟡/❓/Non-implementato) — il
+      # workflow girava SOLO per le PR mergiate a mano (es. #814/#833), non per
+      # quelle auto-mergiate (#822/#828/#829/#831). Verificato: deploy.yml ha la
+      # propria mitigazione via workflow_dispatch, post-merge-followup no.
+      # Fix: dispatch esplicito del path workflow_dispatch (aggiunto in #809)
+      # con GH_PAT — le API autenticate con PAT triggerano i workflow, a
+      # differenza del GITHUB_TOKEN. Non cambiamo il token del merge (resta
+      # github-actions[bot]) per non introdurre un push-triggered deploy
+      # duplicato.
+      - name: Dispatch post-merge follow-up triage
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Dispatching post-merge-followup triage for auto-merged PR #$PR_NUMBER."
+          gh workflow run post-merge-followup.yml \
+            -f pr_number="$PR_NUMBER" \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Root-caused the "post-merge-followup not firing" gap found while auditing the reviewer (#833). It is not a transient outage — it is structural.

`auto-merge-on-lgtm.yml` merges with `GITHUB_TOKEN`. By GitHub design, **events triggered by `GITHUB_TOKEN` do not trigger other workflow runs** (recursion guard). The merge's resulting `pull_request: closed` event therefore never starts `post-merge-followup.yml`. Evidence from `mergedBy` + run history:

| PR | mergedBy | post-merge-followup ran? |
|----|----------|--------------------------|
| #814, #833 | `valerielinc-ops` (manual) | ✅ yes |
| #822, #828, #829, #831 | `app/github-actions` (auto-merge) | ❌ no |

Same rule explains why `deploy.yml` runs as `workflow_dispatch` (it has its own GH_PAT-driven dispatch mitigation) rather than on `push` for auto-merged commits. `post-merge-followup` had no such mitigation, so its triage (🟡 nits, ❓ questions, `## Non implementato`) silently evaporated for every LGTM auto-merge — including #829's funnel-critical ❓ about the dead `mergedCount` writeJson gate (fixed in #831).

## Implementato

- `.github/workflows/auto-merge-on-lgtm.yml`: after a successful squash-merge, add a step that dispatches `post-merge-followup.yml` via its `workflow_dispatch` path (added in #809) using `secrets.GH_PAT`. PAT-authenticated API calls trigger workflows; `GITHUB_TOKEN` ones do not. The dispatch path re-verifies merged + same-owner internally (FOLLOWUP.md), so it is safe to call.
- Merge token left as `GITHUB_TOKEN` (merge actor stays `github-actions[bot]`) deliberately — switching to PAT would also fire a `push` event and duplicate the deploy.

## Non implementato (ancora)

- **Backfill of the already-skipped PRs (#822/#828/#829/#831)** — could be triaged now via `gh workflow run post-merge-followup.yml -f pr_number=<N>`, but #831's ❓ is already resolved (its bug is fixed) and the others were perf/router PRs with no outstanding funnel items. Skipped as not worth the noise; can backfill on request.
- **GH_PAT scope/expiry hardening** — assumes `GH_PAT` stays valid (already used by `discover-404s.yml` / `sync-gsc-orphans.yml` to trigger deploys). No expiry monitoring added here.

## Test plan

- [x] `python3 yaml.safe_load` on the workflow — valid
- [ ] Self-validating: once this PR (manual merge, workflow-validation exception) is on main, the **next** LGTM auto-merged PR should produce a `post-merge-followup` run. Confirm via `gh run list --workflow=post-merge-followup.yml` showing the auto-merged PR.

> Note: modifies `auto-merge-on-lgtm.yml` → AGENTS.md workflow-validation exception. Reviewer will not post; **merge manually** via `gh pr merge --squash --delete-branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)