### PR TITLE
ci(issue-fix): bump tier-high fixer model opus 4.7 -> 4.8

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -60,7 +60,7 @@ jobs:
           body=$(gh issue view "$ISSUE_NUMBER" --json title,body,labels --jq '.title + "\n" + .body + "\n" + (.labels[].name)')
           if echo "$body" | grep -qiE 'crawler|parser|scripts/|build-plugin|\.github/workflows/|test gate|validator|migrator'; then
             echo "tier=high" >> "$GITHUB_OUTPUT"
-            echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"
+            echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
             echo "max_turns=40" >> "$GITHUB_OUTPUT"
           else
             echo "tier=normal" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Implementato

Bump modello **tier-high** in `.github/workflows/issue-fix.yml` da `claude-opus-4-7` -> `claude-opus-4-8`. Allinea il fixer al reviewer gia bumpato in #885. File non era nel checkout locale stale all'inizio del task, scoperto via grep su origin/main.

## Non implementato (ancora)

- Sonnet-tier (`claude-sonnet-4-6`) invariato ovunque: 4.6 e gia l'ultimo Sonnet.
- Verificato `git grep opus-4-7 origin/main` su tutto il repo: dopo questo bump restano 0 ref a 4-7.

## Note merge

Modifica workflow `.github/workflows/*` -> per AGENTS.md eccezione workflow-validation: merge manuale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)