### PR TITLE
perf(ci): skip og-images in submit-indexnow build (38min->29min margin)

### DIFF
--- a/.github/workflows/submit-indexnow-batch.yml
+++ b/.github/workflows/submit-indexnow-batch.yml
@@ -71,6 +71,15 @@ jobs:
         env:
           SEQUENTIAL_PROFILE: '1'
           JOBS_SKIP_URL_VALIDATION: '1'
+          # IndexNow submits only page <loc> URLs from the 6 sub-sitemaps
+          # (pages/blog/glossario/jobs/news/guides) — og:image PNGs are HTML
+          # meta tags, not sitemap entries, and this throwaway dist is never
+          # deployed. Skipping jobOgImagesPlugin (508s / ~8.5 min in run
+          # 26634046820, the largest skippable closeBundle cost) drops the
+          # build from 38 min — dangerously close to the 40-min cap — to
+          # ~29 min, restoring a comfortable margin. jobs-seo-pages (714s) and
+          # related-search-clusters (530s) DO feed sitemap URLs, so they stay.
+          SKIP_JOB_OG_IMAGES: '1'
 
       - name: Submit IndexNow batch
         run: |


### PR DESCRIPTION
## Problema
Il dry-run live [26634046820](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26634046820) (post-#929) è passato **verde** ma il build `build:ci` ha misurato **38m03s** — solo ~2 min sotto il cap di 40 min. Margine fragile: il cron di lunedì può andare in timeout se i job crescono.

## Causa (profiling dello stesso run)
closeBundle totale 2114s / 54 plugin. Top:

| plugin | wall | in sitemap submitted? |
|---|---|---|
| jobs-seo-pages | 714s | ✅ sitemap-jobs.xml → **tenuto** |
| related-search-clusters | 530s | ✅ → **tenuto** |
| **job-og-images** | **508s** | ❌ og:image = meta-tag HTML, non loc → **skippabile** |

## Fix
`SKIP_JOB_OG_IMAGES=1` sul build IndexNow. Sicuro:
- IndexNow legge solo i `<loc>` dei 6 sub-sitemap (pages/blog/glossario/jobs/news/guides); le og:image PNG non vi compaiono.
- Il dist di questo workflow è **throwaway** (mai deployato) → og:image rotte qui non toccano prod.

Atteso: build ~29 min, margine ~10 min sotto il timeout.

## Implementato
- Skip og-images → margine timeout robusto.

## Non implementato (fuori scope)
- No skip di jobs-seo-pages/clusters (alimentano i sitemap submitted).
- No refactor sitemap-only (rischioso sul registry di emit).

Misurerò il nuovo tempo con un run live post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
