### PR TITLE
fix(seo-clusters): honest geo label, relevance floor, term + CSP cleanup

### DIFF
--- a/build-plugins/htmlTemplate.ts
+++ b/build-plugins/htmlTemplate.ts
@@ -18,16 +18,17 @@ import { FAVICON_LINKS, GTAG_SNIPPET, ADSENSE_SNIPPET, BASE_URL, SPA_ACTION_REDI
  *  - Referrer-Policy: limits referrer info leaked to third parties.
  *  - Permissions-Policy: disables sensor APIs we don't use.
  *  - Content-Security-Policy: `upgrade-insecure-requests` auto-upgrades any
- *    stray http:// asset to https:// + `frame-ancestors 'self'` blocks
- *    clickjacking (modern replacement for X-Frame-Options).
- *  NOTE: HSTS cannot be set via meta tag — requires a real HTTP header,
- *  not supported by GitHub Pages. Future: Cloudflare proxy / edge worker.
+ *    stray http:// asset to https:// (this directive works via <meta>).
+ *  NOTE: frame-ancestors (anti-clickjacking) and HSTS are IGNORED when set via
+ *  <meta> (spec: header-only) — they logged a console error on every page load
+ *  and enforced nothing, so they are omitted. Real anti-framing/HSTS needs an
+ *  HTTP-header layer (future: Cloudflare proxy / edge worker).
  *  Restrictive script-src/style-src deliberately omitted — would break
  *  Firebase, AdSense, PostHog, Clarity, GTM and Vite inline styles.
  */
 export const HEAD_PREFIX = `<meta charset="utf-8">
  <meta name="viewport" content="width=device-width,initial-scale=1">
- <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests; frame-ancestors 'self';">
+ <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests;">
  <meta http-equiv="X-Content-Type-Options" content="nosniff">
  <meta name="referrer" content="strict-origin-when-cross-origin">
  <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -684,7 +684,7 @@ class TokenIndex {
    * corpus-order tie breaks. The page only renders MAX_JOBS_PER_PAGE jobs, so
    * avoid materializing/sorting the full match universe for every candidate.
    */
-  matchingJobs(locale: Locale, tokens: readonly string[], maxJobs: number): RawJob[] {
+  matchingJobs(locale: Locale, tokens: readonly string[], maxJobs: number, minOrScore = 1): RawJob[] {
     const __tPostings = profileStart();
     const lists = tokens.map((tok) => this.postings(locale, tok));
     profileRecord('bc:mj-postings-batch', __tPostings);
@@ -702,7 +702,7 @@ class TokenIndex {
     profileRecord('bc:mj-and', __tAnd);
     if (matchingIdx.length < maxJobs) {
       const __tOr = profileStart();
-      this.fillOrMatches(lists, tokens.length, matchingIdx, maxJobs);
+      this.fillOrMatches(lists, tokens.length, matchingIdx, maxJobs, minOrScore);
       profileRecord('bc:mj-or', __tOr);
     }
 
@@ -815,6 +815,7 @@ class TokenIndex {
     fullScore: number,
     out: number[],
     maxJobs: number,
+    minScore: number,
   ): void {
     const scores = this.scratchScores;
     const touched = this.touchedIdx;
@@ -834,7 +835,14 @@ class TokenIndex {
     // the sort variant added +11s across 161,542 OR-merge calls vs the
     // straight scan. Keep the scan; the scratchScores typed array is
     // cache-friendly and bounded by jobs.length (5819).
-    for (let score = fullScore - 1; score >= 1 && out.length < maxJobs; score--) {
+    // `minScore` is the relevance floor: OR-fill only appends jobs matching at
+    // least this many query tokens. For multi-token *content* queries it is 2,
+    // so a job matching only the generic role word ("responsabile") but not the
+    // domain word ("neurologia") is no longer pulled in — that single-token
+    // OR-fill is what flooded "Responsabile Neurologia" with Chef de Rang / Spa
+    // / Vendite listings. For single-content-token queries (e.g. "koch davos",
+    // where the city token is droppable) it stays 1 to preserve recovery.
+    for (let score = fullScore - 1; score >= minScore && out.length < maxJobs; score--) {
       for (let idx = 0; idx < scores.length && out.length < maxJobs; idx++) {
         if (scores[idx] === score) out.push(idx);
       }
@@ -924,11 +932,27 @@ function buildClusterContext(
   // then selects only the first MAX_JOBS_PER_PAGE results in the same order as
   // the former full Map+sort path: AND matches in corpus order, then OR
   // matches by score desc with corpus-order tie breaks.
+  // Relevance floor for OR-fill. The recovery case the OR-fill exists for
+  // drops a *city* token ("koch davos" → surface "koch" jobs); the pollution
+  // case drops a *domain* token ("responsabile neurologia" → surface bare
+  // "responsabile" jobs). Distinguish via the city-stripped keyword: when it
+  // still carries ≥2 content tokens, require ≥2 token matches so a single
+  // generic token can't pull in off-topic listings. Single-content-token
+  // keywords keep minScore=1 so the legitimate city-drop recovery still works.
+  const keywordTokenCount = tokenizeQuery(keyword).length;
+  const minOrScore = keywordTokenCount >= 2 ? 2 : 1;
+
   const __tMatch = profileStart();
-  const matching = index.matchingJobs(candidate.locale, tokens, MAX_JOBS_PER_PAGE);
+  const matching = index.matchingJobs(candidate.locale, tokens, MAX_JOBS_PER_PAGE, minOrScore);
   profileRecord('bc:match', __tMatch);
 
   if (matching.length < MIN_MATCHING_JOBS) return null;
+  // Relevance guard: a multi-content-token query that ends up with zero jobs
+  // (no AND-core and nothing clears the ≥2 OR-floor) would otherwise emit a
+  // thin "0 offerte" doorway under MIN_MATCHING_JOBS=0. Suppress it — there is
+  // no honest, relevant page to serve. Single-token recovery pages are
+  // unaffected (they keep minOrScore=1 and surface their OR matches).
+  if (keywordTokenCount >= 2 && matching.length === 0) return null;
   // Note: with MIN_MATCHING_JOBS=0 the line above is a no-op (length is
   // never negative). Kept as a literal expression of the floor so the
   // constant stays the single source of truth — flip it back to ≥1 here
@@ -1143,7 +1167,12 @@ interface ClusterChromeCopy {
   contextSummary: string;
   /** Region fallback when no city is detected (used for commuter copy). */
   regionFallback: string;
-  /** "Frontaliere region" — used inside H1 to differ from <title>. */
+  /**
+   * Region phrase appended to the H1 to differ from <title>. Only used on the
+   * non-city (Switzerland-aggregate) clusters — canonical `/cerca-lavoro-
+   * svizzera/…` whose job set is nation-wide — so it must read nation-wide
+   * ("in Svizzera"), not "in Ticino", to match the cross-canton listings.
+   */
   regionH1Suffix: string;
   /** Aria label for active filters group. */
   activeFiltersLabel: string;
@@ -1158,7 +1187,7 @@ const CHROME_COPY: Record<Locale, ClusterChromeCopy> = {
     filterChipPrefix: 'ricerca',
     contextSummary: 'Approfondimento: come funziona questa ricerca per i frontalieri',
     regionFallback: 'Ticino',
-    regionH1Suffix: 'in Ticino',
+    regionH1Suffix: 'in Svizzera',
     activeFiltersLabel: 'Filtri attivi',
     resultsCountLabel: (n) => `${n} ${n === 1 ? 'offerta trovata' : 'offerte trovate'}`,
   },
@@ -1168,7 +1197,7 @@ const CHROME_COPY: Record<Locale, ClusterChromeCopy> = {
     filterChipPrefix: 'search',
     contextSummary: 'More about this search for cross-border applicants',
     regionFallback: 'Ticino',
-    regionH1Suffix: 'in Ticino',
+    regionH1Suffix: 'across Switzerland',
     activeFiltersLabel: 'Active filters',
     resultsCountLabel: (n) => `${n} ${n === 1 ? 'job found' : 'jobs found'}`,
   },
@@ -1178,7 +1207,7 @@ const CHROME_COPY: Record<Locale, ClusterChromeCopy> = {
     filterChipPrefix: 'Suche',
     contextSummary: 'Mehr zu dieser Suche für Grenzgänger',
     regionFallback: 'Tessin',
-    regionH1Suffix: 'im Tessin',
+    regionH1Suffix: 'in der Schweiz',
     activeFiltersLabel: 'Aktive Filter',
     resultsCountLabel: (n) => `${n} ${n === 1 ? 'Stelle gefunden' : 'Stellen gefunden'}`,
   },
@@ -1188,7 +1217,7 @@ const CHROME_COPY: Record<Locale, ClusterChromeCopy> = {
     filterChipPrefix: 'recherche',
     contextSummary: 'En savoir plus sur cette recherche pour les frontaliers',
     regionFallback: 'Tessin',
-    regionH1Suffix: 'au Tessin',
+    regionH1Suffix: 'en Suisse',
     activeFiltersLabel: 'Filtres actifs',
     resultsCountLabel: (n) => `${n} ${n === 1 ? 'offre trouvée' : 'offres trouvées'}`,
   },
@@ -1390,6 +1419,9 @@ export function renderClusterPage(inputs: PageInputs): PageOutput {
         ctx.matchingJobs.length,
         ctx.topCompanies,
         topCities,
+        // City clusters are TI cities (Lugano, Mendrisio, …) → keep "in Ticino";
+        // non-city clusters are the Switzerland-aggregate canonical → "in Svizzera".
+        ctx.city ? 'ticino' : 'svizzera',
       );
 
   // AI-enriched FAQ block (when available). Rendered as <dl> for clarity;

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -947,12 +947,13 @@ function buildClusterContext(
   profileRecord('bc:match', __tMatch);
 
   if (matching.length < MIN_MATCHING_JOBS) return null;
-  // Relevance guard: a multi-content-token query that ends up with zero jobs
-  // (no AND-core and nothing clears the ≥2 OR-floor) would otherwise emit a
-  // thin "0 offerte" doorway under MIN_MATCHING_JOBS=0. Suppress it — there is
-  // no honest, relevant page to serve. Single-token recovery pages are
-  // unaffected (they keep minOrScore=1 and surface their OR matches).
-  if (keywordTokenCount >= 2 && matching.length === 0) return null;
+  // NB: deliberately NO zero-match suppression here. A multi-content-token
+  // query that now clears to zero jobs (the ≥2 OR-floor drops the single-token
+  // pollution) keeps emitting as the existing n=0 soft-landing (200 + alert
+  // CTA + intro prose), NOT a 404. Suppressing it (return null) would de-index
+  // already-indexed `/cerca-lavoro-svizzera/ricerca-…/` URLs without a
+  // 410/redirect — flagged 🔴 in PR review. The relevance win is that those
+  // pages no longer list off-topic jobs, not that they vanish from the index.
   // Note: with MIN_MATCHING_JOBS=0 the line above is a no-op (length is
   // never negative). Kept as a literal expression of the floor so the
   // constant stays the single source of truth — flip it back to ≥1 here

--- a/build-plugins/shared/jobBoardCommuterContext.ts
+++ b/build-plugins/shared/jobBoardCommuterContext.ts
@@ -602,12 +602,22 @@ export function isKnownTicinoCommuterCity(location: string): boolean {
  * @param companies  Up to 3-5 unique company names visible on the page.
  * @param locations  Up to 3-5 unique location names visible on the page.
  */
+/**
+ * Geographic scope of the cluster the intro describes. `ticino` keeps the
+ * original canton-scoped wording; `svizzera` switches to nation-wide wording
+ * for the Switzerland-aggregate cluster pages (canonical `/cerca-lavoro-
+ * svizzera/…`) whose job set spans every canton — saying "in Ticino" there
+ * contradicted the listings (jobs in Bern, Zürich, Vaud, …).
+ */
+export type SearchQueryScope = 'ticino' | 'svizzera';
+
 export function renderSearchQueryIntro(
   locale: CommuterLocale,
   query: string,
   matchCount: number,
   companies: string[],
   locations: string[],
+  scope: SearchQueryScope = 'ticino',
 ): string {
   const q = (query || '').trim();
   const safeQ = q.length > 0 ? q : (locale === 'it' ? 'questa ricerca' : locale === 'en' ? 'this search' : locale === 'de' ? 'diese Suche' : 'cette recherche');
@@ -621,39 +631,56 @@ export function renderSearchQueryIntro(
   const angle = stableHash(`${q}|${locale}`) % 3;
 
   if (locale === 'it') {
+    const regIn = scope === 'svizzera' ? 'in Svizzera' : 'in Ticino';
+    const employersTail = scope === 'svizzera'
+      ? 'aziende svizzere e dai principali ATS attivi sul territorio nazionale'
+      : 'aziende ticinesi e dai principali ATS svizzeri attivi nel cantone';
     const intro = angle === 0
-      ? `Questa pagina raccoglie le offerte attive in Ticino legate alla ricerca <strong>"${escAttr(safeQ)}"</strong>: i ${matchCount} annunci qui sotto sono filtrati dal nostro indice di posizioni aperte e ordinati per data di pubblicazione, dalla più recente alla più vecchia.`
+      ? `Questa pagina raccoglie le offerte attive ${regIn} legate alla ricerca <strong>"${escAttr(safeQ)}"</strong>: i ${matchCount} annunci qui sotto sono filtrati dal nostro indice di posizioni aperte e ordinati per data di pubblicazione, dalla più recente alla più vecchia.`
       : angle === 1
-      ? `Stai cercando <strong>"${escAttr(safeQ)}"</strong> in Ticino. Abbiamo indicizzato ${matchCount} posizioni aperte che corrispondono a questa query, raccolte dai portali carriera delle aziende ticinesi e dai principali ATS svizzeri attivi nel cantone.`
+      ? `Stai cercando <strong>"${escAttr(safeQ)}"</strong> ${regIn}. Abbiamo indicizzato ${matchCount} posizioni aperte che corrispondono a questa query, raccolte dai portali carriera delle ${employersTail}.`
       : `Le ${matchCount} offerte raggruppate in questa pagina rispondono alla ricerca <strong>"${escAttr(safeQ)}"</strong>: sono filtrate dal nostro feed proprietario aggiornato ogni 6 ore e mostrano solo posizioni la cui scadenza non è ancora trascorsa.`;
     const context = `${hasCompanies ? `Tra i datori di lavoro che assumono per "${escAttr(safeQ)}" trovi ${topCompanies}. ` : ''}${hasLocations ? `Le località ricorrenti negli annunci sono ${topLocations}: tieni conto di tempi di pendolarismo e tipologia di valico (Brogeda, Stabio, Ponte Tresa) prima di scegliere un\'opportunità rispetto a un\'altra. ` : ''}Per chi è frontaliere italiano, ogni ruolo richiede il Permesso G richiesto dal datore svizzero — è gratuito e di norma rilasciato in 2-6 settimane dopo la firma del contratto.`;
     const valueProp = `Sotto ogni annuncio trovi un link diretto alla pagina ufficiale di candidatura: non chiediamo registrazione, non intermediamo CV. Se vuoi confrontare il lordo CHF con il netto reale per la tua situazione (zona di frontiera vs Permesso B, vecchio vs nuovo accordo fiscale Italia-Svizzera 2024, presenza di figli a carico, telelavoro fino al 25 %), apri il calcolatore Frontaliere Ticino dal menu in alto: in 30 secondi ottieni la cifra netta mensile in CHF e in EUR.`;
     return `<p class="s-clIDbe">${intro}</p>\n<p class="s-clIDbe">${context}</p>\n<p class="s-clIDbe">${valueProp}</p>`;
   }
   if (locale === 'en') {
+    const openings = scope === 'svizzera' ? 'openings across Switzerland' : 'Ticino openings';
+    const regIn = scope === 'svizzera' ? 'across Switzerland' : 'in Ticino';
+    const employersTail = scope === 'svizzera'
+      ? 'Swiss employers\' career portals and the main Swiss ATS active nationwide'
+      : 'Ticino employers\' career portals and the main Swiss ATS active in the canton';
     const intro = angle === 0
-      ? `This page lists active Ticino openings tied to the search <strong>"${escAttr(safeQ)}"</strong>: the ${matchCount} listings below are filtered from our open-position index and sorted from newest to oldest.`
+      ? `This page lists active ${openings} tied to the search <strong>"${escAttr(safeQ)}"</strong>: the ${matchCount} listings below are filtered from our open-position index and sorted from newest to oldest.`
       : angle === 1
-      ? `You are looking for <strong>"${escAttr(safeQ)}"</strong> in Ticino. We indexed ${matchCount} active positions matching this query, collected from Ticino employers\' career portals and the main Swiss ATS active in the canton.`
+      ? `You are looking for <strong>"${escAttr(safeQ)}"</strong> ${regIn}. We indexed ${matchCount} active positions matching this query, collected from ${employersTail}.`
       : `The ${matchCount} listings grouped on this page answer the search <strong>"${escAttr(safeQ)}"</strong>: filtered from our proprietary feed refreshed every 6 hours, showing only positions whose deadline has not passed.`;
     const context = `${hasCompanies ? `Employers hiring for "${escAttr(safeQ)}" include ${topCompanies}. ` : ''}${hasLocations ? `Recurring locations are ${topLocations}: factor in commute time and crossing type (Brogeda, Stabio, Ponte Tresa) before picking one opportunity over another. ` : ''}For Italian cross-border applicants, every role requires the G permit filed by the Swiss employer — it is free of charge and typically issued in 2-6 weeks after contract signature.`;
     const valueProp = `Each listing links directly to the official application page: we never require registration and never intermediate CVs. To compare the CHF gross with real take-home for your specific situation (border zone vs Permit B, old vs new 2024 Italy-Switzerland fiscal agreement, dependent children, teleworking up to 25 %), open the Frontaliere Ticino calculator from the top menu: in 30 seconds you get the monthly net in CHF and EUR.`;
     return `<p class="s-clIDbe">${intro}</p>\n<p class="s-clIDbe">${context}</p>\n<p class="s-clIDbe">${valueProp}</p>`;
   }
   if (locale === 'de') {
+    const regIn = scope === 'svizzera' ? 'in der Schweiz' : 'im Tessin';
+    const employersTail = scope === 'svizzera'
+      ? 'Karriereportalen Schweizer Arbeitgeber und den wichtigsten landesweit aktiven Schweizer ATS'
+      : 'Karriereportalen der Tessiner Arbeitgeber und den wichtigsten Schweizer ATS im Kanton';
     const intro = angle === 0
-      ? `Diese Seite sammelt aktive Stellen im Tessin zur Suche <strong>"${escAttr(safeQ)}"</strong>: die ${matchCount} Anzeigen unten stammen aus unserem Index offener Positionen, sortiert nach Veröffentlichungsdatum von neu nach alt.`
+      ? `Diese Seite sammelt aktive Stellen ${regIn} zur Suche <strong>"${escAttr(safeQ)}"</strong>: die ${matchCount} Anzeigen unten stammen aus unserem Index offener Positionen, sortiert nach Veröffentlichungsdatum von neu nach alt.`
       : angle === 1
-      ? `Sie suchen <strong>"${escAttr(safeQ)}"</strong> im Tessin. Wir haben ${matchCount} aktive Stellen indexiert, die auf diese Anfrage passen — gesammelt aus den Karriereportalen der Tessiner Arbeitgeber und den wichtigsten Schweizer ATS im Kanton.`
+      ? `Sie suchen <strong>"${escAttr(safeQ)}"</strong> ${regIn}. Wir haben ${matchCount} aktive Stellen indexiert, die auf diese Anfrage passen — gesammelt aus den ${employersTail}.`
       : `Die ${matchCount} Inserate auf dieser Seite beantworten die Suche <strong>"${escAttr(safeQ)}"</strong>: gefiltert aus unserem eigenen Feed, alle 6 Stunden aktualisiert, mit ausschliesslich noch offenen Bewerbungsfristen.`;
     const context = `${hasCompanies ? `Zu den Arbeitgebern, die für "${escAttr(safeQ)}" rekrutieren, gehören ${topCompanies}. ` : ''}${hasLocations ? `Häufige Standorte sind ${topLocations}: Pendelzeit und Grenzübergang (Brogeda, Stabio, Ponte Tresa) sollten in die Wahl einer Stelle gegenüber einer anderen einfliessen. ` : ''}Für italienische Grenzgänger erfordert jede Rolle die G-Bewilligung, die der Schweizer Arbeitgeber kostenlos beantragt — die Ausstellung dauert in der Regel 2-6 Wochen nach Vertragsunterzeichnung.`;
     const valueProp = `Jedes Inserat führt direkt zur offiziellen Bewerbungsseite: wir verlangen keine Registrierung und vermitteln keine Lebensläufe. Um den CHF-Bruttolohn mit dem realen Netto für Ihre Situation zu vergleichen (Grenzzone vs. B-Bewilligung, altes vs. neues Steuerabkommen 2024, Kinderzulagen, Homeoffice bis 25 %), öffnen Sie den Frontaliere-Ticino-Rechner über das obere Menü: in 30 Sekunden erhalten Sie das Monatsnetto in CHF und EUR.`;
     return `<p class="s-clIDbe">${intro}</p>\n<p class="s-clIDbe">${context}</p>\n<p class="s-clIDbe">${valueProp}</p>`;
   }
