### PR TITLE
ci(newsletter): add maileroo to send-newsletter provider choices

### DIFF
--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -67,6 +67,7 @@ on:
           - mailgun
           - mailjet
           - mailtrap
+          - maileroo
           - resend
 
 permissions:


### PR DESCRIPTION
## Implementato

Aggiunge `maileroo` alle opzioni dell'input `provider` del `workflow_dispatch` di `send-newsletter.yml`. Il provider Maileroo è già mergiato nel cascade (PR #1060); il workflow passa già `EMAIL_PROVIDER: inputs.provider` e `send-newsletter.mjs` gestisce `maileroo` in single-provider mode + `load-rc-env.mjs` idrata `MAILEROO_API_KEY` da Remote Config. Senza questa opzione, un test forzato su Maileroo non era selezionabile (cascade lo raggiunge solo per ultimo dopo gli altri provider).

Serve per eseguire un test send live via Maileroo (`mode=test`, `provider=maileroo`) e validare invio + tracking end-to-end.

## Non implementato (ancora)

- `send-job-alerts.yml`: nessun input `provider` (usa sempre il cascade di default) → nessuna modifica necessaria; Maileroo è comunque attivo nel cascade job-alert via PR #1060.
- Verifica DKIM/dominio mittente su Maileroo: il send via `newsletter@frontaliereticino.ch` riesce solo se il dominio è verificato nel dashboard Maileroo — da confermare col primo run live. *(blocked: config dashboard provider)*