### PR TITLE
refactor(slugs): dedup source-copy rule into shared helper + close review ❓ with tests

### DIFF
--- a/scripts/lib/dedicated-crawler-common.mjs
+++ b/scripts/lib/dedicated-crawler-common.mjs
@@ -5638,13 +5638,13 @@ export function mergeAndDeduplicate(existingJobs, incomingJobs, qualityCfg, opti
       const prevSlug = job.slug || '';
       if (!job.slugByLocale || typeof job.slugByLocale !== 'object') job.slugByLocale = {};
       if (registered.slugByLocale && typeof registered.slugByLocale === 'object') {
-        for (const [loc, s] of Object.entries(registered.slugByLocale)) {
-          const norm = normalizeSpace(String(s || ''));
-          if (!norm) continue;
-          // Non-source-locale entry that just copies the source slug = no real
-          // translation was registered. Keep whatever the current crawl has.
-          if (srcLang && loc !== srcLang && regSrcSlug && norm === regSrcSlug) continue;
-          job.slugByLocale[loc] = norm;
+        // Per-locale source-copy rule lives in registryPinnedLocaleSlug (single
+        // definition shared with hardenJobLocaleFields, the post-AI backfill, and
+        // regenerate-slugs-by-locale). Returns null for an empty entry or a
+        // non-source-locale entry that merely copies the source slug.
+        for (const loc of Object.keys(registered.slugByLocale)) {
+          const pinned = registryPinnedLocaleSlug(registered, loc, srcLang);
+          if (pinned) job.slugByLocale[loc] = pinned;
         }
       }
       // Master slug is used by the IT path on canton sections. Only enforce

--- a/scripts/lib/shared-jobs-crawler.mjs
+++ b/scripts/lib/shared-jobs-crawler.mjs
@@ -48,6 +48,7 @@ import {
   loadSlugRegistry as _loadSlugRegistry,
   saveSlugRegistry as _saveSlugRegistry,
   getRegisteredSlug as _getRegisteredSlug,
+  registryPinnedLocaleSlug as _registryPinnedLocaleSlug,
   registerJobSlug as _registerJobSlug,
   // FRO-232: merge/dedup utilities extracted from this file
   LOCALES as _LOCALES,
@@ -140,6 +141,7 @@ const buildStableId = _buildStableId;
 const loadSlugRegistry = _loadSlugRegistry;
 const saveSlugRegistry = _saveSlugRegistry;
 const getRegisteredSlug = _getRegisteredSlug;
+const registryPinnedLocaleSlug = _registryPinnedLocaleSlug;
 const registerJobSlug = _registerJobSlug;
 // FRO-232: merge/dedup utilities re-aliases
 const LOCALES = _LOCALES;
@@ -5150,11 +5152,12 @@ async function main() {
                   enriched.slugByLocale = {};
                 }
                 if (pin.slugByLocale && typeof pin.slugByLocale === 'object') {
-                  for (const [loc, s] of Object.entries(pin.slugByLocale)) {
-                    const norm = String(s || '').trim();
-                    if (!norm) continue;
-                    if (srcLang && loc !== srcLang && regSrc && norm === regSrc) continue;
-                    enriched.slugByLocale[loc] = norm;
+                  // Per-locale source-copy rule lives in registryPinnedLocaleSlug
+                  // (single definition shared with mergeAndDeduplicate,
+                  // hardenJobLocaleFields, and regenerate-slugs-by-locale).
+                  for (const loc of Object.keys(pin.slugByLocale)) {
+                    const pinned = registryPinnedLocaleSlug(pin, loc, srcLang);
+                    if (pinned) enriched.slugByLocale[loc] = pinned;
                   }
                 }
                 const enforceMaster = !srcLang

--- a/tests/merge-registry-authoritative.test.ts
+++ b/tests/merge-registry-authoritative.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Verifies the registry pin stays authoritative at the mergeAndDeduplicate
+ * chokepoint after the source-copy rule was de-duplicated into the shared
+ * registryPinnedLocaleSlug helper. A registered job whose fresh crawl carries a
+ * re-translated (drifted) per-locale slug must be restored to the immutable
+ * registry slug, with the drift demoted to previousSlugs.
+ *
+ * Uses SLUG_REGISTRY_PATH_OVERRIDE to inject a controlled registry instead of
+ * the real 10k-entry file (also keeps the real registry untouched by the test).
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const URL_3164 = 'https://recruitingapp-2908.umantis.com/Vacancies/3164/Description/1';
+const LOCKED_EN = 'assistant-psychologist-or-specialist-psychologist-upd-bern';
+const DRIFT_EN = 'psychology-assistant-specialized-psychologist-assistant-upd-bern';
+
+const tmpFiles: string[] = [];
+afterEach(() => {
+  delete process.env.SLUG_REGISTRY_PATH_OVERRIDE;
+  for (const f of tmpFiles.splice(0)) {
+    try { fs.unlinkSync(f); } catch { /* gone */ }
+  }
+});
+
+describe('mergeAndDeduplicate registry authority (post source-copy dedup)', () => {
+  it('restores a registered locale slug when the fresh crawl brings a drifted one', async () => {
+    const registry = {
+      'id|umantis.com|3164': {
+        canonicalSlug: 'psicologo-a-assistente-upd-bern',
+        slugByLocale: {
+          it: 'psicologo-a-assistente-upd-bern',
+          en: LOCKED_EN,
+          de: 'assistenzpsychologin-upd-bern',
+          fr: 'psychologue-assistant-e-upd-bern',
+        },
+      },
+    };
+    const regPath = path.join(os.tmpdir(), `merge-auth-reg-${process.pid}.json`);
+    fs.writeFileSync(regPath, JSON.stringify(registry), 'utf-8');
+    tmpFiles.push(regPath);
+    process.env.SLUG_REGISTRY_PATH_OVERRIDE = regPath;
+
+    const { mergeAndDeduplicate } = await import('../scripts/lib/dedicated-crawler-common.mjs');
+
+    const base = {
+      id: 'umantis-3164',
+      url: URL_3164,
+      title: 'Assistenzpsychologin',
+      company: 'UPD',
+      location: 'Bern',
+      sourceLang: 'de',
+      description: 'x'.repeat(200),
+      crawledAt: '2026-05-20T10:00:00Z',
+      source: 'Company Careers Crawler',
+      titleByLocale: { it: 'Psicologo', en: 'Psychology Assistant', de: 'Assistenzpsychologin', fr: 'Psychologue' },
+    };
+    // Fresh crawl carries a re-translated (drifted) EN slug as the ACTIVE slug
+    // (no prior good slug to win over it), so the registry pin — not the
+    // existing-wins merge rule — is what must correct it.
+    const freshCrawl = { ...base, crawledAt: '2026-06-01T10:00:00Z', slug: 'psicologo-a-assistente-upd-bern', slugByLocale: { it: 'psicologo-a-assistente-upd-bern', en: DRIFT_EN, de: 'assistenzpsychologin-upd-bern', fr: 'psychologue-assistant-e-upd-bern' } };
+
+    const result = mergeAndDeduplicate([], [freshCrawl], {});
+    const merged = result.merged.find((j: { url: string }) => j.url === URL_3164);
+
+    // Registry slug wins over the drifted crawl slug.
+    expect(merged.slugByLocale.en).toBe(LOCKED_EN);
+
+    // The drift is preserved as a bridge so the legacy URL keeps resolving.
+    const enPrev = merged.previousSlugsByLocale?.en || [];
+    const allPrev = [...enPrev, ...(merged.previousSlugs || [])];
+    expect(allPrev).toContain(DRIFT_EN);
+  });
+});

--- a/tests/migrate-all-known-job-slugs-canton-aware.test.ts
+++ b/tests/migrate-all-known-job-slugs-canton-aware.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Explicit verification that migrate-all-known-job-slugs-canton-aware.mjs treats
+ * the jobs.json slug as canonical and ONLY rewrites the canton SECTION prefix —
+ * it never re-derives or mutates the slug body itself. This is the assumption
+ * the upstream slug-stabilization relies on; here it is asserted end-to-end.
+ *
+ * The script resolves data/* against process.cwd(), so it is exercised by
+ * running it with cwd set to a temp fixtures dir (real canton reference data is
+ * copied in; jobs + tracking are minimal fixtures). No source changes needed.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(repoRoot, 'scripts', 'migrate-all-known-job-slugs-canton-aware.mjs');
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* gone */ }
+  }
+});
+
+describe('migrate-all-known-job-slugs-canton-aware', () => {
+  it('rewrites only the canton section prefix and preserves the slug body', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-canton-'));
+    tmpDirs.push(tmp);
+    const dataDir = path.join(tmp, 'data');
+    fs.mkdirSync(dataDir);
+
+    // Real canton reference data (the script mirrors cantonSection.ts from it).
+    fs.copyFileSync(path.join(repoRoot, 'data', 'canton-url-slugs.json'), path.join(dataDir, 'canton-url-slugs.json'));
+    fs.copyFileSync(path.join(repoRoot, 'data', 'canton-municipalities.json'), path.join(dataDir, 'canton-municipalities.json'));
+
+    const SLUG = 'software-engineer-acme-zurich';
+    // One ZH (non-TI) job — its tracking path should migrate TI→ZH section.
+    fs.writeFileSync(path.join(dataDir, 'jobs.json'), JSON.stringify([
+      { id: 'j1', slug: SLUG, canton: 'ZH', location: 'Zürich', slugByLocale: { it: SLUG, en: SLUG, de: SLUG, fr: SLUG } },
+    ]));
+    // Tracking entry currently under the legacy TI section, per locale.
+    fs.writeFileSync(path.join(dataDir, 'all-known-job-slugs.json'), JSON.stringify({
+      [SLUG]: {
+        it: `/cerca-lavoro-ticino/${SLUG}/`,
+        en: `/en/find-jobs-ticino/${SLUG}/`,
+        de: `/de/jobs-im-tessin/${SLUG}/`,
+        fr: `/fr/trouver-emploi-tessin/${SLUG}/`,
+        source: 'gsc-404-import',
+      },
+    }));
+
+    execFileSync('node', [SCRIPT], { cwd: tmp, stdio: 'pipe' });
+
+    const out = JSON.parse(fs.readFileSync(path.join(dataDir, 'all-known-job-slugs.json'), 'utf-8'));
+    const entry = out[SLUG];
+
+    // Section prefix migrated TI → ZH (zurigo / zurich / zuerich / zurich).
+    expect(entry.it).toBe(`/cerca-lavoro-zurigo/${SLUG}/`);
+    expect(entry.en).toContain('/find-jobs-');
+    expect(entry.en).not.toContain('find-jobs-ticino');
+
+    // Slug body preserved verbatim in every locale path (never re-derived).
+    for (const loc of ['it', 'en', 'de', 'fr'] as const) {
+      expect(entry[loc].endsWith(`/${SLUG}/`)).toBe(true);
+    }
+    // Non-locale metadata preserved.
+    expect(entry.source).toBe('gsc-404-import');
+  });
+
+  it('leaves TI jobs untouched (invariance)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-canton-ti-'));
+    tmpDirs.push(tmp);
+    const dataDir = path.join(tmp, 'data');
+    fs.mkdirSync(dataDir);
+    fs.copyFileSync(path.join(repoRoot, 'data', 'canton-url-slugs.json'), path.join(dataDir, 'canton-url-slugs.json'));
+    fs.copyFileSync(path.join(repoRoot, 'data', 'canton-municipalities.json'), path.join(dataDir, 'canton-municipalities.json'));
+
+    const SLUG = 'cuoco-ristorante-lugano';
+    fs.writeFileSync(path.join(dataDir, 'jobs.json'), JSON.stringify([
+      { id: 'j2', slug: SLUG, canton: 'TI', location: 'Lugano', slugByLocale: { it: SLUG } },
+    ]));
+    const original = { [SLUG]: { it: `/cerca-lavoro-ticino/${SLUG}/` } };
+    fs.writeFileSync(path.join(dataDir, 'all-known-job-slugs.json'), JSON.stringify(original));
+
+    execFileSync('node', [SCRIPT], { cwd: tmp, stdio: 'pipe' });
+
+    const out = JSON.parse(fs.readFileSync(path.join(dataDir, 'all-known-job-slugs.json'), 'utf-8'));
+    expect(out[SLUG].it).toBe(`/cerca-lavoro-ticino/${SLUG}/`);
+  });
+});

