### PR TITLE
fix(job-search): cover FR 'offres d'emploi' boilerplate + drop dead null-guard

### DIFF
--- a/services/relatedSearchClusters.ts
+++ b/services/relatedSearchClusters.ts
@@ -81,7 +81,10 @@ export function buildSearchSlug(term: string, locale: Locale): string {
 // Strip only a single leading boilerplate phrase, and only when meaningful
 // query text remains after it.
 const SEARCH_QUERY_BOILERPLATE_PREFIX =
- /^(?:offerte\s+(?:di\s+)?lavoro|posti\s+di\s+lavoro|lavoro|offerte|jobs?|stellenangebote|stellen|offres?\s+(?:d['e]\s*)?emplois?|emplois?|recherche\s+emploi)\s+/i;
+ // Slugs strip apostrophes to hyphens → spaces, so the canonical FR
+ // "offres d'emploi" reaches us as "offres d emploi": match an optional bare
+ // "d" token, not an apostrophe.
+ /^(?:offerte\s+(?:di\s+)?lavoro|posti\s+di\s+lavoro|lavoro|offerte|jobs?|stellenangebote|stellen|offres?\s+(?:d\s+)?emplois?|emplois?|recherche\s+emploi)\s+/i;
 
 function stripSearchQueryBoilerplate(query: string): string {
  // Never empty the query: a slug that is *only* boilerplate (e.g.
@@ -105,7 +108,9 @@ export function parseSearchSlugFilter(initialJobSlug?: string): string | null {
  }
  const query = decoded.replace(/-/g, ' ').replace(/\s+/g, ' ').trim();
  if (!query) return null;
- return stripSearchQueryBoilerplate(query) || null;
+ // stripSearchQueryBoilerplate never returns empty (falls back to the
+ // original term), so no extra null-guard is needed here.
+ return stripSearchQueryBoilerplate(query);
 }
 
 // Tokens are filtered by `t.length >= 4` upstream, so 1-3 char stopwords are

--- a/tests/related-search-clusters.test.ts
+++ b/tests/related-search-clusters.test.ts
@@ -104,9 +104,12 @@ describe('parseSearchSlugFilter — strips job-search boilerplate from seeded qu
     expect(parseSearchSlugFilter('ricerca-offerte-cuoco')).toBe('cuoco');
   });
 
-  it('strips locale boilerplate (DE stellenangebote, FR offres emploi)', () => {
+  it('strips locale boilerplate (DE stellenangebote, FR offres (d) emploi)', () => {
     expect(parseSearchSlugFilter('suche-stellenangebote-koch')).toBe('koch');
     expect(parseSearchSlugFilter('recherche-offres-emploi-cuisinier')).toBe('cuisinier');
+    // Canonical FR "offres d'emploi" → slug strips the apostrophe to a hyphen
+    // (`offres-d-emploi`), reaching the parser as "offres d emploi".
+    expect(parseSearchSlugFilter('recherche-offres-d-emploi-cuisinier')).toBe('cuisinier');
   });
 
   it('never empties the query for a boilerplate-only slug (no blank search box)', () => {


### PR DESCRIPTION
Follow-up ai 2 nit 🟡 del reviewer su #1040.

## Implementato

- **FR boilerplate `offres d'emploi`** (`services/relatedSearchClusters.ts`): la regex copriva solo `offres emploi`. La forma canonica FR `offres d'emploi` diventa slug `offres-d-emploi` → query `offres d emploi`; il vecchio gruppo `(?:d['e]\s*)?` richiedeva apostrofo/`e` subito dopo `d` e trovava invece lo spazio → l'intero ramo `offres…` falliva → le landing FR con boilerplate canonica mantenevano il bug fixato in #1040. Allargato a `offres?\s+(?:d\s+)?emplois?` (gli slug strippano sempre l'apostrofo, quindi si matcha un token `d` nudo, non l'apostrofo). Nuovo test `recherche-offres-d-emploi-cuisinier` → `cuisinier`.
- **Dead code**: rimosso `|| null` in `parseSearchSlugFilter` (L108). `stripSearchQueryBoilerplate` non ritorna mai vuoto (fallback al termine originale) e `query` è già non-vuoto per il guard precedente → il ramo era irraggiungibile. Semplificato a `return stripSearchQueryBoilerplate(query);`.

Suite `related-search-clusters.test.ts`: 63/63 verde. Impact: LOW (stessi 3 caller JobBoard di #1040, comportamento invariato salvo le landing FR con boilerplate canonica). URL-stable.

## Non implementato (ancora)

- **Divergenza static-prerender / SPA** (adversarial ❓ del reviewer su #1040): lo static (`build-plugins/relatedSearchClustersPlugin.ts`) deriva `matchingJobs` da `ctx.keyword` con la query intera (boilerplate incluso) mentre la SPA ora idrata con la query strippata. Già dichiarato come follow-up in #1040: la verità UX è il router/SPA (la statica è scaffolding SEO sostituito all'hydration); allineare la generazione statica rischia churn URL/redirect → fuori scope.

Supersedes l'eventuale issue follow-up batchata da `post-merge-followup.yml` sui nit di #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)