+  const regIn = scope === 'svizzera' ? 'en Suisse' : 'au Tessin';
+  const employersTail = scope === 'svizzera'
+    ? 'portails carrière des employeurs suisses et les principaux ATS suisses présents au niveau national'
+    : 'portails carrière des employeurs tessinois et les principaux ATS suisses présents dans le canton';
   const intro = angle === 0
-    ? `Cette page rassemble les offres actives au Tessin liées à la recherche <strong>"${escAttr(safeQ)}"</strong> : les ${matchCount} annonces ci-dessous sont filtrées depuis notre index de postes ouverts et triées par date de publication, des plus récentes aux plus anciennes.`
+    ? `Cette page rassemble les offres actives ${regIn} liées à la recherche <strong>"${escAttr(safeQ)}"</strong> : les ${matchCount} annonces ci-dessous sont filtrées depuis notre index de postes ouverts et triées par date de publication, des plus récentes aux plus anciennes.`
     : angle === 1
-    ? `Vous cherchez <strong>"${escAttr(safeQ)}"</strong> au Tessin. Nous avons indexé ${matchCount} postes actifs correspondant à cette requête, collectés depuis les portails carrière des employeurs tessinois et les principaux ATS suisses présents dans le canton.`
+    ? `Vous cherchez <strong>"${escAttr(safeQ)}"</strong> ${regIn}. Nous avons indexé ${matchCount} postes actifs correspondant à cette requête, collectés depuis les ${employersTail}.`
     : `Les ${matchCount} annonces regroupées sur cette page répondent à la recherche <strong>"${escAttr(safeQ)}"</strong> : filtrées depuis notre flux propriétaire actualisé toutes les 6 heures, ne montrant que les postes dont l\'échéance n\'est pas encore passée.`;
   const context = `${hasCompanies ? `Les employeurs qui recrutent pour "${escAttr(safeQ)}" incluent ${topCompanies}. ` : ''}${hasLocations ? `Les localités récurrentes sont ${topLocations} : prenez en compte le temps de trajet et le type de passage frontalier (Brogeda, Stabio, Ponte Tresa) avant de choisir une opportunité plutôt qu\'une autre. ` : ''}Pour les frontaliers italiens, chaque poste requiert le permis G demandé par l\'employeur suisse — il est gratuit et délivré en 2-6 semaines après la signature du contrat.`;
   const valueProp = `Chaque annonce renvoie directement à la page de candidature officielle : nous ne demandons aucune inscription et n\'intermédions aucun CV. Pour comparer le brut CHF avec le net réel pour votre situation (zone frontalière vs permis B, ancien vs nouvel accord fiscal 2024, enfants à charge, télétravail jusqu\'à 25 %), ouvrez le calculateur Frontaliere Ticino depuis le menu supérieur : en 30 secondes vous obtenez le net mensuel en CHF et en EUR.`;

