### PR TITLE
perf(related-search): strip boilerplate in postings pre-pass for symmetry

### DIFF
--- a/build-plugins/relatedSearchClustersPlugin.ts
+++ b/build-plugins/relatedSearchClustersPlugin.ts
@@ -2297,7 +2297,11 @@ export function relatedSearchClustersPlugin(rootDir: string): Plugin {
         for (const cand of candidates) {
           const sampleTerm = (cand.sampleTerms || [])[0] || '';
           if (!sampleTerm) continue;
-          const tokens = tokenizeQuery(sampleTerm);
+          // Warm the SAME stripped tokens buildClusterContext queries (L923).
+          // Seeding the raw term would build posting lists for the highest-
+          // frequency boilerplate tokens ("lavoro"/"offerte"/"emploi"/"stellen")
+          // — the most expensive cold builds — that the matcher never requests.
+          const tokens = tokenizeQuery(stripSearchQueryBoilerplate(sampleTerm));
           if (tokens.length === 0) continue;
           let set = tokensByLocale.get(cand.locale);
           if (!set) {


### PR DESCRIPTION
Follow-up al 🟡 nit di #1061 (chiude il loop sullo stesso change).

## Implementato

Il postings pre-pass (`build-plugins/relatedSearchClustersPlugin.ts:~L2300`, hot path che il commento L2284-2288 ottimizza esplicitamente — 70.7s, 68% dei build-contexts) seedava le posting-list dal `sampleTerm` **non strippato**, mentre `buildClusterContext` (L923, post-#1061) interroga solo i token **strippati**. È un superset → corretto, ma cold-buildava le posting-list dei token boilerplate ad **altissima frequenza** (`lavoro`/`offerte`/`emploi`/`stellen`, i build più costosi perché presenti in moltissimi job) che il matcher non richiede mai.

- Applicato `stripSearchQueryBoilerplate(sampleTerm)` anche nel pre-pass → token warmed == token interrogati. Simmetria coi due call-site già strippati in #1061 (matching L923 + floor `keywordTokenCount` L956).
- Effetto: niente cold-build sprecati sui boilerplate token pesanti; cache-hit allineati in `buildClusterContext`. Nessun cambio funzionale (i content-token erano già nel superset).

Test plugin verdi (`related-search-clusters-shell`, `related-search-clusters-emitted` corpus-invariant). Impact: LOW (perf-only, hot path).

## Non implementato (ancora)

Niente — il nit era l'ultimo residuo aperto della serie #1040 → #1046 → #1061. H1/keyword/slug canonico restano invariati come nelle PR precedenti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)