### PR TITLE
fix(ci): drop empty secrets.GH_PAT shadow so trigger-deploy fires

### DIFF
--- a/.github/workflows/discover-404s.yml
+++ b/.github/workflows/discover-404s.yml
@@ -134,5 +134,9 @@ jobs:
             echo "📝 Only state file changed — no deploy needed"
           fi
         env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
+          # GITHUB_PAT NON impostato qui: ereditato da $GITHUB_ENV via lo step
+          # "Load secrets from Remote Config" (load-rc-env.mjs). Prima era
+          # `${{ secrets.GH_PAT }}`, ma GH_PAT non esiste come Actions secret →
+          # shadowava il valore RC con stringa vuota → trigger-deploy.sh saltava
+          # il dispatch (deploy.yml non partiva). Pattern corretto: update-fuel-prices.yml.
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/monitor-gsc-seo.yml
+++ b/.github/workflows/monitor-gsc-seo.yml
@@ -46,8 +46,12 @@ jobs:
         run: node scripts/load-rc-env.mjs
 
       - name: Run GSC Job Indexation Monitor
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        # GITHUB_PAT NON impostato qui: ereditato da $GITHUB_ENV via "Load secrets
+        # from Remote Config". Prima era `${{ secrets.GITHUB_PAT }}` (non esiste
+        # come secret → stringa vuota) che shadowava il valore RC →
+        # monitor-gsc-job-indexation.mjs cadeva su IndexNow invece di triggerare
+        # auto-redeploy su regressioni canonical (funnel-critical). Vedi nota in
+        # generate-article.yml: "Do NOT shadow it with secrets.GITHUB_PAT".
         run: node scripts/monitor-gsc-job-indexation.mjs
 
       - name: Cleanup credentials

--- a/.github/workflows/sync-gsc-orphans.yml
+++ b/.github/workflows/sync-gsc-orphans.yml
@@ -122,5 +122,9 @@ jobs:
             echo "📭 No meaningful data changes — skipping deploy"
           fi
         env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
+          # GITHUB_PAT NON impostato qui: ereditato da $GITHUB_ENV via lo step
+          # "Load secrets from Remote Config" (load-rc-env.mjs). Prima era
+          # `${{ secrets.GH_PAT }}`, ma GH_PAT non esiste come Actions secret →
+          # shadowava il valore RC con stringa vuota → trigger-deploy.sh saltava
+          # il dispatch (deploy.yml non partiva). Pattern corretto: update-fuel-prices.yml.
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Implementato

Rimosso l'anti-pattern in cui `GITHUB_PAT` veniva caricato da Firebase Remote Config (`load-rc-env.mjs` → `$GITHUB_ENV`) ma poi **shadowato** da un env block a stringa vuota, azzerando il dispatch/redeploy.

3 workflow corretti (rimossa la riga di override → eredita il `GITHUB_PAT` RC-loaded da `$GITHUB_ENV`, come il pattern corretto di `update-fuel-prices.yml` / `generate-article.yml`):
- **`discover-404s.yml`** — era `GITHUB_PAT: ${{ secrets.GH_PAT }}` (GH_PAT inesistente) → `trigger-deploy.sh` saltava il dispatch di `deploy.yml` su update di compat-paths.
- **`sync-gsc-orphans.yml`** — idem, su update di job data / tracking.
- **`monitor-gsc-seo.yml`** — era `GITHUB_PAT: ${{ secrets.GITHUB_PAT }}` (inesistente) → `monitor-gsc-job-indexation.mjs` non triggerava auto-redeploy su regressioni canonical, fallback silenzioso a IndexNow (funnel-critical). **Aggiunto in risposta al 🔴 Important del reviewer.**

Stesso root cause del fix auto-merge **#844** (`secrets.GH_PAT`/`secrets.GITHUB_PAT` fantasma; il PAT vero vive in Remote Config). Verificato: nessun altro `GITHUB_PAT: ${{ secrets.* }}` attivo rimane nei workflow.

## Non implementato (ancora)

- **425 crawler dedicati `update-jobs-*.yml`**: pushano job data con `GITHUB_TOKEN` (muto), nessun `trigger-deploy.sh`. **Voluto** — design ad accumulo: i commit vengono raccolti dal deploy frequente di `generate-article.yml` (ogni 30min, PAT corretto). Trigger per-crawler = storm di dispatch. Out of scope.
- **❓ adversarial del reviewer** (RC-load `continue-on-error`): se l'auth Firebase fallisce, `GITHUB_PAT` resta unset → `trigger-deploy.sh` stampa "skipping" (info-log) → stesso end-state pre-fix, senza signal visibile. È pre-existing del helper `load-rc-env.mjs` (non introdotto qui) e riguarda tutti i suoi consumer. Non sistemato in questa PR per non allargare lo scope; candidabile a follow-up (es. `::warning::` quando RC-load fallisce ma il workflow dipende dal PAT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)