### PR TITLE
ci(deploy): switch to branch-based Pages deploy — fixes 0/100 deploy failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,14 +129,13 @@ jobs:
       group: ${{ github.event.inputs.profile_sequential == 'true' && format('pages-build-profile-{0}', github.run_id) || 'pages-build' }}
       cancel-in-progress: false
     # contents: write is needed by the "Publish dist/ to gh-pages" step
-    # (force-push of dist/ to the gh-pages branch — the deploy). Mirrors the
-    # workflow-level block otherwise; the bump from read→write also lets the
-    # existing dist-history `git push origin HEAD:main` land (it had been
-    # failing on the inherited contents:read).
+    # (force-push of dist/ to the gh-pages branch — the deploy) and also lets
+    # the existing dist-history `git push origin HEAD:main` land (it had been
+    # failing on the inherited contents:read). issues: write is for the
+    # failure-reporting step. pages:write / id-token:write are no longer needed
+    # (branch push uses GITHUB_TOKEN + contents:write; no actions/deploy-pages).
     permissions:
       contents: write
-      pages: write
-      id-token: write
       issues: write
     runs-on: ubuntu-latest
     # GitHub free runners cap at 360 min — match it explicitly so cold-start
@@ -968,11 +967,11 @@ jobs:
             --workflow "${{ github.workflow }}"
 
   # ───────────────────────────────────────────────────────────────────────
-  # deploy: publish dist/ to GitHub Pages (actions/deploy-pages reads the
-  # `github-pages` artifact from this run automatically). Inherits the
-  # `pages-deploy` concurrency group so build+deploy together hold the
-  # serial Pages lock for the upload+publish sequence — but each job
-  # individually rilascia la lock when complete.
+  # deploy: branch-based — the build job already force-pushed dist/ to the
+  # gh-pages branch (that IS the publish; GitHub Pages serves the branch). This
+  # job no longer deploys; it only CONFIRMS the gh-pages branch was published so
+  # validate-live → publish/rollback stay gated on a real deploy. The live
+  # go-live check is validate-live polling build-id.txt.
   # ───────────────────────────────────────────────────────────────────────
   deploy:
     needs: build
@@ -1257,38 +1256,24 @@ jobs:
       # may already be live on Pages — reverting our (failed) deploy
       # would clobber a valid newer one. Check the live Pages deployment
       # SHA before proceeding.
-      # ⚠️ KNOWN GAP (branch-based deploy, follow-up tracked): under the new
-      # gh-pages branch deploy the published commit is an orphan authored by
-      # deploy-bot, so it never equals github.sha — this guard therefore always
-      # takes the "newer deploy replaced mine" path and the rollback no-ops.
-      # A bad deploy still surfaces (validate-* go red + a failure issue is
-      # filed) and is overwritten by the next deploy (~20 min cadence), but
-      # there is no automatic revert to last-known-good yet. Rebuilding rollback
-      # for branch-based (snapshot last-good gh-pages, restore via force-push)
-      # is the declared follow-up — see the PR body "Non implementato".
       - name: Verify our deploy is still live (still-live guard)
         id: still-live
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          live_sha=$(gh api \
-            "repos/${{ github.repository }}/deployments?environment=github-pages&per_page=1" \
-            --jq '.[0].sha // empty')
-          my_sha="${{ github.sha }}"
-          echo "Live Pages deployment SHA: ${live_sha:-(unknown)}"
-          echo "My deploy SHA:             $my_sha"
-          if [ -z "$live_sha" ]; then
-            echo "::warning::Could not resolve live deployment SHA — proceeding with rollback as best-effort"
-            echo "still_live=true" >> "$GITHUB_OUTPUT"
-          elif [ "$live_sha" = "$my_sha" ]; then
-            echo "✅ My deploy is still live — rollback is the right action."
-            echo "still_live=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ℹ️ A newer deploy ($live_sha) has already replaced mine on Pages."
-            echo "   Rollback is a no-op — skipping. The newer deploy already removed the bad version."
-            echo "still_live=false" >> "$GITHUB_OUTPUT"
-          fi
+          # Branch-based deploy: automated rollback is DISABLED here (follow-up
+          # #967). The legacy machinery below (artifact restore via
+          # actions/deploy-pages, or re-dispatching deploy.yml at last-good) is
+          # incompatible with branch-based publishing AND would risk a deploy
+          # loop if Pages registers no `github-pages` deployment entry
+          # (live_sha empty → still_live=true → fresh dispatch → fails
+          # validate-live → dispatch again …). Force still_live=false so every
+          # restore step skips cleanly. A bad deploy still surfaces (validate-*
+          # go red + a failure issue is filed) and is overwritten by the next
+          # deploy (~20-min cadence); there is just no automatic revert yet.
+          echo "::warning::Branch-based deploy: automated rollback is disabled (see #967). A bad deploy is visible via red validate-* + failure issue and is replaced by the next deploy; manual recovery if urgent."
+          echo "still_live=false" >> "$GITHUB_OUTPUT"
 
       - name: Get last known good deploy
         if: steps.still-live.outputs.still_live == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,11 +77,6 @@ on:
         required: false
         type: boolean
         default: false
