### PR TITLE
chore(ci): measure exact Claude token/cost per agent run

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -76,6 +76,7 @@ jobs:
           git config user.email "valerielinc@gmail.com"
 
       - name: Run Claude fix
+        id: claude_review
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,3 +131,10 @@ jobs:
             - Mai committare path home assoluti o email personali (Privacy).
             - Se la root cause non è determinabile con confidenza → NON forzare un fix; posta su issue "Root cause non determinata: <cosa hai trovato>. Serve indagine umana." rimuovi nulla e TERMINA senza PR.
             - Se il fix richiede credenziali/segreti non disponibili in CI → documenta in commento e TERMINA senza PR.
+
+      - name: Claude usage metrics
+        if: always()
+        # Exact token/cost for this run (replaces estimates). Writes a table to
+        # the run Step Summary + a grep-able CLAUDE_USAGE line to the log.
+        # Best-effort: never fails the job.
+        run: node scripts/ci/claude-usage-summary.mjs "${{ steps.claude_review.outputs.execution_file }}" "issue-fix"

--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -49,6 +49,7 @@ jobs:
           node-version: '22'
 
       - name: Run Claude follow-up triage
+        id: followup
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,3 +99,10 @@ jobs:
             - Mai chiudere/riaprire issue (nemmeno le superseded — solo commento).
             - Incerto sul filtro → crea con rationale "needs triage".
             - Zero candidate → `## Post-merge follow-up triage: zero outstanding items.` e termina.
+
+      - name: Claude usage metrics
+        if: always()
+        # Exact token/cost for this run (replaces estimates). Writes a table to
+        # the run Step Summary + a grep-able CLAUDE_USAGE line to the log.
+        # Best-effort: never fails the job.
+        run: node scripts/ci/claude-usage-summary.mjs "${{ steps.followup.outputs.execution_file }}" "post-merge-followup"

--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -74,6 +74,7 @@ jobs:
           echo "Review tier: $(grep tier= "$GITHUB_OUTPUT" | head -1)"
 
       - name: Run Claude review
+        id: claude_review
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,3 +124,10 @@ jobs:
             - 🔴 aperto → NON scrivere `## LGTM`.
             - ❓ funnel-critical non escalato (né 🔴 né follow-up issue) → NON scrivere `## LGTM`.
             - Incerto → `❓ q:`, no speculazione.
+
+      - name: Claude usage metrics
+        if: always()
+        # Exact token/cost for this run (replaces estimates). Writes a table to
+        # the run Step Summary + a grep-able CLAUDE_USAGE line to the log.
+        # Best-effort: never fails the job.
+        run: node scripts/ci/claude-usage-summary.mjs "${{ steps.claude_review.outputs.execution_file }}" "pr-review-loop"

