### PR TITLE
fix(auto-merge): merge auto-mergiate PR via GITHUB_PAT so deploy cascades

### DIFF
--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -35,37 +35,65 @@ jobs:
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      # ── Perché tutto questo setup per un semplice merge ──────────────────
+      # Per design GitHub, un push/evento generato dal GITHUB_TOKEN di default
+      # NON triggera altri workflow (anti-ricorsione). Mergiare con GITHUB_TOKEN
+      # quindi:
+      #   - NON fa partire deploy.yml (`on: push: main`) → ogni PR auto-mergiata
+      #     saltava il deploy (es. #829: 0 run deploy per il suo merge commit).
+      #   - NON fa partire post-merge-followup.yml (`on: pull_request: closed`).
+      # Un PAT non ha questo limite: i suoi push/eventi triggerano i workflow.
+      # Il PAT vive in Firebase Remote Config come `GITHUB_PAT` (pattern
+      # zero-cost del repo, NON un Actions secret), caricato in $GITHUB_ENV da
+      # `scripts/load-rc-env.mjs`. Mergiando col PAT, il `pull_request: closed`
+      # fa partire post-merge-followup da solo → niente più dispatch esplicito
+      # (lo step #836/#839 usava `secrets.GH_PAT` che non esiste → era no-op).
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Prepare Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-sa.json
+            echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
+          else
+            echo "⚠️ Nessuna credenziale Firebase SA — GITHUB_PAT non verrà caricato; il merge ripiega su GITHUB_TOKEN (nessun cascade deploy/followup)."
+          fi
+
+      - name: Load secrets from Remote Config
+        continue-on-error: true
+        run: node scripts/load-rc-env.mjs
+
       - name: Squash-merge + delete branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # env.GITHUB_PAT (da Remote Config) → il push del merge triggera
+          # deploy.yml + tests + lighthouse, e il pull_request:closed triggera
+          # post-merge-followup. Fallback a GITHUB_TOKEN se la RC non carica: il
+          # merge avviene comunque, ma senza cascade (comportamento pre-fix).
+          GH_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "Auto-merge PR #$PR_NUMBER triggered by Claude LGTM review."
+          if [ -n "${GITHUB_PAT:-}" ]; then
+            echo "Auto-merge PR #$PR_NUMBER via GITHUB_PAT (cascade attivo: deploy + followup)."
+          else
+            echo "::warning::GITHUB_PAT assente — merge via GITHUB_TOKEN, nessun cascade (deploy/followup non partiranno)."
+          fi
           gh pr merge "$PR_NUMBER" \
             --squash \
             --delete-branch \
             --repo "${{ github.repository }}"
 
-      # Il merge sopra usa GITHUB_TOKEN: per design GitHub, eventi generati dal
-      # GITHUB_TOKEN (qui il `pull_request: closed`) NON triggerano altri
-      # workflow. Conseguenza storica: ogni PR auto-mergiata su `## LGTM`
-      # saltava `post-merge-followup.yml` (triage 🟡/❓/Non-implementato) — il
-      # workflow girava SOLO per le PR mergiate a mano (es. #814/#833), non per
-      # quelle auto-mergiate (#822/#828/#829/#831). Verificato: deploy.yml ha la
-      # propria mitigazione via workflow_dispatch, post-merge-followup no.
-      # Fix: dispatch esplicito del path workflow_dispatch (aggiunto in #809)
-      # con GH_PAT — le API autenticate con PAT triggerano i workflow, a
-      # differenza del GITHUB_TOKEN. Non cambiamo il token del merge (resta
-      # github-actions[bot]) per non introdurre un push-triggered deploy
-      # duplicato.
-      - name: Dispatch post-merge follow-up triage
-        if: success()
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          echo "Dispatching post-merge-followup triage for auto-merged PR #$PR_NUMBER."
-          gh workflow run post-merge-followup.yml \
-            --ref main \
-            -f pr_number="$PR_NUMBER" \
-            --repo "${{ github.repository }}"
+      - name: Cleanup Firebase credentials
+        if: always()
+        run: rm -f /tmp/firebase-sa.json

--- a/.github/workflows/auto-merge-on-lgtm.yml
+++ b/.github/workflows/auto-merge-on-lgtm.yml
@@ -77,22 +77,32 @@ jobs:
 
       - name: Squash-merge + delete branch
         env:
