### PR TITLE
fix(mobile): dati roaming operatori IT aggiornati a offerte attuali (giu 2026)

### DIFF
--- a/components/comparators/MobileOperators.tsx
+++ b/components/comparators/MobileOperators.tsx
@@ -75,8 +75,8 @@ const operators: MobileOperator[] = [
  sms: 200,
  roamingInSwitzerland: {
  included: true,
- dataLimit: 14,
- notes: 'Roaming CH gratuito come UE dall\'8 settembre 2025 (Roam Like At Home esteso). FUP UE applicata ai GB del piano.'
+ dataLimit: 11.4,
+ notes: 'Roaming CH gratuito come UE dall\'8 settembre 2025 (Roam Like At Home esteso). FUP roaming UE/CH 11.4 GB per la fascia 6.95€ (calcolata sul prezzo del piano).'
  },
  setupCost: 2.99,
  contractType: 'prepagato',
@@ -95,9 +95,9 @@ const operators: MobileOperator[] = [
  roamingInSwitzerland: {
  included: true,
  dataLimit: 32,
- notes: 'Roaming CH come Italia dal 5 settembre 2025 per clienti offerte Privati. Vodafone Start: 32 GB UE+UK+Svizzera inclusi.'
+ notes: 'Roaming CH come Italia dal 5 settembre 2025 per clienti offerte Privati. Vodafone Start: 32 GB UE+UK+Svizzera inclusi (17 GB normativi + 15 extra).'
  },
- setupCost: 6.99,
+ setupCost: 10,
  contractType: 'prepagato',
  color: 'from-danger-strong to-danger-strong-hover',
  features: ['32 GB roaming CH inclusi', 'Roam Like Home CH dal 09/2025', '5G disponibile'],
@@ -155,12 +155,12 @@ const operators: MobileOperator[] = [
  included: false,
  costPerMB: 4.88,
  costPerMinute: 0.49,
- notes: 'Nessun roaming CH incluso e nessuna opzione dedicata. Extra UE: 0.49€/min, 0.16€/SMS, 4.88€/MB.'
+ notes: 'Roaming CH non in Roam-Like-Home, ma opzione "Giga Svizzera" 10 GB a 4.99€/settimana (attivazione gratis, si rinnova solo se usata). Senza opzione: tariffe Extra UE 0.49€/min, 0.16€/SMS, 4.88€/MB.'
  },
  setupCost: 0,
  contractType: 'prepagato',
  color: 'from-danger-strong to-danger-strong-hover',
- features: ['200 GB + 5G Full Speed', 'SIM e spedizione gratis', 'Rete WindTre', 'Roaming CH non incluso'],
+ features: ['200 GB + 5G Full Speed', 'SIM e spedizione gratis', 'Rete WindTre', 'Opzione Giga Svizzera 10 GB 4.99€/sett'],
  website: 'https://www.verymobile.it/offerte'
  },
  {
@@ -489,7 +489,7 @@ const MobileOperators: React.FC = () => {
  <p className="text-muted text-lg">
  {t('mobile.subtitle')}
  </p>
- <div className="mt-3"><DataFreshness lastUpdated="2026-05" source="Operatori ufficiali" variant="badge" /></div>
+ <div className="mt-3"><DataFreshness lastUpdated="2026-06" source="Operatori ufficiali" variant="badge" /></div>
  </div>
 
  {/* Warning Banner */}

--- a/services/locales/de-comparatori.ts
+++ b/services/locales/de-comparatori.ts
@@ -345,7 +345,7 @@ const deComparatori: Record<string, string> = {
  'mobile.whichOperator': 'Welchen Anbieter wählen?',
  'mobile.operatorTip1': 'Wohnen in Italien, arbeiten in der Schweiz: Vodafone, Fastweb und ho. Mobile wenden Roam-Like-Home seit September 2025 auch auf die CH an (bis zu 32 GB inkl.). Spusu Oltreconfine enthält 10 GB CH dediziert für 9,98€/Monat.',
  'mobile.operatorTip2': 'Wohnen in der Schweiz, arbeiten in Italien: Wingo Europe Go und Sunrise Swiss Travel+ (unlim. in 8 EU-Ländern inkl. IT) bieten das beste Preis-Leistungs-Verhältnis.',
- 'mobile.operatorTip3': 'TIM und WindTre schliessen die CH nicht in Roam Like Home ein: dedizierte Pässe erforderlich (TIM Opzione Svizzera 5€/5GB, WindTre Travel Pass 19,99€/15GB). Very Mobile bietet keinen CH-Pass.',
+ 'mobile.operatorTip3': 'TIM und WindTre schliessen die CH nicht in Roam Like Home ein: dedizierte Pässe erforderlich (TIM Opzione Svizzera 5€/5GB, WindTre Travel Pass 19,99€/15GB). Very Mobile bietet die Option Giga Svizzera (10 GB für 4,99€/Woche).',
  'mobile.tricksTitle': 'Tricks und Tipps',
  'mobile.trick1': 'Dual SIM: Viele Grenzgänger nutzen 2 SIMs (eine IT + eine CH) für beste Abdeckung',
  'mobile.trick2': 'WiFi Calling: Aktivieren Sie es, um das italienische Netz in der Schweiz via WiFi zu nutzen (kostenlos)',

--- a/services/locales/en-comparatori.ts
+++ b/services/locales/en-comparatori.ts
@@ -345,7 +345,7 @@ const enComparatori: Record<string, string> = {
  'mobile.whichOperator': 'Which operator to choose?',
  'mobile.operatorTip1': 'If you live in Italy and work in Switzerland: Vodafone, Fastweb and ho. Mobile apply Roam-Like-Home to CH from September 2025 (up to 32 GB included). Spusu Oltreconfine includes 10 GB dedicated to CH at €9.98/month.',
  'mobile.operatorTip2': 'If you live in Switzerland and work in Italy: Wingo Europe Go and Sunrise Swiss Travel+ (unlimited in 8 EU countries including IT) offer the best value.',
- 'mobile.operatorTip3': 'TIM and WindTre do not include CH in Roam Like Home: dedicated passes are required (TIM Opzione Svizzera €5/5GB, WindTre Travel Pass €19.99/15GB). Very Mobile offers no CH pass.',
+ 'mobile.operatorTip3': 'TIM and WindTre do not include CH in Roam Like Home: dedicated passes are required (TIM Opzione Svizzera €5/5GB, WindTre Travel Pass €19.99/15GB). Very Mobile has the Giga Svizzera option (10 GB at €4.99/week).',
  'mobile.tricksTitle': 'Tricks and tips',
  'mobile.trick1': 'Dual SIM: Many cross-border workers use 2 SIMs (one IT + one CH) for the best coverage',
  'mobile.trick2': 'WiFi Calling: Enable it to use the Italian network in Switzerland via WiFi (free)',

--- a/services/locales/fr-comparatori.ts
+++ b/services/locales/fr-comparatori.ts
@@ -345,7 +345,7 @@ const frComparatori: Record<string, string> = {
  'mobile.whichOperator': 'Quel opérateur choisir ?',
  'mobile.operatorTip1': 'Résidence en Italie, travail en Suisse : Vodafone, Fastweb et ho. Mobile appliquent Roam-Like-Home à la CH depuis septembre 2025 (jusqu\'à 32 Go inclus). Spusu Oltreconfine inclut 10 Go CH dédiés à 9,98€/mois.',
  'mobile.operatorTip2': 'Résidence en Suisse, travail en Italie : Wingo Europe Go et Sunrise Swiss Travel+ (illimité dans 8 pays UE dont IT) offrent le meilleur rapport qualité-prix.',
- 'mobile.operatorTip3': 'TIM et WindTre n\'incluent pas la CH dans le Roam Like Home : pass dédiés requis (TIM Opzione Svizzera 5€/5Go, WindTre Travel Pass 19,99€/15Go). Very Mobile n\'offre aucun pass CH.',
+ 'mobile.operatorTip3': 'TIM et WindTre n\'incluent pas la CH dans le Roam Like Home : pass dédiés requis (TIM Opzione Svizzera 5€/5Go, WindTre Travel Pass 19,99€/15Go). Very Mobile propose l\'option Giga Svizzera (10 Go à 4,99€/semaine).',
  'mobile.tricksTitle': 'Trucs et astuces',
  'mobile.trick1': 'Double SIM : De nombreux frontaliers utilisent 2 SIM (une IT + une CH) pour la meilleure couverture',
  'mobile.trick2': 'WiFi Calling : Activez-le pour utiliser le réseau italien en Suisse via le WiFi (gratuit)',

--- a/services/locales/it-comparatori.ts
+++ b/services/locales/it-comparatori.ts
@@ -357,7 +357,7 @@ const translations: Record<string, string> = {
  'mobile.whichOperator': 'Quale operatore scegliere?',
  'mobile.operatorTip1': 'Se vivi in Italia e lavori in Svizzera: Vodafone, Fastweb e ho. Mobile applicano Roam-Like-Home alla CH dal settembre 2025 (fino a 32 GB inclusi). Spusu Oltreconfine include 10 GB CH dedicati a 9.98€/mese.',
  'mobile.operatorTip2': 'Se vivi in Svizzera e lavori in Italia: Wingo Europe Go e Sunrise Swiss Travel+ (illim 8 paesi UE inclusa IT) offrono il miglior rapporto qualità/prezzo.',
- 'mobile.operatorTip3': 'TIM e WindTre non includono CH nel Roam Like Home: servono pass dedicati (TIM Opzione Svizzera 5€/5GB, WindTre Travel Pass 19.99€/15GB). Very Mobile non offre alcun pass CH.',
+ 'mobile.operatorTip3': 'TIM e WindTre non includono CH nel Roam Like Home: servono pass dedicati (TIM Opzione Svizzera 5€/5GB, WindTre Travel Pass 19.99€/15GB). Very Mobile ha l\'opzione Giga Svizzera (10 GB a 4.99€/settimana).',
  'mobile.tricksTitle': 'Trucchi e consigli',
  'mobile.trick1': 'Dual SIM: Molti frontalieri usano 2 SIM (una IT + una CH) per avere sempre la migliore copertura',
  'mobile.trick2': 'WiFi Calling: Attivalo per usare la rete italiana anche in Svizzera via WiFi (gratis)',


### PR DESCRIPTION
## Implementato

Follow-up di #1039. Verifica dei dati reali correnti (giugno 2026) per gli operatori **italiani** della pagina `/compara-servizi/confronta-operatori-mobili/`, su fonti ufficiali. Corretti i campi stale:

| Operatore | Campo | Prima | Ora | Fonte |
|---|---|---|---|---|
| **ho. Mobile** | GB roaming CH (FUP) | 14 GB | **11.4 GB** | supporto.ho-mobile.it (tabella ufficiale fascia 6.95€; CH = UE in RLAH) |
| **Vodafone** | costo attivazione | 6.99€ | **10€** | privati.vodafone.it Mobile Start (6.99€ era SIM dati diversa) |
| **Very Mobile** | opzione CH | "nessuna opzione" | **Giga Svizzera 10 GB @4.99€/sett** | verymobile.it/opzioni-estero |
| badge | DataFreshness | 2026-05 | 2026-06 | — |

- La correzione **ho. Mobile** è quella segnalata: il riepilogo "Migliori Opzioni" mostrava 14 GB, il valore reale per la fascia 6.95€ è 11.4 GB. Resta in top-3 IT (valore 11.4/6.95 ancora > Spusu).
- **Very Mobile**: aggiornati `notes` + feature pill + `mobile.operatorTip3` in tutti e 4 i locali (it/en/de/fr) — prima diceva "non offre alcun pass CH", ora falso.
- Verificati e confermati **corretti/invariati**: Fastweb (32 GB, 9.95€, setup 10€), Spusu (10 GB, 9.98€), Iliad, TIM, monthlyCost di tutti.

## Non implementato (ancora)

- **WindTre — attivazione Travel Pass**: il note dice "Attivazione 2.99€", una fonte secondaria (mondomobileweb, revamp 5 mar 2026) indica 1.99€. **Non modificato**: solo fonte secondaria non confermata su pagina ufficiale → non asserisco un numero non verificato (vedi regola verify-before-asserting). Da ricontrollare su windtre.it.
- **Iliad "Giga 200"**: in dismissione, sostituito da "Top 250 Plus" (250 GB, stesso 9.99€) dopo il 30/06/2026. Dati oggi corretti; follow-up dopo quella data per aggiornare nome/GB.
- **Very Mobile cost model**: l'opzione è settimanale (4.99€/sett), non rappresentabile come `monthlyFee` fisso senza inventare un numero → lasciato `included:false` con dettaglio nelle note, `realMonthlyCost` invariato (base 6.99€).

## Verifica

- `tsc --noEmit`: 0 errori nei file toccati (gli errori totali sono in `tests/` + `build-plugins/` pre-esistenti su main).
- Dev server + Playwright sulla pagina live: riepilogo IT = Vodafone 32 GB / Fastweb 32 GB / **ho. Mobile 11.4 GB**; card Very Mobile mostra "Giga Svizzera 10 GB a 4.99€/settimana"; Vodafone attivazione 10€. "Giga Svizzera" presente 3× (note + pill + tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)