### PR TITLE
fix(newsletter): Maileroo open/click attribution + daily cap from all providers

### DIFF
--- a/scripts/lib/email-cascade.mjs
+++ b/scripts/lib/email-cascade.mjs
@@ -631,4 +631,14 @@ function parseEmailAddress(from) {
   return { email: String(from).trim() };
 }
 
+/**
+ * Total theoretical daily send capacity across the whole cascade —
+ * the sum of every provider's daily limit (currently mailgun 100 + resend 100
+ * + mailjet 200 + mailtrap 150 + maileroo 100 = 650). Single source of truth so
+ * callers (e.g. the newsletter per-run cap) stay in sync when providers change.
+ */
+export function getCascadeDailyCapacity() {
+  return PROVIDERS.reduce((sum, p) => sum + p.dailyLimit, 0);
+}
+
 export { PROVIDERS, remainingQuota, isProviderConfigured, syncQuotasFromAPIs };

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -37,6 +37,7 @@ import { selectFeaturedArticleId } from '../services/newsletter-article-rotation
 import { calculateEngagementScore, refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
+import { getCascadeDailyCapacity } from './lib/email-cascade.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -58,17 +59,19 @@ const AI_CONCURRENCY = 5; // Max parallel AI calls
 const EMAIL_PROVIDER = process.env.EMAIL_PROVIDER || 'cascade';
 const SINGLE_PROVIDERS = ['mailgun', 'mailjet', 'mailtrap', 'maileroo'];
 const IS_SINGLE_PROVIDER = SINGLE_PROVIDERS.includes(EMAIL_PROVIDER);
-// cascade ceiling = 650/day (mailgun 100 + resend 100 + mailjet 200 + mailtrap 150 + maileroo 100),
-// resend-only = 100. DAILY_SEND_LIMIT stays 550 (a deliberate per-run cap below the raw ceiling;
-// maileroo adds headroom/redundancy when another provider is down rather than raising the cap).
+// The per-run cap tracks the FULL cascade capacity — the sum of every configured
+// provider's daily limit (getCascadeDailyCapacity, single source of truth in
+// email-cascade.mjs). Currently 650/day = mailgun 100 + resend 100 + mailjet 200
+// + mailtrap 150 + maileroo 100. Adding/removing a provider auto-updates this cap.
+// resend-only legacy mode stays 100.
 // The weekly campaign (campaignId=weekly_{monday}) resumes across daily cron runs and must clear
 // the full active list (~2.5k) before Monday's campaign-ID rollover strands the unsent tail.
 // On healthy days the old 350 cap was the binding limit: 2026-05-26 and 05-27 both hit 350 with
-// mailjet delivering 149-200 and thousands still pending — 550 lets those days clear ~200 more.
+// mailjet delivering 149-200 and thousands still pending. Deriving from providers lets each day
+// clear up to the real ceiling (now 650 incl maileroo) instead of an unused-capacity static number.
 // CAVEAT: on days a provider is down (mailjet "fetch failed" on 05-28..30; 05-29 delivered only
-// 98/350) provider reliability — not this cap — is the binding constraint, and 550 is moot.
-// So 550 is the correct ceiling but not a reliability fix; see follow-up on provider health/unosend.
-const DAILY_SEND_LIMIT = EMAIL_PROVIDER === 'resend' ? 100 : 550;
+// 98/350) provider reliability — not this cap — is the binding constraint, and the cap is moot.
+const DAILY_SEND_LIMIT = EMAIL_PROVIDER === 'resend' ? 100 : getCascadeDailyCapacity();
 
 /**
  * Run async tasks with bounded concurrency.


### PR DESCRIPTION
Bundle di follow-up del rollout Maileroo (#1060), stessa area.

## Implementato

**1. Attribuzione eventi open/click Maileroo (bug reale, trovato in test live)**
I webhook `opened`/`clicked` di Maileroo portano **solo** `message_reference_id` — nessun `event_data.to` e nessun `tags` (a differenza di `accepted`/`delivered`). L'handler li scartava come `invalid_email` (log CF live: `opened → skipped for ?`, `clicked → skipped for ?`).
- `persistDelivery` (send pipeline) scrive un record di lookup autoritativo `maileroo_message_meta/{referenceId}` = `{ email, campaign_id, is_job_alert }`.
- `newsletterMailerooWebhookCore` risolve open/click via quel record (keyed by `message_reference_id`), arricchendo campaign + routing job-alert che il payload omette; fallback ai campi evento per accepted/delivered che il recipient ce l'hanno.
- Test: +3 (resolve via lookup, routing job-alert, skip se non attribuibile).

**2. Cap giornaliero derivato da tutti i provider (incl. maileroo)**
`DAILY_SEND_LIMIT` era il letterale `550`, ignaro del roster. Nuovo `getCascadeDailyCapacity()` in `email-cascade.mjs` (somma dei `dailyLimit`, single source of truth) → cap ora **650** = mailgun 100 + resend 100 + mailjet 200 + mailtrap 150 + maileroo 100, auto-aggiornante. resend-only legacy resta 100.

Verifiche: vitest 13/13 webhook core; `getCascadeDailyCapacity()`→650; `node --check` su entrambi i moduli; root cause confermata dai log CF live (send/delivered ok, open/click skip → ora risolti via lookup).

## Non implementato (ancora)

- `send-job-alerts.mjs`: la scrittura del meta-index è in `persistDelivery` della newsletter; il path job-alert ha il proprio persist. Le **open/click job-alert via Maileroo** non scrivono ancora il lookup → resterebbero non attribuite finché non si aggiunge lo stesso write lì (follow-up; job alert gating separato).
- TTL/cleanup di `maileroo_message_meta` (cresce di 1 doc per messaggio inviato) — non critico ora.
- Doc di test `newsletter_subscribers/maileroo-webhook-test@example.com` (dal test pipeline) non cancellabile con la SA locale read-only — inerte.