### PR TITLE
fix(reviewer): bump tier-high max-turns 25→40 (contract expansion overran budget)

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -35,11 +35,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        # Tier high (opus, max-turns 25, adversarial pass): toccato test gate,
+        # Tier high (opus, max-turns 40, adversarial pass): toccato test gate,
         # workflow CI, script crawler/migrator/validator, build-plugin. Bug in
         # questi path = falso senso di sicurezza che si propaga su ogni merge,
         # quindi probing più profondo paga. Tier normal (sonnet, max-turns 15)
         # per tutto il resto. Vedi REVIEW.md → "Tier review".
+        #
+        # Budget 25→40: con l'espansione del contratto (REVIEW.md no-short-circuit
+        # su tier high + step 7 perf-claim + escalation ❓ funnel-critical, sopra
+        # il cross-file `rg` probing + adversarial check già presenti) il pass
+        # tier-high su un diff reale sforava i 25 turni e terminava
+        # `error_max_turns` SENZA postare review (PR #838, num_turns=26) — peggio
+        # del process gate, perché niente LGTM → PR bloccata e zero finding.
+        # 26 turni ≈ 3.5 min; 40 ≈ ~5.5 min, ben dentro il timeout 15 min.
         run: |
           set -euo pipefail
           files=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')
@@ -57,7 +65,7 @@ jobs:
           if echo "$files" | grep -qE '^(tests/|\.github/workflows/|scripts/|build-plugins/)'; then
             echo "tier=high" >> "$GITHUB_OUTPUT"
             echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"
-            echo "max_turns=25" >> "$GITHUB_OUTPUT"
+            echo "max_turns=40" >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"
             echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Regression from #833's contract expansion. The heavier tier-high review (no-short-circuit + step 7 perf-claim + funnel-critical ❓ escalation, on top of pre-existing cross-file `rg` probing + adversarial check) overran the 25-turn budget on PR #838 and ended `error_max_turns` (`num_turns: 26`) **without posting a review**. That's strictly worse than the old short-circuit: no review → no `## LGTM` → PR stalls in auto-merge limbo, and zero findings surface.

## Implementato

- `.github/workflows/pr-review-loop.yml`: tier-high `max_turns` 25 → 40, with a comment recording why (the contract got heavier, the budget must grow with it). Tier normal stays 15 — no observed overrun on the simpler paths.

Timing: 26 turns took ~3.5 min; 40 ≈ ~5.5 min, well inside the 15-min job timeout.

## Non implementato (ancora)

- **Adaptive/diff-size-scaled turn budget** — a flat 40 may still be tight on very large tier-high diffs and wasteful on tiny ones. Not worth the complexity now; revisit if another `error_max_turns` shows up.
- **Re-review of #838** — that PR got no review due to this bug; after this lands it will be re-triggered and reviewed under the new budget.

> Modifies `pr-review-loop.yml` → AGENTS.md workflow-validation exception. **Merge manually**.

## Test plan

- [x] `yaml.safe_load` valid; `max_turns=40` on the high branch, 15 elsewhere
- [ ] Re-trigger #838 review post-merge → confirm it posts within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)