### PR TITLE
fix(jobs-seo): emit EJP_STRIPPED marker on tiered-thin shells — unblock validate-dist/deploy

### DIFF
--- a/build-plugins/shared/bridgeThinShell.ts
+++ b/build-plugins/shared/bridgeThinShell.ts
@@ -105,6 +105,9 @@ export function buildBridgeThinHtml(cachedHtml: string, targetSlug: string, loca
   // block for JS-enabled users on non-staticOverlay routes.
   const thinMain =
     `<main class="seo-static-content static-bridge-page">` +
+    // audit:text-html-ratio skip marker — deliberately-thin shell, same
+    // contract as legacy STRIP_* paths (uppercase survives minifier).
+    `<!--EJP_STRIPPED-->` +
     `<article class="proposal">` +
     `<h1>${h1Text}</h1>` +
     `<p>${prose}</p>` +

--- a/build-plugins/shared/clusterThinShell.ts
+++ b/build-plugins/shared/clusterThinShell.ts
@@ -102,6 +102,9 @@ export function buildClusterThinHtml(fullHtml: string, locale: string): string {
   // pattern PR #729 introduced for ft-static-article.
   const thinMain =
     `<main class="seo-static-content static-cluster">` +
+    // audit:text-html-ratio skip marker — deliberately-thin shell, same
+    // contract as legacy STRIP_* paths (uppercase survives minifier).
+    `<!--EJP_STRIPPED-->` +
     `<article class="proposal">` +
     `<h1>${h1Text}</h1>` +
     `<p>${prose}</p>` +

--- a/build-plugins/shared/gscKeywordThinShell.ts
+++ b/build-plugins/shared/gscKeywordThinShell.ts
@@ -58,6 +58,10 @@ export function buildGscKeywordThinBody(opts: ThinBodyOpts): string {
   const proseFn = PROSE[opts.locale] || PROSE.it;
   const prose = proseFn(opts.query, opts.listingUrl);
   return (
+    // Deliberately-thin shell (zero-traffic, SPA-hydrated): mark it so
+    // audit:text-html-ratio skips it, same contract as the legacy STRIP_*
+    // paths. Uppercase comment survives the HTML minifier's strip pass.
+    `<!--EJP_STRIPPED-->` +
     `<h1>${opts.h1Title}</h1>` +
     `<p>${prose}</p>`
   );

--- a/build-plugins/shared/softLandingThinShell.ts
+++ b/build-plugins/shared/softLandingThinShell.ts
@@ -91,6 +91,9 @@ export function buildSoftLandingThinHtml(fullHtml: string, locale: string): stri
   // `__EXPIRED_JOB_DATA__` from head).
   const thinArticle =
     `<article class="ft-static-article">` +
+    // audit:text-html-ratio skip marker — deliberately-thin shell, same
+    // contract as legacy STRIP_* paths (uppercase survives minifier).
+    `<!--EJP_STRIPPED-->` +
     `<h1>${h1Text}</h1>` +
     `<p>${prose}</p>` +
     `</article>`;

--- a/tests/seo/thin-shell-ejp-marker.test.ts
+++ b/tests/seo/thin-shell-ejp-marker.test.ts
@@ -83,3 +83,37 @@ describe('thin-shell builders emit the EJP_STRIPPED audit-skip marker', () => {
     });
   }
 });
