### PR TITLE
fix(slugs): registry pin authoritative in second harden slug loop (follow-up #1044)

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -1569,6 +1569,23 @@ export function hardenJobLocaleFields({ dataJobsPath }) {
     }
 
     for (const locale of DEFAULT_LOCALES) {
+      // Registry pin (same authority as the first locale loop above): a locale
+      // whose immutable registry slug is a real translation is governed solely
+      // by the registry — never quality-repaired toward a title-derived form.
+      // Without this guard a registered job whose registry slug is itself
+      // low-quality (boilerplate / federal-placeholder / German-word) would be
+      // "repaired" here, demoting the indexed registry slug to previousSlugs and
+      // churning the canonical away from the indexed URL — exactly the drift
+      // this fix exists to prevent. Re-assert the pin defensively in case an
+      // earlier pass left it unset.
+      const pinnedSlug = registryPinnedLocaleSlug(registeredSlug, locale, titleSourceLang);
+      if (pinnedSlug) {
+        if (String(job.slugByLocale[locale] || '').trim() !== pinnedSlug) {
+          job.slugByLocale[locale] = pinnedSlug;
+          jobChanged = true;
+        }
+        continue;
+      }
       const localizedTitle = String(job.titleByLocale[locale] || '').trim();
       const localizedSlug = String(job.slugByLocale[locale] || '').trim();
       if (!localizedTitle) continue;
@@ -4313,17 +4330,25 @@ const SLUG_REGISTRY_PATH = path.resolve(
   '..', '..', 'data', 'slug-registry.json',
 );
 
+// Resolved at call time so tests can point load/save at a controlled fixture via
+// SLUG_REGISTRY_PATH_OVERRIDE. Unset in all prod/CI paths → identical behavior.
+function resolveSlugRegistryPath() {
+  const override = process.env.SLUG_REGISTRY_PATH_OVERRIDE;
+  return override ? path.resolve(override) : SLUG_REGISTRY_PATH;
+}
+
 export function loadSlugRegistry() {
   try {
-    if (fs.existsSync(SLUG_REGISTRY_PATH)) {
-      return JSON.parse(fs.readFileSync(SLUG_REGISTRY_PATH, 'utf-8'));
+    const registryPath = resolveSlugRegistryPath();
+    if (fs.existsSync(registryPath)) {
+      return JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
     }
   } catch { /* ignore malformed file */ }
   return {};
 }
 
 export function saveSlugRegistry(registry) {
-  fs.writeFileSync(SLUG_REGISTRY_PATH, JSON.stringify(registry, null, 2) + '\n');
+  fs.writeFileSync(resolveSlugRegistryPath(), JSON.stringify(registry, null, 2) + '\n');
 }
 
 export function getRegisteredSlug(job, registry) {
@@ -4333,8 +4358,11 @@ export function getRegisteredSlug(job, registry) {
 }
 
 /**
- * Single source of truth for "the immutable registry slug beats any slug
- * re-derived from a (possibly re-translated) title".
+ * Shared decision for "the immutable registry slug beats any slug re-derived
+ * from a (possibly re-translated) title", used by both title→slug derivation
+ * paths (hardenJobLocaleFields, regenerate-slugs-by-locale.mjs). The same
+ * source-copy rule is also applied inline by mergeAndDeduplicate and the post-AI
+ * backfill in shared-jobs-crawler.mjs; keep those in sync if this changes.
  *
  * Root cause of slug instability: a job's localized slug is derived from its
  * AI-translated title, and AI translation is non-deterministic (temperature +

--- a/scripts/regenerate-slugs-by-locale.mjs
+++ b/scripts/regenerate-slugs-by-locale.mjs
@@ -139,9 +139,17 @@ async function main() {
         // then skip title-based regeneration for this locale entirely.
         const pinnedSlug = registryPinnedLocaleSlug(getRegisteredSlug(job, slugRegistry), locale, sourceLang);
         if (pinnedSlug) {
+          // Defense-in-depth: the registry pin bypasses the cross-job
+          // disambiguator the title-derivation path applies below, so surface a
+          // pre-existing registry collision (two job ids registered to the same
+          // per-locale slug) instead of silently minting two identical URLs.
+          const slugMap = usedSlugs.get(locale);
+          const owner = slugMap.get(pinnedSlug);
+          if (owner && owner !== job.id) {
+            console.warn(`[registry-pin] ${locale} slug "${pinnedSlug}" registered to ${job.id} also owned by ${owner} — canonical split (pre-existing registry collision)`);
+          }
           if (currentSlug && currentSlug !== pinnedSlug) {
             addPreviousSlugForLocale(job, locale, currentSlug, 20);
-            const slugMap = usedSlugs.get(locale);
             if (slugMap.get(currentSlug) === job.id) slugMap.delete(currentSlug);
             slugMap.set(pinnedSlug, job.id);
             sbl[locale] = pinnedSlug;
@@ -151,7 +159,7 @@ async function main() {
           } else if (!currentSlug) {
             sbl[locale] = pinnedSlug;
             job.slugByLocale = sbl;
-            usedSlugs.get(locale).set(pinnedSlug, job.id);
+            slugMap.set(pinnedSlug, job.id);
             sliceChanged = true;
             totalPinned++;
           }

--- a/tests/harden-registry-pin-quality-repair.test.ts
+++ b/tests/harden-registry-pin-quality-repair.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for the second slug-derivation loop in hardenJobLocaleFields.
+ *
+ * The registry pin must be authoritative in BOTH locale loops. The second loop
+ * (quality-repair: boilerplate / italian / federal-placeholder) bypasses the
+ * isSlugStable anti-churn guard, so without an explicit pin guard it would
+ * "repair" a registered job's slug — demoting the immutable, indexed registry
+ * slug to previousSlugs and churning the canonical away from the indexed URL.
+ *
+ * Strategy: two jobs share a boilerplate EN slug (matches SLUG_BOILERPLATE_RE →
+ * needsBoilerplateSlugRepair → isQualityRepair → bypasses isSlugStable). One is
+ * registered (must stay pinned), one is not (must be repaired). This proves the
+ * second loop both fires (control job repaired) and is guarded (registered job
+ * frozen). Uses SLUG_REGISTRY_PATH_OVERRIDE to inject a controlled registry.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const BOILERPLATE_EN = 'permette-di-combinare-efficacemente-informatico-eoc-bellinzona';
+
+const REGISTERED_ID = '990001';
+const UNREGISTERED_ID = '990002';
+
+const tmpFiles: string[] = [];
+afterEach(() => {
+  delete process.env.SLUG_REGISTRY_PATH_OVERRIDE;
+  for (const f of tmpFiles.splice(0)) {
+    try { fs.unlinkSync(f); } catch { /* already gone */ }
+  }
+});
+
+function makeJob(id: string) {
+  return {
+    id: `umantis-${id}`,
+    url: `https://recruitingapp-2908.umantis.com/Vacancies/${id}/Description/1`,
+    title: 'Informatiker/in', // German source title → titleSourceLang = de
+    company: 'EOC',
+    location: 'Bellinzona',
+    addressLocality: 'Bellinzona',
+    slug: 'informatico-a-eoc-bellinzona',
+    titleByLocale: {
+      it: 'Informatico/a',
+      en: 'Computer Scientist',
+      de: 'Informatiker/in',
+      fr: 'Informaticien/ne',
+    },
+    slugByLocale: {
+      it: 'informatico-a-eoc-bellinzona',
+      en: BOILERPLATE_EN, // both jobs start with the same boilerplate EN slug
+      de: 'informatiker-in-eoc-bellinzona',
+      fr: 'informaticien-ne-eoc-bellinzona',
+    },
+  };
+}
+
+describe('hardenJobLocaleFields registry pin — quality-repair loop', () => {
+  it('keeps the registered boilerplate slug pinned while repairing the unregistered one', async () => {
+    // Controlled registry: only the REGISTERED job is locked, to the boilerplate
+    // EN slug (distinct from IT and DE so the source-copy guard does not skip it).
+    const registry = {
+      [`id|umantis.com|${REGISTERED_ID}`]: {
+        canonicalSlug: 'informatico-a-eoc-bellinzona',
+        slugByLocale: {
+          it: 'informatico-a-eoc-bellinzona',
+          en: BOILERPLATE_EN,
+          de: 'informatiker-in-eoc-bellinzona',
+          fr: 'informaticien-ne-eoc-bellinzona',
+        },
+      },
+    };
+    const regPath = path.join(os.tmpdir(), `slug-registry-fixture-${process.pid}.json`);
+    fs.writeFileSync(regPath, JSON.stringify(registry), 'utf-8');
+    tmpFiles.push(regPath);
+    process.env.SLUG_REGISTRY_PATH_OVERRIDE = regPath;
+
+    // Import AFTER setting the override; the path is resolved at call time so the
+    // load picks up the fixture regardless of import order, but this keeps intent
+    // explicit.
+    const { hardenJobLocaleFields } = await import('../scripts/lib/dedicated-crawler-common.mjs');
+
+    const jobsPath = path.join(os.tmpdir(), `harden-quality-repair-${process.pid}.json`);
+    fs.writeFileSync(jobsPath, JSON.stringify([makeJob(REGISTERED_ID), makeJob(UNREGISTERED_ID)], null, 2), 'utf-8');
+    tmpFiles.push(jobsPath);
+
+    hardenJobLocaleFields({ dataJobsPath: jobsPath });
+    const out = JSON.parse(fs.readFileSync(jobsPath, 'utf-8'));
+    const registered = out.find((j: { id: string }) => j.id === `umantis-${REGISTERED_ID}`);
+    const unregistered = out.find((j: { id: string }) => j.id === `umantis-${UNREGISTERED_ID}`);
+
+    // Registered job: registry pin is authoritative — boilerplate slug survives
+    // the quality-repair loop instead of churning the indexed URL, and is NOT
+    // demoted to previousSlugs (no canonical move at all).
+    expect(registered.slugByLocale.en).toBe(BOILERPLATE_EN);
+    expect(registered.previousSlugsByLocale?.en || []).not.toContain(BOILERPLATE_EN);
+
+    // Control: the unregistered job IS repaired by the quality-repair loop — the
+    // boilerplate slug is replaced and demoted to previousSlugs. This proves the
+    // loop actually fires, so the pin assertion above is meaningful (not a no-op).
+    expect(unregistered.slugByLocale.en).not.toBe(BOILERPLATE_EN);
+    expect(unregistered.previousSlugsByLocale?.en || []).toContain(BOILERPLATE_EN);
+  });
+});


