### PR TITLE
test(adsense): guard static-shell rIC fallback (follow-up #856)

### DIFF
--- a/tests/adsense-lazy-load.test.ts
+++ b/tests/adsense-lazy-load.test.ts
@@ -70,6 +70,11 @@ describe('AdSense lazy loading — ADSENSE_SNIPPET (static pages)', () => {
     );
     expect(ADSENSE_LOADER_CONTENT).toContain('IntersectionObserver');
     expect(ADSENSE_LOADER_CONTENT).toContain('rootMargin');
+    // Funnel-critical symmetry with the SPA AdSenseBanner idle fallback: the
+    // static-shell loader must also fall back to requestIdleCallback so Auto
+    // Ads fire on no-scroll sessions across the ~200k SEO pages, not only when
+    // a slot scrolls into view. Guards the rIC fallback against removal.
+    expect(ADSENSE_LOADER_CONTENT).toContain('requestIdleCallback');
   });
 
   it('exposes the correct client id + script URL', () => {


### PR DESCRIPTION
## Implementato

Follow-up al 🟡 nit del reviewer su #856.

Il describe \`ADSENSE_SNIPPET (static pages)\` asseriva solo \`IntersectionObserver\` + \`rootMargin\` sul \`ADSENSE_LOADER_CONTENT\`, lasciando **non presidiato** il fallback \`requestIdleCallback\` in \`build-plugins/constants.ts\`. È lo stesso path funnel-critical Auto Ads che #851 ha aggiunto lato SPA, ma per le ~200k pagine SEO statiche.

Aggiunge \`expect(ADSENSE_LOADER_CONTENT).toContain('requestIdleCallback')\` per simmetria difensiva. 14/14 verdi.

## Non implementato (ancora)

- I ❓ del reviewer su #856 (string-check matcha commenti/type oltre alla chiamata reale) sono limiti intrinseci dello string-assertion, coerenti col pattern esistente del file (\`toContain('IntersectionObserver')\` ecc.) → nessuna azione, non vale un AST-check dedicato.
- CLS strutturale + content-mix → follow-up #858 e dichiarati in #851.