### PR TITLE
fix(workflows): stop shadowing RC GITHUB_PAT with non-existent secret (Closes #878)

### DIFF
--- a/.github/workflows/discover-404s.yml
+++ b/.github/workflows/discover-404s.yml
@@ -134,5 +134,8 @@ jobs:
             echo "📝 Only state file changed — no deploy needed"
           fi
         env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
+          # GITHUB_PAT è caricato in $GITHUB_ENV dallo step "load-rc-env" (Firebase
+          # RC, non un Actions secret — `secrets.GH_PAT` non esiste). NON shadoware
+          # con secrets.*: altrimenti trigger-deploy.sh gira con PAT vuoto e il
+          # deploy non parte (cfr. #878).
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/monitor-gsc-seo.yml
+++ b/.github/workflows/monitor-gsc-seo.yml
@@ -46,8 +46,9 @@ jobs:
         run: node scripts/load-rc-env.mjs
 
       - name: Run GSC Job Indexation Monitor
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        # GITHUB_PAT è caricato in $GITHUB_ENV da "Load secrets from Remote Config"
+        # (Firebase RC, non un Actions secret — `secrets.GITHUB_PAT` non esiste).
+        # NON shadoware con secrets.* o il monitor gira con PAT vuoto (cfr. #878).
         run: node scripts/monitor-gsc-job-indexation.mjs
 
       - name: Cleanup credentials

--- a/.github/workflows/sync-gsc-orphans.yml
+++ b/.github/workflows/sync-gsc-orphans.yml
@@ -122,5 +122,8 @@ jobs:
             echo "📭 No meaningful data changes — skipping deploy"
           fi
         env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
+          # GITHUB_PAT è caricato in $GITHUB_ENV dallo step "load-rc-env" (Firebase
+          # RC, non un Actions secret — `secrets.GH_PAT` non esiste). NON shadoware
+          # con secrets.*: altrimenti trigger-deploy.sh gira con PAT vuoto e il
+          # deploy non parte (cfr. #878).
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Implementato

Fix dello shadowing descritto in #878. Tre workflow caricano `GITHUB_PAT` da Firebase Remote Config (`load-rc-env.mjs` → `$GITHUB_ENV`) ma lo sovrascrivono a step-level con un secret inesistente (`secrets.GH_PAT` / `secrets.GITHUB_PAT`) → la var arriva vuota allo step che la usa.

- `discover-404s.yml:137` — rimossa `GITHUB_PAT: ${{ secrets.GH_PAT }}` (tenuto `GITHUB_REPOSITORY`). `trigger-deploy.sh` ora eredita il PAT RC.
- `sync-gsc-orphans.yml:125` — idem.
- `monitor-gsc-seo.yml:50` — rimosso l'intero `env:` di shadowing (conteneva solo `GITHUB_PAT`).

Aggiunto in ciascuno un commento anti-regressione che replica la nota già presente in `generate-article.yml:529`. Nessun secret nuovo da creare — il valore RC era già in `$GITHUB_ENV`.

PAT validato live (cascade #844): #838 `mergedBy=valerielinc-ops`, `post-merge-followup` + deploy `push` scattati → scope repo + workflow OK. Il bug era puramente lo shadowing.

## Non implementato (ancora)

- **Backfill dei deploy mancati** mentre discover-404s/sync-gsc-orphans non triggeravano — non scriptato; i prossimi run dei due workflow, su cambi dati reali, partiranno col PAT corretto e triggereranno il deploy. Il prossimo deploy regolare include comunque i dati già committati.
- **Guard lint anti-shadowing** (test che fallisce se un workflow setta `GITHUB_PAT: ${{ secrets.* }}`) — follow-up se il pattern si ripresenta; per ora il commento inline + #844 + generate-article.yml documentano la regola.

> Modifica `.github/workflows/**` → eccezione workflow-validation AGENTS.md. **Merge manuale.**

## Test plan

- [x] `yaml.safe_load` sui 3 workflow — validi
- [x] nessun `secrets.GH_PAT`/`secrets.GITHUB_PAT` residuo (solo nei commenti esplicativi)
- [ ] Post-merge: al prossimo trigger di discover-404s con compat-file cambiato, confermare che parte un run deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)