--- a/index.html
+++ b/index.html
@@ -93,12 +93,15 @@
 
     <!-- Security Headers (meta-based, GitHub Pages doesn't support HTTP headers)
          CSP: upgrade-insecure-requests auto-upgrades any stray http:// asset to
-         https://; frame-ancestors 'self' blocks clickjacking (modern X-Frame-Options).
+         https:// — this directive DOES work via <meta>.
          Restrictive script-src/style-src deliberately omitted — would break
          Firebase, AdSense, PostHog, Clarity, GTM and Vite inline styles.
-         NOTE: HSTS cannot be set via meta (requires a real HTTP header, not
-         supported by GitHub Pages). Future: Cloudflare proxy / edge worker. -->
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests; frame-ancestors 'self';">
+         NOTE: frame-ancestors (anti-clickjacking) and HSTS are IGNORED when
+         delivered via <meta> (spec: header-only) — they logged a console error
+         on every load and enforced nothing, so they are not set here. Real
+         anti-framing/HSTS needs an HTTP-header layer (future: Cloudflare proxy
+         / edge worker in front of GitHub Pages). -->
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests;">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">

--- a/scripts/audit-related-search-candidates.mjs
+++ b/scripts/audit-related-search-candidates.mjs
@@ -170,6 +170,11 @@ function sanitizeJobTitle(raw) {
     .trim();
   return decoded
     .replace(/\b([A-Za-zÀ-ÖØ-öø-ÿ]{3,})\/([A-Za-zÀ-ÖØ-öø-ÿ]{1,3})\b/g, '$1 $2')
+    // Mirror of services/relatedSearchClusters.ts: strip dangling " /-a" / " /"
+    // gender remnants (space-anchored, leaves "TCP/IP", "24/7", "(m/w/d)" intact).
+    .replace(/\s+\/-?[a-zà-ÿ]{0,3}(?=[\s,;.)]|$)/gi, '')
+    .replace(/\/-[a-zà-ÿ]{1,3}\b/gi, '')
+    .replace(/\s{2,}/g, ' ')
     .replace(/\s+,/g, ',')
     .trim() || decoded;
 }

