### PR TITLE
fix(crawler-health): exempt legit-empty sources + auto-close recovered issues

### DIFF
--- a/.github/workflows/crawler-health-monitor.yml
+++ b/.github/workflows/crawler-health-monitor.yml
@@ -184,6 +184,42 @@ jobs:
               --repo "$GH_REPO" || echo "Failed to create issue for ${slug} (continuing)."
           done
 
+      - name: Close recovered crawler-health issues
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          # Auto-close `[crawler-health] <slug>: <status>` issues whose crawler
+          # is now healthy in data/crawler-health.json. Without this, a recovered
+          # crawler's issue lingers open forever (the open step only creates,
+          # never closes). Matches by slug parsed from the issue title.
+          if [ ! -f data/crawler-health.json ]; then
+            echo "No health state file; nothing to reconcile."
+            exit 0
+          fi
+          gh issue list --state open --limit 500 \
+            --json number,title --jq '.[] | select(.title | test("^\\[crawler-health\\] ")) | "\(.number)\t\(.title)"' \
+            > /tmp/health-issues.tsv || true
+          if [ ! -s /tmp/health-issues.tsv ]; then
+            echo "No open [crawler-health] issues."
+            exit 0
+          fi
+          while IFS=$'\t' read -r num title; do
+            slug=$(printf '%s' "$title" | sed -E 's/^\[crawler-health\] ([^:]+):.*/\1/')
+            status=$(jq -r --arg s "$slug" '.crawlers[$s].status // "unknown"' data/crawler-health.json)
+            if [ "$status" = "healthy" ]; then
+              echo "Closing #$num — ${slug} is healthy again."
+              gh issue close "$num" --repo "$GH_REPO" \
+                --comment "✅ Auto-closed: crawler \`${slug}\` is now **healthy** in \`data/crawler-health.json\` (recovered)." \
+                || echo "Failed to close #$num (continuing)."
+            else
+              echo "Keeping #$num — ${slug} status=${status}."
+            fi
+          done < /tmp/health-issues.tsv
+
       - name: Fail if any crawler stale
         if: steps.health.outcome == 'failure'
         run: |

--- a/scripts/check-crawler-health.mjs
+++ b/scripts/check-crawler-health.mjs
@@ -85,6 +85,22 @@ const EMPTY_OK_CRAWLERS = new Set([
   // (https://www.zambon.com/it/api/careers-api) returns jobs across
   // BR/DE/IT/FR/ES/CO but currently 0 CH listings. Parser is healthy.
   'zambon',
+  // AIL Lugano: the AJAX endpoint
+  // (https://www.ail.ch/AIL/risorse-umane/offerte-di-lavoro/content/0.html?ajax=true)
+  // currently returns HTTP 200 with "Al momento non ci sono posizioni aperte".
+  // Zero open positions is a legitimate state; the parser is healthy and
+  // re-arms when AIL publishes openings again.
+  'ail-lugano',
+  // Città di Locarno: the careers page
+  // (https://www.locarno.ch/it/albo-comunale/assunzioni-personale) currently
+  // shows "Assunzioni personale (0) — Nessun documento trovato". The
+  // municipality has no active public competitions right now; parser is healthy.
+  'citta-di-locarno',
+  // ALTEN Switzerland: the crawler is scoped to TI/GR openings only
+  // (https://www.alten.ch/career/jobs/). The consultancy currently lists no
+  // Ticino/Graubünden roles; same legitimately-empty regional-filter case as
+  // zurich-insurance-sede-ticino and manor. Parser is healthy.
+  'alten-switzerland',
 ]);
 
 /** Read JSON file, return null on any error. */


### PR DESCRIPTION
## Implementato

Triage completo delle issue crawler aperte. Due classi di problema, entrambe **rumore da falso-positivo / mancato auto-close**, non parser rotti.

**1. Tre crawler flaggati `broken` sono falsi-positivi (sorgenti legittimamente vuote).** Verificato live:
- `ail-lugano` → endpoint AJAX risponde HTTP 200 con *"Al momento non ci sono posizioni aperte"*.
- `citta-di-locarno` → pagina mostra *"Assunzioni personale (0) — Nessun documento trovato"*.
- `alten-switzerland` → crawler scoped a TI/GR; ALTEN non ha aperture Ticino/Grigioni ora (stesso caso di `zurich-insurance-sede-ticino`/`manor`).

I parser funzionano e preservano i dati esistenti. Aggiunti a `EMPTY_OK_CRAWLERS` in `scripts/check-crawler-health.mjs` (stesso pattern già usato per `csvp-poschiavo`/`manor`/`zambon`) → il monitor smette di flaggarli e di aprire issue. Si ri-armano da soli quando le sorgenti pubblicano aperture.

**2. Auto-close issue recuperate.** `crawler-health-monitor.yml` apriva issue ma non le chiudeva mai → restavano aperte dopo il recupero (es. #731/#732/#733 già `healthy`). Aggiunto step `Close recovered crawler-health issues` (`if: always()`) che chiude le `[crawler-health] <slug>: …` il cui crawler è ora `healthy` in `data/crawler-health.json`.

**Verifica:** `npx vitest run tests/scripts/check-crawler-health.test.ts` → 13/13 verdi. `node --check` + YAML parse OK. Diff additivo (+52).

Le ~16 issue `Crawler Failure: …` (HIB 429, PSPE/GZO/IGS 403, KSUri 502, Nestlé/HOCH/CSVM/Somedia fetch-failed, OSCAM aborted) sono fallimenti **transienti** già auto-recuperati: i rispettivi crawler risultano `healthy` in `crawler-health.json`. Le chiudo manualmente come stale (evidence: health file).

## Non implementato (ancora)

- **Auto-close delle issue `Crawler Failure: <workflow>`** (per-workflow, non health): richiede che ogni workflow dedicato chiuda la propria issue on-success (~40 file) o un mapping workflow→slug nel monitor. Out of scope qui — follow-up. Per ora chiuse a mano.
- **Retry/backoff su errori HTTP transienti** (429/5xx/network) nei fetch dei crawler dedicati per non far fallire il workflow al primo blip: ogni crawler ha fetch bespoke → cambio largo, follow-up.
- Nessuna modifica ai parser: nessuno è rotto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)