### PR TITLE
ci(pr-review): bump tier-high reviewer model opus 4.7 -> 4.8

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -64,7 +64,7 @@ jobs:
           fi
           if echo "$files" | grep -qE '^(tests/|\.github/workflows/|scripts/|build-plugins/)'; then
             echo "tier=high" >> "$GITHUB_OUTPUT"
-            echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"
+            echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
             echo "max_turns=40" >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Implementato

Bump modello reviewer **tier-high** in `.github/workflows/pr-review-loop.yml` da `claude-opus-4-7` -> `claude-opus-4-8`.

Tier-high scatta quando la PR tocca `tests/`, `.github/workflows/`, `scripts/`, `build-plugins/` (path dove un bug si propaga su ogni merge, vale il probing piu profondo di Opus). Opus 4.8 e l'ultimo modello Opus.

## Non implementato (ancora)

- **Sonnet-tier resta `claude-sonnet-4-6`** (pr-review-loop.yml:53/63, post-merge-followup.yml:66) - out of scope: 4.6 e gia l'ultimo Sonnet, nessun 4.7/4.8 Sonnet da rimpiazzare. Solo Opus aveva versione vecchia.
- Verificato grep su workflows + scripts: nessun altro ref a modello obsoleto.

## Note merge

Modifica `pr-review-loop.yml` -> per AGENTS.md eccezione workflow-validation: reviewer bot non posta, auto-merge non scatta -> merge manuale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)