### PR TITLE
test(reconcile): cover main-loop return contract + drop dead writeSlices arg

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -1763,7 +1763,11 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
           const enrichedData = fs.existsSync(enrichedFile)
             ? JSON.parse(fs.readFileSync(enrichedFile, 'utf8'))
             : {};
-          const orphanResult = reconcileOrphanSlugs(assembled, orphanSlugs, enrichedData, { dryRun: false, writeSlices: true });
+          // reconcile* mutano `assembled` in place (aggiungono previousSlugs);
+          // NON scrivono slice (l'opzione `writeSlices` non è implementata in
+          // reconcile-job-slugs.mjs — vi si legge solo { dryRun, verbose, max }).
+          // La persistenza canonica è il writeJson sotto, gated su mergedCount.
+          const orphanResult = reconcileOrphanSlugs(assembled, orphanSlugs, enrichedData, { dryRun: false });
           if (orphanResult.mergedCount > 0) {
             console.log(`  🔗 Orphan reconciliation: ${orphanResult.mergedCount} slugs merged into active jobs' previousSlugs`);
             writeJson(DATA_JOBS, assembled);
@@ -1772,7 +1776,7 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
         }
 
         // Reconcile expired slugs → merge into active jobs' previousSlugs
-        const expResult = reconcileExpiredSlugs(assembled, cleanedExpired, { dryRun: false, writeSlices: true });
+        const expResult = reconcileExpiredSlugs(assembled, cleanedExpired, { dryRun: false });
         if (expResult.mergedCount > 0) {
           console.log(`  🔗 Expired reconciliation: ${expResult.mergedCount} slugs merged into active jobs' previousSlugs`);
           writeJson(DATA_JOBS, assembled);

--- a/tests/reconcile-slugs-merged-count-contract.test.ts
+++ b/tests/reconcile-slugs-merged-count-contract.test.ts
@@ -29,6 +29,51 @@ describe('reconcile slug functions — mergedCount return contract', () => {
   });
 });
 
+// The early-return path (above) and the main-loop path return distinct object
+// literals (reconcile-job-slugs.mjs:495 vs :619, :693 vs :808). The static
+// guard in the assemble file only covers the caller, not the function's return
+// shape — so a regression that adds a `merged` alias next to `mergedCount` on
+// the main-loop literal would slip past both. These cases drive non-empty input
+// through the loop and assert the main-loop return contract directly.
+describe('reconcile slug functions — main-loop return contract (non-empty input)', () => {
+  it('reconcileOrphanSlugs merges a high-Jaccard orphan and returns numeric `mergedCount`, no `merged`', () => {
+    // 4-token active slug vs 3-token orphan subset → Jaccard 3/4 = 0.75 ≥ 0.70
+    // (no recognizable companyKey in the slug → full-set scan, threshold 0.70).
+    const activeJobs = [
+      {
+        slug: 'elettricista-cantiere-notturno-rotazione',
+        company: 'Test Co',
+        companyKey: 'testco',
+        slugByLocale: { it: 'elettricista-cantiere-notturno-rotazione' },
+        titleByLocale: { it: 'Elettricista di cantiere' },
+      },
+    ];
+    const res = reconcileOrphanSlugs(activeJobs, ['elettricista-cantiere-notturno'], [], { dryRun: false });
+    expect(res.mergedCount).toBe(1);
+    expect('merged' in res).toBe(false);
+    // The merge must be applied in place — this is the previousSlugs bridge.
+    expect(activeJobs[0].previousSlugs).toContain('elettricista-cantiere-notturno');
+  });
+
+  it('reconcileExpiredSlugs reaches the main-loop return with non-empty input — numeric `mergedCount`, no `merged`', () => {
+    const activeJobs = [
+      {
+        slug: 'magazziniere-turni-deposito-regionale',
+        company: 'Test Co',
+        companyKey: 'testco',
+        slugByLocale: { it: 'magazziniere-turni-deposito-regionale' },
+        titleByLocale: { it: 'Magazziniere' },
+      },
+    ];
+    const expiredJobs = [
+      { slug: 'contabile-clienti-fatturazione-estero', titleByLocale: { it: 'Contabile clienti' } },
+    ];
+    const res = reconcileExpiredSlugs(activeJobs, expiredJobs, { dryRun: false });
+    expect(typeof res.mergedCount).toBe('number');
+    expect('merged' in res).toBe(false);
+  });
+});
+
 describe('assemble-jobs-dataset reconcile guards read the correct property', () => {
   const source = fs.readFileSync(
     path.resolve(root, 'scripts/assemble-jobs-dataset.mjs'),


### PR DESCRIPTION
## Summary

Follow-up to #831, closing the two adversarial-check depth nits the reviewer raised on that PR.

## Implementato

- **Main-loop return-contract tests** (`tests/reconcile-slugs-merged-count-contract.test.ts`): #831's cases only exercised the early-return literal (`reconcile-job-slugs.mjs:495/693`); the main-loop return (`:619/:808`) is a *separate* object literal that neither the early-return cases nor the assemble static guard covered. Added cases that drive non-empty input through the loop and assert the loop return directly (numeric `mergedCount`, no `merged` key). The orphan case exercises a **real merge** — 4-token active slug vs 3-token orphan subset → Jaccard 0.75 ≥ 0.70 threshold, no companyKey → full-set scan — and asserts `previousSlugs` is applied in place. This catches a regression where someone adds a `merged` alias next to `mergedCount` on the loop literal.
- **Drop dead `writeSlices: true` arg** (`scripts/assemble-jobs-dataset.mjs:1766,1775`): `reconcile-job-slugs.mjs` destructures only `{ dryRun, verbose, max }` from options — `writeSlices` was a silent no-op that implied slices get written. Removed from both call sites + added a comment that reconcile mutates `assembled` in place and persistence is the gated `writeJson`. No behavior change (the option was already ignored).

## Resolves

- Reviewer #831 adversarial check #1 (dynamic test only hit early-return) → main-loop cases added.
- Reviewer #831 adversarial check #2 (writeSlices path / slice↔canonical divergence) → **no divergence possible**: these functions never write slices, so there is no slice path to diverge. The misleading arg is removed.

## Non implementato (ancora)

- **Per-crawler slice updates for active jobs after reconcile** — not in scope; if slices ever need to reflect merged `previousSlugs`, `writeSlices` would have to be *implemented* in `reconcile-job-slugs.mjs`, not just passed. The canonical `data/jobs.json` / `public` write (restored in #831) is what the build plugin consumes for the bridge, so this is not currently a funnel gap. Follow-up if slice consumers are added.

## Test plan

- [x] `npx vitest run tests/reconcile-slugs-merged-count-contract.test.ts` — 5 passing (incl. real merge, score 0.750)
- [x] `node --check scripts/assemble-jobs-dataset.mjs` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)