--- a/scripts/ci/claude-usage-summary.mjs
+++ b/scripts/ci/claude-usage-summary.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Parse claude-code-action's `execution_file` and emit EXACT token/cost
+// metrics for the run, so per-workflow Claude burn is measurable (not estimated).
+// Writes a markdown table to $GITHUB_STEP_SUMMARY + a grep-able CLAUDE_USAGE
+// line to stdout (queryable via `gh run view --log`).
+// Usage: node scripts/ci/claude-usage-summary.mjs <execution_file> [label]
+// Best-effort: never throws, never fails the job.
+import fs from 'node:fs';
+
+const file = process.argv[2];
+const label = process.argv[3] || process.env.GITHUB_WORKFLOW || 'claude';
+
+const t = { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0,
+  cache_read_input_tokens: 0, cost_usd: 0, num_turns: 0, duration_ms: 0 };
+
+function addUsage(u) {
+  if (!u || typeof u !== 'object') return;
+  t.input_tokens += u.input_tokens || 0;
+  t.output_tokens += u.output_tokens || 0;
+  t.cache_creation_input_tokens += u.cache_creation_input_tokens || 0;
+  t.cache_read_input_tokens += u.cache_read_input_tokens || 0;
+}
+function parseMessages(raw) {
+  const s = raw.trim();
+  if (!s) return [];
+  try {
+    const j = JSON.parse(s);
+    if (Array.isArray(j)) return j;
+    if (j && Array.isArray(j.messages)) return j.messages;
+    return [j];
+  } catch {
+    const out = [];
+    for (const line of s.split('\n')) {
+      const l = line.trim();
+      if (!l) continue;
+      try { out.push(JSON.parse(l)); } catch { /* skip */ }
+    }
+    return out;
+  }
+}
+
+let parsed = false;
+try {
+  if (file && fs.existsSync(file)) {
+    const msgs = parseMessages(fs.readFileSync(file, 'utf8'));
+    const result = [...msgs].reverse().find((m) => m && m.type === 'result');
+    if (result) {
+      addUsage(result.usage);
+      t.cost_usd = result.total_cost_usd || result.cost_usd || 0;
+      t.num_turns = result.num_turns || 0;
+      t.duration_ms = result.duration_ms || 0;
+      parsed = true;
+    }
+    if (!parsed) {
+      for (const m of msgs) {
+        const u = m?.message?.usage || m?.usage;
+        if (u) { addUsage(u); parsed = true; }
+      }
+    }
+  }
+} catch (e) {
+  console.log(`[claude-usage] non-fatal parse error: ${String(e).slice(0, 120)}`);
+}
+
+const totalIn = t.input_tokens + t.cache_creation_input_tokens + t.cache_read_input_tokens;
+const grand = totalIn + t.output_tokens;
+const fmt = (n) => n.toLocaleString('en-US');
+
+console.log(
+  `CLAUDE_USAGE workflow="${label}" parsed=${parsed} ` +
+  `input=${t.input_tokens} output=${t.output_tokens} ` +
+  `cache_create=${t.cache_creation_input_tokens} cache_read=${t.cache_read_input_tokens} ` +
+  `total_tokens=${grand} cost_usd=${t.cost_usd.toFixed(4)} ` +
+  `turns=${t.num_turns} duration_ms=${t.duration_ms}`
+);
+
+const summary = process.env.GITHUB_STEP_SUMMARY;
+if (summary) {
+  const md = parsed
+    ? [`### 🤖 Claude usage — ${label}`, '', '| metric | value |', '|---|---:|',
+       `| input tokens | ${fmt(t.input_tokens)} |`,
+       `| cache write tokens | ${fmt(t.cache_creation_input_tokens)} |`,
+       `| cache read tokens | ${fmt(t.cache_read_input_tokens)} |`,
+       `| output tokens | ${fmt(t.output_tokens)} |`,
+       `| **total tokens** | **${fmt(grand)}** |`,
+       `| turns | ${t.num_turns} |`,
+       `| **cost (USD, list price)** | **$${t.cost_usd.toFixed(4)}** |`, '',
+       '_Cost is list-price equivalent; actual billing is the Max subscription (OAuth), $0 marginal. Use token figures to compare/optimize workflows._', ''].join('\n')
+    : `### 🤖 Claude usage — ${label}\n\n_No execution_file metrics available (step skipped/failed before Claude ran, or output empty)._\n`;
+  try { fs.appendFileSync(summary, md + '\n'); } catch { /* best effort */ }
+}


### PR DESCRIPTION
## Implementato

Strumenta i 3 workflow agentici per misurare il consumo **esatto** di token/costo Claude per run, sostituendo le stime (durata×frequenza) con dati reali interrogabili.

- **`scripts/ci/claude-usage-summary.mjs`** (nuovo): parsa l'`execution_file` di `claude-code-action@v1` (output confermato esistente) ed estrae input/output/cache-write/cache-read tokens, `total_cost_usd`, `num_turns`, `duration_ms`. Gestisce array/oggetto/JSONL; preferisce il messaggio `type:"result"` (usage cumulativo).
- **`id:`** aggiunto agli step `claude-code-action` (`claude_review` su pr-review-loop & issue-fix, `followup` su post-merge-followup) così `steps.<id>.outputs.execution_file` risolve.
- **Step `Claude usage metrics`** (`if: always()`, ultimo step di ogni workflow): scrive una **tabella** nello Step Summary della run + una riga **`CLAUDE_USAGE …`** grep-abile nel log (aggregabile via `gh run view --log`).
- Best-effort: lo step **non fa mai fallire il job** (file mancante/non parsabile → nota "no metrics" graceful). Testato: parse result-message, missing-file, empty-arg.

### Perché
Il consumo agent era **stimato**: pr-review-loop ~331 run-min/giorno + issue-fix ~275 = **94% del burn agent**, ma senza token reali non si ottimizza con precisione. Questo dà il dato esatto per ogni run → permette di decidere se il tier-high opus@40-turni di pr-review vale il costo, se le re-review su ogni `synchronize` (anche commit bot) sprecano, ecc.

## Non implementato (ancora)
- **Rollup storico** (somma settimanale per workflow dalle righe `CLAUDE_USAGE`): follow-up.
- **Formato `execution_file`**: il parser copre i formati noti di Claude Code; se differisse, degrada a "no metrics" senza rompere → si affina alla prima run osservata.
- Nessun cambio di comportamento agent: le ottimizzazioni vere (gating tier, skip re-review su push bot, dedup) sono separate, da prioritizzare coi dati che questo step ora fornisce.

⚠️ Tocca workflow di review → review-validation App non posta, auto-merge non scatta (eccezione AGENTS.md): **merge manuale** `gh pr merge --squash --delete-branch`.
