### PR TITLE
fix(smoke-test): stop ai-models stdout chatter corrupting smoke.json (orphaned from #887)

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -1190,7 +1190,7 @@ async function _discoverProvider(cfg) {
   for (const id of offeredIds) {
     if (existingIds.has(id)) continue;
     if (cfg.maxAdd && added >= cfg.maxAdd) {
-      console.log(`🔍 [Discovery:${cfg.name}] hit maxAdd cap (${cfg.maxAdd}) — remaining discovered models skipped`);
+      console.error(`🔍 [Discovery:${cfg.name}] hit maxAdd cap (${cfg.maxAdd}) — remaining discovered models skipped`);
       break;
     }
     const fullId = `${cfg.prefix}${id}`;
@@ -1216,7 +1216,9 @@ async function _discoverProvider(cfg) {
   }
 
   if (added > 0 || stale > 0) {
-    console.log(`🔍 [Discovery:${cfg.name}] ${offeredIds.size} usable models, ${added} new added to chain, ${stale} stale pre-exhausted`);
+    // stderr, not stdout: smoke-test-ai-models.mjs redirects this module's stdout
+    // into a JSON file, so a stray stdout line here corrupts that payload.
+    console.error(`🔍 [Discovery:${cfg.name}] ${offeredIds.size} usable models, ${added} new added to chain, ${stale} stale pre-exhausted`);
   }
   return { added, stale };
 }

--- a/scripts/smoke-test-ai-models.mjs
+++ b/scripts/smoke-test-ai-models.mjs
@@ -11,6 +11,16 @@
  */
 import { callLLM, DEFAULT_CHAIN, AI_MODELS, discoverFreeModels } from './lib/ai-models.mjs';
 
+// stdout of this script is a machine-read JSON contract (the workflow pipes it
+// into .tmp/smoke.json and `require()`s it). ai-models.mjs emits diagnostic
+// chatter via console.log (Firestore score-store load, daily-quota notices,
+// etc.); a single such line on stdout corrupts the JSON. Route ALL console.log
+// to stderr so library noise can never leak into the payload — the final JSON
+// is written with process.stdout.write below, bypassing console entirely.
+// (ai-models.mjs does not log during module evaluation, so patching here —
+// after the import, before any call into it — catches every runtime log.)
+console.log = (...args) => console.error(...args);
+
 // Run multi-provider discovery FIRST so dynamically-added models (OpenRouter,
 // Groq, Cerebras, Mistral) are included in the smoke test — otherwise we'd only
 // validate the static chain and never catch a bad auto-discovered id.
@@ -61,4 +71,7 @@ if (dead.length) {
   for (const d of dead) console.error(`  ${d.model}  →  ${d.detail}`);
 }
 
-console.log(JSON.stringify({ summary, results }, null, 2));
+// Emit the JSON payload straight to the real stdout (console.log is patched to
+// stderr above, so this is the ONLY thing the workflow's `> .tmp/smoke.json`
+// redirect captures).
+process.stdout.write(JSON.stringify({ summary, results }, null, 2) + '\n');


### PR DESCRIPTION
## Implementato

Recupera il fix stdout rimasto orfano da #887. Per una race con l'auto-merge-on-LGTM, #887 è stata mergiata sul suo primo commit prima che il secondo (il fix stdout) arrivasse — quindi `main` ha la discovery estesa ma NON il fix che evita la corruzione di `smoke.json`.

**Bug**: lo smoke-test gira `node smoke-test.mjs > .tmp/smoke.json 2> .tmp/smoke.log` — stdout è un contratto JSON che lo step successivo fa `require()`. La discovery logga `console.log("🔍 [Discovery…]")` su **stdout**, finendo dentro `smoke.json` e rompendolo:
```
SyntaxError: .tmp/smoke.json: Unexpected token '🔍', "🔍 [Discov"... is not valid JSON
```
(run live 26621531271 / 26621529275, entrambi falliti).

**Fix a due livelli**:
1. `scripts/lib/ai-models.mjs`: i 2 log diagnostici della discovery (`🔍 [Discovery…]`) passano da `console.log` → `console.error` (stderr è il posto giusto per la diagnostica).
2. `scripts/smoke-test-ai-models.mjs`: ridireziona `console.log = (...args) => console.error(...args)` subito dopo l'import (cintura+bretelle: qualsiasi log residuo non corrompe più stdout), ed emette il JSON finale con `process.stdout.write(...)` invece di `console.log`.

Verificato: `node --check` OK su entrambi i file; cherry-pick pulito su `main` aggiornato.

## Non implementato (ancora)

- **Re-dispatch live dello smoke-test**: avviene DOPO il merge di questa PR (`gh workflow run smoke-test-ai-models.yml --ref main`). Validerà i model id reali di tutti i provider auto-scoperti (OR/Groq/Cerebras/Mistral/NVIDIA/SambaNova/Together/Fireworks/Cohere) — obiettivo originale del fix #1, finora bloccato proprio da questo bug stdout.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>