### PR TITLE
test(adsense): assert SPA idle-load fallback for Auto Ads (follow-up #851)

### DIFF
--- a/tests/adsense-lazy-load.test.ts
+++ b/tests/adsense-lazy-load.test.ts
@@ -136,6 +136,17 @@ describe('AdSense lazy loading — SPA AdSenseBanner component', () => {
     expect(adSenseBanner).toContain('loadAdSenseScript');
   });
 
+  it('idle-loads the script for Auto Ads even when no slot scrolls into view', () => {
+    // Funnel-critical: on SPA routes whose static shell omits the external
+    // adsense-loader (e.g. the homepage), a no-scroll mobile bounce must still
+    // load adsbygoogle.js so anchor + in-page Auto Ads fire. Guard the idle
+    // fallback (rIC with setTimeout fallback) and its cleanup against removal.
+    expect(adSenseBanner).toContain('requestIdleCallback');
+    expect(adSenseBanner).toContain('cancelIdleCallback');
+    // Bot-gated so the idle load never inflates AD_REQUESTS.
+    expect(adSenseBanner).toMatch(/if\s*\(\s*!SKIP_FOR_BOT\s*\)/);
+  });
+
   it('defers unfilled-slot collapse while the reserved box is visible', () => {
     expect(adSenseBanner).toContain('collapseWhenLayoutSafe');
     expect(adSenseBanner).toContain('isElementInViewport');


### PR DESCRIPTION
## Implementato

Follow-up a #851 (auto-mergiata sul primo \`## LGTM\` prima che questo commit-test arrivasse sul branch).

Aggiunge un test nel describe \`SPA AdSenseBanner component\` di \`tests/adsense-lazy-load.test.ts\` che presidia il nuovo percorso idle introdotto in #851:
- \`requestIdleCallback\` presente (idle fallback)
- \`cancelIdleCallback\` presente (cleanup su unmount)
- gate \`if (!SKIP_FOR_BOT)\` presente (no inflazione AD_REQUESTS)

Indirizza il 🟡 nit del reviewer su #851: il describe usava string-assertion sul sorgente ma non copriva il path idle (funnel-critical, Auto Ads). 14/14 test verdi.

## Non implementato (ancora)

- Verifica live fill Auto Ads / RPM post-deploy → tracciata in issue follow-up separata (headless blocca \`adsbygoogle.js\`, non verificabile pre-merge).
- CLS strutturale (mobile p75 1.027) e content-mix low-CPC → follow-up dichiarati in #851, fuori scope qui.