### PR TITLE
ci: open tracking issue on failure for 41 unattended workflows

### DIFF
--- a/.github/workflows/adsense-prereview.yml
+++ b/.github/workflows/adsense-prereview.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   adsense-prereview:
@@ -67,3 +68,19 @@ jobs:
             reports/adsense-prereview-*.json
             reports/adsense-prereview-*.md
           retention-days: 90
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/ai-visibility-check.yml
+++ b/.github/workflows/ai-visibility-check.yml
@@ -134,3 +134,19 @@ jobs:
               --body "$BODY" \
               --label "$ISSUE_LABELS" || echo "⚠ Failed to create issue (labels may not exist yet)"
           fi
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   analytics:
@@ -348,3 +349,19 @@ jobs:
           path: |
             reports/analytics-*.json
           retention-days: 90
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/articles-performance-snapshot.yml
+++ b/.github/workflows/articles-performance-snapshot.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: article-performance-snapshot
@@ -74,3 +75,19 @@ jobs:
           # given the same source data — safe to regenerate on rebase.
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/fetch-article-performance.mjs && git add data/article-performance.json"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/audit-parser-quality.yml
+++ b/.github/workflows/audit-parser-quality.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
@@ -36,3 +37,19 @@ jobs:
 
       - name: Run parser quality audit (strict)
         run: node scripts/audit-parser-quality.mjs --strict
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/batch-faq-articles.yml
+++ b/.github/workflows/batch-faq-articles.yml
@@ -27,6 +27,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   generate-faq:
@@ -138,3 +139,19 @@ jobs:
           echo "- **Concurrency**: ${{ inputs.concurrency || '3' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Skip translate**: ${{ inputs.skip_translate || 'false' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Modified files**: ${{ steps.count.outputs.modified_count || '0' }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/build-evidence-and-tune.yml
+++ b/.github/workflows/build-evidence-and-tune.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -79,11 +80,28 @@ jobs:
           echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving evidence uncommitted."
           exit 1
 
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"
+
   tune-quota:
     needs: build-evidence
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -130,3 +148,19 @@ jobs:
           done
           echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving tune uncommitted."
           exit 1
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -226,6 +226,9 @@ jobs:
                 --label seo-gates,regression \
                 --repo "$GH_REPO" || echo "Failed to create issue for ${name} (continuing)."
             done
+            # Mark that a condition (regression) issue was surfaced, so the
+            # generic crash-reporter below stays silent (no duplicate).
+            echo "opened=true" >> "$GITHUB_OUTPUT"
           fi
 
           if [ "$errors" -gt 0 ]; then
@@ -236,7 +239,13 @@ jobs:
           exit 1
 
       - name: Report unexpected failure to GitHub Issues
-        if: failure() && steps.failgate.conclusion != 'failure'
+        # failgate both opens the issue AND fails the job, so its conclusion
+        # alone can't tell "failed with issue" from "failed without issue"
+        # (missing verdict file, or errors-only with regressed==0). Gate on
+        # an explicit opened=true output: fire only when NO regression issue
+        # was surfaced — covers verdict-missing, errors-only, and any crash
+        # before/outside the gate (build dist, checkout, setup).
+        if: failure() && steps.failgate.outputs.opened != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cathedral-seo-gates-check.yml
+++ b/.github/workflows/cathedral-seo-gates-check.yml
@@ -175,6 +175,7 @@ jobs:
             --repo "$GH_REPO"
 
       - name: Open issue + fail workflow on regression
+        id: failgate
         if: steps.gates.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -233,3 +234,20 @@ jobs:
 
           echo "Gates check reported regressed=${regressed} errors=${errors} — failing the workflow."
           exit 1
