### PR TITLE
ci(review): allow bot-authored PRs in claude review gate

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -84,6 +84,10 @@ jobs:
           REVIEW_TIER: ${{ steps.tier.outputs.tier }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Le PR fix-issue sono aperte da `claude[bot]`: senza whitelist
+          # claude-code-action aborta ("non-human actor"). `*` consente review
+          # anche su PR generate da bot (run 26621967484 → exit 1).
+          allowed_bots: "*"
           show_full_output: true
           # Tool expansion: aggiunti `Bash(rg:*)`, `Bash(git:*)` per consentire
           # cross-file pattern search (REVIEW.md → Reviewer behavior step 5) e


### PR DESCRIPTION
## Implementato
- `allowed_bots: "*"` nello step `Run Claude review` di `.github/workflows/pr-review-loop.yml`.
- Le PR fix-issue sono aperte da `claude[bot]`; senza whitelist `claude-code-action@v1` aborta con `Workflow initiated by non-human actor: claude (type: Bot)` (run 26621967484 → exit code 1), bloccando review → niente `## LGTM` → niente auto-merge.

## Non implementato (ancora)
- Restringere a `"claude[bot]"` invece di `"*"`: scelto `*` su richiesta esplicita user; follow-up possibile se si vuole whitelist puntuale.
- `post-merge-followup.yml` usa la stessa action ma gira post-merge (non triggerata da bot-PR) → fuori scope.

## Note
- Modifica file `.github/workflows/*` → workflow-validation GitHub App: reviewer non posta, auto-merge non scatta. Merge manuale (`gh pr merge --squash --delete-branch`) per eccezione AGENTS.md.