### PR TITLE
perf(cls): preload calculator chunk on home-critical paths

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -81,6 +81,16 @@ const mountApp = async () => {
  import('./App'),
  import('./components/ChunkLoadErrorBoundary'),
  homeCritical ? import('./services/i18n') : Promise.resolve(null),
+ // Preload the calculator chunk on home-critical paths so App's lazy
+ // CalcolatoreTabContent resolves synchronously on first render. Without it
+ // the homepage shows the shared SkeletonFallback (App.tsx:2215) then swaps
+ // to the real layout, collapsing the reserved mobile-widget block and
+ // contributing ~0.12-0.16 to mobile CLS on cold loads (measured via
+ // Playwright cold-vs-warm: total CLS 0.295 → 0.179 when cached). The chunk
+ // is the homepage's primary/LCP content, so preloading is pure win.
+ // `.catch` keeps this preload non-essential: a chunk failure must not block
+ // mount (App's lazy boundary + ChunkLoadErrorBoundary still handle render).
+ homeCritical ? import('@/components/tabs/CalcolatoreTabContent').catch(() => null) : Promise.resolve(null),
  ]);
 
  if (homeCritical && i18n) {


### PR DESCRIPTION
## Contesto
Indagine CLS homepage (mobile field p75 0.88) — vedi #886. Investigazione empirica via Playwright (A/B route-injection sul prod reale).

## Diagnosi (validata)
Il CLS homepage **NON è ad-driven** (riproduce in lab con ad bloccati, ~0.24-0.30). Due sorgenti pinnate:
1. **Lazy-load del chunk `CalcolatoreTabContent`** — la homepage mostra `SkeletonFallback` (Suspense App.tsx:2215) poi swap al layout reale, collassando il blocco widget mobile riservato (`CalcolatoreTabContent.tsx:188`, 191→0px).
2. `#loading-shell` handoff (~0.20, race) + residuo widget-collapse — restano in #886.

**A/B cold-vs-warm (Playwright, mobile, fresh-context vs cache, 4 run):** total CLS **0.295 → 0.179 (−39%)** quando il chunk è già caricato → il lazy-load è un contributore reale su cold load.

## Implementato
- Preload del chunk `CalcolatoreTabContent` nel `Promise.all` di `mountApp` (index.tsx) su `HOME_CRITICAL_PATHS`, accanto a i18n → la lazy in App risolve al primo render, niente transizione fallback→real sulla homepage. È il contenuto primario/LCP della home → preload è pure win anche per LCP.
- `.catch(() => null)`: preload non-essenziale, un fallimento del chunk non blocca il mount (lazy boundary + ChunkLoadErrorBoundary gestiscono il render).
- Scope: solo home-critical paths (homepage + pagine calcolo, dove il componente è sempre necessario). Additiva, reversibile, `mountApp` è entry bootstrap (nessun caller upstream → impact LOW). tsc clean su index.tsx.

## Non implementato (ancora)
- **Residuo widget-collapse ~0.12** (`CalcolatoreTabContent.tsx:188`, persiste anche warm → issue di stato `showDeferredHomeWidgets`/re-suspend, non cache) → #886.
- **`#loading-shell` handoff ~0.20** (race bimodale) → #886. Nessuna fix CSS/scroll-lock testata funziona; serve redesign handoff.
- **Verifica field**: il delta CLS reale va confermato post-deploy via `scripts/monitor-cls-posthog.mjs --window=24 --once` (24-48h). Se non migliora o regredisce → revert. Non validabile in lab pre-deploy (build prod locale va OOM).