### PR TITLE
fix(ci): bump post-merge-followup max-turns 15→20

### DIFF
--- a/.github/workflows/post-merge-followup.yml
+++ b/.github/workflows/post-merge-followup.yml
@@ -64,7 +64,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
-          claude_args: "--max-turns 15 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
+          # max-turns 20 (era 15): il triage completo (parse PR body + reviews,
+          # filtro churn/funnel, dedup, in-flight overlap, gh issue create, +
+          # supersede detection) sforava sistematicamente i 15 turni → 6 run
+          # `error_max_turns` il 2026-05-30 (num_turns 16+) con triage perso per
+          # PR #1015/#1012/#979 (nessun re-run → 🟡/❓ + `## Non implementato`
+          # mai triagiati). 15 troncava prima degli step obbligatori; AGENTS.md
+          # vieta di abbassarli proprio per questo. Allineato a lessons-harvester (20).
+          claude_args: "--max-turns 20 --model claude-sonnet-4-6 --allowedTools 'Bash(gh:*),Read,Grep,Glob'"
           prompt: |
             Triage automatico follow-up per PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }} (${{ github.event_name }}).
 


### PR DESCRIPTION
## Implementato

Bump `--max-turns` di `post-merge-followup.yml` da **15 → 20** (riga 67), allineato a `lessons-harvester` (già 20).

**Root cause (verificato sui log 2026-05-30):** 6 run `error_max_turns` — il triage completo (parse PR body `## Non implementato` + reviews, filtro churn/funnel, dedup, in-flight overlap, `gh issue create`, supersede detection) sforava i 15 turni (`num_turns` 16+). 15 troncava **prima** degli step obbligatori.

**Danno concreto:** triage follow-up **perso** per ≥3 PR mergiate (nessun re-run → 🟡/❓ reviewer + `## Non implementato` mai triagiati):
- PR #1015 (harden automation loop) — nessuna issue follow-up
- PR #1012 (newsletter cap 550) — nessuna issue follow-up
- PR #979 (fix #892) — nessuna issue follow-up

Coerente con AGENTS.md, che **vieta di abbassare** i max-turns di questo workflow proprio perché turni bassi troncano prima degli step obbligatori → `error_max_turns`.

## Non implementato (ancora)

- **Bug API 400 "thinking blocks" su `pr-review-loop`** (7 crash il 05-30, exit 1 con `subtype:success`): è **upstream** in `anthropics/claude-code-action@v1`, non patchabile qui → follow-up separato (indagine timeline + pin/retry/segnalazione upstream in corso). Out of scope per questa PR (file diverso, causa diversa).
- Nessun re-trigger retroattivo del triage perso per #1015/#1012/#979: item deferibili non-bloccanti; backfill manuale via `workflow_dispatch -f pr_number=<N>` se ritenuto utile. Posposto.

## Test plan

- [ ] Post-merge: prossima PR organica mergiata → `post-merge-followup` completa senza `error_max_turns` (verifica `num_turns` < 20 nel log + commento `## Post-merge follow-up triage` postato).

> ⚠️ Modifica `post-merge-followup.yml` → rientra nell'eccezione workflow-validation (AGENTS.md): reviewer GitHub App non posta, auto-merge non scatta → **merge manuale** `gh pr merge --squash --delete-branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)