+
+// The `career-landings` regression (10 > cap 0) is NOT the company-hub path:
+// the audit's classifyFeature maps any `/cerca-lavoro-ticino/azienda-*/` URL
+// to `career-landings`, which also catches expired-job soft-landings whose
+// slug starts with the word "azienda" (e.g. the AMB "Azienda Multiservizi
+// Bellinzona" job, or "azienda di formazione …spital-emmental-burgdorf").
+// Those are soft-landing THIN shells (text ~700 B / html ~7-15 KB per the
+// failing run's text-html-ratio.json), so the softLandingThinShell marker fix
+// above skips them — the marker check runs before feature classification, so a
+// skipped page never reaches the career-landings bucket. (Real company hubs
+// like `entreprise-zurzach-care` sit at 31-67% ratio and were never offenders.)
+describe('career-landings regression is soft-landing thin pages, covered by the marker', () => {
+  const azPath =
+    'dist/cerca-lavoro-ticino/azienda-multiservizi-bellinzona-amb-un-una-assistente-clienti/index.html';
+
+  it('a thin soft-landing under an azienda-* path is skipped, not bucketed as career-landings', async () => {
+    const thin = buildSoftLandingThinHtml(SOFT_LANDING_FULL, 'it');
+    const a = createAuditor({ threshold: 10, failOnOffenders: true });
+    a.collect(azPath, minifyHtml(thin));
+    const r = await a.report();
+    expect(r.extra.skippedEjpStripped).toBe(1);
+    expect(r.byFeature?.['career-landings'] ?? 0).toBe(0);
+    expect(r.offendersTotal).toBe(0);
+  });
+
+  it('control: the same azienda-* path WITHOUT the marker IS bucketed as a career-landings offender', async () => {
+    const lowRatioNoMarker =
+      `<!doctype html><html><head><title>x</title></head><body><h1>Y</h1>${'<div></div>'.repeat(2000)}</body></html>`;
+    const a = createAuditor({ threshold: 10, failOnOffenders: true });
+    a.collect(azPath, lowRatioNoMarker);
+    const r = await a.report();
+    expect(r.byFeature?.['career-landings']).toBe(1);
+  });
+});

