### PR TITLE
fix(mobile): ranking valore + dato Sunrise nel riepilogo Migliori Opzioni operatori

### DIFF
--- a/components/comparators/MobileOperators.tsx
+++ b/components/comparators/MobileOperators.tsx
@@ -270,8 +270,8 @@ const operators: MobileOperator[] = [
  sms: 'illimitati',
  roamingInItaly: {
  included: true,
- dataLimit: 3,
- notes: 'Illim dati/min in 8 paesi UE (DE/AT/FR/IT/LI/GR/ES/PT) + 3 GB extra in Europa/USA/CAN. Esente da rincaro 08/2026.'
+ dataLimit: 'illimitati',
+ notes: 'Dati/min illimitati in 8 paesi UE — Italia inclusa (DE/AT/FR/IT/LI/GR/ES/PT). + 3 GB extra nel resto di Europa/USA/CAN. Esente da rincaro 08/2026.'
  },
  setupCost: 0,
  contractType: 'abbonamento',
@@ -435,18 +435,48 @@ const MobileOperators: React.FC = () => {
  }
  }), [filterCountry, sortBy]);
 
+ // Limite dati roaming rilevante per il frontaliere (IT→CH oppure CH→IT)
+ const roamingDataLimit = (op: MobileOperator): number | string | undefined =>
+ op.country === 'IT' ? op.roamingInSwitzerland?.dataLimit : op.roamingInItaly?.dataLimit;
+
+ // Ranking "migliori opzioni": roaming illimitato prima (più economico in cima),
+ // poi miglior rapporto GB roaming / prezzo. NON solo GB: così non promuove i piani
+ // costosi (es. Swisscom 81.80 CHF) né i micro-roaming da 1 GB.
  const bestForFrontierWorkers = operators
  .filter(op =>
  (op.country === 'IT' && op.roamingInSwitzerland?.included) ||
  (op.country === 'CH' && op.roamingInItaly?.included)
  )
  .sort((a, b) => {
- const aLimit = a.country === 'IT' ? a.roamingInSwitzerland?.dataLimit : a.roamingInItaly?.dataLimit;
- const bLimit = b.country === 'IT' ? b.roamingInSwitzerland?.dataLimit : b.roamingInItaly?.dataLimit;
- const aScore = aLimit === 'illimitati' ? Infinity : (typeof aLimit === 'number' ? aLimit : 0);
- const bScore = bLimit === 'illimitati' ? Infinity : (typeof bLimit === 'number' ? bLimit : 0);
- return bScore - aScore;
+ const aLimit = roamingDataLimit(a);
+ const bLimit = roamingDataLimit(b);
+ const aUnlimited = aLimit === 'illimitati';
+ const bUnlimited = bLimit === 'illimitati';
+ if (aUnlimited !== bUnlimited) return aUnlimited ? -1 : 1;
+ if (aUnlimited && bUnlimited) return a.monthlyCost - b.monthlyCost;
+ const aGB = typeof aLimit === 'number' ? aLimit : 0;
+ const bGB = typeof bLimit === 'number' ? bLimit : 0;
+ return bGB / b.monthlyCost - aGB / a.monthlyCost;
  });