+
+      - name: Report unexpected failure to GitHub Issues
+        if: failure() && steps.failgate.conclusion != 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito (crash pre/fuori detection)
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}
+          Nota: il gate è fallito prima/fuori dallo step di valutazione (es. build dist) — nessuna issue di regressione è stata aperta." \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/cleanup-stale-jobs.yml
+++ b/.github/workflows/cleanup-stale-jobs.yml
@@ -28,6 +28,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 env:
   NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
@@ -84,3 +85,19 @@ jobs:
       - name: Commit Phase 2 (cross-crawler duplicates)
         id: phase2_commit
         run: bash scripts/lib/git-commit-data.sh --slice-only "🔁 Housekeeping — remove cross-crawler duplicate jobs"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/crawler-health-monitor.yml
+++ b/.github/workflows/crawler-health-monitor.yml
@@ -185,7 +185,25 @@ jobs:
           done
 
       - name: Fail if any crawler stale
+        id: failgate
         if: steps.health.outcome == 'failure'
         run: |
           echo "One or more crawlers are stale/broken — see issues created above."
           exit 1
+
+      - name: Report unexpected failure to GitHub Issues
+        if: failure() && steps.failgate.conclusion != 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito (crash pre/fuori detection)
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}
+          Nota: il monitor è fallito prima/fuori dallo step di detection — nessuna issue di condizione è stata aperta." \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/discover-404s.yml
+++ b/.github/workflows/discover-404s.yml
@@ -42,6 +42,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   discover:
@@ -139,3 +140,19 @@ jobs:
           # con secrets.*: altrimenti trigger-deploy.sh gira con PAT vuoto e il
           # deploy non parte (cfr. #878).
           GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/evergreen-refresh-audit.yml
+++ b/.github/workflows/evergreen-refresh-audit.yml
@@ -86,3 +86,19 @@ jobs:
             --label "content,evergreen-refresh"
 
           echo "✅ Created GitHub issue for ${STALE} stale articles"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/fb-jobs-daily-schedule.yml
+++ b/.github/workflows/fb-jobs-daily-schedule.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   contents: write  # to commit fb-posted-jobs.json
+  issues: write
 
 jobs:
   schedule:
@@ -76,3 +77,19 @@ jobs:
           # FB Page's actual scheduled queue.
           bash scripts/lib/git-push-with-retry.sh \
             --in-place-resolver-cmd "node scripts/lib/resolve-fb-posted-jobs-conflict.mjs && git add -A"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -33,6 +33,7 @@ concurrency:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 jobs:
   generate:
@@ -535,3 +536,19 @@ jobs:
           RETRY_COUNT: ${{ steps.decide_trigger.outputs.next_retry }}
           NO_CHANGES_STREAK: ${{ steps.decide_trigger.outputs.next_streak }}
         run: bash scripts/lib/trigger-self.sh
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/gsc-frontaliere-monitor.yml
+++ b/.github/workflows/gsc-frontaliere-monitor.yml
@@ -169,7 +169,25 @@ jobs:
         run: rm -f /tmp/firebase-sa.json
 
       - name: Fail if drift detected
+        id: failgate
         if: ${{ steps.status.outputs.drift == 'true' }}
         run: |
           echo "::error::Brand drift detected — see opened issue and uploaded artifact."
           exit 1
+
+      - name: Report unexpected failure to GitHub Issues
+        if: failure() && steps.failgate.conclusion != 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito (crash pre/fuori detection)
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}
+          Nota: il monitor è fallito prima/fuori dallo step di detection — nessuna issue di condizione è stata aperta." \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/lessons-harvester.yml
+++ b/.github/workflows/lessons-harvester.yml
@@ -24,7 +24,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: read
+  issues: write
   id-token: write
 
 concurrency:
@@ -111,3 +111,19 @@ jobs:
                ```
                Aggiungi in fondo: "⚠️ Proposta auto-generata dal lessons-harvester. Human-gated: rivedere prima di mergere. Se modifica `.github/workflows/` non è prevista (solo `.md`)."
             7. NON mergiare. È una proposta: la rivede un umano.
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/monitor-gsc-seo.yml
+++ b/.github/workflows/monitor-gsc-seo.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   monitor:
@@ -54,3 +55,19 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: rm -f /tmp/firebase-sa.json
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/newsletter-qa.yml
+++ b/.github/workflows/newsletter-qa.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   qa:
@@ -52,3 +53,19 @@ jobs:
 
       - name: Commit QA report
         run: bash scripts/lib/git-commit-data.sh "📋 Auto-generated newsletter QA report" docs/newsletter-qa/
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/orchestrate-crawlers.yml
+++ b/.github/workflows/orchestrate-crawlers.yml
@@ -36,6 +36,7 @@ concurrency:
 permissions:
   contents: read
   actions: write
+  issues: write
 
 env:
   NODE_OPTIONS: '--disable-warning=DEP0040 --disable-warning=DEP0169'
@@ -218,3 +219,19 @@ jobs:
             echo "---- end gh stderr ----"
             exit 1
           fi
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/probe-bazg.yml
+++ b/.github/workflows/probe-bazg.yml
@@ -45,3 +45,19 @@ jobs:
             --title "BAZG API is back online — wire as priority-1 traffic source" \
             --body "The weekly BAZG probe found a working endpoint. Time to wire it as the priority-0 source in \`functions/src/trafficSchedulerCore.js\`, above HERE Maps in the provider waterfall. See the design doc: \`valerielinc-main-design-20260503-183137-border-wait-multi-source.md\`." \
             --label "enhancement"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -25,6 +25,10 @@ concurrency:
   group: production-canary
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   probe:
     name: Probe production for 5XX
@@ -54,3 +58,19 @@ jobs:
           path: probe-output.err
           if-no-files-found: ignore
           retention-days: 7
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/quality-alerts.yml
+++ b/.github/workflows/quality-alerts.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -59,3 +60,19 @@ jobs:
           done
           echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving alert state uncommitted."
           exit 1
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/refresh-indexed-cluster-urls.yml
+++ b/.github/workflows/refresh-indexed-cluster-urls.yml
@@ -25,6 +25,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: indexed-cluster-urls-refresh
@@ -88,3 +89,19 @@ jobs:
           git commit -m "chore(seo): refresh indexed cluster URLs (GSC+GA4+PostHog union)"
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/refresh-indexed-cluster-urls.mjs --days $DAYS --min-impressions $MIN_IMP && git add data/indexed-cluster-urls.json"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/refresh-keyword-config.yml
+++ b/.github/workflows/refresh-keyword-config.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   refresh:
@@ -50,3 +51,19 @@ jobs:
           # regenerate both data files on the new base and re-stage them.
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/generate-keyword-pages-config.mjs && node scripts/cluster-orphan-queries.mjs && git add data/keyword-pages-config.json data/gsc-orphan-queries-clusters.json"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/refresh-noslash-keep.yml
+++ b/.github/workflows/refresh-noslash-keep.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: noslash-keep-refresh
@@ -86,3 +87,19 @@ jobs:
           git commit -m "chore(seo): refresh no-slash keep-list (GSC+GA4+PostHog union)"
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/refresh-noslash-keep.mjs --days $DAYS --min-impressions $MIN_IMP && git add data/noslash-keep.json"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/refresh-thin-promotions.yml
+++ b/.github/workflows/refresh-thin-promotions.yml
@@ -32,6 +32,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: refresh-thin-promotions
@@ -125,3 +126,19 @@ jobs:
           done
           echo "❌ Push failed after $MAX_ATTEMPTS attempts — leaving change uncommitted."
           exit 1
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/revenue-monitor.yml
+++ b/.github/workflows/revenue-monitor.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   monitor:
@@ -80,3 +81,19 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: rm -f /tmp/firebase-sa.json
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/semrush-weekly-snapshot.yml
+++ b/.github/workflows/semrush-weekly-snapshot.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   snapshot:
@@ -101,3 +102,19 @@ jobs:
             REGEN_CMD='node scripts/seo/semrush-snapshot.mjs --dry-run || true; node scripts/seo/semrush-site-audit.mjs --dry-run || true; node scripts/seo/detect-cannibalization.mjs --dry-run || true; node scripts/seo/generate-weekly-report.mjs || true; git add data/seo-snapshots/ reports/ docs/seo-reports/'
           fi
           bash scripts/lib/git-push-with-retry.sh --regenerate-cmd "$REGEN_CMD"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -72,6 +72,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   newsletter:
@@ -149,3 +150,19 @@ jobs:
           else
             node scripts/send-newsletter.mjs --test --target-email "$TARGET" --subject "$SUBJECT" --sections "$SECTIONS" --section-order "$SECTION_ORDER" $VARIANT_FLAG --enhancements "$ENHANCEMENTS"
           fi
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/seo-serp-autopilot.yml
+++ b/.github/workflows/seo-serp-autopilot.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   autopilot:
@@ -104,3 +105,19 @@ jobs:
           bash scripts/lib/git-push-with-retry.sh \
             --branch "$GITHUB_REF_NAME" \
             --regenerate-cmd "git checkout HEAD@{1} -- data/seo-serp-autopilot-last-run.json data/seo-serp-experiment-history.json 2>/dev/null || true; git add data/seo-serp-autopilot-last-run.json data/seo-serp-experiment-history.json"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/sitemap-shard-size-monitor.yml
+++ b/.github/workflows/sitemap-shard-size-monitor.yml
@@ -148,7 +148,11 @@ jobs:
           exit 1
 
       - name: Report unexpected failure to GitHub Issues
-        if: failure() && steps.failgate.conclusion != 'failure'
+        # Fire on a muted failure: either the job failed BEFORE/OUTSIDE the
+        # detection fail-gate (failgate skipped), OR the check exited non-zero
+        # but emitted no report → severity=none → "Open issue" skipped yet
+        # failgate still fired. Both leave ZERO condition issue → report it.
+        if: failure() && (steps.failgate.conclusion != 'failure' || steps.severity.outputs.severity == 'none')
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sitemap-shard-size-monitor.yml
+++ b/.github/workflows/sitemap-shard-size-monitor.yml
@@ -141,7 +141,25 @@ jobs:
           retention-days: 30
 
       - name: Fail job if any shard exceeded thresholds
+        id: failgate
         if: steps.check.outcome == 'failure'
         run: |
           echo "Sitemap shard size check exited non-zero — see report + issue above."
           exit 1
+
+      - name: Report unexpected failure to GitHub Issues
+        if: failure() && steps.failgate.conclusion != 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito (crash pre/fuori detection)
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}
+          Nota: il monitor è fallito prima/fuori dallo step di detection — nessuna issue di condizione è stata aperta." \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/smoke-test-ai-models.yml
+++ b/.github/workflows/smoke-test-ai-models.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   smoke:
@@ -79,3 +80,19 @@ jobs:
             .tmp/smoke.json
             .tmp/smoke.log
           retention-days: 30
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/snapshot-jobs-weekly.yml
+++ b/.github/workflows/snapshot-jobs-weekly.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   snapshot:
@@ -112,3 +113,19 @@ jobs:
           # snapshot + delta + footer pairs + cluster data on top of the new base.
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/assemble-jobs-dataset.mjs || true; node scripts/snapshot-jobs-weekly.mjs; node scripts/compute-weekly-employer-delta.mjs; node scripts/refresh-weekly-employers-top-pairs.mjs; node scripts/audit-related-search-candidates.mjs || true; node scripts/ingest-gsc-orphans-into-candidates.mjs || true; git add data/jobs-snapshots-history/ data/weekly-employers-delta.json data/weekly-employers-top-pairs.json data/related-search-candidates.json data/related-search-enriched.json 2>/dev/null || true"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/submit-indexnow-batch.yml
+++ b/.github/workflows/submit-indexnow-batch.yml
@@ -28,6 +28,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   submit:
@@ -69,3 +70,19 @@ jobs:
           node scripts/submit-indexnow-batch.mjs $ARGS
         env:
           BING_API_KEY: ${{ secrets.BING_API_KEY }}
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/sync-gsc-orphans.yml
+++ b/.github/workflows/sync-gsc-orphans.yml
@@ -33,6 +33,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   sync-orphans:
@@ -127,3 +128,19 @@ jobs:
           # con secrets.*: altrimenti trigger-deploy.sh gira con PAT vuoto e il
           # deploy non parte (cfr. #878).
           GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/topic-candidates-mining.yml
+++ b/.github/workflows/topic-candidates-mining.yml
@@ -19,6 +19,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   mine:
@@ -77,3 +78,19 @@ jobs:
           fi
           git commit -m "chore: refresh topic candidates"
           bash scripts/lib/git-push-with-retry.sh
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/traffic-data-freshness.yml
+++ b/.github/workflows/traffic-data-freshness.yml
@@ -125,3 +125,19 @@ jobs:
             --body "First stale reading detected at $(date -u +%FT%TZ). Reason: ${REASON}. Self-heal dispatched traffic-scheduler. This issue will be auto-closed on next freshness run if data recovers, or promoted to a confirmed bug if it remains stale." \
             --label "traffic-stale-pending"
           echo "Opened pending issue"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/traffic-scheduler.yml
+++ b/.github/workflows/traffic-scheduler.yml
@@ -22,6 +22,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   collect:
@@ -81,3 +82,19 @@ jobs:
         # NOTE: Commit + push goes to main BUT deploy.yml has paths-ignore on
         # data/border-wait-* so this won't trigger a deploy storm — periodic
         # deploys will pick up the new JSON.
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-exchange-history.yml
+++ b/.github/workflows/update-exchange-history.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   update:
@@ -41,3 +42,19 @@ jobs:
 
       - name: Update exchange rate history
         run: node scripts/update-exchange-history.mjs
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-fuel-prices.yml
+++ b/.github/workflows/update-fuel-prices.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   update-fuel-prices:
@@ -103,3 +104,19 @@ jobs:
       - name: Trigger deploy workflow
         if: steps.commit.outputs.has_changes == 'true'
         run: bash scripts/lib/trigger-deploy.sh || true
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-health-premiums.yml
+++ b/.github/workflows/update-health-premiums.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   update-health-premiums:
@@ -80,3 +81,19 @@ jobs:
       - name: Trigger deploy workflow
         if: steps.commit.outputs.has_changes == 'true'
         run: bash scripts/lib/trigger-deploy.sh || true
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/update-unemployment-rate.yml
+++ b/.github/workflows/update-unemployment-rate.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   update:
@@ -55,4 +56,20 @@ jobs:
 
           # GITHUB_TOKEN pushes don't trigger other workflows — trigger deploy manually
           bash scripts/lib/trigger-deploy.sh || true
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"
 

--- a/.github/workflows/update-weather.yml
+++ b/.github/workflows/update-weather.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   update-weather:
@@ -69,3 +70,19 @@ jobs:
           done
           echo "::warning::push failed after 5 attempts — leaving snapshot uncommitted"
           exit 0
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/validate-webcams-nightly.yml
+++ b/.github/workflows/validate-webcams-nightly.yml
@@ -53,3 +53,19 @@ jobs:
               body: `Nightly webcam health check reported failures.\n\n\`\`\`\n${report}\n\`\`\`\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               labels: ['border-wait', 'webcam', 'maintenance'],
             });
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"

--- a/.github/workflows/verify-company-logos-weekly.yml
+++ b/.github/workflows/verify-company-logos-weekly.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   verify:
@@ -50,3 +51,19 @@ jobs:
           # against the rebased base.
           bash scripts/lib/git-push-with-retry.sh \
             --regenerate-cmd "node scripts/verify-company-logos.mjs || true; git add data/company-logos-broken.json"
+
+      - name: Report failure to GitHub Issues
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/lib/github-issue-creator.mjs \
+            --title "Workflow Failure: ${{ github.workflow }}" \
+            --description "## Workflow fallito
+          **Run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Trigger:** ${{ github.event_name }}
+          **Ref:** ${{ github.ref_name }}" \
+            --priority 2 \
+            --label Bug \
+            --workflow "${{ github.workflow }}"


### PR DESCRIPTION
## Implementato

I workflow schedulati/`workflow_run` fallivano in silenzio: nessuna issue GitHub su failure (es. `audit-parser-quality` rimasto rosso ~3h senza issue di tracking). Aggiunto a **45 workflow** copertura issue-on-failure:

**41 workflow unattended** → step canonico `Report failure to GitHub Issues` (`if: failure()`, `continue-on-error: true`, `github-issue-creator.mjs` con titolo stabile `Workflow Failure: <name>` per dedup) + `issues: write` dove mancava.

**4 monitor detection** (`sitemap-shard-size-monitor`, `cathedral-seo-gates-check`, `gsc-frontaliere-monitor`, `crawler-health-monitor`) → reporter **guardato** (risolve 🔴 review). Questi aprono già la propria issue + escono non-zero ON detection; ma un crash PRIMA/FUORI dalla detection (checkout, setup, build dist, secret mancante) falliva il job senza NESSUNA issue — fallimento muto su monitor indicizzazione-critici. Fix: `id: failgate` sullo step di fail-atteso + reporter con `if: failure() && steps.failgate.conclusion != failure`. I detect step sono `continue-on-error` (conclusion=success); il job entra in `failure()` solo via failgate (path atteso → reporter saltato, no dup) o via crash non-detection (failgate skipped → reporter spara). cathedral `push` è filtrato a `branches:[main]` + path script → nessun rumore PR-branch.

Pattern identico ai crawler workflow (443/505 lo avevano già). `github-issue-creator.mjs` usa solo `node:child_process` + `gh` (nessuna dep npm); titolo stabile → failure ripetute dedupano su 1 issue.

**Verifica:** 45 file, tutti `python3 yaml.safe_load` OK + `actionlint` senza nuovi errori (unico finding `submit-indexnow-batch:14` string-empty = pre-esistente su `origin/main`). Diff scoped: solo `.github/workflows/`, zero drive-by. Casi speciali: `production-canary` nuovo blocco permissions; `quality-alerts`/`build-evidence-and-tune` job-level; `lessons-harvester` `issues: read`→`write`; `build-evidence-and-tune` step in entrambi i job.

## Non implementato (ancora)

Esclusi per scelta (dichiarati per gating):
- **Protetti workflow-validation**: `pr-review-loop`, `auto-merge-on-lgtm`, `post-merge-followup`, `issue-fix` — modificarli rompe l’auto-merge GitHub App (AGENTS.md). Hanno già surfacing proprio.
- **CI PR/push**: `tests`, `lighthouse-ci` — fallimenti già visibili sulla PR.
- **Tool manuali `workflow_dispatch`-only** (~11) — attended: chi li lancia vede il risultato.

Risposte agli ❓ adversarial del reviewer:
- actionlint rieseguito centralmente sui 45: nessun nuovo errore sul `--description` multi-line (gli step `run:` con la here-string non sono flaggati).
- Dedup-key: ogni workflow ha `name:` univoco → nessuna collisione nei primi char del titolo; failure dello stesso workflow dedupano correttamente.
- Multi-job: solo `build-evidence-and-tune` ha >1 job con checkout (coperti entrambi); gli altri 40 sono single-job → reporter sull’unico job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)