-      publish_branch_test:
-        description: 'EXPERIMENT (reversible): after build, orphan force-push dist/ to the `gh-pages-test` branch instead of (not in addition to) the normal artifact deploy. Validates whether a ~13 GB site survives a git push to GitHub — the prerequisite for switching off the actions/deploy-pages path (10-min artifact-polling cap that has failed every recent deploy). Does NOT touch the live Pages source or the production gh-pages branch; nothing is published. Off by default.'
-        required: false
-        type: boolean
-        default: false
       parallel_plugins:
         description: 'Force parallel closeBundle even when profile_sequential=true. Default (off) means parallel for production, sequential only for clean profile dispatch runs. Set this to true when you want to dispatch a profile run AND keep the parallel scheduling — useful for measuring parallel build behavior without cron-storm cancellation.'
         required: false
@@ -133,11 +128,11 @@ jobs:
     concurrency:
       group: ${{ github.event.inputs.profile_sequential == 'true' && format('pages-build-profile-{0}', github.run_id) || 'pages-build' }}
       cancel-in-progress: false
-    # contents: write is needed only by the opt-in publish_branch_test step
-    # (orphan force-push of dist/ to gh-pages-test). Mirrors the workflow-level
-    # block otherwise; the bump from read→write also lets the existing
-    # dist-history `git push origin HEAD:main` land (it had been failing on
-    # the inherited contents:read).
+    # contents: write is needed by the "Publish dist/ to gh-pages" step
+    # (force-push of dist/ to the gh-pages branch — the deploy). Mirrors the
+    # workflow-level block otherwise; the bump from read→write also lets the
+    # existing dist-history `git push origin HEAD:main` land (it had been
+    # failing on the inherited contents:read).
     permissions:
       contents: write
       pages: write
@@ -149,9 +144,12 @@ jobs:
     # rendering ~2100 PNGs from scratch) don't fail on the default 6 h
     # ceiling and the failure mode is obvious in the logs if it happens.
     timeout-minutes: 360
+    # The build job now performs the deploy (force-push dist/ to gh-pages), so
+    # it runs in the github-pages environment — the protection rule (main only)
+    # correctly gates who can publish to the branch.
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || steps.deployment_first.outputs.page_url }}
+      url: https://frontaliereticino.ch/
     steps:
       # Free ~25-30 GB on the ubuntu-latest runner before any cache restore
       # or build output lands on disk. Without this the runner ships with
@@ -886,50 +884,41 @@ jobs:
           echo "::warning::[dist-history] push failed after 5 attempts — url-first-seen.json will not be available to the next build's grace-window check"
 
       # ┌────────────────────────────────────────────────────────────────┐
-      # │ EXPERIMENT (opt-in, reversible) — branch-based publish viability │
+      # │ Branch-based deploy — publish dist/ to the `gh-pages` branch.    │
       # │ The actions/deploy-pages path caps Pages status-polling at 10    │
