### PR TITLE
fix(cls): persist home-widgets ErrorBoundary across deferred-flip (mobile CLS 0.122, 72%)

### DIFF
--- a/components/tabs/CalcolatoreTabContent.tsx
+++ b/components/tabs/CalcolatoreTabContent.tsx
@@ -65,11 +65,11 @@ export default function CalcolatoreTabContent() {
  {t('seoContent.calculator.subtitle')}
  </p>
 
- {showDeferredHomeWidgets ? (
- // SilentErrorBoundary contains React #31 / render errors in the home
- // widgets cluster (NewsFeed, DailyDialectPhrase, job-board CTA) so a
- // transient failure does not blank the whole homepage. Errors are still
- // reported to Analytics with a `home-widgets-desktop` label.
+ {/* Persistent SilentErrorBoundary (see mobile block below for rationale):
+ keeping it mounted across the showDeferredHomeWidgets idle-flip and
+ swapping only its children avoids a subtree unmount/remount that
+ collapses this cluster and shifts layout. Contains React #31 / render
+ errors in the desktop home widgets, reported as `home-widgets-desktop`. */}
  <SilentErrorBoundary boundary="home-widgets-desktop" fallback={
  <div className="hidden md:block space-y-2 mb-4" aria-hidden="true">
  <div className="grid grid-cols-1 md:grid-cols-20 gap-2 items-stretch">
@@ -78,6 +78,7 @@ export default function CalcolatoreTabContent() {
  </div>
  </div>
  }>
+ {showDeferredHomeWidgets ? (
  <div className="hidden md:block space-y-2 mb-4">
  <div className="grid grid-cols-1 md:grid-cols-20 gap-2 items-stretch">
  <div className="md:col-span-13 h-full">
@@ -113,7 +114,6 @@ export default function CalcolatoreTabContent() {
  </a>
  </div>
  </div>
- </SilentErrorBoundary>
  ) : (
  <div className="hidden md:block space-y-2 mb-4" aria-hidden="true">
  <div className="grid grid-cols-1 md:grid-cols-20 gap-2 items-stretch">
@@ -123,6 +123,7 @@ export default function CalcolatoreTabContent() {
  <div className="mt-2"><div className="h-12 rounded-xl bg-gradient-to-r from-surface-raised to-edge animate-pulse" /></div>
  </div>
  )}
+ </SilentErrorBoundary>
 
  {/* Mobile: Results-first bottom-sheet layout.
    CLS fix (2026-05-12): the Suspense fallback MUST match the real
@@ -186,10 +187,14 @@ export default function CalcolatoreTabContent() {
      Skeleton fallback inside enlarged to four h-[44px] slots so the fallback itself
      also fills the reserved space, preventing a 32px upward shift when fallback shows. */}
  <div className="md:hidden space-y-2 mt-6 min-h-[192px]" style={{ minHeight: 192 }}>
- {showDeferredHomeWidgets ? (
- // Same as desktop: contain render errors in mobile home widgets so a
- // failure does not blank the homepage on small screens. The whole
- // results-and-input layout above stays usable even if widgets crash.
+ {/* SilentErrorBoundary stays mounted across the showDeferredHomeWidgets
+ flip (fired at idle ~2.3s via requestIdleCallback). Previously it lived
+ only in the `true` branch, so the idle flip mounted/unmounted the whole
+ boundary subtree — a transient unmount that collapsed this block to 0
+ height mid-viewport (Playwright live: 0.122 = 72% of mobile homepage
+ CLS @2303ms). Keeping the boundary persistent and swapping only its
+ children reconciles in place: no unmount, no collapse. Contains React
+ #31 / render errors in the mobile home widgets either way. */}
  <SilentErrorBoundary boundary="home-widgets-mobile" fallback={
  <div aria-hidden="true" className="space-y-2">
  <SkeletonNewsTicker />
@@ -198,6 +203,8 @@ export default function CalcolatoreTabContent() {
  <div className="h-[34px] rounded-xl bg-surface-raised animate-pulse" />
  </div>
  }>
+ {showDeferredHomeWidgets ? (
+ <>
  <Suspense fallback={<SkeletonNewsTicker />}>
  <NewsFeed onNavigate={(tab, article) => {
  setActiveTab(tab as ActiveTab);
@@ -223,7 +230,7 @@ export default function CalcolatoreTabContent() {
  <Suspense fallback={<div className="h-[34px]" />}>
  <DailyDialectPhrase />
  </Suspense>
- </SilentErrorBoundary>
+ </>
  ) : (
  <div aria-hidden="true" className="space-y-2">
  <SkeletonNewsTicker />
@@ -232,6 +239,7 @@ export default function CalcolatoreTabContent() {
  <div className="h-[34px] rounded-xl bg-surface-raised animate-pulse" />
  </div>
  )}
+ </SilentErrorBoundary>
  </div>
 
  {result && (


### PR DESCRIPTION
## Leva RPM #1: CLS mobile (killer viewability)

Attacco la leva grossa dichiarata follow-up. Misura live fresca via Playwright (mobile 390×844, `https://frontaliereticino.ch/`, PerformanceObserver layout-shift con attribution):

```
total CLS = 0.2256
  0.1224 @2303ms  DIV.md:hidden.space-y-2 (home-widgets mobile)  H191→0  ← collasso
  0.0407 @1756ms  stesso blocco  y544→y653 (spinto giù +109px)
  0.0356 @2318ms  DIV.flex.items-center  H34→0
  0.0187 @1337ms  fc-* (Funding Choices consent reflow)
  0.0062 @5794ms  BUTTON.fixed.right-3
```

**Il blocco home-widgets = 72% del CLS mobile.** Collassa H191→0 a 2303ms, esattamente quando `showDeferredHomeWidgets` flippa `false→true` via `requestIdleCallback` (useUIState.ts:172).

## Root cause
`SilentErrorBoundary` viveva **solo nel branch `true`** del ternary. Al idle-flip React vede un cambio di tipo elemento nella stessa posizione (`<div skeleton>` → `<SilentErrorBoundary>`) → **monta/smonta l'intero sottoalbero boundary** = unmount transiente che collassa il cluster a metà viewport.

## Fix
`SilentErrorBoundary` **sempre montato**, swappo solo i suoi figli (skeleton ↔ reale). React riconcilia in-place, niente remount. **Behavior-identical**: stesso skeleton, stesso contenuto, stessa error-containment. Applicato a mobile + blocco desktop identico.

## Validazione
- esbuild transform OK.
- **Non lab-validabile**: il full prod build OOMa in locale (>8GB), e il CLS dell'handoff statico→SPA non si riproduce in `vite dev` (niente HTML pre-renderizzato). Il cambio è però behavior-safe (non può regredire: worst case no-op sul CLS).
- **Field-verify**: `monitor-cls-posthog.mjs --window=24 --once` a 24-48h post-deploy. Approccio ship-and-field-verify già concordato per il CLS hydration-reflow (issue #886).

## Implementato
- Eliminato il remount del cluster home-widgets al deferred-flip (mobile + desktop).

## Non implementato (fuori scope / serve env)
- Funding Choices reflow (0.019) — consent Google, tocco delicato.
- Il push-down +109px @1756ms (qualcosa sopra cresce: probabile ad-slot/result) — da indagare separatamente.
- Iterazione/validazione lab dei fix React rimanenti: serve build prod locale (OOM-blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
