### PR TITLE
fix(test): time-relative cleanup-jobs dedup fixtures — unblock main-red

### DIFF
--- a/tests/cleanup-jobs-archive-dedup-losers.test.ts
+++ b/tests/cleanup-jobs-archive-dedup-losers.test.ts
@@ -140,6 +140,16 @@ function buildJob(overrides: Partial<CleanupSliceJob> & Pick<CleanupSliceJob, 'i
   };
 }
 
+// Recency relative to "now" so fixtures never age past cleanup-jobs.mjs's
+// 60-day stale-prune, which runs BEFORE slug-dedup. Absolute dates here were a
+// time-bomb: once they crossed the 60-day window the older job was pruned as
+// stale instead of archived as a dedup-loser, so the archive assertions went
+// red on a pure calendar boundary (last green 2026-05-30, red 2026-06-01).
+// Keep the relative ordering — the winner is the most recent crawl.
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 86_400_000).toISOString();
+}
+
 describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', () => {
   it('keeps a job when the canonical URL is dead but applyUrl is live', async () => {
     const server = http.createServer((req, res) => {
@@ -200,13 +210,13 @@ describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', 
         id: 'job-loser-001',
         slug: 'engineer-lugano',
         title: 'Engineer Lugano (older)',
-        crawledAt: '2026-04-01T00:00:00.000Z',
+        crawledAt: daysAgo(10),
       }),
       buildJob({
         id: 'job-winner-002',
         slug: 'engineer-lugano',
         title: 'Engineer Lugano (winner)',
-        crawledAt: '2026-04-05T00:00:00.000Z',
+        crawledAt: daysAgo(5),
       }),
       buildJob({
         id: 'job-unique-003',
@@ -214,7 +224,7 @@ describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', 
         title: 'Designer Bellinzona',
         location: 'Bellinzona',
         addressLocality: 'Bellinzona',
-        crawledAt: '2026-04-04T00:00:00.000Z',
+        crawledAt: daysAgo(7),
       }),
     ];
 
@@ -275,13 +285,13 @@ describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', 
         id: 'job-A',
         slug: 'role-shared',
         title: 'Role A',
-        crawledAt: '2026-04-01T00:00:00.000Z',
+        crawledAt: daysAgo(10),
       }),
       buildJob({
         id: 'job-B',
         slug: 'role-shared',
         title: 'Role B',
-        crawledAt: '2026-04-05T00:00:00.000Z',
+        crawledAt: daysAgo(5),
       }),
     ];
 
@@ -316,7 +326,7 @@ describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', 
       id: 'job-A',
       slug: 'role-shared',
       title: 'Role A',
-      crawledAt: '2026-04-01T00:00:00.000Z',
+      crawledAt: daysAgo(10),
     }));
     fs.writeFileSync(slicePath, JSON.stringify({ crawlerKey, jobs: keptJobs }, null, 2), 'utf-8');
 
@@ -341,7 +351,7 @@ describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', 
           id: 'job-loser',
           slug: 'lead-engineer',
           title: 'Lead Engineer (loser)',
-          crawledAt: '2026-04-01T00:00:00.000Z',
+          crawledAt: daysAgo(10),
         }),
         previousSlugs: ['legacy-lead-engineer-2025'],
       },
@@ -349,7 +359,7 @@ describe('cleanup-jobs slice mode — archives within-slice slug-dedup losers', 
         id: 'job-winner',
         slug: 'lead-engineer',
         title: 'Lead Engineer (winner)',
-        crawledAt: '2026-04-05T00:00:00.000Z',
+        crawledAt: daysAgo(5),
       }),
     ];
 
@@ -390,13 +400,13 @@ describe('cleanup-jobs standard mode — archives within-slice slug-dedup losers
         id: 'std-loser',
         slug: 'data-scientist-lugano',
         title: 'Data Scientist Lugano (loser)',
-        crawledAt: '2026-04-01T00:00:00.000Z',
+        crawledAt: daysAgo(10),
       }),
       buildJob({
         id: 'std-winner',
         slug: 'data-scientist-lugano',
         title: 'Data Scientist Lugano (winner)',
-        crawledAt: '2026-04-05T00:00:00.000Z',
+        crawledAt: daysAgo(5),
       }),
       buildJob({
         id: 'std-unique',
@@ -404,7 +414,7 @@ describe('cleanup-jobs standard mode — archives within-slice slug-dedup losers
         title: 'Designer Bellinzona',
         location: 'Bellinzona',
         addressLocality: 'Bellinzona',
-        crawledAt: '2026-04-04T00:00:00.000Z',
+        crawledAt: daysAgo(7),
       }),
     ];
 

