### PR TITLE
fix(smoke-test): illegal top-level return breaks the smoke-test gate

### DIFF
--- a/.github/workflows/smoke-test-ai-models.yml
+++ b/.github/workflows/smoke-test-ai-models.yml
@@ -55,10 +55,12 @@ jobs:
           node -e "
             const r=require('./.tmp/smoke.json');
             const dead=(r.results||[]).filter(x=>x.status==='http_404');
-            if(!dead.length){console.log('_None._');return;}
-            console.log('| Model | Detail |');
-            console.log('|-------|--------|');
-            for(const d of dead){console.log('| \`'+d.model+'\` | '+(d.detail||'').replace(/\\|/g,'\\\\|').slice(0,120)+' |');}
+            if(!dead.length){console.log('_None._');}
+            else{
+              console.log('| Model | Detail |');
+              console.log('|-------|--------|');
+              for(const d of dead){console.log('| \`'+d.model+'\` | '+(d.detail||'').replace(/\\|/g,'\\\\|').slice(0,120)+' |');}
+            }
           " >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload smoke-test artifact


### PR DESCRIPTION
## Implementato

Lo step "Dead models (HTTP 404)" del workflow `smoke-test-ai-models.yml` esegue `node -e "… if(!dead.length){…;return;}"`. Un `return` top-level è un `SyntaxError` in `node -e` (non c'è il module-wrapper CommonJS), quindi lo step esce sempre con codice 1 **appena viene raggiunto**.

Era **mascherato** finché lo stdout dello smoke-test era corrotto: prima di #903 il `require('./.tmp/smoke.json')` allo step precedente falliva per primo (JSON invalido). Ora che #903 ha sistemato lo stdout, `smoke.json` è valido (run live 26623014810 → JSON corretto, 209 risultati) e l'esecuzione raggiunge il `return` → il job fallisce **nonostante lo smoke-test sia sano** = gate permanentemente rosso.

**Fix**: `return` anticipato → blocco `if/else`. Verificato: lo snippet vecchio stampa `Return statement is not allowed here`; il nuovo stampa `_None._` ed esce 0. YAML valido.

## Non implementato (ancora)

- **Rumore dei nuovi provider auto-scoperti** (osservato nello stesso run 26623014810): NVIDIA inietta ~40 modelli del catalogo molti dei quali 404 sull'endpoint `integrate` (code/vision/embed: codegemma, granite-code, kosmos-2, bge-m3, llama2…); SambaNova free dà `http_402` su alcuni; Cohere `error` su modelli vision/non-compat. Il self-healing runtime (404/402→exhausted) + scoring li affossano, e il cap `maxAdd` li limita, ma resta rumore. *Follow-up separato*: stringere i filtri `pick()` per NVIDIA/Cohere (escludere code/vision/embed per nome) — decisione di tuning, fuori scope da questo blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)