### PR TITLE
fix(newsletter): attribute Maileroo open/click events (recover stranded commit)

### DIFF
--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -92,24 +92,40 @@ function getOccurredAt(event) {
 // ── Persist a single event to Firestore ──────────────────────
 
 export async function persistMailerooEvent(db, event) {
-  const email = getRecipient(event);
-  if (!email || !email.includes('@')) return { skipped: true, reason: 'invalid_email' };
-
   const type = mapMailerooEvent(event.event_type);
   if (!type) return { skipped: true, reason: `unknown_event: ${event.event_type}` };
 
-  const campaignId = extractCampaignId(event);
+  const FieldValue = admin.firestore.FieldValue;
+  const refId = event.message_reference_id || event.message_id || '';
+
+  // Maileroo 'opened'/'clicked' events carry NEITHER the recipient nor tags —
+  // only message_reference_id. The send pipeline (persistDelivery) writes an
+  // authoritative lookup record at maileroo_message_meta/{referenceId} with the
+  // real recipient, campaign id and job-alert flag. Read it (keyed by refId) to
+  // resolve the subscriber for opens/clicks and to enrich campaign/routing that
+  // the webhook payload itself omits. Falls back to the event fields when the
+  // record is absent (e.g. an 'accepted'/'delivered' event, which does carry the
+  // recipient in event_data.to).
+  const metaDoc = refId
+    ? (await db.collection('maileroo_message_meta').doc(refId).get()).data()
+    : null;
+  // The lookup record is only authoritative if it actually resolved an email.
+  const meta = (metaDoc && typeof metaDoc.email === 'string' && metaDoc.email.includes('@')) ? metaDoc : null;
+  const email = meta ? meta.email : getRecipient(event);
+  if (!email || !email.includes('@')) return { skipped: true, reason: 'invalid_email' };
+
+  const isJobAlert = meta ? !!meta.is_job_alert : isJobAlertEvent(event);
+  const campaignId = (meta && meta.campaign_id) ? meta.campaign_id : extractCampaignId(event);
   const messageId = event.message_id || event.message_reference_id || '';
   const occurredAt = getOccurredAt(event);
   const data = event.event_data || {};
   const clickedUrl = data.original_url || data.url || '';
   const bounceReason = data.reason || data.reject_reason || '';
 
-  if (isJobAlertEvent(event)) {
-    return persistJobAlertMailerooEvent(db, { email, type, event, messageId, occurredAt, clickedUrl });
+  if (isJobAlert) {
+    return persistJobAlertMailerooEvent(db, { email, type, event, messageId, occurredAt, clickedUrl, campaignId });
   }
 
-  const FieldValue = admin.firestore.FieldValue;
   const subscriberRef = db.collection('newsletter_subscribers').doc(email);
 
   const subscriberUpdate = {

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1428,6 +1428,18 @@ async function persistDelivery(recipient, messageId, meta) {
       sector_interest: recipient.sectorInterest || null,
       sent_at: new Date(),
     }, { merge: true });
+    // Maileroo's open/click webhooks carry only message_reference_id (no recipient,
+    // no tags). Persist an authoritative lookup keyed by that id so the webhook can
+    // resolve the subscriber + real campaign for opens/clicks. See
+    // functions/src/newsletterMailerooWebhookCore.js.
+    if (meta.provider === 'maileroo' && messageId) {
+      await db.collection('maileroo_message_meta').doc(String(messageId)).set({
+        email,
+        campaign_id: meta.campaignId,
+        is_job_alert: false,
+        updated_at: new Date(),
+      }, { merge: true });
+    }
     // Update subscriber-level counters
     await subRef.set({
       last_sent_at: new Date(),

--- a/tests/newsletter-maileroo-webhook-core.test.ts
+++ b/tests/newsletter-maileroo-webhook-core.test.ts
@@ -137,6 +137,61 @@ describe('newsletterMailerooWebhookCore', () => {
     expect(db.__sets.some((s) => s.collection === 'newsletter_subscribers')).toBe(false);
   });
 
+  it('resolves recipient for opened/clicked events (no recipient/tags in payload) via maileroo_message_meta', async () => {
+    // Maileroo opened/clicked webhooks carry only message_reference_id — the send
+    // pipeline pre-seeds the lookup record. Verify the click is attributed.
+    const db = createFakeDb({
+      maileroo_message_meta: {
+        ref_abc: { email: 'resolved@example.com', campaign_id: 'weekly_2026-06-01', is_job_alert: false },
+      },
+    });
+
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'clicked',
+      message_id: '<rfc-id@maileroo>',
+      message_reference_id: 'ref_abc',
+      event_time: 1748764800,
+      tags: null,
+      event_data: { original_url: 'https://frontaliereticino.ch/x', ip: '9.9.9.9' },
+    });
+
+    expect(result).toMatchObject({
+      processed: true,
+      type: 'click',
+      email: 'resolved@example.com',
+      campaignId: 'weekly_2026-06-01',
+    });
+    expect(db.__sets.some((e) => e.collection === 'newsletter_subscribers' && e.docId === 'resolved@example.com')).toBe(true);
+  });
+
+  it('routes opened/clicked to job_alert_subscribers when the lookup record flags job-alert', async () => {
+    const db = createFakeDb({
+      maileroo_message_meta: {
+        ref_ja: { email: 'seeker@example.com', campaign_id: 'job_alert_x', is_job_alert: true },
+      },
+    });
+
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'opened',
+      message_reference_id: 'ref_ja',
+      tags: null,
+      event_data: { ip: '8.8.8.8' },
+    });
+
+    expect(result).toMatchObject({ processed: true, type: 'open', collection: 'job_alert_subscribers' });
+  });
+
+  it('skips opened/clicked when no lookup record exists (unattributable)', async () => {
+    const db = createFakeDb();
+    const result = await persistMailerooEvent(db as any, {
+      event_type: 'clicked',
+      message_reference_id: 'ref_unknown',
+      tags: null,
+      event_data: { original_url: 'https://x/y' },
+    });
+    expect(result).toMatchObject({ skipped: true, reason: 'invalid_email' });
+  });
+
   it('skips deferred (transient) and unknown event types', async () => {
     const db = createFakeDb();
     const deferred = await persistMailerooEvent(db as any, {


### PR DESCRIPTION
## Implementato

Recupera il commit rimasto orfano da #1065: l'auto-merge ha mergiato il PR al solo commit del cap **prima** che il commit di attribuzione open/click fosse reviewato, e il branch è stato cancellato → il fix non è mai arrivato su `main` (Firebase ha skippato il redeploy con "No changes detected", verificato).

I webhook `opened`/`clicked` di Maileroo portano **solo** `message_reference_id` — nessun `event_data.to`, nessun `tags` (a differenza di `accepted`/`delivered`). Confermato dai log CF live: `opened → skipped for ?`, `clicked → skipped for ?`.

- `persistDelivery` (send pipeline) scrive un record di lookup autoritativo `maileroo_message_meta/{referenceId}` = `{ email, campaign_id, is_job_alert }`.
- `newsletterMailerooWebhookCore` risolve open/click via quel record (keyed by `message_reference_id`), arricchendo campaign + routing job-alert che il payload omette; fallback ai campi evento per accepted/delivered che hanno il recipient.
- Test: +3 (resolve via lookup, routing job-alert, skip se non attribuibile). Totale 13/13.

Verifiche: vitest 13/13; `node --check` su entrambi i moduli; root cause confermata via log CF + diff origin/main (entrambe le parti assenti prima di questo PR).

## Non implementato (ancora)

- `send-job-alerts.mjs`: il write del meta-index è in `persistDelivery` della newsletter; il path job-alert ha il proprio persist → open/click job-alert via Maileroo non ancora attribuite (follow-up).
- TTL/cleanup di `maileroo_message_meta` — non critico ora.