### PR TITLE
fix(issues): enable autonomous loop — allowed_bots + crawler auto-route

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -28,7 +28,8 @@ jobs:
     # - Auth via CLAUDE_CODE_OAUTH_TOKEN (subscription Max, zero API cost).
     if: |
       github.event.label.name == 'agent:fix' &&
-      github.event.sender.login == 'valerielinc-ops'
+      (github.event.sender.login == 'valerielinc-ops' ||
+       startsWith(github.event.sender.login, 'claude'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -85,6 +86,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
+          allowed_bots: '*'
           claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
           prompt: |
             Sei l'agent di fix autonomo per la issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}"). Tier: ${{ steps.tier.outputs.tier }}.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
+          allowed_bots: '*'
           claude_args: "--max-turns 12 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
           prompt: |
             Triage automatico issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}").


### PR DESCRIPTION
## Implementato

Sblocca la pipeline issue-agent in modalità **loop completamente autonomo** (scelta esplicita dell'owner con rischio dichiarato: AI scrive codice + reviewer-bot approva + auto-merge a prod, senza umano nel loop sulle issue crawler).

Dopo il fix id-token (#879) il run sul SHA fixato mostrava il gate successivo:
```
OIDC token successfully obtained
##[error]Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

- **`issue-triage.yml`**: `allowed_bots: '*'`. Le issue che triggerano il triage sono quasi tutte bot-created (monitor `github-actions[bot]`, post-merge-followup `claude[bot]`), quindi senza questo il triage falliva su tutte.
- **`issue-fix.yml`**: `allowed_bots: '*'` + sender-gate rilassato da `sender == valerielinc-ops` a `sender == valerielinc-ops || startsWith(sender, 'claude')`. Così quando il triage (`claude[bot]`) applica `agent:fix` a una issue crawler, il fixer parte (auto-route crawler→fix→PR→review-bot→auto-merge).

## Non implementato (ancora)

- **Restringere `allowed_bots`** da `'*'` a lista esplicita (`github-actions[bot]`, `claude[bot]`) — *follow-up* hardening opzionale; `'*'` accettabile perché solo chi ha write può creare issue/applicare label.
- **Re-trigger triage falliti** su #868/#869/#871 — *follow-up*: i prossimi eventi li ricopriranno.

## Note merge
Tocca `.github/workflows/*` → reviewer-bot non recensisce → merge manuale (eccezione AGENTS.md), come #837/#879.
