### PR TITLE
perf(ci): IndexNow batch reads live sitemaps — no rebuild (38min→<1min)

### DIFF
--- a/.github/workflows/submit-indexnow-batch.yml
+++ b/.github/workflows/submit-indexnow-batch.yml
@@ -33,8 +33,11 @@ jobs:
   submit:
     runs-on: ubuntu-latest
     # No build: the script fetches the deployed sitemaps live over HTTP.
-    # 10 min is ample for fetch (~5 s) + batched submission (5 batches × few s).
-    timeout-minutes: 10
+    # Live dry-run (run 26636490673) measured fetch + parse at 29 s total.
+    # 15 min leaves headroom for the real submission worst case — 5 batches ×
+    # 3 endpoints, each up to 30 s + 3 retries + 429 Retry-After waits (60 s
+    # cap) — which a tight 10-min cap could brush under sustained rate-limiting.
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/submit-indexnow-batch.yml
+++ b/.github/workflows/submit-indexnow-batch.yml
@@ -32,12 +32,9 @@ permissions:
 jobs:
   submit:
     runs-on: ubuntu-latest
-    # The full `build:ci` at cathedral scale (23k+ job-seo pages) needs
-    # ~10-15 min on ubuntu-latest (deploy.yml build-profile wall 634-716s);
-    # plus checkout + npm ci + assemble + submit. The old 10-min total cap
-    # turned the OOM fix into a timeout failure. deploy.yml gives its build
-    # job 360 min; 40 here leaves comfortable margin without masking a hang.
-    timeout-minutes: 40
+    # No build: the script fetches the deployed sitemaps live over HTTP.
+    # 10 min is ample for fetch (~5 s) + batched submission (5 batches × few s).
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -46,32 +43,14 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      # The build-plugins (legacyRedirectsPlugin, slugCantonIndex) import the
-      # generated data/jobs.json, which is not committed. Without this step the
-      # vite build below fails to resolve "../data/jobs.json" and the workflow
-      # has been red since 2026-05-18. Mirrors deploy.yml / the CI test gate.
-      - name: Assemble jobs dataset
-        run: node scripts/assemble-jobs-dataset.mjs --stats
-
-      # Use the same build entrypoint as deploy.yml (`npm run build:ci`):
-      # 12 GB heap + --expose-gc + sequential plugins keep peak heap low
-      # (~150 MB/plugin). A plain `vite build` at 8 GB OOMs (exit 134) once
-      # the assembled data/jobs.json drives 23k+ job-seo pages — run
-      # 26632264296 hit "Reached heap limit" at the cathedral scale.
-      # SEQUENTIAL_PROFILE=1 forces the memory-safe sequential closeBundle
-      # path; JOBS_SKIP_URL_VALIDATION=1 skips the network HEAD checks we
-      # don't need just to emit sitemaps.
-      - name: Build to generate full sitemaps
-        run: npm run build:ci
-        env:
-          SEQUENTIAL_PROFILE: '1'
-          JOBS_SKIP_URL_VALIDATION: '1'
-
+      # No `npm ci` / build: submit-indexnow-batch.mjs uses only Node builtins
+      # + fetch, and reads the 6 sub-sitemaps LIVE from the deployed site
+      # (https://frontaliereticino.ch/sitemap-*.xml). IndexNow tells engines to
+      # crawl live URLs, so the published sitemaps are the correct source of
+      # truth — rebuilding the site (~38 min, OOM-prone) just to regenerate XML
+      # the deploy already serves was pure waste. Pass `--local` to read from
+      # dist/ instead (not used here).
       - name: Submit IndexNow batch
         run: |
           ARGS=""