+
+ // Riga compatta e scansionabile per il riepilogo "Migliori opzioni"
+ const renderBestRow = (op: MobileOperator, rank: number) => {
+ const limit = roamingDataLimit(op);
+ const currency = op.country === 'IT' ? '€' : 'CHF';
+ const roamingLabel = limit === 'illimitati' ? t('mobile.roamingUnlimited') : `${limit} GB`;
+ return (
+ <li key={op.name} className="flex items-baseline justify-between gap-3">
+ <span className="flex items-baseline gap-2 min-w-0">
+ <span className="text-success font-bold tabular-nums">{rank}.</span>
+ <strong className="text-strong truncate">{op.name}</strong>
+ </span>
+ <span className="flex items-baseline gap-2 flex-shrink-0">
+ <span className="text-body font-bold tabular-nums whitespace-nowrap">{op.monthlyCost} {currency}</span>
+ <span className="px-2 py-0.5 rounded-full bg-success-strong text-on-accent text-xs font-medium whitespace-nowrap">{roamingLabel}</span>
+ </span>
+ </li>
+ );
+ };
 
  return (
  <div className="space-y-6 pb-8">
@@ -526,30 +556,23 @@ const MobileOperators: React.FC = () => {
  </div>
 
  {/* Best Options Summary */}
- <div className="bg-gradient-to-br from-success-subtle to-success-subtle rounded-2xl border border-success-border p-6">
- <h3 className="text-xl font-bold font-display text-strong mb-4 flex items-center gap-2">
+ <div className="bg-success-subtle rounded-2xl border border-success-border p-6">
+ <h3 className="text-xl font-bold font-display text-strong mb-1 flex items-center gap-2">
  <CheckCircle2 size={20} className="text-success" />
  {t('mobile.bestOptions')}
  </h3>
+ <p className="text-sm text-muted mb-4">{t('mobile.bestOptionsHint')}</p>
  <div className="grid md:grid-cols-2 gap-4">
  <div className="p-4 bg-surface/50 rounded-xl">
- <p className="font-bold text-success mb-2">🇮🇹 {t('mobile.italianWithRoaming')}:</p>
- <ul className="space-y-1 text-sm text-body">
- {bestForFrontierWorkers.filter(op => op.country === 'IT').map(op => (
- <li key={op.name}>
- <strong>{op.name}</strong> - {op.monthlyCost}€/mese - {op.roamingInSwitzerland?.dataLimit === 'illimitati' ? '∞' : op.roamingInSwitzerland?.dataLimit} GB roaming
- </li>
- ))}
+ <p className="font-bold text-success mb-3">🇮🇹 {t('mobile.italianWithRoaming')}</p>
+ <ul className="space-y-2.5 text-sm">
+ {bestForFrontierWorkers.filter(op => op.country === 'IT').slice(0, 3).map((op, i) => renderBestRow(op, i + 1))}
  </ul>
  </div>
  <div className="p-4 bg-surface/50 rounded-xl">
- <p className="font-bold text-success mb-2">🇨🇭 {t('mobile.swissWithRoaming')}:</p>
- <ul className="space-y-1 text-sm text-body">
- {bestForFrontierWorkers.filter(op => op.country === 'CH').map(op => (
- <li key={op.name}>
- <strong>{op.name}</strong> - {op.monthlyCost} CHF/mese - {op.roamingInItaly?.dataLimit === 'illimitati' ? '∞' : op.roamingInItaly?.dataLimit} GB roaming
- </li>
- ))}
+ <p className="font-bold text-success mb-3">🇨🇭 {t('mobile.swissWithRoaming')}</p>
+ <ul className="space-y-2.5 text-sm">
+ {bestForFrontierWorkers.filter(op => op.country === 'CH').slice(0, 3).map((op, i) => renderBestRow(op, i + 1))}
  </ul>
  </div>
  </div>

--- a/services/locales/de-comparatori.ts
+++ b/services/locales/de-comparatori.ts
@@ -327,6 +327,8 @@ const deComparatori: Record<string, string> = {
  'mobile.price': 'Preis',
  'mobile.priceWithRoaming': 'Preis + Roaming inklusive',
  'mobile.bestOptions': 'Beste Optionen für Grenzgänger',
+ 'mobile.bestOptionsHint': 'Die Top 3 nach Verhältnis Roaming-GB / Preis. Vollständiger Vergleich unten.',
+ 'mobile.roamingUnlimited': 'unbegrenztes Roaming',
  'mobile.italianWithRoaming': 'Italienische Anbieter mit CH-Roaming',
  'mobile.swissWithRoaming': 'Schweizer Anbieter mit EU-Roaming',
  'mobile.realCostMonth': 'reale Kosten/Monat',

--- a/services/locales/en-comparatori.ts
+++ b/services/locales/en-comparatori.ts
@@ -327,6 +327,8 @@ const enComparatori: Record<string, string> = {
  'mobile.price': 'Price',
  'mobile.priceWithRoaming': 'Price + Roaming included',
  'mobile.bestOptions': 'Best Options for Cross-Border Workers',
+ 'mobile.bestOptionsHint': 'The top 3 by roaming GB / price ratio. Full comparison below.',
+ 'mobile.roamingUnlimited': 'unlimited roaming',
  'mobile.italianWithRoaming': 'Italian Operators with CH Roaming',
  'mobile.swissWithRoaming': 'Swiss Operators with EU Roaming',
  'mobile.realCostMonth': 'real cost/month',

--- a/services/locales/fr-comparatori.ts
+++ b/services/locales/fr-comparatori.ts
@@ -327,6 +327,8 @@ const frComparatori: Record<string, string> = {
  'mobile.price': 'Prix',
  'mobile.priceWithRoaming': 'Prix + Roaming inclus',
  'mobile.bestOptions': 'Meilleures options pour les frontaliers',
+ 'mobile.bestOptionsHint': 'Le top 3 par rapport Go de roaming / prix. Comparatif complet ci-dessous.',
+ 'mobile.roamingUnlimited': 'roaming illimité',
  'mobile.italianWithRoaming': 'Opérateurs italiens avec roaming CH',
  'mobile.swissWithRoaming': 'Opérateurs suisses avec roaming UE',
  'mobile.realCostMonth': 'coût réel/mois',

--- a/services/locales/it-comparatori.ts
+++ b/services/locales/it-comparatori.ts
@@ -339,6 +339,8 @@ const translations: Record<string, string> = {
  'mobile.price': 'Prezzo',
  'mobile.priceWithRoaming': 'Prezzo + Roaming incluso',
  'mobile.bestOptions': 'Migliori Opzioni per Frontalieri',
+ 'mobile.bestOptionsHint': 'Le 3 migliori per rapporto GB roaming / prezzo. Confronto completo qui sotto.',
+ 'mobile.roamingUnlimited': 'roaming illimitato',
  'mobile.italianWithRoaming': 'Operatori Italiani con Roaming CH',
  'mobile.swissWithRoaming': 'Operatori Svizzeri con Roaming UE',
  'mobile.realCostMonth': 'costo reale/mese',


### PR DESCRIPTION
## Implementato

Pagina **/compara-servizi/confronta-operatori-mobili/** — riepilogo "Migliori Opzioni per Frontalieri".

**Dati corretti**
- **Ranking value-based**: il riepilogo ordinava SOLO per GB roaming → promuoveva piani sbagliati (Swisscom 81.80 CHF/mese al 2° posto perché 40 GB; micro-roaming da 1 GB come Salt Swiss Max / Digitec in lista "migliori"). Ora: roaming illimitato prima (più economico in cima), poi miglior rapporto **GB roaming / prezzo**.
- **Top-3 per paese** invece di scaricare tutti gli operatori con roaming (la colonna CH mostrava 9 righe). Il confronto completo resta nella griglia subito sotto.
- **Sunrise Swiss Travel+ — dato sbagliato**: `roamingInItaly.dataLimit` era `3` GB, ma l'Italia è tra gli 8 paesi UE con **dati illimitati**; i 3 GB sono extra USA/CAN. Corretto a `illimitati` (dato + ranking). Note aggiornate per chiarezza.

**Readability (senza allontanare dal contenuto reale)**
- Righe scansionabili: numero rank + nome a sinistra, prezzo + pill "roaming" a destra (`flex justify-between`, no overflow a larghezza mobile — verificato).
- Pill mostra `roaming illimitato` invece di `∞ GB roaming` quando illimitato.
- Hint sotto al titolo che spiega la curatela ("Le 3 migliori per rapporto GB roaming / prezzo. Confronto completo qui sotto.").
- Rimosso gradient no-op (`from-success-subtle to-success-subtle` → `bg-success-subtle`).
- Nuove key i18n `mobile.bestOptionsHint` + `mobile.roamingUnlimited` in tutti e 4 i locali (it/en/de/fr).

**Verifica**
- `tsc --noEmit`: 0 errori nei file toccati (i 29 errori residui sono in `tests/` pre-esistenti, non miei).
- Dev server + Playwright sulla pagina live: IT top-3 = Vodafone / Fastweb / ho. Mobile; CH top-3 = Yallo (illimitato) / Sunrise (illimitato) / Salt Travel 20 GB. Nessun overflow riga a larghezza mobile.

## Non implementato (ancora)

- **Tip testuali (`mobile.operatorTip2`)**: continuano a citare Wingo+Sunrise come best-value (angolo prezzo), mentre il riepilogo ora evidenzia Yallo+Sunrise+Salt Travel (angolo GB/prezzo). Non è un dato errato — prospettive diverse, entrambe valide → lasciato fuori scope per non fare drive-by su 4 locali.
- **Verifica FUP `ho. Mobile` (14 GB)**: lasciata invariata, plausibile; nessuna fonte contraria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)