### PR TITLE
feat(ci): lessons-harvester — daily auto-improvement loop for agent docs

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -132,6 +132,7 @@ jobs:
             - Mai committare path home assoluti o email personali (Privacy).
             - Se la root cause non è determinabile con confidenza → NON forzare un fix; posta su issue "Root cause non determinata: <cosa hai trovato>. Serve indagine umana." rimuovi nulla e TERMINA senza PR.
             - Se il fix richiede credenziali/segreti non disponibili in CI → documenta in commento e TERMINA senza PR.
+            - **Telemetria outcome (OBBLIGATORIO):** ogni volta che termini, l'ULTIMO commento che posti sulla issue DEVE iniziare con un marker HTML su riga propria: `<!-- FIX_OUTCOME: <code> -->`. `<code>` ∈ `pr-created` (PR aperta) · `blocked-workflows-scope` · `blocked-secrets` · `blocked-admin-settings` · `no-root-cause` · `overlap-skip` · `pr-already-open` · `already-fixed` · `revenue-tracker-manual`. Se apri una PR (passo 7) e non posti altri commenti, aggiungi comunque un commento col solo marker `<!-- FIX_OUTCOME: pr-created -->`. Il lessons-harvester aggrega questi marker per rilevare classi di blocco ricorrenti e proporre migliorie ai doc/prompt (vedi ISSUES.md → "Auto-improvement loop").
 
       - name: Claude usage metrics
         if: always()

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -1,0 +1,113 @@
+name: Lessons harvester (auto-improve agent docs)
+
+# Daily self-improvement loop: aggregate recurring reviewer findings + issue-fix
+# blocked-outcomes (deterministic, zero Claude), drop anything already in the
+# doc-contracts, and — only when a GENUINELY NEW recurring pattern survives —
+# spend ONE Claude turn to draft a surgical rule addition and open a docs PR.
+# Human-gated: the PR is never auto-merged (instructions are high-leverage).
+# Contract: ISSUES.md → "Auto-improvement loop (lessons-harvester)".
+
+on:
+  schedule:
+    - cron: '17 5 * * *' # daily 05:17 UTC
+  workflow_dispatch:
+    inputs:
+      window_days:
+        description: 'Lookback window in days (default 14).'
+        required: false
+        default: '14'
+      threshold:
+        description: 'Min recurrences to count a cluster (default 3).'
+        required: false
+        default: '3'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+  id-token: write
+
+concurrency:
+  group: lessons-harvester
+  cancel-in-progress: false
+
+jobs:
+  harvest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # One pending proposal at a time: if a harvest PR is already open and
+      # awaiting human review, don't pile up a duplicate every day.
+      - name: Guard — existing open proposal
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN=$(gh pr list --state open --search 'head:lessons/auto-harvest' --json number --jq 'length')
+          echo "open_proposals=$OPEN" >> "$GITHUB_OUTPUT"
+          if [ "$OPEN" != "0" ]; then
+            echo "A harvest proposal PR is already open — skipping today's run."
+          fi
+
+      - name: Aggregate recurring patterns (deterministic, zero Claude)
+        id: harvest
+        if: steps.guard.outputs.open_proposals == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WINDOW_DAYS: ${{ github.event.inputs.window_days || '14' }}
+          THRESHOLD: ${{ github.event.inputs.threshold || '3' }}
+          HARVEST_OUT: harvest-clusters.json
+        run: node scripts/ci/harvest-agent-lessons.mjs
+
+      - name: Draft doc-rule proposal (Claude — only if novel patterns)
+        if: steps.guard.outputs.open_proposals == '0' && steps.harvest.outputs.has_novel == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          claude_args: "--max-turns 20 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Bash(git:*),Bash(node:*),Read,Grep,Glob,Edit,Write'"
+          prompt: |
+            Sei l'agent di **auto-improvement** dei doc-contract per agenti. Obiettivo: dai pattern RICORRENTI rilevati, proporre miglioramenti CHIRURGICI alle istruzioni (AGENTS.md / ISSUES.md / REVIEW.md / FOLLOWUP.md) così che reviewer/fixer smettano di ripetere lo stesso problema → turnaround più basso.
+
+            **Bootstrap:**
+            1. Leggi `harvest-clusters.json` (output deterministico di `scripts/ci/harvest-agent-lessons.mjs`). Considera SOLO i cluster con `"novel": true` (gli altri sono già documentati o sono volume operativo).
+            2. Leggi `AGENTS.md`, `ISSUES.md`, `REVIEW.md`, `FOLLOWUP.md` (il loro stile è terse-italiano; rispettalo).
+
+            **Per ogni cluster novel:**
+            - `reviewer-finding/<bucket>` (es. ×N review con 🔴/🟡 sullo stesso tema) → significa che gli agent producono ripetutamente codice che il reviewer corregge sullo stesso punto. Aggiungi una regola PREVENTIVA nel posto giusto (di solito AGENTS.md non-negotiables/Build-And-Test, o REVIEW.md, o il prompt che genera quel codice).
+            - `fix-outcome/<code>` (es. ×N issue-fix bloccati con lo stesso `<code>`) → significa che il fixer sbatte sullo stesso muro. Aggiungi/affina la regola in ISSUES.md → "Abort senza PR" o il capability-guard, così esce frugale o evita di essere instradato.
+
+            **Vincoli (CRITICI):**
+            - CHIRURGICO: poche righe, nello stile esistente. No drive-by, no riscritture. AGENTS.md è iniettato ogni sessione → ogni riga costa token: massima densità.
+            - DEDUP: se rileggendo i doc la regola è di fatto già presente (anche con parole diverse) → NON aggiungerla. Meglio zero modifiche che rumore.
+            - Se NESSUN cluster produce una regola genuinamente nuova e azionabile → **NON aprire PR**, posta nulla, esci. Va benissimo "niente da migliorare oggi".
+            - Mai abbassare gate/quality. Mai toccare logica/codice: SOLO file `.md`.
+
+            **Se (e solo se) hai ≥1 regola nuova utile:**
+            1. `git config user.name "Valerie Linc"; git config user.email "valerielinc@gmail.com"`.
+            2. `git checkout -b lessons/auto-harvest-$(date -u +%Y%m%d)`.
+            3. Applica gli edit `.md` (Edit/Write). Nessun path home assoluto, nessuna email personale.
+            4. Commit conventional (`docs(process): auto-harvested lessons — <temi>`). In fondo: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+            5. `git push -u origin HEAD`.
+            6. `gh pr create` con body OBBLIGATORIO:
+               ```
+               ## Implementato
+               - <regola aggiunta> ← cluster <source/bucket> ×<count> (es. PR/issue #...)
+               ## Non implementato (ancora)
+               - <cluster scartati e perché: già coperto / troppo vago / volume non-istruzione>
+               ```
+               Aggiungi in fondo: "⚠️ Proposta auto-generata dal lessons-harvester. Human-gated: rivedere prima di mergere. Se modifica `.github/workflows/` non è prevista (solo `.md`)."
+            7. NON mergiare. È una proposta: la rivede un umano.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -113,6 +113,16 @@ Per le categorie strategiche (`revenue`, `tracker`) o issue HIGH-risk dove vuoi 
 - Bloccare un singolo fix: rimuovere `agent:fix` dalla issue prima che il fixer apra la PR (concurrency serializza, c'è una finestra).
 - Pausa totale: disabilitare `issue-fix.yml` / `issue-triage.yml` (Actions → workflow → Disable).
 
+## Auto-improvement loop (`lessons-harvester.yml`, daily)
+
+Chiude il feedback loop: i pattern ricorrenti rientrano nelle istruzioni → reviewer/fixer smettono di ripeterli → turnaround più basso. I doc (`AGENTS.md` iniettato ogni sessione, `ISSUES.md`/`REVIEW.md` letti nei prompt) **sono** il canale verso gli agent.
+
+- **Telemetria (deterministica, no Claude)**: il fixer chiude ogni run con un marker `<!-- FIX_OUTCOME: <code> -->` nel commento (codici: `pr-created`, `blocked-workflows-scope`, `blocked-secrets`, `blocked-admin-settings`, `no-root-cause`, `overlap-skip`, `pr-already-open`, `already-fixed`, `revenue-tracker-manual`). I reviewer-finding stanno già nei review body in formato 🔴/🟡/❓ (REVIEW.md). Lo store è GitHub stesso (commenti/review), nessun file accumulatore.
+- **Aggregazione**: `scripts/ci/harvest-agent-lessons.mjs` (zero-Claude, daily) conta su finestra 14gg, soglia ≥3: bucket reviewer-finding (tassonomia regex fissa) + fix-outcome bloccati. Le issue-class (crawler/follow-up/validation) sono **volume operativo, non lezioni** → contesto, mai driver di proposta. Dedup vs i doc-contract esistenti → tiene solo i cluster `novel`.
+- **Proposta (1 turno Claude, solo se `has_novel`)**: redige aggiunte chirurgiche ai doc → apre **1 PR** `lessons/auto-harvest-*`. Frugalità: nessun cluster nuovo = zero token (il giorno comune costa 0). Una sola proposta pendente alla volta (guard su PR aperte).
+- **Gate umano OBBLIGATORIO**: la PR di regole non è mai auto-mergiata (un'istruzione sbagliata degrada *tutti* gli agent). La rivede un umano. Solo `.md`, mai logica.
+- **Kill-switch**: disabilita `lessons-harvester.yml` da Actions UI; oppure alza `THRESHOLD`/abbassa `WINDOW_DAYS` via `workflow_dispatch`.
+
 ## Guardrail (da AGENTS.md, vincolanti)
 
 - Opt-in strategico: mai `agent:fix` automatico su `revenue`/`tracker`/`validation-failure`. Auto-route consentito solo su `crawler`/`follow-up`.

--- a/scripts/ci/harvest-agent-lessons.mjs
+++ b/scripts/ci/harvest-agent-lessons.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Lessons harvester — DETERMINISTIC aggregator (zero Claude).
+//
+// Scans recent reviewer findings, recurring issue classes and issue-fix
+// outcomes, buckets them by a fixed taxonomy, drops anything already covered by
+// the doc-contracts (AGENTS.md / ISSUES.md / REVIEW.md / FOLLOWUP.md), and
+// emits the surviving "novel recurring" clusters. The weekly/daily workflow
+// only spends a Claude turn when this script reports has_novel=true, so the
+// common (nothing-new) day costs zero model tokens.
+//
+// Output:
+//   - writes clusters JSON to $HARVEST_OUT (default: harvest-clusters.json)
+//   - prints a human summary to stdout
+//   - appends `has_novel=<bool>` and `novel_count=<n>` to $GITHUB_OUTPUT
+//
+// Env knobs: WINDOW_DAYS (14), THRESHOLD (3), MAX_PRS (40), MAX_ISSUES (120).
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const WINDOW_DAYS = Number(process.env.WINDOW_DAYS || 14);
+const THRESHOLD = Number(process.env.THRESHOLD || 3);
+const MAX_PRS = Number(process.env.MAX_PRS || 40);
+const MAX_ISSUES = Number(process.env.MAX_ISSUES || 120);
+const OUT = process.env.HARVEST_OUT || 'harvest-clusters.json';
+
+const sinceMs = Date.now() - WINDOW_DAYS * 86_400_000;
+const sinceDay = new Date(sinceMs).toISOString().slice(0, 10);
+
+function gh(args) {
+  try {
+    return execFileSync('gh', args, { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 });
+  } catch (err) {
+    process.stderr.write(`gh ${args.join(' ')} failed: ${err.message}\n`);
+    return '';
+  }
+}
+function ghJson(args) {
+  const raw = gh(args).trim();
+  if (!raw) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+// ---- Reviewer-finding taxonomy: stable buckets via regex on finding text. ----
+// Each finding (a 🔴/🟡/❓ line in a reviewer review body) maps to ONE bucket so
+// recurrence is countable without fuzzy NLP. `docKeys` are substrings searched
+// in the doc corpus to decide "already documented".
+const TAXONOMY = [
+  { key: 'structured-data', re: /structured data|json-?ld|basesalary|postalcode|hiringorganization|jobposting/i, docKeys: ['structured data', 'json-ld', 'basesalary'] },
+  { key: 'missing-test-funnel', re: /missing test|test mancant|no test|senza test|test coverage/i, docKeys: ['test coverage', 'test mancant', 'senza test'] },
+  { key: 'time-bomb-hardcoded', re: /hardcoded|time-?bomb|absolute date|aged? out|invecchia|date assolut/i, docKeys: ['date assolut', 'time-bomb', 'daysago'] },
+  { key: 'cls-layout', re: /\bcls\b|layout shift|reflow|reserve space|min-h-|aspect-ratio/i, docKeys: ['cls', 'reserve space', 'layout shift'] },
+  { key: 'auto-ads', re: /auto ?ads|adsense|anchor ad|vignette|in-page ad/i, docKeys: ['auto ads', 'adsense'] },
+  { key: 'canonical-sitemap', re: /canonical|sitemap|noindex|cross-section/i, docKeys: ['canonical', 'sitemap', 'noindex'] },
+  { key: 'workflow-scope-creds', re: /workflows? scope|github_pat|\bpat\b|credential|secret|branch protection|push.*workflow/i, docKeys: ['workflows`', 'capability-guard', 'github_pat'] },
+  { key: 'i18n-naming', re: /locale|i18n|translat|canton-?aware|naming|brand/i, docKeys: ['locale', 'i18n', 'canton-aware'] },
+  { key: 'router-nav', re: /router|parsepath|staticoverlay|window\.location/i, docKeys: ['router', 'staticoverlay', 'parsepath'] },
+];
+function bucketFinding(text) {
+  for (const t of TAXONOMY) if (t.re.test(text)) return t.key;
+  return null; // unbucketed findings are ignored for recurrence (too noisy)
+}
+
+// ---- 1. Reviewer findings on recently-merged PRs ----
+const findingExamples = {}; // bucket -> [{pr, severity, snippet}]
+const findingCounts = {};
+const mergedPrs = ghJson(['pr', 'list', '--state', 'merged', '--search', `merged:>=${sinceDay}`,
+  '--limit', String(MAX_PRS), '--json', 'number']) || [];
+for (const { number } of mergedPrs) {
+  const data = ghJson(['pr', 'view', String(number), '--json', 'reviews']);
+  const reviews = data?.reviews || [];
+  for (const r of reviews) {
+    if (r.author?.login !== 'claude') continue;
+    const lines = String(r.body || '').split('\n');
+    for (const line of lines) {
+      const sev = line.includes('🔴') ? '🔴' : line.includes('🟡') ? '🟡' : line.includes('❓') ? '❓' : null;
+      if (!sev) continue;
+      const bucket = bucketFinding(line);
+      if (!bucket) continue;
+      findingCounts[bucket] = (findingCounts[bucket] || 0) + 1;
+      (findingExamples[bucket] ||= []).push({ pr: number, severity: sev, snippet: line.trim().slice(0, 160) });
+    }
+  }
+}
+
+// ---- 2. Recurring issue classes (created in window) ----
+function issueClass(title, labels) {
+  const t = title || '';
+  if (/^Crawler Failure/i.test(t)) return 'issue:crawler-failure';
+  if (/Validation Failure|Publish post-deploy/i.test(t)) return 'issue:validation-failure';
+  if (/\[crawler-health\]/i.test(t)) return 'issue:crawler-health';
+  if (/^follow-up\(/i.test(t)) return 'issue:follow-up';
+  const names = (labels || []).map((l) => l.name);
+  if (names.includes('revenue') || names.includes('rpm-canary')) return 'issue:revenue';
+  return null;
+}
+const issueCounts = {};
+const issueExamples = {};
+const allIssues = ghJson(['issue', 'list', '--state', 'all', '--search', `created:>=${sinceDay}`,
+  '--limit', String(MAX_ISSUES), '--json', 'number,title,labels']) || [];
+for (const it of allIssues) {
+  const cls = issueClass(it.title, it.labels);
+  if (!cls) continue;
+  issueCounts[cls] = (issueCounts[cls] || 0) + 1;
+  (issueExamples[cls] ||= []).push({ issue: it.number, title: (it.title || '').slice(0, 80) });
+}
+
+// ---- 3. issue-fix outcomes via FIX_OUTCOME markers in issue comments ----
+// Marker contract (issue-fix.yml prompt): the fixer's terminal comment starts
+// with `<!-- FIX_OUTCOME: <code> -->`. We bucket the blocked/no-pr codes since
+// those are the recurring-burn signal; `pr-created` is the healthy path.
+const outcomeCounts = {};
+const outcomeExamples = {};
+const fixIssues = ghJson(['issue', 'list', '--search', `label:agent:triaged updated:>=${sinceDay}`,
+  '--state', 'all', '--limit', String(MAX_ISSUES), '--json', 'number']) || [];
+for (const { number } of fixIssues.slice(0, MAX_ISSUES)) {
+  const data = ghJson(['issue', 'view', String(number), '--json', 'comments']);
+  const comments = data?.comments || [];
+  for (const c of comments) {
+    const m = String(c.body || '').match(/<!--\s*FIX_OUTCOME:\s*([a-z0-9-]+)\s*-->/i);
+    if (!m) continue;
+    const code = m[1].toLowerCase();
+    if (code === 'pr-created') continue; // healthy
+    const k = `fix-outcome:${code}`;
+    outcomeCounts[k] = (outcomeCounts[k] || 0) + 1;
+    (outcomeExamples[k] ||= []).push({ issue: number });
+  }
+}
+
+// ---- Dedup vs existing doc-contracts ----
+const DOC_FILES = ['AGENTS.md', 'ISSUES.md', 'REVIEW.md', 'FOLLOWUP.md'];
+let corpus = '';
+for (const f of DOC_FILES) { try { corpus += '\n' + fs.readFileSync(f, 'utf-8').toLowerCase(); } catch { /* ignore */ } }
+function alreadyDocumented(bucketKey) {
+  const tax = TAXONOMY.find((t) => t.key === bucketKey);
+  if (tax) return tax.docKeys.some((k) => corpus.includes(k.toLowerCase()));
+  // Non-taxonomy keys (issue-class / fix-outcome codes): check hyphen, space
+  // and nospace variants so "follow-up" matches a doc that writes "follow up".
+  const base = bucketKey.replace(/^[a-z-]+:/, '').toLowerCase();
+  const variants = [base, base.replace(/-/g, ' '), base.replace(/-/g, '')];
+  return variants.some((v) => corpus.includes(v));
+}
+
+// ---- Assemble clusters above threshold + novel ----
+const clusters = [];
+// `driver`: clusters that can drive a doc-rule proposal (an agent repeating a
+// mistake or hitting a wall). issue-class counts are operational VOLUME handled
+// by triage/monitors, not instruction signal → included as context, never a
+// proposal driver (novel stays false for them).
+function consider(source, counts, examples, { driver }) {
+  for (const [key, count] of Object.entries(counts)) {
+    if (count < THRESHOLD) continue;
+    const documented = alreadyDocumented(key);
+    clusters.push({ source, key, count, driver, novel: driver && !documented,
+      alreadyDocumented: documented, examples: (examples[key] || []).slice(0, 5) });
+  }
+}
+consider('reviewer-finding', findingCounts, findingExamples, { driver: true });
+consider('fix-outcome', outcomeCounts, outcomeExamples, { driver: true });
+consider('issue-class', issueCounts, issueExamples, { driver: false });
+
+clusters.sort((a, b) => b.count - a.count);
+const novel = clusters.filter((c) => c.novel);
+
+const result = { generatedForWindowDays: WINDOW_DAYS, threshold: THRESHOLD, since: sinceDay,
+  totalClusters: clusters.length, novelClusters: novel.length, clusters };
+fs.writeFileSync(OUT, JSON.stringify(result, null, 2));
+
+// ---- Human summary ----
+console.log(`Lessons harvest — window ${WINDOW_DAYS}d (since ${sinceDay}), threshold ≥${THRESHOLD}`);
+console.log(`Merged PRs scanned: ${mergedPrs.length} · issues scanned: ${allIssues.length} · fix-issues: ${fixIssues.length}`);
+if (!clusters.length) console.log('No recurring clusters above threshold.');
+for (const c of clusters) {
+  console.log(`  [${c.novel ? 'NOVEL' : 'documented'}] ${c.source}/${c.key} ×${c.count}` +
+    (c.examples?.length ? `  e.g. ${c.examples.map((e) => '#' + (e.pr || e.issue)).join(',')}` : ''));
+}
+console.log(`\n→ novel recurring clusters: ${novel.length}`);
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `has_novel=${novel.length > 0}\nnovel_count=${novel.length}\n`);
+}


### PR DESCRIPTION
## Implementato
Loop di **auto-miglioramento** delle istruzioni agli agent (reviewer/fixer), su richiesta esplicita: i pattern ricorrenti rientrano nei doc-contract → gli agent smettono di ripeterli → turnaround più basso. Cadenza **daily**.

- **`scripts/ci/harvest-agent-lessons.mjs`** (deterministico, zero-Claude): aggrega su finestra 14gg, soglia ≥3 — bucket reviewer-finding (tassonomia regex fissa: structured-data, missing-test, time-bomb/hardcoded, cls, auto-ads, canonical/sitemap, workflow-scope/creds, i18n, router) + `FIX_OUTCOME` bloccati. Dedup vs AGENTS.md/ISSUES.md/REVIEW.md/FOLLOWUP.md → emette solo cluster `novel`. Le issue-class (crawler/follow-up/validation) = volume operativo → contesto, mai driver. Testato in locale su dati reali: oggi 0 novel (tutto già documentato) → 0 token.
- **`.github/workflows/lessons-harvester.yml`** (daily 05:17 UTC + dispatch): esegue l'aggregatore; **solo se `has_novel`** spende 1 turno sonnet per draftare edit `.md` chirurgici e aprire 1 PR `lessons/auto-harvest-*`. **1 sola proposta pendente alla volta** (guard su PR aperte) → daily non genera duplicati.
- **`issue-fix.yml`**: il fixer chiude ogni run con marker `<!-- FIX_OUTCOME: <code> -->` (store = GitHub stesso, nessun file accumulatore).
- **`ISSUES.md`**: documenta loop, codici, soglia, kill-switch.

**Gate umano OBBLIGATORIO**: la PR di regole NON è mai auto-mergiata (un'istruzione sbagliata degrada *tutti* gli agent). Solo `.md`, mai logica. Frugale: giorno senza pattern nuovo = 0 token.

## Non implementato (ancora)
- **Telemetria reviewer dedicata**: riuso il formato 🔴/🟡 esistente nei review body (REVIEW.md) invece di aggiungere un marker → meno superficie modificata; se servisse precisione semantica, follow-up.
- **Storico**: i `FIX_OUTCOME` iniziano ad accumularsi dal merge in poi (i run passati non li hanno) → i cluster fix-outcome diventano significativi dopo qualche giorno.

> ⚠️ Modifica file in `.github/workflows/` (nuovo workflow + 1 riga in issue-fix.yml) → reviewer App-validation fallisce, no auto-merge → **merge manuale** `gh pr merge --squash --delete-branch` (eccezione AGENTS.md). Post-merge: `gh workflow run lessons-harvester.yml -f window_days=30` per uno smoke live.