### PR TITLE
fix(issues): add id-token: write to issue-triage permissions (OIDC)

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,6 +14,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
   triage:


### PR DESCRIPTION
## Implementato

Aggiunge `id-token: write` al blocco `permissions` di `.github/workflows/issue-triage.yml`.

`anthropics/claude-code-action@v1` richiede l'OIDC token (`id-token: write`) per mintare il proprio GitHub token (`setupGitHubToken` → `getOidcToken`). `issue-triage.yml` era l'UNICO workflow Claude-CI senza quel permesso, quindi falliva in modo deterministico 3/3 su ogni issue nuova con:

```
##[error]Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

Runs falliti: 26621180145, 26621187643, 26621285700 (su #868/#869/#871). I workflow gemelli (`pr-review-loop`, `post-merge-followup`, `issue-fix`) hanno già `id-token: write` e funzionano. Fix di 1 riga, allinea triage ai gemelli.

Closes nessuna issue (bug interno della pipeline #837 appena merged).

## Non implementato (ancora)

- **Re-run dei 3 run triage falliti** su #868/#869/#871 — *follow-up*: dopo il merge il triage scatterà sulle prossime issue nuove; i 3 falliti vanno re-triggerati a mano (`gh run rerun`) o lasciati (le issue restano senza `agent:triaged`, verranno gestite al prossimo evento). Non bloccante.
- **Live-validation end-to-end** (#869) e **backfill** (#868) restano i follow-up già tracciati di #837.

## Note merge

PR tocca `.github/workflows/*` → reviewer GitHub-App non può recensire (stessa restrizione di #837) → niente `## LGTM`, niente auto-merge → **merge manuale** `gh pr merge --squash --delete-branch` (clausola eccezione AGENTS.md).