--- a/tests/cleanup-jobs-slug-dedup-audit.test.ts
+++ b/tests/cleanup-jobs-slug-dedup-audit.test.ts
@@ -58,6 +58,15 @@ async function runCleanup(slicePath: string, expiredDir: string): Promise<RunRes
   });
 }
 
+// Recency relative to "now" so fixtures never age past cleanup-jobs.mjs's
+// 60-day stale-prune, which runs BEFORE slug-dedup. Absolute dates were a
+// time-bomb: once past the 60-day window the older jobs were pruned as stale
+// instead of surfacing as slug collisions, so the audit-count line went red on
+// a pure calendar boundary. Keep relative ordering — the newest crawl wins.
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 86_400_000).toISOString();
+}
+
 describe('cleanup-jobs slice slug dedup audit logging', () => {
   it('logs a clear count line listing within-slice slug collisions', async () => {
     const dir = makeTempDir();
@@ -79,7 +88,7 @@ describe('cleanup-jobs slice slug dedup audit logging', () => {
           title: 'Engineer Lugano (older)',
           company: 'TestCo',
           location: 'Lugano',
-          crawledAt: '2026-04-01T00:00:00.000Z',
+          crawledAt: daysAgo(10),
         },
         {
           id: 'job-2-newest',
@@ -88,7 +97,7 @@ describe('cleanup-jobs slice slug dedup audit logging', () => {
           title: 'Engineer Lugano (newest)',
           company: 'TestCo',
           location: 'Lugano',
-          crawledAt: '2026-04-05T00:00:00.000Z',
+          crawledAt: daysAgo(5),
         },
         {
           id: 'job-3-mid',
@@ -97,7 +106,7 @@ describe('cleanup-jobs slice slug dedup audit logging', () => {
           title: 'Engineer Lugano (middle)',
           company: 'TestCo',
           location: 'Lugano',
-          crawledAt: '2026-04-03T00:00:00.000Z',
+          crawledAt: daysAgo(8),
         },
         {
           id: 'job-4-unique',
@@ -106,7 +115,7 @@ describe('cleanup-jobs slice slug dedup audit logging', () => {
           title: 'Designer Bellinzona',
           company: 'TestCo',
           location: 'Bellinzona',
-          crawledAt: '2026-04-04T00:00:00.000Z',
+          crawledAt: daysAgo(7),
         },
       ],
     };


### PR DESCRIPTION
## Implementato
- **Root cause main-red trovata e fixata.** I test `cleanup-jobs-archive-dedup-losers` (4 fail) e `cleanup-jobs-slug-dedup-audit` (1 fail) hardcodavano `crawledAt: '2026-04-0X'`. `scripts/cleanup-jobs.mjs` esegue lo **stale-prune >60 giorni PRIMA** dello slug-dedup: oggi (2026-06-01) quelle date superano i 60gg → il job più vecchio viene rimosso come stale invece di essere archiviato come dedup-loser → le asserzioni archive/audit diventano rosse su **puro confine di calendario** (verde 2026-05-30, rosso 2026-06-01), senza alcuna modifica al codice.
- Sostituite le date assolute con `daysAgo(n)` (relative a now), preservando l'ordine di recency (winner = crawl più recente). **Codice di produzione invariato.** Verificato in locale: **6/6 verde**.
- **Impatto sistemico:** main rosso bloccava OGNI auto-merge via il guard #1005 (vitest-red) → pipeline ferma, backlog non drenabile, PR #1002/#1031/#1032/#1033 tutte bloccate. Questo le sblocca a cascata.

## Non implementato (ancora)
- **Sweep di altri time-bomb test** con date assolute nei fixture (stessa classe, potrebbero scadere): non incluso per restare chirurgico (AGENTS.md #6). Se vuoi, follow-up con un grep `crawledAt: '20..-..'` su tutta la suite.
- Nessuna modifica alla soglia 60gg dello stale-prune (è corretta as-is; il bug era nei fixport, non nel gate — AGENTS.md #1/#5 rispettati).