### PR TITLE
test(slugs): derive ZH it-slug from fixture in migrate test (nit #1068)

### DIFF
--- a/tests/migrate-all-known-job-slugs-canton-aware.test.ts
+++ b/tests/migrate-all-known-job-slugs-canton-aware.test.ts
@@ -57,8 +57,13 @@ describe('migrate-all-known-job-slugs-canton-aware', () => {
     const out = JSON.parse(fs.readFileSync(path.join(dataDir, 'all-known-job-slugs.json'), 'utf-8'));
     const entry = out[SLUG];
 
-    // Section prefix migrated TI → ZH (zurigo / zurich / zuerich / zurich).
-    expect(entry.it).toBe(`/cerca-lavoro-zurigo/${SLUG}/`);
+    // Section prefix migrated TI → ZH. Derive the expected ZH it-slug from the
+    // loaded fixture rather than hardcoding it, so the assertion tracks the
+    // reference data instead of aging against it.
+    const cantonSlugs = JSON.parse(fs.readFileSync(path.join(dataDir, 'canton-url-slugs.json'), 'utf-8'));
+    const zhItSlug = cantonSlugs.cantons.ZH.it;
+    expect(entry.it).toBe(`/cerca-lavoro-${zhItSlug}/${SLUG}/`);
+    expect(entry.it).not.toContain('cerca-lavoro-ticino');
     expect(entry.en).toContain('/find-jobs-');
     expect(entry.en).not.toContain('find-jobs-ticino');
 


### PR DESCRIPTION
## Implementato

Chiude il 🟡 Nit della review di #1068: il test `migrate-all-known-job-slugs-canton-aware` hardcodava `/cerca-lavoro-zurigo/` per l'assertion `it`, fragile rispetto a `canton-url-slugs.json`. Ora deriva lo slug ZH dal fixture caricato (`cantonSlugs.cantons.ZH.it`) e aggiunge `not.toContain('cerca-lavoro-ticino')`, allineandosi alla forma lenient già usata per `en`. Test verde (2/2).

## Non implementato (ancora)

Nulla — fix test-only, una sola assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)