### PR TITLE
fix(auto-merge): pin post-merge-followup dispatch to --ref main

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -66,5 +66,6 @@ jobs:
         run: |
           echo "Dispatching post-merge-followup triage for auto-merged PR #$PR_NUMBER."
           gh workflow run post-merge-followup.yml \
+            --ref main \
             -f pr_number="$PR_NUMBER" \
             --repo "${{ github.repository }}"


### PR DESCRIPTION
## Implementato

- `.github/workflows/auto-merge-on-lgtm.yml`: add explicit `--ref main` to the `gh workflow run post-merge-followup.yml` dispatch added in #836.

Addresses the #836 reviewer ❓: the dispatch defaulted to the default branch implicitly, while every other dispatch in the repo (`refresh-bfs-stats.yml`, `traffic-data-freshness.yml`, `deploy.yml`) pins `--ref main`. A default-branch rename would otherwise silently redirect the dispatch.

## Non implementato (ancora)

- **GH_PAT expiry monitoring** (#836 ❓) — out of scope; failure mode is loud (red X on the step), not silent. No expiry alerting added.
- **merge→mergedAt visibility race** (#836 ❓) — the `workflow_dispatch` path re-verifies `mergedAt`; worst case a single triage aborts with "PR not eligible". Low-risk edge, no retry added.

> Modifies `auto-merge-on-lgtm.yml` → AGENTS.md workflow-validation exception. **Merge manually**.

## Test plan

- [x] `yaml.safe_load` — valid
- [ ] Confirm on next LGTM auto-merge that the dispatched run targets `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)