### PR TITLE
feat(newsletter): add Maileroo email provider (send + tracking + quota)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7,6 +7,7 @@ import { handleMailgunWebhookRequest } from './src/newsletterMailgunWebhookCore.
 import { handleMailjetWebhookRequest } from './src/newsletterMailjetWebhookCore.js';
 import { handleUnosendWebhookRequest } from './src/newsletterUnosendWebhookCore.js';
 import { handleMailtrapWebhookRequest } from './src/newsletterMailtrapWebhookCore.js';
+import { handleMailerooWebhookRequest } from './src/newsletterMailerooWebhookCore.js';
 import { handleSubscriptionManagement } from './src/newsletterSubscriptionManagement.js';
 import { sendNewsletterConfirmationEmail } from './src/newsletterConfirmationEmail.js';
 import { handleSendCalculatorReport } from './src/sendCalculatorReport.js';
@@ -186,6 +187,43 @@ export const newsletterMailtrapWebhook = onRequest(
  const message = error instanceof Error ? error.message : String(error || 'unknown_error');
  const status = /secret/i.test(message) ? 401 : 500;
  console.error('[newsletterMailtrapWebhook] Error:', message);
+ res.status(status).json({ ok: false, error: message });
+ }
+ },
+);
+
+// Maileroo delivery event webhooks
+export const newsletterMailerooWebhook = onRequest(
+ {
+ region: 'europe-west6',
+ memory: '256MiB',
+ timeoutSeconds: 60,
+ cors: false,
+ },
+ async (req, res) => {
+ if (req.method !== 'POST') {
+ res.status(405).json({ ok: false, error: 'method_not_allowed' });
+ return;
+ }
+
+ const payload = Buffer.isBuffer(req.rawBody)
+ ? req.rawBody.toString('utf8')
+ : typeof req.rawBody === 'string'
+ ? req.rawBody
+ : JSON.stringify(req.body || {});
+
+ try {
+ const signingSecret = await getRemoteConfigValue('MAILEROO_WEBHOOK_SECRET');
+ const result = await handleMailerooWebhookRequest({
+ payload,
+ headers: req.headers,
+ signingSecret,
+ });
+ res.status(200).json({ ok: true, result });
+ } catch (error) {
+ const message = error instanceof Error ? error.message : String(error || 'unknown_error');
+ const status = /signature/i.test(message) ? 401 : 500;
+ console.error('[newsletterMailerooWebhook] Error:', message);
  res.status(status).json({ ok: false, error: message });
  }
  },

--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -1,0 +1,256 @@
+import admin from 'firebase-admin';
+import crypto from 'crypto';
+import { refreshEngagementScore } from './lib/engagementScore.js';
+
+/**
+ * Maileroo webhook handler — receives delivery events and stores them in Firestore.
+ *
+ * Maileroo signs each webhook with HMAC-SHA256 over the raw request body using a
+ * shared secret (Maileroo dashboard → Webhooks). The signature is sent in the
+ * `x-maileroo-signature` header as a hex digest (optionally prefixed "sha256=").
+ *
+ * Event types (Maileroo): accepted, delivered, rejected, deferred, failed,
+ * opened, clicked, complained. Payloads may be a single event object or a
+ * batch under { events: [...] }.
+ *
+ * Firestore paths (same as other provider webhooks):
+ *   newsletter_subscribers/{email}/events/{auto-id}
+ *   newsletter_subscribers/{email}/campaign_deliveries/{campaign-id}
+ *   newsletter_subscribers/{email} (status updates: bounced, complained)
+ *   job_alert_subscribers/{email} (when tagged type=job-alert)
+ */
+
+function normalizeEmail(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+// ── Signature verification ───────────────────────────────────
+// HMAC-SHA256(rawBody, secret) → hex, compared against x-maileroo-signature.
+
+export function verifyMailerooSignature({ payload, signature, signingSecret }) {
+  if (!signingSecret || !payload || !signature) return false;
+  const provided = String(signature).replace(/^sha256=/i, '').trim();
+  const expected = crypto
+    .createHmac('sha256', signingSecret)
+    .update(payload, 'utf8')
+    .digest('hex');
+  try {
+    return provided.length === expected.length
+      && crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+// ── Event type mapping (Maileroo → normalized types) ─────────
+
+function mapMailerooEvent(type) {
+  switch (String(type || '').toLowerCase()) {
+    case 'accepted':   return 'send';
+    case 'delivered':  return 'delivered';
+    case 'opened':     return 'open';
+    case 'clicked':    return 'click';
+    case 'rejected':   return 'bounce';
+    case 'failed':     return 'bounce';
+    case 'complained': return 'complaint';
+    // 'deferred' is transient (retry in progress) — no terminal state to record.
+    default: return null;
+  }
+}
+
+// ── Extract identifiers from a Maileroo event ────────────────
+
+function extractCampaignId(event) {
+  const tags = event.tags || {};
+  if (tags && typeof tags === 'object' && !Array.isArray(tags)) {
+    if (tags.campaign_id) return String(tags.campaign_id);
+    if (tags.campaign) return String(tags.campaign);
+  }
+  return event.message_reference_id || event.message_id || 'unknown';
+}
+
+function getRecipient(event) {
+  const data = event.event_data || {};
+  return normalizeEmail(data.to || event.to);
+}
+
+function isJobAlertEvent(event) {
+  const tags = event.tags || {};
+  if (tags && typeof tags === 'object' && !Array.isArray(tags)) {
+    return tags.type === 'job-alert' || tags.type === 'job-alert-retry';
+  }
+  return false;
+}
+
+function getOccurredAt(event) {
+  const t = event.event_time ?? event.inserted_at;
+  if (typeof t === 'number') return new Date(t * 1000).toISOString();
+  if (typeof t === 'string' && t) return t;
+  return new Date().toISOString();
+}
+
+// ── Persist a single event to Firestore ──────────────────────
+
+export async function persistMailerooEvent(db, event) {
+  const email = getRecipient(event);
+  if (!email || !email.includes('@')) return { skipped: true, reason: 'invalid_email' };
+
+  const type = mapMailerooEvent(event.event_type);
+  if (!type) return { skipped: true, reason: `unknown_event: ${event.event_type}` };
+
+  const campaignId = extractCampaignId(event);
+  const messageId = event.message_id || event.message_reference_id || '';
+  const occurredAt = getOccurredAt(event);
+  const data = event.event_data || {};
+  const clickedUrl = data.original_url || data.url || '';
+  const bounceReason = data.reason || data.reject_reason || '';
+
+  if (isJobAlertEvent(event)) {
+    return persistJobAlertMailerooEvent(db, { email, type, event, messageId, occurredAt, clickedUrl });
+  }
+
+  const FieldValue = admin.firestore.FieldValue;
+  const subscriberRef = db.collection('newsletter_subscribers').doc(email);
+
+  const subscriberUpdate = {
+    updated_at: FieldValue.serverTimestamp(),
+  };
+
+  if (type === 'delivered') {
+    subscriberUpdate.last_delivered_at = FieldValue.serverTimestamp();
+  } else if (type === 'open') {
+    subscriberUpdate.last_open_at = FieldValue.serverTimestamp();
+    subscriberUpdate.open_count = FieldValue.increment(1);
+  } else if (type === 'click') {
+    subscriberUpdate.last_click_at = FieldValue.serverTimestamp();
+    subscriberUpdate.click_count = FieldValue.increment(1);
+    subscriberUpdate.last_clicked_url = clickedUrl;
+  } else if (type === 'bounce') {
+    subscriberUpdate.status = 'bounced';
+    subscriberUpdate.bounced_at = FieldValue.serverTimestamp();
+    subscriberUpdate.bounce_reason = bounceReason;
+  } else if (type === 'complaint') {
+    subscriberUpdate.status = 'complained';
+    subscriberUpdate.complained_at = FieldValue.serverTimestamp();
+  }
+
+  await subscriberRef.set(subscriberUpdate, { merge: true });
+
+  // Refresh engagement score after counter changes (FRO-17)
+  if (type === 'open' || type === 'click' || type === 'send') {
+    await refreshEngagementScore(subscriberRef, FieldValue);
+  }
+
+  const deliveryData = {
+    email,
+    campaign_id: campaignId,
+    message_id: messageId,
+    provider: 'maileroo',
+    updated_at: FieldValue.serverTimestamp(),
+  };
+
+  if (type === 'send') deliveryData.sent_at = FieldValue.serverTimestamp();
+  if (type === 'delivered') deliveryData.delivered_at = FieldValue.serverTimestamp();
+  if (type === 'open') deliveryData.opened_at = FieldValue.serverTimestamp();
+  if (type === 'bounce') deliveryData.bounced_at = FieldValue.serverTimestamp();
+  if (type === 'complaint') deliveryData.complained_at = FieldValue.serverTimestamp();
+  if (type === 'click') {
+    deliveryData.clicked_at = FieldValue.serverTimestamp();
+    deliveryData.last_clicked_url = clickedUrl;
+    deliveryData.clicked_links = FieldValue.increment(1);
+  }
+
+  const deliveryDocId = `${campaignId}_${email}`.replace(/[/\\]/g, '_').slice(0, 200);
+  await subscriberRef.collection('campaign_deliveries').doc(deliveryDocId).set(deliveryData, { merge: true });
+
+  await subscriberRef.collection('events').add({
+    email,
+    event_type: type,
+    maileroo_event: event.event_type,
+    campaign_id: campaignId,
+    message_id: messageId,
+    provider: 'maileroo',
+    metadata: {
+      event_id: event.event_id || null,
+      reason: bounceReason || null,
+      original_url: clickedUrl || null,
+      ip: data.ip || null,
+      user_agent: data.user_agent || null,
+      tags: event.tags || null,
+    },
+    timestamp: FieldValue.serverTimestamp(),
+    occurred_at: occurredAt,
+  });
+
+  return { processed: true, type, email, campaignId };
+}
+
+// ── Job alert event handler (mirrors newsletter pattern) ─────
+
+async function persistJobAlertMailerooEvent(db, { email, type, event, messageId, occurredAt, clickedUrl }) {
+  const FieldValue = admin.firestore.FieldValue;
+  const subscriberRef = db.collection('job_alert_subscribers').doc(email);
+
+  const topUpdate = { email, updated_at: FieldValue.serverTimestamp() };
+  if (type === 'delivered') { topUpdate.last_delivered_at = FieldValue.serverTimestamp(); topUpdate.delivered_count = FieldValue.increment(1); }
+  if (type === 'open') { topUpdate.last_open_at = FieldValue.serverTimestamp(); topUpdate.open_count = FieldValue.increment(1); }
+  if (type === 'click') { topUpdate.last_click_at = FieldValue.serverTimestamp(); topUpdate.click_count = FieldValue.increment(1); topUpdate.last_clicked_url = clickedUrl; }
+  if (type === 'bounce') { topUpdate.status = 'bounced'; topUpdate.last_bounced_at = FieldValue.serverTimestamp(); topUpdate.bounce_count = FieldValue.increment(1); }
+  if (type === 'complaint') { topUpdate.status = 'complained'; topUpdate.last_complained_at = FieldValue.serverTimestamp(); }
+  if (type === 'delivered' || type === 'open' || type === 'click') topUpdate.status = 'active';
+
+  await subscriberRef.set(topUpdate, { merge: true });
+
+  await subscriberRef.collection('events').add({
+    email,
+    event_type: type,
+    maileroo_event: event.event_type,
+    message_id: messageId,
+    provider: 'maileroo',
+    metadata: {
+      original_url: clickedUrl || null,
+      tags: event.tags || null,
+    },
+    timestamp: FieldValue.serverTimestamp(),
+    occurred_at: occurredAt,
+  });
+
+  return { processed: true, type, email, collection: 'job_alert_subscribers' };
+}
+
+// ── Request handler ──────────────────────────────────────────
+
+export async function handleMailerooWebhookRequest({ payload, headers, signingSecret }) {
+  const sigHeader = headers?.['x-maileroo-signature'] || headers?.['X-Maileroo-Signature'];
+
+  if (signingSecret) {
+    if (!verifyMailerooSignature({ payload, signature: sigHeader, signingSecret })) {
+      console.warn('[mailerooWebhook] Signature mismatch or missing');
+      throw new Error('Invalid Maileroo webhook signature');
+    }
+  }
+
+  const body = typeof payload === 'string' ? JSON.parse(payload) : (payload || {});
+
+  // Support both a single event object and a batched { events: [...] } payload.
+  const events = Array.isArray(body.events) ? body.events : (body.event_type ? [body] : []);
+  if (events.length === 0) {
+    console.log('[mailerooWebhook] No events in payload (ping or empty batch)');
+    return { ok: true, ping: true };
+  }
+
+  const db = admin.firestore();
+  const results = [];
+  for (const event of events) {
+    try {
+      const result = await persistMailerooEvent(db, event);
+      results.push(result);
+      console.log(`[mailerooWebhook] ${event.event_type} → ${result.type || 'skipped'} for ${getRecipient(event) || '?'}`);
+    } catch (err) {
+      console.error(`[mailerooWebhook] Error processing ${event.event_type}: ${err.message}`);
+      results.push({ error: err.message, event: event.event_type });
+    }
+  }
+
+  return { processed: results.length, results };
+}

--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -2,7 +2,7 @@
 /**
  * email-cascade.mjs — Multi-provider email sending with daily quota tracking.
  *
- * Cascade order: Mailgun → Resend → Mailtrap → Unosend
+ * Cascade order: Mailgun → Resend → Mailjet → Mailtrap → Maileroo
  * Each provider has a daily quota. When one is exhausted, the next takes over.
  * Tracking (persistDelivery) is provider-agnostic — callers handle Firestore writes.
  *
@@ -23,6 +23,7 @@
  *   MAILGUN_DOMAIN           — Mailgun sending domain
  *   UNOSEND_API_KEY          — Unosend API key (6000/mo free tier)
  *   MAILTRAP_API_TOKEN       — Mailtrap API token (1000/mo free tier)
+ *   MAILEROO_API_KEY         — Maileroo sending key (3000/mo free tier)
  *   RESEND_API_KEY           — Resend API key (fallback only)
  */
 
@@ -33,6 +34,7 @@ const PROVIDERS = [
   { id: 'resend',   dailyLimit: 100, monthlyLimit: 3000  },
   { id: 'mailjet',  dailyLimit: 200, monthlyLimit: 6000  },
   { id: 'mailtrap', dailyLimit: 150, monthlyLimit: 4000  },
+  { id: 'maileroo', dailyLimit: 100, monthlyLimit: 3000  },
   // unosend: disabled — re-enable when needed.
   // { id: 'unosend',  dailyLimit: 200, monthlyLimit: 6000  },
 ];
@@ -158,6 +160,15 @@ async function fetchResendDailyUsage() {
   } catch { return 0; }
 }
 
+async function fetchMailerooDailyUsage() {
+  // Maileroo's v2 API exposes no public usage/statistics endpoint (only
+  // send + scheduled-email management). Daily cap is therefore enforced by the
+  // in-memory counter alone — starting from 0 each run is safe (may overshoot
+  // the daily quota slightly across separate runs on the same day, same as the
+  // fallback behaviour of every other provider on API error).
+  return 0;
+}
+
 /**
  * Sync in-memory counters with real provider usage for today.
  * Called once per cascade run. Falls back to 0 on API errors (safe: may overshoot quota slightly).
@@ -166,12 +177,13 @@ async function syncQuotasFromAPIs() {
   if (_quotasSynced && _counterDate === getTodayUTC()) return;
 
   console.log('📊 Syncing quotas from provider APIs...');
-  const [mailgun, mailjet, mailtrap, unosend, resend] = await Promise.all([
+  const [mailgun, mailjet, mailtrap, unosend, resend, maileroo] = await Promise.all([
     fetchMailgunDailyUsage(),
     fetchMailjetDailyUsage(),
     fetchMailtrapDailyUsage(),
     fetchUnosendDailyUsage(),
     fetchResendDailyUsage(),
+    fetchMailerooDailyUsage(),
   ]);
 
   _counterDate = getTodayUTC();
@@ -180,9 +192,10 @@ async function syncQuotasFromAPIs() {
   _counters.mailtrap = mailtrap;
   _counters.unosend = unosend;
   _counters.resend = resend;
+  _counters.maileroo = maileroo;
   _quotasSynced = true;
 
-  console.log(`   Usage today: mailgun=${mailgun}/100, mailjet=${mailjet}/200, mailtrap=${mailtrap}/150, unosend=${unosend}/200, resend=${resend}/100`);
+  console.log(`   Usage today: mailgun=${mailgun}/100, mailjet=${mailjet}/200, mailtrap=${mailtrap}/150, unosend=${unosend}/200, resend=${resend}/100, maileroo=${maileroo}/100`);
 }
 
 // ── Provider availability check ──────────────────────────────
@@ -192,6 +205,7 @@ function isProviderConfigured(providerId) {
     case 'mailjet':    return !!(process.env.MAILJET_API_KEY && process.env.MAILJET_SECRET_KEY);
     case 'mailgun':    return !!(process.env.MAILGUN_API_KEY && process.env.MAILGUN_DOMAIN);
     case 'mailtrap':   return !!process.env.MAILTRAP_API_TOKEN;
+    case 'maileroo':   return !!process.env.MAILEROO_API_KEY;
     case 'unosend':    return !!process.env.UNOSEND_API_KEY;
     case 'resend':     return !!process.env.RESEND_API_KEY;
     default: return false;
@@ -356,6 +370,54 @@ async function sendViaMailtrap(email) {
   return { messageId: data?.message_ids?.[0] || `mailtrap-${Date.now()}`, provider: 'mailtrap' };
 }
 
+// ── Maileroo API (v2) ────────────────────────────────────────
+// Docs: https://maileroo.com/docs/email-api/send-basic-email/
+// Auth: X-Api-Key header. Free tier 3000/mo with custom DKIM domain.
+
+async function sendViaMaileroo(email) {
+  const apiKey = process.env.MAILEROO_API_KEY;
+  const fromParsed = parseEmailAddress(email.from);
+
+  const body = {
+    from: { address: fromParsed.email, display_name: fromParsed.name || undefined },
+    to: (Array.isArray(email.to) ? email.to : [email.to]).map(addr => ({ address: addr })),
+    subject: email.subject,
+    html: email.html,
+    // Enable open + click tracking (parity with Mailgun/Resend).
+    tracking: true,
+  };
+  if (email.text) body.plain = email.text;
+  // Maileroo tags are an object map; cascade tags are [{name, value}].
+  if (email.tags?.length) {
+    body.tags = {};
+    for (const tag of email.tags) {
+      if (tag?.name) body.tags[tag.name] = String(tag.value ?? '');
+    }
+  }
+  // Forward custom email headers (List-Unsubscribe, Feedback-ID, etc.).
+  if (email.headers && typeof email.headers === 'object') body.headers = email.headers;
+
+  const res = await fetch('https://smtp.maileroo.com/api/v2/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': apiKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const err = await res.text().catch(() => '');
+    throw new Error(`Maileroo ${res.status}: ${err.slice(0, 200)}`);
+  }
+
+  const data = await res.json().catch(() => ({}));
+  if (data?.success === false) {
+    throw new Error(`Maileroo error: ${String(data.message || 'unknown').slice(0, 200)}`);
+  }
+  return { messageId: data?.data?.reference_id || `maileroo-${Date.now()}`, provider: 'maileroo' };
+}
+
 // ── Resend API (fallback) ────────────────────────────────────
 // Same as existing implementation but single-email
 
@@ -393,6 +455,7 @@ const SEND_FNS = {
   mailgun: sendViaMailgun,
   mailjet: sendViaMailjet,
   mailtrap: sendViaMailtrap,
+  maileroo: sendViaMaileroo,
   unosend: sendViaUnosend,
   resend: sendViaResend,
 };

--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -54,6 +54,8 @@ const RC_TO_ENV = {
   MAILGUN_DOMAIN:                 ['MAILGUN_DOMAIN'],
   UNOSEND_API_KEY:                ['UNOSEND_API_KEY'],
   MAILTRAP_API_TOKEN:             ['MAILTRAP_API_TOKEN'],
+  MAILEROO_API_KEY:               ['MAILEROO_API_KEY'],
+  MAILEROO_WEBHOOK_SECRET:        ['MAILEROO_WEBHOOK_SECRET'],
 
 
   // Server-only keys (stored with SERVER_ prefix in RC)

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -53,12 +53,14 @@ const AI_CONCURRENCY = 5; // Max parallel AI calls
 
 // ── Email provider selection ──
 // cascade = multi-provider free tier cascade (default)
-// mailgun/mailjet/mailtrap = force a specific cascade provider
+// mailgun/mailjet/mailtrap/maileroo = force a specific cascade provider
 // resend = Resend only (legacy fallback)
 const EMAIL_PROVIDER = process.env.EMAIL_PROVIDER || 'cascade';
-const SINGLE_PROVIDERS = ['mailgun', 'mailjet', 'mailtrap'];
+const SINGLE_PROVIDERS = ['mailgun', 'mailjet', 'mailtrap', 'maileroo'];
 const IS_SINGLE_PROVIDER = SINGLE_PROVIDERS.includes(EMAIL_PROVIDER);
-// cascade ceiling = 550/day (mailgun 100 + resend 100 + mailjet 200 + mailtrap 150), resend = 100.
+// cascade ceiling = 650/day (mailgun 100 + resend 100 + mailjet 200 + mailtrap 150 + maileroo 100),
+// resend-only = 100. DAILY_SEND_LIMIT stays 550 (a deliberate per-run cap below the raw ceiling;
+// maileroo adds headroom/redundancy when another provider is down rather than raising the cap).
 // The weekly campaign (campaignId=weekly_{monday}) resumes across daily cron runs and must clear
 // the full active list (~2.5k) before Monday's campaign-ID rollover strands the unsent tail.
 // On healthy days the old 350 cap was the binding limit: 2026-05-26 and 05-27 both hit 350 with

--- a/scripts/set-maileroo-rc.mjs
+++ b/scripts/set-maileroo-rc.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * One-shot: push the Maileroo sending key (and optional webhook secret) to
+ * Firebase Remote Config so `scripts/load-rc-env.mjs` hydrates them into CI runs
+ * of send-newsletter.yml / send-job-alerts.yml, and so the webhook Cloud
+ * Function (newsletterMailerooWebhook) can read MAILEROO_WEBHOOK_SECRET.
+ *
+ * Safe to re-run: writes/overwrites only the params present in env, publishes
+ * a new RC template version on change.
+ *
+ * Auth:
+ *   GOOGLE_APPLICATION_CREDENTIALS must point at a Firebase SA with the
+ *   `Firebase Remote Config Admin` role.
+ *
+ * Usage:
+ *   MAILEROO_API_KEY=xxxxx \
+ *     GOOGLE_APPLICATION_CREDENTIALS=mcp-gsc-main/service_account_credentials.json \
+ *     node scripts/set-maileroo-rc.mjs
+ *
+ *   # webhook secret too (after creating the webhook in the Maileroo dashboard):
+ *   MAILEROO_API_KEY=xxxxx MAILEROO_WEBHOOK_SECRET=yyyyy ... node scripts/set-maileroo-rc.mjs
+ *
+ * Keys are read from env vars (NEVER hard-coded). Each env present → one RC
+ * param written. Missing envs are skipped silently.
+ */
+
+const PROVIDER_KEYS = [
+  {
+    rcParam: 'MAILEROO_API_KEY',
+    envVar: 'MAILEROO_API_KEY',
+    shapeHint: /^[0-9a-f]{32,}$/i,
+    description: 'Maileroo sending key for the email cascade (newsletter + job alerts)',
+  },
+  {
+    rcParam: 'MAILEROO_WEBHOOK_SECRET',
+    envVar: 'MAILEROO_WEBHOOK_SECRET',
+    shapeHint: null,
+    description: 'Maileroo webhook HMAC-SHA256 shared secret (delivery event tracking)',
+  },
+];
+
+function bail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+async function main() {
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    bail('GOOGLE_APPLICATION_CREDENTIALS not set.');
+  }
+
+  const pending = PROVIDER_KEYS
+    .map(p => ({ ...p, value: (process.env[p.envVar] || '').trim() }))
+    .filter(p => p.value.length > 0);
+
+  if (pending.length === 0) {
+    bail('No Maileroo keys present in env. Set at least one of: ' + PROVIDER_KEYS.map(p => p.envVar).join(', '));
+  }
+
+  for (const p of pending) {
+    if (p.shapeHint && !p.shapeHint.test(p.value)) {
+      console.warn(`⚠️  ${p.envVar} does not match the expected shape — continuing anyway.`);
+    }
+  }
+
+  const adminMod = await import('firebase-admin');
+  const admin = adminMod.default || adminMod;
+  if (!admin.apps.length) {
+    admin.initializeApp({ credential: admin.credential.applicationDefault() });
+  }
+  const rc = admin.remoteConfig();
+  const template = await rc.getTemplate();
+  template.parameters = template.parameters || {};
+
+  const today = new Date().toISOString().slice(0, 10);
+  let changed = 0;
+  for (const p of pending) {
+    const existing = template.parameters[p.rcParam]?.defaultValue?.value;
+    if (existing === p.value) {
+      console.log(`ℹ️  ${p.rcParam} already up-to-date.`);
+      continue;
+    }
+    template.parameters[p.rcParam] = {
+      defaultValue: { value: p.value },
+      valueType: 'STRING',
+      description: `${p.description} (set ${today})`,
+    };
+    changed++;
+    console.log(`📝 Staged ${p.rcParam} for publish.`);
+  }
+
+  if (changed === 0) {
+    console.log('ℹ️  Nothing to publish — every key matches RC already.');
+    return;
+  }
+
+  await rc.publishTemplate(template, { force: true });
+  console.log(`✅ Published ${changed} Maileroo key(s) to Remote Config.`);
+  console.log('   Next CI run of send-newsletter.yml / send-job-alerts.yml picks them up via load-rc-env.mjs.');
+}
+
+main().catch((err) => {
+  console.error('❌ set-maileroo-rc failed:', err?.message || err);
+  process.exit(1);
+});

--- a/tests/newsletter-maileroo-webhook-core.test.ts
+++ b/tests/newsletter-maileroo-webhook-core.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  persistMailerooEvent,
+  verifyMailerooSignature,
+} from '../functions/src/newsletterMailerooWebhookCore.js';
+import crypto from 'crypto';
+
+function createFakeDb(existingDocs: Record<string, Record<string, Record<string, unknown>>> = {}) {
+  const sets: Array<{ collection: string; docId: string; data: Record<string, unknown> }> = [];
+  const adds: Array<{ collection: string; data: Record<string, unknown> }> = [];
+
+  const makeCollection = (name: string) => ({
+    doc: (docId: string) => ({
+      set: async (data: Record<string, unknown>) => {
+        sets.push({ collection: name, docId, data });
+      },
+      get: async () => {
+        const docData = existingDocs[name]?.[docId];
+        return {
+          exists: !!docData,
+          data: () => docData || {},
+        };
+      },
+      collection: (subName: string) => {
+        const subPath = `${name}/${docId}/${subName}`;
+        return {
+          doc: (subDocId: string) => ({
+            set: async (data: Record<string, unknown>, _opts?: unknown) => {
+              sets.push({ collection: subPath, docId: subDocId, data });
+            },
+          }),
+          add: async (data: Record<string, unknown>) => {
+            adds.push({ collection: subPath, data });
+          },
+        };
+      },
+    }),
+    add: async (data: Record<string, unknown>) => {
+      adds.push({ collection: name, data });
+    },
+  });
+
+  return {
+    collection(name: string) {
+      return makeCollection(name);
+    },
+    __sets: sets,
+    __adds: adds,
+  };
+}
+
+describe('newsletterMailerooWebhookCore', () => {
+  it('stores click events across subscriber, delivery and events collections', async () => {
+    const db = createFakeDb({
+      newsletter_subscribers: {
+        'testuser@example.com': { status: 'confirmed', isActive: true },
+      },
+    });
+
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'clicked',
+      message_id: 'msg_123',
+      message_reference_id: 'ref_123',
+      event_time: 1700000000,
+      tags: { campaign_id: 'weekly_2026-03-11', source_channel: 'job_gate' },
+      event_data: {
+        to: 'TestUser@example.com',
+        original_url: 'https://frontaliereticino.ch/cerca-lavoro-ticino/',
+        ip: '1.2.3.4',
+        user_agent: 'Mozilla/5.0',
+      },
+    });
+
+    expect(result).toMatchObject({
+      processed: true,
+      type: 'click',
+      email: 'testuser@example.com',
+      campaignId: 'weekly_2026-03-11',
+    });
+
+    expect(db.__sets.some((e) => e.collection === 'newsletter_subscribers' && e.docId === 'testuser@example.com')).toBe(true);
+    expect(db.__sets.some((e) => e.collection.includes('/campaign_deliveries') && e.docId.includes('weekly_2026-03-11_testuser@example.com'))).toBe(true);
+    expect(db.__adds.some((e) => e.collection.includes('/events'))).toBe(true);
+  });
+
+  it('maps accepted → send and delivered → delivered', async () => {
+    const db = createFakeDb();
+    const accepted = await persistMailerooEvent(db as any, {
+      event_type: 'accepted',
+      message_id: 'm1',
+      event_data: { to: 'a@example.com' },
+    });
+    expect(accepted).toMatchObject({ processed: true, type: 'send' });
+
+    const delivered = await persistMailerooEvent(db as any, {
+      event_type: 'delivered',
+      message_id: 'm2',
+      event_data: { to: 'a@example.com' },
+    });
+    expect(delivered).toMatchObject({ processed: true, type: 'delivered' });
+  });
+
+  it('marks rejected/failed events as bounced on the subscriber', async () => {
+    const db = createFakeDb({
+      newsletter_subscribers: { 'bounce@example.com': { status: 'confirmed' } },
+    });
+
+    await persistMailerooEvent(db as any, {
+      event_type: 'failed',
+      message_id: 'mb',
+      event_data: { to: 'bounce@example.com', reason: 'mailbox unavailable' },
+    });
+
+    const subscriberSet = db.__sets.find(
+      (s) => s.collection === 'newsletter_subscribers' && s.docId === 'bounce@example.com',
+    );
+    expect(subscriberSet!.data.status).toBe('bounced');
+    expect(subscriberSet!.data.bounce_reason).toBe('mailbox unavailable');
+  });
+
+  it('routes job-alert tagged events to job_alert_subscribers', async () => {
+    const db = createFakeDb();
+
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'opened',
+      message_id: 'mja',
+      tags: { type: 'job-alert', alert_id: 'alert_42' },
+      event_data: { to: 'seeker@example.com' },
+    });
+
+    expect(result).toMatchObject({
+      processed: true,
+      type: 'open',
+      collection: 'job_alert_subscribers',
+    });
+    expect(db.__sets.some((s) => s.collection === 'job_alert_subscribers' && s.docId === 'seeker@example.com')).toBe(true);
+    expect(db.__sets.some((s) => s.collection === 'newsletter_subscribers')).toBe(false);
+  });
+
+  it('skips deferred (transient) and unknown event types', async () => {
+    const db = createFakeDb();
+    const deferred = await persistMailerooEvent(db as any, {
+      event_type: 'deferred',
+      event_data: { to: 'x@example.com' },
+    });
+    expect(deferred).toMatchObject({ skipped: true });
+    expect(db.__sets.length).toBe(0);
+  });
+
+  it('skips events with an invalid recipient', async () => {
+    const db = createFakeDb();
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'delivered',
+      event_data: {},
+    });
+    expect(result).toMatchObject({ skipped: true, reason: 'invalid_email' });
+  });
+});
+
+describe('verifyMailerooSignature', () => {
+  const secret = 'whsec-maileroo-test';
+  const payload = JSON.stringify({ event_type: 'delivered', event_data: { to: 'a@example.com' } });
+  const goodSig = crypto.createHmac('sha256', secret).update(payload, 'utf8').digest('hex');
+
+  it('accepts a valid HMAC-SHA256 hex signature', () => {
+    expect(verifyMailerooSignature({ payload, signature: goodSig, signingSecret: secret })).toBe(true);
+  });
+
+  it('accepts a sha256=-prefixed signature', () => {
+    expect(verifyMailerooSignature({ payload, signature: `sha256=${goodSig}`, signingSecret: secret })).toBe(true);
+  });
+
+  it('rejects a tampered signature', () => {
+    expect(verifyMailerooSignature({ payload, signature: goodSig.replace(/.$/, '0'), signingSecret: secret })).toBe(false);
+  });
+
+  it('rejects when signature or secret is missing', () => {
+    expect(verifyMailerooSignature({ payload, signature: '', signingSecret: secret })).toBe(false);
+    expect(verifyMailerooSignature({ payload, signature: goodSig, signingSecret: '' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Implementato

Aggiunge **Maileroo** come 6° provider nel cascade email condiviso da newsletter **e** job-alert, identico agli altri (Mailgun/Resend/Mailjet/Mailtrap/Unosend).

- **Send** (`scripts/lib/email-cascade.mjs`): `sendViaMaileroo` → `POST https://smtp.maileroo.com/api/v2/emails`, auth `X-Api-Key`, body `from`/`to` come oggetti, `tracking:true` (open+click), `plain` per il testo, `tags` array→object, `headers` inoltrati (List-Unsubscribe/Feedback-ID), `reference_id`→messageId. Registrato in `PROVIDERS` (100/gg, 3000/mese free tier), `SEND_FNS`, `isProviderConfigured`.
- **Quota check**: Maileroo non espone endpoint usage pubblico → il cap giornaliero è enforced dal counter in-memory (`fetchMailerooDailyUsage` ritorna 0, stesso fallback safe degli altri provider su errore API). `remainingQuota('maileroo')` salta il provider quando esaurito; log usage aggiornato (`maileroo=N/100`).
- **Tracking** (`functions/src/newsletterMailerooWebhookCore.js` + `index.js`): Cloud Function `newsletterMailerooWebhook` con verifica firma **HMAC-SHA256** header `x-maileroo-signature`, mapping eventi `accepted→send / delivered / opened→open / clicked→click / rejected,failed→bounce / complained→complaint`, routing newsletter **e** job-alert (tag `type=job-alert`), scritture su `newsletter_subscribers/{email}/{events,campaign_deliveries}` + counter open/click/bounce + engagement score, identico agli altri webhook ESP.
- **RC**: `MAILEROO_API_KEY` + `MAILEROO_WEBHOOK_SECRET` mappati in `load-rc-env.mjs`; `scripts/set-maileroo-rc.mjs` one-shot (env-driven, no hardcode). **`MAILEROO_API_KEY` già pubblicata su Remote Config** (verificata, len 64).
- **Single-provider mode**: `EMAIL_PROVIDER=maileroo` in `send-newsletter.mjs`.
- **Test**: `tests/newsletter-maileroo-webhook-core.test.ts` — 10 test (event mapping, job-alert routing, deferred/unknown skip, bounce status, firma HMAC valida/prefissata/manomessa/mancante). 36/36 verdi sull'intera suite webhook (no regressione).

Verifiche eseguite: vitest 10/10 nuovi + 36/36 suite webhook; stub fetch conferma payload send corretto; read-back RC conferma chiave presente; `node --check` su tutti i moduli; GitNexus impact LOW su `syncQuotasFromAPIs`/`isProviderConfigured` (additivo, firme invariate).

## Non implementato (ancora)

- **`MAILEROO_WEBHOOK_SECRET` su RC + registrazione webhook nel dashboard Maileroo**: il secret viene generato lato Maileroo alla creazione del webhook (non disponibile ora). Finché assente, il handler accetta senza verifica firma (parità col comportamento degli altri webhook a secret vuoto). Follow-up: creare webhook nel dashboard puntando a `newsletterMailerooWebhook`, poi `MAILEROO_WEBHOOK_SECRET=… node scripts/set-maileroo-rc.mjs`. *(out of scope: richiede azione manuale sul dashboard)*
- **Quota sync via API**: nessun endpoint usage pubblico Maileroo → niente sync reale cross-run; il cap in-memory resta l'unico vincolo (può overshootare leggermente su run separati nello stesso giorno, come gli altri provider in fallback). *(blocked: limite API provider)*
- **Deploy Cloud Function + smoke send live**: da fare post-merge su `main` (CF auto-deploy); nessun invio reale eseguito in locale per policy. *(follow-up: validare live)*