--- a/scripts/audit-related-search-candidates.mjs
+++ b/scripts/audit-related-search-candidates.mjs
@@ -171,8 +171,9 @@ function sanitizeJobTitle(raw) {
   return decoded
     .replace(/\b([A-Za-zÀ-ÖØ-öø-ÿ]{3,})\/([A-Za-zÀ-ÖØ-öø-ÿ]{1,3})\b/g, '$1 $2')
     // Mirror of services/relatedSearchClusters.ts: strip dangling " /-a" / " /"
-    // gender remnants (space-anchored, leaves "TCP/IP", "24/7", "(m/w/d)" intact).
-    .replace(/\s+\/-?[a-zà-ÿ]{0,3}(?=[\s,;.)]|$)/gi, '')
+    // gender remnants only at end / before punctuation (leaves "Manager /
+    // Director", "TCP/IP", "24/7", "(m/w/d)" intact).
+    .replace(/\s+\/-?[a-zà-ÿ]{0,3}(?=[,;.)]|$)/gi, '')
     .replace(/\/-[a-zà-ÿ]{1,3}\b/gi, '')
     .replace(/\s{2,}/g, ' ')
     .replace(/\s+,/g, ',')

--- a/services/relatedSearchClusters.ts
+++ b/services/relatedSearchClusters.ts
@@ -20,6 +20,13 @@ export function sanitizeJobTitle(raw: string): string {
 
  const normalizedInclusive = decoded
  .replace(/\b([A-Za-zÀ-ÖØ-öø-ÿ]{3,})\/([A-Za-zÀ-ÖØ-öø-ÿ]{1,3})\b/g, '$1 $2')
+ // Strip dangling gender-suffix remnants the inclusive rule above can't reach:
+ // " /-a", " /-in", or a bare " /" left when the slashed gender form
+ // (e.g. "Responsabile Neurologia /-a") was split off. Space-anchored so real
+ // mid-token slashes ("TCP/IP", "24/7", "(m/w/d)") are untouched.
+ .replace(/\s+\/-?[a-zà-ÿ]{0,3}(?=[\s,;.)]|$)/gi, '')
+ .replace(/\/-[a-zà-ÿ]{1,3}\b/gi, '')
+ .replace(/\s{2,}/g, ' ')
  .replace(/\s+,/g, ',')
  .trim();
 

