### PR TITLE
ci(deploy): extended server-side poll → red-at-10min deploys go green (#987)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1099,17 +1099,47 @@ jobs:
           timeout: 1800000
           error_count: 100
 
-      # Both deploy-pages attempts are `continue-on-error`, so a double
-      # failure would otherwise leave the deploy job green. Fail the job
-      # immediately when both attempts failed (Pages busy or the action's
-      # 10-minute polling cap). The previous marker-file extended-polling
-      # step was removed: across all observed runs it never once rescued a
-      # deploy (the live SHA never matched within the 25-minute poll), so
-      # it only ever burned CI time before exiting 1 anyway.
-      - name: Fail if both deploy attempts failed
+      # actions/deploy-pages aborts at its 10-min polling cap (clamped from our
+      # `timeout: 1800000`), but for a ~13 GB / ~470k-file site GitHub Pages
+      # finishes publishing SERVER-SIDE afterwards. Proven 2026-05-30: run
+      # 26665087347 went red at the cap, yet ~32 min later the github-pages
+      # deployment for its sha reached state=success and the live build-id
+      # advanced (1780052190433 → 1780096323338). So a double action-failure is
+      # NOT a real deploy failure — it just means the publish is still syncing.
+      #
+      # The earlier extended-poll was removed for using a 25-min window (too
+      # short) and matching the wrong signal (live SHA, which is a build-id
+      # timestamp, never equals github.sha). This version polls the github-pages
+      # DEPLOYMENT created for THIS sha for up to 40 min and goes GREEN when
+      # Pages reports success — so validate-live → publish (IndexNow, Google
+      # Indexing API, GSC, previous-slug-winners sync, last_known_good) finally
+      # run (issue #987). Only a genuine non-success within 40 min fails the job.
+      - name: Wait for server-side Pages publish (extended, beyond the 10-min action cap)
         if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::error::Both deploy-pages attempts failed (Pages busy or 10-minute polling cap) — treating as a real deploy failure."
+          set -uo pipefail
+          deadline=$(( $(date +%s) + 40*60 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            dep=$(gh api "repos/${GITHUB_REPOSITORY}/deployments?environment=github-pages&sha=${GITHUB_SHA}&per_page=1" --jq '.[0].id // empty' 2>/dev/null || echo "")
+            if [ -n "$dep" ]; then
+              state=$(gh api "repos/${GITHUB_REPOSITORY}/deployments/${dep}/statuses?per_page=1" --jq '.[0].state // empty' 2>/dev/null || echo "")
+              echo "$(date -u +%H:%M:%S) github-pages deployment ${dep} state=${state:-<none>}"
+              case "$state" in
+                success)
+                  echo "✅ GitHub Pages completed the publish server-side (after the action's 10-min cap)."
+                  exit 0 ;;
+                failure|error)
+                  echo "::error::GitHub Pages deployment ${dep} reported ${state}."
+                  exit 1 ;;
+              esac
+            else
+              echo "$(date -u +%H:%M:%S) no github-pages deployment for ${GITHUB_SHA} yet — waiting"
+            fi
+            sleep 60
+          done
+          echo "::error::GitHub Pages did not report success within 40 min for ${GITHUB_SHA} (publish stuck or superseded)."
           exit 1
 
       - name: Save deploy metadata to Firestore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1021,6 +1021,7 @@ jobs:
       pages: write
       id-token: write
       contents: read
+      deployments: read   # the extended server-side poll reads /deployments + /statuses
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url || steps.deployment_first.outputs.page_url }}
@@ -1073,9 +1074,9 @@ jobs:
       # with >1M files the Pages backend's `syncing_files` phase can run
       # well past 10 minutes, causing the action to abort with
       # `Timeout reached, aborting!` even though the deployment itself
-      # eventually completes server-side. The marker-based extended
-      # polling below recognises that case and keeps the job green when
-      # the live site actually came up.
+      # eventually completes server-side. The deployment-status extended
+      # poll below recognises that case and keeps the job green when Pages
+      # reports the publish succeeded.
       - name: Deploy to GitHub Pages
         id: deployment_first
         uses: actions/deploy-pages@v5
