### PR TITLE
fix(validate-live): 25min propagation timeout + accept newer build-id (publish was always skipped)

### DIFF
--- a/scripts/wait-for-pages-propagation.mjs
+++ b/scripts/wait-for-pages-propagation.mjs
@@ -32,7 +32,11 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
 const DEFAULT_LOCAL_PATH = path.join(REPO_ROOT, 'dist', 'build-id.txt');
 const DEFAULT_LIVE_URL = 'https://frontaliereticino.ch/build-id.txt';
-const DEFAULT_TIMEOUT_MS = 4 * 60 * 1000; // 4 min hard ceiling
+// 25 min: for the ~13 GB / ~470k-file site GitHub Pages finishes publishing
+// SERVER-SIDE well past actions/deploy-pages' 10-min action cap (~30 min end to
+// end, measured 2026-05-30). The old 4-min ceiling timed out before our build
+// reached the edge → validate-live failed → publish (IndexNow/indexing) skipped.
+const DEFAULT_TIMEOUT_MS = 25 * 60 * 1000;
 const PER_REQUEST_TIMEOUT_MS = 8_000;
 const UA = 'FrontaliereTicino-PropagationCheck/1.0';
 
@@ -99,6 +103,22 @@ async function main() {
 
   console.log(`[wait-pages] Expecting build-id="${expected}" at ${liveUrl} (timeout ${Math.round(timeoutMs / 1000)}s)`);
 
+  // build-id is a monotonic Date.now() millisecond stamp generated per build.
+  // Accept the live site as "propagated" when it serves a build-id >= ours:
+  // an exact match means our deploy is live; a strictly-greater value means a
+  // NEWER deploy already superseded ours and is live — the site is still at
+  // least as fresh as this run, so the freshness gate is satisfied (under deploy
+  // congestion ours may never be the one that lands, and waiting for an exact
+  // match would time out forever). Falls back to exact string match if either
+  // value isn't a plain number.
+  const expectedNum = /^\d+$/.test(expected) ? Number(expected) : null;
+  const isPropagated = (live) => {
+    if (live == null) return false;
+    if (live === expected) return true;
+    if (expectedNum !== null && /^\d+$/.test(live)) return Number(live) >= expectedNum;
+    return false;
+  };
+
   const startedAt = Date.now();
   let attempt = 0;
   let lastSeen = null;
@@ -106,8 +126,9 @@ async function main() {
     attempt += 1;
     const result = await fetchLiveBuildId(liveUrl);
     const elapsed = Math.round((Date.now() - startedAt) / 1000);
-    if (result.value === expected) {
-      console.log(`[wait-pages] OK — build-id matches after ${elapsed}s (attempt ${attempt})`);
+    if (isPropagated(result.value)) {
+      const how = result.value === expected ? 'matches' : `>= ours (live "${result.value}" ≥ "${expected}", newer deploy live)`;
+      console.log(`[wait-pages] OK — build-id ${how} after ${elapsed}s (attempt ${attempt})`);
       process.exit(0);
     }
     lastSeen = result.value ?? `<status ${result.status}${result.error ? ` ${result.error}` : ''}>`;


### PR DESCRIPTION
## Perché validate-live falliva
Su ogni deploy recente (06:39, 04:30): `deploy=success` + `validate-dist=success` ma **`validate-live=failure` → `publish` skippato** (niente IndexNow/indexing/GSC/last_known_good).

Log:
```
[wait-pages] Expecting build-id="1780123330305" (timeout 240s)
[wait-pages] saw "1780103868544" ... (9 tentativi)
[wait-pages] FAIL — timed out after 211s
```

`wait-for-pages-propagation.mjs` aspetta che il sito live serva il build-id di QUESTO run, ma per il sito da ~13GB Pages completa la pubblicazione **server-side in ~30min** (oltre il cap 10min dell'action). Il wait era solo **4min** → timeout → validate-live rosso → publish saltato.

## Causa: mia regressione
Il timeout esteso (25min) era stato shippato in **#966**, ma il revert **#986** (vicolo cieco branch-based) l'ha buttato via insieme — eppure era corretto e indipendente. Lo ri-applico.

## Fix
1. **Default timeout 4min → 25min** nello script (il suo unico caller è validate-live → il workflow lo eredita senza modifiche, evitando il bug arg-form `--timeout-ms` vs `=`).
2. **Match `>=`**: il build-id è un timestamp `Date.now()` monotono. Accetto se il live build-id ≥ atteso — match esatto = il nostro deploy è live; valore più nuovo = un deploy successivo ha già superato il nostro ed è live → il sito è comunque ≥ fresco → il gate passa invece di andare in timeout per sempre sotto congestione (dove il nostro potrebbe non essere mai quello che atterra).

## Implementato
- validate-live passa quando il sito è live e fresco (entro 25min o se già superato da un deploy più nuovo) → ripartono i post-deploy.

## Non implementato (separato)
- A (ridurre cadenza deploy) resta opzionale in #987 (la congestione che cancella i build non è toccata qui; questo fix fa solo passare validate-live per i deploy che completano).

Verificato: syntax OK + logica isPropagated testata (exact→pass, older→wait, newer→pass, null→wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