--- a/services/relatedSearchClusters.ts
+++ b/services/relatedSearchClusters.ts
@@ -22,9 +22,10 @@ export function sanitizeJobTitle(raw: string): string {
  .replace(/\b([A-Za-zÀ-ÖØ-öø-ÿ]{3,})\/([A-Za-zÀ-ÖØ-öø-ÿ]{1,3})\b/g, '$1 $2')
  // Strip dangling gender-suffix remnants the inclusive rule above can't reach:
  // " /-a", " /-in", or a bare " /" left when the slashed gender form
- // (e.g. "Responsabile Neurologia /-a") was split off. Space-anchored so real
+ // (e.g. "Responsabile Neurologia /-a") was split off. Only fires at end or
+ // before punctuation, so a legit " / " separator ("Manager / Director") and
  // mid-token slashes ("TCP/IP", "24/7", "(m/w/d)") are untouched.
- .replace(/\s+\/-?[a-zà-ÿ]{0,3}(?=[\s,;.)]|$)/gi, '')
+ .replace(/\s+\/-?[a-zà-ÿ]{0,3}(?=[,;.)]|$)/gi, '')
  .replace(/\/-[a-zà-ÿ]{1,3}\b/gi, '')
  .replace(/\s{2,}/g, ' ')
  .replace(/\s+,/g, ',')

