### PR TITLE
fix(crawlers): guard 'undefined' location in slug + JSON-LD addressLocality (#900, #901)

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -136,6 +136,16 @@ export function registerCrawlerSummaryGuard(key, label) {
 function sanitizeJobLocationField(rawValue) {
   if (typeof rawValue !== 'string') return rawValue;
   const original = rawValue;
+  // A detail parser that returns the literal string "undefined"/"null" (or an
+  // empty/whitespace value) slips past every `|| fallback` (truthy) and would
+  // become `addressLocality: "undefined"` → Google rejects the JobPosting
+  // structured data → de-index (AGENTS.md non-negotiable #3). Issue #900.
+  // by-crawler files are Ticino-targeted, so the canton label is a safe,
+  // audit-friendly default (same fallback this function already uses for prose).
+  const trimmedOriginal = original.trim();
+  if (trimmedOriginal === '' || /^(undefined|null)$/i.test(trimmedOriginal)) {
+    return 'Ticino';
+  }
   let s = original
     .replace(/^.*?Location\s*[:.]?\s*/i, '')
     .split(/[\n.;]/)[0]

--- a/scripts/lib/safe-location-token.mjs
+++ b/scripts/lib/safe-location-token.mjs
@@ -10,13 +10,21 @@
  * `JobPosting.jobLocation.address.addressLocality` (Google rejects the
  * structured data → de-index; AGENTS.md non-negotiable #3). Issues #900/#901.
  *
- * Use at every site that interpolates a parser-derived location into a slug.
+ * Adopt at any crawler slug-site that interpolates a parser-derived location.
+ * As of #900/#901 it's wired into hilcona + cedes/laderach/rapelli/davos-klosters-
+ * bergbahnen/otis/burkhalter/volg; other crawlers with the same `|| fallback`
+ * pattern (ksgr, alpiq, prada, sbb, …) remain candidates — see PR #951 body.
+ *
+ * Default fallback `'Ticino'` mirrors `sanitizeJobLocationField` (the choke-point
+ * that backfills `addressLocality`), so a crawler calling this without an
+ * override keeps its slug token and structured-data locality consistent.
+ * Non-TI crawlers pass an explicit fallback (e.g. hilcona → 'Landquart').
  *
  * @param {unknown} value - raw location value from a detail parser.
- * @param {string} [fallback='svizzera'] - safe token when value is missing/invalid.
+ * @param {string} [fallback='Ticino'] - safe token when value is missing/invalid.
  * @returns {string} the trimmed value, or `fallback` if empty/`undefined`/`null`.
  */
-export function safeLocationToken(value, fallback = 'svizzera') {
+export function safeLocationToken(value, fallback = 'Ticino') {
   const s = (value == null ? '' : String(value)).trim();
   if (s === '' || s.toLowerCase() === 'undefined' || s.toLowerCase() === 'null') {
     return fallback;

--- a/scripts/lib/safe-location-token.mjs
+++ b/scripts/lib/safe-location-token.mjs
@@ -1,0 +1,25 @@
+/**
+ * safe-location-token.mjs — guard a location value before it flows into a slug
+ * or JSON-LD `addressLocality`.
+ *
+ * Crawlers build slugs like `slugify(`${title}-company-${raw.location}`)` and
+ * set `addressLocality: loc`. A plain `raw.location || 'fallback'` does NOT
+ * catch the *literal string* `"undefined"` / `"null"` (both truthy), so a
+ * parser that returns those leaks `-undefined` into active job slugs (sitemap
+ * canonical gate failure, issues #823/#824/#852) and `"undefined"` into
+ * `JobPosting.jobLocation.address.addressLocality` (Google rejects the
+ * structured data → de-index; AGENTS.md non-negotiable #3). Issues #900/#901.
+ *
+ * Use at every site that interpolates a parser-derived location into a slug.
+ *
+ * @param {unknown} value - raw location value from a detail parser.
+ * @param {string} [fallback='svizzera'] - safe token when value is missing/invalid.
+ * @returns {string} the trimmed value, or `fallback` if empty/`undefined`/`null`.
+ */
+export function safeLocationToken(value, fallback = 'svizzera') {
+  const s = (value == null ? '' : String(value)).trim();
+  if (s === '' || s.toLowerCase() === 'undefined' || s.toLowerCase() === 'null') {
+    return fallback;
+  }
+  return s;
+}

--- a/scripts/update-burkhalter-jobs.mjs
+++ b/scripts/update-burkhalter-jobs.mjs
@@ -48,6 +48,7 @@ import {
 import { isTargetCanton, getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { extractStableJobId } from './lib/job-match-key.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 /* ── Constants ─────────────────────────────────────────────── */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -207,7 +208,7 @@ function buildJob(raw, description = '') {
   const company = String(raw.company || COMPANY_NAME).trim();
   const city = String(raw.city || '').trim();
   const canton = mapCanton(raw.canton, city) || DEFAULT_CANTON;
-  const slug = slugify(`${title}-${company}-${city}`);
+  const slug = slugify(`${title}-${company}-${safeLocationToken(city)}`);
   const detailUrl = raw.url
     ? (raw.url.startsWith('http') ? raw.url : `${BASE_URL}${raw.url}`)
     : `${BASE_URL}/en/jobs-and-careers/vacancies`;

--- a/scripts/update-cedes-jobs.mjs
+++ b/scripts/update-cedes-jobs.mjs
@@ -14,6 +14,7 @@ import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, deriveLocalizedSlug, mergePreserveLocaleData } from './lib/dedicated-crawler-common.mjs';
 import { fetchCedesJobUrls, fetchCedesDetailPage, slugify, inferEmploymentType } from './lib/cedes-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -62,7 +63,7 @@ async function main() {
     if (!detail?.description || detail.description.length < 120) { console.log(`  ⚠️  ${raw.title}: too short — skipping`); continue; }
     const description = detail.description;
     const urlHash = createHash('sha1').update(raw.url).digest('hex').slice(0, 12);
-    const jobSlug = slugify(`${raw.title}-cedes-${raw.location}`);
+    const jobSlug = slugify(`${raw.title}-cedes-${safeLocationToken(raw.location)}`);
     parsedJobs.push({
       id: `cedes-${urlHash}`, slug: jobSlug,
       slugByLocale: { en: jobSlug },

--- a/scripts/update-davos-klosters-bergbahnen-jobs.mjs
+++ b/scripts/update-davos-klosters-bergbahnen-jobs.mjs
@@ -14,6 +14,7 @@ import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, deriveLocalizedSlug, mergePreserveLocaleData } from './lib/dedicated-crawler-common.mjs';
 import { fetchDavosKlostersBergbahnenJobUrls, fetchDavosKlostersBergbahnenDetailPage, slugify, inferEmploymentType } from './lib/davos-klosters-bergbahnen-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -62,7 +63,7 @@ async function main() {
     if (!detail?.description || detail.description.length < 120) { console.log(`  ⚠️  ${raw.title}: too short — skipping`); continue; }
     const description = detail.description;
     const urlHash = createHash('sha1').update(raw.url).digest('hex').slice(0, 12);
-    const jobSlug = slugify(`${raw.title}-davos-klosters-bergbahnen-${raw.location}`);
+    const jobSlug = slugify(`${raw.title}-davos-klosters-bergbahnen-${safeLocationToken(raw.location)}`);
     parsedJobs.push({
       id: `davos-klosters-bergbahnen-${urlHash}`, slug: jobSlug,
       slugByLocale: { de: jobSlug },

--- a/scripts/update-hilcona-jobs.mjs
+++ b/scripts/update-hilcona-jobs.mjs
@@ -14,6 +14,7 @@ import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, deriveLocalizedSlug, mergePreserveLocaleData } from './lib/dedicated-crawler-common.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
 import { fetchHilconaJobUrls, fetchHilconaDetailPage, slugify, inferEmploymentType } from './lib/hilcona-job-parser.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -60,14 +61,16 @@ async function main() {
     const detail = await fetchHilconaDetailPage(raw.url);
     if (!detail?.description || detail.description.length < 120) { console.log(`  ⚠️  ${raw.title}: too short — skipping`); continue; }
     const description = detail.description;
-    const loc = detail.location || 'Landquart';
+    // Guard upstream of `loc` so a missing/invalid value ("undefined"/"null"/
+    // empty from the detail parser) can never leak the literal string into the
+    // slug (regression that produced live /…-hilcona-undefined/ pages + tripped
+    // the sitemap-canonical gate) NOR into the JSON-LD addressLocality (Google
+    // rejects → de-index; AGENTS.md non-negotiable #3). Issue #900. The guarded
+    // value flows into slug, location, addressLocality and inferAnyCanton.
+    const loc = safeLocationToken(detail.location, 'Landquart');
     const company = detail.company || COMPANY_NAME;
     const urlHash = createHash('sha1').update(raw.url).digest('hex').slice(0, 12);
-    // Guard the location token so a missing/invalid value can never leak the
-    // literal string "undefined" into an emitted URL (regression that produced
-    // live /…-hilcona-undefined/ pages and tripped the sitemap-canonical gate).
-    const slugLoc = loc && loc !== 'undefined' ? loc : 'landquart';
-    const jobSlug = slugify(`${raw.title}-hilcona-${slugLoc}`);
+    const jobSlug = slugify(`${raw.title}-hilcona-${loc}`);
     parsedJobs.push({
       id: `hilcona-${urlHash}`, slug: jobSlug,
       slugByLocale: { de: jobSlug },

--- a/scripts/update-laderach-jobs.mjs
+++ b/scripts/update-laderach-jobs.mjs
@@ -14,6 +14,7 @@ import { writeJobsCrawlerSlice, writeSummaryCrawlerSlice,
 import { runDedicatedBaseCrawler, validateDedicatedLocaleCoverage, detectLang, deriveLocalizedSlug, mergePreserveLocaleData } from './lib/dedicated-crawler-common.mjs';
 import { fetchLaderachJobUrls, fetchLaderachDetailPage, slugify, inferEmploymentType } from './lib/laderach-job-parser.mjs';
 import { inferAnyCanton, isKnownSwissMunicipality } from './lib/target-swiss-locations.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -71,7 +72,7 @@ async function main() {
       continue;
     }
     const urlHash = createHash('sha1').update(raw.url).digest('hex').slice(0, 12);
-    const jobSlug = slugify(`${raw.title}-laderach-${raw.location}`);
+    const jobSlug = slugify(`${raw.title}-laderach-${safeLocationToken(raw.location)}`);
     parsedJobs.push({
       id: `laderach-${urlHash}`, slug: jobSlug,
       slugByLocale: { de: jobSlug },

--- a/scripts/update-otis-jobs.mjs
+++ b/scripts/update-otis-jobs.mjs
@@ -45,6 +45,7 @@ import {
 } from './lib/otis-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
 import { inferAnyCanton } from './lib/target-swiss-locations.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -112,7 +113,7 @@ async function main() {
     // Prefer detail city (from full location text) over listing city
     const city = detail.city || raw.city || 'Ticino';
     const canton = inferAnyCanton(`${city} ${raw.location}`) || detail.canton || DEFAULT_CANTON;
-    const jobSlug = slugify(`${raw.title}-otis-${city}`);
+    const jobSlug = slugify(`${raw.title}-otis-${safeLocationToken(city, 'Ticino')}`);
     parsedJobs.push({
       id: `otis-${urlHash}`,
       slug: jobSlug,

--- a/scripts/update-rapelli-jobs.mjs
+++ b/scripts/update-rapelli-jobs.mjs
@@ -42,6 +42,7 @@ import {
   slugify, inferEmploymentType,
 } from './lib/rapelli-job-parser.mjs';
 import { getCompanyDefaults } from './lib/crawler-location-config.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -104,7 +105,7 @@ async function main() {
     }
     const description = detail.description;
     const urlHash = createHash('sha1').update(raw.url).digest('hex').slice(0, 12);
-    const jobSlug = slugify(`${raw.title}-rapelli-${raw.location}`);
+    const jobSlug = slugify(`${raw.title}-rapelli-${safeLocationToken(raw.location)}`);
     // Only set source locale (IT) — other locales will be filled by:
     // 1. mergePreserveLocaleData (preserves existing translations from previous runs)
     // 2. translate-pending pipeline (AI translation for missing locales)

--- a/scripts/update-volg-jobs.mjs
+++ b/scripts/update-volg-jobs.mjs
@@ -25,6 +25,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { extractStableJobId } from './lib/job-match-key.mjs';
+import { safeLocationToken } from './lib/safe-location-token.mjs';
 import {
   snapshotJobSlugs,
   computeCrawlDiff,
@@ -602,7 +603,7 @@ function getPostalCode(city = '', canton = '') {
 function buildJob(raw) {
   const { url, title, company, city, workload, contractTerms, canton, region } = raw;
   const { employmentType, contractType } = mapEmploymentType(workload, contractTerms);
-  const slug = slugify(`${title}-${company}-${city}`);
+  const slug = slugify(`${title}-${company}-${safeLocationToken(city)}`);
   const sourceLang = detectLang(title, 'de');
   const today = new Date().toISOString().slice(0, 10);
   const postalCode = getPostalCode(city, canton);

--- a/tests/normalize-job-locality-undefined.test.ts
+++ b/tests/normalize-job-locality-undefined.test.ts
@@ -9,11 +9,11 @@ import { describe, it, expect } from 'vitest';
 import { normalizeParsedJobsForSlice } from '../scripts/assemble-jobs-dataset.mjs';
 
 describe('normalizeParsedJobsForSlice — addressLocality "undefined" guard (#900)', () => {
-  it('never persists the literal "undefined" in addressLocality or location', () => {
+  it('rewrites literal "undefined" addressLocality + location to the safe canton default', () => {
     const jobs = [{ slug: 'x', addressLocality: 'undefined', location: 'undefined', canton: 'TI' }];
     normalizeParsedJobsForSlice(jobs);
-    expect(jobs[0].addressLocality.toLowerCase()).not.toBe('undefined');
-    expect(String(jobs[0].location).toLowerCase()).not.toBe('undefined');
+    expect(jobs[0].addressLocality).toBe('Ticino'); // exact: the choke-point fallback
+    expect(jobs[0].location).toBe('Ticino');
   });
 
   it('keeps a valid addressLocality untouched', () => {
@@ -22,10 +22,9 @@ describe('normalizeParsedJobsForSlice — addressLocality "undefined" guard (#90
     expect(jobs[0].addressLocality).toBe('Lugano');
   });
 
-  it('backfills an empty addressLocality from the sanitized location (not "undefined")', () => {
+  it('backfills an empty addressLocality from the sanitized location (→ "Ticino", not "undefined")', () => {
     const jobs = [{ slug: 'x', addressLocality: '', location: 'undefined', canton: 'TI' }];
     normalizeParsedJobsForSlice(jobs);
-    expect(jobs[0].addressLocality.toLowerCase()).not.toBe('undefined');
-    expect(jobs[0].addressLocality.trim()).not.toBe('');
+    expect(jobs[0].addressLocality).toBe('Ticino'); // exact: location sanitized first, then backfilled
   });
 });

--- a/tests/normalize-job-locality-undefined.test.ts
+++ b/tests/normalize-job-locality-undefined.test.ts
@@ -1,0 +1,31 @@
+/**
+ * #900 — choke-point guard: normalizeParsedJobsForSlice (run by writeJobsCrawlerSlice
+ * for every crawler) must never persist `addressLocality: "undefined"`. Google
+ * rejects such JobPosting structured data → de-index (AGENTS.md non-negotiable #3).
+ * Defends ALL crawlers, not just the ones with their own upstream guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeParsedJobsForSlice } from '../scripts/assemble-jobs-dataset.mjs';
+
+describe('normalizeParsedJobsForSlice — addressLocality "undefined" guard (#900)', () => {
+  it('never persists the literal "undefined" in addressLocality or location', () => {
+    const jobs = [{ slug: 'x', addressLocality: 'undefined', location: 'undefined', canton: 'TI' }];
+    normalizeParsedJobsForSlice(jobs);
+    expect(jobs[0].addressLocality.toLowerCase()).not.toBe('undefined');
+    expect(String(jobs[0].location).toLowerCase()).not.toBe('undefined');
+  });
+
+  it('keeps a valid addressLocality untouched', () => {
+    const jobs = [{ slug: 'x', addressLocality: 'Lugano', location: 'Lugano', canton: 'TI' }];
+    normalizeParsedJobsForSlice(jobs);
+    expect(jobs[0].addressLocality).toBe('Lugano');
+  });
+
+  it('backfills an empty addressLocality from the sanitized location (not "undefined")', () => {
+    const jobs = [{ slug: 'x', addressLocality: '', location: 'undefined', canton: 'TI' }];
+    normalizeParsedJobsForSlice(jobs);
+    expect(jobs[0].addressLocality.toLowerCase()).not.toBe('undefined');
+    expect(jobs[0].addressLocality.trim()).not.toBe('');
+  });
+});

--- a/tests/safe-location-token.test.ts
+++ b/tests/safe-location-token.test.ts
@@ -1,0 +1,39 @@
+/**
+ * #900/#901 — safeLocationToken guards a parser-derived location before it
+ * flows into a slug or addressLocality, so the literal string "undefined"/"null"
+ * (truthy → slips past `|| fallback`) can never leak `-undefined` into active
+ * slugs (sitemap-canonical gate) or `addressLocality: "undefined"` into JSON-LD
+ * (Google de-index; AGENTS.md non-negotiable #3).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { safeLocationToken } from '../scripts/lib/safe-location-token.mjs';
+
+describe('safeLocationToken (#900/#901)', () => {
+  it('passes a valid location through unchanged', () => {
+    expect(safeLocationToken('Lugano')).toBe('Lugano');
+  });
+
+  it('returns fallback for the literal "undefined"/"null" string (case-insensitive)', () => {
+    expect(safeLocationToken('undefined')).toBe('svizzera');
+    expect(safeLocationToken('UNDEFINED')).toBe('svizzera');
+    expect(safeLocationToken('null')).toBe('svizzera');
+    expect(safeLocationToken('Null')).toBe('svizzera');
+  });
+
+  it('returns fallback for JS undefined/null/empty/whitespace', () => {
+    expect(safeLocationToken(undefined)).toBe('svizzera');
+    expect(safeLocationToken(null)).toBe('svizzera');
+    expect(safeLocationToken('')).toBe('svizzera');
+    expect(safeLocationToken('   ')).toBe('svizzera');
+  });
+
+  it('honors a custom fallback', () => {
+    expect(safeLocationToken('undefined', 'Landquart')).toBe('Landquart');
+    expect(safeLocationToken(undefined, 'Ticino')).toBe('Ticino');
+  });
+
+  it('trims surrounding whitespace on valid values', () => {
+    expect(safeLocationToken('  Bellinzona  ')).toBe('Bellinzona');
+  });
+});

--- a/tests/safe-location-token.test.ts
+++ b/tests/safe-location-token.test.ts
@@ -14,18 +14,18 @@ describe('safeLocationToken (#900/#901)', () => {
     expect(safeLocationToken('Lugano')).toBe('Lugano');
   });
 
-  it('returns fallback for the literal "undefined"/"null" string (case-insensitive)', () => {
-    expect(safeLocationToken('undefined')).toBe('svizzera');
-    expect(safeLocationToken('UNDEFINED')).toBe('svizzera');
-    expect(safeLocationToken('null')).toBe('svizzera');
-    expect(safeLocationToken('Null')).toBe('svizzera');
+  it('returns default fallback for the literal "undefined"/"null" string (case-insensitive)', () => {
+    expect(safeLocationToken('undefined')).toBe('Ticino');
+    expect(safeLocationToken('UNDEFINED')).toBe('Ticino');
+    expect(safeLocationToken('null')).toBe('Ticino');
+    expect(safeLocationToken('Null')).toBe('Ticino');
   });
 
-  it('returns fallback for JS undefined/null/empty/whitespace', () => {
-    expect(safeLocationToken(undefined)).toBe('svizzera');
-    expect(safeLocationToken(null)).toBe('svizzera');
-    expect(safeLocationToken('')).toBe('svizzera');
-    expect(safeLocationToken('   ')).toBe('svizzera');
+  it('returns default fallback for JS undefined/null/empty/whitespace', () => {
+    expect(safeLocationToken(undefined)).toBe('Ticino');
+    expect(safeLocationToken(null)).toBe('Ticino');
+    expect(safeLocationToken('')).toBe('Ticino');
+    expect(safeLocationToken('   ')).toBe('Ticino');
   });
 
   it('honors a custom fallback', () => {


### PR DESCRIPTION
## Implementato

Chiude #900 e #901 (stessa classe). La stringa **`'undefined'`** da un detail parser supera ogni `|| fallback` (è truthy) e finiva:
- nello **slug attivo** (`-undefined` → fallimento `audit:sitemap-canonicals`, famiglia #823/#852);
- in **`addressLocality`** del JSON-LD `JobPosting` → Google rifiuta la structured data → **de-index** (AGENTS.md non-negotiable #3).

**Fix a strati:**
- **`scripts/lib/safe-location-token.mjs` (NEW)** — helper condiviso: `'undefined'`/`'null'`/vuoto → fallback (default `'Ticino'`, allineato al choke-point). Una definizione, niente copy-paste.
- **`assemble-jobs-dataset.mjs` → `sanitizeJobLocationField`** — `'undefined'`/`'null'`/vuoto → `'Ticino'`. **Choke-point `addressLocality` di TUTTI i crawler** (`writeJobsCrawlerSlice` → `normalizeParsedJobsForSlice`): la JSON-LD non avrà mai `addressLocality:"undefined"`, per ogni crawler presente e futuro (#900).
- **`update-hilcona-jobs.mjs` (#900)** — guard a monte di `loc` via `safeLocationToken(detail.location, 'Landquart')`, rimossa `slugLoc`.
- **7 crawler (#901)** — `cedes`/`laderach`/`rapelli`/`davos-klosters-bergbahnen`/`otis`/`burkhalter`/`volg` usano `safeLocationToken` nello slug.

**Test (8, verdi):** `safe-location-token` (5) + `normalize-job-locality-undefined` choke-point (3). `tsc --noEmit` pulito sui file toccati.

## Non implementato (ancora)

- **Lato SLUG limitato agli 8 crawler di #900/#901** (dichiarazione esplicita, review #951 🔴). Il choke-point copre `addressLocality` per TUTTI i crawler, ma lo slug è costruito a monte per-crawler e NON è rigenerato dal normalizer. Restano con lo stesso anti-pattern `|| fallback` (truthy-bypass) nello slug-site, **latenti** (nessuno emette `'undefined'` oggi — sennò sarebbero nell'audit), **follow-up**: `ksgr`, `alpiq`, `prada`, `sbb`, `bps-suisse`, `corner`, `guess`, `debiopharm`, `confederazione`, `kronenhof`, `casale`, `skyguide`. L'helper è pronto: applicare `safeLocationToken` al loro slug-site. Fuori scope di #900/#901 (che nominano solo gli 8). Tracciato in #952 (sweep dedicato).
- **Verifica live**: gli slug si rigenerano al prossimo run crawler; i `-undefined` già indicizzati sono coperti dal meccanismo previousSlugs (vedi #905, separato).
- `burkhalter`/`otis` erano già a basso rischio; allineati all'helper per consistenza + caso stringa-`'undefined'`.
