### PR TITLE
ci(security): restrict allowed_bots to explicit list (#898)

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -86,7 +86,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
-          allowed_bots: '*'
+          # Whitelist esplicita (hardening #898): mai `*`. I sender bot legittimi
+          # del trigger sono `claude[bot]` (cascade fix → re-trigger) e
+          # `github-actions[bot]` (re-label interno). Il PAT user `valerielinc-ops`
+          # è un account umano → bypassa `allowed_bots`, già coperto dal gate `if`.
+          allowed_bots: 'github-actions[bot], claude[bot]'
           claude_args: "--max-turns ${{ steps.tier.outputs.max_turns }} --model ${{ steps.tier.outputs.model }} --allowedTools 'Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(node:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Grep,Glob,Edit,Write'"
           prompt: |
             Sei l'agent di fix autonomo per la issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}"). Tier: ${{ steps.tier.outputs.tier }}.

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -85,9 +85,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Le PR fix-issue sono aperte da `claude[bot]`: senza whitelist
-          # claude-code-action aborta ("non-human actor"). `*` consente review
-          # anche su PR generate da bot (run 26621967484 → exit 1).
-          allowed_bots: "*"
+          # claude-code-action aborta ("non-human actor"). Whitelist esplicita
+          # (hardening #898): mai `*`. `claude[bot]` copre le PR fix-issue;
+          # `github-actions[bot]` copre eventuali PR aperte da automation interna
+          # (run 26621967484 era exit 1 col precedente vincolo non-human-actor).
+          allowed_bots: "github-actions[bot], claude[bot]"
           show_full_output: true
           # Tool expansion: aggiunti `Bash(rg:*)`, `Bash(git:*)` per consentire
           # cross-file pattern search (REVIEW.md → Reviewer behavior step 5) e


### PR DESCRIPTION
## Implementato
Hardening autonomous-loop: sostituito il wildcard `allowed_bots: '*'` con la lista esplicita `github-actions[bot], claude[bot]` nei due workflow che usano `claude-code-action`:

- `.github/workflows/issue-fix.yml` (riga 89 → ora `allowed_bots: 'github-actions[bot], claude[bot]'`)
- `.github/workflows/pr-review-loop.yml` (riga 90 → ora `allowed_bots: "github-actions[bot], claude[bot]"`)

Quoting preservato per-file (single-quote in issue-fix, double-quote in pr-review-loop). Nessun'altra semantica toccata.

### Verifica sender-gate (richiesta dalla issue)
- **`issue-triage.yml` NON ha `allowed_bots`**: è bash puro (zero-Claude per design), nessuna `claude-code-action` → niente da cambiare lì, nonostante il testo della issue lo citi.
- **`issue-fix.yml`**: il gate `if` ammette sender `valerielinc-ops` (PAT, account **umano** → bypassa `allowed_bots`) oppure login che inizia con `claude` (es. `claude[bot]`). Il bot legittimo è quindi `claude[bot]`; `github-actions[bot]` incluso per coprire eventuale re-label interno. Il PAT user non richiede whitelist perché non è un bot.
- **`pr-review-loop.yml`**: le PR fix-issue sono aperte da `claude[bot]` (era la ragione del `'*'`, run 26621967484). `claude[bot]` copre quel caso; `github-actions[bot]` copre PR da automation interna.

Nessun terzo identità-bot necessaria: la lista `github-actions[bot], claude[bot]` (quella suggerita dalla issue) copre tutti i sender bot legittimi. Il sender PAT `valerielinc-ops` è umano e già gestito dal gate `if`.

YAML validato con `yaml.safe_load`. Branch allineato a `origin/main` (fast-forward, solo data files) per evitare workflow-validation drift.

Closes #898

## Non implementato (ancora)
none deferred — scope della issue interamente coperto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)