--- a/tests/related-search-clusters.test.ts
+++ b/tests/related-search-clusters.test.ts
@@ -535,6 +535,19 @@ describe('sanitizeJobTitle', () => {
     // The regex matches a 3+ letter word, slash, then 1-3 letters
     expect(sanitizeJobTitle('Maintenance/IT')).toBe('Maintenance IT');
   });
+
+  it('strips dangling gender-suffix slash remnants ("/-a", bare " /")', () => {
+    // Source titles like "Responsabile Neurologia /-a, 100%" leaked a bare " /"
+    // into the cluster term shown in <title>/H1/description. Clean it.
+    expect(sanitizeJobTitle('Responsabile Neurologia /-a, 100%')).toBe('Responsabile Neurologia, 100%');
+    expect(sanitizeJobTitle('Responsabile Neurologia /')).toBe('Responsabile Neurologia');
+    expect(sanitizeJobTitle('Infermiere /-in')).toBe('Infermiere');
+  });
+
+  it('leaves legitimate mid-token slashes intact', () => {
+    expect(sanitizeJobTitle('Disponibilità 24/7')).toBe('Disponibilità 24/7');
+    expect(sanitizeJobTitle('Manager (m/w/d)')).toBe('Manager (m/w/d)');
+  });
 });
 
 // ── cleanCanonicalItems ────────────────────────────────────────────────