-      # │ min; with a ~13 GB dist (1.53 GB artifact) every recent deploy   │
-      # │ hit "Timeout reached, aborting!" → 0/100 runs published. Legacy  │
-      # │ "deploy from branch" has no such artifact-polling cap. Before    │
-      # │ switching the production Pages source we must confirm GitHub     │
-      # │ even ACCEPTS a 13 GB git push. This step force-pushes dist/ as a │
-      # │ single orphan commit to `gh-pages-test` (a throwaway branch) —   │
-      # │ `git init` inside dist/ keeps it a standalone tree, so the main  │
-      # │ repo history is NOT bloated and nothing is published (Pages      │
-      # │ source is untouched). Read the wall time + exit status to decide.│
+      # │ min; with a ~13 GB dist (1.53 GB artifact) every deploy hit      │
+      # │ "Timeout reached, aborting!" → 0/100 runs published. Legacy      │
+      # │ "deploy from branch" (Pages source = gh-pages) has no such cap;  │
+      # │ validated by run 26650342310 (13 GB push, ~17.5 min, success).   │
+      # │ `git init` inside dist/ makes a standalone single-commit tree    │
+      # │ force-pushed each run, so the main repo history is NOT bloated.  │
+      # │ .nojekyll disables Jekyll (essential — Pages must NOT try to     │
+      # │ build ~470k files). CNAME ships from public/CNAME via Vite, so   │
+      # │ the custom domain is preserved on the published branch.          │
       # └────────────────────────────────────────────────────────────────┘
-      - name: "[experiment] Orphan force-push dist/ to gh-pages-test"
-        if: github.event_name == 'workflow_dispatch' && inputs.publish_branch_test == true
+      - name: Publish dist/ to gh-pages (branch-based deploy)
+        if: github.event.inputs.profile_sequential != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          echo "dist size: $(du -sh dist | cut -f1), files: $(find dist -type f | wc -l)"
+          echo "dist: $(du -sh dist | cut -f1), $(find dist -type f | wc -l) files"
+          test -f dist/CNAME || echo "frontaliereticino.ch" > dist/CNAME
           cd dist
           touch .nojekyll
           git init -q
-          git checkout -q -b gh-pages-test
+          git checkout -q -b gh-pages
           git config user.email "deploy-bot@frontaliereticino.ch"
           git config user.name "deploy-bot"
           git add -A
-          git commit -qm "experiment: branch-based publish ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
-          echo "Pushing $(du -sh . | cut -f1) as a single orphan commit to gh-pages-test..."
-          time git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages-test
-          echo "✅ 13 GB branch push SUCCEEDED — legacy branch-based Pages deploy is viable"
+          git commit -qm "deploy ${GITHUB_SHA::8} (run ${GITHUB_RUN_ID})"
+          echo "Pushing $(du -sh . | cut -f1) to gh-pages..."
+          time git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+          echo "✅ Published to gh-pages — GitHub Pages will serve it (source = branch)."
 
-      - name: Upload Pages artifact (compression-level 9)
-        if: github.event.inputs.profile_sequential != 'true'
-        id: upload-pages-artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: github-pages
-          path: ${{ runner.temp }}/artifact.tar
-          retention-days: 1
-          if-no-files-found: error
-          # Level 9 = max deflate compression on the zip envelope. Pages
-          # backend extracts the zip first, so our content gets the best
-          # compression ratio in transit (~970 MB vs ~1.21 GB at level 6).
-          compression-level: 9
+      # (Pages artifact upload removed: branch-based deploy publishes via the
+      # gh-pages push above, so actions/upload-pages-artifact + the
+      # actions/deploy-pages job are no longer used.)
 
       - name: Upload write-collisions analysis
         if: always() && github.event.inputs.profile_sequential != 'true'
