### PR TITLE
fix(ci): unblock indexnow build (OOM) + stale staticOverlay test gate

### DIFF
--- a/.github/workflows/submit-indexnow-batch.yml
+++ b/.github/workflows/submit-indexnow-batch.yml
@@ -32,7 +32,12 @@ permissions:
 jobs:
   submit:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The full `build:ci` at cathedral scale (23k+ job-seo pages) needs
+    # ~10-15 min on ubuntu-latest (deploy.yml build-profile wall 634-716s);
+    # plus checkout + npm ci + assemble + submit. The old 10-min total cap
+    # turned the OOM fix into a timeout failure. deploy.yml gives its build
+    # job 360 min; 40 here leaves comfortable margin without masking a hang.
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/submit-indexnow-batch.yml
+++ b/.github/workflows/submit-indexnow-batch.yml
@@ -53,10 +53,19 @@ jobs:
       - name: Assemble jobs dataset
         run: node scripts/assemble-jobs-dataset.mjs --stats
 
+      # Use the same build entrypoint as deploy.yml (`npm run build:ci`):
+      # 12 GB heap + --expose-gc + sequential plugins keep peak heap low
+      # (~150 MB/plugin). A plain `vite build` at 8 GB OOMs (exit 134) once
+      # the assembled data/jobs.json drives 23k+ job-seo pages — run
+      # 26632264296 hit "Reached heap limit" at the cathedral scale.
+      # SEQUENTIAL_PROFILE=1 forces the memory-safe sequential closeBundle
+      # path; JOBS_SKIP_URL_VALIDATION=1 skips the network HEAD checks we
+      # don't need just to emit sitemaps.
       - name: Build to generate full sitemaps
-        run: npx vite build --logLevel warn
+        run: npm run build:ci
         env:
-          NODE_OPTIONS: '--max-old-space-size=8192'
+          SEQUENTIAL_PROFILE: '1'
+          JOBS_SKIP_URL_VALIDATION: '1'
 
       - name: Submit IndexNow batch
         run: |

--- a/tests/regression/meta-tag-refresh-on-nav.test.tsx
+++ b/tests/regression/meta-tag-refresh-on-nav.test.tsx
@@ -125,15 +125,20 @@ describe('2c — parsePath invariants for static-overlay routes', () => {
     expect(route.staticOverlay).toBe(true);
   });
 
-  it('parsePath /cerca-lavoro-ticino/ returns staticOverlay:true (hub HTML emitted by professionLandingsLinksPlugin)', () => {
-    // Bare TI root hub is a build-time static SEO page: 1 H1, 893 anchor links
-    // to profession/city/sector landings, no interactive form. Without
-    // staticOverlay the SPA replaced the static main with JobBoard on hydration
-    // → CLS 0.702 on Lighthouse 2026-05-28. Canonical URL via
-    // window.location.pathname matches buildPath output for this route, so the
-    // 2c canonical-refresh guarantee still holds.
+  it('parsePath /cerca-lavoro-ticino/ does NOT return staticOverlay (SPA hydrates JobBoard — #828)', () => {
+    // PR #721 set staticOverlay:true on the bare TI root to fix CLS 0.702
+    // (Lighthouse 2026-05-28), but #765 then fixed the HTML shape: the bare
+    // root emits an empty `<div id="root">` with `<main class="seo-static-content">`
+    // OUTSIDE root, and App.tsx's useLayoutEffect flips that sibling to
+    // display:none before paint. With the new shape the SPA hydrates JobBoard
+    // (search bar + canton filters + interactive cards) WITHOUT the CLS shift —
+    // identical choreography to every other canton hub (/cerca-lavoro-basilea/,
+    // /cerca-lavoro-zurigo/, …) which already sit at staticOverlay:false.
+    // #828 dropped staticOverlay on the bare root accordingly; staticOverlay:true
+    // would suppress the JobBoard render and strand users on the static hub.
+    // Subpaths (editorial landings, company/city/sector hubs) keep their overlay.
     const { route } = parsePath('/cerca-lavoro-ticino/');
-    expect(route.staticOverlay).toBe(true);
+    expect(route.staticOverlay).toBeFalsy();
   });
 
   it('parsePath /cerca-lavoro-ticino/software-engineer-x/ does NOT return staticOverlay', () => {


### PR DESCRIPTION
Tre fix che sbloccano la pipeline CI.

## 1. IndexNow build OOM (follow-up #916)
Dopo #916 il build di `submit-indexnow-batch.yml` va in **OOM** (exit 134) — run [26632264296](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26632264296). `npx vite build` a 8GB; `data/jobs.json` genera 23k+ pages > 8GB.
**Fix:** `npm run build:ci` (12GB + `--expose-gc`) + `SEQUENTIAL_PROFILE=1` + `JOBS_SKIP_URL_VALIDATION=1` — path identico a deploy.yml.

## 2. Job timeout (🔴 review finding)
Il job aveva `timeout-minutes: 10` **totale**, ma il full `build:ci` a scala cathedral costa ~10-15 min → il fix OOM sarebbe diventato un timeout. **Fix:** `timeout-minutes: 40` (deploy build=360; margine senza mascherare hang).

## 3. Test staticOverlay stale (gate vitest rosso su main)
`meta-tag-refresh-on-nav.test.tsx` asseriva ancora `parsePath('/cerca-lavoro-ticino/').staticOverlay===true` (#721). **#828** l'ha rimosso deliberatamente (#765 ha reso la shape CLS-clean → SPA idrata JobBoard senza shift). Rosso su main da #828 → bloccava vitest + ogni deploy. **Fix:** assert falsy, allineato al codice. 13/13 verde locale; reviewer ha confermato contro router.ts:2894.

## Implementato
- IndexNow build memory-safe + timeout adeguato → workflow torna verde.
- Gate vitest riallineato a #828 → sblocca deploy + questo PR.

## Non implementato (fuori scope)
- Nessuna modalità sitemap-only (full build come deploy).
- Nessuna modifica logica router (#828 corretto; solo test stale).
- Run live end-to-end: da eseguire post-merge per misurare il completamento entro 40min (finora inferito da deploy.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)