--- a/tests/related-search-clusters.test.ts
+++ b/tests/related-search-clusters.test.ts
@@ -28,6 +28,7 @@ import {
   pickBestRelatedSearchForPrompt,
   DEFAULT_CANTON_DISPLAY,
 } from '@/services/relatedSearchClusters';
+import { renderSearchQueryIntro } from '../build-plugins/shared/jobBoardCommuterContext';
 
 // ── Slug round-trip ─────────────────────────────────────────────────────
 
@@ -547,6 +548,9 @@ describe('sanitizeJobTitle', () => {
   it('leaves legitimate mid-token slashes intact', () => {
     expect(sanitizeJobTitle('Disponibilità 24/7')).toBe('Disponibilità 24/7');
     expect(sanitizeJobTitle('Manager (m/w/d)')).toBe('Manager (m/w/d)');
+    // A real " / " separator (not a dangling gender remnant) must survive —
+    // the strip only fires at end / before punctuation.
+    expect(sanitizeJobTitle('Manager / Director')).toBe('Manager / Director');
   });
 });
 
@@ -598,5 +602,41 @@ describe('RELATED_SEARCH_STOPWORDS — sentinel entries', () => {
   it('contains documented domain-noise words', () => {
     expect(RELATED_SEARCH_STOPWORDS.has('clients')).toBe(true);
     expect(RELATED_SEARCH_STOPWORDS.has('team')).toBe(true);
+  });
+});
+
+// ── renderSearchQueryIntro — geo scope (honest region label) ──────────────
+
+describe('renderSearchQueryIntro — geo scope', () => {
+  // The intro picks one of 3 opening angles via a stable hash; only angles 0/1
+  // carry a region phrase, so assert angle-independent invariants across a
+  // fixed query set (hash is pure → deterministic for these exact inputs).
+  const QUERIES = ['Responsabile Neurologia', 'Infermiere', 'Cuoco', 'Ingegnere Civile', 'Magazziniere', 'Operaio Edile'];
+  const render = (q: string, scope: 'ticino' | 'svizzera') =>
+    renderSearchQueryIntro('it', q, 3, ['EOC'], ['Lugano'], scope);
+
+  it('never mislabels the scope on any angle', () => {
+    for (const q of QUERIES) {
+      expect(render(q, 'svizzera')).not.toContain('in Ticino');
+      expect(render(q, 'ticino')).not.toContain('in Svizzera');
+    }
+  });
+
+  it('emits the national label on region-bearing angles', () => {
+    expect(QUERIES.some((q) => render(q, 'svizzera').includes('in Svizzera'))).toBe(true);
+    expect(QUERIES.some((q) => render(q, 'ticino').includes('in Ticino'))).toBe(true);
+  });
+
+  it('defaults to ticino scope (other callers unchanged)', () => {
+    for (const q of QUERIES) {
+      expect(renderSearchQueryIntro('it', q, 3, ['EOC'], ['Lugano'])).toBe(render(q, 'ticino'));
+    }
+  });
+
+  it('localizes the national label per locale on region-bearing angles', () => {
+    const someEn = QUERIES.some((q) => renderSearchQueryIntro('en', q, 3, ['EOC'], ['Lugano'], 'svizzera').includes('Switzerland'));
+    const someDe = QUERIES.some((q) => renderSearchQueryIntro('de', q, 3, ['EOC'], ['Lugano'], 'svizzera').includes('in der Schweiz'));
+    const someFr = QUERIES.some((q) => renderSearchQueryIntro('fr', q, 3, ['EOC'], ['Lugano'], 'svizzera').includes('en Suisse'));
+    expect(someEn && someDe && someFr).toBe(true);
   });
 });


