### PR TITLE
fix(crawlers): address #845 reviewer nits (empty addressLocality + real key guard)

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -188,10 +188,14 @@ export function normalizeParsedJobsForSlice(jobs) {
         locationFixed++;
       }
     }
-    if (typeof job.addressLocality === 'string') {
+    // Guard on .trim(): an empty/whitespace addressLocality is `typeof string`
+    // but carries no city, so it must fall through to the backfill branch
+    // rather than persisting an empty locality (which propagates to
+    // deriveCanton/deriveStreetAddress lookups that key on addressLocality).
+    if (typeof job.addressLocality === 'string' && job.addressLocality.trim()) {
       const cleanedAddr = sanitizeJobLocationField(job.addressLocality);
       if (cleanedAddr !== job.addressLocality) job.addressLocality = cleanedAddr;
-    } else if (!job.addressLocality && typeof job.location === 'string' && job.location.trim()) {
+    } else if (!String(job.addressLocality || '').trim() && typeof job.location === 'string' && job.location.trim()) {
       job.addressLocality = job.location;
       localityBackfilled++;
     }

--- a/tests/job-url-key.test.ts
+++ b/tests/job-url-key.test.ts
@@ -43,20 +43,27 @@ describe('mergeUrlKey (crawl-time merge key — was extractStableJobId)', () => 
   });
 });
 
-describe('extractStableJobId delegates to mergeUrlKey unchanged', () => {
-  const corpus = [
-    'https://jobs.pwc.ch/job-vacancies/x/0441e237-ebd9-4263-9fe5-e21facbd03ba',
-    'https://example.com/jobs/123456/old',
-    'https://example.com/jobs/abcdef0123/old',
-    'https://example.com/jobs/only-a-slug',
-    'https://Example.com/Path/',
-    'https://example.com/jobs/only-a-slug?a=1&amp;b=2',
-    GALENICA,
-    '',
+describe('extractStableJobId output is pinned (real regression guard)', () => {
+  // Pinned expected VALUES, not a comparison to mergeUrlKey — extractStableJobId
+  // now delegates to mergeUrlKey, so `extractStableJobId(u) === mergeUrlKey(u)`
+  // would hold by construction and prove nothing. These literals lock the
+  // observable output so a future change to the shared key (in either module)
+  // is caught here. Complements tests/job-match-key-stable-id.test.ts.
+  const expected: Array<[string, string]> = [
+    ['https://jobs.pwc.ch/job-vacancies/x/0441e237-ebd9-4263-9fe5-e21facbd03ba', 'uuid:0441e237-ebd9-4263-9fe5-e21facbd03ba'],
+    ['https://example.com/jobs/123456/old', 'num:123456'],
+    ['https://example.com/jobs/abcdef0123/old', 'hex:abcdef0123'],
+    ['https://example.com/jobs/only-a-slug', 'url:https://example.com/jobs/only-a-slug'],
+    ['https://Example.com/Path/', 'url:https://example.com/path'],
+    ['https://example.com/jobs/only-a-slug?a=1&amp;b=2', 'url:https://example.com/jobs/only-a-slug?a=1&b=2'],
+    // Galenica: 5-digit id (not ≥6) and no ≥10-char hex run → no stable token,
+    // so the full normalized URL (hash preserved) is the key.
+    [GALENICA, 'url:https://www.galenica.com/it/jobs/#job.id=12345'],
+    ['', ''],
   ];
-  for (const url of corpus) {
-    it(`matches mergeUrlKey for: ${url || '(empty)'}`, () => {
-      expect(extractStableJobId(url)).toBe(mergeUrlKey(url));
+  for (const [url, want] of expected) {
+    it(`extractStableJobId(${url || '(empty)'}) === ${want || '(empty)'}`, () => {
+      expect(extractStableJobId(url)).toBe(want);
     });
   }
 });

--- a/tests/scripts/normalize-parsed-jobs-for-slice.test.ts
+++ b/tests/scripts/normalize-parsed-jobs-for-slice.test.ts
@@ -38,6 +38,17 @@ describe('normalizeParsedJobsForSlice', () => {
     expect(report.localityBackfilled).toBe(1);
   });
 
+  it('backfills addressLocality from location when it is an empty/whitespace string', () => {
+    const empty = [{ location: 'Lugano', addressLocality: '' }];
+    const ws = [{ location: 'Locarno', addressLocality: '   ' }];
+    const r1 = normalizeParsedJobsForSlice(empty);
+    const r2 = normalizeParsedJobsForSlice(ws);
+    expect(empty[0].addressLocality).toBe('Lugano');
+    expect(ws[0].addressLocality).toBe('Locarno');
+    expect(r1.localityBackfilled).toBe(1);
+    expect(r2.localityBackfilled).toBe(1);
+  });
+
   it('defaults addressCountry/country to CH and addressRegion to canton', () => {
     const jobs = [{ location: 'Sion', canton: 'vs' }];
     const report = normalizeParsedJobsForSlice(jobs);


### PR DESCRIPTION
## Implementato

Follow-up a #845 (reviewer ha dato `## LGTM` con 2 🟡 nit; `post-merge-followup.yml` è giù → li gestisco qui invece di droparli).

- **`normalizeParsedJobsForSlice` — empty `addressLocality`** (`scripts/assemble-jobs-dataset.mjs`): il ramo sanitize era guardato solo da `typeof === 'string'`, quindi un `addressLocality: ''` (typeof string ma falsy) saltava il backfill e persisteva una locality vuota → si propaga a `deriveCanton`/`deriveStreetAddress` che keyano su `addressLocality`. Ora il ramo è guardato da `.trim()` e il backfill da `location` cattura sia `''` che `'   '`. Aggiunti i test case.
- **Test guard reale** (`tests/job-url-key.test.ts`): il blocco "delegates to mergeUrlKey" era tautologico dopo il refactor (`extractStableJobId` ora ritorna `mergeUrlKey(url)`). Sostituito con assert su **valori pinnati** dell'output di `extractStableJobId`, così è un vero regression guard indipendente dalla delega.

Test: `tests/job-url-key.test.ts` (26) + `tests/scripts/normalize-parsed-jobs-for-slice.test.ts` (10) verdi.

## Non implementato (ancora)

- **Audit esaustivo di tutti i ~350 `update-*-jobs.mjs`** per entry-point che scrivono slice direttamente bypassando `writeJobsCrawlerSlice` (adversarial check ❓ del reviewer su #845): verificato `runStandardCrawlerPipeline` come funnel + spot-check di una dozzina, non audit completo. Gli script di manutenzione (es. `prune-dedup-from-slices.mjs`) mutano campi esistenti, non aggiungono job → fuori scope.
- **Convergenza identità unica scritta** (merge-key ≡ assemble-key): resta gated come da `docs/CRAWLER-OUTPUT-NORMALIZATION.md`, non in questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)