--- a/scripts/submit-indexnow-batch.mjs
+++ b/scripts/submit-indexnow-batch.mjs
@@ -185,20 +185,28 @@ async function getUrlsFromSitemaps() {
     }
     console.log(`  Source: local ${sitemapDir}`);
   } else {
-    let fetched = 0;
+    const failed = [];
     for (const file of filteredSitemaps) {
       const xml = await fetchSitemapXml(file);
-      if (xml == null) continue;
-      fetched++;
+      // null = unreachable (5xx after retries / 404 / network); an empty but
+      // 200-OK urlset returns '' and is treated as a legitimate empty sitemap.
+      if (xml == null) {
+        failed.push(file);
+        continue;
+      }
       const count = extractUrls(xml, urls);
       console.log(`  ${file}: ${count} raw entries (${urls.size} unique so far)`);
     }
     console.log(`  Source: live ${SITEMAP_BASE}`);
-    // Fail loud rather than submitting only the 4 EXTRA_URLS: if every
-    // sitemap fetch failed the site/network is down, and a near-empty
-    // submission would mask that as a successful run.
-    if (fetched === 0) {
-      console.error(`No sitemaps could be fetched from ${SITEMAP_BASE}. Aborting.`);
+    // Abort on ANY expected sub-sitemap failure, not only when all six fail.
+    // A partial fetch would silently drop a whole content type — e.g. if
+    // sitemap-jobs.xml (the job funnel) 5xx/404s after a deploy while the
+    // other five succeed — and still exit 0, masking the gap as a clean run.
+    if (failed.length > 0) {
+      console.error(
+        `Failed to fetch ${failed.length}/${filteredSitemaps.length} sitemap(s) from ${SITEMAP_BASE}: ${failed.join(', ')}.\n` +
+        `Aborting to avoid a partial submission that would drop those URLs silently.`,
+      );
       process.exit(1);
     }
   }

--- a/scripts/submit-indexnow-batch.mjs
+++ b/scripts/submit-indexnow-batch.mjs
@@ -8,7 +8,12 @@
  * where Bing has a large indexation backlog (e.g. 16k+ pages, 1-4 crawled/day).
  *
  * Features:
- * - Reads all sub-sitemaps from dist/ or public/ to collect every URL
+ * - Fetches all sub-sitemaps LIVE over HTTP from the deployed site (default)
+ *   to collect every URL — no local build required. IndexNow tells engines
+ *   to crawl live URLs, so the live sitemaps are the correct source of truth;
+ *   reading them avoids a full `vite build` (~38 min, OOM-prone) just to
+ *   regenerate XML the deploy already publishes. Pass --local to read from
+ *   dist/ or public/ instead (e.g. when validating a not-yet-deployed build).
  * - Batches URLs in groups of 10,000 (IndexNow API limit)
  * - Submits to multiple IndexNow endpoints (api.indexnow.org, Bing, Yandex)
  * - Verifies the key file is accessible before submitting
@@ -24,9 +29,12 @@
  *   node scripts/submit-indexnow-batch.mjs --dry-run          # Preview URLs without submitting
  *   node scripts/submit-indexnow-batch.mjs --endpoint bing    # Submit only to Bing
  *   node scripts/submit-indexnow-batch.mjs --sitemap jobs     # Only job sitemap URLs
+ *   node scripts/submit-indexnow-batch.mjs --local            # Read sitemaps from dist/public, not live
  *
  * Environment:
  *   INDEXNOW_KEY (optional) — override the default key
+ *   SITEMAP_BASE (optional) — override the live sitemap origin
+ *                             (default https://frontaliereticino.ch)
  */
 
 import { readFileSync, existsSync } from 'node:fs';
@@ -68,8 +76,14 @@ const EXTRA_URLS = [
 // ── CLI argument parsing ──────────────────────────────────────
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
+const USE_LOCAL = args.includes('--local');
 const endpointArg = args.find((_, i, a) => a[i - 1] === '--endpoint');
 const sitemapArg = args.find((_, i, a) => a[i - 1] === '--sitemap');
+
+// Live sitemap origin (default = deployed site). The sub-sitemaps are public
+// XML, always reflecting the latest deploy, so the weekly catch-up can read
+// them directly instead of rebuilding the site.
+const SITEMAP_BASE = (process.env.SITEMAP_BASE || `https://${HOST}`).replace(/\/+$/, '');
 
 if (args.includes('--help') || args.includes('-h')) {
   console.log(`
@@ -79,6 +93,7 @@ Options:
   --dry-run              Preview URLs without submitting
   --endpoint <name>      Submit to a single engine: indexnow, bing, yandex
   --sitemap <filter>     Only include sitemaps matching this substring (e.g. "jobs", "blog")
+  --local                Read sitemaps from dist/ or public/ instead of live HTTP
   --help, -h             Show this help message
 
 Examples:
@@ -99,15 +114,51 @@ function getProjectRoot() {
   return resolve(__dirname, '..');
 }
 
-// ── Collect URLs from sitemaps ────────────────────────────────
-function getUrlsFromSitemaps() {
-  const rootDir = getProjectRoot();
-  const urls = new Set();
+// ── Extract URLs from one sitemap's XML into the accumulator ───
+function extractUrls(xml, urls) {
+  let count = 0;
+  for (const m of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    urls.add(m[1].trim());
+    count++;
+  }
+  for (const m of xml.matchAll(/hreflang="[^"]*"\s+href="([^"]+)"/g)) {
+    urls.add(m[1].trim());
+    count++;
+  }
+  return count;
+}
 
-  // Prefer dist/ (post-build) over public/ (pre-build source)
-  const sitemapDir = existsSync(resolve(rootDir, 'dist', 'sitemap-pages.xml'))
-    ? resolve(rootDir, 'dist')
-    : resolve(rootDir, 'public');
+// ── Fetch one sub-sitemap live over HTTP (with retry) ─────────
+async function fetchSitemapXml(file) {
+  const url = `${SITEMAP_BASE}/${file}`;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: { Accept: 'application/xml,text/xml' },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (res.ok) return await res.text();
+      if (res.status >= 500 && attempt < MAX_RETRIES) {
+        await sleep(2000 * attempt);
+        continue;
+      }
+      console.log(`  ${file}: HTTP ${res.status} — skipping`);
+      return null;
+    } catch (err) {
+      if (attempt < MAX_RETRIES) {
+        await sleep(2000 * attempt);
+        continue;
+      }
+      console.log(`  ${file}: fetch error (${err.message}) — skipping`);
+      return null;
+    }
+  }
+  return null;
+}
+
+// ── Collect URLs from sitemaps (live by default, --local for FS) ─
+async function getUrlsFromSitemaps() {
+  const urls = new Set();
 
   const filteredSitemaps = sitemapArg
     ? SUB_SITEMAPS.filter((f) => f.includes(sitemapArg))
@@ -118,22 +169,37 @@ function getUrlsFromSitemaps() {
     process.exit(1);
   }
 
-  for (const file of filteredSitemaps) {
-    const filePath = resolve(sitemapDir, file);
-    try {
-      const xml = readFileSync(filePath, 'utf-8');
-      let count = 0;
-      for (const m of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
-        urls.add(m[1].trim());
-        count++;
+  if (USE_LOCAL) {
+    // Prefer dist/ (post-build) over public/ (pre-build source)
+    const rootDir = getProjectRoot();
+    const sitemapDir = existsSync(resolve(rootDir, 'dist', 'sitemap-pages.xml'))
+      ? resolve(rootDir, 'dist')
+      : resolve(rootDir, 'public');
+    for (const file of filteredSitemaps) {
+      try {
+        const count = extractUrls(readFileSync(resolve(sitemapDir, file), 'utf-8'), urls);
+        console.log(`  ${file}: ${count} raw entries (${urls.size} unique so far)`);
+      } catch {
+        console.log(`  ${file}: not found — skipping`);
       }
-      for (const m of xml.matchAll(/hreflang="[^"]*"\s+href="([^"]+)"/g)) {
-        urls.add(m[1].trim());
-        count++;
-      }
+    }
+    console.log(`  Source: local ${sitemapDir}`);
+  } else {
+    let fetched = 0;
+    for (const file of filteredSitemaps) {
+      const xml = await fetchSitemapXml(file);
+      if (xml == null) continue;
+      fetched++;
+      const count = extractUrls(xml, urls);
       console.log(`  ${file}: ${count} raw entries (${urls.size} unique so far)`);
-    } catch {
-      console.log(`  ${file}: not found — skipping`);
+    }
+    console.log(`  Source: live ${SITEMAP_BASE}`);
+    // Fail loud rather than submitting only the 4 EXTRA_URLS: if every
+    // sitemap fetch failed the site/network is down, and a near-empty
+    // submission would mask that as a successful run.
+    if (fetched === 0) {
+      console.error(`No sitemaps could be fetched from ${SITEMAP_BASE}. Aborting.`);
+      process.exit(1);
     }
   }
 
@@ -142,7 +208,6 @@ function getUrlsFromSitemaps() {
     for (const url of EXTRA_URLS) urls.add(url);
   }
 
-  console.log(`  Source directory: ${sitemapDir}`);
   return [...urls].sort();
 }
 
@@ -333,8 +398,8 @@ async function main() {
   console.log('=== IndexNow Batch Submission ===\n');
 
   // 1. Collect URLs
-  console.log('Collecting URLs from sitemaps...');
-  const urlList = getUrlsFromSitemaps();
+  console.log(`Collecting URLs from sitemaps (${USE_LOCAL ? 'local files' : `live ${SITEMAP_BASE}`})...`);
+  const urlList = await getUrlsFromSitemaps();
   console.log(`\nTotal unique URLs: ${urlList.length}\n`);
 
   if (urlList.length === 0) {

--- a/scripts/submit-indexnow-batch.mjs
+++ b/scripts/submit-indexnow-batch.mjs
@@ -186,6 +186,7 @@ async function getUrlsFromSitemaps() {
     console.log(`  Source: local ${sitemapDir}`);
   } else {
     const failed = [];
+    const empty = [];
     for (const file of filteredSitemaps) {
       const xml = await fetchSitemapXml(file);
       // null = unreachable (5xx after retries / 404 / network); an empty but
@@ -195,6 +196,7 @@ async function getUrlsFromSitemaps() {
         continue;
       }
       const count = extractUrls(xml, urls);
+      if (count === 0) empty.push(file);
       console.log(`  ${file}: ${count} raw entries (${urls.size} unique so far)`);
     }
     console.log(`  Source: live ${SITEMAP_BASE}`);
@@ -208,6 +210,13 @@ async function getUrlsFromSitemaps() {
         `Aborting to avoid a partial submission that would drop those URLs silently.`,
       );
       process.exit(1);
+    }
+    // A 200-OK sitemap with zero URLs is treated as legitimately empty (some
+    // categories can be small), but a normally-populated one returning 0 —
+    // e.g. sitemap-jobs.xml truncated by a partial deploy — would otherwise
+    // hide behind its count line. Surface it loudly so it's visible in logs.
+    if (empty.length > 0) {
+      console.warn(`  ⚠️  ${empty.length} sitemap(s) returned 200 but 0 URLs: ${empty.join(', ')} — verify this is expected.`);
     }
   }
 


### PR DESCRIPTION
## Idea (dalla domanda dell'utente)
Il workflow settimanale di catch-up IndexNow rebuildava **tutto il sito** (~38 min, OOM-prone) solo per leggere l'XML dei sitemap che **il deploy pubblica già**. IndexNow dice ai motori di crawlare URL **live** → i sitemap deployati sono la fonte di verità corretta.

## Fix
`submit-indexnow-batch.mjs` ora fetcha i 6 sub-sitemap **live via HTTP** (default `https://frontaliereticino.ch`, override `SITEMAP_BASE`); `--local` legge ancora da `dist/`/`public/`. Lo script usa solo builtin Node + `fetch`, quindi il workflow elimina `npm ci` + `Assemble` + `build:ci`: resta checkout + setup-node + submit.

- Runtime **~38 min → <1 min**, niente OOM/timeout.
- Fail-loud se nessun sitemap è fetchabile (non maschera un'outage come run pulito).
- Verificato in locale (dry-run): **40.867 URL uniche** raccolte in ~5s, 5 batch da 10k.

## Contesto
- La submission IndexNow **incrementale per-deploy** (deploy.yml `validate-live`: Google Indexing API + IndexNow + GSC sulle URL nuove) **resta invariata** — riusa già il dist del deploy.
- Questo workflow è il **catch-up settimanale di TUTTE le URL** per il backlog Bing: la cadenza cron resta, cambia solo la fonte (live invece di build).

## Supersede
Sostituisce l'hardening del build #929/#940 per questo workflow (#940 già chiuso). Il fix gate staticOverlay di #929 resta a sé (già su main).

## Non implementato (fuori scope)
- Nessuna modifica a `submit-indexnow.js` (per-deploy) né a deploy.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
