### PR TITLE
docs(authgate): mark round-2 headline experiment launched

### DIFF
--- a/docs/AUTHGATE-HEADLINE-EXPERIMENT.md
+++ b/docs/AUTHGATE-HEADLINE-EXPERIMENT.md
@@ -69,11 +69,16 @@ Exact copy tested, all 4 locales (source of truth: `CHALLENGER_HEADLINES` in
 | de | Weiter zum vollständigen Stellenangebot | Vollständiges Stellenangebot gratis freischalten | So bewirbst du dich für diese Stelle |
 | fr | Continuer pour voir l'annonce complète | Débloquez gratuitement l'annonce complète | Découvrez comment postuler à cette offre |
 
-**PostHog setup required to start the round:**
-1. Create feature flag `authgate-headline-v2` with three variant keys:
-   `control`, `free_unlock`, `apply_now` (even split, e.g. 34/33/33).
-2. Roll out to the same audience as v1 (gate viewers).
-3. Disable / archive `authgate-headline-v1` (round closed).
+**PostHog setup — DONE, round launched 2026-06-01:**
+1. ✅ Feature flag `authgate-headline-v2` created (PostHog flag id `196322`),
+   three variant keys `control` / `free_unlock` / `apply_now`, split 34/33/33,
+   rollout 100%.
+2. ✅ Same audience as v1 (gate viewers — no property filter, bucketed in
+   `services/authGateExperiment.ts`).
+3. ✅ `authgate-headline-v1` deactivated (round 1 closed).
+
+Bucketing is live from 2026-06-01; first attributed events accrue from then.
+Re-run `node scripts/query-authgate-experiment.mjs` to read the round-2 arms.
 
 **Calling the round (when to stop):**
 - Wait for ≥ ~1500–2000 attributed persons per arm (round 1 reached


### PR DESCRIPTION
## Implementato
Aggiorna `docs/AUTHGATE-HEADLINE-EXPERIMENT.md`: sezione Round 2 passa da "PostHog setup required to start" a "DONE, round launched 2026-06-01".

Stato reale riflesso nel doc:
- Flag PostHog `authgate-headline-v2` creato e attivo (id 196322), varianti `control`/`free_unlock`/`apply_now` @ 34/33/33, rollout 100%.
- Flag round-1 `authgate-headline-v1` disattivato (round chiuso).
- Bucketing live dal 2026-06-01 (codice già deployato in PR #1006, `FLAG_KEY='authgate-headline-v2'`).

Doc-only change. Nessuna modifica a codice o workflow.

## Non implementato (ancora)
- Lettura risultati round-2 / decisione winner: follow-up quando ogni arm raggiunge ~1500–2000 persone attribuite (out of scope qui — il test è appena partito, 0 eventi).
- Nessuna modifica a copy/i18n: le 4-locale challenger erano già in `services/authGateExperiment.ts` (PR #1006).