### PR TITLE
fix(adsense): idle-load adsbygoogle.js so Auto Ads fire on no-scroll SPA sessions

### DIFF
--- a/components/shared/AdSenseBanner.tsx
+++ b/components/shared/AdSenseBanner.tsx
@@ -229,7 +229,37 @@ export default function AdSenseBanner({
  }
  }, { rootMargin: '200px 0px' });
  io.observe(wrapper);
- return () => io.disconnect();
+
+ // Auto Ads idle fallback: load adsbygoogle.js once the page goes idle even
+ // if this slot never scrolls into view. Without it, SPA routes whose static
+ // shell omits the external adsense-loader (e.g. the homepage) never load the
+ // script on a no-scroll / quick-bounce mobile session, so the anchor +
+ // in-page Auto Ads (the top RPM earners) never fire. Mirrors the
+ // requestIdleCallback fallback in ADSENSE_LOADER_CONTENT (build-plugins/
+ // constants.ts). Bot-gated to avoid inflating AD_REQUESTS. Loading the
+ // script alone enables Auto Ads; this slot's own push still waits for the
+ // IntersectionObserver, so manual slots stay lazy.
+ let idleHandle: number | undefined;
+ let idleTimer: ReturnType<typeof setTimeout> | undefined;
+ if (!SKIP_FOR_BOT) {
+ const ric = (window as unknown as {
+ requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+ }).requestIdleCallback;
+ if (typeof ric === 'function') {
+ idleHandle = ric(() => loadAdSenseScript(), { timeout: 3000 });
+ } else {
+ idleTimer = setTimeout(() => loadAdSenseScript(), 2500);
+ }
+ }
+
+ return () => {
+ io.disconnect();
+ const cic = (window as unknown as {
+ cancelIdleCallback?: (handle: number) => void;
+ }).cancelIdleCallback;
+ if (idleHandle !== undefined && typeof cic === 'function') cic(idleHandle);
+ if (idleTimer !== undefined) clearTimeout(idleTimer);
+ };
  }, [enabled, adSlot, loadAdSenseScript]);
 
  // ── Wait for measurable width, then push ─────────────────


### PR DESCRIPTION
## Contesto / Diagnosi RPM

RPM AdSense crollato 4.1→1.1 CHF (27-29/05). Due cause:
1. **Acuta** — regressione SSG `async walkHtml` (#802) → ~2540 articoli serviti come stub senza ad → già revertita in #822 (recovery attesa 24-48h).
2. **Strutturale** (questa PR) — leva RPM mancante.

### Root cause strutturale
Nel SPA, `adsbygoogle.js` veniva caricato **solo** da `AdSenseBanner` quando uno slot `<ins>` manuale entrava a 200px dal viewport (IntersectionObserver, **nessun** fallback idle). Le build-plugin static page hanno il loader esterno `/assets/adsense-loader-*.js` **con** fallback `requestIdleCallback`, ma le route SPA il cui shell statico omette quel loader (es. **homepage**, `count 0` su live) dipendono solo dal componente.

→ Su sessione mobile breve / no-scroll / bounce, lo script non caricava mai → **anchor + in-page Auto Ads (top earner, ~95% revenue) non partivano mai**. Era loader-gating degli Auto Ads, vietato da AGENTS.md non-negotiable #7. Coerente con l'audit 19/05 (coverage 42-49%, "0 in-page ads", in-page Auto Ads = "single biggest unused revenue lever").

## Implementato

- Fallback `requestIdleCallback` (timeout 3s; `setTimeout` 2.5s per browser senza rIC) in `AdSenseBanner.tsx`: carica `adsbygoogle.js` quando la pagina va idle **anche se lo slot non entra mai nel viewport**, abilitando gli Auto Ads su ogni route SPA.
- **Bot-gated** via `SKIP_FOR_BOT` → non gonfia `AD_REQUESTS`.
- **Lazy invariato per gli slot manuali**: caricare lo script abilita solo gli Auto Ads; il push del singolo `<ins>` resta legato all'IntersectionObserver (LCP preservato).
- Cleanup completo (`cancelIdleCallback` / `clearTimeout`) su unmount.
- Mirror del pattern già provato in `ADSENSE_LOADER_CONTENT` (build-plugins/constants.ts).
- Test: `adsense-lazy-load` + `app-no-blanket-no-auto-ads` verdi (16/16). tsc clean. Impact `AdSenseBanner` = LOW (0 caller diretti, modifica interna additiva).

## Non implementato (ancora)

- **Fix CLS** (mobile p75 1.027 / desktop 0.725 — killer viewability strutturale): root = reflow handoff statico→SPA su `main.seo-static-content`. Out of scope qui (architettura staticOverlay sensibile, serve attribution RUM dedicata) → **follow-up**.
- **Content-mix**: flood cronaca/traffico low-CPC diluisce RPM vs high-CPC (stipendio/fisco). Decisione strategica → **follow-up**.
- **Loader App-level**: il fix copre tutte le pagine che montano ≥1 `AdSenseBanner` (= tutte le content page). Pagine ipotetiche senza alcun banner non sono coperte → non necessario ora, posposto.
- **Verifica live fill Auto Ads**: l'ambiente headless blocca `adsbygoogle.js` (ERR_BLOCKED_BY_CLIENT) e `SKIP_FOR_BOT` salta il push → non verificabile pre-merge; osservare RPM su `main` post-deploy.