### PR TITLE
docs(process): encode 2026-06-01 pipeline learnings (token burn + main-red)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,9 @@ gh workflow run audit-dist-from-run.yml -f deploy_run_id=<run_id> -f audits=<aud
 
 CI test gate: `npm ci`, `node scripts/assemble-jobs-dataset.mjs --stats`, `node scripts/migrate-all-known-job-slugs-canton-aware.mjs`, `npm test`.
 
+- **Test fixture: mai date assolute.** Test con pipeline a stale-prune temporale (es. `cleanup-jobs.mjs`, soglia 60gg) → `crawledAt`/`datePosted` **relativi a now** (`daysAgo(n)`), mai literal tipo `'2026-04-01'`. Date hardcoded = time-bomb: superata la soglia il job viene pruned-stale invece di seguire il path testato → suite rossa su **puro confine di calendario**, senza code change (outage main-red 2026-06-01, fix #1035: green 05-30 → red 06-01 quando le date crossarono i 60gg).
+- **main rosso blocca a cascata.** `auto-merge-on-lgtm` fira su `## LGTM` **senza attendere vitest**, ma il vitest-red su `main` resta e **ogni branch lo eredita** finché non fa `merge origin/main`. Quindi un main rosso ferma di fatto il drain (PR mergiano red, la red non si pulisce). Priorità assoluta: tenere `main` verde; se rosso, fixare la root cause prima di ogni altro lavoro di pipeline.
+
 ## Architecture
 
 - React 19 + TypeScript + Vite + Tailwind.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -85,7 +85,12 @@ Trigger sull'aggiunta della label `agent:fix`. La label È il consenso. Può met
 
 - Root cause non determinabile con confidenza → commento "serve indagine umana" + termina.
 - Fix richiede credenziali/segreti non in CI → documenta + termina.
+- **Capability-guard scope `.github/workflows/**` (valuta a turno ~1, PRIMA di implementare).** L'ambiente `issue-fix` ha solo `GH_TOKEN` (GitHub App, **senza scope `workflows`**) e nessun PAT → il push di file workflow fallisce **sempre**. Se la diagnosi mostra che il fix toccherebbe `.github/workflows/**` → posta il diff proposto + "serve PAT con scope `workflows` / mano umana" e **TERMINA SUBITO**, senza implementare. Idem per repo-setting/branch-protection/admin-API (es. `gh api .../branches/main/protection` → 403). Razionale (misurato): fare il fix completo e scoprire il blocco al push spreca ~1M token/run — #983 tier-high opus, 23 turni, $0.55, **0 PR**; contro #1009 early-exit normal, 7 turni, $0.22. Il guard è nel prompt di `issue-fix.yml` (#1033).
 - Mai un fix speculativo pur di produrre una PR.
+
+### Drenare il backlog `agent:fix` (re-label sequenziale)
+
+`issue-fix` ha `concurrency: { group: issue-fix, cancel-in-progress: false }`: GitHub tiene **un solo run pending** per gruppo e un nuovo trigger **cancella (supersede) il pending precedente**. Re-labelare in raffica N issue → sopravvivono solo la prima (già `in_progress`) e l'ultima (pending); quelle in mezzo finiscono `cancelled` **silenziosamente** (osservato: #974/#959/#960 droppate). Per ri-processare più issue: re-applica `agent:fix` **una alla volta**, aspettando che la precedente sia almeno `in_progress` prima della successiva. È anche la protezione anti-pile-up (no N agent concorrenti = no OOM / no burst quota Max condivisa).
 
 ## Local fixer (`/fix-issue N`)
 


### PR DESCRIPTION
## Implementato
Codifica nei doc-contract di 3 scoperte fatte oggi osservando la pipeline issue-fix/triage/reviewer (drain backlog + token observation):

- **AGENTS.md → Build And Test**: (1) test fixture **mai con date assolute** — i test `cleanup-jobs` dedup hardcodavano `2026-04-..` che hanno superato lo stale-prune 60gg → main rosso su puro confine di calendario (fix #1035, nessun code change). (2) **main rosso blocca a cascata**: auto-merge fira su `## LGTM` senza attendere vitest → ogni branch eredita il red finché non `merge origin/main`.
- **ISSUES.md → Abort senza PR**: **capability-guard scope `.github/workflows/**`** — `issue-fix` ha `GH_TOKEN` senza scope `workflows` e niente PAT → fix su file workflow non pushabili, deve early-exit a turno ~1 (misurato: #983 ~1M token/$0.55 per 0 PR vs #1009 early-exit $0.22). Guard già live in #1033.
- **ISSUES.md → nuova subsection**: drenare il backlog `agent:fix` richiede **re-label sequenziale** — la concurrency `issue-fix` tiene 1 pending e supersede-cancella il resto; il batch a raffica droppa silenziosamente le issue di mezzo (osservato #974/#959/#960).

## Non implementato (ancora)
- Nessun cambio di codice/comportamento: solo documentazione (8 righe, +0 -0 logica).
- Possibile follow-up: abbassare il tier di `.github/workflows/`-scope da high→normal in `issue-fix.yml` (col guard early-exit, opus su quel turno-1 è sprecato) — fuori scope qui (è code change, non doc).