### PR TITLE
refactor(seo): consolidate EJP_STRIPPED marker into one canonical export (#930 item 1)

### DIFF
--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -21,6 +21,7 @@ import { buildSoftLandingThinHtml } from './shared/softLandingThinShell';
 import { buildGscKeywordThinBody, GSC_KEYWORD_THIN_HEAD_SCRIPT } from './shared/gscKeywordThinShell';
 import { jobDescriptionTextToHtml, inlineTextToHtml } from './shared/jobDescription/toHtml';
 import { markCantonNoindex } from './shared/cantonNoindexRegistry';
+import { EJP_STRIPPED_MARKER } from './shared/ejpMarker';
 import { WriteCollector } from './batchWrite';
 import { buildFlatBridgeFromSibling } from './flatHtmlRedirectPlugin';
 import { buildTitleWithBrand, truncateHeadline, TITLE_BRAND_SUFFIX, TITLE_MAX_CHARS } from './shared/titleSuffix';
@@ -593,11 +594,7 @@ const STRIP_EXPIRED_JOB_PROSE = (process.env.STRIP_EXPIRED_JOB_PROSE ?? '1') !==
 // (set STRIP_ACTIVE_JOB_PROSE=0 to keep prose). When on, the same marker
 // is emitted and audits skip the page just like for expired pages.
 const STRIP_ACTIVE_JOB_PROSE = (process.env.STRIP_ACTIVE_JOB_PROSE ?? '1') !== '0';
-// Use UPPERCASE placeholder-comment form so it survives the HTML minifier's
-// comment-strip pass (htmlMinify.ts preserves only <!--[A-Z][A-Z0-9_]*-->;
-// the prior lowercase `<!--ejp-stripped-->` was being stripped, defeating
-// the audit-text-html-ratio skip).
-const EJP_STRIPPED_MARKER = '<!--EJP_STRIPPED-->';
+// EJP_STRIPPED_MARKER imported from ./shared/ejpMarker (single source of truth).
 
 export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  return {

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -53,6 +53,7 @@ import { buildSeoPageHtml } from './shared/seoPageShell';
 import { buildTitleWithBrand, TITLE_MAX_CHARS } from './shared/titleSuffix';
 import { getTrafficEvidenceFilter } from './shared/trafficEvidenceFilter';
 import { buildClusterThinHtml } from './shared/clusterThinShell';
+import { EJP_STRIPPED_MARKER } from './shared/ejpMarker';
 import {
   renderJobBoardCommuterContext,
   renderSearchQueryIntro,
@@ -139,7 +140,7 @@ const HUB_PAGE_SIZE = 200;
 // Opt out with STRIP_CLUSTER_SEO_PROSE=0 to re-emit the full prose
 // (e.g. for an A/B test of organic CTR vs. SERP impressions).
 const STRIP_CLUSTER_SEO_PROSE = (process.env.STRIP_CLUSTER_SEO_PROSE ?? '1') !== '0';
-const EJP_STRIPPED_MARKER = '<!--EJP_STRIPPED-->';
+// EJP_STRIPPED_MARKER imported from ./shared/ejpMarker (single source of truth).
 
 // ── Utilities ───────────────────────────────────────────────────────────
 

--- a/build-plugins/shared/bridgePageProse.ts
+++ b/build-plugins/shared/bridgePageProse.ts
@@ -44,6 +44,8 @@
  * Pure: identical (locale, bridgeKind) inputs produce identical HTML.
  */
 
+import { EJP_STRIPPED_MARKER } from './ejpMarker';
+
 // Local feature flag: skip the prose entirely on bridge pages (slug rename
 // / legacy alias redirects). Default ON because bridges are pure redirect
 // vehicles — Google de-duplicates via canonical, and these pages add bulk
@@ -57,11 +59,7 @@
 // vi.stubEnv() — module-load reads cannot be overridden by tests.
 const isStripBridgeProse = (): boolean =>
   (process.env.STRIP_BRIDGE_PAGE_PROSE ?? '1') !== '0';
-// Use UPPERCASE placeholder-comment form so it survives the HTML minifier's
-// comment-strip pass (htmlMinify.ts preserves only <!--[A-Z][A-Z0-9_]*-->;
-// the prior lowercase `<!--ejp-stripped-->` was being stripped, defeating
-// the audit-text-html-ratio skip).
-const EJP_STRIPPED_MARKER = '<!--EJP_STRIPPED-->';
+// EJP_STRIPPED_MARKER imported from ./ejpMarker (single source of truth).
 
 export type BridgeProseLocale = 'it' | 'en' | 'de' | 'fr';
 

--- a/build-plugins/shared/bridgeThinShell.ts
+++ b/build-plugins/shared/bridgeThinShell.ts
@@ -32,6 +32,8 @@
 // JS see the thin static body (≥50 words + JSON-LD + canonical), which
 // remains a valid indexable page.
 
+import { EJP_STRIPPED_MARKER } from './ejpMarker';
+
 const LOCALE_LISTING_PATH: Record<string, string> = {
   it: '/cerca-lavoro-ticino/',
   en: '/en/find-jobs-ticino/',
@@ -107,7 +109,7 @@ export function buildBridgeThinHtml(cachedHtml: string, targetSlug: string, loca
     `<main class="seo-static-content static-bridge-page">` +
     // audit:text-html-ratio skip marker — deliberately-thin shell, same
     // contract as legacy STRIP_* paths (uppercase survives minifier).
-    `<!--EJP_STRIPPED-->` +
+    EJP_STRIPPED_MARKER +
     `<article class="proposal">` +
     `<h1>${h1Text}</h1>` +
     `<p>${prose}</p>` +

--- a/build-plugins/shared/clusterThinShell.ts
+++ b/build-plugins/shared/clusterThinShell.ts
@@ -45,6 +45,8 @@
 // lifts hit URLs into thin-page-promotions-active.json → next deploy
 // returns 'full' for them. ≤25 h self-heal.
 
+import { EJP_STRIPPED_MARKER } from './ejpMarker';
+
 const LOCALE_LISTING_PATH: Record<string, string> = {
   it: '/cerca-lavoro-svizzera/',
   en: '/en/find-jobs-switzerland/',
@@ -104,7 +106,7 @@ export function buildClusterThinHtml(fullHtml: string, locale: string): string {
     `<main class="seo-static-content static-cluster">` +
     // audit:text-html-ratio skip marker — deliberately-thin shell, same
     // contract as legacy STRIP_* paths (uppercase survives minifier).
-    `<!--EJP_STRIPPED-->` +
+    EJP_STRIPPED_MARKER +
     `<article class="proposal">` +
     `<h1>${h1Text}</h1>` +
     `<p>${prose}</p>` +

--- a/build-plugins/shared/ejpMarker.mjs
+++ b/build-plugins/shared/ejpMarker.mjs
@@ -1,0 +1,15 @@
+// ejpMarker.mjs
+//
+// Canonical audit:text-html-ratio skip marker — the SINGLE source of truth
+// for the `<!--EJP_STRIPPED-->` literal. Deliberately-thin SEO shells
+// (expired-job soft-landings, cluster/bridge/gsc-keyword thin bodies) embed
+// this comment so scripts/audit-text-html-ratio.mjs knows the low word-count
+// is intentional and skips the page. Uppercase so it survives HTML
+// minification (the prior lowercase `<!--ejp-stripped-->` was being stripped,
+// defeating the skip).
+//
+// This file is plain `.mjs` so the Node-run auditor (scripts/, no tsx loader,
+// CI Node 20/22 without type-stripping) can import it directly. The TS
+// build-plugins import it via ./ejpMarker.ts, which re-exports this value.
+// The literal must stay byte-identical everywhere — define it ONCE, here.
+export const EJP_STRIPPED_MARKER = '<!--EJP_STRIPPED-->';

--- a/build-plugins/shared/ejpMarker.ts
+++ b/build-plugins/shared/ejpMarker.ts
@@ -1,0 +1,9 @@
+// ejpMarker.ts
+//
+// TS-facing re-export of the canonical audit:text-html-ratio skip marker.
+// The literal lives once in ./ejpMarker.mjs (plain JS so the Node-run
+// auditor in scripts/ can import it without a tsx loader on CI Node 20/22).
+// TS build-plugins import EJP_STRIPPED_MARKER from here (extensionless,
+// resolved by Vite / moduleResolution:bundler). The marker VALUE must stay
+// byte-identical everywhere — see ejpMarker.mjs for the single definition.
+export { EJP_STRIPPED_MARKER } from './ejpMarker.mjs';

--- a/build-plugins/shared/gscKeywordThinShell.ts
+++ b/build-plugins/shared/gscKeywordThinShell.ts
@@ -26,6 +26,8 @@
 // URL into thin-page-promotions-active.json → next deploy returns
 // 'full' for it. Self-heal latency ≤25 h.
 
+import { EJP_STRIPPED_MARKER } from './ejpMarker';
+
 interface ThinBodyOpts {
   locale: string;
   /** Display string for the query, e.g. "infermieri turno notte". */
@@ -61,7 +63,7 @@ export function buildGscKeywordThinBody(opts: ThinBodyOpts): string {
     // Deliberately-thin shell (zero-traffic, SPA-hydrated): mark it so
     // audit:text-html-ratio skips it, same contract as the legacy STRIP_*
     // paths. Uppercase comment survives the HTML minifier's strip pass.
-    `<!--EJP_STRIPPED-->` +
+    EJP_STRIPPED_MARKER +
     `<h1>${opts.h1Title}</h1>` +
     `<p>${prose}</p>`
   );

--- a/build-plugins/shared/softLandingThinShell.ts
+++ b/build-plugins/shared/softLandingThinShell.ts
@@ -20,6 +20,8 @@
 // shrinks that first-paint payload; user UX after hydration is
 // identical to today.
 
+import { EJP_STRIPPED_MARKER } from './ejpMarker';
+
 const LOCALE_LISTING_PATH: Record<string, string> = {
   it: '/cerca-lavoro-ticino/',
   en: '/en/find-jobs-ticino/',
@@ -93,7 +95,7 @@ export function buildSoftLandingThinHtml(fullHtml: string, locale: string): stri
     `<article class="ft-static-article">` +
     // audit:text-html-ratio skip marker — deliberately-thin shell, same
     // contract as legacy STRIP_* paths (uppercase survives minifier).
-    `<!--EJP_STRIPPED-->` +
+    EJP_STRIPPED_MARKER +
     `<h1>${h1Text}</h1>` +
     `<p>${prose}</p>` +
     `</article>`;

--- a/scripts/audit-text-html-ratio.mjs
+++ b/scripts/audit-text-html-ratio.mjs
@@ -20,6 +20,7 @@ import { readFile, stat, writeFile } from 'node:fs/promises';
 import { join, relative, isAbsolute } from 'node:path';
 import { writeAuditReport, relBaseline } from './lib/auditReport.mjs';
 import { walkHtmlFiles, ROOT, DEFAULT_DIST } from './lib/audit-runner.mjs';
+import { EJP_STRIPPED_MARKER } from '../build-plugins/shared/ejpMarker.mjs';
 
 const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
 
@@ -112,7 +113,7 @@ export function createAuditor(opts = {}) {
       // survives the HTML minifier's comment-strip pass (which only
       // preserves <!--[A-Z][A-Z0-9_]*-->); accept the legacy lowercase
       // form as well for backward compat with un-minified test fixtures.
-      if (html.includes('<!--EJP_STRIPPED-->') || html.includes('<!--ejp-stripped-->')) {
+      if (html.includes(EJP_STRIPPED_MARKER) || html.includes('<!--ejp-stripped-->')) {
         skippedEjpStripped++;
         return;
       }

--- a/tests/seo/thin-shell-ejp-marker.test.ts
+++ b/tests/seo/thin-shell-ejp-marker.test.ts
@@ -22,8 +22,9 @@ import { buildGscKeywordThinBody } from '../../build-plugins/shared/gscKeywordTh
 import { buildSoftLandingThinHtml } from '../../build-plugins/shared/softLandingThinShell';
 import { buildBridgeThinHtml } from '../../build-plugins/shared/bridgeThinShell';
 import { buildClusterThinHtml } from '../../build-plugins/shared/clusterThinShell';
+import { EJP_STRIPPED_MARKER } from '../../build-plugins/shared/ejpMarker';
 
-const MARKER = '<!--EJP_STRIPPED-->';
+const MARKER = EJP_STRIPPED_MARKER;
 
 // Wrap a body fragment in a minimal document so the auditor can scan it.
 const wrap = (body: string) =>


### PR DESCRIPTION
## Implementato

Item 1 of #930: dedup the `<!--EJP_STRIPPED-->` audit-skip marker into a single source of truth.

Before: the literal was hardcoded across 4 thin-shell builders + the auditor + a unit test, and the const `EJP_STRIPPED_MARKER` was redefined locally in 3 places (jobsSeoPagesPlugin, relatedSearchClustersPlugin, bridgePageProse) — 9+ copies of the same string, each a place the value could drift.

- **New `build-plugins/shared/ejpMarker.mjs`** — the literal `'<!--EJP_STRIPPED-->'` is now defined exactly once here. Plain `.mjs` (not `.ts`) so the Node-run `scripts/audit-text-html-ratio.mjs` can `import` it directly: that script runs via `node scripts/...` with **no tsx loader**, and CI uses Node 20/22 which do not strip TS types — a `.ts` import would break the auditor at runtime.
- **New `build-plugins/shared/ejpMarker.ts`** — re-exports the const for the TS build-plugins (extensionless `./ejpMarker` import, resolved by Vite / `moduleResolution:bundler`).
- Replaced the **3 local const definitions** with an import (none were exported, so no external importers to preserve — verified via grep).
- Replaced the **4 thin-shell builders'** hardcoded literals (`softLandingThinShell`, `clusterThinShell`, `bridgeThinShell`, `gscKeywordThinShell`) and the **auditor's** uppercase `html.includes(...)` check with the imported const.
- Updated the unit test `tests/seo/thin-shell-ejp-marker.test.ts` (`const MARKER`) to source the value from the canonical export.

Marker VALUE is byte-identical everywhere — pure dedup, no behaviour change. The legacy lowercase `<!--ejp-stripped-->` backward-compat literal in the auditor, and the independent `.toContain`/`.toBe` assertions in the other marker tests (`expired-job-prose-marker`, `related-search-clusters-shell`, `bridge-page-prose`), are intentionally left as raw literals — good test hygiene to assert against a known expected value rather than the same const under test.

### Test plan
- [x] `npx vitest run` on the 4 marker test files → **32 passed**
- [x] `node -e "import('./scripts/audit-text-html-ratio.mjs')"` → auditor imports cleanly via plain Node (no tsx)
- [x] `tsc --noEmit` → no new errors on any touched file (19 pre-existing unrelated errors: missing `data/jobs.json` in worktree + unrelated test type issues)

## Non implementato (ancora)

Items 2, 3, 4 of #930 — all monitoring/verify follow-ups, out of scope for this surgical dedup:

- **Item 2 — nearFloor drift visibility for EJP-marked shells**: monitoring/verify follow-up — out of scope for this surgical dedup.
- **Item 3 — gsc-keyword marker survivability in the real emit path**: monitoring/verify follow-up — out of scope for this surgical dedup.
- **Item 4 — post-deploy validate-dist confirmation**: monitoring/verify follow-up — out of scope for this surgical dedup.

Refs #930 (item 1 of 4) — not `Closes` since #930 is only partially covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)