--- a/tests/registry-key-and-uniqueness.test.ts
+++ b/tests/registry-key-and-uniqueness.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Closes review ❓s left open by the slug-pin PRs:
+ *  1. fingerprintJob URL→registry-key derivation (id|umantis.com|<id>) — the
+ *     mapping the harden/merge pins rely on, previously only assumed.
+ *  2. registerJobSlug does NOT enforce GLOBAL per-locale slug uniqueness across
+ *     fingerprints — it is per-fingerprint immutable only. Documents that
+ *     cross-job per-locale uniqueness is a downstream concern (usedSlugs in
+ *     mergeAndDeduplicate / regenerate-slugs), not a registration guarantee.
+ *  3. registryPinnedLocaleSlug's source-copy decision is fully governed by the
+ *     passed sourceLang — a mislabeled source flips the over/under-pin outcome.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  fingerprintJob,
+  registerJobSlug,
+  registryPinnedLocaleSlug,
+} from '../scripts/lib/dedicated-crawler-common.mjs';
+
+describe('fingerprintJob → registry key', () => {
+  it('derives id|umantis.com|<id> from a umantis vacancy URL', () => {
+    const fp = fingerprintJob({
+      url: 'https://recruitingapp-2908.umantis.com/Vacancies/3164/Description/1',
+    });
+    expect(fp).toBe('id|umantis.com|3164');
+  });
+
+  it('is stable across the subdomain / trailing path of the same vacancy', () => {
+    const a = fingerprintJob({ url: 'https://recruitingapp-2908.umantis.com/Vacancies/3164/Description/1' });
+    const b = fingerprintJob({ url: 'https://recruitingapp-9999.umantis.com/Vacancies/3164/Application' });
+    expect(a).toBe(b);
+    expect(a).toBe('id|umantis.com|3164');
+  });
+
+  it('falls back to a tl| signature when the URL has no extractable identity', () => {
+    const fp = fingerprintJob({ url: '', title: 'Nurse', location: 'Bern', company: 'X' });
+    expect(fp.startsWith('tl|')).toBe(true);
+  });
+});
+
+describe('registerJobSlug', () => {
+  it('is per-fingerprint immutable — never overwrites an existing entry', () => {
+    const registry: Record<string, unknown> = {};
+    const job = {
+      url: 'https://recruitingapp-1.umantis.com/Vacancies/100/Description/1',
+      slug: 'first-slug',
+      slugByLocale: { it: 'first-slug', en: 'first-en' },
+    };
+    registerJobSlug(job, registry);
+    registerJobSlug({ ...job, slug: 'second-slug', slugByLocale: { it: 'second-slug', en: 'second-en' } }, registry);
+    expect((registry['id|umantis.com|100'] as { canonicalSlug: string }).canonicalSlug).toBe('first-slug');
+  });
+
+  it('does NOT enforce global per-locale uniqueness across fingerprints', () => {
+    const registry: Record<string, unknown> = {};
+    // Two DISTINCT jobs (different fingerprints) registering the SAME en slug.
+    registerJobSlug({ url: 'https://recruitingapp-1.umantis.com/Vacancies/100/Description/1', slug: 'a-it', slugByLocale: { it: 'a-it', en: 'shared-en' } }, registry);
+    registerJobSlug({ url: 'https://recruitingapp-1.umantis.com/Vacancies/200/Description/1', slug: 'b-it', slugByLocale: { it: 'b-it', en: 'shared-en' } }, registry);
+    // Both are registered; the duplicate en slug is NOT rejected at registration.
+    // (Cross-job per-locale uniqueness is enforced downstream, not here.)
+    expect(Object.keys(registry)).toHaveLength(2);
+    expect((registry['id|umantis.com|100'] as { slugByLocale: Record<string, string> }).slugByLocale.en).toBe('shared-en');
+    expect((registry['id|umantis.com|200'] as { slugByLocale: Record<string, string> }).slugByLocale.en).toBe('shared-en');
+  });
+});
+
+describe('registryPinnedLocaleSlug — sourceLang sensitivity', () => {
+  // Registry where the EN slot is a byte copy of the DE (source) slot — i.e. no
+  // real EN translation was registered (a pre-localization entry).
+  const sourceCopyReg = { slugByLocale: { de: 'pflegefachperson-spital', en: 'pflegefachperson-spital' } };
+
+  it('correctly detects the source copy and does NOT pin when sourceLang is right', () => {
+    expect(registryPinnedLocaleSlug(sourceCopyReg, 'en', 'de')).toBeNull();
+  });
+
+  it('OVER-pins the source copy when sourceLang is mislabeled', () => {
+    // Mislabeled source 'it': regSrc = registry.it (absent) → source-copy guard
+    // cannot fire → the EN source-copy is wrongly treated as a real translation.
+    // Documents why correct titleSourceLang detection matters for the guard.
+    expect(registryPinnedLocaleSlug(sourceCopyReg, 'en', 'it')).toBe('pflegefachperson-spital');
+  });
+});