### PR DESCRIPTION
Follow-up al 🔴 Important della review di #1044.

## Contesto

#1044 ha aggiunto il registry-pin per fermare il churn di slug da traduzione AI non-deterministica. Il reviewer ha trovato un buco reale: il pin in `hardenJobLocaleFields` faceva `continue` **solo** sul primo loop locale. Un **secondo** loop di derivazione slug gira dopo e, per i casi quality-repair (`needsBoilerplateSlugRepair` / `needsItalianSlugRepair`), **bypassa** il guard anti-churn `isSlugStable` — quindi un job registrato il cui slug registry è esso stesso low-quality veniva "riparato" lì, demotando lo slug registry immutabile/indicizzato a `previousSlugs` e spostando il canonical via dall'URL indicizzato. Il pin non era "authoritative" come dichiarato.

## Implementato

- **Guard del secondo loop** (`scripts/lib/dedicated-crawler-common.mjs` L1571) con lo stesso `registryPinnedLocaleSlug()`: un locale registrato è governato **solo** dal registry e salta il quality-repair. Il repair resta pienamente attivo per i job **non registrati/fresh** — la registrazione cattura lo slug *post-repair*, quindi i bad-slug si correggono al primo crawl, prima del lock. Scelta di design: una volta indicizzato, stabilità > correzione cosmetica (coerente con la tesi di immutabilità di #1044).
- **`regenerate-slugs-by-locale.mjs`** (🟡 nit review): `console.warn` su collisione registry per-locale pre-esistente nel path di pin (che bypassa il disambiguatore cross-job del path title-derived).
- **`loadSlugRegistry`/`saveSlugRegistry`** risolvono il path a call-time onorando `SLUG_REGISTRY_PATH_OVERRIDE` → registry iniettabile nei test; **unset in tutti i path prod/CI = comportamento identico**. JSDoc di `registryPinnedLocaleSlug` ammorbidito (🟡 nit: la regola source-copy è ancora inline in `mergeAndDeduplicate` + backfill post-AI).
- **Test** `tests/harden-registry-pin-quality-repair.test.ts`: due job condividono uno slug EN boilerplate; il registrato resta pinnato (nessuna demotion) mentre il non-registrato è riparato e demoto a `previousSlugs` — prova che il secondo loop **scatta** (control) ed è **guardato** (registered).

Test: 9 nuovi/correlati verdi + suite slug/crawler/localization (90) verde. `node --check` ok su entrambi i file. Registry tracked non mutato.

## Non implementato (ancora)

- **Deduplicare la regola source-copy** nei 3 call site (`mergeAndDeduplicate`, backfill post-AI in `shared-jobs-crawler.mjs`, helper): solo ammorbidito il commento. Migrazione a `registryPinnedLocaleSlug` ovunque = refactor più ampio, fuori scope di questo hotfix (follow-up se il guard cambia).
- **❓ della review** (fingerprint URL→key, unicità globale per-locale dello slug registry, detection `titleSourceLang` su titoli degeneri): non coperti da nuovi test mirati; il fingerprint è esercitato indirettamente (il test fallirebbe loud se cambiasse), gli altri sono assunzioni pre-esistenti non introdotte da questa PR.
- **Redirect 301 dell'URL orfano originale** (psychology-assistant-...): come #1044, resta lato `seo-404-compat-paths.json`, follow-up se emergono 404 reali da GSC.

Supersedes: nessuna issue aperta (il 🔴 era un finding di review post-merge, non un'issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)