### PR TITLE
fix(related-search): align static cluster matching with SPA boilerplate strip + correct guard test

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -947,7 +947,13 @@ function buildClusterContext(
   // still carries ≥2 content tokens, require ≥2 token matches so a single
   // generic token can't pull in off-topic listings. Single-content-token
   // keywords keep minScore=1 so the legitimate city-drop recovery still works.
-  const keywordTokenCount = tokenizeQuery(keyword).length;
+  //
+  // Count CONTENT tokens only: strip the same leading boilerplate as the
+  // matching tokens above. Otherwise `offerte lavoro <role>` inflates the count
+  // by +2 ("offerte","lavoro") → minOrScore=2 even when the post-strip content
+  // is a single token, which would suppress the very city-drop recovery this
+  // floor means to preserve (and re-diverge the static page from the SPA).
+  const keywordTokenCount = tokenizeQuery(stripSearchQueryBoilerplate(keyword)).length;
   const minOrScore = keywordTokenCount >= 2 ? 2 : 1;
 
   const __tMatch = profileStart();

--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -63,6 +63,7 @@ import {
 import {
   getJobBoardSectionSlug,
   getSearchSlugPrefix,
+  stripSearchQueryBoilerplate,
 } from '../services/relatedSearchClusters';
 import {
   AGGREGATE_KEY,
@@ -912,7 +913,14 @@ function buildClusterContext(
     return null;
   }
 
-  const tokens = tokenizeQuery(sampleTerm);
+  // Match jobs on the boilerplate-stripped term so the static job set mirrors
+  // what the SPA shows after hydration (parseSearchSlugFilter strips the same
+  // leading "offerte lavoro" / "offres d emploi" prefix). Without this, the AND
+  // phase here matched [offerte, lavoro, <role>] → 0 and the OR-fill surfaced
+  // any job mentioning "offerta"/"lavoro" in its description, diluting the page
+  // with off-intent listings the hydrated board no longer shows. The displayed
+  // keyword/H1 (and thus the canonical slug) are intentionally left untouched.
+  const tokens = tokenizeQuery(stripSearchQueryBoilerplate(sampleTerm));
   profileRecord('bc:tokenize', __tTokenize);
   if (tokens.length === 0) return null;
 

--- a/services/relatedSearchClusters.ts
+++ b/services/relatedSearchClusters.ts
@@ -101,8 +101,17 @@ export const SEARCH_QUERY_BOILERPLATE_PHRASES: readonly string[] = [
  'offerte di lavoro',
  'posti di lavoro',
  'offerte lavoro',
+ // FR: full parity with the prior /offres?\s+(?:d\s+)?emplois?/ — singular
+ // "offre", optional bare "d" (apostrophe hyphenated by slugs), plural
+ // "emplois". Longest forms first so the alternation strips the most.
+ 'offres d emplois',
+ 'offre d emplois',
  'offres d emploi',
+ 'offre d emploi',
+ 'offres emplois',
+ 'offre emplois',
  'offres emploi',
+ 'offre emploi',
  'recherche emploi',
  'stellenangebote',
  'stellen',

--- a/services/relatedSearchClusters.ts
+++ b/services/relatedSearchClusters.ts
@@ -85,16 +85,49 @@ export function buildSearchSlug(term: string, locale: Locale): string {
 // intent ("offerte di lavoro cuoco", "lavoro infermiere", "stellenangebote
 // koch"). These words never occur in job titles, so leaving them in the
 // seeded query makes the strict AND-match impossible to satisfy and forces
-// every such slug-landing into the "Nessun risultato esatto" fuzzy fallback.
-// Strip only a single leading boilerplate phrase, and only when meaningful
-// query text remains after it.
-const SEARCH_QUERY_BOILERPLATE_PREFIX =
- // Slugs strip apostrophes to hyphens → spaces, so the canonical FR
- // "offres d'emploi" reaches us as "offres d emploi": match an optional bare
- // "d" token, not an apostrophe.
- /^(?:offerte\s+(?:di\s+)?lavoro|posti\s+di\s+lavoro|lavoro|offerte|jobs?|stellenangebote|stellen|offres?\s+(?:d\s+)?emplois?|emplois?|recherche\s+emploi)\s+/i;
+// every such slug-landing into the "Nessun risultato esatto" fuzzy fallback —
+// and, on the static cluster pages, into the same OR-fallback dilution. The
+// same strip is therefore applied both here (SPA query seed) and at build time
+// (build-plugins/relatedSearchClustersPlugin.ts, related-search matching) so
+// the static and hydrated job sets stay in lockstep.
+//
+// Single source of truth: the phrase list below derives BOTH the strip regex
+// and the token allow-list asserted by the cluster guard test
+// (tests/seo/related-search-clusters-emitted.test.ts). Multi-word phrases come
+// first so the alternation strips the longest leading match. Slugs hyphenate
+// apostrophes, so the canonical FR "offres d'emploi" arrives as "offres d
+// emploi" — listed verbatim with a bare "d" token.
+export const SEARCH_QUERY_BOILERPLATE_PHRASES: readonly string[] = [
+ 'offerte di lavoro',
+ 'posti di lavoro',
+ 'offerte lavoro',
+ 'offres d emploi',
+ 'offres emploi',
+ 'recherche emploi',
+ 'stellenangebote',
+ 'stellen',
+ 'lavoro',
+ 'offerte',
+ 'jobs',
+ 'job',
+ 'emplois',
+ 'emploi',
+];
 
-function stripSearchQueryBoilerplate(query: string): string {
+// Every individual word that may legitimately be stripped as boilerplate.
+// The guard test asserts no slug-seeded query ever loses a word outside this
+// set, so an over-broad phrase (or a cluster term that genuinely starts with
+// one of these words) is caught instead of being silently truncated.
+export const SEARCH_QUERY_BOILERPLATE_TOKENS: ReadonlySet<string> = new Set(
+ SEARCH_QUERY_BOILERPLATE_PHRASES.flatMap((p) => p.split(' ')),
+);
+
+const SEARCH_QUERY_BOILERPLATE_PREFIX = new RegExp(
+ `^(?:${SEARCH_QUERY_BOILERPLATE_PHRASES.map((p) => p.replace(/\s+/g, '\\s+')).join('|')})\\s+`,
+ 'i',
+);
+
+export function stripSearchQueryBoilerplate(query: string): string {
  // Never empty the query: a slug that is *only* boilerplate (e.g.
  // /ricerca-lavoro/) keeps its original term so the box is not left blank.
  const stripped = query.replace(SEARCH_QUERY_BOILERPLATE_PREFIX, '').trim();

--- a/tests/related-search-clusters.test.ts
+++ b/tests/related-search-clusters.test.ts
@@ -27,6 +27,7 @@ import {
   buildRelatedSearches,
   pickBestRelatedSearchForPrompt,
   DEFAULT_CANTON_DISPLAY,
+  stripSearchQueryBoilerplate,
 } from '@/services/relatedSearchClusters';
 import { renderSearchQueryIntro } from '../build-plugins/shared/jobBoardCommuterContext';
 
@@ -123,6 +124,47 @@ describe('parseSearchSlugFilter — strips job-search boilerplate from seeded qu
   it('does not strip boilerplate words that appear mid-query', () => {
     expect(parseSearchSlugFilter('ricerca-agente-immobiliare')).toBe('agente immobiliare');
     expect(parseSearchSlugFilter('ricerca-cuoco-offerte')).toBe('cuoco offerte');
+  });
+});
+
+describe('stripSearchQueryBoilerplate — UNDER-strip guard (shared by SPA seed + static cluster matching)', () => {
+  // Both parseSearchSlugFilter (SPA) and buildClusterContext (build-plugin job
+  // matching) call this function, so a future narrowing of the phrase list that
+  // stopped stripping a real boilerplate form would silently reintroduce the
+  // static/SPA divergence. These assertions lock that each canonical form is
+  // still removed — the inverse direction of the corpus over-strip guard in
+  // tests/seo/related-search-clusters-emitted.test.ts.
+  it('removes the canonical IT job-search prefixes', () => {
+    expect(stripSearchQueryBoilerplate('offerte lavoro medico')).toBe('medico');
+    expect(stripSearchQueryBoilerplate('offerte di lavoro infermiere')).toBe('infermiere');
+    expect(stripSearchQueryBoilerplate('posti di lavoro saldatore')).toBe('saldatore');
+    expect(stripSearchQueryBoilerplate('lavoro cuoco')).toBe('cuoco');
+    expect(stripSearchQueryBoilerplate('offerte cadro lugano')).toBe('cadro lugano');
+  });
+
+  it('removes the canonical DE prefixes', () => {
+    expect(stripSearchQueryBoilerplate('stellenangebote koch')).toBe('koch');
+    expect(stripSearchQueryBoilerplate('stellen pflege')).toBe('pflege');
+    expect(stripSearchQueryBoilerplate('jobs verkauf')).toBe('verkauf');
+  });
+
+  it('removes FR offre(s) (d) emploi(s) — full parity with the prior regex', () => {
+    for (const form of [
+      'offres d emploi cuisinier',
+      'offre d emploi cuisinier',
+      'offres emploi cuisinier',
+      'offre emploi cuisinier',
+      'offres d emplois cuisinier',
+      'offres emplois cuisinier',
+      'recherche emploi cuisinier',
+    ]) {
+      expect(stripSearchQueryBoilerplate(form), `not stripped: "${form}"`).toBe('cuisinier');
+    }
+  });
+
+  it('leaves a non-boilerplate term untouched (matching path stays intact)', () => {
+    expect(stripSearchQueryBoilerplate('tecnico data center')).toBe('tecnico data center');
+    expect(stripSearchQueryBoilerplate('responsabile neurologia')).toBe('responsabile neurologia');
   });
 });
 

--- a/tests/seo/related-search-clusters-emitted.test.ts
+++ b/tests/seo/related-search-clusters-emitted.test.ts
@@ -29,6 +29,7 @@ import {
   parseSearchSlugFilter,
   getSearchSlugPrefix,
   getJobBoardSectionSlug,
+  SEARCH_QUERY_BOILERPLATE_TOKENS,
 } from '@/services/relatedSearchClusters';
 import type { Locale } from '@/services/i18n';
 
@@ -474,3 +475,99 @@ describe.skipIf(RUN_DIST_GATES && HAS_DIST && HAS_PAGES)(
     });
   },
 );
+
+// Data-driven boilerplate-strip invariant. Runs WITHOUT a dist build: it reads
+// the candidate corpus directly, so it gates every CI run rather than only
+// RUN_DIST_GATES builds.
+//
+// `parseSearchSlugFilter` strips a leading job-search boilerplate prefix
+// ("offerte lavoro", "offres d emploi", …) from the slug-seeded query so the
+// strict AND-match can succeed (see services/relatedSearchClusters.ts). The
+// risk this guard locks: the strip must NEVER silently drop a real content word
+// — only recognised boilerplate tokens. A slug like ricerca-offerte-lavoro-medico
+// must yield "medico" (3 boilerplate words removed), and a future over-broad
+// phrase, or a cluster term legitimately starting with a content word that the
+// pattern happens to match, is caught here instead of shipping a slug↔query
+// desync to thousands of indexed pages.
+//
+// NOTE: the "offerte speciali" → "speciali" case from #1045 is, by design,
+// indistinguishable from the intentional "offerte lavoro X" strip — "offerte"
+// is genuine boilerplate in this job-board corpus and no such non-job term is
+// emitted. This guard asserts the boundary that IS decidable: only allow-listed
+// tokens are ever removed.
+const CANDIDATES_PATH = resolve(__dirname, '..', '..', 'data', 'related-search-candidates.json');
+
+const SEARCH_PREFIXES = ['ricerca-', 'search-', 'suche-', 'recherche-'] as const;
+
+/** Reproduce parseSearchSlugFilter's pre-strip query (prefix removed, dashes → spaces). */
+function rawQueryFromSlug(slug: string): string | null {
+  const hit = SEARCH_PREFIXES.find((p) => slug.startsWith(p));
+  if (!hit) return null;
+  const rest = slug.slice(hit.length).trim();
+  if (!rest) return null;
+  let decoded = rest;
+  try {
+    decoded = decodeURIComponent(rest);
+  } catch {
+    /* keep raw */
+  }
+  return decoded.replace(/-/g, ' ').replace(/\s+/g, ' ').trim() || null;
+}
+
+describe('related-search boilerplate strip — corpus invariant (no dist build needed)', () => {
+  function loadCandidateSlugs(): string[] {
+    if (!existsSync(CANDIDATES_PATH)) return [];
+    const parsed: unknown = JSON.parse(readFileSync(CANDIDATES_PATH, 'utf8'));
+    const arr = Array.isArray(parsed)
+      ? parsed
+      : (parsed as { candidates?: unknown[] })?.candidates
+        ?? Object.values(parsed as Record<string, unknown>).find(Array.isArray) as unknown[]
+        ?? [];
+    const slugs = new Set<string>();
+    for (const c of arr) {
+      const slug = (c as { slug?: unknown })?.slug;
+      if (typeof slug === 'string' && slug) slugs.add(slug);
+    }
+    return [...slugs];
+  }
+
+  it('strips ONLY allow-listed boilerplate tokens — never a content word', () => {
+    const slugs = loadCandidateSlugs();
+    expect(slugs.length, 'no candidate slugs loaded from related-search-candidates.json').toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    let strippedCount = 0;
+    for (const slug of slugs) {
+      const raw = rawQueryFromSlug(slug);
+      if (raw === null) continue; // not a search slug
+      const parsed = parseSearchSlugFilter(slug);
+      // Every search slug must still seed a non-empty query (no blank box).
+      if (!parsed) {
+        offenders.push(`${slug} → null/empty query`);
+        continue;
+      }
+      if (parsed === raw) continue; // nothing stripped
+      strippedCount++;
+      // The strip only removes a LEADING prefix, so the result is a suffix.
+      if (!raw.endsWith(parsed)) {
+        offenders.push(`${slug} → "${parsed}" is not a trailing slice of "${raw}"`);
+        continue;
+      }
+      const removed = raw.slice(0, raw.length - parsed.length).trim();
+      const removedWords = removed.split(' ').filter(Boolean);
+      const bad = removedWords.filter((w) => !SEARCH_QUERY_BOILERPLATE_TOKENS.has(w.toLowerCase()));
+      if (bad.length > 0) {
+        offenders.push(`${slug} → removed non-boilerplate word(s) [${bad.join(', ')}] (raw="${raw}", parsed="${parsed}")`);
+      }
+    }
+
+    // Sanity: the IT "offerte lavoro …" corpus guarantees real strips happen,
+    // otherwise the assertion would pass vacuously.
+    expect(strippedCount, 'no slug was stripped — corpus or strip pattern changed unexpectedly').toBeGreaterThan(0);
+    expect(offenders, `boilerplate strip touched non-allow-listed words:\n${offenders.slice(0, 15).join('\n')}`).toEqual([]);
+  });
+
+  it('the reported addetto-a-cucina slug seeds the real intent', () => {
+    expect(parseSearchSlugFilter('ricerca-offerte-lavoro-addetto-a-cucina')).toBe('addetto a cucina');
+  });
+});


### PR DESCRIPTION
Follow-up a #1040/#1046. **Closes #1045**. **Supersedes #1050**.

## Implementato

### 1. Static/SPA alignment delle ricerche correlate
Dopo #1040 la SPA seeda la query **boilerplate-stripped** (`offerte lavoro medico` → `medico`), ma le pagine cluster statiche (`build-plugins/relatedSearchClustersPlugin.ts`) matchavano ancora i job sul **sample term intero**: la fase AND trovava 0, e l'OR-fill faceva emergere qualunque job che citasse `offerta`/`lavoro` nella descrizione → pagina diluita con offerte off-intent, **divergente** dal board idratato sullo stesso URL.
- Applicato `stripSearchQueryBoilerplate` ai token di matching del build-plugin → il set job statico rispecchia la SPA.
- **H1/keyword visualizzati e slug canonico invariati** → nessun churn SEO/URL.

### 2. Single source of truth del vocabolario boilerplate
`relatedSearchClusters.ts`: lista-frasi unica che deriva **sia** la regex di strip **sia** un token allow-list esportato. `stripSearchQueryBoilerplate` ora esportata (riusata dal plugin). Comportamento di strip invariato (parità con #1040/#1046, FR `offres d'emploi` incluso).

### 3. Guard-test corretto (sostituisce #1050)
#1050 asseriva identità secca slug↔term → **falliva su 4.350 pagine `ricerca-offerte-lavoro-*` intenzionali** (reviewer 🔴, gate non passabile su dist prod). Sostituito con un **invariante corpus-driven** che gira **senza build dist**:
- Su ogni candidate slug (`data/related-search-candidates.json`), lo strip rimuove **solo** parole nell'allow-list boilerplate, **mai** una parola-contenuto; ogni slug seeda comunque una query non vuota.
- Assert anti-vacuo: `strippedCount > 0` (strip reali avvengono).
- Verificato localmente sull'intero corpus (~180k candidati): **verde**, nessun offender.

Test: `related-search-clusters-emitted.test.ts` + `related-search-clusters.test.ts` verdi (corpus-invariant 621ms). Impact: LOW (export additivo + 1 call-site nel matching build).

## Non implementato (ancora)

- **H1/keyword statici non strippati**: l'H1 indicizzato resta `Offerte lavoro <ruolo>` (match search-intent GSC, SEO-positivo) mentre il search box SPA mostra `<ruolo>`. Divergenza puramente di display, non di set job; cambiare l'H1 su migliaia di pagine = SEO churn sotto moratorium → fuori scope.
- **Caso semantico "offerte speciali" → "speciali"** (#1045): per design indistinguibile dallo strip intenzionale `offerte lavoro X` (`offerte` è boilerplate genuino in questo corpus job-board; nessun term simile è emesso). Il guard asserisce il confine **decidibile** (solo token allow-listed rimossi), come notato nel commento del test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)