### PR TITLE
perf(reconcile): inverted slug-token index for worst-case no-company-match path

### DIFF
--- a/scripts/reconcile-job-slugs.mjs
+++ b/scripts/reconcile-job-slugs.mjs
@@ -230,6 +230,18 @@ function buildActiveIndex(activeJobs) {
   const allSlugSet = new Set();             // all current + previous slugs
   const slugTokenCache = new WeakMap();     // job → Map<slugString, Set<token>>
   const titleTokenCache = new WeakMap();    // job → Map<locale, Set<token>>
+  // Inverted index: slug-token → Set<job>. Used by findBestMatch's
+  // no-company-match path to short-circuit the all-active-jobs scan
+  // (6265 → ~50-100 candidates per orphan), turning the dominant
+  // `for (const job of candidates)` O(E × C × S) loop into one driven
+  // by `orphanTokens.size` bucket lookups. The bucket scope mirrors
+  // what the scoring loop already iterates: each job's `job.slug` +
+  // every `job.slugByLocale[*]`. previousSlugs are intentionally
+  // EXCLUDED — the scoring inner loop iterates the same canonical+locale
+  // slug list, so widening the bucket would let pre-filtered candidates
+  // pass that the scoring would still reject (wasted work, not a
+  // correctness bug).
+  const slugTokenToJobs = new Map();        // token → Set<job>
 
   for (const job of activeJobs) {
     // Index by company key
@@ -251,15 +263,34 @@ function buildActiveIndex(activeJobs) {
     }
 
     // Pre-tokenize all slugs (canonical + locale variants) — saves
-    // repeated `tokenizeSlug` calls inside `findBestMatch`.
+    // repeated `tokenizeSlug` calls inside `findBestMatch`. We also fold
+    // every emitted token into the inverted index (`slugTokenToJobs`)
+    // so the no-company-match candidate set can be derived by bucket
+    // union instead of scanning all 6265 active jobs.
     const slugCache = new Map();
-    if (job.slug) slugCache.set(job.slug, tokenizeSlug(job.slug));
+    const jobTokensUnion = new Set();
+    const collectSlug = (s) => {
+      if (!s || slugCache.has(s)) return;
+      const toks = tokenizeSlug(s);
+      slugCache.set(s, toks);
+      for (const t of toks) jobTokensUnion.add(t);
+    };
+    if (job.slug) collectSlug(job.slug);
     if (job.slugByLocale) {
-      for (const s of Object.values(job.slugByLocale)) {
-        if (s && !slugCache.has(s)) slugCache.set(s, tokenizeSlug(s));
-      }
+      for (const s of Object.values(job.slugByLocale)) collectSlug(s);
     }
     slugTokenCache.set(job, slugCache);
+    // Push job into each of its union tokens' bucket. The union
+    // dedup avoids duplicate inserts when several locale slugs share
+    // the same token (e.g. company name appearing in every locale slug).
+    for (const t of jobTokensUnion) {
+      let bucket = slugTokenToJobs.get(t);
+      if (!bucket) {
+        bucket = new Set();
+        slugTokenToJobs.set(t, bucket);
+      }
+      bucket.add(job);
+    }
 
     // Pre-tokenize all titles (per-locale) — saves repeated `tokenizeTitle`
     // calls inside `findBestMatch` Strategy B (title-to-title Jaccard).
@@ -272,7 +303,13 @@ function buildActiveIndex(activeJobs) {
     }
   }
 
-  return { byCompanyKey, allSlugSet, slugTokenCache, titleTokenCache };
+  return {
+    byCompanyKey,
+    allSlugSet,
+    slugTokenCache,
+    titleTokenCache,
+    slugTokenToJobs,
+  };
 }
 
 /**
@@ -348,10 +385,35 @@ function findBestMatch(orphanSlug, enrichment, activeJobs, index, knownCompanyKe
   if (companyKey && index.byCompanyKey[companyKey]) {
     candidates = index.byCompanyKey[companyKey];
     if (verbose) console.log(`  🔍 Company match: "${companyKey}" — ${candidates.length} candidates`);
+  } else if (index.slugTokenToJobs) {
+    // No company narrowing — use the inverted slug-token index to derive
+    // candidates whose union of (canonical+locale) slug tokens shares
+    // ≥ 2 tokens with `orphanTokens`. This is a SUPERSET of jobs that
+    // could pass the scoring guard (`overlap < 2 → continue`, line ~386),
+    // so eliminating it costs only wasted score work — never a missed
+    // match. Cuts the no-company path from O(activeJobs.length × …) to
+    // O(orphanTokens.size × avg-bucket + matchedCandidates.size × …),
+    // which on production data shrinks ~6265 to ~50-150 candidates.
+    const candidateOverlap = new Map(); // job → tokens-in-common count
+    for (const tok of orphanTokens) {
+      const bucket = index.slugTokenToJobs.get(tok);
+      if (!bucket) continue;
+      for (const j of bucket) {
+        candidateOverlap.set(j, (candidateOverlap.get(j) || 0) + 1);
+      }
+    }
+    candidates = [];
+    for (const [j, n] of candidateOverlap) {
+      if (n >= 2) candidates.push(j);
+    }
+    if (verbose) {
+      console.log(`  🔍 No company match — inverted index narrowed to ${candidates.length} candidates (from ${activeJobs.length})`);
+    }
   } else {
-    // No company narrowing — use full set but require higher threshold
+    // Defensive fallback for callers that built the index with a code
+    // path predating the inverted-index field (older imports, tests).
     candidates = activeJobs;
-    if (verbose) console.log(`  🔍 No company match — scanning all ${candidates.length} jobs`);
+    if (verbose) console.log(`  🔍 No company match — scanning all ${candidates.length} jobs (no inverted index)`);
   }
 
   const orphanLocale = enrichment?.locale || detectSlugLocale(orphanSlug);


### PR DESCRIPTION
## Summary

Follow-up to #829 (pre-tokenize). Attacks il worst-case `reconcileExpiredSlugs`: quando `companyKey` non matcha o l'inferred key non ha bucket, old code → `candidates = activeJobs` (~6265). Inner scoring loop walking ~6265 per ognuno dei 4906 expired = 7m22s.

Fix: `buildActiveIndex` ora costruisce `slugTokenToJobs: Map<token, Set<job>>` parallelo al pre-tokenize. `findBestMatch` no-company-match path: union dei bucket dei token di orphan + filter ≥2 token overlap. Candidates 6265 → ~50-150 per orphan.

## Implementato

- `buildActiveIndex`: nuovo `slugTokenToJobs` Map. Per ogni job, union dei token da `job.slug` + `job.slugByLocale[*]` (stesso scope iterato dalla Strategy A), inserisce job in ogni bucket di token presente nell'union.
- `findBestMatch`: nuovo branch `else if (index.slugTokenToJobs)`. Per ogni orphan token, lookup bucket; count per-job tokens-in-common; filter ≥2 (superset della guard `overlap < 2 → continue` esistente). Defensive fallback a `activeJobs` se index manca il campo.
- `previousSlugs` ESCLUSO dall'index — scoring loop itera solo `[slug, ...slugByLocale]`, includere previousSlugs sarebbe wasted score work.

## Byte invariant

Pre-filter ≥2 è SUPERSET di jobs che passerebbero scoring guard (overlap<2→continue). Tutti i match veri sono nel candidate set. Smoke test 3 scenari locali:

1. Company-match path: untouched → mergedCount=1, slug merged in previousSlugs. Identico a prima.
2. No-company-match (inverted path): narrows 3→1 candidate, scoring rejects su threshold (jaccard 0.6 < 0.7) — same decision come pre-PR.
3. Worst-case 5×3 sample: mergedCount=1, skippedCount=2, `data-scientist-lugano-old → data-scientist-lugano` score 0.750 — output byte-identico.

`JSON.stringify(activeJobs).includes('__cached')` = false (no pollution).

## Stima impatto

| Step | Pre-#829 | Post-#829 live | Post-this PR (est) |
|---|---:|---:|---:|
| Assemble jobs | 494 s | ~430 s | **~120-180 s** |
| └ reconcile inner loop | 442 s | ~380 s | **~70-130 s** |

Worst-case shrink ~3-5× sul 7m22s inner loop. Wall finale dipende da frazione expired che colpisce no-company-match path.

## Non implementato (ancora)

- Inverted index per titleTokens (Strategy B) — non implementato. Strategy B itera `job.titleByLocale[*]` per ogni candidate; con candidate set già ridotto dall'index slug, il costo titleByLocale è ammortizzato. Follow-up se profiler mostra Strategy B come hot.
- Parallel reconcileExpiredSlugs in worker_threads — out of scope, possibile post-this-PR se servono ulteriori gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)