### PR DESCRIPTION
Debito tecnico + test mancanti dai PR slug-pin (#1044 / #1058).

## Implementato

### Dedup regola source-copy (1 definizione, non 3)
La regola "salta un'entry registry per-locale che è solo una copia dello slug source" era duplicata inline in `mergeAndDeduplicate` e nel backfill post-AI (`shared-jobs-crawler.mjs`), oltre che nell'helper `registryPinnedLocaleSlug`. Ora **entrambi i punti chiamano l'helper** per il pin per-locale. Una sola definizione condivisa da tutte e 4 le path (helper, harden, merge, backfill, regenerate). L'enforcement del master slug (`canonicalSlug`/`enforceMaster`) resta inline — l'helper possiede solo la decisione per-locale. **Behavior-preserving**: suite `merge-source-copy-protection` invariata e verde.

### Verifica inheritance (D — "anche gli altri path ereditano URL-stabile > correzione cosmetica")
- Audit esaustivo di **tutti** i siti che scrivono `slug`/`slugByLocale[*]`. Conclusione: i veri chokepoint di pin (merge, backfill, harden, regenerate) sono l'ultima parola; le derivazioni nei singoli crawler (`ensureLocaleFields`, `update-*.mjs`) girano **a monte** del pin di `mergeAndDeduplicate` → vengono corrette da esso, NON sono leak persistenti. Per questo NON ho wrappato 14 siti upstream (sarebbe speculativo + alto rischio su path CRITICAL) — la correttezza è garantita dai chokepoint.
- `tests/merge-registry-authoritative.test.ts` prova che lo slug registry resta authoritative al merge dopo il dedup (drift → registry, demote a previousSlugs).

### Test che chiudono le ❓ della review
- `tests/registry-key-and-uniqueness.test.ts`:
  - **fingerprint URL→key**: `fingerprintJob(umantis URL)` === `id|umantis.com|3164`, stabile su subdomain/path.
  - **registerJobSlug**: per-fingerprint immutable; **NON** impone unicità globale per-locale tra fingerprint diversi (documentato — l'unicità cross-job è downstream, `usedSlugs`).
  - **titleSourceLang sensitivity**: la decisione source-copy dipende dal `sourceLang` passato; un source mislabeled ribalta over/under-pin.
- `tests/migrate-all-known-job-slugs-canton-aware.test.ts`: la migrazione canton riscrive **solo il prefisso di sezione** e **preserva lo slug body verbatim** (tratta lo slug di `jobs.json` come canonico); job TI invariati. Eseguita come subprocess su fixture temporanee (cwd override) — zero modifica al sorgente.

Test: 107 verdi (suite slug/crawler/localization + 10 nuovi). `node --check` ok. GitNexus detect low-risk, 0 process. Registry tracked non mutato dai test (override `SLUG_REGISTRY_PATH_OVERRIDE` da #1058).

## Non implementato (ancora)

- **Wrap dei ~14 siti slug upstream** (`ensureLocaleFields` per-crawler, `update-grace/supsi/skyguide/usi/sunrise/ibsa-jobs.mjs`, `clean-lis-data.mjs`, `sync-gsc-orphans.mjs`): deliberatamente NON fatto. Girano prima del pin di `mergeAndDeduplicate` che li corregge → non sono leak persistenti. Wrapparli = refactor speculativo ad alto rischio fuori scope.
- **`assemble-jobs-dataset.mjs:~275`** (`delete job.slugByLocale[locale]` su collisione base-slug senza registry guard): segnalato dall'audit come edge teorico (cancella un locale slug se collide con baseSlug di altro job). Non toccato — è un path di dedup collisioni, raro, e l'harden a valle ripinna; follow-up se emerge in pratica.
- **Migrazione registry deliberata per bad-slug legacy congelati**: come da scelta #1058 (pin authoritative anche su quality-repair), uno slug registrato low-quality resta congelato; ripulirlo richiede una migrazione registry esplicita — non in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)