### PR TITLE
docs(agents): MCP usage rules to cut retry-rework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,8 @@ Iniettato in ogni sessione agent. Detail durevole nei docs, carica on-demand.
 - Mai `send-newsletter.mjs --send` locale. Usa `--preview` o `--test --target-email <email>`.
 - Nuovi GitHub Actions workflow → run live su `main` post-merge: `gh workflow run <workflow>.yml --ref main`.
 - E2E: Playwright CLI o Codex Browser. No preview-only tools.
-- Touch function/class/method → GitNexus impact analysis prima. Pre-commit → GitNexus detect changes.
+- Playwright MCP (`browser_*`): artifact (screenshot/network dump) SOLO in `$CLAUDE_JOB_DIR/tmp` o worktree root — MAI `/tmp` (fuori allowed-roots → "File access denied") né `file://` (protocol blocked, servi via http). Prima di `browser_click`/`browser_evaluate` su pagina dinamica → `browser_snapshot` fresco (ref vecchi → "Ref eXXX not found"). MCP gira `--isolated` (profilo in-memory) → niente lock "Browser already in use" tra job paralleli.
+- Touch function/class/method → GitNexus impact analysis prima. Pre-commit → GitNexus detect changes. **In worktree** passa esplicito `repo:"frontaliere-si-o-no"` a `detect_changes`/`impact`/`context`: l'index è keyed sul nome del repo principale, l'auto-detect manda il path del worktree → `Repository "...wt..." not found. Available: frontaliere-si-o-no`.
 - Mai full build locale; trigger/validate via GitHub Actions.
 
 ## Post-merge feedback handling


### PR DESCRIPTION
## Implementato

Evidence-based fix da audit retry-correlation (321 sessioni, ogni tool_use→tool_result pairato per id). Per-call error rate reale: gitnexus 5.1% (5/99), playwright 6.5% (45/689) — il report 51%/50% "edit-turn" era confounding, non causazione.

**AGENTS.md — 2 regole d'uso (zero capability rimossa):**
- **gitnexus**: in worktree passare esplicito `repo:"frontaliere-si-o-no"` a `detect_changes`/`impact`/`context`. Tutti i 5 errori gitnexus erano `Repository "...wt..." not found` (auto-detect manda il path del worktree, l'index è keyed sul nome repo). `impact`/`context`/`query` = 0 errori. gitnexus è un confounder puro: CLAUDE.md lo mandata prima di ogni edit → presente nel ~100% degli edit-turn per policy, ride i retry, non li causa.
- **playwright**: artifact SOLO in `$CLAUDE_JOB_DIR/tmp`/worktree (mai `/tmp`/`file://`); `browser_snapshot` fresco prima di click/evaluate. Copre 8 root-denied + 6 ENOENT + 2 file:// + stale-ref.

**Plugin config (locale, fuori repo — già applicato):** `@playwright/mcp` lanciato con `--isolated` (profilo in-memory) → elimina i 9 errori "Browser already in use" tra job paralleli. File: `~/.claude/plugins/.../playwright/.mcp.json` (cache + marketplace).

## Non implementato (ancora)

- **Selettori ambigui / page-closed-mid-call / bad-arg-schema (browser_evaluate)** (~12/45 errori playwright): comportamento model, non difetto capability né config → fuori scope di una regola statica. Follow-up se ricorrenti.
- **Nessuna capability rimossa** per design: il report era esplicito "not causation". Entrambi i server restano.
- **Playwright `--isolated` non è in-repo**: config plugin-managed, applicata localmente; non versionabile qui.