### PR TITLE
test(ci): guardrail per parity caller-vs-callee permissions in reusable workflow

### DIFF
--- a/scripts/check-workflow-permissions-parity.mjs
+++ b/scripts/check-workflow-permissions-parity.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * check-workflow-permissions-parity.mjs
+ *
+ * Guardrail against the #772→#778 class of bug: a caller job that invokes a
+ * reusable workflow (`uses: ./.github/workflows/<file>.yml`) MUST declare, in
+ * its own `permissions:` block, every permission scope that the reusable
+ * (callee) workflow's job(s) request — at a level that is at least as strong.
+ *
+ * GitHub Actions semantics: a reusable workflow CANNOT escalate beyond what the
+ * caller grants. If the callee job needs `issues: write` but the caller only
+ * grants `issues: read` (or omits it), the run fails at LOAD time with
+ * `startup_failure` (run_duration_ms=1000, billable={}) — silently, before any
+ * job is scheduled. This script catches that statically.
+ *
+ * Permission level ordering: none < read < write.
+ * A caller satisfies a callee scope iff caller_level >= callee_level.
+ * `write` covers `read` (GitHub grants read implicitly when write is granted).
+ *
+ * The check is purely textual (no Claude, no network). It uses a tiny
+ * indentation-based YAML-subset reader sufficient for the `permissions:` and
+ * `jobs:` shapes used in this repo's workflows.
+ *
+ * Usage:
+ *   node scripts/check-workflow-permissions-parity.mjs   # scan repo, exit 1 on violation
+ *
+ * Exit codes: 0 = parity OK, 1 = parity violation, 2 = parse/IO error.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname, basename, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const WORKFLOWS_DIR = resolve(ROOT, '.github/workflows');
+
+const LEVEL = { none: 0, read: 1, write: 2 };
+
+/** Number of leading spaces on a line. */
+function indentOf(line) {
+  const m = line.match(/^( *)/);
+  return m ? m[1].length : 0;
+}
+
+/** Strip a trailing `# comment` (our scalar values are unquoted, so this is safe). */
+function stripComment(s) {
+  const i = s.indexOf('#');
+  return (i === -1 ? s : s.slice(0, i)).trim();
+}
+
+/**
+ * Parse a `permissions:` block whose header sits at column `headerIndent`.
+ * Returns { mode: 'map', perms: {scope: level} } for the map form, or
+ * { mode: 'scalar', value: 'write-all'|'read-all'|'write'|'read'|... } for the
+ * shorthand scalar form (e.g. `permissions: read-all`).
+ */
+function parsePermissionsBlock(lines, start, headerIndent) {
+  const header = stripComment(lines[start]);
+  const inline = header.match(/^permissions:\s*(\S.*)$/);
+  if (inline) {
+    const val = inline[1].trim();
+    if (val === '{}') return { mode: 'map', perms: {} };
+    return { mode: 'scalar', value: val };
+  }
+  const perms = {};
+  for (let i = start + 1; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw.trim() === '' || raw.trim().startsWith('#')) continue;
+    const ind = indentOf(raw);
+    if (ind <= headerIndent) break; // dedent → block ended
+    const body = stripComment(raw);
+    const kv = body.match(/^([a-z][a-z0-9-]*):\s*(read|write|none)\s*$/);
+    if (kv) perms[kv[1]] = kv[2];
+  }
+  return { mode: 'map', perms };
+}
+
+/**
+ * Effective numeric level a descriptor grants for a given scope.
+ * Scalar `write-all`/`read-all` (and bare `write`/`read`) apply to every scope.
+ */
+function effectiveLevel(descriptor, scope) {
+  if (!descriptor) return LEVEL.none;
+  if (descriptor.mode === 'scalar') {
+    if (descriptor.value === 'write-all' || descriptor.value === 'write') return LEVEL.write;
+    if (descriptor.value === 'read-all' || descriptor.value === 'read') return LEVEL.read;
+    return LEVEL.none;
+  }
+  const v = descriptor.perms[scope];
+  return v ? LEVEL[v] : LEVEL.none;
+}
+
+/**
+ * Parse a workflow YAML string into:
+ *   { isReusable, calleePermsByScope, calleeScalarAll, callers }
+ *
+ * - calleePermsByScope: union (max level) of permissions requested across the
+ *   reusable workflow's jobs — what a caller must grant.
+ * - calleeScalarAll: 0|1|2 if the reusable uses a job-level scalar `*-all`.
+ * - callers: jobs with `uses: ./.github/workflows/<file>`, each with the job's
+ *   own `permissions:` descriptor (or null if absent).
+ */
+export function parseWorkflow(yaml) {
+  const lines = yaml.split('\n');
+  let isReusable = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const t = stripComment(lines[i]);
+    if (/^workflow_call:/.test(t) || /^on:\s*workflow_call\b/.test(t)) isReusable = true;
+    if (/^on:\s*$/.test(t)) {
+      for (let j = i + 1; j < lines.length; j++) {
+        if (lines[j].trim() === '' || lines[j].trim().startsWith('#')) continue;
+        if (indentOf(lines[j]) === 0) break;
+        if (/^\s*workflow_call:/.test(lines[j])) { isReusable = true; break; }
+      }
+    }
+  }
+
+  let jobsStart = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^jobs:\s*$/.test(stripComment(lines[i]))) { jobsStart = i; break; }
+  }
+
+  const calleePermsByScope = {};
+  let calleeScalarAll = 0;
+  const callers = [];
+
+  if (jobsStart !== -1) {
+    const jobHeaderIndent = 2;
+    for (let i = jobsStart + 1; i < lines.length; i++) {
+      const raw = lines[i];
+      if (raw.trim() === '' || raw.trim().startsWith('#')) continue;
+      if (indentOf(raw) === 0) break; // left jobs:
+      if (indentOf(raw) !== jobHeaderIndent) continue;
+      const jm = raw.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+      if (!jm) continue;
+      const jobName = jm[1];
+
+      let calleeFile = null;
+      let callerPerms = null;
+      let jobPermsDesc = null;
+
+      for (let j = i + 1; j < lines.length; j++) {
+        const b = lines[j];
+        if (b.trim() === '' || b.trim().startsWith('#')) continue;
+        const bi = indentOf(b);
+        if (bi <= jobHeaderIndent) break; // next job / dedent
+        const bt = stripComment(b);
+        if (bi === jobHeaderIndent + 2) {
+          const useMatch = bt.match(/^uses:\s*\.\/\.github\/workflows\/([A-Za-z0-9._-]+)\s*$/);
+          if (useMatch) calleeFile = useMatch[1];
+          if (/^permissions:/.test(bt)) {
+            const desc = parsePermissionsBlock(lines, j, bi);
+            callerPerms = desc;
+            jobPermsDesc = desc;
+          }
+        }
+      }
+
+      // Reusable workflow: this job's permissions block IS the caller requirement.
+      if (isReusable && jobPermsDesc) {
+        if (jobPermsDesc.mode === 'scalar') {
+          calleeScalarAll = Math.max(calleeScalarAll, effectiveLevel(jobPermsDesc, '__any__'));
+        } else {
+          for (const [scope, v] of Object.entries(jobPermsDesc.perms)) {
+            calleePermsByScope[scope] = Math.max(calleePermsByScope[scope] || 0, LEVEL[v]);
+          }
+        }
+      }
+
+      if (calleeFile) callers.push({ job: jobName, calleeFile, callerPerms });
+    }
+  }
+
+  return { isReusable, calleePermsByScope, calleeScalarAll, callers };
+}
+
+/**
+ * Compare one caller job against a callee workflow's parsed requirements.
+ * Returns an array of violation strings (empty = parity OK).
+ */
+export function compareCallerVsCallee(callerJob, callerPermsDescriptor, calleeReq, ctx) {
+  const violations = [];
+  const { calleePermsByScope, calleeScalarAll } = calleeReq;
+
+  if (calleeScalarAll > 0) {
+    const callerAll = effectiveLevel(callerPermsDescriptor, '__any__');
+    if (callerAll < calleeScalarAll) {
+      violations.push(
+        `${ctx}: callee requires ${calleeScalarAll === 2 ? 'write-all' : 'read-all'} ` +
+        `but caller job "${callerJob}" does not grant an equal-or-stronger all-scope permission.`,
+      );
+    }
+    return violations;
+  }
+
+  for (const [scope, neededLevel] of Object.entries(calleePermsByScope)) {
+    if (neededLevel === 0) continue;
+    const granted = effectiveLevel(callerPermsDescriptor, scope);
+    if (granted < neededLevel) {
+      const need = neededLevel === 2 ? 'write' : 'read';
+      const have = granted === 2 ? 'write' : granted === 1 ? 'read' : 'none/absent';
+      violations.push(
+        `${ctx}: callee needs "${scope}: ${need}" but caller job "${callerJob}" grants "${scope}: ${have}". ` +
+        `Add \`${scope}: ${need}\` to the caller's permissions block, or the reusable workflow will startup_failure.`,
+      );
+    }
+  }
+  return violations;
+}
+
+/**
+ * Run the full repo scan. `readFile` / `listDir` are injectable for testing.
+ * Returns { violations: string[], checkedPairs: number }.
+ */
+export function checkRepo({
+  workflowsDir = WORKFLOWS_DIR,
+  readFile = (p) => readFileSync(p, 'utf-8'),
+  listDir = (d) => readdirSync(d),
+} = {}) {
+  const files = listDir(workflowsDir).filter((f) => /\.ya?ml$/.test(f));
+  const parsed = new Map();
+  for (const f of files) {
+    try {
+      parsed.set(f, parseWorkflow(readFile(join(workflowsDir, f))));
+    } catch (e) {
+      throw new Error(`Failed to parse .github/workflows/${f}: ${e.message}`);
+    }
+  }
+
+  const violations = [];
+  let checkedPairs = 0;
+
+  for (const [callerFile, callerWf] of parsed) {
+    for (const caller of callerWf.callers) {
+      const callee = parsed.get(caller.calleeFile);
+      if (!callee) {
+        violations.push(
+          `${callerFile} job "${caller.job}": uses ./.github/workflows/${caller.calleeFile} which was not found.`,
+        );
+        continue;
+      }
+      if (!callee.isReusable) {
+        violations.push(
+          `${callerFile} job "${caller.job}": ${caller.calleeFile} is referenced via \`uses:\` but does not declare \`on: workflow_call\`.`,
+        );
+        continue;
+      }
+      checkedPairs++;
+      const ctx = `${callerFile} → ${caller.calleeFile}`;
+      violations.push(...compareCallerVsCallee(caller.job, caller.callerPerms, callee, ctx));
+    }
+  }
+
+  return { violations, checkedPairs };
+}
+
+// CLI entry point
+if (basename(process.argv[1] || '') === basename(fileURLToPath(import.meta.url))) {
+  try {
+    const { violations, checkedPairs } = checkRepo();
+    if (violations.length > 0) {
+      console.error('✗ Workflow permissions parity violations found:\n');
+      for (const v of violations) console.error('  • ' + v);
+      console.error(
+        `\n${violations.length} violation(s) across ${checkedPairs} caller→callee pair(s). ` +
+        'A caller must declare every permission its reusable (callee) workflow requires, ' +
+        'at an equal-or-stronger level, or the run fails with startup_failure.',
+      );
+      process.exit(1);
+    }
+    console.log(`✓ Workflow permissions parity OK (${checkedPairs} caller→callee pair(s) checked).`);
+    process.exit(0);
+  } catch (e) {
+    console.error('✗ check-workflow-permissions-parity error: ' + e.message);
+    process.exit(2);
+  }
+}

