### PR TITLE
fix(deploy): no rollback on validate-live propagation-timeout (live not broken)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1270,16 +1270,28 @@ jobs:
       issues: write     # github-issue-creator on publish failure (PR #772 added to the called job; must be declared at this caller too or the reusable workflow startup_failures)
 
   # ───────────────────────────────────────────────────────────────────────
-  # rollback: revert Pages to last_known_good if either validate fails.
+  # rollback: revert Pages to last_known_good if either validate fails for a
+  # reason that means the LIVE SITE IS BAD.
   # Still-live guard: skip rollback if a newer deploy has already replaced
   # ours on Pages — the bad version is gone, no need to clobber the new
   # good one.
+  #
+  # NOT a rollback trigger: validate-live `propagation_timeout`. That means our
+  # build-id never went live within the window (Pages publish backlog under
+  # deploy congestion) — but the live site is an OLDER VALID build the whole
+  # time, not broken. Rolling back to an even-older last_known_good would only
+  # regress the site and add another publish to the backlog (the thrash that
+  # wedged every deploy during the 2026-05-30 dispatch storm). So we gate
+  # rollback OFF when validate-live's ONLY failure reason is propagation_timeout;
+  # the next deploy lands normally once Pages drains. A genuine live-broken
+  # failure (5xx / e2e / CLS / visual) leaves failure_kind empty → rollback fires.
   # ───────────────────────────────────────────────────────────────────────
   rollback:
     needs: [deploy, validate-dist, validate-live]
     if: |
       always() &&
-      (needs.validate-dist.result == 'failure' || needs.validate-live.result == 'failure') &&
+      (needs.validate-dist.result == 'failure' ||
+       (needs.validate-live.result == 'failure' && needs.validate-live.outputs.failure_kind != 'propagation_timeout')) &&
       needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/post-deploy-validate-live.yml
+++ b/.github/workflows/post-deploy-validate-live.yml
@@ -28,10 +28,23 @@ on:
         description: 'github.event_name from the caller (workflow_dispatch / push / etc.)'
         required: true
         type: string
+    outputs:
+      # Lets the caller (deploy.yml) distinguish a PROPAGATION-TIMEOUT failure
+      # (our build-id never went live within the window — the live site is an
+      # older VALID build, nothing is broken) from a genuine LIVE-BROKEN failure
+      # (5xx / e2e / CLS / visual regression). Empty on success or on a
+      # live-broken failure; 'propagation_timeout' when only propagation timed
+      # out. deploy.yml gates `rollback` OFF for propagation_timeout — rolling
+      # back to an even-older last_known_good would only regress the site.
+      failure_kind:
+        description: "'propagation_timeout' if the deploy never propagated live; empty otherwise."
+        value: ${{ jobs.validate-live.outputs.failure_kind }}
 
 jobs:
   validate-live:
     runs-on: ubuntu-latest
+    outputs:
+      failure_kind: ${{ steps.classify.outputs.failure_kind }}
     permissions:
       contents: read    # read-only — winners git push moved to publish.yml
       actions: read     # for download-artifact same-run
@@ -101,12 +114,45 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
         run: npx playwright install --with-deps chromium
 
+      # ── Propagation wait (separated from smoke so we can tell a not-yet-live
+      # deploy apart from a broken one) ──────────────────────────────────────
+      # wait-for-pages-propagation.mjs exits 0 when the live build-id is OURS or
+      # NEWER (a later deploy already superseded us — site still ≥ as fresh), and
+      # exits 1 only when the live build-id stays OLDER than ours for the whole
+      # window (our deploy genuinely hasn't landed on Pages yet). Under deploy
+      # congestion the Pages publish backlog can make ours land minutes-to-hours
+      # after this window — but the live site is an EARLIER VALID build the whole
+      # time, NOT broken. So a propagation timeout must NOT trigger rollback.
+      - name: Wait for Pages propagation (our build-id or newer must be live)
+        id: propagation
+        continue-on-error: true
+        env:
+          LIVE_BASE_URL: https://frontaliereticino.ch
+        run: node scripts/wait-for-pages-propagation.mjs
+
+      - name: Classify propagation timeout (no rollback for this)
+        if: steps.propagation.outcome == 'failure'
+        id: classify
+        run: |
+          echo "::warning::[validate-live] Pages propagation timed out — our build-id is not live yet. The live site is an older VALID build (not broken); the next deploy will land once Pages drains. Flagging propagation_timeout → caller skips rollback, and publish is gated off (no IndexNow on not-yet-live URLs)."
+          echo "failure_kind=propagation_timeout" >> "$GITHUB_OUTPUT"
+
+      # Job still FAILS on propagation timeout (so `publish` — gated on
+      # validate-live success — does not submit IndexNow/Google/GSC for URLs that
+      # aren't live yet), but the caller reads `failure_kind` and skips rollback.
+      # Skip the smoke + downstream gates: they would only test the stale live
+      # build, which its own deploy already validated.
+      - name: Fail on propagation timeout (skip smoke against stale live)
+        if: steps.propagation.outcome == 'failure'
+        run: |
+          echo "::error::[validate-live] propagation_timeout — deploy not live within window. Skipping smoke/gates; caller will NOT rollback (live is a valid earlier build)."
+          exit 1
+
       - name: Live smoke (probe 5xx + e2e:live)
         env:
           PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
           LIVE_BASE_URL: https://frontaliereticino.ch
         run: |