### PR DESCRIPTION
Diagnosi della pagina live `/cerca-lavoro-ticino/ricerca-mansioni-responsabile-neurologia/` (statico vs SPA idratato). Trovati 5 casi; 1 era un falso positivo (marker `<!--EJP_STRIPPED-->` = skip-audit intenzionale), gli altri 4 reali e fixati.

## Implementato

- **Geo label onesto.** H1/intro dicevano "in Ticino" ma il job set è CH-wide (canonical = aggregate `/cerca-lavoro-svizzera/`). `renderSearchQueryIntro` prende un param `scope` (`'ticino'|'svizzera'`) e parametrizza regione + aggettivi datore in tutti e 4 i locali; `CHROME_COPY.regionH1Suffix` passa a wording nazionale per i cluster non-city. I cluster city (città TI) restano "in Ticino". `regionFallback` (grammatica commuter-context) non toccato.
- **Floor di rilevanza (relevance pollution).** "Responsabile Neurologia" elencava ~85% job hotel/spa/vendite: l'OR-fill aggiungeva match mono-token ("responsabile") senza soglia. `fillOrMatches`/`matchingJobs` ora hanno `minScore`; il caller lo mette a 2 quando il keyword (city-stripped) ha ≥2 token di contenuto → un ruolo generico da solo non trascina più off-topic. Keyword a 1 token restano `minScore=1`, preservando il recovery city-drop documentato (es. "koch davos"). Le pagine con AND-core restano emesse con i soli job rilevanti; quelle senza restano soft-landing n=0 (200, **nessun de-index**).
- **" /" pendente nel termine.** La forma di genere "Responsabile Neurologia /-a" lasciava un " /" nudo in `<title>`/H1/description. `sanitizeJobTitle` (+ mirror audit) strippa i resti " /-a"/" /" solo a fine stringa / prima di punteggiatura, così "Manager / Director", "TCP/IP", "24/7", "(m/w/d)" restano intatti. Solo display: lo slug/canonical non cambia. Test di regressione aggiunti.
- **CSP `frame-ancestors` via `<meta>`.** Ignorato per spec (solo-header): non applicava nulla e logga un console error a ogni load. Rimosso da `index.html` e `htmlTemplate.ts` (`HEAD_PREFIX`); tenuto `upgrade-insecure-requests` (funziona via meta).

Test: `tests/related-search-clusters*.ts` (63, inclusi nuovi geo-scope + slash) + sweep plugin (`sitemap-jobs-mirror-drop`, `related-search-clusters-emitted`, `job-board-text-ratio-regression`, `router`, 502) verdi. `tsc --noEmit`: nessun errore nei file toccati.

## Non implementato (ancora)

- **Bonus zero-suppression (rimosso post-review).** La guardia `return null` su cluster multi-token con AND-core=0 de-indicizzava URL live senza 410/redirect (🔴 reviewer) → rimossa. Quei cluster restano soft-landing n=0 indicizzabili.
- **Marker `EJP_STRIPPED`**: non è un bug → nessuna modifica (skip-marker canonico di `audit-text-html-ratio.mjs`).
- **Callers `renderSearchQueryIntro` in `jobsSeoPagesPlugin.ts`** (3): default `scope='ticino'`, confermati TI-scoped dal reviewer (copy hardcoded "Canton Ticino") → deferral corretto.
- **`#911`** (6 canonical cross-section TI→CH nel sitemap): correlato alla stessa architettura TI-mirror/CH-aggregate ma questa PR cambia la *label*, non il canonical href del sitemap → non chiuso.
- **Anti-clickjacking reale**: non ottenibile su GitHub Pages (no header HTTP). Posposto a Cloudflare/edge worker; frame-bust JS scartato (rischio di bloccare il framing legittimo di Google).
- **Gate audit AND-ratio**: non aggiunto (sarebbe nuovo script CI) — il floor in-plugin copre il caso reale; gate dedicato = follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)