@@ -1132,6 +1133,11 @@ jobs:
                   exit 0 ;;
                 failure|error)
                   echo "::error::GitHub Pages deployment ${dep} reported ${state}."
+                  exit 1 ;;
+                inactive)
+                  # A newer deploy superseded this sha's deployment — our publish
+                  # won't land; stop waiting (the newer deploy carries everything).
+                  echo "::warning::Deployment ${dep} is inactive (superseded by a newer deploy) — not waiting further."
                   exit 1 ;;
               esac
             else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1111,10 +1111,21 @@ jobs:
       # The earlier extended-poll was removed for using a 25-min window (too
       # short) and matching the wrong signal (live SHA, which is a build-id
       # timestamp, never equals github.sha). This version polls the github-pages
-      # DEPLOYMENT created for THIS sha for up to 40 min and goes GREEN when
-      # Pages reports success — so validate-live → publish (IndexNow, Google
-      # Indexing API, GSC, previous-slug-winners sync, last_known_good) finally
-      # run (issue #987). Only a genuine non-success within 40 min fails the job.
+      # DEPLOYMENT(s) for THIS sha for up to 40 min and goes GREEN when Pages
+      # reports success — so validate-live → publish (IndexNow, Google Indexing
+      # API, GSC, previous-slug-winners sync, last_known_good) finally run
+      # (issue #987).
+      #
+      # ONLY `success` is a terminal GREEN. The action emits two attempts
+      # (deployment_first + retry) → two Deployment objects per sha; on abort at
+      # the 10-min cap it may stamp a transient `error`/`failure`/cancel status
+      # BEFORE Pages finishes server-side. So `error`/`failure` are NOT treated
+      # as terminal — we keep polling (a genuinely failed publish simply never
+      # reaches success and falls through to the 40-min deadline → red, slow but
+      # correct). We check ALL deployments for the sha and succeed if ANY is
+      # success; we give up early only when EVERY deployment for the sha is
+      # `inactive` (definitively superseded by a newer deploy that carries the
+      # same content).
       - name: Wait for server-side Pages publish (extended, beyond the 10-min action cap)
         if: steps.deployment_first.outcome == 'failure' && steps.deployment.outcome == 'failure'
         env:
@@ -1123,29 +1134,29 @@ jobs:
           set -uo pipefail
           deadline=$(( $(date +%s) + 40*60 ))
           while [ "$(date +%s)" -lt "$deadline" ]; do
-            dep=$(gh api "repos/${GITHUB_REPOSITORY}/deployments?environment=github-pages&sha=${GITHUB_SHA}&per_page=1" --jq '.[0].id // empty' 2>/dev/null || echo "")
-            if [ -n "$dep" ]; then
-              state=$(gh api "repos/${GITHUB_REPOSITORY}/deployments/${dep}/statuses?per_page=1" --jq '.[0].state // empty' 2>/dev/null || echo "")
-              echo "$(date -u +%H:%M:%S) github-pages deployment ${dep} state=${state:-<none>}"
-              case "$state" in
-                success)
+            ids=$(gh api "repos/${GITHUB_REPOSITORY}/deployments?environment=github-pages&sha=${GITHUB_SHA}&per_page=20" --jq '.[].id' 2>/dev/null || echo "")
+            if [ -n "$ids" ]; then
+              any_active=0
+              for d in $ids; do
+                st=$(gh api "repos/${GITHUB_REPOSITORY}/deployments/${d}/statuses?per_page=1" --jq '.[0].state // empty' 2>/dev/null || echo "")
+                echo "$(date -u +%H:%M:%S) github-pages deployment ${d} state=${st:-<none>}"
+                if [ "$st" = "success" ]; then
                   echo "✅ GitHub Pages completed the publish server-side (after the action's 10-min cap)."
