### PR TITLE
test(adsense): pin post-IO rIC no-scroll guard (follow-up #861)

### DIFF
--- a/tests/adsense-lazy-load.test.ts
+++ b/tests/adsense-lazy-load.test.ts
@@ -75,6 +75,12 @@ describe('AdSense lazy loading — ADSENSE_SNIPPET (static pages)', () => {
     // Ads fire on no-scroll sessions across the ~200k SEO pages, not only when
     // a slot scrolls into view. Guards the rIC fallback against removal.
     expect(ADSENSE_LOADER_CONTENT).toContain('requestIdleCallback');
+    // Pin the *post-IO* scheduling site specifically. The loader has two rIC
+    // call sites — `timeout:4000` (IntersectionObserver-unavailable branch) and
+    // `timeout:6000` (the no-scroll guard that fires after the observer is set
+    // up). A bare `toContain('requestIdleCallback')` would stay green if a
+    // refactor dropped only the 6000 site — the exact regression this guards.
+    expect(ADSENSE_LOADER_CONTENT).toContain('timeout:6000');
   });
 
   it('exposes the correct client id + script URL', () => {


### PR DESCRIPTION
## Implementato

Follow-up al 🟡 nit del reviewer su #861.

\`ADSENSE_LOADER_CONTENT\` ha **due** call site \`requestIdleCallback\`: \`timeout:4000\` (ramo IntersectionObserver-unavailable) e \`timeout:6000\` (il vero no-scroll guard, post-IO). Un \`toContain('requestIdleCallback')\` nudo restava verde anche se un refactor rimuoveva solo il sito 6000 — esattamente la regressione no-scroll che questi guard esistono per prevenire.

Aggiunge \`expect(ADSENSE_LOADER_CONTENT).toContain('timeout:6000')\` per identificare univocamente il post-IO scheduling site. 14/14 verdi.

I ❓ del reviewer su #861 sono risolti senza modifica: il file è gated dal CI (\`vitest.config.ts\` include \`tests/**/*.test.{ts,tsx}\`; \`.github/workflows/tests.yml\` gira l'intera suite come gate bloccante su ogni PR + push a main), quindi le assertion sono effettive, non cosmetiche.

## Non implementato (ancora)

- Migrazione da string-assertion ad AST-check: fuori scope, incoerente col pattern del file; il pin su \`timeout:6000\` chiude il leak concreto senza over-engineering.
- CLS strutturale + content-mix RPM → follow-up #858 / dichiarati in #851.