@@ -1006,13 +995,13 @@ jobs:
       group: 'pages-deploy'
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    # Branch-based deploy: this job no longer publishes via actions/deploy-pages
+    # (the build job force-pushes dist/ to gh-pages and GitHub Pages serves that
+    # branch). It now only CONFIRMS the gh-pages publish and keeps the
+    # validate-live → publish/rollback DAG gated. No `environment: github-pages`
+    # (no Actions deployment happens here) and no pages/id-token scopes needed.
     permissions:
-      pages: write
-      id-token: write
       contents: read
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || steps.deployment_first.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -1052,54 +1041,29 @@ jobs:
             echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json" >> "$GITHUB_ENV"
           fi
 
-      # GitHub Pages allows only one deployment at a time. When concurrent
-      # pushes trigger this workflow, the second run can hit "in progress
-      # deployment" errors. Retry once after a short wait to handle this.
-      #
-      # `actions/deploy-pages@v5` ALSO caps its internal status polling at
-      # 10 minutes (the `timeout: 1800000` we pass is silently clamped to
-      # 600000 — see the warning emitted at start of the step). For sites
-      # with >1M files the Pages backend's `syncing_files` phase can run
-      # well past 10 minutes, causing the action to abort with
-      # `Timeout reached, aborting!` even though the deployment itself
-      # eventually completes server-side. The marker-based extended
-      # polling below recognises that case and keeps the job green when
-      # the live site actually came up.
-      - name: Deploy to GitHub Pages
-        id: deployment_first
-        uses: actions/deploy-pages@v5
-        continue-on-error: true
-        with:
-          timeout: 1800000
-          error_count: 100
-
-      - name: Wait for previous Pages deployment to finish
-        if: steps.deployment_first.outcome == 'failure'
+      # Branch-based deploy gate. The build job force-pushed dist/ to the
+      # gh-pages branch as commit "deploy <sha> (run <id>)"; GitHub Pages
+      # (source = gh-pages) publishes it automatically with no 10-minute
+      # artifact-polling cap. Here we just confirm the branch carries THIS
+      # run's commit so validate-live → publish/rollback stay gated on a real
+      # publish. Live-content verification remains validate-live's job.
+      - name: Confirm gh-pages publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::warning::First deploy attempt failed (likely Pages busy or 10-minute polling cap). Retrying in 30s..."
-          sleep 30
-
-      - name: Deploy to GitHub Pages (retry)
-        id: deployment
-        if: steps.deployment_first.outcome == 'failure'
-        uses: actions/deploy-pages@v5
-        continue-on-error: true
-        with:
-          timeout: 1800000
-          error_count: 100
-
-      # Both deploy-pages attempts are `continue-on-error`, so a double
-      # failure would otherwise leave the deploy job green. Fail the job
-      # immediately when both attempts failed (Pages busy or the action's
-      # 10-minute polling cap). The previous marker-file extended-polling
-      # step was removed: across all observed runs it never once rescued a
-      # deploy (the live SHA never matched within the 25-minute poll), so
-      # it only ever burned CI time before exiting 1 anyway.
-      - name: Fail if both deploy attempts failed
-        if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome == 'failure'
-        run: |
-          echo "::error::Both deploy-pages attempts failed (Pages busy or 10-minute polling cap) — treating as a real deploy failure."
-          exit 1
+          set -euo pipefail
+          head_sha=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" gh-pages | cut -f1)
+          if [ -z "$head_sha" ]; then
+            echo "::error::gh-pages branch missing — build job did not publish."
+            exit 1
+          fi
+          subject=$(git log -1 --format=%s "$head_sha" 2>/dev/null || echo "")
+          echo "gh-pages HEAD: $head_sha"
+          echo "subject: ${subject:-<not fetched>}"
+          if [ -n "$subject" ] && ! echo "$subject" | grep -q "run ${GITHUB_RUN_ID}"; then
+            echo "::warning::gh-pages HEAD is not this run's commit (a newer concurrent deploy may have superseded it) — proceeding; validate-live checks the live site."
+          fi
+          echo "✅ gh-pages published; GitHub Pages will serve the branch."
 
       - name: Save deploy metadata to Firestore
         if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1052,18 +1052,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # The build job force-pushed dist/ to gh-pages (the deploy). Confirm
