### PR TITLE
fix(profiler): mirror boilerplate strip in cluster-emission profiler (last #1064 nit)

### DIFF
--- a/scripts/profile-cluster-emission.mjs
+++ b/scripts/profile-cluster-emission.mjs
@@ -73,6 +73,28 @@ function tokenizeQuery(query) {
     .filter((tok) => tok.length >= 2);
 }
 
+// Boilerplate strip — keep in sync with services/relatedSearchClusters.ts
+// (SEARCH_QUERY_BOILERPLATE_PHRASES). Duplicated here for the same reason as
+// tokenizeQuery: this profiler runs under plain `node` and can't import the
+// .ts source. buildClusterContext strips these leading job-search prefixes
+// before matching (since #1061), so the profiler must too or its AND/OR
+// buckets diverge from production.
+const SEARCH_QUERY_BOILERPLATE_PHRASES = [
+  'offerte di lavoro', 'posti di lavoro', 'offerte lavoro',
+  'offres d emplois', 'offre d emplois', 'offres d emploi', 'offre d emploi',
+  'offres emplois', 'offre emplois', 'offres emploi', 'offre emploi',
+  'recherche emploi', 'stellenangebote', 'stellen',
+  'lavoro', 'offerte', 'jobs', 'job', 'emplois', 'emploi',
+];
+const SEARCH_QUERY_BOILERPLATE_PREFIX = new RegExp(
+  `^(?:${SEARCH_QUERY_BOILERPLATE_PHRASES.map((p) => p.replace(/\s+/g, '\\s+')).join('|')})\\s+`,
+  'i',
+);
+function stripSearchQueryBoilerplate(query) {
+  const stripped = query.replace(SEARCH_QUERY_BOILERPLATE_PREFIX, '').trim();
+  return stripped || query;
+}
+
 function queryMatchScore(haystack, queryTokens) {
   if (queryTokens.length === 0) return 0;
   let score = 0;
@@ -134,7 +156,9 @@ function filterAndDedupeCandidates(all, minJobCount) {
 function countMatchesForCluster(candidate, jobs, haystackCache) {
   const sampleTerm = (candidate.sampleTerms || [])[0] || '';
   if (!sampleTerm) return 0;
-  const tokens = tokenizeQuery(sampleTerm);
+  // Strip leading boilerplate to mirror buildClusterContext (L923) — match on
+  // content tokens only, not the inflated "offerte lavoro <role>" superset.
+  const tokens = tokenizeQuery(stripSearchQueryBoilerplate(sampleTerm));
   if (tokens.length === 0) return 0;
 
   const fullScore = tokens.length;


### PR DESCRIPTION
Follow-up all'ultimo 🟡 nit di #1064. Chiude definitivamente la serie #1040 → #1046 → #1061 → #1064.

## Implementato

`scripts/profile-cluster-emission.mjs` **duplica** la logica di matching del plugin (gira sotto `node` puro → non può importare il `.ts`) e tokenizzava il `sampleTerm` **raw**. Ma `buildClusterContext` strippa il prefisso boilerplate (`offerte lavoro` / `offres d emploi`) prima del matching dal #1061 → i bucket AND/OR del profiler (la fonte dei numeri 70.7s/68% citati nei commenti del plugin) contavano il superset gonfiato dai boilerplate token.

- Aggiunto `stripSearchQueryBoilerplate` locale (parità con `services/relatedSearchClusters.ts`, stesso pattern di duplicazione di `tokenizeQuery`, commento keep-in-sync) e applicato a L137 → i bucket del profiler rispecchiano la produzione.
- `node --check` OK; strip verificato (`offerte lavoro addetto a cucina` → `addetto a cucina`, `offres d emploi cuisinier` → `cuisinier`, term non-boilerplate invariati).

Tool dev, non funnel-critico. Impact: LOW (solo profiler).

## Non implementato (ancora)

Verificato via `git grep tokenizeQuery(sampleTerm)`: questo era l'**ultimo** call-site raw rimasto. Tutti i path (matching L923, floor L956, pre-pass L2304, profiler L137) ora strippano in modo coerente. Catena chiusa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)