### PR TITLE
fix(cls): reserve viewport height in JobBoard loading state (job-filter CLS 0.87)

### DIFF
--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4454,7 +4454,16 @@ const JobBoard: React.FC<JobBoardProps> = ({
  );
  }
  return (
- <div className="flex items-center justify-center py-20">
+ // Reserve ~viewport height during the async job fetch. Search/filter URLs
+ // (e.g. /cerca-lavoro-ticino/concorsi-…, ricerca-*) render this JobBoard
+ // WITHOUT staticOverlay, so App.tsx display:none's the full-height static
+ // SEO body on hydration. A short `py-20` spinner then collapsed the page to
+ // ~116px and it jumped back to N×72px when jobs resolved → CLS p75 0.87
+ // (jobs_filter_concorsi). min-h-[80vh] (same reserve convention as
+ // SkeletonComparator) keeps height stable through static→spinner→list so
+ // the lab CLS drops <0.25 and the audit-cls-live lab_post_fix override clears
+ // the gate without waiting weeks for CrUX to roll forward.
+ <div className="flex items-center justify-center min-h-[80vh]">
  <Loader2 className="w-9 h-9 text-accent animate-spin" />
  </div>
  );


### PR DESCRIPTION
## Implementato

Fix dell'unico hard-regression del CLS gate post-deploy (`scripts/audit-cls-live.mjs`): **`jobs_filter_concorsi@mobile` CLS p75 = 0.87** (URL `/cerca-lavoro-ticino/concorsi-per-l-assunzione-di-personale-citta-di-lugano-lugano/`).

**Root cause:** le URL search/filter (`/cerca-lavoro-ticino/{ricerca-*|concorsi-*}`) rendono `JobBoard` **senza `staticOverlay`** → in hydration `App.tsx:245-253` fa `display:none` sull'HTML statico SEO a piena altezza, e il loading branch (`JobBoard.tsx:4456`) mostrava uno spinner `py-20` (~116px). La pagina collassava (~500px+ di shift) e risaltava a N×72px quando i job async risolvevano → CLS 0.87. Gli altri 6 template auditati erano già a posto (lab CLS 0.00–0.14 via `lab_post_fix`).

**Fix:** `py-20` → `min-h-[80vh]` sul container di loading (stessa convenzione reserve-space di `SkeletonComparator`, che passa il gate a CLS 0.000). L'altezza resta stabile attraverso statico→spinner→lista. Appena il **lab** CLS scende <0.25, l'override `lab_post_fix` preferisce il lab al CrUX e **sblocca il gate immediatamente** — non aspetta le ~4 settimane della rolling window CrUX (come si sono sbloccati gli altri 6 template).

- Nessun Auto Ads toccato (già bounded in `index.css:441-468`); nessun cambio routing/SEO/canonical. Solo reserve-space (AGENTS.md #7).
- Impatto: render/layout-only (className literal in un branch di render di JobBoard) — nessuna signature di simbolo cambiata.

## Non implementato (ancora)

- **Canonical mismatch (bug reale, funnel-critico, fuori scope CLS):** 6 URL `/cerca-lavoro-ticino/ricerca-*` nel `sitemap-jobs.xml` con canonical cross-section verso `/cerca-lavoro-svizzera/ricerca-*` (fa fallire `audit:sitemap-canonicals` + `validate:sitemap-pages`). Emerso investigando, NON appartiene a questa PR (CLS). Tracciato in **#911**. Fix probabile nel canonical emitter dei cluster-page (`jobsSeoPagesPlugin.ts`/resolver canton), stessa famiglia del city-lock #697/#701.
- **`text-html-ratio` ratchet (altra causa del blocco validate-dist):** gestito da **#897** (emette marker `EJP_STRIPPED` sui tiered-thin shell — root-cause fix, non rebaseline). Fuori scope di questa PR.
- **`staticOverlay` per le search-landing (Option A alternativa):** più "architetturale" ma richiede verifica build-side che lo static HTML sia emesso per ogni slug (rischio pagina vuota), non fattibile senza full build locale (OOM). Scelto reserve-space (Option B) per zero rischio SEO.

## Test plan

- [ ] **Post-deploy (live, non verificabile pre-merge):** `audit-cls-live` mostra `jobs_filter_concorsi@mobile` con `src=lab_post_fix` e CLS <0.25. Il gate `validate-live` gira solo post-deploy contro la URL live, quindi non verificabile in PR. Da spuntare osservando il primo deploy post-merge.
- [ ] **Visual regression (live):** `tests/e2e/seo-visual-regression.spec.ts` gira nel job `validate-live` post-deploy contro il sito live — non eseguibile pre-merge senza full build (OOM). Da osservare post-merge; se rompe, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)