+          # the branch exists; GitHub Pages (source = gh-pages) then serves it.
+          # We intentionally don't try to match the orphan commit SHA here —
+          # it isn't in this job's checkout — so the real go-live verification
+          # is validate-live polling build-id.txt on the live site.
           head_sha=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" gh-pages | cut -f1)
           if [ -z "$head_sha" ]; then
             echo "::error::gh-pages branch missing — build job did not publish."
             exit 1
           fi
-          subject=$(git log -1 --format=%s "$head_sha" 2>/dev/null || echo "")
-          echo "gh-pages HEAD: $head_sha"
-          echo "subject: ${subject:-<not fetched>}"
-          if [ -n "$subject" ] && ! echo "$subject" | grep -q "run ${GITHUB_RUN_ID}"; then
-            echo "::warning::gh-pages HEAD is not this run's commit (a newer concurrent deploy may have superseded it) — proceeding; validate-live checks the live site."
-          fi
-          echo "✅ gh-pages published; GitHub Pages will serve the branch."
+          echo "✅ gh-pages published (HEAD $head_sha); validate-live confirms the live go-live."
 
       - name: Save deploy metadata to Firestore
         if: success()
@@ -1258,6 +1257,15 @@ jobs:
       # may already be live on Pages — reverting our (failed) deploy
       # would clobber a valid newer one. Check the live Pages deployment
       # SHA before proceeding.
+      # ⚠️ KNOWN GAP (branch-based deploy, follow-up tracked): under the new
+      # gh-pages branch deploy the published commit is an orphan authored by
+      # deploy-bot, so it never equals github.sha — this guard therefore always
+      # takes the "newer deploy replaced mine" path and the rollback no-ops.
+      # A bad deploy still surfaces (validate-* go red + a failure issue is
+      # filed) and is overwritten by the next deploy (~20 min cadence), but
+      # there is no automatic revert to last-known-good yet. Rebuilding rollback
+      # for branch-based (snapshot last-good gh-pages, restore via force-push)
+      # is the declared follow-up — see the PR body "Non implementato".
       - name: Verify our deploy is still live (still-live guard)
         id: still-live
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,12 +84,10 @@ on:
         default: false
 
 permissions:
-  # This workflow only needs repository read access: the previous-slug winners
-  # sync moved to post-deploy-validation.yml, while the deploy itself only
-  # uploads artifacts and publishes to GitHub Pages.
+  # Workflow default is read-only. The build job overrides with contents:write
+  # for the gh-pages publish (branch-based deploy). pages:write / id-token:write
+  # were dropped: no actions/deploy-pages or upload-pages-artifact remains.
   contents: read
-  pages: write
-  id-token: write
   issues: write     # for github-issue-creator on build/deploy failure
 
 jobs:

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -106,7 +106,13 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
           LIVE_BASE_URL: https://frontaliereticino.ch
         run: |
-          node scripts/wait-for-pages-propagation.mjs
+          # Branch-based deploy: the `deploy` job now returns in seconds (it
+          # only confirms the gh-pages branch exists), so the full GitHub-Pages
+          # branch-publish latency for ~470k files — the push alone is ~17.5 min
+          # — now falls inside THIS wait instead of inside the old blocking
+          # actions/deploy-pages step. Bump the propagation timeout from the
+          # 4-min default to 25 min so build-id actually matches before we fail.
+          node scripts/wait-for-pages-propagation.mjs --timeout-ms 1500000
           npm run probe:5xx
           npm run test:e2e:live
 

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -112,7 +112,7 @@ jobs:
           # — now falls inside THIS wait instead of inside the old blocking
           # actions/deploy-pages step. Bump the propagation timeout from the
           # 4-min default to 25 min so build-id actually matches before we fail.
-          node scripts/wait-for-pages-propagation.mjs --timeout-ms 1500000
+          node scripts/wait-for-pages-propagation.mjs --timeout-ms=1500000
           npm run probe:5xx
           npm run test:e2e:live
 


