### PR TITLE
ci(deploy): paths-ignore per merge non-dist — mitiga deploy-starvation (①)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,25 @@ on:
   push:
     branches:
       - main
+    # paths-ignore è una DENYLIST applicata solo se TUTTI i file del push
+    # matchano (un push misto docs+codice deploya comunque). Sicuro per
+    # definizione: un path dimenticato deploya, non viene saltato.
+    # Obiettivo: non bruciare un build SEO da ~25min su merge che NON cambiano
+    # il dist deployato (deploy-starvation: build lungo vs merge ~5min via
+    # auto-merge PAT). I path sotto non sono letti dalla build del dist:
+    #   - docs/markdown, file CI/workflow, test, config agent: nessun output dist.
+    # NON ignorati (toccano il dist): build-plugins/, services/, components/,
+    # scripts/ (assemble-jobs gira a build-time), data/jobs*, vite/index/package.
     paths-ignore:
       - 'data/border-wait-current.json'
       - 'data/border-wait-history/**'
       - 'data/border-wait-averages.json'
       - 'data/weather-snapshot.json'
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
+      - 'tests/**'
+      - '.claude/**'
   workflow_dispatch:
     inputs:
       article_id:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,15 @@ on:
     #   - docs/markdown, file CI/workflow, test, config agent: nessun output dist.
     # NON ignorati (toccano il dist): build-plugins/, services/, components/,
     # scripts/ (assemble-jobs gira a build-time), data/jobs*, vite/index/package.
+    # NB: usiamo `*.md` (root) + `docs/**`, NON `**/*.md`: `public/**/*.md`
+    # (es. press-kit) è copiato verbatim da Vite (publicDir) nel dist → resta
+    # dist-bound e deve poter deployare.
     paths-ignore:
       - 'data/border-wait-current.json'
       - 'data/border-wait-history/**'
       - 'data/border-wait-averages.json'
       - 'data/weather-snapshot.json'
-      - '**/*.md'
+      - '*.md'
       - 'docs/**'
       - '.github/**'
       - 'tests/**'


### PR DESCRIPTION
## Implementato

Mitigazione **parziale** della deploy-starvation (① del piano). Estende `paths-ignore` di `deploy.yml` con path che **non** producono output dist → un merge che tocca SOLO quei path non scatena il build SEO da ~25min:
- `*.md` (root: README/AGENTS/CLAUDE/REVIEW/…), `docs/**`, `.github/**`, `tests/**`, `.claude/**`

**Sicurezza:** `paths-ignore` è denylist applicata solo se TUTTI i file del push matchano → push misto docs+codice deploya comunque; path dimenticato deploya (non saltato). Uso `*.md` (root) + `docs/**`, **non** `**/*.md`, perché `public/**/*.md` (press-kit) è copiato verbatim da Vite (publicDir) nel dist → resta dist-bound. Nessun build-plugin legge `.md` (content in `services/locales/*.ts`).

## Non implementato (ancora)

- **① è mitigazione PARZIALE, non risolve la starvation da sola** (review #956 🔴, claim ammorbidito). Misura dai dati (ultimi 80 deploy run): sorgente trigger = **push PR-merge** (la maggioranza) + molti **workflow_dispatch**; solo **5/80 sono commit crawler** (`Auto-update`), perché i crawler pushano via `GITHUB_TOKEN` che NON cascata sul deploy (#847). Quindi:
  - ① elimina i PR-merge **solo**-docs/CI/test (≈30% dei push recenti: es. `docs(agents)`, `test(ci)`, `ci(deploy)`). Reale ma parziale.
  - ① **non** tocca: i deploy `workflow_dispatch` (molti, manuali), né i PR-merge di contenuto, né la **durata del build da 25min** (root vero).
- **④ — build da 25min** (root): profilato (190k expired-soft-landing + 517k cluster + 130s canonical-fallback-pre-pass). Leva = cache cross-build in `jobsSeoPagesPlugin`. Tracciato in **#957** (effort dedicato, alto rischio).
- **② debounce/schedule deploy**, **③ throttle auto-merge / commit-rate**: leve complementari per la quota restante di trigger (workflow_dispatch + content merges). Non incluse qui.
