### PR TITLE
feat(dedup): gate semantico near-duplicate per pubblicazione articoli

### DIFF
--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -118,6 +118,7 @@ import { extractArticleText } from './lib/extract-article-text.mjs';
 import { hasDomainAnchor } from './lib/discovery/domainAnchor.mjs';
 import { matchesFrontaliereAnchor, matchesFrontaliereUnambiguousAnchor } from './lib/discovery/frontaliereAnchor.mjs';
 import { isNonItalianScript, nonItalianScriptRatio } from './lib/itLanguageCheck.mjs';
+import { checkSemanticNearDuplicate } from './lib/scoring/semanticDedup.mjs';
 
 // ── Smarter generator inputs (Phase 3 — spec 2026-05-06) ───────
 // data/article-performance.json is produced weekly by Phase 1A.
@@ -7483,6 +7484,9 @@ async function generateAndValidateArticle(url, sourceContext = null) {
   // Step 3a.2: Check for duplicates BEFORE translating (saves 3 API calls on duplicates)
   console.error('🔍 Verifica duplicati:');
   checkForDuplicates(data);
+  // Step 3a.3: Semantic near-duplicate gate — catches same-story/different-
+  // vocabulary dupes the lexical Jaccard above cannot see (cosine ≥ ceiling).
+  await checkSemanticNearDuplicate(data);
 
   // Step 3b: Translate to EN/DE/FR (only runs if not a duplicate)
   await translateArticle(data);

--- a/scripts/lib/scoring/constants.mjs
+++ b/scripts/lib/scoring/constants.mjs
@@ -13,6 +13,22 @@ export const GSC_MIN_SIGNAL = 5;
 // signal is too weak to trust embedding-based prediction.
 export const EMBEDDING_MIN_COSINE = 0.4;
 
+// Semantic near-duplicate ceiling (2026-05-30). The lexical Jaccard gates
+// in create-article.mjs (`checkForDuplicates`) miss articles that re-tell
+// the SAME story with different vocabulary — e.g. "Aumento salari Svizzera
+// 2024" vs "Aumenti salariali Ticino 2025" share ~0 title tokens yet sit
+// at cosine 0.876. When a candidate's title+excerpt embedding is at or
+// above this cosine to an already-published article, it's a near-duplicate
+// and is rejected pre-publish. Tunable via env NEAR_DUP_COSINE; degrades
+// to a no-op when the embedding store is missing or the API call fails.
+export const EMBEDDING_NEAR_DUP_COSINE = Math.min(
+  1,
+  Math.max(
+    EMBEDDING_MIN_COSINE,
+    Number.parseFloat(process.env.NEAR_DUP_COSINE || '0.86') || 0.86,
+  ),
+);
+
 // Confidence multipliers per cascade stage. Final score = rawScore * confidence.
 export const CONFIDENCE_GSC = 1.0;
 export const CONFIDENCE_EMBEDDING = 0.8;

--- a/scripts/lib/scoring/semanticDedup.mjs
+++ b/scripts/lib/scoring/semanticDedup.mjs
@@ -1,0 +1,111 @@
+// scripts/lib/scoring/semanticDedup.mjs
+//
+// Semantic near-duplicate gate for the article publish pipeline.
+//
+// The lexical Jaccard signals in create-article.mjs (`checkForDuplicates`)
+// miss articles that re-tell the SAME story with different vocabulary. Real
+// case (2026-05-29): "Aumento salari Svizzera 2024: +1.5-2% ma solo per
+// specialisti" vs the already-published "Aumenti salariali Ticino fino al 2%
+// nel 2025" share ~0 title tokens (aumento≠aumenti, salari≠salariali,
+// svizzera≠ticino, 2024≠2025) so every Jaccard gate reads ~0 — yet they sit
+// at cosine 0.876, i.e. the same article.
+//
+// This gate embeds the new title+excerpt in the SAME text format the
+// published corpus uses (build-article-embeddings.mjs `articleText`:
+// `${title}\n\n${excerpt}` sliced to 4000 chars) and rejects when the nearest
+// published neighbour is at/above EMBEDDING_NEAR_DUP_COSINE.
+//
+// Fail-open by design: degrades to a no-op (publish proceeds) when the
+// embedding store is absent or the embedding API call fails, so a transient
+// outage never blocks the pipeline.
+
+import { embedOne } from '../evidence/embeddingClient.mjs';
+import { findTopK, loadEmbeddingStore, loadEmbeddingMeta } from './embeddingMatcher.mjs';
+import { EMBEDDING_NEAR_DUP_COSINE, EMBEDDING_TOP_K } from './constants.mjs';
+
+/**
+ * Build the corpus-comparable embedding text for an article. Must stay in
+ * sync with build-article-embeddings.mjs `articleText` or cosines drift.
+ *
+ * @param {string} title
+ * @param {string} excerpt
+ * @returns {string}
+ */
+export function buildDedupText(title, excerpt) {
+  return `${title || ''}\n\n${excerpt || ''}`.slice(0, 4000);
+}
+
+/**
+ * Reject a candidate article when it is a semantic near-duplicate of an
+ * already-published one. Throws on duplicate (consistent with
+ * checkForDuplicates), returns the data object otherwise.
+ *
+ * Dependencies are injectable so the gate is unit-testable without the
+ * embedding API or the on-disk store (mirrors cascadedScore's opts shape).
+ *
+ * @param {object} data — article data; reads data.content.it.{title,excerpt},
+ *   data.id, data.slugs?.it / data.slug for self-exclusion.
+ * @param {{
+ *   embedFn?: (text: string) => Promise<Float32Array>,
+ *   store?: object,
+ *   meta?: object,
+ *   threshold?: number,
+ *   k?: number,
+ *   log?: (msg: string) => void,
+ * }} [opts]
+ * @returns {Promise<object>} the same data object when not a duplicate
+ * @throws {Error} when a published neighbour is at/above the threshold
+ */
+export async function checkSemanticNearDuplicate(data, opts = {}) {
+  const log = opts.log || ((msg) => console.error(msg));
+  const threshold = typeof opts.threshold === 'number' ? opts.threshold : EMBEDDING_NEAR_DUP_COSINE;
+  const k = typeof opts.k === 'number' ? opts.k : EMBEDDING_TOP_K;
+
+  const store = opts.store !== undefined ? opts.store : loadEmbeddingStore();
+  if (!store) {
+    log('  ⏭️  Dedup semantico saltato (store embedding assente)');
+    return data;
+  }
+
+  const title = data?.content?.it?.title || '';
+  const excerpt = data?.content?.it?.excerpt || '';
+  const text = buildDedupText(title, excerpt);
+  if (!text.trim()) return data;
+
+  const embedFn = opts.embedFn || embedOne;
+  let vec;
+  try {
+    vec = await embedFn(text);
+  } catch (err) {
+    log(`  ⏭️  Dedup semantico saltato (embed fallito: ${err.message})`);
+    return data;
+  }
+  if (!(vec instanceof Float32Array) || vec.length === 0) {
+    log('  ⏭️  Dedup semantico saltato (embedding vuoto)');
+    return data;
+  }
+
+  const meta = opts.meta !== undefined ? opts.meta : loadEmbeddingMeta();
+  const topK = findTopK(vec, { store, meta, k });
+
+  // The new article isn't in the store yet, but a re-publish could match
+  // itself — exclude any neighbour that resolves to this same article.
+  const selfSlug = data?.slugs?.it || data?.slug || data?.id;
+  const nearest = topK.find((t) => t.slug && t.slug !== selfSlug && t.slug !== data?.id);
+
+  if (nearest && nearest.cosine >= threshold) {
+    throw new Error(
+      `❌ DUPLICATO SEMANTICO RILEVATO:\n`
+      + `   Nuovo:     "${title}" [${data?.id}]\n`
+      + `   Esistente: [${nearest.slug}]\n`
+      + `   Cosine:    ${nearest.cosine.toFixed(3)} ≥ ${threshold} (near-duplicate)\n`
+      + `   Stessa notizia con parole diverse — scegli un argomento distinto o più specifico.`,
+    );
+  }
+
+  log(
+    '  ✅ Nessun duplicato semantico'
+    + (nearest ? ` (vicino più simile: ${nearest.slug} @ ${nearest.cosine.toFixed(3)})` : ''),
+  );
+  return data;
+}

--- a/tests/scripts/lib/scoring/semanticDedup.test.ts
+++ b/tests/scripts/lib/scoring/semanticDedup.test.ts
@@ -1,0 +1,120 @@
+// tests/scripts/lib/scoring/semanticDedup.test.ts
+//
+// Semantic near-duplicate gate. Covers the real regression: two articles
+// that tell the same story with disjoint vocabulary (lexical Jaccard ~0)
+// but sit at cosine 0.876 — the lexical gates miss them, this one must not.
+
+import { describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+
+import { buildDedupText, checkSemanticNearDuplicate } from '../../../../scripts/lib/scoring/semanticDedup.mjs';
+
+const DIM = 4;
+
+function slugHash(slug: string): string {
+  return createHash('sha256').update(slug, 'utf8').digest('hex');
+}
+
+/** Build a synthetic store + meta in the shape findTopK consumes. */
+function makeStore(entries: Array<{ slug: string; vec: number[] }>) {
+  const store = {
+    vectors: entries.map((e) => Float32Array.from(e.vec)),
+    hashes: entries.map((e) => slugHash(e.slug)),
+    dim: DIM,
+    count: entries.length,
+  };
+  const meta = {
+    dim: DIM,
+    count: entries.length,
+    perArticle: Object.fromEntries(
+      entries.map((e) => [e.slug, { hash: slugHash(e.slug), byteOffset: 0 }]),
+    ),
+  };
+  return { store, meta };
+}
+
+/** A query vector at a known cosine to a unit basis vector. */
+function vecAtCosine(cos: number): number[] {
+  // cosine to [1,0,0,0] is the first component of the normalized vector.
+  const sin = Math.sqrt(Math.max(0, 1 - cos * cos));
+  return [cos, sin, 0, 0];
+}
+
+const article = (id: string, title: string, excerpt = '') => ({
+  id,
+  slugs: { it: id },
+  content: { it: { title, excerpt } },
+});
+
+describe('buildDedupText', () => {
+  it('matches the corpus format: title\\n\\nexcerpt, capped at 4000', () => {
+    expect(buildDedupText('T', 'E')).toBe('T\n\nE');
+    expect(buildDedupText('x'.repeat(5000), 'y').length).toBe(4000);
+    expect(buildDedupText('', '')).toBe('\n\n');
+  });
+});
+
+describe('checkSemanticNearDuplicate', () => {
+  const published = [{ slug: 'aumenti-stipendi-ticino-2025', vec: [1, 0, 0, 0] }];
+
+  it('REJECTS a same-story/different-words article at cosine ≥ threshold (the real 0.876 case)', async () => {
+    const { store, meta } = makeStore(published);
+    const embedFn = vi.fn().mockResolvedValue(Float32Array.from(vecAtCosine(0.876)));
+    const data = article(
+      'salari-specialisti-svizzera-2024',
+      'Aumento salari in Svizzera: +1.5-2% nel 2024, ma solo per gli specialisti',
+    );
+    await expect(
+      checkSemanticNearDuplicate(data, { store, meta, embedFn, threshold: 0.86, log: () => {} }),
+    ).rejects.toThrow(/DUPLICATO SEMANTICO/);
+    expect(embedFn).toHaveBeenCalledOnce();
+  });
+
+  it('ALLOWS a related-but-distinct article below threshold', async () => {
+    const { store, meta } = makeStore(published);
+    const embedFn = vi.fn().mockResolvedValue(Float32Array.from(vecAtCosine(0.70)));
+    const data = article('stipendi-neolaureati-2026', 'Stipendi neolaureati a confronto');
+    const out = await checkSemanticNearDuplicate(data, {
+      store, meta, embedFn, threshold: 0.86, log: () => {},
+    });
+    expect(out).toBe(data);
+  });
+
+  it('excludes the article itself (re-publish must not self-trigger)', async () => {
+    const { store, meta } = makeStore([{ slug: 'self-article', vec: [1, 0, 0, 0] }]);
+    const embedFn = vi.fn().mockResolvedValue(Float32Array.from([1, 0, 0, 0])); // cosine 1.0 to self
+    const data = article('self-article', 'Self');
+    const out = await checkSemanticNearDuplicate(data, {
+      store, meta, embedFn, threshold: 0.86, log: () => {},
+    });
+    expect(out).toBe(data); // not rejected
+  });
+
+  it('fails open when the embedding store is absent', async () => {
+    const embedFn = vi.fn();
+    const data = article('whatever', 'X');
+    const out = await checkSemanticNearDuplicate(data, { store: null, embedFn, log: () => {} });
+    expect(out).toBe(data);
+    expect(embedFn).not.toHaveBeenCalled(); // short-circuits before embedding
+  });
+
+  it('fails open when the embedding API call throws', async () => {
+    const { store, meta } = makeStore(published);
+    const embedFn = vi.fn().mockRejectedValue(new Error('no provider'));
+    const data = article('x', 'Aumento salari Svizzera 2024');
+    const out = await checkSemanticNearDuplicate(data, {
+      store, meta, embedFn, threshold: 0.86, log: () => {},
+    });
+    expect(out).toBe(data); // transient outage never blocks publish
+  });
+
+  it('fails open when the embedding is empty/invalid', async () => {
+    const { store, meta } = makeStore(published);
+    const embedFn = vi.fn().mockResolvedValue(new Float32Array(0));
+    const data = article('x', 'Aumento salari Svizzera 2024');
+    const out = await checkSemanticNearDuplicate(data, {
+      store, meta, embedFn, threshold: 0.86, log: () => {},
+    });
+    expect(out).toBe(data);
+  });
+});


### PR DESCRIPTION
## Contesto

Due articoli pubblicati lo stesso giorno (2026-05-29) raccontano la **stessa notizia** con parole diverse:

- `salari-specialisti-svizzera-2024` — "Aumento salari in Svizzera: +1.5-2% nel 2024, ma solo per gli specialisti"
- `aumenti-stipendi-ticino-2025` — "Aumenti salariali in Ticino fino al 2% nel 2025"

I gate anti-duplicato esistenti (`checkForDuplicates` in `create-article.mjs`) sono **tutti Jaccard lessicale su titoli/excerpt/id/entità**. I due titoli condividono ~0 token (aumento≠aumenti, salari≠salariali, svizzera≠ticino, 2024≠2025) → ogni Jaccard legge ~0 → passano entrambi. Ma la **cosine semantica = 0.876** (near-identical). Peggio: quel cosine alto era usato come *segnale positivo di traffico* (rawScore = predictedSessions × cosineTop1), non come flag duplicato.

## Implementato

- Nuovo `scripts/lib/scoring/semanticDedup.mjs` → `checkSemanticNearDuplicate(data, opts)`: embedda `title\n\nexcerpt` nello **stesso formato del corpus pubblicato** (`build-article-embeddings.mjs` `articleText`), gira `findTopK` sul vicino pubblicato più simile, e **throwa duplicato** se cosine ≥ `EMBEDDING_NEAR_DUP_COSINE`.
- Nuova costante `EMBEDDING_NEAR_DUP_COSINE` in `scripts/lib/scoring/constants.mjs`: default **0.86**, override via env `NEAR_DUP_COSINE`, clampata a `[EMBEDDING_MIN_COSINE, 1]`. 0.86 becca la coppia reale (0.876) lasciando passare i vicini a 0.70.
- Wiring in `create-article.mjs`: chiamato subito dopo il gate lessicale `checkForDuplicates`, dentro `generateAndValidateArticle` (async), prima della traduzione → skip-early, zero spreco di cicli LLM.
- **Fail-open**: degrada a no-op (publish procede) se store embedding assente, embed API fallisce, o embedding vuoto → un outage transiente non blocca mai la pipeline.
- Riusa store + `findTopK` già esistenti: la cosine è già a costo zero, nessuna nuova dipendenza.
- Test `tests/scripts/lib/scoring/semanticDedup.test.ts` (7 casi): reject sul caso reale 0.876, allow sotto soglia, esclusione self (re-publish), fail-open su store assente / API throw / embedding vuoto. 46/46 verde sull'intera scoring suite.

## Non implementato (ancora)

- **Redirect/canonical dell'articolo 2024 già live verso il 2025** — out of scope: questa PR previene NUOVI doppioni, non bonifica i 2 già pubblicati. Follow-up se vuoi consolidare i vicini storici (cluster a ~0.86-0.87: `salari-svizzera-aumentati-2025`, `stipendi-svizzeri-crescono-2025`).
- **Tuning della soglia su tutto il corpus** — 0.86 scelta sul caso osservato; non ho fatto sweep sull'intero corpus 2616 articoli per misurare false-positive rate. Env-tunable apposta. Follow-up: backtest se emergono reject legittimi-ma-distinti.
- **Gate semantico anche al momento della selezione candidato** (cascadedScore) — la cosine è già calcolata lì nello `_score_breakdown`; spostarlo a monte risparmierebbe anche l'embed in publish. Posposto: il publish-gate è il punto hard authoritative e copre il caso; ottimizzazione separata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)