### PR DESCRIPTION
## Problema
**0 deploy riusciti su 100 run** — il path `actions/deploy-pages` clampa il polling Pages a 10 min e il dist ~13GB (artifact 1.53GB) non sincronizza in tempo. Sito di produzione **fermo da ore**: niente va live (incluse le fix CLS #949, IndexNow #943, gate #929 + tutti gli update job-crawler).

## Soluzione (validata)
Switch al deploy **branch-based** ("deploy from branch", no cap di polling). Viability confermata da [run 26650342310](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/26650342310): **push 13GB riuscito in ~17.5 min**.

## Modifiche
- **build job** fa force-push di `dist/` su `gh-pages` come singolo commit orphan (`git init` dentro `dist/` → niente bloat sul repo main; `.nojekyll` disabilita Jekyll su ~470k file; `CNAME` arriva da `public/CNAME` → dominio custom preservato).
- **deploy job**: rimossi i 2 tentativi `actions/deploy-pages` + l'upload dell'artifact github-pages; sostituiti da un gate leggero "conferma gh-pages pubblicato" così `validate-live → publish/rollback` restano gated.
- build job gira nell'environment `github-pages` (ora esegue il publish) → la protection rule main-only resta a guardia di chi deploya.

## Rollout (sequenza sicura)
1. Merge di questa PR.
2. Un build popola `gh-pages` (push 13GB, ~17min).
3. **Flip del Pages source** a "Deploy from branch: `gh-pages` /" via API — **solo dopo** che gh-pages è popolato, così il live non è mai servito da un branch vuoto.
4. `validate-live` polla `build-id.txt` live → conferma il go-live.

## Validazione
- YAML valido; actionlint pulito (1 warning residuo riga 186 = SC2005 pre-esistente).
- Meccanismo push 13GB già provato live (run sopra).
- Non lab-validabile il full deploy (build OOM locale) → validazione via live run post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Implementato
- build job: force-push di `dist/` → `gh-pages` (orphan, `.nojekyll`, CNAME preservato) = il deploy.
- deploy job: rimossi i 2 tentativi `actions/deploy-pages` + upload artifact github-pages; gate "conferma gh-pages pubblicato".
- build job nell'environment `github-pages` (protection main-only sul publish).
- Fix review: Confirm step onesto (no più check `git log` su commit non nel checkout).

## Non implementato (ancora) — revert-risk dichiarato
- **Rollback automatico** (follow-up #967): la still-live guard confronta `github.sha`, ma branch-based pubblica un commit orphan deploy-bot → guard no-op → **nessun revert automatico al last-known-good**. Revert-risk: un dist rotto resta live finché il deploy successivo (~20min) non lo sovrascrive. Mitigazione: validate-* vanno comunque rossi + issue di failure (il deploy cattivo è visibile, non silente). Rework tracciato in #967 (snapshot `gh-pages-last-good` + restore via force-push + guard su `build-id.txt`).
- **Flip del Pages source**: fatto come step di rollout manuale via API DOPO che gh-pages è popolato (non in questa PR), così il live non è mai servito da branch vuoto.
- **Go-live viability non provata end-to-end** (revert-risk): la run 26650342310 ha validato solo il *git push* da 13GB, NON che GitHub Pages **serva** un branch da ~470k file né in quanto tempo. Il primo deploy reale + il flip del source sono il test. Blast radius limitato dal flip manuale (fatto solo dopo populate; se Pages non serve il branch, si ri-flippa il source a `workflow`). validate-live (timeout 25min) conferma il go-live prima di `publish`.

## Review addressed
- 🔴 validate-live 4-min timeout → `--timeout-ms 1500000` (publish non parte più a vuoto).
- 🔴 rollback deploy-loop → guard forza `still_live=false` (restore legacy skip, no dispatch).
- 🔴 completeness + go-live revert-risk → sezioni sopra.
- nits: header deploy job aggiornato, scope `pages/id-token` rimossi dal build, Confirm step onesto.