-          # env.GITHUB_PAT (da Remote Config) → il push del merge triggera
-          # deploy.yml + tests + lighthouse, e il pull_request:closed triggera
-          # post-merge-followup. Fallback a GITHUB_TOKEN se la RC non carica: il
-          # merge avviene comunque, ma senza cascade (comportamento pre-fix).
-          GH_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          # Token primario = env.GITHUB_PAT (da Remote Config): il push del merge
+          # triggera deploy.yml + tests + lighthouse, e il pull_request:closed
+          # triggera post-merge-followup. Il GITHUB_TOKEN di fallback serve in
+          # DUE casi (entrambi → merge avviene ma senza cascade, = pre-fix):
+          #   1. RC non carica → env.GITHUB_PAT vuoto → fallback diretto.
+          #   2. Merge col PAT fallisce (es. PAT senza scope PR-write) → retry
+          #      sotto con GITHUB_TOKEN, così l'auto-merge non si rompe mai.
+          PRIMARY_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HAS_PAT: ${{ env.GITHUB_PAT != '' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ -n "${GITHUB_PAT:-}" ]; then
-            echo "Auto-merge PR #$PR_NUMBER via GITHUB_PAT (cascade attivo: deploy + followup)."
+          if [ "$HAS_PAT" = "true" ]; then
+            echo "Auto-merge PR #$PR_NUMBER via GITHUB_PAT (cascade atteso: deploy + followup)."
           else
             echo "::warning::GITHUB_PAT assente — merge via GITHUB_TOKEN, nessun cascade (deploy/followup non partiranno)."
           fi
-          gh pr merge "$PR_NUMBER" \
-            --squash \
-            --delete-branch \
-            --repo "${{ github.repository }}"
+          if ! GH_TOKEN="$PRIMARY_TOKEN" gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "$REPO"; then
+            if [ "$HAS_PAT" = "true" ]; then
+              echo "::warning::Merge col GITHUB_PAT fallito (scope insufficiente?) — retry con GITHUB_TOKEN, nessun cascade."
+              GH_TOKEN="$FALLBACK_TOKEN" gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "$REPO"
+            else
+              exit 1
+            fi
+          fi
 
       - name: Cleanup Firebase credentials
         if: always()


### PR DESCRIPTION
## Implementato

Le PR auto-mergiate su `## LGTM` **non triggeravano `deploy.yml`** (né `post-merge-followup.yml`). Causa: `auto-merge-on-lgtm.yml` mergiava con `GITHUB_TOKEN`, e per design GitHub gli eventi generati dal `GITHUB_TOKEN` di default **non triggerano altri workflow** (anti-ricorsione). Quindi:
- `deploy.yml` (`on: push: main`) → mai per PR auto-mergiate. Verificato su **#829** (merge commit `790b00f8`): **0 run deploy**. Ultimo run-success deploy = **2026-05-25**.
- `post-merge-followup.yml` (`on: pull_request: closed`) → mai (= outage follow-up dal 28/05 in tracking).

Fix:
- Carica `GITHUB_PAT` da **Firebase Remote Config** (`scripts/load-rc-env.mjs`, pattern zero-cost già usato in generate-article/monitor-gsc-seo), non da un Actions secret.
- Mergia con `GH_TOKEN: ${{ env.GITHUB_PAT || secrets.GITHUB_TOKEN }}`. Il push del merge fa cascade → `deploy.yml` + `tests.yml` + `lighthouse-ci.yml`; il `pull_request: closed` fa cascade → `post-merge-followup.yml`.
- **Rimosso** lo step di dispatch esplicito `post-merge-followup` aggiunto in #836/#839: usava `secrets.GH_PAT` che **non esiste** nel repo (solo 3 secret: CLAUDE_CODE_OAUTH_TOKEN, FIREBASE_SERVICE_ACCOUNT_JSON, GSC_SERVICE_ACCOUNT_JSON) → era un no-op. Ora il `pull_request:closed` cascade lo copre direttamente, quindi tenerlo creerebbe doppio-trigger.
- Setup steps (checkout/node/npm ci --ignore-scripts/Firebase creds) replicano il pattern canonico del repo; cleanup creds in `always()`.
- **Fail-soft**: se la RC non carica, `GH_TOKEN` ripiega su `GITHUB_TOKEN` → il merge avviene comunque (comportamento pre-fix, nessun cascade) e logga un `::warning::`. Auto-merge non si rompe mai.

Collisione `generate-article.yml` ("Generate Blog Article"): **nessuna** — è `schedule + workflow_dispatch`, zero `on: push`, quindi il cascade del merge non lo tocca.

## Non implementato (ancora)

- **Scope PAT non verificato pre-merge**: il merge col PAT richiede che `GITHUB_PAT` (RC) abbia contents:write + PR:write sul repo. Il PAT è già usato per dispatchare `generate-article.yml` (actions:write), quindi è quasi certamente un classic PAT `repo`+`workflow`. Se mancasse PR-write il merge fallirebbe (no fallback su failure, solo su PAT assente). → **verifica live post-merge** alla prima PR organica auto-mergiata.
- **`lighthouse-ci.yml` su ogni merge**: il suo trigger `push: main` non ha `paths` filter → ora gira su ogni auto-merge (prima muto). Ha concurrency, ma è CI più pesante. Non aggiunto un paths filter qui per non allargare lo scope — follow-up se i minuti CI diventano un problema.
- **Push diretti dei crawler** (`💼 Auto-update X jobs`) e cron-commit: se anch'essi pushano con `GITHUB_TOKEN`, restano muti per il deploy. Non toccato — path diverso (push diretto, non PR). Da verificare separatamente.

## Note merge
Questa PR modifica `.github/workflows/auto-merge-on-lgtm.yml` → per l'eccezione in AGENTS.md la GitHub App reviewer non posta e l'auto-merge non scatta → **merge manuale** via `gh pr merge --squash --delete-branch`. La validità del fix si osserva sulla prossima PR organica auto-mergiata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)