### PR TITLE
fix(ci): assemble jobs dataset before build in submit-indexnow-batch

### DIFF
--- a/.github/workflows/submit-indexnow-batch.yml
+++ b/.github/workflows/submit-indexnow-batch.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The build-plugins (legacyRedirectsPlugin, slugCantonIndex) import the
+      # generated data/jobs.json, which is not committed. Without this step the
+      # vite build below fails to resolve "../data/jobs.json" and the workflow
+      # has been red since 2026-05-18. Mirrors deploy.yml / the CI test gate.
+      - name: Assemble jobs dataset
+        run: node scripts/assemble-jobs-dataset.mjs --stats
+
       - name: Build to generate full sitemaps
         run: npx vite build --logLevel warn
         env:


### PR DESCRIPTION
## Implementato
`submit-indexnow-batch.yml` esegue `npx vite build` per generare le sitemap complete, ma i build-plugins (`legacyRedirectsPlugin.ts:13`, `shared/slugCantonIndex.ts:19`) importano `data/jobs.json` (generato, non committato). Senza assemblarlo prima, il build fallisce su `Could not resolve "../data/jobs.json"` → **workflow rosso dal 2026-05-18** (run 25/05 + 18/05 falliti).

Conseguenza: la ri-sottomissione batch IndexNow (catch-up indexation Bing/Yandex) **non gira da ~2 settimane**, rallentando il recupero dal declassamento sitewide causato dalla regressione stub #802 (vedi #888 — jobs position 3.61→8.65).

Aggiunto lo step `node scripts/assemble-jobs-dataset.mjs --stats` dopo `npm ci`, **mirror di `deploy.yml:254` e della CI test gate**. Validato localmente: lo step crea `data/jobs.json` (96MB) in un worktree fresco → l'import si risolve.

## Non implementato (ancora)
- Build vite completo non eseguito localmente (OOM) — il fix è validato sul root cause (import resolution); il build vero gira in CI.
- Recupero **Google** jobs ranking (la leva grande) NON dipende da IndexNow (Bing/Yandex): dipende dal revert #802→#822 + Google Indexing API. Verificare separatamente che `submit-google-indexing-jobs.js` ri-sottometta i job URL post-#822 (tracciato in #888).
- `refresh-indexed-cluster-urls.yml` (failure 28/05) — da investigare separatamente.

Refs #888.