--- a/tests/workflow-permissions-parity.test.ts
+++ b/tests/workflow-permissions-parity.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseWorkflow,
+  compareCallerVsCallee,
+  checkRepo,
+  // @ts-expect-error — .mjs guardrail script has no .d.ts; runtime ESM import is fine under vitest.
+} from '../scripts/check-workflow-permissions-parity.mjs';
+
+/**
+ * Guardrail for the #772→#778 class of bug: a caller job invoking a reusable
+ * (`workflow_call`) workflow must declare, in its own `permissions:` block,
+ * every scope the callee's job(s) request — at an equal-or-stronger level —
+ * or the run dies at load time with `startup_failure`.
+ *
+ * The deterministic checker lives in
+ * scripts/check-workflow-permissions-parity.mjs (zero-Claude, pure parsing).
+ * These tests cover:
+ *   1) the live repo (.github/workflows) has parity (regression gate), and
+ *   2) the parser + comparator behave correctly on parity-OK and
+ *      parity-violation fixtures.
+ */
+
+const REUSABLE = `name: callee
+on:
+  workflow_call:
+jobs:
+  do-thing:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write   # github-issue-creator on failure
+    steps:
+      - run: echo hi
+`;
+
+const CALLER_OK = `name: caller-ok
+on:
+  push:
+jobs:
+  call-it:
+    uses: ./.github/workflows/callee.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      issues: write
+`;
+
+// Same caller but MISSING issues:write — the exact #772 regression.
+const CALLER_VIOLATION = `name: caller-bad
+on:
+  push:
+jobs:
+  call-it:
+    uses: ./.github/workflows/callee.yml
+    secrets: inherit
+    permissions:
+      contents: read
+`;
+
+// Caller grants issues:read where callee needs issues:write — weaker level.
+const CALLER_WEAKER = `name: caller-weaker
+on:
+  push:
+jobs:
+  call-it:
+    uses: ./.github/workflows/callee.yml
+    permissions:
+      contents: read
+      issues: read
+`;
+
+describe('check-workflow-permissions-parity — live repo gate', () => {
+  it('all caller→callee permission pairs in .github/workflows have parity', () => {
+    const { violations, checkedPairs } = checkRepo();
+    expect(
+      violations,
+      `Reusable-workflow caller/callee permission mismatch detected:\n${violations.join('\n')}`,
+    ).toEqual([]);
+    // There is at least the deploy.yml → post-deploy-* trio; guard the wiring
+    // so a refactor that silently stops parsing callers fails loudly.
+    expect(checkedPairs, 'expected at least the deploy.yml reusable-workflow callers to be checked').toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('check-workflow-permissions-parity — parser', () => {
+  it('detects a reusable workflow and unions its job permission requirements', () => {
+    const wf = parseWorkflow(REUSABLE);
+    expect(wf.isReusable).toBe(true);
+    expect(wf.calleePermsByScope).toEqual({ contents: 1, issues: 2 });
+  });
+
+  it('extracts caller jobs, callee file, and the caller permissions block', () => {
+    const wf = parseWorkflow(CALLER_OK);
+    expect(wf.isReusable).toBe(false);
+    expect(wf.callers).toHaveLength(1);
+    expect(wf.callers[0].calleeFile).toBe('callee.yml');
+    expect(wf.callers[0].job).toBe('call-it');
+    expect(wf.callers[0].callerPerms).toEqual({ mode: 'map', perms: { contents: 'read', issues: 'write' } });
+  });
+});
+
+describe('check-workflow-permissions-parity — comparator', () => {
+  const callee = parseWorkflow(REUSABLE);
+
+  it('parity-OK fixture yields no violations', () => {
+    const caller = parseWorkflow(CALLER_OK).callers[0];
+    const v = compareCallerVsCallee(caller.job, caller.callerPerms, callee, 'caller-ok → callee.yml');
+    expect(v).toEqual([]);
+  });
+
+  it('parity-violation fixture (missing issues:write) is flagged', () => {
+    const caller = parseWorkflow(CALLER_VIOLATION).callers[0];
+    const v = compareCallerVsCallee(caller.job, caller.callerPerms, callee, 'caller-bad → callee.yml');
+    expect(v).toHaveLength(1);
+    expect(v[0]).toMatch(/issues.*write/);
+    expect(v[0]).toMatch(/none\/absent/);
+  });
+
+  it('weaker-level grant (issues:read where write is needed) is flagged', () => {
+    const caller = parseWorkflow(CALLER_WEAKER).callers[0];
+    const v = compareCallerVsCallee(caller.job, caller.callerPerms, callee, 'caller-weaker → callee.yml');
+    expect(v).toHaveLength(1);
+    expect(v[0]).toMatch(/grants "issues: read"/);
+  });
+});
+
+describe('check-workflow-permissions-parity — repo scan over fixtures', () => {
+  it('checkRepo flags a violating caller via the injectable fs', () => {
+    const files: Record<string, string> = {
+      'callee.yml': REUSABLE,
+      'caller-bad.yml': CALLER_VIOLATION,
+    };
+    const { violations, checkedPairs } = checkRepo({
+      workflowsDir: '/virtual',
+      listDir: () => Object.keys(files),
+      readFile: (p: string) => files[p.split('/').pop() as string],
+    });
+    expect(checkedPairs).toBe(1);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatch(/issues/);
+  });
+
+  it('checkRepo passes when caller grants a superset', () => {
+    const files: Record<string, string> = {
+      'callee.yml': REUSABLE,
+      'caller-ok.yml': CALLER_OK,
+    };
+    const { violations } = checkRepo({
+      workflowsDir: '/virtual',
+      listDir: () => Object.keys(files),
+      readFile: (p: string) => files[p.split('/').pop() as string],
+    });
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Implementato

Guardrail deterministico (zero-Claude, pure parsing) contro la classe di bug #772→#778: un job caller che invoca un reusable workflow (`uses: ./.github/workflows/<file>.yml`) DEVE dichiarare nel proprio blocco `permissions:` ogni scope che il callee richiede, a un livello equal-or-stronger (`none < read < write`). In caso contrario il run muore al **load** con `startup_failure` (`run_duration_ms=1000`, `billable={}`), silenziosamente, prima di schedulare qualsiasi job — bloccando deploy → SEO refresh, IndexNow, Google Indexing (impatto funnel/traffico).

- **`scripts/check-workflow-permissions-parity.mjs`**: parser YAML-subset basato su indentazione (no dipendenza `js-yaml`/`yaml`, non presenti nel repo). Estrae per ogni workflow: se è reusable (`on: workflow_call`), l'unione (max-level) dei `permissions:` dei suoi job (= ciò che il caller deve concedere), e i job caller con il loro `permissions:`. Confronta ogni coppia caller→callee. Gestisce map form, scalar shorthand (`write-all`/`read-all`), e `write` che copre `read`. Exit 0 = OK, 1 = violazione, 2 = errore parse/IO. Funzioni esportate per il test; `checkRepo` accetta `readFile`/`listDir` iniettabili per i fixture.
- **`tests/workflow-permissions-parity.test.ts`** (vitest): 8 test. (1) gate live-repo che fa parity su tutte le coppie reali in `.github/workflows` (≥3 = i 3 caller di `deploy.yml` → `post-deploy-validate-dist/live/publish.yml`); (2) fixture parity-OK e parity-violation (manca `issues: write` = la regressione #772 esatta) + livello più debole (`issues: read` dove serve `write`); (3) scan via fs iniettabile.

**Wiring**: il test è auto-discovered dall'include esistente di vitest `tests/**/*.test.{ts,tsx}` → gira nel gate `npm test` già in CI (test.yml). Nessuna modifica a file workflow → auto-merge normale.

**Verifica**: rimosso a mano `issues: write` dai caller di `deploy.yml` → lo script esce 1 con messaggio puntuale per ciascuna delle 3 coppie; ripristinato → esce 0. `npx vitest run tests/workflow-permissions-parity.test.ts` = 8/8 green.

## Non implementato (ancora)

- Re-trigger dei deploy mancati per #773/#776/#777 (punto separato del PR body di #778, operativo non tooling — fuori scope di questo guardrail).
- Validazione di permission scope più esotici via scalar `*-all` parziali oltre `read-all`/`write-all` (non usati nel repo; il modello copre i casi presenti). Follow-up se mai introdotti.
- Parsing di `permissions:` top-level del caller come fallback per i job senza blocco proprio: in questo repo ogni caller reusable dichiara il proprio blocco a livello job (GitHub ignora il top-level per i job reusable), quindi non necessario; documentato nello scope se cambia.

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)