-          node scripts/wait-for-pages-propagation.mjs
           npm run probe:5xx
           npm run test:e2e:live
 
@@ -176,8 +222,11 @@ jobs:
           path: test-results/
           retention-days: 14
 
+      # propagation_timeout is an expected transient under Pages publish
+      # congestion (live is a valid earlier build, not broken) — not a bug, so
+      # don't open/append a "Validation Failure (live)" issue for it.
       - name: Report failure to GitHub Issues
-        if: failure()
+        if: failure() && steps.classify.outputs.failure_kind != 'propagation_timeout'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Implementato

`validate-live` falliva in due modi diversissimi ma `rollback` li trattava uguale:

1. **propagation_timeout** — `wait-for-pages-propagation.mjs` non ha mai visto il nostro `build-id` (né uno più nuovo) andare live nella finestra. Sotto backlog di pubblicazione Pages (congestione deploy, es. lo storm di `workflow_dispatch` del 2026-05-30) il sito live è un build **precedente VALIDO** per tutto il tempo — non è rotto, il nostro deploy semplicemente non è ancora atterrato.
2. **live_broken** — propagazione OK, ma 5xx / e2e / CLS / visual-regression sul sito live.

Rollback su (1) ripubblicava un last_known_good **ancora più vecchio** sopra un live fresco-o-uguale **e** aggiungeva un altro publish al backlog → il thrash che ha bloccato ogni deploy durante lo storm (deploy=success, vlive=failure→rollback, ripeti).

**Fix (solo control-flow CI, nessun cambio dati/SEO):**
- `post-deploy-validate-live.yml`: separato il wait-di-propagazione dallo step smoke. Su timeout emette output `failure_kind=propagation_timeout`. Il job **fallisce comunque** (così `publish` — gated su validate-live success — non sottomette IndexNow/Google/GSC per URL non ancora live) ma salta smoke/gates (testerebbero il live stale già validato dal suo deploy).
- `deploy.yml`: `rollback` ora scatta solo se `validate-dist` fallisce **oppure** `validate-live` fallisce per un motivo **diverso** da `propagation_timeout`. Un live_broken reale lascia `failure_kind` vuoto → rollback scatta come prima.
- `propagation_timeout` non apre più una issue Bug (transiente atteso, non un bug; riduce rumore issue → frugalità quota).

**Evidenza (run reali 2026-05-30):** deploy job verde ma validate-live in timeout su build-id mai propagato → rollback su falso-positivo. Run 26682196187 (finestra drenata) verde end-to-end conferma che la macchina deploy funziona; il problema era il rollback-thrash, non size/branch/crawler. Il fix `#996` (accept-newer ≥) era già in prod e copre il caso supersede (live più nuovo); questo PR copre il caso complementare (live più vecchio = non-atterrato) lato rollback.

## Non implementato (ancora)

- **Anti-backlog a monte** (rate-limit/serializzazione dei `workflow_dispatch` o debounce dei trigger) per impedire che un burst di deploy faccia cadere il live ore indietro. Out of scope qui: è una scelta architetturale sul trigger; questo PR rende solo il rollback robusto al sintomo. Follow-up.
- **Still-live guard del rollback**: resta invariato (imperfetto ma ora meno sollecitato, dato che propagation_timeout non lo invoca più). Follow-up se emergono clobber residui.
- Non chiude `#987` (deploy rosso al cap 10min di actions/deploy-pages): questo PR affronta la sfaccettatura rollback-thrash dei post-deploy steps, non il cap dell'action. Relates `#987`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)