-                  exit 0 ;;
-                failure|error)
-                  echo "::error::GitHub Pages deployment ${dep} reported ${state}."
-                  exit 1 ;;
-                inactive)
-                  # A newer deploy superseded this sha's deployment — our publish
-                  # won't land; stop waiting (the newer deploy carries everything).
-                  echo "::warning::Deployment ${dep} is inactive (superseded by a newer deploy) — not waiting further."
-                  exit 1 ;;
-              esac
+                  exit 0
+                fi
+                # error/failure/in_progress/pending/<none> may still reach success → keep waiting
+                if [ "$st" != "inactive" ]; then any_active=1; fi
+              done
+              if [ "$any_active" = "0" ]; then
+                echo "::warning::All github-pages deployments for ${GITHUB_SHA} are inactive (superseded by a newer deploy) — not waiting further."
+                exit 1
+              fi
             else
               echo "$(date -u +%H:%M:%S) no github-pages deployment for ${GITHUB_SHA} yet — waiting"
             fi
             sleep 60
           done
-          echo "::error::GitHub Pages did not report success within 40 min for ${GITHUB_SHA} (publish stuck or superseded)."
+          echo "::error::GitHub Pages did not report success within 40 min for ${GITHUB_SHA} (publish stuck or genuinely failed)."
           exit 1
 
       - name: Save deploy metadata to Firestore


### PR DESCRIPTION
## Misura decisiva (2026-05-30)
Triggerato un deploy artifact post-revert (run 26665087347) e osservato:
- il job `deploy` va **rosso** al cap 10min di `actions/deploy-pages`;
- **~32min dopo**, il deployment github-pages per quel sha raggiunge `state=success` e il **build-id live AVANZA** (1780052190433 → 1780096323338).

→ **GitHub Pages PUBBLICA i 13GB server-side**, solo oltre il cap dell'action. NON è un tetto di scala. La causa degli "0/100 success" è che l'action molla a 10min → run rosso → `validate-live`/`publish` (gated su deploy verde) non scattano.

## Fix (B — polling esteso)
Sostituito l'hard-fail "Fail if both attempts failed" con un **poll del deployment github-pages per QUESTO sha, fino a 40min**: exit 0 quando Pages riporta `success`, fail solo su non-success genuino. Così il deploy job va **verde quando il publish atterra davvero** → ripartono i post-deploy (issue #987).

Corregge i 2 bug del vecchio extended-poll (rimosso): finestra 25min (troppo corta, il publish è ~32min) + match su build-id-live (timestamp) vs github.sha (mai uguali).

## Implementato
- Deploy job va verde su publish server-side completato → `validate-live` + `publish` finalmente girano: **Google Indexing API + IndexNow + GSC + sync previous-slug-winners + last_known_good**.

## Non implementato (separato)
- **A (ridurre cadenza deploy)**: la congestione (build cancellati da push ogni ~15min) resta — molti deploy non completano. B fa sì che quelli che COMPLETANO vadano verdi+pubblichino, ma non riduce le cancellazioni. A è un cambio di policy freshness (deploy su schedule/batch) da valutare a parte. Non bloccante: ~1-2 deploy/h completano comunque → sito si aggiorna.
- **Build incrementale**: esclusa (esperimento aprile, +11min/deploy per l'80% di build con churn; non toccherebbe il publish).
- Trade-off: il deploy job ora tiene il lock `pages-deploy` fino a 40min → serializza meglio i deploy (un completamento alla volta), non peggiora il build (concurrency separata).

Chiude (parzialmente) #987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## Review addressed (round 2)
- 🔴 **deployments:read mancante** → aggiunto allo scope del deploy job (altrimenti 403 → fix DOA).
- 🔴 **error/failure transitorio terminale** → ora solo `success` è terminale-verde; `error/failure/in_progress` non bloccano (poll fino al deadline); `success` su QUALSIASI dei deployment per lo sha (D1+D2); exit early solo se TUTTI inactive (superseded). Copre anche l'adversarial D1-vs-D2.
- 🟡 commento marker-poll stale → aggiornato.
- 🟡 **green-path mai eseguito e2e** → verificabile solo live: confermo sul prossimo double-failure reale che il job va verde + validate-live/publish partono.
- 🟡 **restore-from-artifact.yml** stesso anti-pattern (deploy-pages senza poll) → path di recovery manuale raro; **follow-up #987** (lo stesso fix andrà applicato lì se mai servirà un restore sul sito 13GB). Non incluso qui per tenere la PR scoped al path di deploy principale.
