### PR TITLE
fix(translate): stop needsRetranslation re-flag loop, suppress unfixable jobs

### DIFF
--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -1738,7 +1738,9 @@ export async function assembleJobsDataset({ withStats = false } = {}) {
     // translate-pending pipeline fills the missing locales.
     let partialDescriptionFlags = 0;
     for (const job of assembled) {
-      if (job.needsRetranslation) continue;
+      // Skip already-flagged and jobs the pipeline gave up on (localeMismatchSuppressed)
+      // — re-flagging suppressed jobs keeps needsRetranslation set on them.
+      if (job.needsRetranslation || job.localeMismatchSuppressed) continue;
       const descriptions = job.descriptionByLocale && typeof job.descriptionByLocale === 'object'
         ? job.descriptionByLocale
         : {};

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -277,6 +277,10 @@ export function applyPerLocaleSlugCollisionGuard(jobs) {
         delete job.titleByLocale[locale];
       }
       job.needsRetranslation = true;
+      // We just invalidated a hallucinated title → the job genuinely needs work
+      // again, so lift any prior give-up suppression.
+      delete job.localeMismatchSuppressed;
+      delete job.localeMismatchSuppressedLen;
       count++;
       if (details.length < 10) {
         details.push(`${canton}/${locale}/${slug}: ${myId} → owned by ${owner}`);
@@ -708,7 +712,10 @@ export function writeJobsCrawlerSlice(crawlerKey, jobs) {
   };
   let flagged = 0;
   for (const job of jobs) {
-    if (job.needsRetranslation) continue;
+    // Skip already-flagged and jobs the pipeline gave up on (relocalize sets
+    // localeMismatchSuppressed after repeated failed retranslation runs) —
+    // re-flagging suppressed jobs is what kept the backlog looping.
+    if (job.needsRetranslation || job.localeMismatchSuppressed) continue;
     const sl = job.sourceLang || 'it';
     const titles = job.titleByLocale || {};
     let needsFlag = false;

--- a/scripts/cleanup-jobs.mjs
+++ b/scripts/cleanup-jobs.mjs
@@ -574,6 +574,11 @@ async function main() {
                 job.description = fallback;
               }
               job.needsRetranslation = true;
+              // We just rewrote the description (genuine content change) → lift any
+              // prior give-up so the fresh text gets a new translation attempt and
+              // the suppressed counter isn't inflated by a now-stale marker.
+              delete job.localeMismatchSuppressed;
+              delete job.localeMismatchSuppressedLen;
               enriched++;
             }
           }

--- a/scripts/flag-wrong-locale-descriptions.mjs
+++ b/scripts/flag-wrong-locale-descriptions.mjs
@@ -77,7 +77,9 @@ function processFile(filePath, label) {
 
   let flagged = 0;
   for (const job of jobs) {
-    if (job.needsRetranslation) continue;
+    // Skip already-flagged and jobs the pipeline gave up on (relocalize sets
+    // localeMismatchSuppressed) — re-flagging suppressed jobs reopens the loop.
+    if (job.needsRetranslation || job.localeMismatchSuppressed) continue;
     if (hasWrongLocaleDescription(job)) {
       job.needsRetranslation = true;
       flagged += 1;

--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -4831,6 +4831,21 @@ export function mergePreserveLocaleData(existingJobs, freshJobs, opts = {}) {
       fresh.needsRetranslation = true;
     }
 
+    // Carry over the retranslation give-up state (relocalize-pending-jobs sets
+    // localeMismatchSuppressed after MAX failed attempts). Without this, every
+    // re-crawl silently drops the marker, bypassing the >15% source-drift
+    // auto-reset gate and reopening the re-flag loop. reconcileRetranslationState
+    // still lifts it on the next run if the fresh source actually drifted.
+    if (old.localeMismatchSuppressed && !fresh.localeMismatchSuppressed) {
+      fresh.localeMismatchSuppressed = true;
+      if (typeof old.localeMismatchSuppressedLen === 'number') {
+        fresh.localeMismatchSuppressedLen = old.localeMismatchSuppressedLen;
+      }
+      if (typeof old.retranslationAttempts === 'number') {
+        fresh.retranslationAttempts = old.retranslationAttempts;
+      }
+    }
+
     // Translation stability lock (Fix 2): when the source-locale title is
     // bytewise unchanged from the previous crawl AND the previous record has
     // full locale coverage for titles/descriptions/slugs, clear

--- a/scripts/log-translation-stats.mjs
+++ b/scripts/log-translation-stats.mjs
@@ -49,6 +49,7 @@ const files = fs.existsSync(CRAWLERS_DIR)
 
 let total = 0;
 let needsRetranslation = 0;
+let suppressed = 0;
 let incomplete = 0;
 const byLocale = { it: 0, en: 0, de: 0, fr: 0 };
 const topCompanies = [];
@@ -64,6 +65,7 @@ for (const file of files) {
     const flagged = !!job.needsRetranslation;
     const inc = isIncomplete(job);
     if (flagged) needsRetranslation++;
+    if (job.localeMismatchSuppressed) suppressed++;
     if (inc) {
       incomplete++;
       companyPending++;
@@ -95,6 +97,7 @@ const entry = {
   label,
   total,
   needsRetranslation,
+  suppressed,
   incomplete,
   complete: total - incomplete,
   missingByLocale: byLocale,
@@ -106,6 +109,7 @@ console.log(`   Total jobs:          ${total}`);
 console.log(`   Complete:            ${entry.complete} (${Math.round(entry.complete/total*100)}%)`);
 console.log(`   Incomplete:          ${incomplete}`);
 console.log(`     needsRetranslation:  ${needsRetranslation}`);
+console.log(`     suppressed (gave up): ${suppressed}`);
 console.log(`     Missing by locale:   IT=${byLocale.it} EN=${byLocale.en} DE=${byLocale.de} FR=${byLocale.fr}`);
 if (topCompanies.length > 0) {
   console.log(`   Top pending companies:`);

--- a/scripts/mark-locale-mismatched-jobs.mjs
+++ b/scripts/mark-locale-mismatched-jobs.mjs
@@ -23,7 +23,10 @@ const jobs = JSON.parse(fs.readFileSync(DATA_JOBS_PATH, 'utf-8'));
 let flagged = 0;
 
 for (const job of jobs) {
-  if (job.needsRetranslation) continue;
+  // Skip jobs already flagged, and jobs the pipeline gave up on after repeated
+  // failed retranslation runs (relocalize-pending-jobs sets localeMismatchSuppressed).
+  // Re-flagging the latter is what made the needsRetranslation backlog loop forever.
+  if (job.needsRetranslation || job.localeMismatchSuppressed) continue;
   let jobHasMismatch = false;
   for (const locale of LOCALES) {
     const description = String(job.descriptionByLocale?.[locale] || '').trim();

--- a/scripts/relocalize-pending-jobs.mjs
+++ b/scripts/relocalize-pending-jobs.mjs
@@ -177,6 +177,42 @@ export function reconcileRetranslationState(job, { attempted = false } = {}) {
 }
 
 /**
+ * Locale-content signature of a job (titles + descriptions across locales).
+ * Used to detect whether the shared crawler ACTUALLY touched a job in a run:
+ * the crawler stops at its per-run budget and on quota, so a company slice can
+ * hold far more flagged jobs than were translated. A give-up attempt must only
+ * be counted for jobs whose content actually changed — never for the un-reached
+ * tail (counting those would suppress translatable backlog; see
+ * reconcileRetranslationState). Erring toward "unchanged ⇒ not attempted" is the
+ * safe side: it can only delay a give-up, never cause a false suppression.
+ */
+export function jobLocaleSignature(job) {
+  return `${JSON.stringify(job.titleByLocale || {})} ${JSON.stringify(job.descriptionByLocale || {})}`;
+}
+
+/** Snapshot { slug → signature } for one company's jobs (call before the crawler runs). */
+export function snapshotCompanySignatures(jobs, companyKey) {
+  const m = new Map();
+  for (const j of jobs) {
+    if (normalizeCompanyKey(j.companyKey || j.company || '') !== companyKey) continue;
+    if (j.slug) m.set(j.slug, jobLocaleSignature(j));
+  }
+  return m;
+}
+
+/** Slugs whose locale content changed vs the pre-crawler snapshot (= actually attempted). */
+export function changedSlugsSince(snapshot, jobs, companyKey) {
+  const changed = new Set();
+  for (const j of jobs) {
+    if (normalizeCompanyKey(j.companyKey || j.company || '') !== companyKey) continue;
+    if (!j.slug) continue;
+    const before = snapshot.get(j.slug);
+    if (before === undefined || before !== jobLocaleSignature(j)) changed.add(j.slug);
+  }
+  return changed;
+}
+
+/**
  * Check if a job has incomplete locale coverage.
  * Returns true if any locale is missing an adequate title or description.
  */
@@ -403,9 +439,12 @@ function clearRetranslationFlags(jobs) {
  *
  * @param {string} companyKey - The crawler/company key (e.g. 'abb-svizzera-sede-ticino')
  * @param {Array} assembledJobs - The current jobs from jobs.json
+ * @param {Set<string>} [attemptedSlugs] - Slugs the crawler actually translated
+ *   this run (locale content changed). Only these advance the give-up counter;
+ *   omitting the set means "nothing attempted" — the safe default.
  * @returns {number} Number of jobs updated in the per-crawler file
  */
-function syncTranslationsToCrawlerFile(companyKey, assembledJobs) {
+function syncTranslationsToCrawlerFile(companyKey, assembledJobs, attemptedSlugs) {
   const crawlerFilePath = path.join(BY_CRAWLER_DIR, `${companyKey}.json`);
 
   if (!fs.existsSync(crawlerFilePath)) {
@@ -572,10 +611,14 @@ function syncTranslationsToCrawlerFile(companyKey, assembledJobs) {
       }
     }
 
-    // This job was actually translated this run (attempted=true): clear its flag
-    // if now complete, otherwise advance the give-up counter and suppress after
-    // MAX_RETRANSLATION_ATTEMPTS real failed attempts.
-    const outcome = reconcileRetranslationState(crawlerJob, { attempted: true });
+    // Advance the give-up counter only if the crawler actually translated THIS job
+    // this run (its locale content changed). Jobs that merely sat in the processed
+    // company's slice but were never reached by the per-run budget must NOT count —
+    // otherwise the un-reached tail gets mass-suppressed (frozen source-copy locales).
+    const attempted = !!(attemptedSlugs && (
+      attemptedSlugs.has(crawlerJob.slug) || (assembled && attemptedSlugs.has(assembled.slug))
+    ));
+    const outcome = reconcileRetranslationState(crawlerJob, { attempted });
     if (outcome === 'cleared') {
       console.log(`     ✅ Cleared needsRetranslation for: ${crawlerJob.slug?.slice(0, 60)}`);
       changed = true;
@@ -600,9 +643,11 @@ function syncTranslationsToCrawlerFile(companyKey, assembledJobs) {
  * Increment retry counter directly on per-crawler file for stuck jobs.
  * This catches jobs that don't appear in the assembled dataset (e.g. companies
  * not in the shared crawler's census) where syncTranslationsToCrawlerFile can't
- * match them. After 3 failed attempts, clear the flag to break the loop.
+ * match them. After 3 failed attempts, suppress the flag to break the loop.
+ * @param {Set<string>} [attemptedSlugs] - Slugs the crawler actually translated
+ *   this run; only these advance the give-up counter.
  */
-function incrementRetryCounterOnCrawlerFile(companyKey, handledSlugs) {
+function incrementRetryCounterOnCrawlerFile(companyKey, handledSlugs, attemptedSlugs) {
   const crawlerFilePath = path.join(BY_CRAWLER_DIR, `${companyKey}.json`);
 
   if (!fs.existsSync(crawlerFilePath)) return;
@@ -617,9 +662,11 @@ function incrementRetryCounterOnCrawlerFile(companyKey, handledSlugs) {
     // double-incrementing the retry counter in the same pipeline run.
     if (handledSlugs && handledSlugs.has(job.slug)) continue;
 
-    // This company was processed this run (attempted=true): advance the give-up
-    // counter for jobs still incomplete, suppress after MAX attempts.
-    const outcome = reconcileRetranslationState(job, { attempted: true });
+    // Advance the give-up counter only for jobs the crawler actually translated
+    // this run (content changed) — never the un-reached tail of a processed
+    // company (that would mass-suppress translatable backlog).
+    const attempted = !!(attemptedSlugs && attemptedSlugs.has(job.slug));
+    const outcome = reconcileRetranslationState(job, { attempted });
     if (outcome === 'gaveup') {
       console.log(`     🛑 Giving up after ${MAX_RETRANSLATION_ATTEMPTS} direct attempts: ${String(job.slug || '').slice(0, 60)}`);
     }
@@ -852,10 +899,18 @@ async function main() {
     }
 
     try {
+      // Snapshot locale content BEFORE the crawler so we can tell which jobs it
+      // actually translated (changed) vs the budget-unreached tail.
+      const preCrawlerJobs = readJson(DATA_JOBS_PATH);
+      const preSig = Array.isArray(preCrawlerJobs)
+        ? snapshotCompanySignatures(preCrawlerJobs, key) : new Map();
+
       await runSharedCrawler([key], companyJobCount);
 
       // Save progress after each company: clear flags and write to disk
       const currentJobs = readJson(DATA_JOBS_PATH);
+      const attemptedSlugs = Array.isArray(currentJobs)
+        ? changedSlugsSince(preSig, currentJobs, key) : new Set();
       if (Array.isArray(currentJobs)) {
         const cleared = clearRetranslationFlags(currentJobs);
         if (cleared > 0) {
@@ -888,7 +943,7 @@ async function main() {
         // Previously, sync was gated on cleared > 0, creating a loop: shared crawler
         // improved translations in jobs.json, but improvements never reached per-crawler
         // slices (source of truth). Next assemble started from stale data.
-        const syncResult = syncTranslationsToCrawlerFile(key, currentJobs);
+        const syncResult = syncTranslationsToCrawlerFile(key, currentJobs, attemptedSlugs);
         if (syncResult.updated > 0) {
           console.log(`   📁 ${key}: ${syncResult.updated} jobs synced to per-crawler file`);
         }
@@ -896,8 +951,8 @@ async function main() {
         // Increment retry counter directly on per-crawler file for stuck jobs.
         // This catches jobs that don't appear in the assembled dataset (e.g. companies
         // not in the shared crawler's census) where syncTranslationsToCrawlerFile can't
-        // match them. After 3 failed attempts, clear the flag to break the loop.
-        incrementRetryCounterOnCrawlerFile(key, syncResult.handledSlugs);
+        // match them. After 3 failed attempts, suppress the flag to break the loop.
+        incrementRetryCounterOnCrawlerFile(key, syncResult.handledSlugs, attemptedSlugs);
       }
 
       totalProcessed += companyJobCount;
@@ -943,6 +998,9 @@ async function main() {
 
         console.log(`   🔁 Retrying ${key} (${count} jobs)...`);
         try {
+          const preRetryJobs = readJson(DATA_JOBS_PATH);
+          const preRetrySig = Array.isArray(preRetryJobs)
+            ? snapshotCompanySignatures(preRetryJobs, key) : new Map();
           await runSharedCrawler([key], count);
           const afterRetry = readJson(DATA_JOBS_PATH);
           if (Array.isArray(afterRetry)) {
@@ -951,7 +1009,8 @@ async function main() {
               fs.writeFileSync(DATA_JOBS_PATH, JSON.stringify(afterRetry, null, 2) + '\n', 'utf-8');
               totalFixed += cleared;
               console.log(`   ✅ ${key} retry: ${cleared} more jobs translated`);
-              syncTranslationsToCrawlerFile(key, afterRetry);
+              const retryAttempted = changedSlugsSince(preRetrySig, afterRetry, key);
+              syncTranslationsToCrawlerFile(key, afterRetry, retryAttempted);
             }
           }
         } catch {

--- a/scripts/relocalize-pending-jobs.mjs
+++ b/scripts/relocalize-pending-jobs.mjs
@@ -118,21 +118,32 @@ function sourceChangedSinceSuppression(job) {
 }
 
 /**
- * Per-run state machine that drives the needsRetranslation give-up cycle.
- * Mutates `job` in place and returns the outcome. Runs for EVERY job in EVERY
- * slice on EVERY run (unlike the per-company sync path, which the throughput /
- * time budget can skip — that gap is what let stuck jobs loop forever).
+ * State machine for the needsRetranslation give-up cycle. Mutates `job` in place
+ * and returns the outcome.
+ *
+ * CRITICAL: the give-up counter must only advance when a translation was actually
+ * ATTEMPTED on this job and still failed — NOT merely because the job sat in the
+ * queue. relocalize runs with `--max-jobs 100` against thousands of flagged jobs,
+ * so most are never reached by the throughput budget on a given run. Counting an
+ * attempt per-run (per queue presence) would suppress the entire un-reached
+ * backlog after a few runs, permanently pulling translatable jobs out of the pool
+ * (source-language text frozen on IT/EN/FR pages — a duplicate-content / indexing
+ * regression). Hence `attempted`:
+ *   - direct-scan over all slices → attempted=false (reset + clear only)
+ *   - per-company sync of jobs actually translated this run → attempted=true
  *
  *   'reset'   — a re-crawl rewrote a suppressed job → give-up lifted, retry
  *   'cleared' — flagged job now passes isIncomplete() → flag + bookkeeping cleared
- *   'gaveup'  — flagged job still incomplete after MAX_RETRANSLATION_ATTEMPTS → suppressed
- *   'counted' — flagged job still incomplete, attempt counter bumped
+ *   'gaveup'  — attempted, still incomplete after MAX_RETRANSLATION_ATTEMPTS → suppressed
+ *   'counted' — attempted, still incomplete → attempt counter bumped
+ *   'waiting' — still incomplete but NOT attempted this run → left flagged, no count
  *   'noop'    — nothing to do
  *
  * @param {object} job
- * @returns {'reset'|'cleared'|'gaveup'|'counted'|'noop'}
+ * @param {{ attempted?: boolean }} [opts]
+ * @returns {'reset'|'cleared'|'gaveup'|'counted'|'waiting'|'noop'}
  */
-export function reconcileRetranslationState(job) {
+export function reconcileRetranslationState(job, { attempted = false } = {}) {
   let outcome = 'noop';
   // A re-crawl rewrote a previously-suppressed job → drop the give-up so the
   // fresh content gets a new translation attempt.
@@ -151,7 +162,9 @@ export function reconcileRetranslationState(job) {
     delete job.localeMismatchSuppressedLen;
     return 'cleared';
   }
-  // Still incomplete after being flagged. Count one give-up attempt for this run.
+  // Still incomplete. Only advance the give-up counter if a translation was
+  // actually attempted on this job this run — otherwise leave it queued.
+  if (!attempted) return 'waiting';
   const attempts = (job.retranslationAttempts || 0) + 1;
   job.retranslationAttempts = attempts;
   if (attempts >= MAX_RETRANSLATION_ATTEMPTS) {
@@ -559,30 +572,18 @@ function syncTranslationsToCrawlerFile(companyKey, assembledJobs) {
       }
     }
 
-    // Clear needsRetranslation flag only if job is now complete (all locales translated)
-    if (crawlerJob.needsRetranslation && !isIncomplete(crawlerJob)) {
+    // This job was actually translated this run (attempted=true): clear its flag
+    // if now complete, otherwise advance the give-up counter and suppress after
+    // MAX_RETRANSLATION_ATTEMPTS real failed attempts.
+    const outcome = reconcileRetranslationState(crawlerJob, { attempted: true });
+    if (outcome === 'cleared') {
       console.log(`     ✅ Cleared needsRetranslation for: ${crawlerJob.slug?.slice(0, 60)}`);
-      delete crawlerJob.needsRetranslation;
-      delete crawlerJob.retranslationAttempts;
-      delete crawlerJob.localeMismatchSuppressed;
-      delete crawlerJob.localeMismatchSuppressedLen;
       changed = true;
-    }
-
-    // Break infinite retry loop: if the pipeline has tried MAX_RETRANSLATION_ATTEMPTS
-    // times and still can't produce translations that pass isIncomplete(), suppress
-    // the job (localeMismatchSuppressed) so the flaggers stop re-queuing it. Auto-
-    // resets on the next crawl cycle when fresh source data arrives.
-    if (crawlerJob.needsRetranslation && isIncomplete(crawlerJob)) {
-      const attempts = (crawlerJob.retranslationAttempts || 0) + 1;
-      crawlerJob.retranslationAttempts = attempts;
+    } else if (outcome === 'gaveup') {
+      console.log(`     🛑 Giving up after ${MAX_RETRANSLATION_ATTEMPTS} attempts: ${crawlerJob.slug?.slice(0, 60)}`);
       changed = true;
-      if (attempts >= MAX_RETRANSLATION_ATTEMPTS) {
-        console.log(`     🛑 Giving up after ${attempts} attempts: ${crawlerJob.slug?.slice(0, 60)}`);
-        delete crawlerJob.needsRetranslation;
-        crawlerJob.localeMismatchSuppressed = true;
-        crawlerJob.localeMismatchSuppressedLen = (crawlerJob.description || '').trim().length;
-      }
+    } else if (outcome === 'counted' || outcome === 'reset') {
+      changed = true;
     }
 
     if (changed) updated += 1;
@@ -612,21 +613,17 @@ function incrementRetryCounterOnCrawlerFile(companyKey, handledSlugs) {
   let changed = false;
   for (const job of crawlerData.jobs) {
     if (!job.needsRetranslation) continue;
-    if (!isIncomplete(job)) continue;
     // Skip jobs already handled by syncTranslationsToCrawlerFile to avoid
     // double-incrementing the retry counter in the same pipeline run.
     if (handledSlugs && handledSlugs.has(job.slug)) continue;
 
-    const attempts = (job.retranslationAttempts || 0) + 1;
-    job.retranslationAttempts = attempts;
-    changed = true;
-
-    if (attempts >= MAX_RETRANSLATION_ATTEMPTS) {
-      console.log(`     🛑 Giving up after ${attempts} direct attempts: ${String(job.slug || '').slice(0, 60)}`);
-      delete job.needsRetranslation;
-      job.localeMismatchSuppressed = true;
-      job.localeMismatchSuppressedLen = (job.description || '').trim().length;
+    // This company was processed this run (attempted=true): advance the give-up
+    // counter for jobs still incomplete, suppress after MAX attempts.
+    const outcome = reconcileRetranslationState(job, { attempted: true });
+    if (outcome === 'gaveup') {
+      console.log(`     🛑 Giving up after ${MAX_RETRANSLATION_ATTEMPTS} direct attempts: ${String(job.slug || '').slice(0, 60)}`);
     }
+    if (outcome !== 'noop' && outcome !== 'waiting') changed = true;
   }
 
   if (changed) {
@@ -679,8 +676,13 @@ async function main() {
   // FIRST: scan per-crawler files DIRECTLY for orphaned needsRetranslation flags.
   // Some crawler files have jobs that don't make it into the assembled dataset
   // (e.g. failed quality gate). This runs unconditionally before any early exit.
+  // attempted=false here: this scan does NOT translate, so it only clears flags on
+  // now-complete jobs and lifts give-up on re-crawled ones — it must NEVER count a
+  // give-up attempt (that would suppress un-reached backlog; see
+  // reconcileRetranslationState). Give-up counting happens only in the per-company
+  // sync paths below, which run on jobs actually translated this run.
   let directCleared = 0;
-  let directGivenUp = 0;
+  let directReset = 0;
   if (fs.existsSync(BY_CRAWLER_DIR)) {
     for (const file of fs.readdirSync(BY_CRAWLER_DIR).filter(f => f.endsWith('.json') && !f.includes('-locale-cache'))) {
       const filePath = path.join(BY_CRAWLER_DIR, file);
@@ -688,10 +690,10 @@ async function main() {
       if (!crawlerData?.jobs || !Array.isArray(crawlerData.jobs)) continue;
       let fileChanged = false;
       for (const job of crawlerData.jobs) {
-        const outcome = reconcileRetranslationState(job);
-        if (outcome !== 'noop') fileChanged = true;
+        const outcome = reconcileRetranslationState(job, { attempted: false });
+        if (outcome === 'reset' || outcome === 'cleared') fileChanged = true;
         if (outcome === 'cleared') directCleared++;
-        else if (outcome === 'gaveup') directGivenUp++;
+        else if (outcome === 'reset') directReset++;
       }
       if (fileChanged) {
         fs.writeFileSync(filePath, JSON.stringify(crawlerData, null, 2) + '\n', 'utf-8');
@@ -701,8 +703,8 @@ async function main() {
   if (directCleared > 0) {
     console.log(`⚡ Cleared ${directCleared} stale needsRetranslation flags from per-crawler files`);
   }
-  if (directGivenUp > 0) {
-    console.log(`🛑 Suppressed ${directGivenUp} job(s) after ${MAX_RETRANSLATION_ATTEMPTS} failed retranslation runs (locale detectors unsatisfiable)`);
+  if (directReset > 0) {
+    console.log(`♻️  Lifted give-up on ${directReset} re-crawled job(s) (source changed)`);
   }
 
   // Find all jobs needing translation (flagged or incomplete)
@@ -1010,8 +1012,11 @@ async function main() {
 // Importing the module (e.g. from tests, to exercise reconcileRetranslationState /
 // isIncomplete) must NOT trigger a full relocalization that mutates slice files.
 const invokedDirectly = (() => {
-  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
-  catch { return false; }
+  try {
+    const entry = process.argv[1];
+    if (!entry) return false; // node REPL / no script → not a direct invocation
+    return import.meta.url === `file://${entry}` || import.meta.url.endsWith(entry);
+  } catch { return false; }
 })();
 
 if (invokedDirectly) {

--- a/scripts/relocalize-pending-jobs.mjs
+++ b/scripts/relocalize-pending-jobs.mjs
@@ -46,6 +46,13 @@ const LOCALES = ['it', 'en', 'de', 'fr'];
 const MIN_DESC_CHARS = 120;
 const MIN_TITLE_CHARS = 3;
 const DRY_RUN = String(process.env.RELOCALIZE_DRY_RUN || '0') === '1';
+// After this many runs where a flagged job still fails isIncomplete(), give up:
+// LibreTranslate cannot satisfy the locale detectors (proper-noun-heavy text,
+// structural fragments, mixed-language source). Suppress it via
+// `localeMismatchSuppressed` so the flaggers stop re-queuing it every run and
+// it stops starving genuinely-pending jobs. Auto-resets when the source changes
+// (re-crawl) — see needsTranslation() and the direct-scan in run().
+const MAX_RETRANSLATION_ATTEMPTS = 3;
 
 // Parse --max-jobs from CLI args (takes precedence over env var)
 function parseMaxJobs() {
@@ -90,8 +97,70 @@ function readJson(filePath) {
  * Returns true if the job has needsRetranslation flag or incomplete locale coverage.
  */
 function needsTranslation(job) {
+  // Gave up on this job after MAX_RETRANSLATION_ATTEMPTS failed runs. Stay out of
+  // the work pool unless the source content changed since we suppressed it
+  // (re-crawl brings fresh text worth a new attempt).
+  if (job.localeMismatchSuppressed && !sourceChangedSinceSuppression(job)) return false;
   if (job.needsRetranslation) return true;
   return isIncomplete(job);
+}
+
+/**
+ * True if the job's source description length drifted >15% from the snapshot
+ * taken when it was suppressed — i.e. a re-crawl rewrote the content, so the
+ * give-up no longer applies and we should retry.
+ */
+function sourceChangedSinceSuppression(job) {
+  const snap = job.localeMismatchSuppressedLen;
+  if (typeof snap !== 'number') return true; // no snapshot → treat as changed (retry)
+  const now = (job.description || '').trim().length;
+  return Math.abs(now - snap) > snap * 0.15;
+}
+
+/**
+ * Per-run state machine that drives the needsRetranslation give-up cycle.
+ * Mutates `job` in place and returns the outcome. Runs for EVERY job in EVERY
+ * slice on EVERY run (unlike the per-company sync path, which the throughput /
+ * time budget can skip — that gap is what let stuck jobs loop forever).
+ *
+ *   'reset'   — a re-crawl rewrote a suppressed job → give-up lifted, retry
+ *   'cleared' — flagged job now passes isIncomplete() → flag + bookkeeping cleared
+ *   'gaveup'  — flagged job still incomplete after MAX_RETRANSLATION_ATTEMPTS → suppressed
+ *   'counted' — flagged job still incomplete, attempt counter bumped
+ *   'noop'    — nothing to do
+ *
+ * @param {object} job
+ * @returns {'reset'|'cleared'|'gaveup'|'counted'|'noop'}
+ */
+export function reconcileRetranslationState(job) {
+  let outcome = 'noop';
+  // A re-crawl rewrote a previously-suppressed job → drop the give-up so the
+  // fresh content gets a new translation attempt.
+  if (job.localeMismatchSuppressed && sourceChangedSinceSuppression(job)) {
+    delete job.localeMismatchSuppressed;
+    delete job.localeMismatchSuppressedLen;
+    delete job.retranslationAttempts;
+    outcome = 'reset';
+  }
+  if (!job.needsRetranslation) return outcome;
+  if (!isIncomplete(job)) {
+    // Now complete + consistent: clear flag and all give-up bookkeeping.
+    delete job.needsRetranslation;
+    delete job.retranslationAttempts;
+    delete job.localeMismatchSuppressed;
+    delete job.localeMismatchSuppressedLen;
+    return 'cleared';
+  }
+  // Still incomplete after being flagged. Count one give-up attempt for this run.
+  const attempts = (job.retranslationAttempts || 0) + 1;
+  job.retranslationAttempts = attempts;
+  if (attempts >= MAX_RETRANSLATION_ATTEMPTS) {
+    delete job.needsRetranslation;
+    job.localeMismatchSuppressed = true;
+    job.localeMismatchSuppressedLen = (job.description || '').trim().length;
+    return 'gaveup';
+  }
+  return 'counted';
 }
 
 /**
@@ -306,6 +375,8 @@ function clearRetranslationFlags(jobs) {
     if (job.needsRetranslation && !isIncomplete(job)) {
       delete job.needsRetranslation;
       delete job.retranslationAttempts;
+      delete job.localeMismatchSuppressed;
+      delete job.localeMismatchSuppressedLen;
       cleared += 1;
     }
   }
@@ -493,20 +564,24 @@ function syncTranslationsToCrawlerFile(companyKey, assembledJobs) {
       console.log(`     ✅ Cleared needsRetranslation for: ${crawlerJob.slug?.slice(0, 60)}`);
       delete crawlerJob.needsRetranslation;
       delete crawlerJob.retranslationAttempts;
+      delete crawlerJob.localeMismatchSuppressed;
+      delete crawlerJob.localeMismatchSuppressedLen;
       changed = true;
     }
 
-    // Break infinite retry loop: if the pipeline has tried 3+ times and still can't
-    // produce translations that pass isIncomplete(), clear the flag. The job will
-    // be picked up again on its next crawl cycle with fresh source data.
+    // Break infinite retry loop: if the pipeline has tried MAX_RETRANSLATION_ATTEMPTS
+    // times and still can't produce translations that pass isIncomplete(), suppress
+    // the job (localeMismatchSuppressed) so the flaggers stop re-queuing it. Auto-
+    // resets on the next crawl cycle when fresh source data arrives.
     if (crawlerJob.needsRetranslation && isIncomplete(crawlerJob)) {
       const attempts = (crawlerJob.retranslationAttempts || 0) + 1;
       crawlerJob.retranslationAttempts = attempts;
       changed = true;
-      if (attempts >= 3) {
-        console.log(`     ⚠️  Giving up after ${attempts} attempts: ${crawlerJob.slug?.slice(0, 60)}`);
+      if (attempts >= MAX_RETRANSLATION_ATTEMPTS) {
+        console.log(`     🛑 Giving up after ${attempts} attempts: ${crawlerJob.slug?.slice(0, 60)}`);
         delete crawlerJob.needsRetranslation;
-        delete crawlerJob.retranslationAttempts;
+        crawlerJob.localeMismatchSuppressed = true;
+        crawlerJob.localeMismatchSuppressedLen = (crawlerJob.description || '').trim().length;
       }
     }
 
@@ -546,10 +621,11 @@ function incrementRetryCounterOnCrawlerFile(companyKey, handledSlugs) {
     job.retranslationAttempts = attempts;
     changed = true;
 
-    if (attempts >= 3) {
-      console.log(`     ⚠️  Giving up after ${attempts} direct attempts: ${String(job.slug || '').slice(0, 60)}`);
+    if (attempts >= MAX_RETRANSLATION_ATTEMPTS) {
+      console.log(`     🛑 Giving up after ${attempts} direct attempts: ${String(job.slug || '').slice(0, 60)}`);
       delete job.needsRetranslation;
-      delete job.retranslationAttempts;
+      job.localeMismatchSuppressed = true;
+      job.localeMismatchSuppressedLen = (job.description || '').trim().length;
     }
   }
 
@@ -604,6 +680,7 @@ async function main() {
   // Some crawler files have jobs that don't make it into the assembled dataset
   // (e.g. failed quality gate). This runs unconditionally before any early exit.
   let directCleared = 0;
+  let directGivenUp = 0;
   if (fs.existsSync(BY_CRAWLER_DIR)) {
     for (const file of fs.readdirSync(BY_CRAWLER_DIR).filter(f => f.endsWith('.json') && !f.includes('-locale-cache'))) {
       const filePath = path.join(BY_CRAWLER_DIR, file);
@@ -611,11 +688,10 @@ async function main() {
       if (!crawlerData?.jobs || !Array.isArray(crawlerData.jobs)) continue;
       let fileChanged = false;
       for (const job of crawlerData.jobs) {
-        if (job.needsRetranslation && !isIncomplete(job)) {
-          delete job.needsRetranslation;
-          directCleared++;
-          fileChanged = true;
-        }
+        const outcome = reconcileRetranslationState(job);
+        if (outcome !== 'noop') fileChanged = true;
+        if (outcome === 'cleared') directCleared++;
+        else if (outcome === 'gaveup') directGivenUp++;
       }
       if (fileChanged) {
         fs.writeFileSync(filePath, JSON.stringify(crawlerData, null, 2) + '\n', 'utf-8');
@@ -623,7 +699,10 @@ async function main() {
     }
   }
   if (directCleared > 0) {
-    console.log(`⚡ Cleared ${directCleared} stale needsRetranslation flags from per-crawler files\n`);
+    console.log(`⚡ Cleared ${directCleared} stale needsRetranslation flags from per-crawler files`);
+  }
+  if (directGivenUp > 0) {
+    console.log(`🛑 Suppressed ${directGivenUp} job(s) after ${MAX_RETRANSLATION_ATTEMPTS} failed retranslation runs (locale detectors unsatisfiable)`);
   }
 
   // Find all jobs needing translation (flagged or incomplete)
@@ -755,7 +834,8 @@ async function main() {
           const incompleteSlugs = new Set(companyIncomplete.map(j => j.slug).filter(Boolean));
           let flagged = 0;
           for (const cj of crawlerData.jobs) {
-            if (incompleteSlugs.has(cj.slug) && !cj.needsRetranslation && isIncomplete(cj)) {
+            if (incompleteSlugs.has(cj.slug) && !cj.needsRetranslation
+                && !cj.localeMismatchSuppressed && isIncomplete(cj)) {
               cj.needsRetranslation = true;
               cj.retranslationAttempts = 0;
               flagged++;
@@ -926,7 +1006,17 @@ async function main() {
   console.log('✅ Re-localization complete.');
 }
 
-main().catch((err) => {
-  console.error('❌ Re-localization failed:', err?.message || err);
-  process.exit(1);
-});
+// Only run the pipeline when invoked directly (`node scripts/relocalize-pending-jobs.mjs`).
+// Importing the module (e.g. from tests, to exercise reconcileRetranslationState /
+// isIncomplete) must NOT trigger a full relocalization that mutates slice files.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('❌ Re-localization failed:', err?.message || err);
+    process.exit(1);
+  });
+}

--- a/tests/relocalize-suppression-loop.test.ts
+++ b/tests/relocalize-suppression-loop.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs script, no type declarations
+import { reconcileRetranslationState, isIncomplete } from '../scripts/relocalize-pending-jobs.mjs';
+
+/**
+ * Regression gate for the needsRetranslation give-up loop.
+ *
+ * Before the fix, `mark-locale-mismatched-jobs.mjs` re-flagged the same jobs
+ * every run while the per-company give-up only ran for companies the throughput
+ * budget actually processed — so stuck jobs (LibreTranslate can't satisfy the
+ * locale detectors) bounced between flagged and cleared forever, keeping the
+ * backlog pinned at ~2000–5700. reconcileRetranslationState() runs for every
+ * slice every run and suppresses a job after MAX_RETRANSLATION_ATTEMPTS so the
+ * flaggers stop re-queuing it. This test pins that convergence.
+ */
+
+// A job that is permanently incomplete: the EN locale is missing entirely, so
+// isIncomplete() always returns true no matter how many times we "translate".
+function stuckJob() {
+  return {
+    slug: 'stuck-job',
+    sourceLang: 'de',
+    description: 'Allgemeine Informationen über diese Stelle bei einem Schweizer Unternehmen. '.repeat(3),
+    title: 'Pflegefachfrau',
+    needsRetranslation: true,
+    titleByLocale: { de: 'Pflegefachfrau', it: '', en: '', fr: '' },
+    descriptionByLocale: { de: 'x'.repeat(200), it: '', en: '', fr: '' },
+  };
+}
+
+describe('reconcileRetranslationState — give-up convergence', () => {
+  it('a permanently-incomplete flagged job is suppressed after MAX attempts, then stops looping', () => {
+    const job = stuckJob();
+    expect(isIncomplete(job)).toBe(true);
+
+    // Run 1 and 2: attempt counter bumps, still flagged.
+    expect(reconcileRetranslationState(job)).toBe('counted');
+    expect(job.needsRetranslation).toBe(true);
+    expect(reconcileRetranslationState(job)).toBe('counted');
+    expect(job.needsRetranslation).toBe(true);
+
+    // Run 3: give up — flag dropped, suppression marker set.
+    expect(reconcileRetranslationState(job)).toBe('gaveup');
+    expect(job.needsRetranslation).toBeUndefined();
+    expect(job.localeMismatchSuppressed).toBe(true);
+    expect(typeof job.localeMismatchSuppressedLen).toBe('number');
+
+    // Subsequent runs: no flag, source unchanged → no work, no re-flag loop.
+    expect(reconcileRetranslationState(job)).toBe('noop');
+    expect(job.needsRetranslation).toBeUndefined();
+    expect(job.localeMismatchSuppressed).toBe(true);
+  });
+
+  it('a re-crawl (source length drift >15%) lifts the give-up so the job retries', () => {
+    const job = stuckJob();
+    reconcileRetranslationState(job);
+    reconcileRetranslationState(job);
+    reconcileRetranslationState(job); // suppressed
+    expect(job.localeMismatchSuppressed).toBe(true);
+
+    // Re-crawl rewrites the source description (much shorter now).
+    job.description = 'Kurzbeschreibung.';
+    const outcome = reconcileRetranslationState(job);
+    expect(outcome).toBe('reset');
+    expect(job.localeMismatchSuppressed).toBeUndefined();
+    expect(job.retranslationAttempts).toBeUndefined();
+  });
+
+  it('a flagged job that becomes complete is cleared, not suppressed', () => {
+    const job = {
+      slug: 'recovered',
+      sourceLang: 'it',
+      description: 'Descrizione completa della posizione lavorativa presso un ospedale ticinese con molte responsabilità cliniche e gestionali quotidiane.',
+      title: 'Infermiere',
+      needsRetranslation: true,
+      retranslationAttempts: 2,
+      titleByLocale: {
+        it: 'Infermiere diplomato',
+        en: 'Registered nurse specialist',
+        de: 'Diplomierte Pflegefachperson',
+        fr: 'Infirmier diplômé spécialisé',
+      },
+      descriptionByLocale: {
+        it: 'Descrizione completa della posizione lavorativa presso un ospedale ticinese con responsabilità cliniche e organizzative quotidiane molto importanti.',
+        en: 'Full description of the clinical nursing position at a hospital with substantial daily clinical and organisational responsibilities for the whole ward.',
+        de: 'Vollständige Beschreibung der pflegerischen Stelle in einem Krankenhaus mit erheblicher täglicher klinischer und organisatorischer Verantwortung im Team.',
+        fr: 'Description complète du poste de soins infirmiers dans un hôpital avec des responsabilités cliniques et organisationnelles quotidiennes très importantes ici.',
+      },
+    };
+    // Only assert the clearing path if the fixture is genuinely complete by the
+    // production detector; otherwise the give-up path is the correct behaviour.
+    if (!isIncomplete(job)) {
+      expect(reconcileRetranslationState(job)).toBe('cleared');
+      expect(job.needsRetranslation).toBeUndefined();
+      expect(job.retranslationAttempts).toBeUndefined();
+      expect(job.localeMismatchSuppressed).toBeUndefined();
+    }
+  });
+});

--- a/tests/relocalize-suppression-loop.test.ts
+++ b/tests/relocalize-suppression-loop.test.ts
@@ -9,9 +9,13 @@ import { reconcileRetranslationState, isIncomplete } from '../scripts/relocalize
  * every run while the per-company give-up only ran for companies the throughput
  * budget actually processed — so stuck jobs (LibreTranslate can't satisfy the
  * locale detectors) bounced between flagged and cleared forever, keeping the
- * backlog pinned at ~2000–5700. reconcileRetranslationState() runs for every
- * slice every run and suppresses a job after MAX_RETRANSLATION_ATTEMPTS so the
- * flaggers stop re-queuing it. This test pins that convergence.
+ * backlog pinned at ~2000–5700.
+ *
+ * The give-up counter must ONLY advance when a translation was actually attempted
+ * on a job (`attempted: true`) — never for mere queue presence (`attempted:
+ * false`), or the un-reached backlog (relocalize runs --max-jobs 100 against
+ * thousands of flagged jobs) would be mass-suppressed, freezing source-language
+ * text on IT/EN/FR pages. These tests pin both halves.
  */
 
 // A job that is permanently incomplete: the EN locale is missing entirely, so
@@ -29,44 +33,54 @@ function stuckJob() {
 }
 
 describe('reconcileRetranslationState — give-up convergence', () => {
-  it('a permanently-incomplete flagged job is suppressed after MAX attempts, then stops looping', () => {
+  it('an ATTEMPTED, permanently-incomplete job is suppressed after MAX attempts, then stops looping', () => {
     const job = stuckJob();
     expect(isIncomplete(job)).toBe(true);
 
-    // Run 1 and 2: attempt counter bumps, still flagged.
-    expect(reconcileRetranslationState(job)).toBe('counted');
+    // Runs 1 and 2: a real translation was attempted and failed → counter bumps.
+    expect(reconcileRetranslationState(job, { attempted: true })).toBe('counted');
     expect(job.needsRetranslation).toBe(true);
-    expect(reconcileRetranslationState(job)).toBe('counted');
+    expect(reconcileRetranslationState(job, { attempted: true })).toBe('counted');
     expect(job.needsRetranslation).toBe(true);
 
     // Run 3: give up — flag dropped, suppression marker set.
-    expect(reconcileRetranslationState(job)).toBe('gaveup');
+    expect(reconcileRetranslationState(job, { attempted: true })).toBe('gaveup');
     expect(job.needsRetranslation).toBeUndefined();
     expect(job.localeMismatchSuppressed).toBe(true);
     expect(typeof job.localeMismatchSuppressedLen).toBe('number');
 
     // Subsequent runs: no flag, source unchanged → no work, no re-flag loop.
-    expect(reconcileRetranslationState(job)).toBe('noop');
-    expect(job.needsRetranslation).toBeUndefined();
+    expect(reconcileRetranslationState(job, { attempted: true })).toBe('noop');
     expect(job.localeMismatchSuppressed).toBe(true);
   });
 
-  it('a re-crawl (source length drift >15%) lifts the give-up so the job retries', () => {
+  it('an UN-ATTEMPTED incomplete job is NEVER suppressed — it stays queued (no mass-suppression of the backlog)', () => {
     const job = stuckJob();
-    reconcileRetranslationState(job);
-    reconcileRetranslationState(job);
-    reconcileRetranslationState(job); // suppressed
-    expect(job.localeMismatchSuppressed).toBe(true);
-
-    // Re-crawl rewrites the source description (much shorter now).
-    job.description = 'Kurzbeschreibung.';
-    const outcome = reconcileRetranslationState(job);
-    expect(outcome).toBe('reset');
+    // Simulate many runs where the throughput budget never reaches this job.
+    for (let i = 0; i < 10; i++) {
+      expect(reconcileRetranslationState(job, { attempted: false })).toBe('waiting');
+    }
+    // Still flagged, never counted, never suppressed → drains later via throughput.
+    expect(job.needsRetranslation).toBe(true);
     expect(job.localeMismatchSuppressed).toBeUndefined();
     expect(job.retranslationAttempts).toBeUndefined();
   });
 
-  it('a flagged job that becomes complete is cleared, not suppressed', () => {
+  it('a re-crawl (source length drift >15%) lifts the give-up so the job retries', () => {
+    const job = stuckJob();
+    reconcileRetranslationState(job, { attempted: true });
+    reconcileRetranslationState(job, { attempted: true });
+    reconcileRetranslationState(job, { attempted: true }); // suppressed
+    expect(job.localeMismatchSuppressed).toBe(true);
+
+    // Re-crawl rewrites the source description (much shorter now).
+    job.description = 'Kurzbeschreibung.';
+    expect(reconcileRetranslationState(job, { attempted: false })).toBe('reset');
+    expect(job.localeMismatchSuppressed).toBeUndefined();
+    expect(job.retranslationAttempts).toBeUndefined();
+  });
+
+  it('a flagged job that is now complete is cleared (not suppressed), regardless of attempted', () => {
     const job = {
       slug: 'recovered',
       sourceLang: 'it',
@@ -87,13 +101,13 @@ describe('reconcileRetranslationState — give-up convergence', () => {
         fr: 'Description complète du poste de soins infirmiers dans un hôpital avec des responsabilités cliniques et organisationnelles quotidiennes très importantes ici.',
       },
     };
-    // Only assert the clearing path if the fixture is genuinely complete by the
-    // production detector; otherwise the give-up path is the correct behaviour.
-    if (!isIncomplete(job)) {
-      expect(reconcileRetranslationState(job)).toBe('cleared');
-      expect(job.needsRetranslation).toBeUndefined();
-      expect(job.retranslationAttempts).toBeUndefined();
-      expect(job.localeMismatchSuppressed).toBeUndefined();
-    }
+    // The fixture must be genuinely complete by the production detector — assert
+    // it so a detector change can't turn the test below into a vacuous no-op.
+    expect(isIncomplete(job)).toBe(false);
+
+    expect(reconcileRetranslationState(job, { attempted: false })).toBe('cleared');
+    expect(job.needsRetranslation).toBeUndefined();
+    expect(job.retranslationAttempts).toBeUndefined();
+    expect(job.localeMismatchSuppressed).toBeUndefined();
   });
 });

--- a/tests/relocalize-suppression-loop.test.ts
+++ b/tests/relocalize-suppression-loop.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
-// @ts-expect-error — plain .mjs script, no type declarations
-import { reconcileRetranslationState, isIncomplete } from '../scripts/relocalize-pending-jobs.mjs';
+import {
+  reconcileRetranslationState,
+  isIncomplete,
+  snapshotCompanySignatures,
+  changedSlugsSince,
+  // @ts-expect-error — plain .mjs script, no type declarations
+} from '../scripts/relocalize-pending-jobs.mjs';
 
 /**
  * Regression gate for the needsRetranslation give-up loop.
@@ -109,5 +114,32 @@ describe('reconcileRetranslationState — give-up convergence', () => {
     expect(job.needsRetranslation).toBeUndefined();
     expect(job.retranslationAttempts).toBeUndefined();
     expect(job.localeMismatchSuppressed).toBeUndefined();
+  });
+});
+
+describe('attempted-detection — only crawler-touched jobs count as attempted', () => {
+  // Pins the call-site wiring: relocalize runs --max-jobs N against a company
+  // slice with more flagged jobs than the budget reaches. Only the jobs whose
+  // locale content actually changed must be marked attempted; the un-reached
+  // tail must NOT be (else it gets mass-suppressed).
+  it('changedSlugsSince returns only the jobs whose locale content changed', () => {
+    const before = [
+      { slug: 'reached', companyKey: 'acme', titleByLocale: { it: 'A' }, descriptionByLocale: { it: 'x' } },
+      { slug: 'untouched', companyKey: 'acme', titleByLocale: { it: 'B' }, descriptionByLocale: { it: 'y' } },
+      { slug: 'other-co', companyKey: 'globex', titleByLocale: { it: 'C' }, descriptionByLocale: { it: 'z' } },
+    ];
+    const snap = snapshotCompanySignatures(before, 'acme');
+
+    // Crawler translated only 'reached'; 'untouched' (budget-unreached) is unchanged.
+    const after = [
+      { slug: 'reached', companyKey: 'acme', titleByLocale: { it: 'A', en: 'A-en' }, descriptionByLocale: { it: 'x', en: 'x-en' } },
+      { slug: 'untouched', companyKey: 'acme', titleByLocale: { it: 'B' }, descriptionByLocale: { it: 'y' } },
+      { slug: 'other-co', companyKey: 'globex', titleByLocale: { it: 'C', en: 'C-en' }, descriptionByLocale: { it: 'z' } },
+    ];
+    const attempted = changedSlugsSince(snap, after, 'acme');
+
+    expect(attempted.has('reached')).toBe(true);
+    expect(attempted.has('untouched')).toBe(false); // un-reached tail → never suppressed
+    expect(attempted.has('other-co')).toBe(false);  // different company, ignored
   });
 });


### PR DESCRIPTION
## Contesto

Indagine partita da "perché trovo sempre >3000 pending translate". Il numero **non è** pending da tradurre: è il contatore `needsRetranslation`. Le due metriche di `log-translation-stats` venivano lette insieme:

- **pending** reali (mancano traduzioni): ~160–360, drenano correttamente.
- **needsRetranslation** (flag locale-mismatch): oscillava 2000↔5700, mai a zero.

Scomposizione dei ~2184 flagged (origin/main):

| Bucket | N | % |
|---|---|---|
| Non tradotti (locali = copia source) | 1537 | 70% |
| Completi + detector-clean, flag fantasma | 533 | 24% |
| 1 locale sbagliato | 12 | <1% |
| Distinti ma ≥2 locali sospetti (rotti + falsi-positivi) | 102 | 5% |

**Root cause del loop:** `mark-locale-mismatched-jobs.mjs` e il quality-gate di `assemble` ri-aggiungono il flag a ogni run, mentre il give-up per-company girava **solo sulle company che il budget throughput/tempo processa davvero**. I job stuck (LibreTranslate non soddisfa i detector) non avanzavano mai il contatore tentativi → loop infinito.

## Implementato

- **Give-up gated su tentativi reali** (`reconcileRetranslationState(job, { attempted })`, pura + esportata): il direct-scan su ogni slice gira con `attempted:false` → solo reset + clear dei flag su job ora completi e lift della soppressione sui re-crawlati; ritorna `'waiting'` sui job ancora incompleti, **mai** suppress. Il counter del give-up avanza **solo** nei path per-company (`syncTranslationsToCrawlerFile` / `incrementRetryCounterOnCrawlerFile`), che girano sui job davvero tradotti nel run. Dopo `MAX_RETRANSLATION_ATTEMPTS` (3) tentativi reali falliti → marker durevole `localeMismatchSuppressed` + snapshot lunghezza source.
- **`needsTranslation()`**: i job suppressi restano fuori dal pool finché un re-crawl non fa driftare la lunghezza source >15% (auto-reset).
- **Flagger rispettano il marker**: `mark-locale-mismatched-jobs.mjs`, quality-gate di `assemble-jobs-dataset.mjs` e `flag-wrong-locale-descriptions.mjs` saltano i job suppressi → niente ri-flagging.
- **Carry-over al re-crawl**: `dedicated-crawler-common.mjs` propaga `localeMismatchSuppressed` / `localeMismatchSuppressedLen` / `retranslationAttempts` su `fresh`, così il re-crawl non perde il marker (il reset resta gated dal drift >15%).
- **Reset su content-change**: lo slug-collision guard di `assemble` azzera la soppressione quando invalida un titolo (lavoro genuino di nuovo necessario).
- **Visibilità**: `log-translation-stats` riporta un contatore `suppressed` nello storico per monitorare il fix.
- **Guard `main()` invoked-directly** (hardened contro `argv[1]` vuoto): il modulo è importabile dai test senza triggerare una relocalizzazione reale.
- **Test** `tests/relocalize-suppression-loop.test.ts`: convergenza give-up (attempted), **job non-attempted mai soppresso** (regression del finding #1), reset su re-crawl, path 'cleared' non-vacuo (`isIncomplete(fixture)===false` asserito).

**Atteso (corretto post-review):** il give-up conta solo i **tentativi reali** (job davvero tradotti nel run), non la presenza in coda → niente soppressione di massa del backlog non processato. Il contatore `needsRetranslation` **cala gradualmente** man mano che il throughput sopprime solo i job irreparabili (≥3 tentativi reali falliti); il backlog traducibile (~1537) resta in coda e drena via traduzione. Sparisce l'oscillazione del re-flag loop (niente più spike a 5700). La traduzione vera è invariata.

## Non implementato (ancora)

- **Throughput sul backlog reale (~1537 non tradotti, 70%)** — out of scope: limite di velocità (cap `--max-jobs`, time-budget, lentezza LibreTranslate) vs inflow giornaliero, non il loop. Correlato a #1000 (tradurre descrizioni source-copy tedesche), che resta valido e separato. Non `Closes`.
- **Detector false-positive tuning** (soglia 0.5 di `mark` vs 0.65 di `isIncomplete`): non toccato; il give-up durevole neutralizza il loop a valle senza ritoccare i detector. Possibile follow-up per ridurre i tentativi sprecati pre-soppressione.
- **Verifica live**: da osservare sul prossimo cron `translate-pending` post-merge (nuovo campo `suppressed` nello storico).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
