### PR TITLE
fix(ai-models): capture per-model skip reason in smoke output

### DIFF
--- a/scripts/lib/ai-models.mjs
+++ b/scripts/lib/ai-models.mjs
@@ -2525,17 +2525,28 @@ export async function callLLM(messages, opts = {}) {
         console.warn(`⏭️  [${model}] Skipped — exhausted (daily limit, future hits silenced)`);
         _exhaustedLogged.add(model);
       }
+      // Record the skip reason so the aggregate "All AI models failed … Errors:"
+      // message is never empty when every candidate is skipped pre-flight (e.g.
+      // a single-model chain whose only model is exhausted, as in the smoke
+      // test). Without this the harness surfaces a blank cause — undiagnosable.
+      errors.push(`${model}: skipped — exhausted (daily limit / consecutive 429s / timeout circuit-breaker)`);
       continue;
     }
 
     // Skip models whose provider is cooling down (recent 429)
     const provider = getProvider(model);
     if (isProviderCoolingDown(provider)) {
+      errors.push(`${model}: skipped — provider ${provider} cooling down (recent 429)`);
       continue;
     }
 
-    // Skip models without API keys
+    // Skip models without API keys. Distinguish the two reasons isModelAvailable
+    // returns false (missing key vs already-exhausted) so the output is actionable.
     if (!isModelAvailable(model)) {
+      const reason = getApiKeyForProvider(provider)
+        ? 'exhausted'
+        : `no API key for provider ${provider}`;
+      errors.push(`${model}: skipped — ${reason}`);
       continue;
     }
 
