### PR TITLE
ci(lighthouse): paths filter on push:main trigger (#848)

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -26,6 +26,36 @@ on:
       - 'lighthouserc.json'
   push:
     branches: [main]
+    # Since #844 every auto-merge pushes to main; without a paths filter this
+    # heavy CI ran on data-only / workflow-only / docs-only merges too. Only
+    # run when something that can change the *rendered* output of the audited
+    # pages moves. Conservative: when unsure whether a path affects rendering
+    # it is INCLUDED (a missed regression is worse than an extra run).
+    paths:
+      # Application source that produces rendered DOM / styles / scripts.
+      - 'App.tsx'
+      - 'index.tsx'
+      - 'index.html'
+      - 'index.css'
+      - 'constants.ts'
+      - 'types.ts'
+      - 'components/**'
+      - 'hooks/**'
+      - 'services/**'
+      - 'build-plugins/**'
+      - 'public/**'
+      # Build / dependency config that changes the emitted bundle.
+      - 'vite.config.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tailwind.config.js'
+      # The audit definition itself.
+      - 'lighthouserc.json'
+      - '.github/workflows/lighthouse-ci.yml'
+    # Implicitly EXCLUDED (no path here ⇒ no run): pure data churn that does not
+    # change layout — data/** job slices, *.jsonl accumulators,
+    # dist-size-history.jsonl, snapshot json — plus docs/**, scripts/**,
+    # functions/**, server/**, tests/**, reports/** and other workflow files.
 
 permissions:
   contents: read


### PR DESCRIPTION
## Implementato
Da #844 ogni auto-merge fa un push su `main`. Il trigger `push: branches:[main]` di `lighthouse-ci.yml` non aveva `paths` filter, quindi questa CI pesante (Lighthouse su 6 template prod) girava anche su merge **data-only**, **workflow-only** e **docs-only** — spreco di minuti GitHub Actions e di quota.

Aggiunto un `paths` filter al trigger `push: main`. Lighthouse audita l'output **renderizzato** delle pagine prod, quindi gira solo quando cambia qualcosa che può alterare quel rendering.

**Include** (run Lighthouse):
- `App.tsx`, `index.tsx`, `index.html`, `index.css`, `constants.ts`, `types.ts`
- `components/**`, `hooks/**`, `services/**`, `build-plugins/**`, `public/**`
- `vite.config.ts`, `package.json`, `package-lock.json`, `tailwind.config.js`
- `lighthouserc.json`, `.github/workflows/lighthouse-ci.yml` (la def dell'audit stesso)

**Escluso** (no run — nessun path elencato ⇒ skip):
- churn dati che non cambia layout: `data/**` (slice job, border-wait, snapshot), `*.jsonl` accumulator (`dist-size-history.jsonl`, `thin-page-promotions.jsonl`)
- `docs/**`, `scripts/**`, `functions/**`, `server/**`, `tests/**`, `reports/**`
- altri workflow files

**Rationale**: scelta conservativa — quando incerto se un path tocca il rendering, è **incluso** (saltare una regressione reale di CLS/LCP/perf, che degrada RPM AdSense, è peggio di una run extra). Nessuna soglia/gate audit toccato. YAML validato (`yaml.safe_load` OK, 17 path).

## Non implementato (ancora)
- **Allineamento del filtro `pull_request`**: il trigger `pull_request` aveva già un `paths` filter più stretto (solo `build-plugins/**`, `services/locales/**`, `vite.config.ts`, `index.css`, `index.html`, `package.json`, il workflow, `lighthouserc.json`) — omette `components/**`, `App.tsx`, `services/**` ecc. Quindi una PR che tocca solo un componente NON ottiene Lighthouse pre-merge, ma il push su main risultante ora sì. Gap pre-esistente, non allargo lo scope: lasciato fuori per restare chirurgico (follow-up se si vuole simmetria PR↔push).
- **Misura empirica minuti CI / mese**: l'issue suggeriva di stimare il consumo. Non fatto — il filtro elimina l'overhead alla radice a prescindere dal volume, quindi la misura diventa moot.

Closes #848