### PR TITLE
feat(issues): agent-driven issue triage + fix pipeline

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -1,0 +1,125 @@
+name: Issue fix (Claude → PR)
+
+on:
+  issues:
+    types: [labeled]
+
+# Serializza i fixer: un agent alla volta evita N PR concorrenti sullo stesso
+# data file (crawler config) + rispetta il cap OOM (max parallel agent). Le issue
+# in coda vengono processate appena lo slot si libera.
+concurrency:
+  group: issue-fix
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  fix:
+    # Gate (tutti necessari):
+    # - L'evento è l'aggiunta della label `agent:fix` (opt-in esplicito, mai
+    #   trigger su qualunque label). Solo collaborator/owner possono labellare,
+    #   quindi la label È il consenso umano.
+    # - sender == owner: belt-and-suspenders contro label aggiunte da automation
+    #   esterne / bot non fidati.
+    # - Auth via CLAUDE_CODE_OAUTH_TOKEN (subscription Max, zero API cost).
+    if: |
+      github.event.label.name == 'agent:fix' &&
+      github.event.sender.login == 'valerielinc-ops'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Determine fix tier
+        id: tier
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        # Tier high (opus, max-turns alti): issue che toccherà con ogni probabilità
+        # scripts/crawler/build-plugin/workflow/test (categoria crawler, o body che
+        # cita questi path). Bug lì = rischio propagato su ogni merge. Tier normal
+        # (sonnet) per il resto. Mirror della logica di pr-review-loop.
+        run: |
+          set -euo pipefail
+          body=$(gh issue view "$ISSUE_NUMBER" --json title,body,labels --jq '.title + "\n" + .body + "\n" + (.labels[].name)')
+          if echo "$body" | grep -qiE 'crawler|parser|scripts/|build-plugin|\.github/workflows/|test gate|validator|migrator'; then
+            echo "tier=high" >> "$GITHUB_OUTPUT"
+            echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"
+            echo "max_turns=40" >> "$GITHUB_OUTPUT"
+          else
+            echo "tier=normal" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
+            echo "max_turns=30" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Fix tier: $(grep tier= "$GITHUB_OUTPUT" | head -1)"
+
+      - name: Configure git identity
+        run: |
+          git config user.name "Valerie Linc"
+          git config user.email "valerielinc@gmail.com"
+
+      - name: Run Claude fix
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          REPO: ${{ github.repository }}
+          FIX_TIER: ${{ steps.tier.outputs.tier }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
+          prompt: |
+            Sei l'agent di fix autonomo per la issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}"). Tier: ${{ steps.tier.outputs.tier }}.
+
+            **Bootstrap (in quest'ordine):**
+            1. Leggi `ISSUES.md` → "Fix flow" — contratto operativo del fixer.
+            2. Leggi `AGENTS.md` — non-negotiables + Privacy + architettura. VINCOLANTE.
+            3. Carica la issue: `gh issue view $ISSUE_NUMBER --json number,title,body,labels,comments`.
+
+            **Pre-condizioni (abort se falliscono):**
+            - Se esiste già una PR aperta che cita "#$ISSUE_NUMBER" (`gh pr list --state open --search "$ISSUE_NUMBER in:body" --json number`) → posta commento "PR già in volo: #<n>, skip." e TERMINA. No doppioni.
+            - Se la issue è categoria `revenue` o `tracker` (strategica) → posta "Richiede giudizio umano, non auto-fixabile. Rimuovere `agent:fix`." e TERMINA.
+
+            **Fix flow (vedi ISSUES.md):**
+            1. Branch isolato: `git checkout -b fix/issue-$ISSUE_NUMBER`.
+            2. Diagnosi root cause della issue (NON sintomo). Per categoria `crawler`: il selector è driftato → rigenera/aggiusta il parser; preferisci `node scripts/generate-company-parser.mjs` o l'edit mirato del parser/config citato nel body.
+            3. Applica fix CHIRURGICO (AGENTS.md non-negotiable #6: no drive-by refactor, no speculative abstraction).
+            4. Mai abbassare quality gate/test/validation per "far passare" (non-negotiable #1).
+            5. Commit con identity canonica già configurata. Messaggio conventional, in fondo nessuna email non-canonica.
+            6. Push del branch: `git push -u origin fix/issue-$ISSUE_NUMBER`.
+            7. Apri PR con `gh pr create`. Body OBBLIGATORIO (REVIEW.md completeness contract):
+               ```
+               ## Implementato
+               - <cosa fa il fix>
+               Closes #$ISSUE_NUMBER
+
+               ## Non implementato (ancora)
+               - <scope NON fatto + motivo: out of scope / follow-up / blocked / posposto>
+               ```
+            8. La PR entra automaticamente in `pr-review-loop` → review → `## LGTM` → `auto-merge-on-lgtm`. NON mergiare a mano.
+
+            **Constraint:**
+            - Changes chirurgiche, root-cause, una issue alla volta.
+            - Mai toccare file fuori scope della issue.
+            - Mai disabilitare AdSense Auto Ads (non-negotiable #7).
+            - Mai committare path home assoluti o email personali (Privacy).
+            - Se la root cause non è determinabile con confidenza → NON forzare un fix; posta su issue "Root cause non determinata: <cosa hai trovato>. Serve indagine umana." rimuovi nulla e TERMINA senza PR.
+            - Se il fix richiede credenziali/segreti non disponibili in CI → documenta in commento e TERMINA senza PR.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,70 @@
+name: Issue triage (Claude classify + dedup)
+
+on:
+  issues:
+    types: [opened]
+
+# Anti-storm: solo una run triage alla volta. I monitor (post-deploy validate,
+# crawler-health) aprono issue in burst; serializzare evita due triage che
+# chiudono a vicenda lo stesso canonical come duplicato (race su gh issue close).
+concurrency:
+  group: issue-triage
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    # Gate:
+    # - Issue non già triagiata (label agent:triaged assente) → evita loop se un
+    #   altro automation ri-tocca l'issue.
+    # - Auth via CLAUDE_CODE_OAUTH_TOKEN (subscription Max, zero API cost), stesso
+    #   pattern di pr-review-loop / post-merge-followup.
+    # Nessun gate sull'autore: le issue sono per lo più auto-generate dai monitor
+    # del repo stesso (post-deploy validate, crawler-health, rpm-canary). Triage è
+    # read-mostly (dedup-close + classify comment + label), basso blast-radius.
+    if: ${{ !contains(github.event.issue.labels.*.name, 'agent:triaged') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude triage
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          REPO: ${{ github.repository }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          claude_args: "--max-turns 12 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
+          prompt: |
+            Triage automatico issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}").
+
+            **Bootstrap:**
+            1. Leggi `ISSUES.md` — contratto operativo completo (categorie, dedup, routing, label policy).
+            2. Carica l'issue: `gh issue view $ISSUE_NUMBER --json number,title,body,labels,createdAt`.
+            3. Carica le issue aperte simili per dedup (vedi ISSUES.md → Dedup):
+               `gh issue list --state open --limit 100 --json number,title,labels,createdAt`.
+
+            **Esegui workflow di triage come specificato in ISSUES.md → "Triage flow":**
+            - Classifica l'issue in UNA categoria (validation-failure | crawler | follow-up | revenue | tracker | other).
+            - Dedup: se è uno storm-duplicate di un canonical aperto più vecchio della stessa categoria/workflow → `gh issue close $ISSUE_NUMBER --comment "Duplicate of #<canonical> — chiudo per ridurre rumore." --reason "not planned"` e applica label `duplicate`. NON chiudere il canonical.
+            - Routing (vedi ISSUES.md → "Routing policy"):
+              - categoria `crawler` → applica `agent:fix` (`gh issue edit $ISSUE_NUMBER --add-label "agent:fix"`). Regen parser è deterministico e basso-rischio.
+              - categoria `follow-up`, `validation-failure`, `revenue`, `tracker` → NON applicare `agent:fix`. Posta UN commento di classificazione con la raccomandazione ("apply `agent:fix` se vuoi tentativo autonomo" / "richiede mano umana").
+            - SEMPRE come ultimo passo: `gh issue edit $ISSUE_NUMBER --add-label "agent:triaged"` (anche se chiusa come duplicate).
+
+            **Constraint:**
+            - Read-only eccetto: `gh issue close`, `gh issue edit` (label), `gh issue comment`.
+            - Mai aprire PR, mai modificare codice, mai chiudere il canonical di un dedup.
+            - Una sola classificazione per run.
+            - Incerto sulla categoria → `other` + commento "needs manual triage", nessun `agent:fix`.
+            - Mai applicare `agent:fix` a categoria `revenue` o `tracker` (richiedono giudizio strategico).

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,134 @@
+# Issue Automation Instructions
+
+Contratto operativo per la pipeline issue-agent: `issue-triage.yml` (classify + dedup) e `issue-fix.yml` (fix → PR). Companion locale: `/fix-issue N` (`.claude/commands/fix-issue.md`).
+
+## Scopo
+
+Le issue di questo repo sono per lo più **auto-generate dai monitor** (post-deploy validate dist/live, crawler-health, rpm-canary, follow-up post-merge). Vanno instradate per categoria, non trattate da un singolo agent indistinto. Obiettivo: ridurre il rumore (dedup storm) + risolvere autonomamente le categorie deterministiche, lasciando alla mano umana solo lo strategico.
+
+## Categorie
+
+| Categoria | Segnale (titolo/label) | Natura |
+|---|---|---|
+| `validation-failure` | "Validation Failure (dist\|live)", label `bug`+`priority:urgent` | alert post-deploy, spesso dupe/transiente |
+| `crawler` | "Crawler Failure", "[crawler-health] ...broken", label `priority:high` | selector drift, parser da rigenerare |
+| `follow-up` | "follow-up(#NNN)", label `follow-up` | micro-task / verifica deferred |
+| `revenue` | label `revenue` / `rpm-canary`, "RPM canary" | monetizzazione, strategico |
+| `tracker` | "master tracker", "recovery", senza label automation | piano umano multi-step |
+| `other` | nessun match | da triage manuale |
+
+## Triage flow (`issue-triage.yml`, on `issues: opened`)
+
+1. **Classifica** l'issue in UNA categoria.
+2. **Dedup**: confronta con le issue aperte. Una nuova issue è duplicate-storm se esiste un canonical aperto **più vecchio** della stessa categoria E stesso workflow/target (es. due "Validation Failure (dist)" consecutive, o due "[crawler-health] X broken" stessa company). Chiudi la nuova (`gh issue close --reason "not planned"`) con commento `Duplicate of #<canonical>`, applica label `duplicate`. **Mai chiudere il canonical.**
+3. **Routing** (vedi sotto).
+4. **Sempre** come ultimo step: applica `agent:triaged` (anche su issue chiuse come dup). Idempotenza: il workflow ha `if: !contains(labels,'agent:triaged')`.
+
+### Routing policy
+
+| Categoria | Azione triage |
+|---|---|
+| `crawler` | **Auto-applica `agent:fix`.** Regen parser è deterministico, basso blast-radius, già coperto da `generate-company-parser.mjs`. |
+| `follow-up` | NO auto-fix. Commento classificazione + "apply `agent:fix` se vuoi tentativo autonomo". |
+| `validation-failure` | NO auto-fix (spesso transiente — verifica prima la run successiva). Dedup aggressivo. Commento. |
+| `revenue` / `tracker` | NO auto-fix MAI. Richiede giudizio strategico → mano umana (`/fix-issue` locale o manuale). |
+| `other` | NO auto-fix. Commento "needs manual triage". |
+
+Razionale opt-in: solo `crawler` è auto-instradato perché è l'unica categoria con un fix-path deterministico e ripetuto. Tutto il resto richiede consenso umano esplicito = aggiunta manuale della label `agent:fix`. Coerente con AGENTS.md (opt-in, no automation cieca su revenue/funnel).
+
+## Fix flow (`issue-fix.yml`, on `issues: labeled == agent:fix`)
+
+Trigger SOLO sull'aggiunta della label `agent:fix` da parte dell'owner. La label È il consenso.
+
+1. **Pre-check**: PR aperta già citante la issue → skip. Categoria `revenue`/`tracker` → abort con commento.
+2. Branch `fix/issue-<N>`.
+3. Diagnosi **root cause** (non sintomo). `crawler` → rigenera parser / edit mirato selector+config.
+4. Fix **chirurgico** (AGENTS.md #6). Mai abbassare gate (#1). Mai disabilitare Auto Ads (#7).
+5. Commit identity canonica `Valerie Linc <valerielinc@gmail.com>`. No path home assoluti, no email personali (Privacy).
+6. Push branch + `gh pr create`.
+7. PR body OBBLIGATORIO `## Implementato` (con `Closes #N`) + `## Non implementato (ancora)` (REVIEW.md completeness contract).
+8. La PR fluisce in `pr-review-loop` → `## LGTM` → `auto-merge-on-lgtm`. **L'agent NON mergia a mano.**
+
+### Tier (mirror di pr-review-loop)
+
+| Tier | Trigger | Model / max-turns |
+|---|---|---|
+| high | issue tocca `crawler`/`parser`/`scripts/`/`build-plugin`/`.github/workflows/`/test gate | opus, 40 |
+| normal | resto | sonnet, 30 |
+
+### Abort senza PR (no fix forzato)
+
+- Root cause non determinabile con confidenza → commento "serve indagine umana" + termina.
+- Fix richiede credenziali/segreti non in CI → documenta + termina.
+- Mai un fix speculativo pur di produrre una PR.
+
+## Local fixer (`/fix-issue N`)
+
+Per le categorie strategiche (`revenue`, `tracker`) o issue HIGH-risk dove vuoi supervisione: worktree-first, GitNexus impact, approvazione umana prima del push.
+
+> ⚠️ `.gitignore` ignora `.claude/` (eccetto `settings.json`), quindi il file del comando `/fix-issue` **non è version-controlled**: vive solo localmente in `.claude/commands/fix-issue.md`. Lo spec completo è riprodotto qui sotto (Appendice A) per ricrearlo su qualsiasi clone.
+
+## Label
+
+| Label | Significato | Chi la mette |
+|---|---|---|
+| `agent:fix` | opt-in: l'agent tenta un fix → PR | triage (solo `crawler`) o owner manuale |
+| `agent:triaged` | issue già processata da triage | triage (anti-loop) |
+| `duplicate` | storm-duplicate, chiusa | triage |
+
+## Kill-switch
+
+- Disattivare auto-fix crawler: in `issue-triage.yml` rimuovere il ramo che applica `agent:fix`, oppure disabilitare il workflow da GitHub UI.
+- Bloccare un singolo fix: rimuovere `agent:fix` dalla issue prima che il fixer apra la PR (concurrency serializza, c'è una finestra).
+- Pausa totale: disabilitare `issue-fix.yml` / `issue-triage.yml` (Actions → workflow → Disable).
+
+## Guardrail (da AGENTS.md, vincolanti)
+
+- Opt-in: mai `agent:fix` automatico fuori da `crawler`.
+- Concurrency cap: un fixer/triage alla volta (no OOM, no PR concorrenti su stesso data file).
+- PR sempre via reviewer + `## LGTM`; mai bypass auto-merge.
+- Changes chirurgiche, root-cause, no drive-by.
+- Privacy: identity canonica, no path home, no email personali.
+
+---
+
+## Appendice A — `.claude/commands/fix-issue.md` (local-only, non tracciato)
+
+Salva questo contenuto in `.claude/commands/fix-issue.md` su ogni clone dove vuoi il comando `/fix-issue` (è gitignored, vedi sopra).
+
+````markdown
+---
+description: Fix a GitHub issue locally with human supervision (worktree-first, GitNexus impact). For strategic/high-risk issues the CI fixer shouldn't auto-handle.
+argument-hint: <issue-number>
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(npm:*), Bash(node:*), Read, Grep, Glob, Edit, Write
+---
+
+Fix locale supervisionato della issue **#$ARGUMENTS**.
+
+Companion locale di `issue-fix.yml` (CI). Usalo per le categorie che la pipeline NON auto-fixa: `revenue`, `tracker`, o issue HIGH-risk dove vuoi controllo. Differenza chiave: **tu approvi prima del push**.
+
+## Bootstrap
+1. Leggi `ISSUES.md` → "Fix flow" e `AGENTS.md` (non-negotiables + Privacy + Workflow).
+2. `gh issue view $ARGUMENTS --json number,title,body,labels,comments`.
+3. Classifica la categoria (ISSUES.md → Categorie).
+
+## Pre-condizioni
+- PR aperta già citante `#$ARGUMENTS` → fermati (no doppione).
+- Worktree-first obbligatorio: `git fetch origin main` + verifica `git rev-parse main` == `git rev-parse origin/main`; se divergono basa il worktree su `origin/main`.
+
+## Flow
+1. `git worktree add .claude/worktrees/fix-issue-$ARGUMENTS origin/main -b fix/issue-$ARGUMENTS`.
+2. GitNexus impact PRIMA di editare function/class/method. HIGH/CRITICAL → fermati e avvisa.
+3. Diagnosi root cause (non sintomo). `gitnexus_query` non grep cieco.
+4. Fix chirurgico: no drive-by, no speculative abstraction. Mai abbassare gate, mai disabilitare Auto Ads.
+5. STOP — mostra il diff e attendi approvazione umana prima di commit/push.
+6. Dopo OK: `gitnexus_detect_changes()`, poi commit (identity `Valerie Linc <valerielinc@gmail.com>`, no path home, no email personali).
+7. Push + `gh pr create`. Body `## Implementato` (`Closes #$ARGUMENTS`) + `## Non implementato (ancora)`.
+8. PR → `pr-review-loop` → `## LGTM` → auto-merge. Attendi `MERGED`, poi rimuovi worktree + branch + ref remoto.
+
+## Constraint
+- Approvazione umana del diff prima del push.
+- Una issue alla volta, changes chirurgiche.
+- Reviewer + `## LGTM`; mai merge a mano (salvo eccezione workflow-file AGENTS.md).
+````
+


### PR DESCRIPTION
## Implementato

Pipeline agent-driven per gestire le issue (per lo più auto-generate dai monitor del repo) instradandole per categoria invece che con un singolo agent indistinto.

- **`.github/workflows/issue-triage.yml`** (trigger `issues: opened`): un agent Claude (sonnet, OAuth token zero-cost, stesso pattern di `pr-review-loop`/`post-merge-followup`) classifica ogni nuova issue in una categoria, fa **dedup degli storm** (validation-failure / crawler-health aprono burst di duplicati → chiude i dupe linkando il canonical, mai chiude il canonical), e applica `agent:triaged` (anti-loop via `if: !contains(labels,'agent:triaged')`). Routing **opt-in**: auto-applica `agent:fix` SOLO alla categoria `crawler` (fix-path deterministico = regen parser); tutto il resto riceve un commento di classificazione e resta in mano umana.
- **`.github/workflows/issue-fix.yml`** (trigger `issues: labeled == agent:fix`, gate `sender == owner`): il fixer. Branch `fix/issue-N`, diagnosi root-cause, fix chirurgico, PR con body completeness-contract (`Closes #N`). La PR fluisce nella pipeline esistente `pr-review-loop → ## LGTM → auto-merge-on-lgtm`; l'agent non mergia a mano. Tier opus/sonnet mirror di `pr-review-loop`. Pre-check anti-doppione (PR già aperta) + abort senza-PR se root cause incerta o servono segreti non in CI.
- **`ISSUES.md`**: contratto operativo (categorie, triage flow, routing policy, fix flow, tier, kill-switch, guardrail) — companion di `REVIEW.md`/`FOLLOWUP.md`. Include in Appendice A lo spec completo del comando locale `/fix-issue` (vedi sotto).
- **Label nuove** (create via `gh`): `agent:fix` (opt-in trigger del fixer), `agent:triaged` (anti-loop triage).
- **`/fix-issue N`** (comando locale, scritto in `.claude/commands/` del clone): companion supervisionato per le categorie strategiche `revenue`/`tracker` — worktree-first, GitNexus impact, **approvazione umana del diff prima del push**. `.claude/` è gitignored (eccetto `settings.json`) quindi il file non è tracciabile; lo spec è in `ISSUES.md` Appendice A per ricrearlo su ogni clone.

Guardrail rispettati (AGENTS.md): opt-in (no `agent:fix` automatico fuori da `crawler`, mai su `revenue`/`tracker`), `concurrency` cap (un triage/fixer alla volta → no OOM, no PR concorrenti su stesso data file), PR sempre via reviewer + `## LGTM`, identity canonica, no path home/email personali.

## Non implementato (ancora)

- **Auto-resolve validation-failure transienti** (verifica se la run post-deploy successiva è verde e auto-chiude) — *posposto*: il triage gira su `opened`, non conosce run future. Richiede un workflow separato schedulato o un hook sul post-deploy-validate. Follow-up se il dedup da solo non basta a contenere il rumore.
- **Dedup semantico fuzzy** tra issue (oltre il match titolo/categoria) — *out of scope*: già tracciato come esigenza generale in #771 per `post-merge-followup.yml`; stessa soluzione andrà condivisa.
- **Backfill triage sulle ~30 issue già aperte** — *follow-up*: i workflow agiscono solo su nuove issue (`opened`) e su `labeled`. Le issue esistenti vanno triagiate applicando `agent:fix` a mano (o un `workflow_dispatch` di backfill, non incluso qui per tenere lo scope minimo).
- **Validazione live end-to-end** dei due workflow — *follow-up obbligatorio post-merge* (memory `test_new_workflows_live`): dopo il merge, etichettare manualmente una issue `crawler` di test con `agent:fix` e osservare che il fixer apra una PR valida; verificare che il triage chiuda un dupe. Da fare su `main`.
- **GitNexus impact/detect_changes**: N/A — la PR aggiunge solo YAML + Markdown, nessun simbolo codice (function/class/method) toccato.

## Note merge

Questa PR **aggiunge** due workflow file ma **non modifica** nessuno dei file protetti elencati in AGENTS.md (`pr-review-loop.yml`, `auto-merge-on-lgtm.yml`, `post-merge-followup.yml`, `REVIEW.md`, `FOLLOWUP.md`). Il reviewer bot dovrebbe postare normalmente. Se la GitHub App workflow-validation blocca il posting per via dei nuovi `.github/workflows/*`, merge manuale `gh pr merge --squash --delete-branch` come da clausola eccezione AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