@@ -2544,6 +2555,7 @@ export async function callLLM(messages, opts = {}) {
     const apiModelId = getApiModelId(model);
     const modelLimit = MODEL_MAX_OUTPUT_TOKENS[apiModelId];
     if (modelLimit && o.maxTokens > modelLimit) {
+      errors.push(`${model}: skipped — model max output ${modelLimit} < requested maxTokens ${o.maxTokens}`);
       continue;
     }
 
@@ -2557,6 +2569,7 @@ export async function callLLM(messages, opts = {}) {
       if (estTokens > reqLimit) {
         // One-line log per skip so ops can see the cascade in the workflow output
         console.warn(`⏭️  [${model}] Skipped — request would exceed ${reqLimit}-token limit (estimated ${estTokens})`);
+        errors.push(`${model}: skipped — request ~${estTokens} tokens exceeds ${reqLimit}-token input cap`);
         continue;
       }
     }

--- a/scripts/smoke-test-ai-models.mjs
+++ b/scripts/smoke-test-ai-models.mjs
@@ -45,7 +45,17 @@ for (const model of MODELS) {
     const msg = String(e?.message || e);
     detail = msg.slice(0, 220);
     const m = msg.match(/\bHTTP\s+(\d{3})\b/);
-    if (m) status = `http_${m[1]}`;
+    // Classify pre-flight skips FIRST: callLLM now records WHY a model was
+    // skipped ("skipped — exhausted", "skipped — no API key …", etc.). Before
+    // this, a fully-skipped single-model chain surfaced as a blank-cause
+    // "All AI models failed. … Errors: " and was bucketed into generic `error`,
+    // making the run undiagnosable. Surface the skip class so the summary tells
+    // us the regression is daily-quota exhaustion, not a broken adapter.
+    if (/skipped — no API key/i.test(msg)) status = 'no_key';
+    else if (/skipped — exhausted/i.test(msg)) status = 'skipped_exhausted';
+    else if (/skipped — provider .* cooling down/i.test(msg)) status = 'cooldown';
+    else if (/skipped — /i.test(msg)) status = 'skipped';
+    else if (m) status = `http_${m[1]}`;
     else if (/timeout|ETIMEDOUT|abort/i.test(msg)) status = 'timeout';
     else if (/ENOTFOUND|ECONNRESET|ECONN/i.test(msg)) status = 'net';
     else if (/No API key|missing.+key/i.test(msg)) status = 'no_key';

--- a/tests/scripts/ai-models-skip-error-capture.test.ts
+++ b/tests/scripts/ai-models-skip-error-capture.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// Regression guard for the smoke-test "empty Errors" bug (Refs #891).
+//
+// When callLLM is given a single-model chain whose only candidate is skipped
+// pre-flight (exhausted / no API key / cooling down / token cap), the loop used
+// to exit with an empty `errors` array, producing the undiagnosable message
+// "All AI models failed. Chain: [X]. Errors: " — exactly what the 2026-05-29
+// smoke run (#26660264763) surfaced for 169/180 failures (ms:0, blank cause).
+//
+// The fix records a per-model skip reason so the aggregate is always populated.
+const aiModels = await import('../../scripts/lib/ai-models.mjs');
+
+describe('ai-models pre-flight skip error-capture', () => {
+  beforeEach(() => {
+    aiModels.resetState();
+  });
+
+  it('propagates the exhaustion reason into the thrown error (not empty)', async () => {
+    const model = 'mistral/ministral-8b-latest';
+    aiModels.markModelExhausted(model);
+
+    let caught: Error | undefined;
+    try {
+      await aiModels.callLLM([{ role: 'user', content: "Reply with 'ok'." }], {
+        chain: [model],
+        retries: 0,
+        maxTokens: 8,
+      });
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught).toBeDefined();
+    const detail = String(caught?.message || '');
+    // The bug: detail ended with "Errors: " (empty). The fix: the per-model
+    // skip reason MUST be present so smoke output is diagnosable.
+    expect(detail).not.toMatch(/Errors:\s*$/);
+    expect(detail).toContain(model);
+    expect(detail).toMatch(/skipped — exhausted/i);
+  });
+
+  it('reports a missing API key as the skip reason when no provider key is set', async () => {
+    // Pick a provider that has no key in the test env. We assert the message
+    // distinguishes "no API key" from "exhausted" so ops can act on it.
+    const prevGroq = process.env.GROQ_API_KEY;
+    delete process.env.GROQ_API_KEY;
+    try {
+      const model = 'groq/llama-3.3-70b-versatile';
+      let caught: Error | undefined;
+      try {
+        await aiModels.callLLM([{ role: 'user', content: "Reply with 'ok'." }], {
+          chain: [model],
+          retries: 0,
+          maxTokens: 8,
+        });
+      } catch (e) {
+        caught = e as Error;
+      }
+      expect(caught).toBeDefined();
+      const detail = String(caught?.message || '');
+      expect(detail).not.toMatch(/Errors:\s*$/);
+      expect(detail).toMatch(/no API key for provider/i);
+    } finally {
+      if (prevGroq !== undefined) process.env.GROQ_API_KEY = prevGroq;
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

Root-cause + fix for the empty-`Errors` smoke output flagged in smoke run #26660264763 (`pass:3, error:180`, 169/180 with `ms:0` and blank cause).

**Bug:** `callLLM` skips a candidate model pre-flight (exhausted / no API key / provider cooling down / token cap) via a bare `continue` without pushing anything to the `errors` array. For a single-model chain (as the smoke test uses, `chain: [model]`) whose only model is skipped, the loop exits with `errors` empty and throws:

```
All AI models failed. Chain: [X]. Errors:
```

— an undiagnosable blank cause. The smoke harness then bucketed it into generic `error`.

**Fix (surgical):**
- `scripts/lib/ai-models.mjs` — each skip guard in `callLLM` now records a descriptive reason into `errors`: `skipped — exhausted`, `skipped — no API key for provider <p>`, `skipped — provider <p> cooling down`, `skipped — model max output … < requested maxTokens`, `skipped — request ~N tokens exceeds cap`. The aggregate `Errors:` string is now never empty.
- `scripts/smoke-test-ai-models.mjs` — classify skip causes into distinct statuses (`skipped_exhausted`, `no_key`, `cooldown`, `skipped`) instead of generic `error`, so the summary itself reveals the cause (daily-quota exhaustion vs broken adapter).
- `tests/scripts/ai-models-skip-error-capture.test.ts` — new regression test: a single-model chain whose model is exhausted, and one whose provider key is missing, both throw with the reason embedded (asserts `not /Errors:\s*$/`).

**Root-cause verdict (B):** the 61→3 pass drop is **environmental/state, NOT an adapter regression**. The smoke log shows 179 models `still exhausted until 2026-05-30T00:00` — restored from the Firestore ScoreStore by `initScoreStore`. These were marked exhausted by prior production runs hitting daily free-tier quotas/429s; the smoke run executed at 20:23 (before the midnight daily reset), so the persisted exhaustion silently skipped nearly the whole chain. Discovery confirms every provider key is present and valid (NVIDIA 103 / OpenRouter 23 / Groq 8 / Cerebras 2 / Cohere 11 / Mistral 47 / SambaNova 8 / Fireworks 5 usable models from authenticated `/models` calls) — no env-var mismatch. `together: 0` is expected: account returns HTTP 401 (`account unauthorized 2026-03`, static entries already removed), not a regression.

## Non implementato (ancora)

- **Together 401**: account-level authorization issue, not a code bug. No fix — would need a valid Together account. (out of scope)
- **NVIDIA catalog noise** (24 http_404 + code/vision/embed models polluting discovery): pre-existing, tracked separately. Refs #932. (follow-up)
- **Re-dispatch verification**: the real adapter health can only be confirmed by re-running the smoke workflow AFTER the daily reset (post 00:00 UTC) when exhaustion clears. Not yet green, hence `Refs #891` not `Closes`. A clean re-run should show the bulk of the 169 `ms:0` entries become real `pass` / `http_*` / `error` with populated `detail`. (posposto — needs live re-dispatch)

Refs #891
Refs #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)