--- a/tests/seo/thin-shell-ejp-marker.test.ts
+++ b/tests/seo/thin-shell-ejp-marker.test.ts
@@ -94,6 +94,43 @@ describe('thin-shell builders emit the EJP_STRIPPED audit-skip marker', () => {
 // above skips them — the marker check runs before feature classification, so a
 // skipped page never reaches the career-landings bucket. (Real company hubs
 // like `entreprise-zurzach-care` sit at 31-67% ratio and were never offenders.)
+// Production-input-shape coverage (reviewer adversarial ❓: the block-replace
+// regexes were only exercised against quoted, un-minified fixtures, but each
+// builder's real input differs):
+//   - cluster: renderClusterPage returns `minifyHtml(buildSimplePage(...))`
+//     (seoPageShell.ts:285), so buildClusterThinHtml receives ALREADY-MINIFIED
+//     HTML — the single-token class is UNQUOTED (`<main class=cluster-seo-prose>`)
+//     with no inter-tag whitespace. The quoted CLUSTER_FULL fixture above does
+//     NOT exercise that shape; only the regex's `["']?` + lookahead does.
+//   - soft-landing / bridge: fed RAW template HTML (jobHtmlCache stores the
+//     pre-minify literal; buildSoftLandingHtml only collapses leading
+//     whitespace), so their classes stay QUOTED multi-token — already matched
+//     by the fixtures.
+// This guards the one divergent path: minified, unquoted cluster input must
+// still match the regex, emit the marker, and be skipped by the auditor. If a
+// future minifier change or regex edit breaks the unquoted match,
+// buildClusterThinHtml silently returns full HTML (no marker) and the deploy
+// goes red again — this test fails first.
+describe('cluster thin builder matches the real minified (unquoted-class) production input', () => {
+  it('minified <main class=cluster-seo-prose> is thinned, marked, and audit-skipped', async () => {
+    const minifiedFull = minifyHtml(CLUSTER_FULL);
+    // Sanity: the input really is the unquoted production shape, not the quoted fixture.
+    expect(minifiedFull).toContain('<main class=cluster-seo-prose>');
+    expect(minifiedFull).not.toContain('<main class="cluster-seo-prose"');
+
+    const thin = buildClusterThinHtml(minifiedFull, 'it');
+    // Regex matched the unquoted form → block was replaced (not returned verbatim).
+    expect(thin).not.toBe(minifiedFull);
+    expect(thin).toContain(MARKER);
+
+    const a = createAuditor({ threshold: 10, failOnOffenders: true });
+    a.collect('dist/cerca-lavoro-ticino/ricerca-foo/index.html', minifyHtml(thin));
+    const r = await a.report();
+    expect(r.extra.skippedEjpStripped).toBe(1);
+    expect(r.offendersTotal).toBe(0);
+  });
+});
+
 describe('career-landings regression is soft-landing thin pages, covered by the marker', () => {
   const azPath =
     'dist/cerca-lavoro-ticino/azienda-multiservizi-bellinzona-amb-un-una-assistente-clienti/index.html';

--- a/tests/seo/thin-shell-ejp-marker.test.ts
+++ b/tests/seo/thin-shell-ejp-marker.test.ts
@@ -1,0 +1,85 @@
+/**
+ * thin-shell-ejp-marker.test.ts
+ *
+ * The tiered-emission thin shells (PRs #723 previousSlug bridges, #740 GSC
+ * keyword landings, #725 expired soft-landings, #742 related-search clusters)
+ * are deliberately low-text-ratio crawler shells that SPA-hydrate to full
+ * content. They are thinned only for zero-traffic, ≥15-day-old URLs with an
+ * hourly self-heal promotion loop.
+ *
+ * They MUST carry the `<!--EJP_STRIPPED-->` marker so audit-text-html-ratio
+ * skips them, exactly like the legacy STRIP_* paths. When the four thin-shell
+ * builders forgot the marker, 65039 job-board + 10851 spa-locale + 8581
+ * spa-other offenders regressed past the ratchet baseline and blocked every
+ * deploy. This guards each builder against losing the marker again.
+ */
+
+import { describe, expect, it } from 'vitest';
+// @ts-ignore: .mjs script with no .d.ts (resolved at runtime via vitest)
+import { createAuditor } from '../../scripts/audit-text-html-ratio.mjs';
+import { minifyHtml } from '../../build-plugins/shared/htmlMinify';
+import { buildGscKeywordThinBody } from '../../build-plugins/shared/gscKeywordThinShell';
+import { buildSoftLandingThinHtml } from '../../build-plugins/shared/softLandingThinShell';
+import { buildBridgeThinHtml } from '../../build-plugins/shared/bridgeThinShell';
+import { buildClusterThinHtml } from '../../build-plugins/shared/clusterThinShell';
+
+const MARKER = '<!--EJP_STRIPPED-->';
+
+// Wrap a body fragment in a minimal document so the auditor can scan it.
+const wrap = (body: string) =>
+  `<!doctype html><html><head><title>x</title>` +
+  `<link rel="canonical" href="https://frontaliereticino.ch/cerca-lavoro-ticino/foo/"></head>` +
+  `<body>${body}</body></html>`;
+
+// Full docs shaped so each builder's block-replace regex matches.
+const SOFT_LANDING_FULL = wrap(
+  `<h1>Foo Engineer — Acme</h1>` +
+    `<article class="ft-static-article"><h2>Heavy</h2>${'<p>lorem ipsum dolor sit amet</p>'.repeat(40)}</article>`,
+);
+const BRIDGE_FULL = wrap(
+  `<h1>Bar Specialist — Beta</h1>` +
+    `<main class="seo-static-content static-job-page"><h2>Heavy</h2>${'<p>lorem ipsum dolor sit amet</p>'.repeat(40)}</main>`,
+);
+const CLUSTER_FULL = wrap(
+  `<h1>Lavoro Lugano</h1>` +
+    `<main class="cluster-seo-prose"><h2>Heavy</h2>${'<p>lorem ipsum dolor sit amet</p>'.repeat(40)}</main>`,
+);
+
+// Each entry: a thin HTML string that the auditor must SKIP via the marker.
+const cases: Array<{ name: string; html: string }> = [
+  {
+    name: 'gsc-keyword landing',
+    html: wrap(
+      buildGscKeywordThinBody({
+        h1Title: 'Lavoro infermiere Ticino',
+        query: 'infermiere',
+        listingUrl: '/cerca-lavoro-ticino/',
+        locale: 'it',
+      }),
+    ),
+  },
+  { name: 'soft-landing (expired)', html: buildSoftLandingThinHtml(SOFT_LANDING_FULL, 'it') },
+  { name: 'bridge (previousSlug)', html: buildBridgeThinHtml(BRIDGE_FULL, 'bar-specialist-beta', 'it') },
+  { name: 'cluster (related-search)', html: buildClusterThinHtml(CLUSTER_FULL, 'it') },
+];
+
+describe('thin-shell builders emit the EJP_STRIPPED audit-skip marker', () => {
+  for (const { name, html } of cases) {
+    it(`${name}: output carries <!--EJP_STRIPPED-->`, () => {
+      expect(html).toContain(MARKER);
+    });
+
+    it(`${name}: marker survives htmlMinify`, () => {
+      expect(minifyHtml(html)).toContain(MARKER);
+    });
+
+    it(`${name}: audit-text-html-ratio skips it (minified, end-to-end)`, async () => {
+      const a = createAuditor({ threshold: 10, failOnOffenders: true });
+      a.collect('dist/cerca-lavoro-ticino/foo/index.html', minifyHtml(html));
+      const r = await a.report();
+      expect(r.extra.skippedEjpStripped).toBe(1);
+      expect(r.offendersTotal).toBe(0);
+      expect(r.extra.scanned).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Root-causes and fixes the `validate-dist` deploy block (`audit-text-html-ratio` ratchet) that has stopped production deploys since ~2026-05-29 (last successful deploy 05-25). Nothing merged since — including this session's funnel/reviewer fixes — has reached prod.

### Root cause

`audit-text-html-ratio.mjs` is a ratchet gate: pages with visible-text/HTML ratio ≤10% that are **not noindex** and lack the `<!--EJP_STRIPPED-->` marker count as offenders against `data/text-html-ratio-baseline.json` (captured 2026-05-26). The tiered-emission thin shells shipped right after:
- #723 — previousSlug bridges (`bridgeThinShell.ts`)
- #740 — GSC keyword landings, the biggest bucket (`gscKeywordThinShell.ts`)
- #725 — expired soft-landings (`softLandingThinShell.ts`)
- #742 — related-search clusters (`clusterThinShell.ts`)

These are deliberately low-text-ratio crawler shells that SPA-hydrate to full content, thinned **only** for zero-traffic, ≥15-day-old URLs (`data/url-pruning-approved-patterns.json`), with an hourly self-heal that re-promotes any URL that gains traffic. They are the same dist-shrink mechanism the legacy `STRIP_*` paths use — but the four builders **never emitted the `<!--EJP_STRIPPED-->` marker**, so the audit scanned them and they regressed massively past baseline: job-board 65039 (cap 340), spa-locale 10851 (cap 9), spa-other 8581 (cap 2), career-landings 10 (cap 0).

## Implementato

- Emit `<!--EJP_STRIPPED-->` in the thin body of all four builders (`gscKeywordThinShell.ts`, `softLandingThinShell.ts`, `bridgeThinShell.ts`, `clusterThinShell.ts`), matching the legacy precedent at `jobsSeoPagesPlugin.ts:3193/10587`. Uppercase so it survives the HTML minifier's comment-strip pass.
- `tests/seo/thin-shell-ejp-marker.test.ts`: drives all four builders end-to-end (build → `minifyHtml` → `createAuditor`) and asserts the auditor skips them (`skippedEjpStripped=1`, `offendersTotal=0`). 12 new tests; 29 green including the existing builder suites (`related-search-clusters-shell`, `bridge-page-prose`, `expired-job-prose-marker`).

This is a **root-cause fix, not a gate downgrade**: the 10% threshold and the baseline are untouched (AGENTS.md Non-Negotiable #1). The thin pages were always meant to be skip-marked; the builders just forgot.

## Non implementato (ancora) / risk

- **The marked thin pages are `index,follow` + self-canonical** (GSC landings, soft-landings, career-landings). Adding the marker hides them from the text/HTML quality gate while they stay indexable — acceptable because thinning happens **only** for zero-traffic, ≥15-day-old URLs guarded by the hourly self-heal promotion loop (the same safety contract the legacy `STRIP_*` marker relied on), and each shell carries `<h1>` + a ≥50-word paragraph (AGENTS.md #4). Bridges are cross-canonical (de-indexed) so no risk. If tighter coverage is wanted later, keep the auditor's `nearFloor` band un-suppressed for drift visibility — follow-up.
- **No baseline regen** — not needed; with the marker the offender counts fall back under baseline. If a residual category still regresses post-deploy, a 5th thin path exists and needs the same one-line marker.

## Test plan

- [x] `npx vitest run tests/seo/thin-shell-ejp-marker.test.ts` — 12 passing
- [x] existing builder suites green (29 total)
- [ ] Post-merge: confirm a deploy run reaches `validate-dist` **success** and publishes (first successful prod deploy since 05-25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)