### PR TITLE
fix(ci): deterministic FIX_OUTCOME backstop in issue-fix telemetry

### DIFF
--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -140,3 +140,26 @@ jobs:
         # the run Step Summary + a grep-able CLAUDE_USAGE line to the log.
         # Best-effort: never fails the job.
         run: node scripts/ci/claude-usage-summary.mjs "${{ steps.claude_review.outputs.execution_file }}" "issue-fix"
+
+      - name: Emit FIX_OUTCOME telemetry (deterministic backstop)
+        if: always()
+        # The agent SHOULD post a granular `<!-- FIX_OUTCOME: <code> -->` marker,
+        # but prompt-emitted markers are unreliable (observed: #974 ran with the
+        # marker prompt on main yet posted none). This backstop guarantees the
+        # lessons-harvester always has a queryable marker: pr-created if this run
+        # opened a PR on fix/issue-<N>, else a coarse no-pr-unspecified. It never
+        # overwrites the agent's own granular marker. Best-effort: never fails.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -uo pipefail
+          HAS=$(gh issue view "$ISSUE" --json comments --jq '[.comments[].body | select(test("<!-- FIX_OUTCOME:"))] | length' 2>/dev/null || echo 0)
+          if [ "${HAS:-0}" != "0" ]; then
+            echo "FIX_OUTCOME marker already present (agent-posted) — no backstop needed."
+            exit 0
+          fi
+          PR=$(gh pr list --head "fix/issue-$ISSUE" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -n "${PR:-}" ]; then OUT=pr-created; else OUT=no-pr-unspecified; fi
+          echo "FIX_OUTCOME issue=$ISSUE outcome=$OUT (deterministic backstop)"
+          gh issue comment "$ISSUE" --body "$(printf '<!-- FIX_OUTCOME: %s -->\n_Outcome rilevato dal post-step deterministico (telemetria lessons-harvester)._' "$OUT")" || true


### PR DESCRIPTION
## Implementato
Rende affidabile la telemetria `FIX_OUTCOME` del lessons-harvester (#1051). Osservazione live: **#974 ha girato con il prompt-marker già su main eppure l'agent non ha emesso alcun marker** → l'harvester era cieco su quel run. I marker prompt-based sono fragili (il modello dimentica).

- Aggiunto post-step `if: always()` in `issue-fix.yml`: garantisce sempre un commento `<!-- FIX_OUTCOME: <code> -->` queryabile.
  - `pr-created` se il run ha aperto una PR su `fix/issue-<N>` (stato osservabile deterministico), altrimenti `no-pr-unspecified`.
  - **Non sovrascrive** il marker granulare dell'agent se presente (lo completa solo se manca).
  - Best-effort: non fallisce mai il job.

## Non implementato (ancora)
- **Granularità del backstop**: il post-step distingue solo `pr-created` vs `no-pr-unspecified` (il "perché" del blocco resta best-effort dall'agent). Inferire deterministicamente il codice di blocco (workflows-scope/secrets/...) richiederebbe parsing del commento dell'agent → non fatto per restare robusto; i blocchi ricorrenti restano comunque rilevabili come classe `no-pr`.

> ⚠️ Modifica `.github/workflows/issue-fix.yml` → reviewer App-validation può fallire → eventuale **merge manuale** `gh pr merge --squash --delete-branch`.